### PR TITLE
fix: relay Signals reset to plugins

### DIFF
--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -12,7 +12,7 @@ use nu_plugin_protocol::{
 };
 use nu_protocol::{
     ast::Operator, engine::Sequence, CustomValue, IntoSpanned, PipelineData, PluginMetadata,
-    PluginSignature, ShellError, Signals, Span, Spanned, Value,
+    PluginSignature, ShellError, SignalAction, Signals, Span, Spanned, Value,
 };
 use nu_utils::SharedCow;
 use std::{
@@ -665,8 +665,8 @@ impl PluginInterface {
     }
 
     /// Send the plugin a ctrl-c signal.
-    pub fn ctrlc(&self) -> Result<(), ShellError> {
-        self.write(PluginInput::Ctrlc)?;
+    pub fn signal(&self, action: SignalAction) -> Result<(), ShellError> {
+        self.write(PluginInput::Signal(action))?;
         self.flush()
     }
 

--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -664,7 +664,7 @@ impl PluginInterface {
         self.flush()
     }
 
-    /// Send the plugin a ctrl-c signal.
+    /// Send the plugin a signal.
     pub fn signal(&self, action: SignalAction) -> Result<(), ShellError> {
         self.write(PluginInput::Signal(action))?;
         self.flush()

--- a/crates/nu-plugin-engine/src/persistent.rs
+++ b/crates/nu-plugin-engine/src/persistent.rs
@@ -310,7 +310,7 @@ impl RegisteredPlugin for PersistentPlugin {
             // RAII guard that will be stored on the plugin.
             let plugin = Arc::downgrade(&self);
             handlers.register(Box::new(move |action| {
-                // write a Ctrl-C packet through the PluginInterface if the plugin is alive and
+                // write a signal packet through the PluginInterface if the plugin is alive and
                 // running
                 if let Some(plugin) = plugin.upgrade() {
                     if let Ok(mutable) = plugin.mutable.lock() {

--- a/crates/nu-plugin-protocol/src/lib.rs
+++ b/crates/nu-plugin-protocol/src/lib.rs
@@ -23,7 +23,7 @@ pub mod test_util;
 
 use nu_protocol::{
     ast::Operator, engine::Closure, ByteStreamType, Config, DeclId, LabeledError, PipelineData,
-    PluginMetadata, PluginSignature, ShellError, Span, Spanned, Value,
+    PluginMetadata, PluginSignature, ShellError, SignalAction, Span, Spanned, Value,
 };
 use nu_utils::SharedCow;
 use serde::{Deserialize, Serialize};
@@ -208,8 +208,8 @@ pub enum PluginInput {
     Drop(StreamId),
     /// See [`StreamMessage::Ack`].
     Ack(StreamId),
-    /// Signal a ctrlc event
-    Ctrlc,
+    /// Relay signals to the plugin
+    Signal(SignalAction),
 }
 
 impl TryFrom<PluginInput> for StreamMessage {

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -525,8 +525,8 @@ impl EngineInterface {
         self.state.writer.is_stdout()
     }
 
-    /// Register a closure which will be called when the engine receives a Ctrl-C signal. Returns a
-    /// RAII guard that will keep the closure alive until it is dropped.
+    /// Register a closure which will be called when the engine receives an interrupt signal.
+    /// Returns a RAII guard that will keep the closure alive until it is dropped.
     pub fn register_signal_handler(&self, handler: Handler) -> Result<HandlerGuard, ShellError> {
         self.state.signal_handlers.register(handler)
     }

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -64,7 +64,8 @@ struct EngineInterfaceState {
         mpsc::Sender<(EngineCallId, mpsc::Sender<EngineCallResponse<PipelineData>>)>,
     /// The synchronized output writer
     writer: Box<dyn PluginWrite<PluginOutput>>,
-    // Mirror signals from `EngineState`
+    /// Mirror signals from `EngineState`. You can make use of this with
+    /// `engine_interface.signals()` when constructing a Stream that requires signals
     signals: Signals,
     /// Registered signal handlers
     signal_handlers: Handlers,

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -11,9 +11,9 @@ use nu_plugin_protocol::{
     PluginOutput, ProtocolInfo,
 };
 use nu_protocol::{
-    engine::{ctrlc, Closure, Sequence},
-    Config, DeclId, LabeledError, PipelineData, PluginMetadata, PluginSignature, ShellError,
-    Signals, Span, Spanned, Value,
+    engine::{Closure, Sequence},
+    Config, DeclId, Handler, HandlerGuard, Handlers, LabeledError, PipelineData, PluginMetadata,
+    PluginSignature, ShellError, SignalAction, Signals, Span, Spanned, Value,
 };
 use nu_utils::SharedCow;
 use std::{
@@ -66,8 +66,8 @@ struct EngineInterfaceState {
     writer: Box<dyn PluginWrite<PluginOutput>>,
     // Mirror signals from `EngineState`
     signals: Signals,
-    /// Registered Ctrl-C handlers
-    ctrlc_handlers: ctrlc::Handlers,
+    /// Registered signal handlers
+    signal_handlers: Handlers,
 }
 
 impl std::fmt::Debug for EngineInterfaceState {
@@ -122,7 +122,7 @@ impl EngineInterfaceManager {
                 engine_call_subscription_sender: subscription_tx,
                 writer: Box::new(writer),
                 signals: Signals::new(Arc::new(AtomicBool::new(false))),
-                ctrlc_handlers: ctrlc::Handlers::new(),
+                signal_handlers: Handlers::new(),
             }),
             protocol_info_mut,
             plugin_call_sender: Some(plug_tx),
@@ -337,9 +337,12 @@ impl InterfaceManager for EngineInterfaceManager {
                     });
                 self.send_engine_call_response(id, response)
             }
-            PluginInput::Ctrlc => {
-                self.state.signals.trigger();
-                self.state.ctrlc_handlers.run();
+            PluginInput::Signal(action) => {
+                match action {
+                    SignalAction::Interrupt => self.state.signals.trigger(),
+                    SignalAction::Reset => self.state.signals.reset(),
+                }
+                self.state.signal_handlers.run(action);
                 Ok(())
             }
         }
@@ -523,11 +526,8 @@ impl EngineInterface {
 
     /// Register a closure which will be called when the engine receives a Ctrl-C signal. Returns a
     /// RAII guard that will keep the closure alive until it is dropped.
-    pub fn register_ctrlc_handler(
-        &self,
-        handler: ctrlc::Handler,
-    ) -> Result<ctrlc::Guard, ShellError> {
-        self.state.ctrlc_handlers.register(handler)
+    pub fn register_signal_handler(&self, handler: Handler) -> Result<HandlerGuard, ShellError> {
+        self.state.signal_handlers.register(handler)
     }
 
     /// Get the full shell configuration from the engine. As this is quite a large object, it is

--- a/crates/nu-protocol/src/engine/mod.rs
+++ b/crates/nu-protocol/src/engine/mod.rs
@@ -34,5 +34,3 @@ pub use stack_out_dest::*;
 pub use state_delta::*;
 pub use state_working_set::*;
 pub use variable::*;
-
-pub mod ctrlc;

--- a/crates/nu-protocol/src/pipeline/handlers.rs
+++ b/crates/nu-protocol/src/pipeline/handlers.rs
@@ -99,14 +99,14 @@ mod tests {
         let called1_clone = Arc::clone(&called1);
         let called2_clone = Arc::clone(&called2);
 
-        let _guard1 = handlers.register(Box::new(move || {
+        let _guard1 = handlers.register(Box::new(move |_| {
             called1_clone.store(true, Ordering::SeqCst);
         }));
-        let _guard2 = handlers.register(Box::new(move || {
+        let _guard2 = handlers.register(Box::new(move |_| {
             called2_clone.store(true, Ordering::SeqCst);
         }));
 
-        handlers.run();
+        handlers.run(SignalAction::Interrupt);
 
         assert!(called1.load(Ordering::SeqCst));
         assert!(called2.load(Ordering::SeqCst));
@@ -119,7 +119,7 @@ mod tests {
         let called = Arc::new(AtomicBool::new(false));
         let called_clone = Arc::clone(&called);
 
-        let guard = handlers.register(Box::new(move || {
+        let guard = handlers.register(Box::new(move |_| {
             called_clone.store(true, Ordering::Relaxed);
         }));
 
@@ -131,7 +131,7 @@ mod tests {
         // Ensure the handler is removed after dropping the guard
         assert_eq!(handlers.handlers.lock().unwrap().len(), 0);
 
-        handlers.run();
+        handlers.run(SignalAction::Interrupt);
 
         // Ensure the handler is not called after being dropped
         assert!(!called.load(Ordering::Relaxed));

--- a/crates/nu-protocol/src/pipeline/mod.rs
+++ b/crates/nu-protocol/src/pipeline/mod.rs
@@ -1,4 +1,5 @@
 pub mod byte_stream;
+mod handlers;
 pub mod list_stream;
 mod metadata;
 mod out_dest;
@@ -6,6 +7,7 @@ mod pipeline_data;
 mod signals;
 
 pub use byte_stream::*;
+pub use handlers::*;
 pub use list_stream::*;
 pub use metadata::*;
 pub use out_dest::*;

--- a/crates/nu-protocol/src/pipeline/signals.rs
+++ b/crates/nu-protocol/src/pipeline/signals.rs
@@ -4,6 +4,8 @@ use std::sync::{
     Arc,
 };
 
+use serde::{Deserialize, Serialize};
+
 /// Used to check for signals to suspend or terminate the execution of Nushell code.
 ///
 /// For now, this struct only supports interruption (ctrl+c or SIGINT).
@@ -80,4 +82,12 @@ impl Signals {
             signals.store(false, Ordering::Relaxed);
         }
     }
+}
+
+/// The types of things that can be signaled. Its anticipated this will change as we learn how we'd
+/// like signals to be handled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SignalAction {
+    Interrupt,
+    Reset,
 }

--- a/crates/nu-protocol/src/pipeline/signals.rs
+++ b/crates/nu-protocol/src/pipeline/signals.rs
@@ -77,15 +77,15 @@ impl Signals {
         self.signals.is_none()
     }
 
-    pub(crate) fn reset(&self) {
+    pub fn reset(&self) {
         if let Some(signals) = &self.signals {
             signals.store(false, Ordering::Relaxed);
         }
     }
 }
 
-/// The types of things that can be signaled. Its anticipated this will change as we learn how we'd
-/// like signals to be handled.
+/// The types of things that can be signaled. It's anticipated this will change as we learn more
+/// about how we'd like signals to be handled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SignalAction {
     Interrupt,

--- a/crates/nu-protocol/src/plugin/registered.rs
+++ b/crates/nu-protocol/src/plugin/registered.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, sync::Arc};
 
-use crate::{engine::ctrlc, PluginGcConfig, PluginIdentity, PluginMetadata, ShellError};
+use crate::{Handlers, PluginGcConfig, PluginIdentity, PluginMetadata, ShellError};
 
 /// Trait for plugins registered in the [`EngineState`](crate::engine::EngineState).
 pub trait RegisteredPlugin: Send + Sync {
@@ -36,10 +36,7 @@ pub trait RegisteredPlugin: Send + Sync {
     fn as_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
 
     /// Give this plugin a chance to register for Ctrl-C signals.
-    fn configure_ctrlc_handler(
-        self: Arc<Self>,
-        _handler: &ctrlc::Handlers,
-    ) -> Result<(), ShellError> {
+    fn configure_signal_handler(self: Arc<Self>, _handler: &Handlers) -> Result<(), ShellError> {
         Ok(())
     }
 }

--- a/crates/nu_plugin_example/src/commands/ctrlc.rs
+++ b/crates/nu_plugin_example/src/commands/ctrlc.rs
@@ -16,7 +16,7 @@ impl PluginCommand for Ctrlc {
     }
 
     fn usage(&self) -> &str {
-        "Example command that demonstrates registering a ctrl-c handler"
+        "Example command that demonstrates registering an interrupt signal handler"
     }
 
     fn signature(&self) -> Signature {
@@ -35,12 +35,12 @@ impl PluginCommand for Ctrlc {
         _input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let (sender, receiver) = mpsc::channel::<()>();
-        let _guard = engine.register_ctrlc_handler(Box::new(move || {
+        let _guard = engine.register_signal_handler(Box::new(move |_| {
             let _ = sender.send(());
         }));
 
         eprintln!("interrupt status: {:?}", engine.signals().interrupted());
-        eprintln!("waiting for ctrl-c signal...");
+        eprintln!("waiting for interrupt signal...");
         receiver.recv().expect("handler went away");
         eprintln!("interrupt status: {:?}", engine.signals().interrupted());
         eprintln!("peace.");

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,7 +1,4 @@
-use nu_protocol::{
-    engine::{ctrlc::Handlers, EngineState},
-    Signals,
-};
+use nu_protocol::{engine::EngineState, Handlers, SignalAction, Signals};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -11,12 +8,12 @@ pub(crate) fn ctrlc_protection(engine_state: &mut EngineState) {
     let interrupt = Arc::new(AtomicBool::new(false));
     engine_state.set_signals(Signals::new(interrupt.clone()));
 
-    let ctrlc_handlers = Handlers::new();
-    engine_state.ctrlc_handlers = Some(ctrlc_handlers.clone());
+    let signal_handlers = Handlers::new();
+    engine_state.signal_handlers = Some(signal_handlers.clone());
 
     ctrlc::set_handler(move || {
         interrupt.store(true, Ordering::Relaxed);
-        ctrlc_handlers.run();
+        signal_handlers.run(SignalAction::Interrupt);
     })
     .expect("Error setting Ctrl-C handler");
 }


### PR DESCRIPTION
This PR will close #13501

# Description

This PR expands on [the relay of signals to running plugin processes](https://github.com/nushell/nushell/pull/13181). The Ctrlc relay has been generalized to SignalAction::Interrupt and when reset_signal is called on the main EngineState, a SignalAction::Reset is now relayed to running plugins.

# User-Facing Changes

The signal handler closure now takes a `signals::SignalAction`, while previously it took no arguments. The handler will now be called on both interrupt and reset. The method to register a handler on the plugin side is now called `register_signal_handler` instead of `register_ctrlc_handler` [example](https://github.com/nushell/nushell/pull/13510/files#diff-3e04dff88fd0780a49778a3d1eede092ec729a1264b4ef07ca0d2baa859dad05L38). This will only affect plugin authors who have started making use of https://github.com/nushell/nushell/pull/13181, which isn't currently part of an official release.

The change will also require all of user's plugins to be recompiled in order that they don't error when a signal is received on the PluginInterface.

# Testing

```
: example ctrlc
interrupt status: false
waiting for interrupt signal...
^Cinterrupt status: true
peace.
Error:   × Operation interrupted
   ╭─[display_output hook:1:1]
 1 │ if (term size).columns >= 100 { table -e } else { table }
   · ─┬
   ·  ╰── This operation was interrupted
   ╰────

: example ctrlc
interrupt status: false   <-- NOTE status is false
waiting for interrupt signal...
^Cinterrupt status: true
peace.
Error:   × Operation interrupted
   ╭─[display_output hook:1:1]
 1 │ if (term size).columns >= 100 { table -e } else { table }
   · ─┬
   ·  ╰── This operation was interrupted
   ╰────
   ```
