### PR TITLE
don't force stripping ansi codes from strings in `stor`

### DIFF
--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -424,11 +424,7 @@ pub fn value_to_sql(value: Value) -> Result<Box<dyn rusqlite::ToSql>, ShellError
         Value::Filesize { val, .. } => Box::new(val),
         Value::Duration { val, .. } => Box::new(val),
         Value::Date { val, .. } => Box::new(val),
-        Value::String { val, .. } => {
-            // don't store ansi escape sequences in the database
-            // escape single quotes
-            Box::new(nu_utils::strip_ansi_unlikely(&val).into_owned())
-        }
+        Value::String { val, .. } => Box::new(val),
         Value::Binary { val, .. } => Box::new(val),
         Value::Nothing { .. } => Box::new(rusqlite::types::Null),
         val => {


### PR DESCRIPTION
# Description

The current version of `stor` forces stripping ansi code coloring from all the strings.
In this PR, I propose to keep strings unchanged.

The logic behind the proposed changes was best described in the [discord](https://discord.com/channels/601130461678272522/601130461678272524/1266387441074442272):
<img width="773" alt="image" src="https://github.com/user-attachments/assets/063cdebd-684f-46f1-aca1-faeb4827723d">

with proposed changes we can store colored output:
```
stor reset; stor create --table-name test --columns {a: str};
ls | table | {a: $in} | stor insert --table-name test | null;
stor open | query db 'select a from test' | get a.0 
```

<img width="704" alt="image" src="https://github.com/user-attachments/assets/8f062808-18fc-498b-a77e-a118f6b9953a">


# User-Facing Changes

If one was using `stor` together with ansi colored input, and then was querying `stor` with search operations, they might break. But I don't think that it is a big problem, as one will just need to use `ansi reset` before storing data.

# Tests + Formatting

Tests are okay.

Thanks to @fdncred for spending time to help me write these changes 🙏