### PR TITLE
Report parse warnings and compile errors when running script files

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -76,10 +76,19 @@ pub fn evaluate_file(
     trace!("parsing file: {}", file_path_str);
     let block = parse(&mut working_set, Some(file_path_str), &file, false);
 
+    if let Some(warning) = working_set.parse_warnings.first() {
+        report_error(&working_set, warning);
+    }
+
     // If any parse errors were found, report the first error and exit.
     if let Some(err) = working_set.parse_errors.first() {
         report_error(&working_set, err);
         std::process::exit(1);
+    }
+
+    if let Some(err) = working_set.compile_errors.first() {
+        report_error(&working_set, err);
+        // Not a fatal error, for now
     }
 
     // Look for blocks whose name starts with "main" and replace it with the filename.


### PR DESCRIPTION
# Description

Report parse warnings and compile errors when running script files.

It's useful to report this information to script authors and users so they can know if they need to update something in the near future.

I also found that moving some errors from eval to compile time meant some error tests can fail (in `tests/repl`) so this is a good idea to keep those passing.

# User-Facing Changes
- Report parse warnings when running script files
- Report compile errors when running script files
