### PR TITLE
Fix the signature of `view ir`

### DIFF
--- a/crates/nu-command/src/debug/view_ir.rs
+++ b/crates/nu-command/src/debug/view_ir.rs
@@ -10,7 +10,7 @@ impl Command for ViewIr {
     }
 
     fn signature(&self) -> Signature {
-        Signature::new(self.name())
+        Signature::build(self.name())
             .required(
                 "closure",
                 SyntaxShape::Closure(None),
@@ -22,6 +22,7 @@ impl Command for ViewIr {
                 Some('j'),
             )
             .input_output_type(Type::Nothing, Type::String)
+            .category(Category::Debug)
     }
 
     fn usage(&self) -> &str {


### PR DESCRIPTION
# Description

Fix `view ir` to use `Signature::build()` rather than `new()`, which is required for `--help` to work. Also add `Category::Debug`, as that's most appropriate.
