### PR TITLE
Group dependabot bumps for uutils/coreutils

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,13 @@ updates:
         patterns:
           - "polars"
           - "polars-*"
+      # uutils/coreutils also versions all their workspace crates the same at the moment
+      # Most of them have bleeding edge version requirements (some not)
+      # see: https://github.com/uutils/coreutils/blob/main/Cargo.toml
+      uutils:
+        patterns:
+          - "uucore"
+          - "uu_*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Similar to #13084 for polars. This familiy of crates has shared
versioning and tends to at least depend on the same `uucore` crate.
