### PR TITLE
show file name in error messages instead of "main"

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -1,4 +1,4 @@
-use crate::util::eval_source;
+use crate::util::{eval_source, evaluate_block_with_exit_code, make_main_call};
 use log::{info, trace};
 use nu_engine::{convert_env_values, eval_block};
 use nu_parser::parse;
@@ -126,11 +126,17 @@ pub fn evaluate_file(
 
         // Invoke the main command with arguments.
         // Arguments with whitespaces are quoted, thus can be safely concatenated by whitespace.
-        let args = format!("main {}", args.join(" "));
-        eval_source(
+        let main_call_block = make_main_call(
+            engine_state,
+            source_filename.to_string_lossy().to_string(),
+            args,
+            true,
+        )?;
+
+        evaluate_block_with_exit_code(
             engine_state,
             stack,
-            args.as_bytes(),
+            main_call_block,
             "<commandline>",
             input,
             true,

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -126,12 +126,14 @@ pub fn evaluate_file(
 
         // Invoke the main command with arguments.
         // Arguments with whitespaces are quoted, thus can be safely concatenated by whitespace.
+        let mut working_set = StateWorkingSet::new(engine_state);
         let main_call_block = make_main_call(
-            engine_state,
+            &mut working_set,
             source_filename.to_string_lossy().to_string(),
             args,
             true,
         )?;
+        engine_state.merge_delta(working_set.delta)?;
 
         evaluate_block_with_exit_code(
             engine_state,

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -1,15 +1,20 @@
 use nu_cmd_base::hook::eval_hook;
 use nu_engine::{eval_block, eval_block_with_early_return};
-use nu_parser::{escape_quote_string, lex, parse, unescape_unquote_string, Token, TokenContents};
+use nu_parser::{
+    escape_quote_string, find_longest_command, lex, lite_parse, parse, parse_internal_call,
+    unescape_unquote_string, Token, TokenContents,
+};
+use nu_protocol::ast::{Block, Expr, Expression, Pipeline};
 use nu_protocol::{
     debugger::WithoutDebug,
     engine::{EngineState, Stack, StateWorkingSet},
-    report_error, report_error_new, PipelineData, ShellError, Span, Value,
+    report_error, report_error_new, PipelineData, ShellError, Signature, Span, Value,
 };
 #[cfg(windows)]
 use nu_utils::enable_vt_processing;
 use nu_utils::perf;
 use std::path::Path;
+use std::sync::Arc;
 
 // This will collect environment variables from std::env and adds them to a stack.
 //
@@ -199,17 +204,126 @@ fn gather_env_vars(
     }
 }
 
-pub fn eval_source(
+pub fn make_main_call(
+    engine_state: &mut EngineState,
+    fname: String,
+    args: &[String],
+    redirect_env: bool,
+) -> Result<Arc<Block>, ShellError> {
+    let mut working_set = StateWorkingSet::new(engine_state);
+    let source = format!("{} {}", fname, args.join(" "));
+    let source = source.as_bytes();
+    let file_id = working_set.add_file("<commandline>".to_string(), source);
+    let file_span = working_set.get_span_for_file(file_id);
+    let (tokens, err) = lex(source, file_span.start, &[], &[], false);
+    if let Some(err) = err {
+        working_set.error(err)
+    }
+    let (lite_block, err) = lite_parse(tokens.as_slice());
+    if let Some(err) = err {
+        working_set.error(err);
+    }
+    let lite_command = &lite_block.block[0].commands[0];
+
+    let (decl_id, command_len) =
+        find_longest_command(&working_set, b"main", &lite_command.parts[1..])
+            .expect("already checked that a main def exists");
+
+    let parsed_call = parse_internal_call(
+        &mut working_set,
+        Span::concat(&lite_command.parts[..command_len + 1]),
+        &lite_command.parts[(command_len + 1)..],
+        decl_id,
+    );
+
+    let expression = Expression::new(
+        &mut working_set,
+        Expr::Call(parsed_call.call),
+        Span::concat(lite_command.parts.as_slice()),
+        parsed_call.output,
+    );
+
+    if let Some(warning) = working_set.parse_warnings.first() {
+        report_error(&working_set, warning);
+    }
+
+    // If any parse errors were found, report the first error and exit.
+    if let Some(err) = working_set.parse_errors.first() {
+        report_error(&working_set, err);
+        std::process::exit(1);
+    }
+
+    if let Some(err) = working_set.compile_errors.first() {
+        report_error(&working_set, err);
+        // Not a fatal error, for now
+    }
+
+    let mut block = Block {
+        signature: Box::new(Signature::new("")),
+        pipelines: vec![Pipeline::from_vec(vec![expression])],
+        captures: vec![],
+        redirect_env,
+        ir_block: None,
+        span: Some(file_span),
+    };
+
+    match nu_engine::compile(&working_set, &block) {
+        Ok(ir_block) => {
+            block.ir_block = Some(ir_block);
+        }
+        Err(err) => working_set.compile_errors.push(err),
+    }
+
+    engine_state.merge_delta(working_set.delta)?;
+
+    Ok(Arc::new(block))
+}
+
+pub fn evaluate_block(
     engine_state: &mut EngineState,
     stack: &mut Stack,
-    source: &[u8],
+    block: Arc<Block>,
+    input: PipelineData,
+    allow_return: bool,
+) -> Result<Option<i32>, ShellError> {
+    let pipeline = if allow_return {
+        eval_block_with_early_return::<WithoutDebug>(engine_state, stack, &block, input)
+    } else {
+        eval_block::<WithoutDebug>(engine_state, stack, &block, input)
+    }?;
+
+    let status = if let PipelineData::ByteStream(..) = pipeline {
+        pipeline.print(engine_state, stack, false, false)?
+    } else {
+        if let Some(hook) = engine_state.get_config().hooks.display_output.clone() {
+            let pipeline = eval_hook(
+                engine_state,
+                stack,
+                Some(pipeline),
+                vec![],
+                &hook,
+                "display_output",
+            )?;
+            pipeline.print(engine_state, stack, false, false)
+        } else {
+            pipeline.print(engine_state, stack, true, false)
+        }?
+    };
+
+    Ok(status.map(|status| status.code()))
+}
+
+pub fn evaluate_block_with_exit_code(
+    engine_state: &mut EngineState,
+    stack: &mut Stack,
+    block: Arc<Block>,
     fname: &str,
     input: PipelineData,
     allow_return: bool,
 ) -> i32 {
     let start_time = std::time::Instant::now();
 
-    let exit_code = match evaluate_source(engine_state, stack, source, fname, input, allow_return) {
+    let exit_code = match evaluate_block(engine_state, stack, block, input, allow_return) {
         Ok(code) => code.unwrap_or(0),
         Err(err) => {
             report_error_new(engine_state, &err);
@@ -237,14 +351,16 @@ pub fn eval_source(
     exit_code
 }
 
-fn evaluate_source(
+pub fn eval_source(
     engine_state: &mut EngineState,
     stack: &mut Stack,
     source: &[u8],
     fname: &str,
     input: PipelineData,
     allow_return: bool,
-) -> Result<Option<i32>, ShellError> {
+) -> i32 {
+    let start_time = std::time::Instant::now();
+
     let (block, delta) = {
         let mut working_set = StateWorkingSet::new(engine_state);
         let output = parse(
@@ -259,7 +375,7 @@ fn evaluate_source(
 
         if let Some(err) = working_set.parse_errors.first() {
             report_error(&working_set, err);
-            return Ok(Some(1));
+            return 1;
         }
 
         if let Some(err) = working_set.compile_errors.first() {
@@ -270,33 +386,19 @@ fn evaluate_source(
         (output, working_set.render())
     };
 
-    engine_state.merge_delta(delta)?;
+    if let Err(err) = engine_state.merge_delta(delta) {
+        report_error_new(engine_state, &err);
+        return 1;
+    }
 
-    let pipeline = if allow_return {
-        eval_block_with_early_return::<WithoutDebug>(engine_state, stack, &block, input)
-    } else {
-        eval_block::<WithoutDebug>(engine_state, stack, &block, input)
-    }?;
-
-    let status = if let PipelineData::ByteStream(..) = pipeline {
-        pipeline.print(engine_state, stack, false, false)?
-    } else {
-        if let Some(hook) = engine_state.get_config().hooks.display_output.clone() {
-            let pipeline = eval_hook(
-                engine_state,
-                stack,
-                Some(pipeline),
-                vec![],
-                &hook,
-                "display_output",
-            )?;
-            pipeline.print(engine_state, stack, false, false)
-        } else {
-            pipeline.print(engine_state, stack, true, false)
-        }?
-    };
-
-    Ok(status.map(|status| status.code()))
+    let exit_code =
+        evaluate_block_with_exit_code(engine_state, stack, block, fname, input, allow_return);
+    perf!(
+        &format!("eval_source {}", &fname),
+        start_time,
+        engine_state.get_config().use_ansi_coloring
+    );
+    exit_code
 }
 
 #[cfg(test)]

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -22,6 +22,7 @@ pub use nu_protocol::parser_path::*;
 pub use parse_keywords::*;
 
 pub use parser::{
-    is_math_expression_like, parse, parse_block, parse_expression, parse_external_call,
-    parse_unit_value, trim_quotes, trim_quotes_str, unescape_unquote_string, DURATION_UNIT_GROUPS,
+    find_longest_command, is_math_expression_like, parse, parse_block, parse_expression,
+    parse_external_call, parse_internal_call, parse_unit_value, trim_quotes, trim_quotes_str,
+    unescape_unquote_string, DURATION_UNIT_GROUPS,
 };

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -325,6 +325,43 @@ fn main_script_can_have_subcommands2() {
 }
 
 #[test]
+fn main_script_use_filename_in_error() {
+    Playground::setup("main_filename", |dirs, sandbox| {
+        sandbox.mkdir("main_filename");
+        sandbox.with_files(&[FileWithContent(
+            "script.nu",
+            r#"def main [--foo: string] {
+                print foo
+            }"#,
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), pipeline("nu script.nu --foo"));
+
+        assert!(actual.err.contains("script.nu --foo"));
+        assert!(!actual.err.contains("main --foo"));
+    })
+}
+
+#[test]
+fn main_script_subcommand_use_filename_in_error() {
+    Playground::setup("main_filename", |dirs, sandbox| {
+        sandbox.mkdir("main_filename");
+        sandbox.with_files(&[FileWithContent(
+            "script.nu",
+            r#"def main [] {}
+            def 'main asdf' [--foo: string] {
+                print foo
+            }"#,
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), pipeline("nu script.nu asdf --foo"));
+
+        assert!(actual.err.contains("script.nu asdf --foo"));
+        assert!(!actual.err.contains("main asdf --foo"));
+    })
+}
+
+#[test]
 fn source_empty_file() {
     Playground::setup("source_empty_file", |dirs, sandbox| {
         sandbox.mkdir("source_empty_file");


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes. 

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR changes the way main defs in scripts are called, so that error messages show the source as `<scriptname> ...` rather than `main ...`. This fixes #10191. I had to refactor `parse_internal_command` a bit to avoid duplicating a bunch of code, and I'm not super happy with how it looks now but can't think of a better way. 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
