### PR TITLE
update to latest reedline commit 919292e

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5006,8 +5006,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8c676a3f3814a23c6a0fc9dff6b6c35b2e04df8134aae6f3929cc34de21a53"
+source = "git+https://github.com/nushell/reedline?branch=main#919292e40fd417e3da882692021961b444150c59"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,8 +305,8 @@ bench = false
 
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
-# [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+[patch.crates-io]
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Run all benchmarks with `cargo bench`


### PR DESCRIPTION
# Description

This PR updates nushell to the latest reedline commit which has some vi keyboard mode changes.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
