### PR TITLE
JSON format output keeps braces on same line (issue #13326)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,7 +3193,10 @@ dependencies = [
 name = "nu-json"
 version = "0.95.1"
 dependencies = [
+ "fancy-regex",
  "linked-hash-map",
+ "nu-path",
+ "nu-test-support",
  "num-traits",
  "serde",
  "serde_json",

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
-authors = ["The Nushell Project Developers", "Christian Zangl <laktak@cdak.net>"]
+authors = [
+    "The Nushell Project Developers",
+    "Christian Zangl <laktak@cdak.net>",
+]
 description = "Fork of serde-hjson"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-json"
 edition = "2021"
@@ -19,9 +22,11 @@ default = ["preserve_order"]
 [dependencies]
 linked-hash-map = { version = "0.5", optional = true }
 num-traits = { workspace = true }
-serde = { workspace =  true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-# nu-path = { path="../nu-path", version = "0.95.1" }
-# serde_json = "1.0"
+nu-test-support = { path = "../nu-test-support", version = "0.95.1" }
+nu-path = { path = "../nu-path", version = "0.95.1" }
+serde_json = "1.0"
+fancy-regex = "0.13.0"

--- a/crates/nu-json/src/ser.rs
+++ b/crates/nu-json/src/ser.rs
@@ -714,7 +714,7 @@ impl<'a> HjsonFormatter<'a> {
             stack: Vec::new(),
             at_colon: false,
             indent,
-            braces_same_line: false,
+            braces_same_line: true,
         }
     }
 }

--- a/crates/nu-json/tests/main.rs
+++ b/crates/nu-json/tests/main.rs
@@ -1,7 +1,5 @@
-// FIXME: re-enable tests
-/*
-use nu_json::Value;
 use fancy_regex::Regex;
+use nu_json::Value;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -21,15 +19,7 @@ fn txt(text: &str) -> String {
 }
 
 fn hjson_expectations() -> PathBuf {
-    let assets = nu_test_support::fs::assets().join("nu_json");
-
-    nu_path::canonicalize(assets.clone()).unwrap_or_else(|e| {
-        panic!(
-            "Couldn't canonicalize hjson assets path {}: {:?}",
-            assets.display(),
-            e
-        )
-    })
+    nu_test_support::fs::assets().join("nu_json")
 }
 
 fn get_test_content(name: &str) -> io::Result<String> {
@@ -73,7 +63,8 @@ macro_rules! run_test {
             let actual_hjson = txt(&actual_hjson);
             let actual_json = $fix(serde_json::to_string_pretty(&udata).unwrap());
             let actual_json = txt(&actual_json);
-            if rhjson != actual_hjson {
+            // nu_json::to_string now outputs json instead of hjson!
+            if rjson != actual_hjson {
                 println!(
                     "{:?}\n---hjson expected\n{}\n---hjson actual\n{}\n---\n",
                     name, rhjson, actual_hjson
@@ -85,7 +76,7 @@ macro_rules! run_test {
                     name, rjson, actual_json
                 );
             }
-            assert!(rhjson == actual_hjson && rjson == actual_json);
+            assert!(rjson == actual_hjson && rjson == actual_json);
         }
     }};
 }
@@ -208,5 +199,3 @@ fn test_hjson() {
         panic!();
     }
 }
-
-*/

--- a/crates/nu-json/tests/main.rs
+++ b/crates/nu-json/tests/main.rs
@@ -9,7 +9,7 @@ fn txt(text: &str) -> String {
 
     #[cfg(windows)]
     {
-        out.replace("\r\n", "").replace("\n", "")
+        out.replace("\r\n", "").replace('\n', "")
     }
 
     #[cfg(not(windows))]
@@ -40,7 +40,7 @@ fn get_result_content(name: &str) -> io::Result<(String, String)> {
     let p1 = format!("{}/{}_result.json", expectations.display(), name);
     let p2 = format!("{}/{}_result.hjson", expectations.display(), name);
 
-    Ok((fs::read_to_string(&p1)?, fs::read_to_string(&p2)?))
+    Ok((fs::read_to_string(p1)?, fs::read_to_string(p2)?))
 }
 
 macro_rules! run_test {
@@ -189,7 +189,7 @@ fn test_hjson() {
 
     let missing = all
         .into_iter()
-        .filter(|x| done.iter().find(|y| &x == y) == None)
+        .filter(|x| !done.iter().any(|y| x == y))
         .collect::<Vec<String>>();
 
     if !missing.is_empty() {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This is a minor breaking change to JSON output syntax/style of the `to json` command.

This fixes #13326 by setting `braces_same_line` to true when creating a new `HjsonFormatter`.
This then simply tells `HjsonFormatter` to keep the braces on the same line when outputting which is what I expected nu's `to json` command to do.
There are almost no changes to nushell itself, all changes are contained within `nu-json` crate (minus any documentation updates).

Oh, almost forgot to mention, to get the tests compiling, I added fancy_regex as a _dev_ dependency to nu-json. I could look into eliminating that if desirable.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

**Breaking Change**
nushell now outputs the desired result using the reproduction command from the issue:
```
echo '{"version": "v0.4.4","notes": "blablabla","pub_date": "2024-05-04T16:05:00Z","platforms":{"windows-x86_64":{"signature": "blablabla","url": "https://blablabla"}}}' | from json | to json
```

outputs:
```
{
  "version": "v0.4.4",
  "notes": "blablabla",
  "pub_date": "2024-05-04T16:05:00Z",
  "platforms": {
    "windows-x86_64": {
      "signature": "blablabla",
      "url": "https://blablabla"
    }
  }
}
```

whereas previously it would push the opening braces onto a new line:
```
{
  "version": "v0.4.4",
  "notes": "blablabla",
  "pub_date": "2024-05-04T16:05:00Z",
  "platforms":
  {
    "windows-x86_64":
    {
      "signature": "blablabla",
      "url": "https://blablabla"
    }
  }
}
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
toolkit check pr mostly passes - there are regrettably some tests not passing on my windows machine _before making any changes_ (I may look into this as a separate issue)

I have re-enabled the [hjson tests](https://github.com/nushell/nushell/blob/main/crates/nu-json/tests/main.rs).
This is done in the second commit 🙂 
They have a crucial difference to what they were previously asserting:
  * nu-json outputs in json syntax, not hjson syntax
I think this is desirable, but I'm not aware of the history of these tests.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
I suspect there `to json` command examples will need updating to match, haven't checked yet!
