### PR TITLE
Allow calling main subcommands without defining main

### DIFF
--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -22,6 +22,7 @@ pub use nu_protocol::parser_path::*;
 pub use parse_keywords::*;
 
 pub use parser::{
-    is_math_expression_like, parse, parse_block, parse_expression, parse_external_call,
-    parse_unit_value, trim_quotes, trim_quotes_str, unescape_unquote_string, DURATION_UNIT_GROUPS,
+    find_longest_command, is_math_expression_like, parse, parse_block, parse_expression,
+    parse_external_call, parse_internal_call, parse_unit_value, trim_quotes, trim_quotes_str,
+    unescape_unquote_string, DURATION_UNIT_GROUPS,
 };

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -325,6 +325,60 @@ fn main_script_can_have_subcommands2() {
 }
 
 #[test]
+fn main_script_can_have_subcommands3() {
+    Playground::setup("main_subcommands", |dirs, sandbox| {
+        sandbox.mkdir("main_subcommands");
+        sandbox.with_files(&[FileWithContent(
+            "script.nu",
+            r#"def "main foo" [x: int] {
+                    print ($x + 100)
+                  }"#,
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), pipeline("nu script.nu foo 23"));
+
+        assert!(actual.out.eq("123"));
+    })
+}
+
+#[test]
+fn main_script_use_filename_in_error() {
+    Playground::setup("main_filename", |dirs, sandbox| {
+        sandbox.mkdir("main_filename");
+        sandbox.with_files(&[FileWithContent(
+            "script.nu",
+            r#"def main [--foo: string] {
+                print foo
+            }"#,
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), pipeline("nu script.nu --foo"));
+
+        assert!(actual.err.contains("script.nu --foo"));
+        assert!(!actual.err.contains("main --foo"));
+    })
+}
+
+#[test]
+fn main_script_subcommand_use_filename_in_error() {
+    Playground::setup("main_filename", |dirs, sandbox| {
+        sandbox.mkdir("main_filename");
+        sandbox.with_files(&[FileWithContent(
+            "script.nu",
+            r#"def main [] {}
+            def 'main asdf' [--foo: string] {
+                print foo
+            }"#,
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), pipeline("nu script.nu asdf --foo"));
+
+        assert!(actual.err.contains("script.nu asdf --foo"));
+        assert!(!actual.err.contains("main asdf --foo"));
+    })
+}
+
+#[test]
 fn source_empty_file() {
     Playground::setup("source_empty_file", |dirs, sandbox| {
         sandbox.mkdir("source_empty_file");


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
At the moment, calling a script with a subcommand is only possible when main is defined. I.e. the following code does not work:
```
def 'main foo' [] {
    print 'hello from main foo'
}
```
When calling the above script with the argument `main`, it will just do nothing, because the code for calling main only runs when main itself is defined, even when a subcommand is called. 
This PR changes the way script calling works quite a bit and has overlap with #13445 in that regard.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
