### PR TITLE
Path migration part 2: `nu-test-support`

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -721,7 +721,7 @@ fn file_completion_quoted() {
         "`te#st.txt`".to_string(),
         "`te'st.txt`".to_string(),
         "`te(st).txt`".to_string(),
-        format!("`{}`", folder("test dir".into())),
+        format!("`{}`", folder("test dir")),
     ];
 
     match_suggestions(expected_paths, suggestions);

--- a/crates/nu-cli/tests/completions/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/completions/support/completions_helpers.rs
@@ -1,5 +1,6 @@
 use nu_engine::eval_block;
 use nu_parser::parse;
+use nu_path::{AbsolutePathBuf, PathBuf};
 use nu_protocol::{
     debugger::WithoutDebug,
     engine::{EngineState, Stack, StateWorkingSet},
@@ -7,14 +8,14 @@ use nu_protocol::{
 };
 use nu_test_support::fs;
 use reedline::Suggestion;
-use std::path::{PathBuf, MAIN_SEPARATOR};
+use std::path::MAIN_SEPARATOR;
 
 fn create_default_context() -> EngineState {
     nu_command::add_shell_command_context(nu_cmd_lang::create_default_context())
 }
 
 // creates a new engine with the current path into the completions fixtures folder
-pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
+pub fn new_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
     // Target folder inside assets
     let dir = fs::fixtures().join("completions");
     let dir_str = dir
@@ -69,7 +70,7 @@ pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
 }
 
 // creates a new engine with the current path into the completions fixtures folder
-pub fn new_dotnu_engine() -> (PathBuf, String, EngineState, Stack) {
+pub fn new_dotnu_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
     // Target folder inside assets
     let dir = fs::fixtures().join("dotnu_completions");
     let dir_str = dir
@@ -114,7 +115,7 @@ pub fn new_dotnu_engine() -> (PathBuf, String, EngineState, Stack) {
     (dir, dir_str, engine_state, stack)
 }
 
-pub fn new_quote_engine() -> (PathBuf, String, EngineState, Stack) {
+pub fn new_quote_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
     // Target folder inside assets
     let dir = fs::fixtures().join("quoted_completions");
     let dir_str = dir
@@ -149,7 +150,7 @@ pub fn new_quote_engine() -> (PathBuf, String, EngineState, Stack) {
     (dir, dir_str, engine_state, stack)
 }
 
-pub fn new_partial_engine() -> (PathBuf, String, EngineState, Stack) {
+pub fn new_partial_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
     // Target folder inside assets
     let dir = fs::fixtures().join("partial_completions");
     let dir_str = dir
@@ -205,16 +206,15 @@ pub fn match_suggestions(expected: Vec<String>, suggestions: Vec<Suggestion>) {
 }
 
 // append the separator to the converted path
-pub fn folder(path: PathBuf) -> String {
+pub fn folder(path: impl Into<PathBuf>) -> String {
     let mut converted_path = file(path);
     converted_path.push(MAIN_SEPARATOR);
-
     converted_path
 }
 
 // convert a given path to string
-pub fn file(path: PathBuf) -> String {
-    path.into_os_string().into_string().unwrap_or_default()
+pub fn file(path: impl Into<PathBuf>) -> String {
+    path.into().into_os_string().into_string().unwrap()
 }
 
 // merge_input executes the given input into the engine
@@ -223,7 +223,7 @@ pub fn merge_input(
     input: &[u8],
     engine_state: &mut EngineState,
     stack: &mut Stack,
-    dir: PathBuf,
+    dir: AbsolutePathBuf,
 ) -> Result<(), ShellError> {
     let (block, delta) = {
         let mut working_set = StateWorkingSet::new(engine_state);

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -606,7 +606,7 @@ mod test {
         Playground::setup("test_expand_glob", |dirs, play| {
             play.with_files(&[Stub::EmptyFile("a.txt"), Stub::EmptyFile("b.txt")]);
 
-            let cwd = dirs.test();
+            let cwd = dirs.test().as_std_path();
 
             let actual = expand_glob("*.txt", cwd, Span::unknown(), &Signals::empty()).unwrap();
             let expected = &["a.txt", "b.txt"];

--- a/crates/nu-command/tests/commands/database/into_sqlite.rs
+++ b/crates/nu-command/tests/commands/database/into_sqlite.rs
@@ -465,7 +465,7 @@ fn make_sqlite_db(dirs: &Dirs, nu_table: &str) -> PathBuf {
     );
 
     assert!(nucmd.status.success());
-    testdb_path
+    testdb_path.into()
 }
 
 fn insert_test_rows(dirs: &Dirs, nu_table: &str, sql_query: Option<&str>, expected: Vec<TestRow>) {

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -437,7 +437,7 @@ fn rm_prints_filenames_on_error() {
             .collect();
         sandbox.with_files(&with_files);
 
-        let test_dir = dirs.test();
+        let test_dir = dirs.test().as_std_path();
 
         set_dir_read_only(test_dir, true);
         let _cleanup = Cleanup {

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -1,3 +1,4 @@
+use nu_path::AbsolutePath;
 use nu_test_support::fs::{files_exist_at, Stub::EmptyFile};
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
@@ -405,10 +406,10 @@ fn removes_file_after_cd() {
 }
 
 struct Cleanup<'a> {
-    dir_to_clean: &'a Path,
+    dir_to_clean: &'a AbsolutePath,
 }
 
-fn set_dir_read_only(directory: &Path, read_only: bool) {
+fn set_dir_read_only(directory: &AbsolutePath, read_only: bool) {
     let mut permissions = fs::metadata(directory).unwrap().permissions();
     permissions.set_readonly(read_only);
     fs::set_permissions(directory, permissions).expect("failed to set directory permissions");
@@ -437,7 +438,7 @@ fn rm_prints_filenames_on_error() {
             .collect();
         sandbox.with_files(&with_files);
 
-        let test_dir = dirs.test().as_std_path();
+        let test_dir = dirs.test();
 
         set_dir_read_only(test_dir, true);
         let _cleanup = Cleanup {

--- a/crates/nu-command/tests/commands/source_env.rs
+++ b/crates/nu-command/tests/commands/source_env.rs
@@ -10,7 +10,7 @@ fn sources_also_files_under_custom_lib_dirs_path() {
         let file = dirs.test().join("config.toml");
         let library_path = dirs.test().join("lib");
 
-        nu.with_config(&file);
+        nu.with_config(file);
         nu.with_files(&[FileWithContent(
             "config.toml",
             &format!(

--- a/crates/nu-command/tests/commands/source_env.rs
+++ b/crates/nu-command/tests/commands/source_env.rs
@@ -1,4 +1,3 @@
-use nu_test_support::fs::AbsolutePath;
 use nu_test_support::fs::Stub::{FileWithContent, FileWithContentToBeTrimmed};
 use nu_test_support::nu;
 use nu_test_support::pipeline;
@@ -8,17 +7,18 @@ use nu_test_support::playground::Playground;
 #[test]
 fn sources_also_files_under_custom_lib_dirs_path() {
     Playground::setup("source_test_1", |dirs, nu| {
-        let file = AbsolutePath::new(dirs.test().join("config.toml"));
-        let library_path = AbsolutePath::new(dirs.test().join("lib"));
+        let file = dirs.test().join("config.toml");
+        let library_path = dirs.test().join("lib");
 
         nu.with_config(&file);
         nu.with_files(&[FileWithContent(
             "config.toml",
             &format!(
                 r#"
-                lib_dirs = ["{library_path}"]
+                lib_dirs = ["{}"]
                 skip_welcome_message = true
-            "#
+            "#,
+                library_path.as_os_str().to_str().unwrap(),
             ),
         )]);
 

--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -1,6 +1,6 @@
 use nu_test_support::fs::file_contents;
 use nu_test_support::fs::{
-    files_exist_at, AbsoluteFile,
+    files_exist_at,
     Stub::{EmptyFile, FileWithContent, FileWithPermission},
 };
 use nu_test_support::nu;
@@ -55,7 +55,7 @@ fn copies_the_file_inside_directory_if_path_to_copy_is_directory() {
 
 fn copies_the_file_inside_directory_if_path_to_copy_is_directory_impl(progress: bool) {
     Playground::setup("ucp_test_2", |dirs, _| {
-        let expected_file = AbsoluteFile::new(dirs.test().join("sample.ini"));
+        let expected_file = dirs.test().join("sample.ini");
         let progress_flag = if progress { "-p" } else { "" };
 
         // Get the hash of the file content to check integrity after copy.
@@ -64,13 +64,13 @@ fn copies_the_file_inside_directory_if_path_to_copy_is_directory_impl(progress: 
             cwd: dirs.formats(),
             "cp {} ../formats/sample.ini {}",
             progress_flag,
-            expected_file.dir()
+            expected_file.parent().unwrap().as_os_str().to_str().unwrap(),
         );
 
         assert!(dirs.test().join("sample.ini").exists());
 
         // Check the integrity of the file.
-        let after_cp_hash = get_file_hash(expected_file);
+        let after_cp_hash = get_file_hash(expected_file.display());
         assert_eq!(first_hash, after_cp_hash);
     })
 }

--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -1,4 +1,3 @@
-use nu_test_support::fs::AbsolutePath;
 use nu_test_support::fs::Stub::{FileWithContent, FileWithContentToBeTrimmed};
 use nu_test_support::nu;
 use nu_test_support::pipeline;
@@ -7,10 +6,10 @@ use nu_test_support::playground::Playground;
 #[test]
 fn use_module_file_within_block() {
     Playground::setup("use_test_1", |dirs, nu| {
-        let file = AbsolutePath::new(dirs.test().join("spam.nu"));
+        let file = dirs.test().join("spam.nu");
 
         nu.with_files(&[FileWithContent(
-            &file.to_string(),
+            file.as_os_str().to_str().unwrap(),
             r#"
                 export def foo [] {
                     echo "hello world"
@@ -37,10 +36,10 @@ fn use_module_file_within_block() {
 #[test]
 fn use_keeps_doc_comments() {
     Playground::setup("use_doc_comments", |dirs, nu| {
-        let file = AbsolutePath::new(dirs.test().join("spam.nu"));
+        let file = dirs.test().join("spam.nu");
 
         nu.with_files(&[FileWithContent(
-            &file.to_string(),
+            file.as_os_str().to_str().unwrap(),
             r#"
                 # this is my foo command
                 export def foo [

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -234,35 +234,28 @@ macro_rules! nu_with_plugins {
 }
 
 use crate::{Outcome, NATIVE_PATH_ENV_VAR};
-use std::ffi::OsStr;
+use nu_path::{AbsolutePath, AbsolutePathBuf, Path};
 use std::{
-    path::Path,
+    ffi::OsStr,
     process::{Command, Stdio},
 };
 use tempfile::tempdir;
 
 #[derive(Default)]
 pub struct NuOpts {
-    pub cwd: Option<String>,
+    pub cwd: Option<AbsolutePathBuf>,
     pub locale: Option<String>,
     pub envs: Option<Vec<(String, String)>>,
     pub collapse_output: Option<bool>,
 }
 
 pub fn nu_run_test(opts: NuOpts, commands: impl AsRef<str>, with_std: bool) -> Outcome {
-    let test_bins = crate::fs::binaries();
-
-    let cwd = std::env::current_dir().expect("Could not get current working directory.");
-    let test_bins = nu_path::canonicalize_with(&test_bins, cwd).unwrap_or_else(|e| {
-        panic!(
-            "Couldn't canonicalize dummy binaries path {}: {:?}",
-            test_bins.display(),
-            e
-        )
-    });
+    let test_bins = crate::fs::binaries()
+        .canonicalize()
+        .expect("Could not canonicalize dummy binaries path");
 
     let mut paths = crate::shell_os_paths();
-    paths.insert(0, test_bins);
+    paths.insert(0, test_bins.into());
 
     let commands = commands.as_ref().lines().collect::<Vec<_>>().join("; ");
 
@@ -271,7 +264,7 @@ pub fn nu_run_test(opts: NuOpts, commands: impl AsRef<str>, with_std: bool) -> O
         Err(_) => panic!("Couldn't join paths for PATH var."),
     };
 
-    let target_cwd = opts.cwd.unwrap_or(".".to_string());
+    let target_cwd = opts.cwd.unwrap_or_else(crate::fs::root);
     let locale = opts.locale.unwrap_or("en_US.UTF-8".to_string());
     let executable_path = crate::fs::executable_path();
 
@@ -439,7 +432,7 @@ fn collapse_output(out: &str) -> String {
     out.replace('\n', "")
 }
 
-fn setup_command(executable_path: &Path, target_cwd: &str) -> Command {
+fn setup_command(executable_path: &AbsolutePath, target_cwd: &AbsolutePath) -> Command {
     let mut command = Command::new(executable_path);
 
     command

--- a/crates/nu-test-support/src/playground.rs
+++ b/crates/nu-test-support/src/playground.rs
@@ -6,5 +6,5 @@ mod play;
 mod tests;
 
 pub use director::Director;
-pub use nu_process::{Executable, NuProcess, NuResult, Outcome};
+pub use nu_process::{Executable, NuProcess, Outcome};
 pub use play::{Dirs, EnvironmentVariable, Playground};

--- a/crates/nu-test-support/src/playground/director.rs
+++ b/crates/nu-test-support/src/playground/director.rs
@@ -83,7 +83,7 @@ impl Director {
 }
 
 impl Executable for Director {
-    fn execute(&mut self) -> NuResult {
+    fn execute(&mut self) -> Result<Outcome, NuError> {
         use std::process::Stdio;
 
         match self.executable() {

--- a/crates/nu-test-support/src/playground/nu_process.rs
+++ b/crates/nu-test-support/src/playground/nu_process.rs
@@ -1,12 +1,13 @@
 use super::EnvironmentVariable;
 use crate::fs::{binaries as test_bins_path, executable_path};
-use std::ffi::{OsStr, OsString};
-use std::fmt;
-use std::path::Path;
-use std::process::{Command, ExitStatus};
+use std::{
+    ffi::{OsStr, OsString},
+    fmt,
+    process::{Command, ExitStatus},
+};
 
 pub trait Executable {
-    fn execute(&mut self) -> NuResult;
+    fn execute(&mut self) -> Result<Outcome, NuError>;
 }
 
 #[derive(Clone, Debug)]
@@ -23,8 +24,6 @@ impl Outcome {
         }
     }
 }
-
-pub type NuResult = Result<Outcome, NuError>;
 
 #[derive(Debug)]
 pub struct NuError {
@@ -69,14 +68,10 @@ impl NuProcess {
         self
     }
 
-    pub fn get_cwd(&self) -> Option<&Path> {
-        self.cwd.as_ref().map(Path::new)
-    }
-
     pub fn construct(&self) -> Command {
         let mut command = Command::new(executable_path());
 
-        if let Some(cwd) = self.get_cwd() {
+        if let Some(cwd) = &self.cwd {
             command.current_dir(cwd);
         }
 

--- a/crates/nu-test-support/src/playground/tests.rs
+++ b/crates/nu-test-support/src/playground/tests.rs
@@ -1,11 +1,4 @@
 use crate::playground::Playground;
-use std::path::{Path, PathBuf};
-
-fn path(p: &Path) -> PathBuf {
-    let cwd = std::env::current_dir().expect("Could not get current working directory.");
-    nu_path::canonicalize_with(p, cwd)
-        .unwrap_or_else(|e| panic!("Couldn't canonicalize path {}: {:?}", p.display(), e))
-}
 
 #[test]
 fn current_working_directory_in_sandbox_directory_created() {
@@ -13,7 +6,7 @@ fn current_working_directory_in_sandbox_directory_created() {
         let original_cwd = dirs.test();
         nu.within("some_directory_within");
 
-        assert_eq!(path(nu.cwd()), original_cwd.join("some_directory_within"));
+        assert_eq!(nu.cwd(), original_cwd.join("some_directory_within"));
     })
 }
 
@@ -25,6 +18,6 @@ fn current_working_directory_back_to_root_from_anywhere() {
         nu.within("some_directory_within");
         nu.back_to_playground();
 
-        assert_eq!(path(nu.cwd()), *original_cwd);
+        assert_eq!(nu.cwd(), original_cwd);
     })
 }

--- a/tests/plugins/nu_plugin_nu_example.rs
+++ b/tests/plugins/nu_plugin_nu_example.rs
@@ -4,7 +4,7 @@ use assert_cmd::Command;
 fn call() {
     // Add the `nu` binaries to the path env
     let path_env = std::env::join_paths(
-        std::iter::once(nu_test_support::fs::binaries()).chain(
+        std::iter::once(nu_test_support::fs::binaries().into()).chain(
             std::env::var_os(nu_test_support::NATIVE_PATH_ENV_VAR)
                 .as_deref()
                 .map(std::env::split_paths)

--- a/tests/plugins/registry_file.rs
+++ b/tests/plugins/registry_file.rs
@@ -162,7 +162,7 @@ fn plugin_rm_then_restart_nu() {
         contents.upsert_plugin(PluginRegistryItem {
             name: "foo".into(),
             // this doesn't exist, but it should be ok
-            filename: dirs.test().join("nu_plugin_foo"),
+            filename: dirs.test().join("nu_plugin_foo").into(),
             shell: None,
             data: valid_plugin_item_data(),
         });
@@ -238,7 +238,7 @@ fn plugin_rm_from_custom_path() {
         contents.upsert_plugin(PluginRegistryItem {
             name: "foo".into(),
             // this doesn't exist, but it should be ok
-            filename: dirs.test().join("nu_plugin_foo"),
+            filename: dirs.test().join("nu_plugin_foo").into(),
             shell: None,
             data: valid_plugin_item_data(),
         });
@@ -286,7 +286,7 @@ fn plugin_rm_using_filename() {
         contents.upsert_plugin(PluginRegistryItem {
             name: "foo".into(),
             // this doesn't exist, but it should be ok
-            filename: dirs.test().join("nu_plugin_foo"),
+            filename: dirs.test().join("nu_plugin_foo").into(),
             shell: None,
             data: valid_plugin_item_data(),
         });
@@ -344,7 +344,7 @@ fn warning_on_invalid_plugin_item() {
         contents.upsert_plugin(PluginRegistryItem {
             name: "badtest".into(),
             // this doesn't exist, but it should be ok
-            filename: dirs.test().join("nu_plugin_badtest"),
+            filename: dirs.test().join("nu_plugin_badtest").into(),
             shell: None,
             data: PluginRegistryItemData::Invalid,
         });


### PR DESCRIPTION
# Description
Part 2 of replacing `std::path` types with `nu_path` types added in #13115. This PR targets `nu-test-support`.