### PR TITLE
`random chars` doc clarifications

### DIFF
--- a/crates/nu-command/src/random/chars.rs
+++ b/crates/nu-command/src/random/chars.rs
@@ -19,7 +19,12 @@ impl Command for SubCommand {
         Signature::build("random chars")
             .input_output_types(vec![(Type::Nothing, Type::String)])
             .allow_variants_without_examples(true)
-            .named("length", SyntaxShape::Int, "Number of chars (default 25)", Some('l'))
+            .named(
+                "length",
+                SyntaxShape::Int,
+                "Number of chars (default 25)",
+                Some('l'),
+            )
             .category(Category::Random)
     }
 

--- a/crates/nu-command/src/random/chars.rs
+++ b/crates/nu-command/src/random/chars.rs
@@ -19,12 +19,12 @@ impl Command for SubCommand {
         Signature::build("random chars")
             .input_output_types(vec![(Type::Nothing, Type::String)])
             .allow_variants_without_examples(true)
-            .named("length", SyntaxShape::Int, "Number of chars", Some('l'))
+            .named("length", SyntaxShape::Int, "Number of chars (default 25)", Some('l'))
             .category(Category::Random)
     }
 
     fn usage(&self) -> &str {
-        "Generate random chars."
+        "Generate random chars uniformly distributed over ASCII letters and numbers: a-z, A-Z and 0-9."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -44,7 +44,7 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Generate random chars",
+                description: "Generate a string with 25 random chars",
                 example: "random chars",
                 result: None,
             },


### PR DESCRIPTION
# Description

Clarified `random chars` help/doc:

* Default string length in absence of a `--length` arg is 25
* Characters are *"uniformly distributed over ASCII letters and numbers: a-z, A-Z and 0-9"* (copied from the [`rand` crate doc](https://docs.rs/rand/latest/rand/distributions/struct.Alphanumeric.html).

# User-Facing Changes

Help/Doc only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib

# After Submitting

N/A