### PR TITLE
Clarify `random int` help

### DIFF
--- a/crates/nu-command/src/random/int.rs
+++ b/crates/nu-command/src/random/int.rs
@@ -59,8 +59,8 @@ impl Command for SubCommand {
                 result: None,
             },
             Example {
-                description: "Generate a random integer between 1 (inclusive) and 10 (inclusive)",
-                example: "random int 1..10",
+                description: "Generate a random integer between -10 (inclusive) and 10 (inclusive)",
+                example: "random int (-10)..10",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/random/int.rs
+++ b/crates/nu-command/src/random/int.rs
@@ -15,7 +15,11 @@ impl Command for SubCommand {
         Signature::build("random int")
             .input_output_types(vec![(Type::Nothing, Type::Int)])
             .allow_variants_without_examples(true)
-            .optional("range", SyntaxShape::Range, "Range of values.")
+            .optional(
+                "range",
+                SyntaxShape::Range,
+                "Range of potential values, inclusive of both start and end values.",
+            )
             .category(Category::Random)
     }
 
@@ -40,12 +44,12 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Generate an unconstrained random integer",
+                description: "Generate a non-negative random integer",
                 example: "random int",
                 result: None,
             },
             Example {
-                description: "Generate a random integer less than or equal to 500",
+                description: "Generate a random integer between 0 (inclusive) and 500 (inclusive)",
                 example: "random int ..500",
                 result: None,
             },
@@ -55,7 +59,7 @@ impl Command for SubCommand {
                 result: None,
             },
             Example {
-                description: "Generate a random integer between 1 and 10",
+                description: "Generate a random integer between 1 (inclusive) and 10 (inclusive)",
                 example: "random int 1..10",
                 result: None,
             },


### PR DESCRIPTION
# Description

Minor nitpicks, but the `random int` help and examples were a bit ambiguous in several aspects.  Updated to clarify that:

* An unconstrained `random int` returns a non-negative integer.  That is, the smallest potential value is 0.  Technically integers include negative numbers as well, and `random int` will never return one unless you pass it a range with a negative lower-bound.

* To that end, changed the final example to demonstrate a negative lower-bound.

* The range is inclusive. While most people would probably assume this, the changes make this explicit in the examples and argument description.

# User-Facing Changes

Help only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib

# After Submitting

N/A