### PR TITLE
Clean up arguments added to stack after `CallDecl` engine call

### DIFF
--- a/crates/nu-plugin-engine/src/context.rs
+++ b/crates/nu-plugin-engine/src/context.rs
@@ -257,12 +257,9 @@ impl<'a> PluginExecutionContext for PluginExecutionCommandContext<'a> {
             }
         }
 
-        decl.run(
-            &self.engine_state,
-            stack,
-            &(&call_builder.finish()).into(),
-            input,
-        )
+        call_builder.with(stack, |stack, call| {
+            decl.run(&self.engine_state, stack, call, input)
+        })
     }
 
     fn boxed(&self) -> Box<dyn PluginExecutionContext + 'static> {


### PR DESCRIPTION
# Description

Just realized I hadn't been cleaning up the arguments added to the `Stack` after the `CallDecl` engine call was finished, so there could be a bit of a memory leak if a plugin made many calls during the duration of a single plugin call. This is a quick patch to that.

I'm probably going to revise how this all works at some point soon because I think it is a bit of a pitfall. It would be good to make it much more difficult to make a mistake with it, perhaps with a guard like Ian did for the redirection stuff.

# After Submitting
- [ ] release with 0.96.1
