### PR TITLE
Mention the actual output type on an OutputMismatch error

### DIFF
--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -1055,7 +1055,11 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
                     .span
             };
 
-            output_errors.push(ParseError::OutputMismatch(output_type.clone(), span))
+            output_errors.push(ParseError::OutputMismatch(
+                output_type.clone(),
+                current_output_type.clone(),
+                span,
+            ))
         }
     }
 

--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -61,7 +61,11 @@ pub enum ParseError {
 
     #[error("Command output doesn't match {0}.")]
     #[diagnostic(code(nu::parser::output_type_mismatch))]
-    OutputMismatch(Type, #[label("command doesn't output {0}")] Span),
+    OutputMismatch(
+        Type,
+        Type,
+        #[label("expected {0}, but command outputs {1}")] Span,
+    ),
 
     #[error("Type mismatch during operation.")]
     #[diagnostic(code(nu::parser::type_mismatch))]
@@ -554,7 +558,7 @@ impl ParseError {
             ParseError::TypeMismatch(_, _, s) => *s,
             ParseError::TypeMismatchHelp(_, _, s, _) => *s,
             ParseError::InputMismatch(_, s) => *s,
-            ParseError::OutputMismatch(_, s) => *s,
+            ParseError::OutputMismatch(_, _, s) => *s,
             ParseError::MissingRequiredFlag(_, s) => *s,
             ParseError::IncompleteMathExpression(s) => *s,
             ParseError::UnknownState(_, s) => *s,


### PR DESCRIPTION
# Description

This improves the error when the determined output of a custom command doesn't match the specified output type by adding the actual determined output type.

# User-Facing Changes

Previous: `command doesn't output {0}`

New: `expected {0}, but command outputs {1}`

# Tests + Formatting
Passing.

# After Submitting
- [ ] release notes? (minor change, but helpful)
