### PR TITLE
Set the capacity of the Vec used in `gather_captures()` to the number of captures expected

### DIFF
--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -262,7 +262,7 @@ impl Stack {
     }
 
     pub fn gather_captures(&self, engine_state: &EngineState, captures: &[VarId]) -> Stack {
-        let mut vars = vec![];
+        let mut vars = Vec::with_capacity(captures.len());
 
         let fake_span = Span::new(0, 0);
 


### PR DESCRIPTION
# Description

Just more efficient allocation during `Stack::gather_captures()` so that we don't have to grow the `Vec` needlessly.

# User-Facing Changes
Slightly better performance.
