### PR TITLE
add --quiet flag to `watch` command

### DIFF
--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -61,6 +61,7 @@ impl Command for Watch {
                 "Watch all directories under `<path>` recursively. Will be ignored if `<path>` is a file (default: true)",
                 Some('r'),
             )
+            .switch("quiet", "Hide the initial status message (default: false)", Some('q'))
             .switch("verbose", "Operate in verbose mode (default: false)", Some('v'))
             .category(Category::FileSystem)
     }
@@ -93,6 +94,8 @@ impl Command for Watch {
         let closure: Closure = call.req(engine_state, stack, 1)?;
 
         let verbose = call.has_flag(engine_state, stack, "verbose")?;
+
+        let quiet = call.has_flag(engine_state, stack, "quiet")?;
 
         let debounce_duration_flag: Option<Spanned<i64>> =
             call.get_flag(engine_state, stack, "debounce-ms")?;
@@ -161,7 +164,9 @@ impl Command for Watch {
         // need to cache to make sure that rename event works.
         debouncer.cache().add_root(&path, recursive_mode);
 
-        eprintln!("Now watching files at {path:?}. Press ctrl+c to abort.");
+        if !quiet {
+            eprintln!("Now watching files at {path:?}. Press ctrl+c to abort.");
+        }
 
         let mut closure = ClosureEval::new(engine_state, stack, closure);
 


### PR DESCRIPTION

# Description
Adds a `--quiet` flag to the `watch` command, silencing the message usually shown when invoking `watch`.

Resolves #13411

As implemented, `--quiet` is orthogonal to `--verbose`. I'm open to improving the flag's name, behaviour and/or documentation to make it more user-friendly, as I realise this may be surprising as-is.

```
> watch path {|a b c| echo $a $b $c}
Now watching files at "/home/user/path". Press ctrl+c to abort.
───┬───────────────────────
 0 │ Remove                
 1 │ /home/user/path 
 2 │                       
───┴───────────────────────
^C
> watch --quiet path {|a b c| echo $a $b $c}
───┬───────────────────────
 0 │ Remove                
 1 │ /home/user/path 
 2 │                       
───┴───────────────────────
^C
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Adds `--quiet`/`-q` flag to `watch`, which removes the initial status message.

# Tests + Formatting
No new tests.
`cargo test --workspace` fails 1 test (`commands::umkdir::mkdir_umask_permission`), but that test fails on main too, so I think it is a spurious error on my local machine.

