### PR TITLE
Fix a typo in an example

### DIFF
--- a/crates/nu-command/src/random/binary.rs
+++ b/crates/nu-command/src/random/binary.rs
@@ -45,7 +45,7 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Generate 16 random bytes",
-            example: "random bytes 16",
+            example: "random binary 16",
             result: None,
         }]
     }


### PR DESCRIPTION
Accidentally used the old name of the command, `random bytes`, instead of the correct one.
