### PR TITLE
Clarify `default` command help

### DIFF
--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -27,7 +27,7 @@ impl Command for Default {
     }
 
     fn usage(&self) -> &str {
-        "Sets a default value to use if a row's column is missing or null."
+        "Sets a default value if a row's column is missing or null."
     }
 
     fn run(

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -27,7 +27,7 @@ impl Command for Default {
     }
 
     fn usage(&self) -> &str {
-        "Sets a default row's column if missing or null."
+        "Sets a default value to use if a row's column is missing or null."
     }
 
     fn run(

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -27,7 +27,7 @@ impl Command for Default {
     }
 
     fn usage(&self) -> &str {
-        "Sets a default row's column if missing."
+        "Sets a default row's column if missing or null."
     }
 
     fn run(
@@ -65,6 +65,20 @@ impl Command for Default {
                     ],
                     Span::test_data(),
                 )),
+            },
+            Example {
+                description: r#"Replace the missing value in the "a" column of a list"#,
+                example: "[{a:1 b:2} {b:1}] | default 'N/A' a",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "a" => Value::test_int(1),
+                        "b" => Value::test_int(2),
+                    }),
+                    Value::test_record(record! {
+                        "a" => Value::test_string("N/A"),
+                        "b" => Value::test_int(1),
+                    }),
+                ])),
             },
         ]
     }


### PR DESCRIPTION
# Description

Updates `default` command description to be more clear and adds an example for a missing values in a list-of-records.

# User-Facing Changes

Help/doc only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

- Update `nothing` doc in Book to reference `default` per https://github.com/nushell/nushell.github.io/issues/1073 - This was a bit of a rabbit trail on the path to that update. ;-)