### PR TITLE
save: print to stderr for bytestream

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -121,9 +121,11 @@ impl Command for Save {
                             } else {
                                 match stderr {
                                     ChildPipe::Pipe(mut pipe) => {
-                                        io::copy(&mut pipe, &mut io::sink())
+                                        io::copy(&mut pipe, &mut io::stderr())
                                     }
-                                    ChildPipe::Tee(mut tee) => io::copy(&mut tee, &mut io::sink()),
+                                    ChildPipe::Tee(mut tee) => {
+                                        io::copy(&mut tee, &mut io::stderr())
+                                    }
                                 }
                                 .err_span(span)?;
                             }

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -484,11 +484,11 @@ fn save_from_child_process_dont_sink_stderr() {
         );
         assert_eq!(actual.err.trim_end(), " New Err");
 
-        let actual = file_contents(expected_file).trim_end();
-        assert_eq!(actual, "Old New");
+        let actual = file_contents(expected_file);
+        assert_eq!(actual.trim_end(), "Old New");
 
-        let actual = file_contents(expected_stderr_file).trim_end();
-        assert_eq!(actual, "Old Err");
+        let actual = file_contents(expected_stderr_file);
+        assert_eq!(actual.trim_end(), "Old Err");
     })
 }
 
@@ -515,13 +515,13 @@ fn parent_redirection_doesnt_affect_save() {
         );
         assert_eq!(actual.err.trim_end(), " New Err");
 
-        let actual = file_contents(expected_file).trim_end();
-        assert_eq!(actual, "Old New");
+        let actual = file_contents(expected_file);
+        assert_eq!(actual.trim_end(), "Old New");
 
-        let actual = file_contents(expected_stderr_file).trim_end();
-        assert_eq!(actual, "Old Err");
+        let actual = file_contents(expected_stderr_file);
+        assert_eq!(actual.trim_end(), "Old Err");
 
-        let actual = file_contents(dirs.test().join("empty_file")).trim_end();
-        assert_eq!(actual, "");
+        let actual = file_contents(dirs.test().join("empty_file"));
+        assert_eq!(actual.trim_end(), "");
     })
 }

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -482,13 +482,13 @@ fn save_from_child_process_dont_sink_stderr() {
             $env.BAZ = " New Err";
             do -i {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -a -r save_test_22/log.txt"#,
         );
-        assert_eq!(actual.err, " New Err\n");
+        assert_eq!(actual.err.trim_end(), " New Err");
 
-        let actual = file_contents(expected_file);
-        assert_eq!(actual, "Old New\n");
+        let actual = file_contents(expected_file).trim_end();
+        assert_eq!(actual, "Old New");
 
-        let actual = file_contents(expected_stderr_file);
-        assert_eq!(actual, "Old Err\n");
+        let actual = file_contents(expected_stderr_file).trim_end();
+        assert_eq!(actual, "Old Err");
     })
 }
 
@@ -513,15 +513,15 @@ fn parent_redirection_doesnt_affect_save() {
             };
             tttt e> ("save_test_23" | path join empty_file)"#
         );
-        assert_eq!(actual.err, " New Err\n");
+        assert_eq!(actual.err.trim_end(), " New Err");
 
-        let actual = file_contents(expected_file);
-        assert_eq!(actual, "Old New\n");
+        let actual = file_contents(expected_file).trim_end();
+        assert_eq!(actual, "Old New");
 
-        let actual = file_contents(expected_stderr_file);
+        let actual = file_contents(expected_stderr_file).trim_end();
         assert_eq!(actual, "Old Err");
 
-        let actual = file_contents(dirs.test().join("empty_file"));
+        let actual = file_contents(dirs.test().join("empty_file")).trim_end();
         assert_eq!(actual, "");
     })
 }

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -494,7 +494,7 @@ fn save_from_child_process_dont_sink_stderr() {
 
 #[test]
 fn parent_redirection_doesnt_affect_save() {
-    Playground::setup("save_test_22", |dirs, sandbox| {
+    Playground::setup("save_test_23", |dirs, sandbox| {
         sandbox.with_files(&[
             Stub::FileWithContent("log.txt", "Old"),
             Stub::FileWithContent("err.txt", "Old Err"),
@@ -508,10 +508,10 @@ fn parent_redirection_doesnt_affect_save() {
             r#"
             $env.FOO = " New";
             $env.BAZ = " New Err";
-            def test [] {
-                do -i {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -a -r save_test_22/log.txt,
+            def tttt [] {
+                do -i {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -a -r save_test_23/log.txt
             };
-            test e> empty_file"#
+            tttt e> ("save_test_23" | path join empty_file)"#
         );
         assert_eq!(actual.err, " New Err\n");
 
@@ -519,7 +519,7 @@ fn parent_redirection_doesnt_affect_save() {
         assert_eq!(actual, "Old New\n");
 
         let actual = file_contents(expected_stderr_file);
-        assert_eq!(actual, "Old Err\n");
+        assert_eq!(actual, "Old Err");
 
         let actual = file_contents(dirs.test().join("empty_file"));
         assert_eq!(actual, "");


### PR DESCRIPTION
# Description
Fixes: #13260 

When user run a command like this:
```nushell
$env.FOO = " New";
$env.BAZ = " New Err";
do -i {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -a -r save_test_22/log.txt
```

`save` command sinks the output of previous commands' stderr output.  I think it should be `stderr`.

# User-Facing Changes
```nushell
$env.FOO = " New";
$env.BAZ = " New Err";
do -i {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -a -r save_test_22/log.txt
```
The command will output ` New Err` to stderr.

# Tests + Formatting
Added 2 cases.