### PR TITLE
Fix `keybindings list` being empty by default

### DIFF
--- a/crates/nu-cli/src/commands/keybindings_list.rs
+++ b/crates/nu-cli/src/commands/keybindings_list.rs
@@ -61,10 +61,12 @@ impl Command for KeybindingsList {
             .map(|option| call.has_flag(engine_state, stack, option))
             .collect::<Result<Vec<_>, ShellError>>()?;
 
+        let no_option_specified = presence.iter().all(|present| !*present);
+
         let records = all_options
             .iter()
             .zip(presence)
-            .filter(|(_, present)| *present)
+            .filter(|(_, present)| no_option_specified || *present)
             .flat_map(|(option, _)| get_records(option, call.head))
             .collect();
 

--- a/crates/nu-cli/tests/commands/keybindings_list.rs
+++ b/crates/nu-cli/tests/commands/keybindings_list.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn not_empty() {
+    let result = nu!("keybindings list | is-not-empty");
+    assert_eq!(result.out, "true");
+}

--- a/crates/nu-cli/tests/commands/mod.rs
+++ b/crates/nu-cli/tests/commands/mod.rs
@@ -1,1 +1,2 @@
+mod keybindings_list;
 mod nu_highlight;


### PR DESCRIPTION
# Description

Made a mistake when fixing this for IR. The default behavior with no options set is to list everything. Restored that.

This should go in the 0.96.1 patch release.

# Tests + Formatting
Added regression test.

