### PR TITLE
don't allow break/continue in `each` and `items` command

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/break_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/break_.rs
@@ -21,7 +21,9 @@ impl Command for Break {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nu.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html
+
+  WARN: Don't try to use it in closure.  Although it will raise error, statements before `break` will be executed"#
     }
 
     fn command_type(&self) -> CommandType {

--- a/crates/nu-cmd-lang/src/core_commands/break_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/break_.rs
@@ -23,7 +23,7 @@ impl Command for Break {
         r#"This command is a parser keyword. For details, check:
   https://www.nushell.sh/book/thinking_in_nu.html
 
-  WARN: break should be used only in `while`, `loop`, `for`"#
+  break can only be used in while, loop, and for loops. It can not be used with each or other filter commands"#
     }
 
     fn command_type(&self) -> CommandType {

--- a/crates/nu-cmd-lang/src/core_commands/break_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/break_.rs
@@ -23,7 +23,7 @@ impl Command for Break {
         r#"This command is a parser keyword. For details, check:
   https://www.nushell.sh/book/thinking_in_nu.html
 
-  WARN: Don't try to use it in closure.  Although it will raise error, statements before `break` will be executed"#
+  WARN: break should be used only in `while`, `loop`, `for`"#
     }
 
     fn command_type(&self) -> CommandType {

--- a/crates/nu-cmd-lang/src/core_commands/continue_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/continue_.rs
@@ -23,7 +23,7 @@ impl Command for Continue {
         r#"This command is a parser keyword. For details, check:
   https://www.nushell.sh/book/thinking_in_nu.html
 
-  WARN: Don't try to use it in closure.  Although it will raise error, statements before `continue` will be executed"#
+  WARN: continue should be only used in `while`, `loop`, `for`"#
     }
 
     fn command_type(&self) -> CommandType {

--- a/crates/nu-cmd-lang/src/core_commands/continue_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/continue_.rs
@@ -23,7 +23,7 @@ impl Command for Continue {
         r#"This command is a parser keyword. For details, check:
   https://www.nushell.sh/book/thinking_in_nu.html
 
-  WARN: continue should be only used in `while`, `loop`, `for`"#
+  continue can only be used in while, loop, and for loops. It can not be used with each or other filter commands"#
     }
 
     fn command_type(&self) -> CommandType {

--- a/crates/nu-cmd-lang/src/core_commands/continue_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/continue_.rs
@@ -21,7 +21,9 @@ impl Command for Continue {
 
     fn extra_usage(&self) -> &str {
         r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nu.html"#
+  https://www.nushell.sh/book/thinking_in_nu.html
+
+  WARN: Don't try to use it in closure.  Although it will raise error, statements before `continue` will be executed"#
     }
 
     fn command_type(&self) -> CommandType {

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -132,8 +132,6 @@ with 'transpose' first."#
                             Ok(data) => Some(data.into_value(head).unwrap_or_else(|err| {
                                 Value::error(chain_error_with_input(err, is_error, span), span)
                             })),
-                            Err(ShellError::Continue { span }) => Some(Value::nothing(span)),
-                            Err(ShellError::Break { .. }) => None,
                             Err(error) => {
                                 let error = chain_error_with_input(error, is_error, span);
                                 Some(Value::error(error, span))
@@ -149,10 +147,6 @@ with 'transpose' first."#
                         .map_while(move |value| {
                             let value = match value {
                                 Ok(value) => value,
-                                Err(ShellError::Continue { span }) => {
-                                    return Some(Value::nothing(span))
-                                }
-                                Err(ShellError::Break { .. }) => return None,
                                 Err(err) => return Some(Value::error(err, head)),
                             };
 
@@ -163,8 +157,6 @@ with 'transpose' first."#
                                 .and_then(|data| data.into_value(head))
                             {
                                 Ok(value) => Some(value),
-                                Err(ShellError::Continue { span }) => Some(Value::nothing(span)),
-                                Err(ShellError::Break { .. }) => None,
                                 Err(error) => {
                                     let error = chain_error_with_input(error, is_error, span);
                                     Some(Value::error(error, span))

--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -60,7 +60,6 @@ impl Command for Items {
 
                                 match result {
                                     Ok(value) => Some(value),
-                                    Err(ShellError::Break { .. }) => None,
                                     Err(err) => {
                                         let err = chain_error_with_input(err, false, span);
                                         Some(Value::error(err, head))

--- a/crates/nu-command/tests/commands/break_.rs
+++ b/crates/nu-command/tests/commands/break_.rs
@@ -15,12 +15,3 @@ fn break_while_loop() {
 
     assert_eq!(actual.out, "hello");
 }
-
-#[test]
-fn break_each() {
-    let actual = nu!("
-        [1, 2, 3, 4, 5] | each {|x| if $x > 3 { break }; $x} | math sum
-        ");
-
-    assert_eq!(actual.out, "6");
-}

--- a/crates/nu-command/tests/commands/each.rs
+++ b/crates/nu-command/tests/commands/each.rs
@@ -59,22 +59,6 @@ fn each_while_uses_enumerate_index() {
 }
 
 #[test]
-fn each_element_continue_command() {
-    let actual =
-        nu!("[1,2,3,4,6,7] | each { |x| if ($x mod 2 == 0) {continue} else { $x }} | to nuon");
-
-    assert_eq!(actual.out, "[1, 3, 7]");
-}
-
-#[test]
-fn each_element_break_command() {
-    let actual =
-        nu!("[1,2,5,4,6,7] | each { |x| if ($x mod 3 == 0) {break} else { $x }} | to nuon");
-
-    assert_eq!(actual.out, "[1, 2, 5, 4]");
-}
-
-#[test]
 fn errors_in_nested_each_show() {
     let actual = nu!("[[1,2]] | each {|x| $x | each {|y| error make {msg: \"oh noes\"} } }");
     assert!(actual.err.contains("oh noes"))


### PR DESCRIPTION
# Description
Fixes: #11451

# User-Facing Changes
### Before
```nushell
❯ [1 2 3] | each {|e| break; print $e }
╭────────────╮
│ empty list │
╰────────────╯
```

### After
```
❯ [1 2 3] | each {|e| break; print $e }
Error: nu::shell::eval_block_with_input

  × Eval block failed with pipeline input
   ╭─[entry #9:1:2]
 1 │ [1 2 3] | each {|e| break; print $e }
   ·  ┬
   ·  ╰── source value
   ╰────

Error:   × Break used outside of loop
   ╭─[entry #9:1:21]
 1 │ [1 2 3] | each {|e| break; print $e }
   ·                     ──┬──
   ·                       ╰── used outside of loop
   ╰────
```

# Tests + Formatting
Removes some tests.