### PR TITLE
Update query-web example to use new chunks

### DIFF
--- a/crates/nu_plugin_query/src/query_web.rs
+++ b/crates/nu_plugin_query/src/query_web.rs
@@ -81,7 +81,7 @@ pub fn web_examples() -> Vec<Example<'static>> {
             result: None
         },
         Example {
-            example: "http get https://www.nushell.sh | query web --query 'h2, h2 + p' | each {str join} | group 2 | each {rotate --ccw tagline description} | flatten",
+            example: "http get https://www.nushell.sh | query web --query 'h2, h2 + p' | each {str join} | chunks 2 | each {rotate --ccw tagline description} | flatten",
             description: "Pass multiple css selectors to extract several elements within single query, group the query results together and rotate them to create a table",
             result: None,
         },


### PR DESCRIPTION
# Description

A `query web` example uses the (soon to be deprecated) `group` command.  Updated it to use `chunks` replacement.

# User-Facing Changes

Help-only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A