### PR TITLE
Fix order of I/O types in `take until`

### DIFF
--- a/crates/nu-command/src/filters/take/take_until.rs
+++ b/crates/nu-command/src/filters/take/take_until.rs
@@ -11,13 +11,10 @@ impl Command for TakeUntil {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![
-                (
-                    Type::List(Box::new(Type::Any)),
-                    Type::List(Box::new(Type::Any)),
-                ),
-                (Type::table(), Type::table()),
-            ])
+            .input_output_types(vec![(
+                Type::List(Box::new(Type::Any)),
+                Type::List(Box::new(Type::Any)),
+            )])
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),

--- a/crates/nu-command/src/filters/take/take_until.rs
+++ b/crates/nu-command/src/filters/take/take_until.rs
@@ -12,11 +12,11 @@ impl Command for TakeUntil {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_output_types(vec![
-                (Type::table(), Type::table()),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),
                 ),
+                (Type::table(), Type::table()),
             ])
             .required(
                 "predicate",


### PR DESCRIPTION
# Description
Just a quick one, but `List(Any)` has to come before `Table`, because `List(Any)` is a valid match for `Table`, so it will choose `Table` output even if the input was actually `List(Any)`. I ended up removing `Table` because it's just not needed at all anyway.

Though, I'm not really totally sure this is correct - I think the parser should probably actually just have some idea of what the more specific type is, and choose the most specific type match, rather than just doing it in order. I guess this will result in the output just always being `List(Any)` for now. Still better than a bad typecheck error

# User-Facing Changes

Fixes the following contrived example:

```nushell
def foo []: nothing -> list<int> {
  seq 1 10 | # list<int>
    each { |n| $n * 20 } | # this causes the type to become list<any>
    take until { |x| $x < 10 } } # table is first, so now this is type table
    # ...but table is not compatible with list<int>
}
```

# After Submitting
- [ ] make typechecker type choice more robust
- [ ] release notes
