### PR TITLE
Make the `store-env` IR instruction also update config

### DIFF
--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -367,7 +367,11 @@ fn eval_instruction<D: DebugContext>(
             let key = get_env_var_name_case_insensitive(ctx, key);
 
             if !is_automatic_env_var(&key) {
+                let is_config = key == "config";
                 ctx.stack.add_env_var(key.into_owned(), value);
+                if is_config {
+                    ctx.stack.update_config(ctx.engine_state)?;
+                }
                 Ok(Continue)
             } else {
                 Err(ShellError::AutomaticEnvVarSetManually {


### PR DESCRIPTION
# Description

Follow up fix to #13332, so that changes to config when running under IR actually happen as well. Since I merged them around the same time, I forgot about this.
