### PR TITLE
Simplify column look-up in `default`

### DIFF
--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -102,18 +102,11 @@ fn default(
                         val: ref mut record,
                         ..
                     } => {
-                        let mut found = false;
-
-                        for (col, val) in record.to_mut().iter_mut() {
-                            if *col == column.item {
-                                found = true;
-                                if matches!(val, Value::Nothing { .. }) {
-                                    *val = value.clone();
-                                }
+                        if let Some(val) = record.to_mut().get_mut(&column.item) {
+                            if matches!(val, Value::Nothing { .. }) {
+                                *val = value.clone();
                             }
-                        }
-
-                        if !found {
+                        } else {
                             record.to_mut().push(column.item.clone(), value.clone());
                         }
 

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -102,12 +102,13 @@ fn default(
                         val: ref mut record,
                         ..
                     } => {
-                        if let Some(val) = record.to_mut().get_mut(&column.item) {
+                        let record = record.to_mut();
+                        if let Some(val) = record.get_mut(&column.item) {
                             if matches!(val, Value::Nothing { .. }) {
                                 *val = value.clone();
                             }
                         } else {
-                            record.to_mut().push(column.item.clone(), value.clone());
+                            record.push(column.item.clone(), value.clone());
                         }
 
                         item


### PR DESCRIPTION
# Description
Since we make the promise that record keys/columns are exclusice we
don't have to go through all columns after we have found the first one.
Should permit some short-circuiting if the column is found early.

# User-Facing Changes
(-)

# Tests + Formatting
(-)
