### PR TITLE
Keep forward slash when autocomplete on Windows

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -308,6 +308,67 @@ fn file_completions() {
     match_suggestions(&expected_paths, &suggestions);
 }
 
+#[cfg(windows)]
+#[test]
+fn file_completions_with_mixed_separators() {
+    // Create a new engine
+    let (dir, dir_str, engine, stack) = new_dotnu_engine();
+
+    // Instantiate a new completer
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+
+    // Create Expected values
+    let expected_paths: Vec<String> = vec![
+        file(dir.join("lib-dir1").join("bar.nu")),
+        file(dir.join("lib-dir1").join("baz.nu")),
+        file(dir.join("lib-dir1").join("xyzzy.nu")),
+    ];
+    let expecetd_slash_paths: Vec<String> = expected_paths
+        .iter()
+        .map(|s| s.replace(MAIN_SEPARATOR, "/"))
+        .collect();
+
+    let target_dir = format!("ls {dir_str}/lib-dir1/");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    match_suggestions(&expecetd_slash_paths, &suggestions);
+
+    let target_dir = format!("cp {dir_str}\\lib-dir1/");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    match_suggestions(&expecetd_slash_paths, &suggestions);
+
+    let target_dir = format!("ls {dir_str}/lib-dir1\\/");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    match_suggestions(&expecetd_slash_paths, &suggestions);
+
+    let target_dir = format!("ls {dir_str}\\lib-dir1\\/");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    match_suggestions(&expecetd_slash_paths, &suggestions);
+
+    let target_dir = format!("ls {dir_str}\\lib-dir1\\");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    match_suggestions(&expected_paths, &suggestions);
+
+    let target_dir = format!("ls {dir_str}/lib-dir1\\");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    match_suggestions(&expected_paths, &suggestions);
+
+    let target_dir = format!("ls {dir_str}/lib-dir1/\\");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    match_suggestions(&expected_paths, &suggestions);
+
+    let target_dir = format!("ls {dir_str}\\lib-dir1/\\");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    match_suggestions(&expected_paths, &suggestions);
+}
+
 #[test]
 fn partial_completions() {
     // Create a new engine

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -122,28 +122,28 @@ fn variables_double_dash_argument_with_flagcompletion(mut completer: NuCompleter
     let suggestions = completer.complete("tst --", 6);
     let expected: Vec<String> = vec!["--help".into(), "--mod".into()];
     // dbg!(&expected, &suggestions);
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn variables_single_dash_argument_with_flagcompletion(mut completer: NuCompleter) {
     let suggestions = completer.complete("tst -", 5);
     let expected: Vec<String> = vec!["--help".into(), "--mod".into(), "-h".into(), "-s".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn variables_command_with_commandcompletion(mut completer_strings: NuCompleter) {
     let suggestions = completer_strings.complete("my-c ", 4);
     let expected: Vec<String> = vec!["my-command".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn variables_subcommands_with_customcompletion(mut completer_strings: NuCompleter) {
     let suggestions = completer_strings.complete("my-command ", 11);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
@@ -152,7 +152,7 @@ fn variables_customcompletion_subcommands_with_customcompletion_2(
 ) {
     let suggestions = completer_strings.complete("my-command ", 11);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[test]
@@ -181,19 +181,19 @@ fn dotnu_completions() {
     let completion_str = "source-env ".to_string();
     let suggestions = completer.complete(&completion_str, completion_str.len());
 
-    match_suggestions(expected.clone(), suggestions);
+    match_suggestions(&expected, &suggestions);
 
     // Test use completion
     let completion_str = "use ".to_string();
     let suggestions = completer.complete(&completion_str, completion_str.len());
 
-    match_suggestions(expected.clone(), suggestions);
+    match_suggestions(&expected, &suggestions);
 
     // Test overlay use completion
     let completion_str = "overlay use ".to_string();
     let suggestions = completer.complete(&completion_str, completion_str.len());
 
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[test]
@@ -263,16 +263,16 @@ fn file_completions() {
         let target_dir = format!("cp {dir_str}{separator}");
         let slash_suggestions = completer.complete(&target_dir, target_dir.len());
 
-        let expected_slash_paths = expected_paths
+        let expected_slash_paths: Vec<String> = expected_paths
             .iter()
             .map(|s| s.replace('\\', "/"))
             .collect();
 
-        match_suggestions(expected_slash_paths, slash_suggestions);
+        match_suggestions(&expected_slash_paths, &slash_suggestions);
     }
 
     // Match the results
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 
     // Test completions for a file
     let target_dir = format!("cp {}", folder(dir.join("another")));
@@ -282,7 +282,7 @@ fn file_completions() {
     let expected_paths: Vec<String> = vec![file(dir.join("another").join("newfile"))];
 
     // Match the results
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 
     // Test completions for hidden files
     let target_dir = format!("ls {}{MAIN_SEPARATOR}.", folder(dir.join(".hidden_folder")));
@@ -296,16 +296,16 @@ fn file_completions() {
         let target_dir = format!("ls {}/.", folder(dir.join(".hidden_folder")));
         let slash_suggestions = completer.complete(&target_dir, target_dir.len());
 
-        let expected_slash = expected_paths
+        let expected_slash: Vec<String> = expected_paths
             .iter()
             .map(|s| s.replace('\\', "/"))
             .collect();
 
-        match_suggestions(expected_slash, slash_suggestions)
+        match_suggestions(&expected_slash, &slash_suggestions);
     }
 
     // Match the results
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 }
 
 #[test]
@@ -329,7 +329,7 @@ fn partial_completions() {
     ];
 
     // Match the results
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 
     // Test completions for the files whose name begin with "h"
     // and are present under directories whose names begin with "pa"
@@ -350,7 +350,7 @@ fn partial_completions() {
     ];
 
     // Match the results
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 
     // Test completion for all files under directories whose names begin with "pa"
     let dir_str = folder(dir.join("pa"));
@@ -371,7 +371,7 @@ fn partial_completions() {
     ];
 
     // Match the results
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 
     // Test completion for a single file
     let dir_str = file(dir.join("fi").join("so"));
@@ -382,7 +382,7 @@ fn partial_completions() {
     let expected_paths: Vec<String> = vec![file(dir.join("final_partial").join("somefile"))];
 
     // Match the results
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 
     // Test completion where there is a sneaky `..` in the path
     let dir_str = file(dir.join("par").join("..").join("fi").join("so"));
@@ -418,7 +418,7 @@ fn partial_completions() {
     ];
 
     // Match the results
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 
     // Test completion for all files under directories whose names begin with "pa"
     let file_str = file(dir.join("partial-a").join("have"));
@@ -432,7 +432,7 @@ fn partial_completions() {
     ];
 
     // Match the results
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 
     // Test completion for all files under directories whose names begin with "pa"
     let file_str = file(dir.join("partial-a").join("have_ext."));
@@ -446,7 +446,7 @@ fn partial_completions() {
     ];
 
     // Match the results
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 }
 
 #[test]
@@ -481,14 +481,14 @@ fn command_ls_with_filecompletion() {
         ".hidden_folder/".to_string(),
     ];
 
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 
     let target_dir = "ls custom_completion.";
     let suggestions = completer.complete(target_dir, target_dir.len());
 
     let expected_paths: Vec<String> = vec!["custom_completion.nu".to_string()];
 
-    match_suggestions(expected_paths, suggestions)
+    match_suggestions(&expected_paths, &suggestions);
 }
 
 #[test]
@@ -523,14 +523,14 @@ fn command_open_with_filecompletion() {
         ".hidden_folder/".to_string(),
     ];
 
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 
     let target_dir = "open custom_completion.";
     let suggestions = completer.complete(target_dir, target_dir.len());
 
     let expected_paths: Vec<String> = vec!["custom_completion.nu".to_string()];
 
-    match_suggestions(expected_paths, suggestions)
+    match_suggestions(&expected_paths, &suggestions);
 }
 
 #[test]
@@ -565,7 +565,7 @@ fn command_rm_with_globcompletion() {
         ".hidden_folder/".to_string(),
     ];
 
-    match_suggestions(expected_paths, suggestions)
+    match_suggestions(&expected_paths, &suggestions)
 }
 
 #[test]
@@ -600,7 +600,7 @@ fn command_cp_with_globcompletion() {
         ".hidden_folder/".to_string(),
     ];
 
-    match_suggestions(expected_paths, suggestions)
+    match_suggestions(&expected_paths, &suggestions)
 }
 
 #[test]
@@ -635,7 +635,7 @@ fn command_save_with_filecompletion() {
         ".hidden_folder/".to_string(),
     ];
 
-    match_suggestions(expected_paths, suggestions)
+    match_suggestions(&expected_paths, &suggestions)
 }
 
 #[test]
@@ -670,7 +670,7 @@ fn command_touch_with_filecompletion() {
         ".hidden_folder/".to_string(),
     ];
 
-    match_suggestions(expected_paths, suggestions)
+    match_suggestions(&expected_paths, &suggestions)
 }
 
 #[test]
@@ -705,7 +705,7 @@ fn command_watch_with_filecompletion() {
         ".hidden_folder/".to_string(),
     ];
 
-    match_suggestions(expected_paths, suggestions)
+    match_suggestions(&expected_paths, &suggestions)
 }
 
 #[rstest]
@@ -713,19 +713,19 @@ fn subcommand_completions(mut subcommand_completer: NuCompleter) {
     let prefix = "foo br";
     let suggestions = subcommand_completer.complete(prefix, prefix.len());
     match_suggestions(
-        vec!["foo bar".to_string(), "foo aabrr".to_string()],
-        suggestions,
+        &vec!["foo bar".to_string(), "foo aabrr".to_string()],
+        &suggestions,
     );
 
     let prefix = "foo b";
     let suggestions = subcommand_completer.complete(prefix, prefix.len());
     match_suggestions(
-        vec![
+        &vec![
             "foo bar".to_string(),
             "foo abaz".to_string(),
             "foo aabrr".to_string(),
         ],
-        suggestions,
+        &suggestions,
     );
 }
 
@@ -751,7 +751,7 @@ fn file_completion_quoted() {
         format!("`{}`", folder("test dir".into())),
     ];
 
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 
     let dir: PathBuf = "test dir".into();
     let target_dir = format!("open '{}'", folder(dir.clone()));
@@ -762,7 +762,7 @@ fn file_completion_quoted() {
         format!("`{}`", file(dir.join("single quote"))),
     ];
 
-    match_suggestions(expected_paths, suggestions)
+    match_suggestions(&expected_paths, &suggestions)
 }
 
 #[test]
@@ -797,7 +797,7 @@ fn flag_completions() {
     ];
 
     // Match results
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[test]
@@ -826,16 +826,16 @@ fn folder_with_directorycompletions() {
         let target_dir = format!("cd {dir_str}/");
         let slash_suggestions = completer.complete(&target_dir, target_dir.len());
 
-        let expected_slash_paths = expected_paths
+        let expected_slash_paths: Vec<String> = expected_paths
             .iter()
             .map(|s| s.replace('\\', "/"))
             .collect();
 
-        match_suggestions(expected_slash_paths, slash_suggestions);
+        match_suggestions(&expected_slash_paths, &slash_suggestions);
     }
 
     // Match the results
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 }
 
 #[test]
@@ -877,7 +877,7 @@ fn variables_completions() {
     ];
 
     // Match results
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 
     // Test completions for $nu.h (filter)
     let suggestions = completer.complete("$nu.h", 5);
@@ -891,7 +891,7 @@ fn variables_completions() {
     ];
 
     // Match results
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 
     // Test completions for $nu.os-info
     let suggestions = completer.complete("$nu.os-info.", 12);
@@ -903,7 +903,7 @@ fn variables_completions() {
         "name".into(),
     ];
     // Match results
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 
     // Test completions for custom var
     let suggestions = completer.complete("$actor.", 7);
@@ -913,7 +913,7 @@ fn variables_completions() {
     let expected: Vec<String> = vec!["age".into(), "name".into()];
 
     // Match results
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 
     // Test completions for custom var (filtering)
     let suggestions = completer.complete("$actor.n", 8);
@@ -923,7 +923,7 @@ fn variables_completions() {
     let expected: Vec<String> = vec!["name".into()];
 
     // Match results
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 
     // Test completions for $env
     let suggestions = completer.complete("$env.", 5);
@@ -936,7 +936,7 @@ fn variables_completions() {
     let expected: Vec<String> = vec!["PATH".into(), "PWD".into(), "TEST".into()];
 
     // Match results
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 
     // Test completions for $env
     let suggestions = completer.complete("$env.T", 6);
@@ -946,12 +946,12 @@ fn variables_completions() {
     let expected: Vec<String> = vec!["TEST".into()];
 
     // Match results
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 
     let suggestions = completer.complete("$", 1);
     let expected: Vec<String> = vec!["$actor".into(), "$env".into(), "$in".into(), "$nu".into()];
 
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[test]
@@ -970,7 +970,7 @@ fn alias_of_command_and_flags() {
     #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec!["test_a/".to_string(), "test_b/".to_string()];
 
-    match_suggestions(expected_paths, suggestions)
+    match_suggestions(&expected_paths, &suggestions)
 }
 
 #[test]
@@ -989,7 +989,7 @@ fn alias_of_basic_command() {
     #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec!["test_a/".to_string(), "test_b/".to_string()];
 
-    match_suggestions(expected_paths, suggestions)
+    match_suggestions(&expected_paths, &suggestions)
 }
 
 #[test]
@@ -1011,7 +1011,7 @@ fn alias_of_another_alias() {
     #[cfg(not(windows))]
     let expected_paths: Vec<String> = vec!["test_a/".to_string(), "test_b/".to_string()];
 
-    match_suggestions(expected_paths, suggestions)
+    match_suggestions(&expected_paths, &suggestions)
 }
 
 fn run_external_completion(completer: &str, input: &str) -> Vec<Suggestion> {
@@ -1074,35 +1074,35 @@ fn unknown_command_completion() {
         ".hidden_folder/".to_string(),
     ];
 
-    match_suggestions(expected_paths, suggestions)
+    match_suggestions(&expected_paths, &suggestions)
 }
 
 #[rstest]
 fn flagcompletion_triggers_after_cursor(mut completer: NuCompleter) {
     let suggestions = completer.complete("tst -h", 5);
     let expected: Vec<String> = vec!["--help".into(), "--mod".into(), "-h".into(), "-s".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn customcompletion_triggers_after_cursor(mut completer_strings: NuCompleter) {
     let suggestions = completer_strings.complete("my-command c", 11);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn customcompletion_triggers_after_cursor_piped(mut completer_strings: NuCompleter) {
     let suggestions = completer_strings.complete("my-command c | ls", 11);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn flagcompletion_triggers_after_cursor_piped(mut completer: NuCompleter) {
     let suggestions = completer.complete("tst -h | ls", 5);
     let expected: Vec<String> = vec!["--help".into(), "--mod".into(), "-h".into(), "-s".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[test]
@@ -1136,77 +1136,77 @@ fn filecompletions_triggers_after_cursor() {
         ".hidden_folder/".to_string(),
     ];
 
-    match_suggestions(expected_paths, suggestions);
+    match_suggestions(&expected_paths, &suggestions);
 }
 
 #[rstest]
 fn extern_custom_completion_positional(mut extern_completer: NuCompleter) {
     let suggestions = extern_completer.complete("spam ", 5);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn extern_custom_completion_long_flag_1(mut extern_completer: NuCompleter) {
     let suggestions = extern_completer.complete("spam --foo=", 11);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn extern_custom_completion_long_flag_2(mut extern_completer: NuCompleter) {
     let suggestions = extern_completer.complete("spam --foo ", 11);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn extern_custom_completion_long_flag_short(mut extern_completer: NuCompleter) {
     let suggestions = extern_completer.complete("spam -f ", 8);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn extern_custom_completion_short_flag(mut extern_completer: NuCompleter) {
     let suggestions = extern_completer.complete("spam -b ", 8);
     let expected: Vec<String> = vec!["cat".into(), "dog".into(), "eel".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn extern_complete_flags(mut extern_completer: NuCompleter) {
     let suggestions = extern_completer.complete("spam -", 6);
     let expected: Vec<String> = vec!["--foo".into(), "-b".into(), "-f".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn custom_completer_triggers_cursor_before_word(mut custom_completer: NuCompleter) {
     let suggestions = custom_completer.complete("cmd foo  bar", 8);
     let expected: Vec<String> = vec!["cmd".into(), "foo".into(), "".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn custom_completer_triggers_cursor_on_word_left_boundary(mut custom_completer: NuCompleter) {
     let suggestions = custom_completer.complete("cmd foo bar", 8);
     let expected: Vec<String> = vec!["cmd".into(), "foo".into(), "".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn custom_completer_triggers_cursor_next_to_word(mut custom_completer: NuCompleter) {
     let suggestions = custom_completer.complete("cmd foo bar", 11);
     let expected: Vec<String> = vec!["cmd".into(), "foo".into(), "bar".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn custom_completer_triggers_cursor_after_word(mut custom_completer: NuCompleter) {
     let suggestions = custom_completer.complete("cmd foo bar ", 12);
     let expected: Vec<String> = vec!["cmd".into(), "foo".into(), "bar".into(), "".into()];
-    match_suggestions(expected, suggestions);
+    match_suggestions(&expected, &suggestions);
 }
 
 #[ignore = "was reverted, still needs fixing"]

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -32,7 +32,6 @@ fn completer() -> NuCompleter {
 fn completer_strings() -> NuCompleter {
     // Create a new engine
     let (dir, _, mut engine, mut stack) = new_engine();
-
     // Add record value as example
     let record = r#"def animals [] { ["cat", "dog", "eel" ] }
     def my-command [animal: string@animals] { print $animal }"#;
@@ -258,6 +257,20 @@ fn file_completions() {
         folder(dir.join(".hidden_folder")),
     ];
 
+    #[cfg(windows)]
+    {
+        let separator = '/';
+        let target_dir = format!("cp {dir_str}{separator}");
+        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+
+        let expected_slash_paths = expected_paths
+            .iter()
+            .map(|s| s.replace('\\', "/"))
+            .collect();
+
+        match_suggestions(expected_slash_paths, slash_suggestions);
+    }
+
     // Match the results
     match_suggestions(expected_paths, suggestions);
 
@@ -272,11 +285,24 @@ fn file_completions() {
     match_suggestions(expected_paths, suggestions);
 
     // Test completions for hidden files
-    let target_dir = format!("ls {}/.", folder(dir.join(".hidden_folder")));
+    let target_dir = format!("ls {}{MAIN_SEPARATOR}.", folder(dir.join(".hidden_folder")));
     let suggestions = completer.complete(&target_dir, target_dir.len());
 
     let expected_paths: Vec<String> =
         vec![file(dir.join(".hidden_folder").join(".hidden_subfile"))];
+
+    #[cfg(windows)]
+    {
+        let target_dir = format!("ls {}/.", folder(dir.join(".hidden_folder")));
+        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+
+        let expected_slash = expected_paths
+            .iter()
+            .map(|s| s.replace('\\', "/"))
+            .collect();
+
+        match_suggestions(expected_slash, slash_suggestions)
+    }
 
     // Match the results
     match_suggestions(expected_paths, suggestions);
@@ -464,6 +490,7 @@ fn command_ls_with_filecompletion() {
 
     match_suggestions(expected_paths, suggestions)
 }
+
 #[test]
 fn command_open_with_filecompletion() {
     let (_, _, engine, stack) = new_engine();
@@ -793,6 +820,19 @@ fn folder_with_directorycompletions() {
         folder(dir.join("test_b")),
         folder(dir.join(".hidden_folder")),
     ];
+
+    #[cfg(windows)]
+    {
+        let target_dir = format!("cd {dir_str}/");
+        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+
+        let expected_slash_paths = expected_paths
+            .iter()
+            .map(|s| s.replace('\\', "/"))
+            .collect();
+
+        match_suggestions(expected_slash_paths, slash_suggestions);
+    }
 
     // Match the results
     match_suggestions(expected_paths, suggestions);

--- a/crates/nu-cli/tests/completions/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/completions/support/completions_helpers.rs
@@ -185,7 +185,7 @@ pub fn new_partial_engine() -> (PathBuf, String, EngineState, Stack) {
 }
 
 // match a list of suggestions with the expected values
-pub fn match_suggestions(expected: Vec<String>, suggestions: Vec<Suggestion>) {
+pub fn match_suggestions(expected: &Vec<String>, suggestions: &Vec<Suggestion>) {
     let expected_len = expected.len();
     let suggestions_len = suggestions.len();
     if expected_len != suggestions_len {
@@ -195,13 +195,13 @@ pub fn match_suggestions(expected: Vec<String>, suggestions: Vec<Suggestion>) {
             Expected: {expected:#?}\n"
         )
     }
-    assert_eq!(
-        expected,
-        suggestions
-            .into_iter()
-            .map(|it| it.value)
-            .collect::<Vec<_>>()
-    );
+
+    let suggestoins_str = suggestions
+        .iter()
+        .map(|it| it.value.clone())
+        .collect::<Vec<_>>();
+
+    assert_eq!(expected, &suggestoins_str);
 }
 
 // append the separator to the converted path


### PR DESCRIPTION
Related #7044 

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

When autocomplete path with `/` on Windows, paths keep with slash instead of backslash(`\`).

If mixed both, path completion uses a last path seperator.

![image](https://github.com/nushell/nushell/assets/4014016/b09633fd-0e4a-4cd9-9c14-2bca30625804)

![image](https://github.com/nushell/nushell/assets/4014016/e1f228f8-4cce-43eb-a34a-dfa54efd2ebb)

![image](https://github.com/nushell/nushell/assets/4014016/0694443a-3017-4828-be60-5f39ffd96440)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

![completion](https://github.com/nushell/nushell/assets/4014016/03626544-6a14-4d8b-a607-21a4472f8037)

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
