### PR TITLE
Add multipart/form-data uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2749,6 +2749,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "multipart-rs"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ea34e5c0fa65ba84707cfaf5bf43d500f1c5a4c6c36327bf5541c5bcd17e98"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "memchr",
+ "mime",
+ "uuid",
+]
+
+[[package]]
 name = "multiversion"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,6 +2891,7 @@ dependencies = [
  "log",
  "miette",
  "mimalloc",
+ "multipart-rs",
  "nix",
  "nu-cli",
  "nu-cmd-base",
@@ -2908,7 +2923,6 @@ dependencies = [
  "tango-bench",
  "tempfile",
  "time",
- "ureq_multipart",
  "winresource",
 ]
 
@@ -3065,6 +3079,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "mockito",
+ "multipart-rs",
  "native-tls",
  "nix",
  "notify-debouncer-full",
@@ -3122,7 +3137,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "ureq",
- "ureq_multipart",
  "url",
  "uu_cp",
  "uu_mkdir",
@@ -5107,21 +5121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom",
- "libc",
- "spin",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rkyv"
 version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5329,38 +5328,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
-dependencies = [
- "log",
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -5787,12 +5754,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "sqlparser"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5925,12 +5886,6 @@ dependencies = [
  "rustversion",
  "syn 2.0.60",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -6544,12 +6499,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "ureq"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6561,24 +6510,9 @@ dependencies = [
  "log",
  "native-tls",
  "once_cell",
- "rustls",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "url",
- "webpki-roots",
-]
-
-[[package]]
-name = "ureq_multipart"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22baf2d124865fc4d505f5942222a57f6a3eae8a133819d7fd6194423e3f6e91"
-dependencies = [
- "mime",
- "mime_guess",
- "rand",
- "ureq",
 ]
 
 [[package]]
@@ -6982,15 +6916,6 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -7447,12 +7372,6 @@ dependencies = [
  "quote",
  "syn 2.0.60",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,6 +2908,7 @@ dependencies = [
  "tango-bench",
  "tempfile",
  "time",
+ "ureq_multipart",
  "winresource",
 ]
 
@@ -3121,6 +3122,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "ureq",
+ "ureq_multipart",
  "url",
  "uu_cp",
  "uu_mkdir",
@@ -5105,6 +5107,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5312,6 +5329,38 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -5738,6 +5787,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "sqlparser"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5870,6 +5925,12 @@ dependencies = [
  "rustversion",
  "syn 2.0.60",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -6483,6 +6544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "ureq"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6494,9 +6561,24 @@ dependencies = [
  "log",
  "native-tls",
  "once_cell",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq_multipart"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22baf2d124865fc4d505f5942222a57f6a3eae8a133819d7fd6194423e3f6e91"
+dependencies = [
+ "mime",
+ "mime_guess",
+ "rand",
+ "ureq",
 ]
 
 [[package]]
@@ -6900,6 +6982,15 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -7356,6 +7447,12 @@ dependencies = [
  "quote",
  "syn 2.0.60",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ miette = "7.2"
 mime = "0.3"
 mime_guess = "2.0"
 mockito = { version = "1.4", default-features = false }
+multipart-rs = "0.1.11"
 native-tls = "0.2"
 nix = { version = "0.28", default-features = false }
 notify-debouncer-full = { version = "0.3", default-features = false }
@@ -166,7 +167,6 @@ umask = "2.1"
 unicode-segmentation = "1.11"
 unicode-width = "0.1"
 ureq = { version = "2.10", default-features = false }
-ureq_multipart = "1.1.1"
 url = "2.2"
 uu_cp = "0.0.27"
 uu_mkdir = "0.0.27"
@@ -208,10 +208,10 @@ dirs = { workspace = true }
 log = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-backtrace", "fancy"] }
 mimalloc = { version = "0.1.42", default-features = false, optional = true }
+multipart-rs = { workspace = true }
 serde_json = { workspace = true }
 simplelog = "0.12"
 time = "0.3"
-ureq_multipart = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # Our dependencies don't use OpenSSL on Windows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,7 @@ umask = "2.1"
 unicode-segmentation = "1.11"
 unicode-width = "0.1"
 ureq = { version = "2.10", default-features = false }
+ureq_multipart = "1.1.1"
 url = "2.2"
 uu_cp = "0.0.27"
 uu_mkdir = "0.0.27"
@@ -210,6 +211,7 @@ mimalloc = { version = "0.1.42", default-features = false, optional = true }
 serde_json = { workspace = true }
 simplelog = "0.12"
 time = "0.3"
+ureq_multipart = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # Our dependencies don't use OpenSSL on Windows

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -90,6 +90,7 @@ titlecase = { workspace = true }
 toml = { workspace = true, features = ["preserve_order"]}
 unicode-segmentation = { workspace = true }
 ureq = { workspace = true, default-features = false, features = ["charset", "gzip", "json", "native-tls"] }
+ureq_multipart = { workspace = true }
 url = { workspace = true }
 uu_cp = { workspace = true }
 uu_mkdir = { workspace = true }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -60,6 +60,7 @@ lscolors = { workspace = true, default-features = false, features = ["nu-ansi-te
 md5 = { workspace = true }
 mime = { workspace = true }
 mime_guess = { workspace = true }
+multipart-rs = { workspace = true }
 native-tls = { workspace = true }
 notify-debouncer-full = { workspace = true, default-features = false }
 num-format = { workspace = true }
@@ -90,7 +91,6 @@ titlecase = { workspace = true }
 toml = { workspace = true, features = ["preserve_order"]}
 unicode-segmentation = { workspace = true }
 ureq = { workspace = true, default-features = false, features = ["charset", "gzip", "json", "native-tls"] }
-ureq_multipart = { workspace = true }
 url = { workspace = true }
 uu_cp = { workspace = true }
 uu_mkdir = { workspace = true }

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -281,17 +281,21 @@ pub fn send_request(
 
                     for (col, val) in val.into_owned() {
                         if let Value::Binary { val, .. } = val {
-                            let headers = format!(
-                                r#"Content-Type: application/octet-stream
-                                Content-Disposition: form-data; name="{}"; filename="{}"
-                                Content-Transfer-Encoding: binary
-                                "#,
-                                col, col,
-                            );
-                            builder.add(&mut Cursor::new(val), &headers).map_err(err)?;
+                            let headers = [
+                                "Content-Type: application/octet-stream".to_string(),
+                                "Content-Transfer-Encoding: binary".to_string(),
+                                format!(
+                                    "Content-Disposition: form-data; name=\"{}\"; filename=\"{}\"",
+                                    col, col
+                                ),
+                                format!("Content-Length: {}", val.len()),
+                            ];
+                            builder
+                                .add(&mut Cursor::new(val), &headers.join("\n"))
+                                .map_err(err)?;
                         } else {
                             let headers =
-                                format!(r#"Content-Disposition: form-data; name="{}""#, col,);
+                                format!(r#"Content-Disposition: form-data; name="{}""#, col);
                             builder
                                 .add(val.coerce_into_string()?.as_bytes(), &headers)
                                 .map_err(err)?;

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -127,6 +127,11 @@ impl Command for SubCommand {
                 example: "open foo.json | http post https://www.example.com",
                 result: None,
             },
+            Example {
+                description: "Upload a file to example.com",
+                example: "http post --content-type multipart/form-data https://www.example.com { audio: (open -r file.mp3) }",
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/tests/commands/network/http/post.rs
+++ b/crates/nu-command/tests/commands/network/http/post.rs
@@ -210,9 +210,10 @@ fn http_post_multipart_is_success() {
             Matcher::Regex("multipart/form-data; boundary=.*".to_string()),
         )
         .match_body(Matcher::AllOf(vec![
-            Matcher::Regex(r#"Content-Disposition: form-data; name="foo""#.to_string()),
-            Matcher::Regex(r#"Content-Type: application/octet-stream"#.to_string()),
-            Matcher::Regex(r#"bar"#.to_string()),
+            Matcher::Regex(r#"(?m)^Content-Disposition: form-data; name="foo""#.to_string()),
+            Matcher::Regex(r#"(?m)^Content-Type: application/octet-stream"#.to_string()),
+            Matcher::Regex(r#"(?m)^Content-Length: 3"#.to_string()),
+            Matcher::Regex(r#"(?m)^bar"#.to_string()),
         ]))
         .with_status(200)
         .create();

--- a/crates/nu-command/tests/commands/network/http/post.rs
+++ b/crates/nu-command/tests/commands/network/http/post.rs
@@ -1,4 +1,4 @@
-use mockito::Server;
+use mockito::{Matcher, Server, ServerOpts};
 use nu_test_support::{nu, pipeline};
 
 #[test]
@@ -196,4 +196,34 @@ fn http_post_redirect_mode_error() {
     assert!(&actual.err.contains(
         "Redirect encountered when redirect handling mode was 'error' (301 Moved Permanently)"
     ));
+}
+#[test]
+fn http_post_multipart_is_success() {
+    let mut server = Server::new_with_opts(ServerOpts {
+        assert_on_drop: true,
+        ..Default::default()
+    });
+    let _mock = server
+        .mock("POST", "/")
+        .match_header(
+            "content-type",
+            Matcher::Regex("multipart/form-data; boundary=.*".to_string()),
+        )
+        .match_body(Matcher::AllOf(vec![
+            Matcher::Regex(r#"Content-Disposition: form-data; name="foo""#.to_string()),
+            Matcher::Regex(r#"Content-Type: application/octet-stream"#.to_string()),
+            Matcher::Regex(r#"bar"#.to_string()),
+        ]))
+        .with_status(200)
+        .create();
+
+    let actual = nu!(pipeline(
+        format!(
+            "http post --content-type multipart/form-data {url} {{foo: ('bar' | into binary) }}",
+            url = server.url()
+        )
+        .as_str()
+    ));
+
+    assert!(actual.out.is_empty())
 }


### PR DESCRIPTION
Fixes nushell/nushell#11046

# Description
This adds support for `multipart/form-data` (RFC 7578) uploads to nushell.

Binary data is uploaded as files (`application/octet-stream`), everything else is uploaded as plain text.

```console
$ http post https://echo.free.beeceptor.com --content-type multipart/form-data {cargo: (open -r Cargo.toml | into binary ), description: "It's some TOML"} | upsert ip "<redacted>"
╭───────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ method            │ POST                                                                                                                                                                    │
│ protocol          │ https                                                                                                                                                                   │
│ host              │ echo.free.beeceptor.com                                                                                                                                                 │
│ path              │ /                                                                                                                                                                       │
│ ip                │ <redacted>                                                                                                                                                              │
│                   │ ╭─────────────────┬────────────────────────────────────────────────────────────────────╮                                                                                │
│ headers           │ │ Host            │ echo.free.beeceptor.com                                            │                                                                                │
│                   │ │ User-Agent      │ nushell                                                            │                                                                                │
│                   │ │ Content-Length  │ 9453                                                               │                                                                                │
│                   │ │ Accept          │ */*                                                                │                                                                                │
│                   │ │ Accept-Encoding │ gzip                                                               │                                                                                │
│                   │ │ Content-Type    │ multipart/form-data; boundary=a15f6a14-5768-4a6a-b3a4-686a112d9e27 │                                                                                │
│                   │ ╰─────────────────┴────────────────────────────────────────────────────────────────────╯                                                                                │
│ parsedQueryParams │ {record 0 fields}                                                                                                                                                       │
│                   │ ╭─────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ │
│ parsedBody        │ │                 │ ╭─────────────┬────────────────╮                                                                                                                  │ │
│                   │ │ textFields      │ │ description │ It's some TOML │                                                                                                                  │ │
│                   │ │                 │ ╰─────────────┴────────────────╯                                                                                                                  │ │
│                   │ │                 │ ╭───┬───────┬──────────┬──────────────────────────┬───────────────────────────┬───────────────────────────────────────────┬────────────────╮      │ │
│                   │ │ files           │ │ # │ name  │ fileName │       Content-Type       │ Content-Transfer-Encoding │            Content-Disposition            │ Content-Length │      │ │
│                   │ │                 │ ├───┼───────┼──────────┼──────────────────────────┼───────────────────────────┼───────────────────────────────────────────┼────────────────┤      │ │
│                   │ │                 │ │ 0 │ cargo │ cargo    │ application/octet-stream │ binary                    │ form-data; name="cargo"; filename="cargo" │ 9101           │      │ │
│                   │ │                 │ ╰───┴───────┴──────────┴──────────────────────────┴───────────────────────────┴───────────────────────────────────────────┴────────────────╯      │ │
│                   │ ╰─────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ │
╰───────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
# User-Facing Changes
`http post --content-type multipart/form-data` now accepts a record which is uploaded as `multipart/form-data`.
Binary data is uploaded as files (`application/octet-stream`), everything else is uploaded as plain text.

Previously `http post --content-type multipart/form-data` rejected records, so there's no BC break.

# Tests + Formatting

Added.

# After Submitting
- [ ] update docs to showcase new functionality
