### PR TITLE
Switch from dirs_next 2.0 to dirs 5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,24 +1219,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "dirs"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2873,7 +2873,7 @@ dependencies = [
  "assert_cmd",
  "crossterm",
  "ctrlc",
- "dirs-next",
+ "dirs",
  "log",
  "miette",
  "mimalloc",
@@ -3047,7 +3047,7 @@ dependencies = [
  "deunicode",
  "dialoguer",
  "digest",
- "dirs-next",
+ "dirs",
  "dtparse",
  "encoding_rs",
  "fancy-regex",
@@ -3245,7 +3245,7 @@ dependencies = [
 name = "nu-path"
 version = "0.95.1"
 dependencies = [
- "dirs-next",
+ "dirs",
  "omnipath",
  "pwd",
 ]
@@ -3835,6 +3835,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-multimap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ ctrlc = "3.4"
 deunicode = "1.6.0"
 dialoguer = { default-features = false, version = "0.11" }
 digest = { default-features = false, version = "0.10" }
-dirs-next = "2.0"
+dirs = "5.0"
 dtparse = "2.0"
 encoding_rs = "0.8"
 fancy-regex = "0.13"
@@ -201,7 +201,7 @@ reedline = { workspace = true, features = ["bashisms", "sqlite"] }
 
 crossterm = { workspace = true }
 ctrlc = { workspace = true }
-dirs-next = { workspace = true }
+dirs = { workspace = true }
 log = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-backtrace", "fancy"] }
 mimalloc = { version = "0.1.42", default-features = false, optional = true }
@@ -229,7 +229,7 @@ nu-test-support = { path = "./crates/nu-test-support", version = "0.95.1" }
 nu-plugin-protocol = { path = "./crates/nu-plugin-protocol", version = "0.95.1" }
 nu-plugin-core = { path = "./crates/nu-plugin-core", version = "0.95.1" }
 assert_cmd = "2.0"
-dirs-next = { workspace = true }
+dirs = { workspace = true }
 tango-bench = "0.5"
 pretty_assertions = { workspace = true }
 regex = { workspace = true }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -140,7 +140,7 @@ trash-support = ["trash"]
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.95.1" }
 nu-test-support = { path = "../nu-test-support", version = "0.95.1" }
 
-dirs-next = { workspace = true }
+dirs = { workspace = true }
 mockito = { workspace = true, default-features = false }
 quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -606,7 +606,7 @@ mod test {
             assert_eq!(actual, expected);
 
             let actual = expand_glob("~/foo.txt", cwd, Span::unknown(), &Signals::empty()).unwrap();
-            let home = dirs_next::home_dir().expect("failed to get home dir");
+            let home = dirs::home_dir().expect("failed to get home dir");
             let expected: Vec<OsString> = vec![home.join("foo.txt").into()];
             assert_eq!(actual, expected);
         })

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -151,7 +151,7 @@ fn filesystem_change_to_home_directory() {
             "
         );
 
-        assert_eq!(Some(PathBuf::from(actual.out)), dirs_next::home_dir());
+        assert_eq!(Some(PathBuf::from(actual.out)), dirs::home_dir());
     })
 }
 

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -309,7 +309,7 @@ fn external_arg_expand_tilde() {
             "#
         ));
 
-        let home = dirs_next::home_dir().expect("failed to find home dir");
+        let home = dirs::home_dir().expect("failed to find home dir");
 
         assert_eq!(
             actual.out,

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["/fuzz"]
 bench = false
 
 [dependencies]
-dirs-next = { workspace = true }
+dirs = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 omnipath = { workspace = true }

--- a/crates/nu-path/src/helpers.rs
+++ b/crates/nu-path/src/helpers.rs
@@ -3,14 +3,14 @@ use omnipath::WinPathExt;
 use std::path::PathBuf;
 
 pub fn home_dir() -> Option<PathBuf> {
-    dirs_next::home_dir()
+    dirs::home_dir()
 }
 
 /// Return the data directory for the current platform or XDG_DATA_HOME if specified.
 pub fn data_dir() -> Option<PathBuf> {
     match std::env::var("XDG_DATA_HOME").map(PathBuf::from) {
         Ok(xdg_data) if xdg_data.is_absolute() => Some(canonicalize(&xdg_data).unwrap_or(xdg_data)),
-        _ => get_canonicalized_path(dirs_next::data_dir()),
+        _ => get_canonicalized_path(dirs::data_dir()),
     }
 }
 
@@ -20,7 +20,7 @@ pub fn cache_dir() -> Option<PathBuf> {
         Ok(xdg_cache) if xdg_cache.is_absolute() => {
             Some(canonicalize(&xdg_cache).unwrap_or(xdg_cache))
         }
-        _ => get_canonicalized_path(dirs_next::cache_dir()),
+        _ => get_canonicalized_path(dirs::cache_dir()),
     }
 }
 
@@ -30,7 +30,7 @@ pub fn config_dir() -> Option<PathBuf> {
         Ok(xdg_config) if xdg_config.is_absolute() => {
             Some(canonicalize(&xdg_config).unwrap_or(xdg_config))
         }
-        _ => get_canonicalized_path(dirs_next::config_dir()),
+        _ => get_canonicalized_path(dirs::config_dir()),
     }
 }
 

--- a/crates/nu-path/src/tilde.rs
+++ b/crates/nu-path/src/tilde.rs
@@ -77,7 +77,7 @@ fn user_home_dir(username: &str) -> PathBuf {
 fn user_home_dir(username: &str) -> PathBuf {
     use std::path::Component;
 
-    match dirs_next::home_dir() {
+    match dirs::home_dir() {
         None => {
             // Termux always has the same home directory
             #[cfg(target_os = "android")]
@@ -145,7 +145,7 @@ fn expand_tilde_with_another_user_home(path: &Path) -> PathBuf {
 /// Expand tilde ("~") into a home directory if it is the first path component
 pub fn expand_tilde(path: impl AsRef<Path>) -> PathBuf {
     // TODO: Extend this to work with "~user" style of home paths
-    expand_tilde_with_home(path, dirs_next::home_dir())
+    expand_tilde_with_home(path, dirs::home_dir())
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> Result<()> {
                     },
                 );
             } else if let Some(old_config) =
-                nu_path::get_canonicalized_path(dirs_next::config_dir()).map(|p| p.join("nushell"))
+                nu_path::get_canonicalized_path(dirs::config_dir()).map(|p| p.join("nushell"))
             {
                 let xdg_config_empty = nushell_config_path
                     .read_dir()

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -235,7 +235,7 @@ fn test_xdg_config_empty() {
         playground.with_env("XDG_CONFIG_HOME", "");
 
         let actual = run(playground, "$nu.default-config-dir");
-        let expected = dirs_next::config_dir().unwrap().join("nushell");
+        let expected = dirs::config_dir().unwrap().join("nushell");
         assert_eq!(
             actual,
             adjust_canonicalization(expected.canonicalize().unwrap_or(expected))
@@ -250,7 +250,7 @@ fn test_xdg_config_bad() {
         playground.with_env("XDG_CONFIG_HOME", xdg_config_home);
 
         let actual = run(playground, "$nu.default-config-dir");
-        let expected = dirs_next::config_dir().unwrap().join("nushell");
+        let expected = dirs::config_dir().unwrap().join("nushell");
         assert_eq!(
             actual,
             adjust_canonicalization(expected.canonicalize().unwrap_or(expected))


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Replaces the `dirs_next` family of crates with `dirs`. `dirs_next` was born when the `dirs` crates were abandoned three years ago, but they're being maintained again and most projects depend on `dirs` nowadays. `dirs_next` has been abandoned since.

This came up while working on https://github.com/nushell/nushell/pull/13382.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
None.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Tests and formatter have been run.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
