### PR TITLE
Raise error when using `o>|` pipe

### DIFF
--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -653,7 +653,7 @@ fn try_lex_special_piped_item(
             return (
                 None,
                 Some(ParseError::Expected(
-                    "`|`.  Redirection stdout to pipe is the same as piping directly.",
+                    "`|`.  Redirecting stdout to a pipe is the same as normal piping.",
                     Span::new(span_offset + offset, span_offset + offset + o_pipe_len),
                 )),
             );

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -653,7 +653,7 @@ fn try_lex_special_piped_item(
             return (
                 None,
                 Some(ParseError::Expected(
-                    "|, note: redirection stdout to pipe is the same as piping directly.",
+                    "|.  Note: redirection stdout to pipe is the same as piping directly.",
                     Span::new(span_offset + offset, span_offset + offset + o_pipe_len),
                 )),
             );

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -653,7 +653,7 @@ fn try_lex_special_piped_item(
             return (
                 None,
                 Some(ParseError::Expected(
-                    "|.  Note: redirection stdout to pipe is the same as piping directly.",
+                    "`|`.  Redirection stdout to pipe is the same as piping directly.",
                     Span::new(span_offset + offset, span_offset + offset + o_pipe_len),
                 )),
             );

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1167,5 +1167,5 @@ fn error_on_out_greater_pipe() {
     let actual = nu!(r#""foo" o>| print"#);
     assert!(actual
         .err
-        .contains("Redirection stdout to pipe is the same as piping directly"))
+        .contains("Redirecting stdout to a pipe is the same as normal piping"))
 }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1161,3 +1161,11 @@ fn command_not_found_error_shows_not_found_2() {
             && actual.err.contains("Did you mean `for`?")
     );
 }
+
+#[test]
+fn error_on_out_greater_pipe() {
+    let actual = nu!(r#""foo" o>| print"#);
+    assert!(actual
+        .err
+        .contains("redirection stdout to pipe is the same as piping directly"))
+}

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1167,5 +1167,5 @@ fn error_on_out_greater_pipe() {
     let actual = nu!(r#""foo" o>| print"#);
     assert!(actual
         .err
-        .contains("redirection stdout to pipe is the same as piping directly"))
+        .contains("Redirection stdout to pipe is the same as piping directly"))
 }


### PR DESCRIPTION
# Description
From the feedbacks from @amtoine , it's good to make nushell shows error for `o>|` syntax.

# User-Facing Changes
## Before
```nushell
'foo' o>| print                                                                                                                                                                                                                     07/09/2024 06:44:23 AM
Error: nu::parser::parse_mismatch

  × Parse mismatch during operation.
   ╭─[entry #6:1:9]
 1 │ 'foo' o>| print
   ·         ┬
   ·         ╰── expected redirection target
```

## After
```nushell
'foo' o>| print                                                                                                                                                                                                                     07/09/2024 06:47:26 AM
Error: nu::parser::parse_mismatch

  × Parse mismatch during operation.
   ╭─[entry #1:1:7]
 1 │ 'foo' o>| print
   ·       ─┬─
   ·        ╰── expected `|`.  Redirection stdout to pipe is the same as piping directly.
   ╰────
```

# Tests + Formatting
Added one test
