### PR TITLE
Make assignment and `const` consistent with `let`/`mut`

### DIFF
--- a/crates/nu-command/tests/commands/complete.rs
+++ b/crates/nu-command/tests/commands/complete.rs
@@ -95,13 +95,13 @@ fn capture_error_with_both_stdout_stderr_messages_not_hang_nushell() {
 
 #[test]
 fn combined_pipe_redirection() {
-    let actual = nu!("$env.FOO = hello; $env.BAR = world; nu --testbin echo_env_mixed out-err FOO BAR o+e>| complete | get stdout");
+    let actual = nu!("$env.FOO = 'hello'; $env.BAR = 'world'; nu --testbin echo_env_mixed out-err FOO BAR o+e>| complete | get stdout");
     assert_eq!(actual.out, "helloworld");
 }
 
 #[test]
 fn err_pipe_redirection() {
     let actual =
-        nu!("$env.FOO = hello; nu --testbin echo_env_stderr FOO e>| complete | get stdout");
+        nu!("$env.FOO = 'hello'; nu --testbin echo_env_stderr FOO e>| complete | get stdout");
     assert_eq!(actual.out, "hello");
 }

--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -24,6 +24,13 @@ fn let_takes_pipeline() {
 }
 
 #[test]
+fn let_takes_pipeline_with_declared_type() {
+    let actual = nu!(r#"let x: list<string> = [] | append "hello world"; print $x.0"#);
+
+    assert_eq!(actual.out, "hello world");
+}
+
+#[test]
 fn let_pipeline_allows_in() {
     let actual =
         nu!(r#"def foo [] { let x = $in | str length; print ($x + 10) }; "hello world" | foo"#);

--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -46,6 +46,13 @@ fn mut_takes_pipeline() {
 }
 
 #[test]
+fn mut_takes_pipeline_with_declared_type() {
+    let actual = nu!(r#"mut x: list<string> = [] | append "hello world"; print $x.0"#);
+
+    assert_eq!(actual.out, "hello world");
+}
+
+#[test]
 fn mut_pipeline_allows_in() {
     let actual =
         nu!(r#"def foo [] { mut x = $in | str length; print ($x + 10) }; "hello world" | foo"#);

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -144,7 +144,7 @@ fn errors_if_attempting_to_delete_home() {
     Playground::setup("rm_test_8", |dirs, _| {
         let actual = nu!(
             cwd: dirs.root(),
-            "$env.HOME = myhome ; rm -rf ~"
+            "$env.HOME = 'myhome' ; rm -rf ~"
         );
 
         assert!(actual.err.contains("please use -I or -i"));

--- a/crates/nu-command/tests/commands/table.rs
+++ b/crates/nu-command/tests/commands/table.rs
@@ -2567,7 +2567,7 @@ fn theme_cmd(theme: &str, footer: bool, then: &str) -> String {
         with_footer = "$env.config.footer_mode = \"always\"".to_string();
     }
 
-    format!("$env.config.table.mode = {theme}; $env.config.table.header_on_separator = true; {with_footer}; {then}")
+    format!("$env.config.table.mode = \"{theme}\"; $env.config.table.header_on_separator = true; {with_footer}; {then}")
 }
 
 #[test]

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -6,6 +6,7 @@ pub enum TokenContents {
     Comment,
     Pipe,
     PipePipe,
+    AssignmentOperator,
     ErrGreaterPipe,
     OutErrGreaterPipe,
     Semicolon,
@@ -297,6 +298,10 @@ pub fn lex_item(
 
     let mut err = None;
     let output = match &input[(span.start - span_offset)..(span.end - span_offset)] {
+        b"=" | b"+=" | b"++=" | b"-=" | b"*=" | b"/=" => Token {
+            contents: TokenContents::AssignmentOperator,
+            span,
+        },
         b"out>" | b"o>" => Token {
             contents: TokenContents::OutGreaterThan,
             span,

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -70,6 +70,12 @@ fn is_item_terminator(
             || special_tokens.contains(&c))
 }
 
+/// Assignment operators have special handling distinct from math expressions, as they cause the
+/// rest of the pipeline to be consumed.
+pub fn is_assignment_operator(bytes: &[u8]) -> bool {
+    matches!(bytes, b"=" | b"+=" | b"++=" | b"-=" | b"*=" | b"/=")
+}
+
 // A special token is one that is a byte that stands alone as its own token. For example
 // when parsing a signature you may want to have `:` be able to separate tokens and also
 // to be handled as its own token to notify you you're about to parse a type in the example
@@ -298,7 +304,7 @@ pub fn lex_item(
 
     let mut err = None;
     let output = match &input[(span.start - span_offset)..(span.end - span_offset)] {
-        b"=" | b"+=" | b"++=" | b"-=" | b"*=" | b"/=" => Token {
+        bytes if is_assignment_operator(bytes) => Token {
             contents: TokenContents::AssignmentOperator,
             span,
         },

--- a/crates/nu-parser/src/lite_parser.rs
+++ b/crates/nu-parser/src/lite_parser.rs
@@ -167,10 +167,43 @@ pub fn lite_parse(tokens: &[Token]) -> (LiteBlock, Option<ParseError>) {
     let mut last_token = TokenContents::Eol;
     let mut file_redirection = None;
     let mut curr_comment: Option<Vec<Span>> = None;
+    let mut is_assignment = false;
     let mut error = None;
 
     for (idx, token) in tokens.iter().enumerate() {
-        if let Some((source, append, span)) = file_redirection.take() {
+        if is_assignment {
+            match &token.contents {
+                // Consume until semicolon or terminating EOL. Assignments absorb pipelines and
+                // redirections.
+                TokenContents::Eol => {
+                    // Handle `[Command] [Pipe] ([Comment] | [Eol])+ [Command]`
+                    //
+                    // `[Eol]` branch checks if previous token is `[Pipe]` to construct pipeline
+                    // and so `[Comment] | [Eol]` should be ignore to make it work
+                    let actual_token = last_non_comment_token(tokens, idx);
+                    if actual_token != Some(TokenContents::Pipe) {
+                        is_assignment = false;
+                        pipeline.push(&mut command);
+                        block.push(&mut pipeline);
+                    }
+
+                    if last_token == TokenContents::Eol {
+                        // Clear out the comment as we're entering a new comment
+                        curr_comment = None;
+                    }
+                }
+                TokenContents::Semicolon => {
+                    is_assignment = false;
+                    pipeline.push(&mut command);
+                    block.push(&mut pipeline);
+                }
+                TokenContents::Comment => {
+                    command.comments.push(token.span);
+                    curr_comment = None;
+                }
+                _ => command.push(token.span),
+            }
+        } else if let Some((source, append, span)) = file_redirection.take() {
             match &token.contents {
                 TokenContents::PipePipe => {
                     error = error.or(Some(ParseError::ShellOrOr(token.span)));
@@ -188,6 +221,11 @@ pub fn lite_parse(tokens: &[Token]) -> (LiteBlock, Option<ParseError>) {
                         command.push(span);
                         command.push(token.span)
                     }
+                }
+                TokenContents::AssignmentOperator => {
+                    error = error.or(Some(ParseError::Expected("redirection target", token.span)));
+                    command.push(span);
+                    command.push(token.span);
                 }
                 TokenContents::OutGreaterThan
                 | TokenContents::OutGreaterGreaterThan
@@ -246,6 +284,15 @@ pub fn lite_parse(tokens: &[Token]) -> (LiteBlock, Option<ParseError>) {
                     // For example, this is currently allowed: ^echo thing o> out.txt extra_arg
 
                     // If we have a comment, go ahead and attach it
+                    if let Some(curr_comment) = curr_comment.take() {
+                        command.comments = curr_comment;
+                    }
+                    command.push(token.span);
+                }
+                TokenContents::AssignmentOperator => {
+                    // When in assignment mode, we'll just consume pipes or redirections as part of
+                    // the command.
+                    is_assignment = true;
                     if let Some(curr_comment) = curr_comment.take() {
                         command.comments = curr_comment;
                     }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1430,7 +1430,8 @@ fn parse_binary_with_base(
                     | TokenContents::ErrGreaterThan
                     | TokenContents::ErrGreaterGreaterThan
                     | TokenContents::OutErrGreaterThan
-                    | TokenContents::OutErrGreaterGreaterThan => {
+                    | TokenContents::OutErrGreaterGreaterThan
+                    | TokenContents::AssignmentOperator => {
                         working_set.error(ParseError::Expected("binary", span));
                         return garbage(working_set, span);
                     }

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1178,7 +1178,10 @@ fn test_nothing_comparison_eq() {
 #[case(b"let a = 1 err> /dev/null")]
 #[case(b"let a = 1 out> /dev/null")]
 #[case(b"let a = 1 out+err> /dev/null")]
-fn test_redirection_with_let(#[case] phase: &[u8]) {
+#[case(b"mut a = 1 err> /dev/null")]
+#[case(b"mut a = 1 out> /dev/null")]
+#[case(b"mut a = 1 out+err> /dev/null")]
+fn test_redirection_with_letmut(#[case] phase: &[u8]) {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
     working_set.add_decl(Box::new(Let));

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1142,18 +1142,17 @@ fn test_nothing_comparison_eq() {
 #[rstest]
 #[case(b"let a = 1 err> /dev/null")]
 #[case(b"let a = 1 out> /dev/null")]
-#[case(b"mut a = 1 err> /dev/null")]
-#[case(b"mut a = 1 out> /dev/null")]
 #[case(b"let a = 1 out+err> /dev/null")]
-#[case(b"mut a = 1 out+err> /dev/null")]
-fn test_redirection_with_letmut(#[case] phase: &[u8]) {
+fn test_redirection_with_let(#[case] phase: &[u8]) {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
+    working_set.add_decl(Box::new(Let));
     let _block = parse(&mut working_set, None, phase, true);
-    assert!(matches!(
-        working_set.parse_errors.first(),
-        Some(ParseError::RedirectingBuiltinCommand(_, _, _))
-    ));
+    assert!(
+        working_set.parse_errors.is_empty(),
+        "parse errors: {:?}",
+        working_set.parse_errors
+    );
 }
 
 #[rstest]

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -415,3 +415,9 @@ fn const_raw_string() {
     let actual = nu!(r#"const x = r#'abc'#; $x"#);
     assert_eq!(actual.out, "abc");
 }
+
+#[test]
+fn const_takes_pipeline() {
+    let actual = nu!(r#"const list = 'bar_baz_quux' | split row '_'; $list | length"#);
+    assert_eq!(actual.out, "3");
+}

--- a/tests/plugins/env.rs
+++ b/tests/plugins/env.rs
@@ -6,9 +6,9 @@ fn get_env_by_name() {
         cwd: ".",
         plugin: ("nu_plugin_example"),
         r#"
-            $env.FOO = bar
+            $env.FOO = 'bar'
             example env FOO | print
-            $env.FOO = baz
+            $env.FOO = 'baz'
             example env FOO | print
         "#
     );
@@ -21,7 +21,7 @@ fn get_envs() {
     let result = nu_with_plugins!(
         cwd: ".",
         plugin: ("nu_plugin_example"),
-        "$env.BAZ = foo; example env | get BAZ"
+        "$env.BAZ = 'foo'; example env | get BAZ"
     );
     assert!(result.status.success());
     assert_eq!("foo", result.out);

--- a/tests/repl/test_config.rs
+++ b/tests/repl/test_config.rs
@@ -20,7 +20,7 @@ fn mutate_nu_config_nested_ls() -> TestResult {
 fn mutate_nu_config_nested_table() -> TestResult {
     run_test_std(
         r#"
-            $env.config.table.trim.methodology = wrapping
+            $env.config.table.trim.methodology = 'wrapping'
             $env.config.table.trim.wrapping_try_keep_words = false
             $env.config.table.trim.wrapping_try_keep_words
         "#,

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -296,6 +296,22 @@ fn assign_expressions() -> TestResult {
 }
 
 #[test]
+fn assign_takes_pipeline() -> TestResult {
+    run_test(
+        r#"mut foo = 'bar'; $foo = $foo | str upcase | str reverse; $foo"#,
+        "RAB",
+    )
+}
+
+#[test]
+fn append_assign_takes_pipeline() -> TestResult {
+    run_test(
+        r#"mut foo = 'bar'; $foo ++= $foo | str upcase; $foo"#,
+        "barBAR",
+    )
+}
+
+#[test]
 fn string_interpolation_paren_test() -> TestResult {
     run_test(r#"$"('(')(')')""#, "()")
 }


### PR DESCRIPTION
# Description

This makes assignment operations and `const` behave the same way `let` and `mut` do, absorbing the rest of the pipeline.

Changes the lexer to be able to recognize assignment operators as a separate token, and then makes the lite parser continue to push spans into the same command regardless of any redirections or pipes if an assignment operator is encountered. Because the pipeline is no longer split up by the lite parser at this point, it's trivial to just parse the right hand side as if it were a subexpression not contained within parentheses.

# User-Facing Changes
Big breaking change. These are all now possible:

```nushell
const path = 'a' | path join 'b'

mut x = 2
$x = random int
$x = [1 2 3] | math sum

$env.FOO = random chars
```

In the past, these would have led to (an attempt at) bare word string parsing. So while `$env.FOO = bar` would have previously set the environment variable `FOO` to the string `"bar"`, it now tries to run the command named `bar`, hence the major breaking change.

However, this is desirable because it is very consistent - if you see the `=`, you can just assume it absorbs everything else to the right of it.

# Tests + Formatting
Added tests for the new behaviour. Adjusted some existing tests that depended on the right hand side of assignments being parsed as barewords.

# After Submitting
- [ ] release notes (breaking change!)
