### PR TITLE
Fix main binary being rebuilt when nothing has changed

### DIFF
--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -14,5 +14,5 @@ fn main() {
     // Tango uses dynamic linking, to allow us to dynamically change between two bench suit at runtime.
     // This is currently not supported on non nightly rust, on windows.
     println!("cargo:rustc-link-arg-benches=-rdynamic");
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=scripts/build.rs");
 }


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

The build script is currently re-run on each `cargo build` even when it has not changed. The `rerun-if-changed` line points to `/build.rs`, but `build.rs` is actually located at `/scripts/build.rs`. This updates that path.

# User-Facing Changes
N/A

# Tests + Formatting
N/A
