### PR TITLE
bump nushell to 0.96.2 for patch release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "nu"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "assert_cmd",
  "crossterm",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cli"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "chrono",
  "crossterm",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-base"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "indexmap",
  "miette",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-extra"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "fancy-regex",
  "heck 0.5.0",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-lang"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "itertools 0.12.1",
  "nu-engine",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-plugin"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "itertools 0.12.1",
  "nu-engine",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "nu-color-config"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "nu-ansi-term",
  "nu-engine",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "nu-command"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "alphanumeric-sort",
  "base64 0.22.1",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "nu-derive-value"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "convert_case",
  "proc-macro-error",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "log",
  "nu-glob",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "nu-explore"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "ansi-str",
  "anyhow",
@@ -3186,14 +3186,14 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "doc-comment",
 ]
 
 [[package]]
 name = "nu-json"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "fancy-regex",
  "linked-hash-map",
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "nu-lsp"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "assert-json-diff",
  "crossbeam-channel",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "nu-parser"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "bytesize",
  "chrono",
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "dirs",
  "omnipath",
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "log",
  "nix",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-core"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "interprocess",
  "log",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-engine"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "log",
  "nu-engine",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-protocol"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "bincode",
  "nu-protocol",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-test-support"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "nu-ansi-term",
  "nu-cmd-lang",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "nu-pretty-hex"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "heapless",
  "nu-ansi-term",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "brotli",
  "byte-unit",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "nu-std"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "log",
  "miette",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "chrono",
  "itertools 0.12.1",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "nu-table"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "fancy-regex",
  "nu-ansi-term",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "nu-term-grid"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "nu-utils",
  "unicode-width",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "nu-test-support"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "nu-glob",
  "nu-path",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_example"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "nu-cmd-lang",
  "nu-plugin",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_formats"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "eml-parser",
  "ical",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_gstat"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "git2",
  "nu-plugin",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_inc"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_polars"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "chrono",
  "chrono-tz 0.9.0",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_query"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "gjson",
  "nu-plugin",
@@ -3553,7 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_stress_internals"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "interprocess",
  "serde",
@@ -3679,7 +3679,7 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nuon"
-version = "0.96.1"
+version = "0.96.2"
 dependencies = [
  "chrono",
  "fancy-regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
 rust-version = "1.77.2"
-version = "0.96.1"
+version = "0.96.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -183,22 +183,22 @@ windows-sys = "0.48"
 winreg = "0.52"
 
 [dependencies]
-nu-cli = { path = "./crates/nu-cli", version = "0.96.1" }
-nu-cmd-base = { path = "./crates/nu-cmd-base", version = "0.96.1" }
-nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.96.1" }
-nu-cmd-plugin = { path = "./crates/nu-cmd-plugin", version = "0.96.1", optional = true }
-nu-cmd-extra = { path = "./crates/nu-cmd-extra", version = "0.96.1" }
-nu-command = { path = "./crates/nu-command", version = "0.96.1" }
-nu-engine = { path = "./crates/nu-engine", version = "0.96.1" }
-nu-explore = { path = "./crates/nu-explore", version = "0.96.1" }
-nu-lsp = { path = "./crates/nu-lsp/", version = "0.96.1" }
-nu-parser = { path = "./crates/nu-parser", version = "0.96.1" }
-nu-path = { path = "./crates/nu-path", version = "0.96.1" }
-nu-plugin-engine = { path = "./crates/nu-plugin-engine", optional = true, version = "0.96.1" }
-nu-protocol = { path = "./crates/nu-protocol", version = "0.96.1" }
-nu-std = { path = "./crates/nu-std", version = "0.96.1" }
-nu-system = { path = "./crates/nu-system", version = "0.96.1" }
-nu-utils = { path = "./crates/nu-utils", version = "0.96.1" }
+nu-cli = { path = "./crates/nu-cli", version = "0.96.2" }
+nu-cmd-base = { path = "./crates/nu-cmd-base", version = "0.96.2" }
+nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.96.2" }
+nu-cmd-plugin = { path = "./crates/nu-cmd-plugin", version = "0.96.2", optional = true }
+nu-cmd-extra = { path = "./crates/nu-cmd-extra", version = "0.96.2" }
+nu-command = { path = "./crates/nu-command", version = "0.96.2" }
+nu-engine = { path = "./crates/nu-engine", version = "0.96.2" }
+nu-explore = { path = "./crates/nu-explore", version = "0.96.2" }
+nu-lsp = { path = "./crates/nu-lsp/", version = "0.96.2" }
+nu-parser = { path = "./crates/nu-parser", version = "0.96.2" }
+nu-path = { path = "./crates/nu-path", version = "0.96.2" }
+nu-plugin-engine = { path = "./crates/nu-plugin-engine", optional = true, version = "0.96.2" }
+nu-protocol = { path = "./crates/nu-protocol", version = "0.96.2" }
+nu-std = { path = "./crates/nu-std", version = "0.96.2" }
+nu-system = { path = "./crates/nu-system", version = "0.96.2" }
+nu-utils = { path = "./crates/nu-utils", version = "0.96.2" }
 reedline = { workspace = true, features = ["bashisms", "sqlite"] }
 
 crossterm = { workspace = true }
@@ -227,9 +227,9 @@ nix = { workspace = true, default-features = false, features = [
 ] }
 
 [dev-dependencies]
-nu-test-support = { path = "./crates/nu-test-support", version = "0.96.1" }
-nu-plugin-protocol = { path = "./crates/nu-plugin-protocol", version = "0.96.1" }
-nu-plugin-core = { path = "./crates/nu-plugin-core", version = "0.96.1" }
+nu-test-support = { path = "./crates/nu-test-support", version = "0.96.2" }
+nu-plugin-protocol = { path = "./crates/nu-plugin-protocol", version = "0.96.2" }
+nu-plugin-core = { path = "./crates/nu-plugin-core", version = "0.96.2" }
 assert_cmd = "2.0"
 dirs = { workspace = true }
 tango-bench = "0.5"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -5,27 +5,27 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cli"
 edition = "2021"
 license = "MIT"
 name = "nu-cli"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 bench = false
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.1" }
-nu-command = { path = "../nu-command", version = "0.96.1" }
-nu-test-support = { path = "../nu-test-support", version = "0.96.1" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.2" }
+nu-command = { path = "../nu-command", version = "0.96.2" }
+nu-test-support = { path = "../nu-test-support", version = "0.96.2" }
 rstest = { workspace = true, default-features = false }
 tempfile = { workspace = true }
 
 [dependencies]
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.96.1" }
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-path = { path = "../nu-path", version = "0.96.1" }
-nu-parser = { path = "../nu-parser", version = "0.96.1" }
-nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.96.1", optional = true }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.96.1" }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.96.2" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-path = { path = "../nu-path", version = "0.96.2" }
+nu-parser = { path = "../nu-parser", version = "0.96.2" }
+nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.96.2", optional = true }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
+nu-color-config = { path = "../nu-color-config", version = "0.96.2" }
 nu-ansi-term = { workspace = true }
 reedline = { workspace = true, features = ["bashisms", "sqlite"] }
 

--- a/crates/nu-cmd-base/Cargo.toml
+++ b/crates/nu-cmd-base/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 license = "MIT"
 name = "nu-cmd-base"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-base"
-version = "0.96.1"
+version = "0.96.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-parser = { path = "../nu-parser", version = "0.96.1" }
-nu-path = { path = "../nu-path", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-parser = { path = "../nu-parser", version = "0.96.2" }
+nu-path = { path = "../nu-path", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
 
 indexmap = { workspace = true }
 miette = { workspace = true }

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-cmd-extra"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-extra"
-version = "0.96.1"
+version = "0.96.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,13 +13,13 @@ version = "0.96.1"
 bench = false
 
 [dependencies]
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.96.1" }
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-json = { version = "0.96.1", path = "../nu-json" }
-nu-parser = { path = "../nu-parser", version = "0.96.1" }
-nu-pretty-hex = { version = "0.96.1", path = "../nu-pretty-hex" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.96.2" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-json = { version = "0.96.2", path = "../nu-json" }
+nu-parser = { path = "../nu-parser", version = "0.96.2" }
+nu-pretty-hex = { version = "0.96.2", path = "../nu-pretty-hex" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
 
 # Potential dependencies for extras
 heck = { workspace = true }
@@ -33,6 +33,6 @@ v_htmlescape = { workspace = true }
 itertools = { workspace = true }
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.1" }
-nu-command = { path = "../nu-command", version = "0.96.1" }
-nu-test-support = { path = "../nu-test-support", version = "0.96.1" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.2" }
+nu-command = { path = "../nu-command", version = "0.96.2" }
+nu-test-support = { path = "../nu-test-support", version = "0.96.2" }

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -6,16 +6,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-lang"
 edition = "2021"
 license = "MIT"
 name = "nu-cmd-lang"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-parser = { path = "../nu-parser", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-parser = { path = "../nu-parser", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
 
 itertools = { workspace = true }
 shadow-rs = { version = "0.29", default-features = false }

--- a/crates/nu-cmd-plugin/Cargo.toml
+++ b/crates/nu-cmd-plugin/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 license = "MIT"
 name = "nu-cmd-plugin"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-plugin"
-version = "0.96.1"
+version = "0.96.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-path = { path = "../nu-path", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1", features = ["plugin"] }
-nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.96.1" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-path = { path = "../nu-path", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2", features = ["plugin"] }
+nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.96.2" }
 
 itertools = { workspace = true }
 

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -5,18 +5,18 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-color-confi
 edition = "2021"
 license = "MIT"
 name = "nu-color-config"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-json = { path = "../nu-json", version = "0.96.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-json = { path = "../nu-json", version = "0.96.2" }
 nu-ansi-term = { workspace = true }
 
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.96.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.96.2" }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-command"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-command"
-version = "0.96.1"
+version = "0.96.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,21 +13,21 @@ version = "0.96.1"
 bench = false
 
 [dependencies]
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.96.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.96.1" }
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-glob = { path = "../nu-glob", version = "0.96.1" }
-nu-json = { path = "../nu-json", version = "0.96.1" }
-nu-parser = { path = "../nu-parser", version = "0.96.1" }
-nu-path = { path = "../nu-path", version = "0.96.1" }
-nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
-nu-system = { path = "../nu-system", version = "0.96.1" }
-nu-table = { path = "../nu-table", version = "0.96.1" }
-nu-term-grid = { path = "../nu-term-grid", version = "0.96.1" }
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.96.2" }
+nu-color-config = { path = "../nu-color-config", version = "0.96.2" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-glob = { path = "../nu-glob", version = "0.96.2" }
+nu-json = { path = "../nu-json", version = "0.96.2" }
+nu-parser = { path = "../nu-parser", version = "0.96.2" }
+nu-path = { path = "../nu-path", version = "0.96.2" }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
+nu-system = { path = "../nu-system", version = "0.96.2" }
+nu-table = { path = "../nu-table", version = "0.96.2" }
+nu-term-grid = { path = "../nu-term-grid", version = "0.96.2" }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
 nu-ansi-term = { workspace = true }
-nuon = { path = "../nuon", version = "0.96.1" }
+nuon = { path = "../nuon", version = "0.96.2" }
 
 alphanumeric-sort = { workspace = true }
 base64 = { workspace = true }
@@ -137,8 +137,8 @@ sqlite = ["rusqlite"]
 trash-support = ["trash"]
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.1" }
-nu-test-support = { path = "../nu-test-support", version = "0.96.1" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.2" }
+nu-test-support = { path = "../nu-test-support", version = "0.96.2" }
 
 dirs = { workspace = true }
 mockito = { workspace = true, default-features = false }

--- a/crates/nu-derive-value/Cargo.toml
+++ b/crates/nu-derive-value/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-derive-value"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-derive-value"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 proc-macro = true

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-engine"
 edition = "2021"
 license = "MIT"
 name = "nu-engine"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.96.1" }
-nu-path = { path = "../nu-path", version = "0.96.1" }
-nu-glob = { path = "../nu-glob", version = "0.96.1" }
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
+nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.96.2" }
+nu-path = { path = "../nu-path", version = "0.96.2" }
+nu-glob = { path = "../nu-glob", version = "0.96.2" }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
 log = { workspace = true }
 
 [features]

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -5,21 +5,21 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-explore"
 edition = "2021"
 license = "MIT"
 name = "nu-explore"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
-nu-parser = { path = "../nu-parser", version = "0.96.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.96.1" }
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-table = { path = "../nu-table", version = "0.96.1" }
-nu-json = { path = "../nu-json", version = "0.96.1" }
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
+nu-parser = { path = "../nu-parser", version = "0.96.2" }
+nu-color-config = { path = "../nu-color-config", version = "0.96.2" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-table = { path = "../nu-table", version = "0.96.2" }
+nu-json = { path = "../nu-json", version = "0.96.2" }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
 nu-ansi-term = { workspace = true }
-nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.96.1" }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.96.2" }
 
 anyhow = { workspace = true }
 log = { workspace = true }

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-glob"
-version = "0.96.1"
+version = "0.96.2"
 authors = ["The Nushell Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 description = """

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-json"
 edition = "2021"
 license = "MIT"
 name = "nu-json"
-version = "0.96.1"
+version = "0.96.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -26,7 +26,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.96.1" }
-nu-path = { path = "../nu-path", version = "0.96.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.96.2" }
+nu-path = { path = "../nu-path", version = "0.96.2" }
 serde_json = "1.0"
 fancy-regex = "0.13.0"

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -3,14 +3,14 @@ authors = ["The Nushell Project Developers"]
 description = "Nushell's integrated LSP server"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-lsp"
 name = "nu-lsp"
-version = "0.96.1"
+version = "0.96.2"
 edition = "2021"
 license = "MIT"
 
 [dependencies]
-nu-cli = { path = "../nu-cli", version = "0.96.1" }
-nu-parser = { path = "../nu-parser", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
+nu-cli = { path = "../nu-cli", version = "0.96.2" }
+nu-parser = { path = "../nu-parser", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
 
 reedline = { workspace = true }
 
@@ -23,8 +23,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.1" }
-nu-command = { path = "../nu-command", version = "0.96.1" }
-nu-test-support = { path = "../nu-test-support", version = "0.96.1" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.2" }
+nu-command = { path = "../nu-command", version = "0.96.2" }
+nu-test-support = { path = "../nu-test-support", version = "0.96.2" }
 
 assert-json-diff = "2.0"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -5,17 +5,17 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-parser"
 edition = "2021"
 license = "MIT"
 name = "nu-parser"
-version = "0.96.1"
+version = "0.96.2"
 exclude = ["/fuzz"]
 
 [lib]
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-path = { path = "../nu-path", version = "0.96.1" }
-nu-plugin-engine = { path = "../nu-plugin-engine", optional = true, version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-path = { path = "../nu-path", version = "0.96.2" }
+nu-plugin-engine = { path = "../nu-plugin-engine", optional = true, version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
 
 bytesize = { workspace = true }
 chrono = { default-features = false, features = ['std'], workspace = true }

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-path"
 edition = "2021"
 license = "MIT"
 name = "nu-path"
-version = "0.96.1"
+version = "0.96.2"
 exclude = ["/fuzz"]
 
 [lib]

--- a/crates/nu-plugin-core/Cargo.toml
+++ b/crates/nu-plugin-core/Cargo.toml
@@ -5,14 +5,14 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-plugin-core
 edition = "2021"
 license = "MIT"
 name = "nu-plugin-core"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
-nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.96.1", default-features = false }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
+nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.96.2", default-features = false }
 
 rmp-serde = { workspace = true }
 serde = { workspace = true }

--- a/crates/nu-plugin-engine/Cargo.toml
+++ b/crates/nu-plugin-engine/Cargo.toml
@@ -5,18 +5,18 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-plugin-engi
 edition = "2021"
 license = "MIT"
 name = "nu-plugin-engine"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
-nu-system = { path = "../nu-system", version = "0.96.1" }
-nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.96.1" }
-nu-plugin-core = { path = "../nu-plugin-core", version = "0.96.1", default-features = false }
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
+nu-system = { path = "../nu-system", version = "0.96.2" }
+nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.96.2" }
+nu-plugin-core = { path = "../nu-plugin-core", version = "0.96.2", default-features = false }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
 
 serde = { workspace = true }
 log = { workspace = true }

--- a/crates/nu-plugin-protocol/Cargo.toml
+++ b/crates/nu-plugin-protocol/Cargo.toml
@@ -5,14 +5,14 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-plugin-prot
 edition = "2021"
 license = "MIT"
 name = "nu-plugin-protocol"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.96.1", features = ["plugin"] }
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2", features = ["plugin"] }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
 
 bincode = "1.3"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/nu-plugin-test-support/Cargo.toml
+++ b/crates/nu-plugin-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-plugin-test-support"
-version = "0.96.1"
+version = "0.96.2"
 edition = "2021"
 license = "MIT"
 description = "Testing support for Nushell plugins"
@@ -12,14 +12,14 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.96.1", features = ["plugin"] }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1", features = ["plugin"] }
-nu-parser = { path = "../nu-parser", version = "0.96.1", features = ["plugin"] }
-nu-plugin = { path = "../nu-plugin", version = "0.96.1" }
-nu-plugin-core = { path = "../nu-plugin-core", version = "0.96.1" }
-nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.96.1" }
-nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.96.1" }
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.1" }
+nu-engine = { path = "../nu-engine", version = "0.96.2", features = ["plugin"] }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2", features = ["plugin"] }
+nu-parser = { path = "../nu-parser", version = "0.96.2", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.96.2" }
+nu-plugin-core = { path = "../nu-plugin-core", version = "0.96.2" }
+nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.96.2" }
+nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.96.2" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.2" }
 nu-ansi-term = { workspace = true }
 similar = "2.5"
 

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -5,17 +5,17 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-plugin"
 edition = "2021"
 license = "MIT"
 name = "nu-plugin"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
-nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.96.1" }
-nu-plugin-core = { path = "../nu-plugin-core", version = "0.96.1", default-features = false }
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
+nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.96.2" }
+nu-plugin-core = { path = "../nu-plugin-core", version = "0.96.2", default-features = false }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
 
 log = { workspace = true }
 thiserror = "1.0"

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-pretty-hex"
 edition = "2021"
 license = "MIT"
 name = "nu-pretty-hex"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 doctest = false

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-protocol"
 edition = "2021"
 license = "MIT"
 name = "nu-protocol"
-version = "0.96.1"
+version = "0.96.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,10 +13,10 @@ version = "0.96.1"
 bench = false
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
-nu-path = { path = "../nu-path", version = "0.96.1" }
-nu-system = { path = "../nu-system", version = "0.96.1" }
-nu-derive-value = { path = "../nu-derive-value", version = "0.96.1" }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
+nu-path = { path = "../nu-path", version = "0.96.2" }
+nu-system = { path = "../nu-system", version = "0.96.2" }
+nu-derive-value = { path = "../nu-derive-value", version = "0.96.2" }
 
 brotli = { workspace = true, optional = true }
 byte-unit = { version = "5.1", features = [ "serde" ] }
@@ -53,7 +53,7 @@ plugin = [
 serde_json = { workspace = true }
 strum = "0.26"
 strum_macros = "0.26"
-nu-test-support = { path = "../nu-test-support", version = "0.96.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.96.2" }
 pretty_assertions = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/nu-std/Cargo.toml
+++ b/crates/nu-std/Cargo.toml
@@ -5,12 +5,12 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-std"
 edition = "2021"
 license = "MIT"
 name = "nu-std"
-version = "0.96.1"
+version = "0.96.2"
 
 [dependencies]
-nu-parser = { version = "0.96.1", path = "../nu-parser" }
-nu-protocol = { version = "0.96.1", path = "../nu-protocol" }
-nu-engine = { version = "0.96.1", path = "../nu-engine" }
+nu-parser = { version = "0.96.2", path = "../nu-parser" }
+nu-protocol = { version = "0.96.2", path = "../nu-protocol" }
+nu-engine = { version = "0.96.2", path = "../nu-engine" }
 miette = { workspace = true, features = ["fancy-no-backtrace"] }
 
 log = "0.4"

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["The Nushell Project Developers", "procs creators"]
 description = "Nushell system querying"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-system"
 name = "nu-system"
-version = "0.96.1"
+version = "0.96.2"
 edition = "2021"
 license = "MIT"
 

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -5,20 +5,20 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-table"
 edition = "2021"
 license = "MIT"
 name = "nu-table"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.96.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-color-config = { path = "../nu-color-config", version = "0.96.2" }
 nu-ansi-term = { workspace = true }
 once_cell = { workspace = true }
 fancy-regex = { workspace = true }
 tabled = { workspace = true, features = ["color"], default-features = false }
 
 [dev-dependencies]
-# nu-test-support = { path="../nu-test-support", version = "0.96.1"  }
+# nu-test-support = { path="../nu-test-support", version = "0.96.2"  }

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -5,12 +5,12 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-term-grid"
 edition = "2021"
 license = "MIT"
 name = "nu-term-grid"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
 
 unicode-width = { workspace = true }

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-test-suppor
 edition = "2021"
 license = "MIT"
 name = "nu-test-support"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 doctest = false
 bench = false
 
 [dependencies]
-nu-path = { path = "../nu-path", version = "0.96.1" }
-nu-glob = { path = "../nu-glob", version = "0.96.1" }
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
+nu-path = { path = "../nu-path", version = "0.96.2" }
+nu-glob = { path = "../nu-glob", version = "0.96.2" }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
 
 num-format = { workspace = true }
 which = { workspace = true }

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-utils"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-utils"
-version = "0.96.1"
+version = "0.96.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -1,6 +1,6 @@
 # Nushell Config File
 #
-# version = "0.96.1"
+# version = "0.96.2"
 
 # For more information on defining custom themes, see
 # https://www.nushell.sh/book/coloring_and_theming.html

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -1,6 +1,6 @@
 # Nushell Environment Config File
 #
-# version = "0.96.1"
+# version = "0.96.2"
 
 def create_left_prompt [] {
     let dir = match (do --ignore-shell-errors { $env.PWD | path relative-to $nu.home-path }) {

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -10,10 +10,10 @@ name = "nu_plugin_custom_values"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2", features = ["plugin"] }
 serde = { workspace = true, default-features = false }
 typetag = "0.2"
 
 [dev-dependencies]
-nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.96.1" }
+nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.96.2" }

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_exam
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_example"
-version = "0.96.1"
+version = "0.96.2"
 
 [[bin]]
 name = "nu_plugin_example"
@@ -15,9 +15,9 @@ bench = false
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2", features = ["plugin"] }
 
 [dev-dependencies]
-nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.96.1" }
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.1" }
+nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.96.2" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.2" }

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -5,12 +5,12 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_form
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_formats"
-version = "0.96.1"
+version = "0.96.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2", features = ["plugin"] }
 
 indexmap = { workspace = true }
 eml-parser = "0.1"
@@ -18,4 +18,4 @@ ical = "0.11"
 rust-ini = "0.21.0"
 
 [dev-dependencies]
-nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.96.1" }
+nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.96.2" }

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gsta
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_gstat"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 doctest = false
@@ -16,7 +16,7 @@ name = "nu_plugin_gstat"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
+nu-plugin = { path = "../nu-plugin", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
 
 git2 = "0.19"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_inc"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 doctest = false
@@ -16,7 +16,7 @@ name = "nu_plugin_inc"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2", features = ["plugin"] }
 
 semver = "1.0"

--- a/crates/nu_plugin_nu_example/nu_plugin_nu_example.nu
+++ b/crates/nu_plugin_nu_example/nu_plugin_nu_example.nu
@@ -6,7 +6,7 @@
 # it also allows us to test the plugin interface with something manually implemented in a scripting
 # language without adding any extra dependencies to our tests.
 
-const NUSHELL_VERSION = "0.96.1"
+const NUSHELL_VERSION = "0.96.2"
 const PLUGIN_VERSION = "0.1.0" # bump if you change commands!
 
 def main [--stdio] {

--- a/crates/nu_plugin_polars/Cargo.toml
+++ b/crates/nu_plugin_polars/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu_plugin_polars"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_polars"
-version = "0.96.1"
+version = "0.96.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -17,10 +17,10 @@ bench = false
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
-nu-plugin = { path = "../nu-plugin", version = "0.96.1" }
-nu-path = { path = "../nu-path", version = "0.96.1" }
-nu-utils = { path = "../nu-utils", version = "0.96.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
+nu-plugin = { path = "../nu-plugin", version = "0.96.2" }
+nu-path = { path = "../nu-path", version = "0.96.2" }
+nu-utils = { path = "../nu-utils", version = "0.96.2" }
 
 # Potential dependencies for extras
 chrono = { workspace = true, features = ["std", "unstable-locales"], default-features = false }
@@ -76,9 +76,9 @@ optional = false
 version = "0.41"
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.1" }
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
-nu-parser = { path = "../nu-parser", version = "0.96.1" }
-nu-command = { path = "../nu-command", version = "0.96.1" }
-nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.96.1" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.96.2" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
+nu-parser = { path = "../nu-parser", version = "0.96.2" }
+nu-command = { path = "../nu-command", version = "0.96.2" }
+nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.96.2" }
 tempfile.workspace = true

--- a/crates/nu_plugin_python/nu_plugin_python_example.py
+++ b/crates/nu_plugin_python/nu_plugin_python_example.py
@@ -27,7 +27,7 @@ import sys
 import json
 
 
-NUSHELL_VERSION = "0.96.1"
+NUSHELL_VERSION = "0.96.2"
 PLUGIN_VERSION = "0.1.0" # bump if you change commands!
 
 

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_quer
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_query"
-version = "0.96.1"
+version = "0.96.2"
 
 [lib]
 doctest = false
@@ -16,8 +16,8 @@ name = "nu_plugin_query"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
+nu-plugin = { path = "../nu-plugin", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
 
 gjson = "0.8"
 scraper = { default-features = false, version = "0.19" }

--- a/crates/nu_plugin_stress_internals/Cargo.toml
+++ b/crates/nu_plugin_stress_internals/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_stre
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_stress_internals"
-version = "0.96.1"
+version = "0.96.2"
 
 [[bin]]
 name = "nu_plugin_stress_internals"

--- a/crates/nuon/Cargo.toml
+++ b/crates/nuon/Cargo.toml
@@ -5,14 +5,14 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nuon"
 edition = "2021"
 license = "MIT"
 name = "nuon"
-version = "0.96.1"
+version = "0.96.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-parser = { path = "../nu-parser", version = "0.96.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.96.1" }
-nu-engine = { path = "../nu-engine", version = "0.96.1" }
+nu-parser = { path = "../nu-parser", version = "0.96.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.96.2" }
+nu-engine = { path = "../nu-engine", version = "0.96.2" }
 once_cell = { workspace = true }
 fancy-regex = { workspace = true }
 


### PR DESCRIPTION
# Description

In preparation for a patch release the PR bumps nushell to 0.96.2

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
