### PR TITLE
reset signals in catch block

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -116,6 +116,7 @@ fn handle_catch(
     stack: &mut Stack,
     eval_block_fn: EvalBlockFn,
 ) -> Result<PipelineData, ShellError> {
+    engine_state.reset_signals();
     if let Some(catch_block) = catch_block {
         let catch_block = engine_state.get_block(catch_block.block_id);
         // Put the error value in the positional closure var

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -182,7 +182,7 @@ impl EngineState {
         &self.signals
     }
 
-    pub fn reset_signals(&mut self) {
+    pub fn reset_signals(&self) {
         self.signals.reset()
     }
 


### PR DESCRIPTION
# Description
Fixes:  #13394

The issue only happened if user runs a script.  The ctrlc signal is reset during repl. 
This pr is going to reset it in `catch` block.

# User-Facing Changes
```nushell
let tmp = mktemp --directory
print $tmp
try {
    sleep 10sec
} catch {
    rm -rf $tmp
}
```

After pressing ctrl-c, the `$tmp` file will be removed.

# Tests + Formatting
Sorry I think it's hard to add a test.
