### PR TITLE
Fix `select` cell path renaming behavior

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -240,7 +240,7 @@ fn select(
                                 //FIXME: improve implementation to not clone
                                 match input_val.clone().follow_cell_path(&path.members, false) {
                                     Ok(fetcher) => {
-                                        record.push(path.to_string().replace('.', "_"), fetcher);
+                                        record.push(path.to_string(), fetcher);
                                         if !columns_with_value.contains(&path) {
                                             columns_with_value.push(path);
                                         }
@@ -271,7 +271,7 @@ fn select(
                             // FIXME: remove clone
                             match v.clone().follow_cell_path(&cell_path.members, false) {
                                 Ok(result) => {
-                                    record.push(cell_path.to_string().replace('.', "_"), result);
+                                    record.push(cell_path.to_string(), result);
                                 }
                                 Err(e) => return Err(e),
                             }
@@ -295,7 +295,7 @@ fn select(
                         //FIXME: improve implementation to not clone
                         match x.clone().follow_cell_path(&path.members, false) {
                             Ok(value) => {
-                                record.push(path.to_string().replace('.', "_"), value);
+                                record.push(path.to_string(), value);
                             }
                             Err(e) => return Err(e),
                         }

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -50,7 +50,7 @@ fn complex_nested_columns() {
         r#"
                 {sample}
                 | select nu."0xATYKARNU" nu.committers.name nu.releases.version
-                | get nu_releases_version
+                | get "nu.releases.version"
                 | where $it > "0.8"
                 | get 0
             "#


### PR DESCRIPTION
# Description

Fixes #13359

In an attempt to generate names for flat columns resulting from a nested
accesses #3016 generated new column names on nested selection, out of
convenience, that composed the cell path as a string (including `.`) and
then simply replaced all `.` with `_`. As we permit `.` in column names
as long as you quote this surprisingly alters `select`ed columns.


# User-Facing Changes
New columns generated by selection with nested cell paths will for now
be named with a string containing the keys separated by `.` instead of
`_`. We may want to reconsider the semantics for nested access.

# Tests + Formatting
- Alter test to breaking change on nested `select`
