### PR TITLE
Fix parsing record values containing colons

### DIFF
--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -458,8 +458,7 @@ pub fn lex_signature(
     )
 }
 
-// temporary name because i cant decide on a better one
-pub fn lex_but_ignore_specials_after_special(
+pub fn lex_alternating_special_tokens(
     input: &[u8],
     span_offset: usize,
     additional_whitespace: &[u8],
@@ -505,7 +504,7 @@ fn lex_internal(
     in_signature: bool,
     // after lexing a special item, disable special items when lexing the next item.
     // necessary because colons are special in records, but datetime literals may contain colons
-    ignore_specials_after_special: bool,
+    alternate_specials: bool,
 ) -> (Vec<Token>, Option<ParseError>) {
     let mut specials_disabled = false;
 
@@ -638,8 +637,7 @@ fn lex_internal(
         } else if c == b' ' || c == b'\t' || additional_whitespace.contains(&c) {
             // If the next character is non-newline whitespace, skip it.
             curr_offset += 1;
-        } else if ignore_specials_after_special && !specials_disabled && special_tokens.contains(&c)
-        {
+        } else if alternate_specials && !specials_disabled && special_tokens.contains(&c) {
             // If disabling special items but if they're not currently disabled, handle a special item
             // character right here, bypassing lex_item
             output.push(Token::new(

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -472,9 +472,11 @@ pub struct LexState<'a> {
     pub span_offset: usize,
 }
 
-// Lex until the output is max_tokens longer than before the call, or until the input is exhausted.
-// The behaviour here is non-obvious (maybe non-useful) iff your additional_whitespace doesn't include newline:
-// If you pass `output` in a state where the last token is an Eol, this might *remove* tokens.
+/// Lex until the output is `max_tokens` longer than before the call, or until the input is exhausted.
+/// The return value indicates how many tokens the call added to / removed from the output.
+///
+/// The behaviour here is non-obvious when `additional_whitespace` doesn't include newline:
+/// If you pass a `state` where the last token in the output is an Eol, this might *remove* tokens.
 pub fn lex_n_tokens(
     state: &mut LexState,
     additional_whitespace: &[u8],

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -464,6 +464,7 @@ pub fn lex_signature(
     (state.output, state.error)
 }
 
+#[derive(Debug)]
 pub struct LexState<'a> {
     pub input: &'a [u8],
     pub output: Vec<Token>,

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -16,7 +16,7 @@ pub use flatten::{
     flatten_block, flatten_expression, flatten_pipeline, flatten_pipeline_element, FlatShape,
 };
 pub use known_external::KnownExternal;
-pub use lex::{lex, lex_signature, Token, TokenContents};
+pub use lex::{lex, lex_n_tokens, lex_signature, LexState, Token, TokenContents};
 pub use lite_parser::{lite_parse, LiteBlock, LiteCommand};
 pub use nu_protocol::parser_path::*;
 pub use parse_keywords::*;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5761,20 +5761,18 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
             idx += 1;
 
             let bareword_error = |string_value: &Expression| {
-                let string_span = working_set.get_span_contents(string_value.span);
-                let colon_position = string_span
+                working_set
+                    .get_span_contents(string_value.span)
                     .iter()
                     .find_position(|b| **b == b':')
-                    .map(|(i, _)| string_value.span.start + i);
-                if let Some(colon_position) = colon_position {
-                    Some(ParseError::InvalidLiteral(
-                        "colon".to_string(),
-                        "bare word specifying record value".to_string(),
-                        Span::new(colon_position, colon_position + 1),
-                    ))
-                } else {
-                    None
-                }
+                    .map(|(i, _)| {
+                        let colon_position = i + string_value.span.start;
+                        ParseError::InvalidLiteral(
+                            "colon".to_string(),
+                            "bare word specifying record value".to_string(),
+                            Span::new(colon_position, colon_position + 1),
+                        )
+                    })
             };
             let value_span = working_set.get_span_contents(value.span);
             let parse_error = match value.expr {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1,5 +1,5 @@
 use crate::{
-    lex::{is_assignment_operator, lex, lex_but_ignore_specials_after_special, lex_signature},
+    lex::{is_assignment_operator, lex, lex_alternating_special_tokens, lex_signature},
     lite_parser::{lite_parse, LiteCommand, LitePipeline, LiteRedirection, LiteRedirectionTarget},
     parse_keywords::*,
     parse_patterns::parse_pattern,
@@ -5668,7 +5668,7 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
     let source = working_set.get_span_contents(inner_span);
 
     let (tokens, err) =
-        lex_but_ignore_specials_after_special(source, start, &[b'\n', b'\r', b','], &[b':'], true);
+        lex_alternating_special_tokens(source, start, &[b'\n', b'\r', b','], &[b':'], true);
     if let Some(err) = err {
         working_set.error(err);
     }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1,5 +1,5 @@
 use crate::{
-    lex::{is_assignment_operator, lex, lex_signature},
+    lex::{is_assignment_operator, lex, lex_but_ignore_specials_after_special, lex_signature},
     lite_parser::{lite_parse, LiteCommand, LitePipeline, LiteRedirection, LiteRedirectionTarget},
     parse_keywords::*,
     parse_patterns::parse_pattern,
@@ -5667,7 +5667,8 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
     let inner_span = Span::new(start, end);
     let source = working_set.get_span_contents(inner_span);
 
-    let (tokens, err) = lex(source, start, &[b'\n', b'\r', b','], &[b':'], true);
+    let (tokens, err) =
+        lex_but_ignore_specials_after_special(source, start, &[b'\n', b'\r', b','], &[b':'], true);
     if let Some(err) = err {
         working_set.error(err);
     }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5850,8 +5850,7 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
                 )
             } else {
                 let value = parse_value(working_set, tokens[idx].span, &SyntaxShape::Any);
-                if let Some(parse_error) = check_record_key_or_value(&working_set, &value, "value")
-                {
+                if let Some(parse_error) = check_record_key_or_value(working_set, &value, "value") {
                     working_set.error(parse_error);
                     garbage(working_set, value.span)
                 } else {

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -2439,3 +2439,56 @@ mod operator {
         );
     }
 }
+
+mod record {
+    use super::*;
+
+    use nu_protocol::ast::RecordItem;
+
+    #[rstest]
+    #[case(b"{ :: x }", "Invalid literal")] // Key is bare colon
+    #[case(b"{ a: x:y }", "Invalid literal")] // Value is bare word with colon
+    #[case(b"{ a: x('y'):z }", "Invalid literal")] // Value is bare string interpolation with colon
+    #[case(b"{ ;: x }", "Parse mismatch during operation.")] // Key is a non-item token
+    #[case(b"{ a: || }", "Parse mismatch during operation.")] // Value is a non-item token
+    fn refuse_confusing_record(#[case] expr: &[u8], #[case] error: &str) {
+        dbg!(String::from_utf8_lossy(expr));
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        parse(&mut working_set, None, expr, false);
+        assert_eq!(
+            working_set.parse_errors.first().map(|e| e.to_string()),
+            Some(error.to_string())
+        );
+    }
+
+    #[rstest]
+    #[case(b"{ a: 2024-07-23T22:54:54.532100627+02:00 b:xy }")]
+    fn parse_datetime_in_record(#[case] expr: &[u8]) {
+        dbg!(String::from_utf8_lossy(expr));
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        let block = parse(&mut working_set, None, expr, false);
+        assert!(working_set.parse_errors.first().is_none());
+        let pipeline_el_expr = &block
+            .pipelines
+            .first()
+            .unwrap()
+            .elements
+            .first()
+            .unwrap()
+            .expr
+            .expr;
+        dbg!(pipeline_el_expr);
+        match pipeline_el_expr {
+            Expr::FullCellPath(v) => match &v.head.expr {
+                Expr::Record(fields) => assert!(matches!(
+                    fields[0],
+                    RecordItem::Pair(_, Expression { ty: Type::Date, .. })
+                )),
+                _ => panic!("Expected record head"),
+            },
+            _ => panic!("Expected full cell path"),
+        }
+    }
+}


### PR DESCRIPTION
This PR is an attempt to fix #8257 and fix #10985 (which is duplicate-ish)

# Description
The parser currently doesn't know how to deal with colons appearing while lexing whitespace-terminated tokens specifying a record value. Most notably, this means you can't use datetime literals in record value position (and as a consequence, `| to nuon | from nuon` roundtrips can fail), but it also means that bare words containing colons cause a non-useful error message. 
![image](https://github.com/user-attachments/assets/f04a8417-ee18-44e7-90eb-a0ecef943a0f)

`parser::parse_record` calls `lex::lex` with the `:` colon character in the `special_tokens` argument. This allows colons to terminate record keys, but as a side effect, it also causes colons to terminate record *values*. I added a new function `lex::lex_n_tokens`, which allows the caller to drive the lexing process more explicitly, and used it in `parser::parse_record` to let colons terminate record keys while not giving them special treatment when appearing in record values.

This PR description previously said: *Another approach suggested in one of the issues was to support an additional datetime literal format that doesn't require colons. I like that that wouldn't require new `lex::lex_internal` behaviour, but an advantage of my approach is that it also newly allows for string record values given as bare words containing colons. I think this eliminates another possible source of confusion.* It was determined that this is undesirable, and in the current state of this PR, bare word record values with colons are rejected explicitly. The better error message is still a win.

# User-Facing Changes
In addition to the above, this PR also disables the use of "special" (non-item) tokens in record key and value position, and the use of a single bare `:` as a record key.

Examples of behaviour *before* this PR:
```nu
{ a: b } # Valid, same as { 'a': 'b' }
{ a: b:c } # Error: expected ':'
{ a: 2024-08-13T22:11:09 } # Error: expected ':'
{ :: 1 } # Valid, same as { ':': 1 }
{ ;: 1 } # Valid, same as { ';': 1 }
{ a: || } # Valid, same as { 'a': '||' }
```

Examples of behaviour *after* this PR:
```nu
{ a: b } # (Unchanged) Valid, same as { 'a': 'b' }
{ a: b:c } # Error: colon in bare word specifying record value
{ a: 2024-08-13T22:11:09 } # Valid, same as { a: (2024-08-13T22:11:09) }
{ :: 1 } # Error: colon in bare word specifying record key
{ ;: 1 } # Error: expected item in record key position
{ a: || } # Error: expected item in record value position
```

# Tests + Formatting
I added tests, but I'm not sure if they're sufficient and in the right place.

# After Submitting
I don't think documentation changes are needed for this, but please let me know if you disagree.
