### PR TITLE
Use the Default implementation of Suggestion

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -99,10 +99,9 @@ impl CommandCompletion {
                 suggestion: Suggestion {
                     value: String::from_utf8_lossy(&x.0).to_string(),
                     description: x.1,
-                    style: None,
-                    extra: None,
                     span: reedline::Span::new(span.start - offset, span.end - offset),
                     append_whitespace: true,
+                    ..Suggestion::default()
                 },
                 kind: Some(SuggestionKind::Command(x.2)),
             })
@@ -118,11 +117,9 @@ impl CommandCompletion {
                 .map(move |x| SemanticSuggestion {
                     suggestion: Suggestion {
                         value: x,
-                        description: None,
-                        style: None,
-                        extra: None,
                         span: reedline::Span::new(span.start - offset, span.end - offset),
                         append_whitespace: true,
+                        ..Suggestion::default()
                     },
                     // TODO: is there a way to create a test?
                     kind: None,
@@ -136,11 +133,9 @@ impl CommandCompletion {
                     results.push(SemanticSuggestion {
                         suggestion: Suggestion {
                             value: format!("^{}", external.suggestion.value),
-                            description: None,
-                            style: None,
-                            extra: None,
                             span: external.suggestion.span,
                             append_whitespace: true,
+                            ..Suggestion::default()
                         },
                         kind: external.kind,
                     })

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -443,14 +443,11 @@ pub fn map_value_completions<'a>(
             return Some(SemanticSuggestion {
                 suggestion: Suggestion {
                     value: s,
-                    description: None,
-                    style: None,
-                    extra: None,
                     span: reedline::Span {
                         start: span.start - offset,
                         end: span.end - offset,
                     },
-                    append_whitespace: false,
+                    ..Suggestion::default()
                 },
                 kind: Some(SuggestionKind::Type(x.get_type())),
             });
@@ -460,14 +457,11 @@ pub fn map_value_completions<'a>(
         if let Ok(record) = x.as_record() {
             let mut suggestion = Suggestion {
                 value: String::from(""), // Initialize with empty string
-                description: None,
-                style: None,
-                extra: None,
                 span: reedline::Span {
                     start: span.start - offset,
                     end: span.end - offset,
                 },
-                append_whitespace: false,
+                ..Suggestion::default()
             };
 
             // Iterate the cols looking for `value` and `description`

--- a/crates/nu-cli/src/completions/directory_completions.rs
+++ b/crates/nu-cli/src/completions/directory_completions.rs
@@ -48,14 +48,12 @@ impl Completer for DirectoryCompletion {
         .map(move |x| SemanticSuggestion {
             suggestion: Suggestion {
                 value: x.1,
-                description: None,
                 style: x.2,
-                extra: None,
                 span: reedline::Span {
                     start: x.0.start - offset,
                     end: x.0.end - offset,
                 },
-                append_whitespace: false,
+                ..Suggestion::default()
             },
             // TODO????
             kind: None,

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -116,14 +116,13 @@ impl Completer for DotNuCompletion {
                     .map(move |x| SemanticSuggestion {
                         suggestion: Suggestion {
                             value: x.1,
-                            description: None,
                             style: x.2,
-                            extra: None,
                             span: reedline::Span {
                                 start: x.0.start - offset,
                                 end: x.0.end - offset,
                             },
                             append_whitespace: true,
+                            ..Suggestion::default()
                         },
                         // TODO????
                         kind: None,

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -53,14 +53,12 @@ impl Completer for FileCompletion {
         .map(move |x| SemanticSuggestion {
             suggestion: Suggestion {
                 value: x.1,
-                description: None,
                 style: x.2,
-                extra: None,
                 span: reedline::Span {
                     start: x.0.start - offset,
                     end: x.0.end - offset,
                 },
-                append_whitespace: false,
+                ..Suggestion::default()
             },
             // TODO????
             kind: None,

--- a/crates/nu-cli/src/completions/flag_completions.rs
+++ b/crates/nu-cli/src/completions/flag_completions.rs
@@ -51,13 +51,12 @@ impl Completer for FlagCompletion {
                             suggestion: Suggestion {
                                 value: String::from_utf8_lossy(&named).to_string(),
                                 description: Some(flag_desc.to_string()),
-                                style: None,
-                                extra: None,
                                 span: reedline::Span {
                                     start: span.start - offset,
                                     end: span.end - offset,
                                 },
                                 append_whitespace: true,
+                                ..Suggestion::default()
                             },
                             // TODO????
                             kind: None,
@@ -78,13 +77,12 @@ impl Completer for FlagCompletion {
                         suggestion: Suggestion {
                             value: String::from_utf8_lossy(&named).to_string(),
                             description: Some(flag_desc.to_string()),
-                            style: None,
-                            extra: None,
                             span: reedline::Span {
                                 start: span.start - offset,
                                 end: span.end - offset,
                             },
                             append_whitespace: true,
+                            ..Suggestion::default()
                         },
                         // TODO????
                         kind: None,

--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -85,11 +85,8 @@ impl Completer for VariableCompletion {
                             output.push(SemanticSuggestion {
                                 suggestion: Suggestion {
                                     value: env_var.0,
-                                    description: None,
-                                    style: None,
-                                    extra: None,
                                     span: current_span,
-                                    append_whitespace: false,
+                                    ..Suggestion::default()
                                 },
                                 kind: Some(SuggestionKind::Type(env_var.1.get_type())),
                             });
@@ -157,11 +154,8 @@ impl Completer for VariableCompletion {
                 output.push(SemanticSuggestion {
                     suggestion: Suggestion {
                         value: builtin.to_string(),
-                        description: None,
-                        style: None,
-                        extra: None,
                         span: current_span,
-                        append_whitespace: false,
+                        ..Suggestion::default()
                     },
                     // TODO is there a way to get the VarId to get the type???
                     kind: None,
@@ -184,11 +178,8 @@ impl Completer for VariableCompletion {
                         output.push(SemanticSuggestion {
                             suggestion: Suggestion {
                                 value: String::from_utf8_lossy(v.0).to_string(),
-                                description: None,
-                                style: None,
-                                extra: None,
                                 span: current_span,
-                                append_whitespace: false,
+                                ..Suggestion::default()
                             },
                             kind: Some(SuggestionKind::Type(
                                 working_set.get_variable(*v.1).ty.clone(),
@@ -215,11 +206,8 @@ impl Completer for VariableCompletion {
                     output.push(SemanticSuggestion {
                         suggestion: Suggestion {
                             value: String::from_utf8_lossy(v.0).to_string(),
-                            description: None,
-                            style: None,
-                            extra: None,
                             span: current_span,
-                            append_whitespace: false,
+                            ..Suggestion::default()
                         },
                         kind: Some(SuggestionKind::Type(
                             working_set.get_variable(*v.1).ty.clone(),
@@ -255,11 +243,8 @@ fn nested_suggestions(
                 output.push(SemanticSuggestion {
                     suggestion: Suggestion {
                         value: col.clone(),
-                        description: None,
-                        style: None,
-                        extra: None,
                         span: current_span,
-                        append_whitespace: false,
+                        ..Suggestion::default()
                     },
                     kind: Some(kind.clone()),
                 });
@@ -272,11 +257,8 @@ fn nested_suggestions(
                 output.push(SemanticSuggestion {
                     suggestion: Suggestion {
                         value: column_name,
-                        description: None,
-                        style: None,
-                        extra: None,
                         span: current_span,
-                        append_whitespace: false,
+                        ..Suggestion::default()
                     },
                     kind: Some(kind.clone()),
                 });

--- a/crates/nu-cli/src/menus/help_completions.rs
+++ b/crates/nu-cli/src/menus/help_completions.rs
@@ -110,13 +110,12 @@ impl NuHelpCompleter {
                 Suggestion {
                     value: decl.name().into(),
                     description: Some(long_desc),
-                    style: None,
                     extra: Some(extra),
                     span: reedline::Span {
                         start: pos - line.len(),
                         end: pos,
                     },
-                    append_whitespace: false,
+                    ..Suggestion::default()
                 }
             })
             .collect()

--- a/crates/nu-cli/src/menus/menu_completions.rs
+++ b/crates/nu-cli/src/menus/menu_completions.rs
@@ -142,10 +142,9 @@ fn convert_to_suggestions(
             vec![Suggestion {
                 value: text,
                 description,
-                style: None,
                 extra,
                 span,
-                append_whitespace: false,
+                ..Suggestion::default()
             }]
         }
         Value::List { vals, .. } => vals
@@ -154,9 +153,6 @@ fn convert_to_suggestions(
             .collect(),
         _ => vec![Suggestion {
             value: format!("Not a record: {value:?}"),
-            description: None,
-            style: None,
-            extra: None,
             span: reedline::Span {
                 start: if only_buffer_difference {
                     pos - line.len()
@@ -169,7 +165,7 @@ fn convert_to_suggestions(
                     line.len()
                 },
             },
-            append_whitespace: false,
+            ..Suggestion::default()
         }],
     }
 }


### PR DESCRIPTION
# Description

Take advantage of the `Default` implementation of `Suggestion`.  This in particular should make code compatible forward-compatible with https://github.com/nushell/reedline/pull/798.

# User-Facing Changes
None

# Tests + Formatting

Existing coverage.