### PR TITLE
Fix `$in` in range expressions

### DIFF
--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -432,7 +432,17 @@ impl Expression {
             Expr::Int(_) => {}
             Expr::Float(_) => {}
             Expr::Binary(_) => {}
-            Expr::Range(_) => {}
+            Expr::Range(range) => {
+                if let Some(from) = &mut range.from {
+                    from.replace_in_variable(working_set, new_var_id);
+                }
+                if let Some(next) = &mut range.next {
+                    next.replace_in_variable(working_set, new_var_id);
+                }
+                if let Some(to) = &mut range.to {
+                    to.replace_in_variable(working_set, new_var_id);
+                }
+            }
             Expr::Var(var_id) | Expr::VarDecl(var_id) => {
                 if *var_id == IN_VARIABLE_ID {
                     *var_id = new_var_id;

--- a/tests/repl/test_engine.rs
+++ b/tests/repl/test_engine.rs
@@ -77,7 +77,11 @@ fn in_used_twice_and_also_in_pipeline() -> TestResult {
 
 // #13441
 #[test]
-fn in_used_in_range() -> TestResult {
+fn in_used_in_range_from() -> TestResult {
+    run_test(r#"6 | $in..10 | math sum"#, "40")
+}
+#[test]
+fn in_used_in_range_to() -> TestResult {
     run_test(r#"6 | 3..$in | math sum"#, "18")
 }
 

--- a/tests/repl/test_engine.rs
+++ b/tests/repl/test_engine.rs
@@ -75,6 +75,12 @@ fn in_used_twice_and_also_in_pipeline() -> TestResult {
     )
 }
 
+// #13441
+#[test]
+fn in_used_in_range() -> TestResult {
+    run_test(r#"6 | 3..$in | math sum"#, "18")
+}
+
 #[test]
 fn help_works_with_missing_requirements() -> TestResult {
     run_test(r#"each --help | lines | length"#, "72")


### PR DESCRIPTION
# Description

Fixes #13441.

I must have forgotten that `Expr::Range` can contain other expressions, so I wasn't searching for `$in` to replace within it. Easy fix.

# User-Facing Changes
Bug fix, ranges like `6 | 3..$in` work as expected now.

# Tests + Formatting
Added regression test.
