### PR TITLE
Doc and examples for multi-dot directory traversal

### DIFF
--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -134,13 +134,23 @@ impl Command for Cd {
                 result: None,
             },
             Example {
-                description: "Change to the previous working directory ($OLDPWD)",
+                description: r#"Change to the previous working directory (same as "cd $env.OLDPWD")"#,
                 example: r#"cd -"#,
                 result: None,
             },
             Example {
                 description: "Changing directory with a custom command requires 'def --env'",
                 example: r#"def --env gohome [] { cd ~ }"#,
+                result: None,
+            },
+            Example {
+                description: "Move two directories up in the tree (the parent directory's parent). Additional dots can be added for additional levels.",
+                example: r#"cd ..."#,
+                result: None,
+            },
+            Example {
+                description: "The cd command itself is often optional. Simply entering a path to a directory will cd to it.",
+                example: r#"/home"#,
                 result: None,
             },
         ]

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -86,17 +86,17 @@ impl Command for UCp {
             },
             Example {
                 description: "Copy only if source file is newer than target file",
-                example: "cp -u a b",
+                example: "cp -u myfile newfile",
                 result: None,
             },
             Example {
                 description: "Copy file preserving mode and timestamps attributes",
-                example: "cp --preserve [ mode timestamps ] a b",
+                example: "cp --preserve [ mode timestamps ] myfile newfile",
                 result: None,
             },
             Example {
                 description: "Copy file erasing all attributes",
-                example: "cp --preserve [] a b",
+                example: "cp --preserve [] myfile newfile",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -99,6 +99,11 @@ impl Command for UCp {
                 example: "cp --preserve [] a b",
                 result: None,
             },
+            Example {
+                description: "Copy file to a directory three levels above its current location",
+                example: "cp myfile ....",
+                result: None,
+            },
         ]
     }
 

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -40,6 +40,11 @@ impl Command for UMv {
                 example: "mv *.txt my/subdirectory",
                 result: None,
             },
+            Example {
+                description: r#"Move a file into the "my" directory two levels up in the directory tree"#,
+                example: "mv test.txt .../my/",
+                result: None,
+            },
         ]
     }
 


### PR DESCRIPTION
# Description

With this PR, we should be able to close https://github.com/nushell/nushell.github.io/issues/1225

Help/doc/examples updated for:

* `cd` to show multi-dot traversal
* `cd` to show implicit `cd` with bare directory path
* Fixed/clarified another example that mentioned `$OLDPATH` while I was in there
* `mv` and `cp` examples for multi-dot traversal
* Updated `cp` examples to use more consistent (and clear) filenames

# User-Facing Changes

Help/doc only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A
