### PR TITLE
Rework `help` generation internals

### DIFF
--- a/crates/nu-cli/src/menus/help_completions.rs
+++ b/crates/nu-cli/src/menus/help_completions.rs
@@ -1,4 +1,4 @@
-use nu_engine::documentation::get_flags_section;
+use nu_engine::documentation::{get_flags_section, HelpStyle};
 use nu_protocol::{engine::EngineState, levenshtein_distance, Config};
 use nu_utils::IgnoreCaseExt;
 use reedline::{Completer, Suggestion};
@@ -19,6 +19,9 @@ impl NuHelpCompleter {
 
     fn completion_helper(&self, line: &str, pos: usize) -> Vec<Suggestion> {
         let folded_line = line.to_folded_case();
+
+        let mut help_style = HelpStyle::default();
+        help_style.update_from_config(&self.engine_state, &self.config);
 
         let mut commands = self
             .engine_state
@@ -60,12 +63,9 @@ impl NuHelpCompleter {
                 let _ = write!(long_desc, "Usage:\r\n  > {}\r\n", sig.call_signature());
 
                 if !sig.named.is_empty() {
-                    long_desc.push_str(&get_flags_section(
-                        Some(&self.engine_state),
-                        Some(&self.config),
-                        &sig,
-                        |v| v.to_parsable_string(", ", &self.config),
-                    ))
+                    long_desc.push_str(&get_flags_section(&sig, &help_style, |v| {
+                        v.to_parsable_string(", ", &self.config)
+                    }))
                 }
 
                 if !sig.required_positional.is_empty()

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -148,7 +148,7 @@ fn get_documentation(
                     format!(
                         "  {help_subcolor_one}\"{}\" + {RESET}<{help_subcolor_two}{}{RESET}>: {}",
                         String::from_utf8_lossy(kw),
-                        document_shape(&shape),
+                        document_shape(shape),
                         positional.desc
                     )
                 }
@@ -169,7 +169,7 @@ fn get_documentation(
                     format!(
                         "  {help_subcolor_one}\"{}\" + {RESET}<{help_subcolor_two}{}{RESET}>: {} (optional)",
                         String::from_utf8_lossy(kw),
-                        document_shape(&shape),
+                        document_shape(shape),
                         positional.desc
                     )
                 }

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -281,34 +281,10 @@ fn get_documentation(
 
         if !nu_config.use_ansi_coloring {
             let _ = write!(long_desc, "\n  > {}\n", example.example);
-        } else if let Some(highlighter) = engine_state.find_decl(b"nu-highlight", &[]) {
-            let decl = engine_state.get_decl(highlighter);
-            let call = Call::new(Span::unknown());
-
-            match decl.run(
-                engine_state,
-                stack,
-                &(&call).into(),
-                Value::string(example.example, Span::unknown()).into_pipeline_data(),
-            ) {
-                Ok(output) => {
-                    let result = output.into_value(Span::unknown());
-                    match result.and_then(Value::coerce_into_string) {
-                        Ok(s) => {
-                            let _ = write!(long_desc, "\n  > {s}\n");
-                        }
-                        _ => {
-                            let _ = write!(long_desc, "\n  > {}\n", example.example);
-                        }
-                    }
-                }
-                Err(_) => {
-                    let _ = write!(long_desc, "\n  > {}\n", example.example);
-                }
-            }
         } else {
-            let _ = write!(long_desc, "\n  > {}\n", example.example);
-        }
+            let code_string = nu_highlight_string(example.example, engine_state, stack);
+            let _ = write!(long_desc, "\n  > {code_string}\n");
+        };
 
         if let Some(result) = &example.result {
             let mut table_call = Call::new(Span::unknown());

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -542,11 +542,7 @@ where
         }
         let _ = write!(long_desc, " - {}", flag.desc);
         if let Some(value) = &flag.default_value {
-            let _ = write!(
-                long_desc,
-                " (default: {help_subcolor_two}{}{RESET})",
-                &value_formatter(value)
-            );
+            let _ = write!(long_desc, " (default: {})", &value_formatter(value));
         }
         long_desc.push('\n');
     }

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -9,6 +9,11 @@ use nu_protocol::{
 use std::{collections::HashMap, fmt::Write};
 use terminal_size::{Height, Width};
 
+/// ANSI style reset
+const RESET: &str = "\x1b[0m";
+/// ANSI set default color (as set in the terminal)
+const DEFAULT_COLOR: &str = "\x1b[39m";
+
 pub fn get_full_help(
     command: &dyn Command,
     engine_state: &EngineState,
@@ -84,8 +89,6 @@ fn get_documentation(
         "shape_block",
         "\x1b[94m",
     ); // default: light blue (nobold, should be bolding the *names*)
-
-    const RESET: &str = "\x1b[0m"; // reset
 
     let cmd_name = &sig.name;
     let mut long_desc = String::new();
@@ -503,9 +506,6 @@ where
         help_subcolor_two = "\x1b[94m".to_string();
     }
 
-    const RESET: &str = "\x1b[0m"; // reset
-    const D: &str = "\x1b[39m"; // default
-
     let mut long_desc = String::new();
     let _ = write!(long_desc, "\n{help_section_name}Flags{RESET}:\n");
     for flag in &signature.named {
@@ -525,7 +525,7 @@ where
                         "  {help_subcolor_one}-{}{}{RESET} (required parameter) {:?} - {}{}\n",
                         short,
                         if !flag.long.is_empty() {
-                            format!("{D},{RESET} {help_subcolor_one}--{}", flag.long)
+                            format!("{DEFAULT_COLOR},{RESET} {help_subcolor_one}--{}", flag.long)
                         } else {
                             "".into()
                         },
@@ -538,7 +538,7 @@ where
                         "  {help_subcolor_one}-{}{}{RESET} <{help_subcolor_two}{:?}{RESET}> - {}{}\n",
                         short,
                         if !flag.long.is_empty() {
-                            format!("{D},{RESET} {help_subcolor_one}--{}", flag.long)
+                            format!("{DEFAULT_COLOR},{RESET} {help_subcolor_one}--{}", flag.long)
                         } else {
                             "".into()
                         },
@@ -564,7 +564,7 @@ where
                     "  {help_subcolor_one}-{}{}{RESET} (required parameter) - {}{}\n",
                     short,
                     if !flag.long.is_empty() {
-                        format!("{D},{RESET} {help_subcolor_one}--{}", flag.long)
+                        format!("{DEFAULT_COLOR},{RESET} {help_subcolor_one}--{}", flag.long)
                     } else {
                         "".into()
                     },
@@ -576,7 +576,7 @@ where
                     "  {help_subcolor_one}-{}{}{RESET} - {}{}\n",
                     short,
                     if !flag.long.is_empty() {
-                        format!("{D},{RESET} {help_subcolor_one}--{}", flag.long)
+                        format!("{DEFAULT_COLOR},{RESET} {help_subcolor_one}--{}", flag.long)
                     } else {
                         "".into()
                     },

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -14,7 +14,12 @@ pub fn get_full_help(
     engine_state: &EngineState,
     stack: &mut Stack,
 ) -> String {
+    // Precautionary step to capture any command output generated during this operation. We
+    // internally call several commands (`table`, `ansi`, `nu-highlight`) and get their
+    // `PipelineData` using this `Stack`, any other output should not be redirected like the main
+    // execution.
     let stack = &mut stack.start_capture();
+
     let signature = command.signature().update_from_command(command);
 
     get_documentation(

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -459,7 +459,7 @@ fn get_argument_for_color_value(
     }
 }
 
-// document shape helps showing more useful information
+/// Make syntax shape presentable by stripping custom completer info
 pub fn document_shape(shape: SyntaxShape) -> SyntaxShape {
     match shape {
         SyntaxShape::CompleterWrapper(inner_shape, _) => *inner_shape,

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -105,6 +105,13 @@ fn get_documentation(
         long_desc.push_str("\n\n");
     }
 
+    // TODO: improve the subcommand name resolution
+    // issues:
+    // - Aliases are included
+    //   - https://github.com/nushell/nushell/issues/11657
+    // - Subcommands are included violating module scoping
+    //   - https://github.com/nushell/nushell/issues/11447
+    //   - https://github.com/nushell/nushell/issues/11625
     let mut subcommands = vec![];
     let signatures = engine_state.get_signatures(true);
     for sig in signatures {

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -68,7 +68,6 @@ fn get_documentation(
     let nu_config = stack.get_config(engine_state);
 
     // Create ansi colors
-    //todo make these configurable -- pull from enginestate.config
     let help_section_name: String = get_ansi_color_for_component_or_default(
         engine_state,
         &nu_config,
@@ -82,13 +81,12 @@ fn get_documentation(
         "shape_external",
         "\x1b[36m",
     ); // default: cyan
-       // was const bb: &str = "\x1b[1;34m"; // bold blue
     let help_subcolor_two: String = get_ansi_color_for_component_or_default(
         engine_state,
         &nu_config,
         "shape_block",
         "\x1b[94m",
-    ); // default: light blue (nobold, should be bolding the *names*)
+    ); // default: light blue
 
     let cmd_name = &sig.name;
     let mut long_desc = String::new();
@@ -478,7 +476,6 @@ pub fn get_flags_section<F>(
 where
     F: FnMut(&nu_protocol::Value) -> String,
 {
-    //todo make these configurable -- pull from enginestate.config
     let help_section_name: String;
     let help_subcolor_one: String;
     let help_subcolor_two: String;
@@ -499,14 +496,12 @@ where
             "shape_external",
             "\x1b[36m",
         ); // default: cyan
-           // was const bb: &str = "\x1b[1;34m"; // bold blue
         help_subcolor_two = get_ansi_color_for_component_or_default(
             engine_state,
             nu_config,
             "shape_block",
             "\x1b[94m",
-        );
-    // default: light blue (nobold, should be bolding the *names*)
+        ); // default: light blue
     } else {
         help_section_name = "\x1b[32m".to_string();
         help_subcolor_one = "\x1b[36m".to_string();

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -517,93 +517,38 @@ where
     let mut long_desc = String::new();
     let _ = write!(long_desc, "\n{help_section_name}Flags{RESET}:\n");
     for flag in &signature.named {
-        let default_str = if let Some(value) = &flag.default_value {
-            format!(
+        // Indentation
+        long_desc.push_str("  ");
+        // Short flag shown before long flag
+        if let Some(short) = flag.short {
+            let _ = write!(long_desc, "{help_subcolor_one}-{}{RESET}", short);
+            if !flag.long.is_empty() {
+                let _ = write!(long_desc, "{DEFAULT_COLOR},{RESET} ");
+            }
+        }
+        if !flag.long.is_empty() {
+            let _ = write!(long_desc, "{help_subcolor_one}--{}{RESET}", flag.long);
+        }
+        if flag.required {
+            long_desc.push_str(" (required parameter)")
+        }
+        // Type/Syntax shape info
+        if let Some(arg) = &flag.arg {
+            let _ = write!(
+                long_desc,
+                " <{help_subcolor_two}{}{RESET}>",
+                document_shape(arg)
+            );
+        }
+        let _ = write!(long_desc, " - {}", flag.desc);
+        if let Some(value) = &flag.default_value {
+            let _ = write!(
+                long_desc,
                 " (default: {help_subcolor_two}{}{RESET})",
                 &value_formatter(value)
-            )
-        } else {
-            "".to_string()
-        };
-
-        let msg = if let Some(arg) = &flag.arg {
-            if let Some(short) = flag.short {
-                if flag.required {
-                    format!(
-                        "  {help_subcolor_one}-{}{}{RESET} (required parameter) {:?} - {}{}\n",
-                        short,
-                        if !flag.long.is_empty() {
-                            format!("{DEFAULT_COLOR},{RESET} {help_subcolor_one}--{}", flag.long)
-                        } else {
-                            "".into()
-                        },
-                        arg,
-                        flag.desc,
-                        default_str,
-                    )
-                } else {
-                    format!(
-                        "  {help_subcolor_one}-{}{}{RESET} <{help_subcolor_two}{:?}{RESET}> - {}{}\n",
-                        short,
-                        if !flag.long.is_empty() {
-                            format!("{DEFAULT_COLOR},{RESET} {help_subcolor_one}--{}", flag.long)
-                        } else {
-                            "".into()
-                        },
-                        arg,
-                        flag.desc,
-                        default_str,
-                    )
-                }
-            } else if flag.required {
-                format!(
-                    "  {help_subcolor_one}--{}{RESET} (required parameter) <{help_subcolor_two}{:?}{RESET}> - {}{}\n",
-                    flag.long, arg, flag.desc, default_str,
-                )
-            } else {
-                format!(
-                    "  {help_subcolor_one}--{}{RESET} <{help_subcolor_two}{:?}{RESET}> - {}{}\n",
-                    flag.long, arg, flag.desc, default_str,
-                )
-            }
-        } else if let Some(short) = flag.short {
-            if flag.required {
-                format!(
-                    "  {help_subcolor_one}-{}{}{RESET} (required parameter) - {}{}\n",
-                    short,
-                    if !flag.long.is_empty() {
-                        format!("{DEFAULT_COLOR},{RESET} {help_subcolor_one}--{}", flag.long)
-                    } else {
-                        "".into()
-                    },
-                    flag.desc,
-                    default_str,
-                )
-            } else {
-                format!(
-                    "  {help_subcolor_one}-{}{}{RESET} - {}{}\n",
-                    short,
-                    if !flag.long.is_empty() {
-                        format!("{DEFAULT_COLOR},{RESET} {help_subcolor_one}--{}", flag.long)
-                    } else {
-                        "".into()
-                    },
-                    flag.desc,
-                    default_str
-                )
-            }
-        } else if flag.required {
-            format!(
-                "  {help_subcolor_one}--{}{RESET} (required parameter) - {}{}\n",
-                flag.long, flag.desc, default_str,
-            )
-        } else {
-            format!(
-                "  {help_subcolor_one}--{}{RESET} - {}\n",
-                flag.long, flag.desc
-            )
-        };
-        long_desc.push_str(&msg);
+            );
+        }
+        long_desc.push('\n');
     }
     long_desc
 }

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -105,6 +105,20 @@ fn get_documentation(
         long_desc.push_str("\n\n");
     }
 
+    if !sig.search_terms.is_empty() {
+        let _ = write!(
+            long_desc,
+            "{help_section_name}Search terms{RESET}: {help_subcolor_one}{}{RESET}\n\n",
+            sig.search_terms.join(", "),
+        );
+    }
+
+    let _ = write!(
+        long_desc,
+        "{help_section_name}Usage{RESET}:\n  > {}\n",
+        sig.call_signature()
+    );
+
     // TODO: improve the subcommand name resolution
     // issues:
     // - Aliases are included
@@ -125,20 +139,6 @@ fn get_documentation(
             ));
         }
     }
-
-    if !sig.search_terms.is_empty() {
-        let _ = write!(
-            long_desc,
-            "{help_section_name}Search terms{RESET}: {help_subcolor_one}{}{RESET}\n\n",
-            sig.search_terms.join(", "),
-        );
-    }
-
-    let _ = write!(
-        long_desc,
-        "{help_section_name}Usage{RESET}:\n  > {}\n",
-        sig.call_signature()
-    );
 
     if !subcommands.is_empty() {
         let _ = write!(long_desc, "\n{help_section_name}Subcommands{RESET}:\n");

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -26,7 +26,7 @@ pub fn get_full_help(
     )
 }
 
-// Utility returns nu-highlighted string
+/// Syntax highlight code using the `nu-highlight` command if available
 fn nu_highlight_string(code_string: &str, engine_state: &EngineState, stack: &mut Stack) -> String {
     if let Some(highlighter) = engine_state.find_decl(b"nu-highlight", &[]) {
         let decl = engine_state.get_decl(highlighter);

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -112,21 +112,18 @@ fn get_documentation(
     }
 
     if !sig.search_terms.is_empty() {
-        let text = format!(
-            "{help_section_name}Search terms{RESET}: {help_subcolor_one}{}{}\n\n",
+        let _ = write!(
+            long_desc,
+            "{help_section_name}Search terms{RESET}: {help_subcolor_one}{}{RESET}\n\n",
             sig.search_terms.join(", "),
-            RESET
         );
-        let _ = write!(long_desc, "{text}");
     }
 
-    let text = format!(
-        "{}Usage{}:\n  > {}\n",
-        help_section_name,
-        RESET,
+    let _ = write!(
+        long_desc,
+        "{help_section_name}Usage{RESET}:\n  > {}\n",
         sig.call_signature()
     );
-    let _ = write!(long_desc, "{text}");
 
     if !subcommands.is_empty() {
         let _ = write!(long_desc, "\n{help_section_name}Subcommands{RESET}:\n");
@@ -207,13 +204,13 @@ fn get_documentation(
         }
 
         if let Some(rest_positional) = &sig.rest_positional {
-            let text = format!(
+            let _ = writeln!(
+                long_desc,
                 "  ...{help_subcolor_one}{}{RESET} <{help_subcolor_two}{}{RESET}>: {}",
                 rest_positional.name,
                 document_shape(rest_positional.shape.clone()),
                 rest_positional.desc
             );
-            let _ = writeln!(long_desc, "{text}");
         }
     }
 

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -440,6 +440,11 @@ fn get_argument_for_color_value(
     }
 }
 
+/// Contains the settings for ANSI colors in help output
+///
+/// By default contains a fixed set of (4-bit) colors
+///
+/// Can reflect configuration using [`HelpStyle::update_from_config`]
 pub struct HelpStyle {
     section_name: String,
     subcolor_one: String,
@@ -460,6 +465,13 @@ impl Default for HelpStyle {
 }
 
 impl HelpStyle {
+    /// Pull colors from the [`Config`]
+    ///
+    /// Uses some arbitrary `shape_*` settings, assuming they are well visible in the terminal theme.
+    ///
+    /// Implementation detail: currently executes `ansi` command internally thus requiring the
+    /// [`EngineState`] for execution.
+    /// See <https://github.com/nushell/nushell/pull/10623> for details
     pub fn update_from_config(&mut self, engine_state: &EngineState, nu_config: &Config) {
         update_ansi_from_config(
             &mut self.section_name,

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -148,7 +148,7 @@ fn get_documentation(
                     format!(
                         "  {help_subcolor_one}\"{}\" + {RESET}<{help_subcolor_two}{}{RESET}>: {}",
                         String::from_utf8_lossy(kw),
-                        document_shape(*shape.clone()),
+                        document_shape(&shape),
                         positional.desc
                     )
                 }
@@ -156,7 +156,7 @@ fn get_documentation(
                     format!(
                         "  {help_subcolor_one}{}{RESET} <{help_subcolor_two}{}{RESET}>: {}",
                         positional.name,
-                        document_shape(positional.shape.clone()),
+                        document_shape(&positional.shape),
                         positional.desc
                     )
                 }
@@ -169,7 +169,7 @@ fn get_documentation(
                     format!(
                         "  {help_subcolor_one}\"{}\" + {RESET}<{help_subcolor_two}{}{RESET}>: {} (optional)",
                         String::from_utf8_lossy(kw),
-                        document_shape(*shape.clone()),
+                        document_shape(&shape),
                         positional.desc
                     )
                 }
@@ -190,7 +190,7 @@ fn get_documentation(
                     format!(
                         "  {help_subcolor_one}{}{RESET} <{help_subcolor_two}{}{RESET}>: {}{}",
                         positional.name,
-                        document_shape(positional.shape.clone()),
+                        document_shape(&positional.shape),
                         positional.desc,
                         opt_suffix,
                     )
@@ -204,7 +204,7 @@ fn get_documentation(
                 long_desc,
                 "  ...{help_subcolor_one}{}{RESET} <{help_subcolor_two}{}{RESET}>: {}",
                 rest_positional.name,
-                document_shape(rest_positional.shape.clone()),
+                document_shape(&rest_positional.shape),
                 rest_positional.desc
             );
         }
@@ -495,9 +495,9 @@ impl HelpStyle {
 }
 
 /// Make syntax shape presentable by stripping custom completer info
-pub fn document_shape(shape: SyntaxShape) -> SyntaxShape {
+fn document_shape(shape: &SyntaxShape) -> &SyntaxShape {
     match shape {
-        SyntaxShape::CompleterWrapper(inner_shape, _) => *inner_shape,
+        SyntaxShape::CompleterWrapper(inner_shape, _) => inner_shape,
         _ => shape,
     }
 }

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -9,7 +9,7 @@ use std::{
     thread,
 };
 
-use nu_engine::documentation::get_flags_section;
+use nu_engine::documentation::{get_flags_section, HelpStyle};
 use nu_plugin_core::{
     ClientCommunicationIo, CommunicationMode, InterfaceManager, PluginEncoder, PluginRead,
     PluginWrite,
@@ -657,6 +657,7 @@ fn print_help(plugin: &impl Plugin, encoder: impl PluginEncoder) {
     println!("Encoder: {}", encoder.name());
 
     let mut help = String::new();
+    let help_style = HelpStyle::default();
 
     plugin.commands().into_iter().for_each(|command| {
         let signature = command.signature();
@@ -670,7 +671,7 @@ fn print_help(plugin: &impl Plugin, encoder: impl PluginEncoder) {
                 }
             })
             .and_then(|_| {
-                let flags = get_flags_section(None, None, &signature, |v| format!("{:#?}", v));
+                let flags = get_flags_section(&signature, &help_style, |v| format!("{:#?}", v));
                 write!(help, "{flags}")
             })
             .and_then(|_| writeln!(help, "\nParameters:"))


### PR DESCRIPTION
Reworking some of the sprawling code we use to generate the `help cmd` or `cmd --help` output.

This touches mainly the rendering and not the gathering of the necessary data (see open bugs under [label:help-system](https://github.com/nushell/nushell/issues?q=sort%3Aupdated-desc+is%3Aopen+label%3Ahelp-system))

Fixes #9076 
Fixes the syntax shape output on flags to be consistent.

## Example
```nushell
def test [
  positional: int,
  documented: float, # this has documentation
  default = 50,
  optional?,
  --a = "bla",
  --bla (-b) = "bla", # named with default
] {}
```

### before
![grafik](https://github.com/user-attachments/assets/1867984f-1289-4ad0-bdf5-c49ec56dfddb)


### after

![grafik](https://github.com/user-attachments/assets/8fca526f-d878-4d52-b970-fc41c7e8859c)
