### PR TITLE
Remove uutils reference from usage

### DIFF
--- a/crates/nu-command/src/filesystem/mktemp.rs
+++ b/crates/nu-command/src/filesystem/mktemp.rs
@@ -11,7 +11,7 @@ impl Command for Mktemp {
     }
 
     fn usage(&self) -> &str {
-        "Create temporary files or directories using uutils/coreutils mktemp."
+        "Create temporary files or directories."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -21,7 +21,7 @@ impl Command for UCp {
     }
 
     fn usage(&self) -> &str {
-        "Copy files using uutils/coreutils cp."
+        "Copy files."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -52,8 +52,8 @@ impl Command for UCp {
                 "preserve",
                 SyntaxShape::List(Box::new(SyntaxShape::String)),
                 "preserve only the specified attributes (empty list means no attributes preserved)
-                    if not specified only mode is preserved
-                    possible values: mode, ownership (unix only), timestamps, context, link, links, xattr",
+                    if not specified only mode is preserved possible values: mode, ownership (unix only),
+                    timestamps, context, link, links, xattr",
                 None
             )
             .switch("debug", "explain how a file is copied. Implies -v", None)

--- a/crates/nu-command/src/filesystem/umkdir.rs
+++ b/crates/nu-command/src/filesystem/umkdir.rs
@@ -29,7 +29,7 @@ impl Command for UMkdir {
     }
 
     fn usage(&self) -> &str {
-        "Create directories, with intermediary directories if required using uutils/coreutils mkdir."
+        "Create directories, with intermediary directories if required."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -15,7 +15,7 @@ impl Command for UMv {
     }
 
     fn usage(&self) -> &str {
-        "Move files or directories using uutils/coreutils mv."
+        "Move or rename files."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/platform/whoami.rs
+++ b/crates/nu-command/src/platform/whoami.rs
@@ -9,7 +9,7 @@ impl Command for Whoami {
     }
 
     fn usage(&self) -> &str {
-        "Get the current username using uutils/coreutils whoami."
+        "Get the current username."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/system/uname.rs
+++ b/crates/nu-command/src/system/uname.rs
@@ -16,7 +16,7 @@ impl Command for UName {
     }
 
     fn usage(&self) -> &str {
-        "Print certain system information using uutils/coreutils uname."
+        "Print certain system information."
     }
 
     fn search_terms(&self) -> Vec<&str> {


### PR DESCRIPTION
# Description

Minor cleanup - During the transition to `uutils/coreutils` versions of some commands, both old and new versions existed simultaneously, so the usage for the `uutils` version was different.

Now that the transition is complete, this is an internal detail that doesn't need to be part of the usage.

Note: Left *"coreutils"* as a search term for each as that might still be handy.

# User-Facing Changes

Doc/help

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A