### PR TITLE
Make plugins able to find and call other commands

### DIFF
--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -1316,6 +1316,22 @@ pub(crate) fn handle_engine_call(
         } => context
             .eval_closure(closure, positional, input, redirect_stdout, redirect_stderr)
             .map(EngineCallResponse::PipelineData),
+        EngineCall::FindDecl(name) => context.find_decl(&name).map(|decl_id| {
+            if let Some(decl_id) = decl_id {
+                EngineCallResponse::Identifier(decl_id)
+            } else {
+                EngineCallResponse::empty()
+            }
+        }),
+        EngineCall::CallDecl {
+            decl_id,
+            call,
+            input,
+            redirect_stdout,
+            redirect_stderr,
+        } => context
+            .call_decl(decl_id, call, input, redirect_stdout, redirect_stderr)
+            .map(EngineCallResponse::PipelineData),
     }
 }
 

--- a/crates/nu-plugin-protocol/src/lib.rs
+++ b/crates/nu-plugin-protocol/src/lib.rs
@@ -22,7 +22,7 @@ mod tests;
 pub mod test_util;
 
 use nu_protocol::{
-    ast::Operator, engine::Closure, ByteStreamType, Config, LabeledError, PipelineData,
+    ast::Operator, engine::Closure, ByteStreamType, Config, DeclId, LabeledError, PipelineData,
     PluginMetadata, PluginSignature, ShellError, Span, Spanned, Value,
 };
 use nu_utils::SharedCow;
@@ -494,6 +494,21 @@ pub enum EngineCall<D> {
         /// Whether to redirect stderr from external commands
         redirect_stderr: bool,
     },
+    /// Find a declaration by name
+    FindDecl(String),
+    /// Call a declaration with args
+    CallDecl {
+        /// The id of the declaration to be called (can be found with `FindDecl`)
+        decl_id: DeclId,
+        /// Information about the call (head span, arguments, etc.)
+        call: EvaluatedCall,
+        /// Pipeline input to the call
+        input: D,
+        /// Whether to redirect stdout from external commands
+        redirect_stdout: bool,
+        /// Whether to redirect stderr from external commands
+        redirect_stderr: bool,
+    },
 }
 
 impl<D> EngineCall<D> {
@@ -511,6 +526,8 @@ impl<D> EngineCall<D> {
             EngineCall::LeaveForeground => "LeaveForeground",
             EngineCall::GetSpanContents(_) => "GetSpanContents",
             EngineCall::EvalClosure { .. } => "EvalClosure",
+            EngineCall::FindDecl(_) => "FindDecl",
+            EngineCall::CallDecl { .. } => "CallDecl",
         }
     }
 
@@ -544,6 +561,20 @@ impl<D> EngineCall<D> {
                 redirect_stdout,
                 redirect_stderr,
             },
+            EngineCall::FindDecl(name) => EngineCall::FindDecl(name),
+            EngineCall::CallDecl {
+                decl_id,
+                call,
+                input,
+                redirect_stdout,
+                redirect_stderr,
+            } => EngineCall::CallDecl {
+                decl_id,
+                call,
+                input: f(input)?,
+                redirect_stdout,
+                redirect_stderr,
+            },
         })
     }
 }
@@ -556,6 +587,7 @@ pub enum EngineCallResponse<D> {
     PipelineData(D),
     Config(SharedCow<Config>),
     ValueMap(HashMap<String, Value>),
+    Identifier(usize),
 }
 
 impl<D> EngineCallResponse<D> {
@@ -570,6 +602,7 @@ impl<D> EngineCallResponse<D> {
             EngineCallResponse::PipelineData(data) => EngineCallResponse::PipelineData(f(data)?),
             EngineCallResponse::Config(config) => EngineCallResponse::Config(config),
             EngineCallResponse::ValueMap(map) => EngineCallResponse::ValueMap(map),
+            EngineCallResponse::Identifier(id) => EngineCallResponse::Identifier(id),
         })
     }
 }

--- a/crates/nu-protocol/src/ir/call.rs
+++ b/crates/nu-protocol/src/ir/call.rs
@@ -239,7 +239,7 @@ impl CallBuilder {
         }
         self.inner.args_len += 1;
         if let Some(span) = argument.span() {
-            self.inner.span = self.inner.span.append(span);
+            self.inner.span = self.inner.span.merge(span);
         }
         stack.arguments.push(argument);
         self

--- a/crates/nu_plugin_example/src/commands/call_decl.rs
+++ b/crates/nu_plugin_example/src/commands/call_decl.rs
@@ -1,0 +1,78 @@
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{
+    IntoSpanned, LabeledError, PipelineData, Record, Signature, Spanned, SyntaxShape, Value,
+};
+
+use crate::ExamplePlugin;
+
+pub struct CallDecl;
+
+impl PluginCommand for CallDecl {
+    type Plugin = ExamplePlugin;
+
+    fn name(&self) -> &str {
+        "example call-decl"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .required(
+                "name",
+                SyntaxShape::String,
+                "the name of the command to call",
+            )
+            .optional(
+                "named_args",
+                SyntaxShape::Record(vec![]),
+                "named arguments to pass to the command",
+            )
+            .rest(
+                "positional_args",
+                SyntaxShape::Any,
+                "positional arguments to pass to the command",
+            )
+    }
+
+    fn usage(&self) -> &str {
+        "Demonstrates calling other commands from plugins using `call_decl()`."
+    }
+
+    fn extra_usage(&self) -> &str {
+        "
+The arguments will not be typechecked at parse time. This command is for
+demonstration only, and should not be used for anything real.
+"
+        .trim()
+    }
+
+    fn run(
+        &self,
+        _plugin: &ExamplePlugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let name: Spanned<String> = call.req(0)?;
+        let named_args: Option<Record> = call.opt(1)?;
+        let positional_args: Vec<Value> = call.rest(2)?;
+
+        let decl_id = engine.find_decl(&name.item)?.ok_or_else(|| {
+            LabeledError::new(format!("Can't find `{}`", name.item))
+                .with_label("not in scope", name.span)
+        })?;
+
+        let mut new_call = EvaluatedCall::new(call.head);
+
+        for (key, val) in named_args.into_iter().flatten() {
+            new_call.add_named(key.into_spanned(val.span()), val);
+        }
+
+        for val in positional_args {
+            new_call.add_positional(val);
+        }
+
+        let result = engine.call_decl(decl_id, new_call, input, true, false)?;
+
+        Ok(result)
+    }
+}

--- a/crates/nu_plugin_example/src/commands/mod.rs
+++ b/crates/nu_plugin_example/src/commands/mod.rs
@@ -13,11 +13,13 @@ pub use three::Three;
 pub use two::Two;
 
 // Engine interface demos
+mod call_decl;
 mod config;
 mod disable_gc;
 mod env;
 mod view_span;
 
+pub use call_decl::CallDecl;
 pub use config::Config;
 pub use disable_gc::DisableGc;
 pub use env::Env;

--- a/crates/nu_plugin_example/src/lib.rs
+++ b/crates/nu_plugin_example/src/lib.rs
@@ -27,6 +27,7 @@ impl Plugin for ExamplePlugin {
             Box::new(Env),
             Box::new(ViewSpan),
             Box::new(DisableGc),
+            Box::new(CallDecl),
             // Stream demos
             Box::new(CollectBytes),
             Box::new(Echo),

--- a/tests/plugins/call_decl.rs
+++ b/tests/plugins/call_decl.rs
@@ -1,0 +1,42 @@
+use nu_test_support::nu_with_plugins;
+
+#[test]
+fn call_to_json() {
+    let result = nu_with_plugins!(
+        cwd: ".",
+        plugin: ("nu_plugin_example"),
+        r#"
+            [42] | example call-decl 'to json' {indent: 4}
+        "#
+    );
+    assert!(result.status.success());
+    // newlines are removed from test output
+    assert_eq!("[    42]", result.out);
+}
+
+#[test]
+fn call_reduce() {
+    let result = nu_with_plugins!(
+        cwd: ".",
+        plugin: ("nu_plugin_example"),
+        r#"
+            [1 2 3] | example call-decl 'reduce' {fold: 10} { |it, acc| $it + $acc }
+        "#
+    );
+    assert!(result.status.success());
+    assert_eq!("16", result.out);
+}
+
+#[test]
+fn call_scope_variables() {
+    let result = nu_with_plugins!(
+        cwd: ".",
+        plugin: ("nu_plugin_example"),
+        r#"
+            let test_var = 10
+            example call-decl 'scope variables' | where name == '$test_var' | length
+        "#
+    );
+    assert!(result.status.success());
+    assert_eq!("1", result.out);
+}

--- a/tests/plugins/mod.rs
+++ b/tests/plugins/mod.rs
@@ -1,3 +1,4 @@
+mod call_decl;
 mod config;
 mod core_inc;
 mod custom_values;


### PR DESCRIPTION
# Description

Adds functionality to the plugin interface to support calling internal commands from plugins. For example, using `view ir --json`:

```rust
let closure: Value = call.req(0)?;

let Some(decl_id) = engine.find_decl("view ir")? else {
    return Err(LabeledError::new("`view ir` not found"));
};

let ir_json = engine.call_decl(
    decl_id,
    EvaluatedCall::new(call.head)
        .with_named("json".into_spanned(call.head), Value::bool(true, call.head))
        .with_positional(closure),
    PipelineData::Empty,
    true,
    false,
)?.into_value()?.into_string()?;

let ir = serde_json::from_value(&ir_json);

// ...
```

# User-Facing Changes

Plugin developers can now use `EngineInterface::find_decl()` and `call_decl()` to call internal commands, which could be handy for formatters like `to csv` or `to nuon`, or for reflection commands that help gain insight into the engine.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
- [ ] release notes
- [ ] update plugin protocol documentation: `FindDecl`, `CallDecl` engine calls; `Identifier` engine call response
