### PR TITLE
Add `--upgrade` switch for `mv` command

### DIFF
--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -31,6 +31,11 @@ impl Command for UMv {
                 result: None,
             },
             Example {
+                description: "Move only if source file is newer than target file",
+                example: "mv -u new/test.txt old/",
+                result: None,
+            },
+            Example {
                 description: "Move many files into a directory",
                 example: "mv *.txt my/subdirectory",
                 result: None,
@@ -49,6 +54,11 @@ impl Command for UMv {
             .switch("verbose", "explain what is being done.", Some('v'))
             .switch("progress", "display a progress bar", Some('p'))
             .switch("interactive", "prompt before overwriting", Some('i'))
+            .switch(
+                "update",
+                "move and overwite only when the SOURCE file is newer than the destination file or when the destination file is missing",
+                Some('u')
+            )
             .switch("no-clobber", "do not overwrite an existing file", Some('n'))
             .rest(
                 "paths",
@@ -76,6 +86,11 @@ impl Command for UMv {
             uu_mv::OverwriteMode::Interactive
         } else {
             uu_mv::OverwriteMode::Force
+        };
+        let update = if call.has_flag(engine_state, stack, "update")? {
+            UpdateMode::ReplaceIfOlder
+        } else {
+            UpdateMode::ReplaceAll
         };
 
         #[allow(deprecated)]
@@ -164,7 +179,7 @@ impl Command for UMv {
             verbose,
             suffix: String::from("~"),
             backup: BackupMode::NoBackup,
-            update: UpdateMode::ReplaceAll,
+            update,
             target_dir: None,
             no_target_dir: false,
             strip_slashes: false,

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -56,7 +56,7 @@ impl Command for UMv {
             .switch("interactive", "prompt before overwriting", Some('i'))
             .switch(
                 "update",
-                "move and overwite only when the SOURCE file is newer than the destination file or when the destination file is missing",
+                "move and overwrite only when the SOURCE file is newer than the destination file or when the destination file is missing",
                 Some('u')
             )
             .switch("no-clobber", "do not overwrite an existing file", Some('n'))


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Add `--upgrade, -u` switch for `mv` command, corresponding to `cp`.

Closes #13458.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
```plain
❯ help mv | find update
╭──────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│        0 │   -u, --update - move and overwite only when the SOURCE file is newer than the destination file or when the destination file is missing       │
╰──────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:
-->
- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- [x] `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library
<!--
> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

P.S.  
The standard test kit (`nu-test-support`) doesn't provide utility to create file with modification timestamp, and I didn't find any test for this in `cp` command. I had tested on my local machine but I'm not sure how to integrate it into ci. If unit testing is required, I may need your guidance.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
- [x] Command docs are auto generated.
