### PR TITLE
fix: Make `log` respect `use_ansi_coloring` setting.

### DIFF
--- a/crates/nu-std/std/log.nu
+++ b/crates/nu-std/std/log.nu
@@ -282,7 +282,9 @@ export def custom [
         $level_prefix
     }
 
-    let ansi = if ($ansi | is-empty) {
+    let ansi = if not $env.config.use_ansi_coloring {
+        ""
+    } else if ($ansi | is-empty) {
         if ($log_level not-in $valid_levels_for_defaulting) {
             log-level-deduction-error "ansi" (metadata $log_level).span $log_level
         }

--- a/crates/nu-std/std/log.nu
+++ b/crates/nu-std/std/log.nu
@@ -282,7 +282,8 @@ export def custom [
         $level_prefix
     }
 
-    let ansi = if not $env.config.use_ansi_coloring {
+    let use_color = ($env | get config? | get use_ansi_coloring? | $in != false)
+    let ansi = if not $use_color {
         ""
     } else if ($ansi | is-empty) {
         if ($log_level not-in $valid_levels_for_defaulting) {

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -11,7 +11,7 @@ def create_left_prompt [] {
 
     let path_color = (if (is-admin) { ansi red_bold } else { ansi green_bold })
     let separator_color = (if (is-admin) { ansi light_red_bold } else { ansi light_green_bold })
-    let path_segment = $"($path_color)($dir)"
+    let path_segment = $"($path_color)($dir)(ansi reset)"
 
     $path_segment | str replace --all (char path_sep) $"($separator_color)(char path_sep)($path_color)"
 }


### PR DESCRIPTION
# Very briefly
Fixes: #13317 
- Ignore ansi coloring on logs if this setting is true.
- Add a reset after the default left prompt (before prompt character) which fixes all-red text when `use_ansi_coloring` is false.

# Description

## Firstly,
argumentation about the changes to `crates/nu-std/std/log.nu`

Previous behavior colored the output of all log, even when the setting `use_ansi_coloring` was false.
![image](https://github.com/user-attachments/assets/a82991c4-ff46-455d-8dac-248de2456d78)

Current behavior honors the setting.
![image](https://github.com/user-attachments/assets/6d5365db-e05d-4d2a-8981-f22303dff081)

## Second,
While testing different scenarios, I found out that the default setting on both (`0.95`, arch linux) and the source (`0.96`)  all text was displayed in red (the color used for the present-working-directory part of the prompt) after setting `use_ansi_coloring` to `false` ([comment with picture of the issue and reproduction steps](https://github.com/nushell/nushell/issues/13317#issuecomment-2247439894)). To which my response was adding a `(ansi reset)` at the end of the directory part of the prompt in the default config (`crates/nu-utils/src/sample_config/default_env.nu`) file. All later parts follow the `use_ansi_coloring` setting and their assigned colors.

# User-Facing Changes
I would say the color, but don't know if that counts as "user-facing".

# Tests + Formatting
- Formatting was applied as advised.
- 1314 tests passed and 24 ignored, none failed.
- Clippy  did not pass due to an error on the following files:
`crates/nu-protocol/src/engine/argument.rs:81:5` and `crates/nu-protocol/src/engine/error_handler.rs:19:5`
throwing the error `you should consider adding a 'Default' implementation for 'ErrorHandlerStack'`.
As those files are out of the scope of the current issue, they have **not** been changed.