### PR TITLE
bump rust-toolchain to 1.78

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -198,7 +198,7 @@ pub fn redirect_env(engine_state: &EngineState, caller_stack: &mut Stack, callee
     }
 
     // set config to callee config, to capture any updates to that
-    caller_stack.config = callee_stack.config.clone();
+    caller_stack.config.clone_from(&callee_stack.config)
 }
 
 fn eval_external(

--- a/crates/nu-protocol/src/engine/argument.rs
+++ b/crates/nu-protocol/src/engine/argument.rs
@@ -71,7 +71,7 @@ impl Argument {
 }
 
 /// Stores the argument context for calls in IR evaluation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ArgumentStack {
     arguments: Vec<Argument>,
 }

--- a/crates/nu-protocol/src/engine/error_handler.rs
+++ b/crates/nu-protocol/src/engine/error_handler.rs
@@ -10,7 +10,7 @@ pub struct ErrorHandler {
 }
 
 /// Keeps track of error handlers pushed during evaluation of an IR block.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ErrorHandlerStack {
     handlers: Vec<ErrorHandler>,
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,4 +16,4 @@ profile = "default"
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 4 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.77.2"
+channel = "1.78.0"


### PR DESCRIPTION
# Description

Following the 1.80 rust release, this PR bumps our nushell rust-toolchain.toml to 1.78 as per our process.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
