### PR TITLE
support SyntaxShape::OneOf in named args

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4778,6 +4778,31 @@ pub fn parse_value(
         }
 
         SyntaxShape::ExternalArgument => parse_regular_external_arg(working_set, span),
+        SyntaxShape::OneOf(possible_shapes) => {
+            for s in possible_shapes {
+                let starting_error_count = working_set.parse_errors.len();
+                let value = parse_value(working_set, span, s);
+
+                if starting_error_count == working_set.parse_errors.len() {
+                    return value;
+                } else if let Some(
+                    ParseError::Expected(..) | ParseError::ExpectedWithStringMsg(..),
+                ) = working_set.parse_errors.last()
+                {
+                    working_set.parse_errors.truncate(starting_error_count);
+                    continue;
+                }
+            }
+
+            if working_set.parse_errors.is_empty() {
+                working_set.error(ParseError::ExpectedWithStringMsg(
+                    format!("one of a list of accepted shapes: {possible_shapes:?}"),
+                    span,
+                ));
+            }
+
+            Expression::garbage(working_set, span)
+        }
 
         SyntaxShape::Any => {
             if bytes.starts_with(b"[") {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4703,7 +4703,7 @@ pub fn parse_value(
             | SyntaxShape::ExternalArgument => {}
             SyntaxShape::OneOf(possible_shapes) => {
                 if !possible_shapes
-                    .into_iter()
+                    .iter()
                     .any(|s| matches!(s, SyntaxShape::List(_)))
                 {
                     working_set.error(ParseError::Expected("non-[] value", span));

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4701,6 +4701,15 @@ pub fn parse_value(
             | SyntaxShape::String
             | SyntaxShape::GlobPattern
             | SyntaxShape::ExternalArgument => {}
+            SyntaxShape::OneOf(possible_shapes) => {
+                if !possible_shapes
+                    .into_iter()
+                    .any(|s| matches!(s, SyntaxShape::List(_)))
+                {
+                    working_set.error(ParseError::Expected("non-[] value", span));
+                    return Expression::garbage(working_set, span);
+                }
+            }
             _ => {
                 working_set.error(ParseError::Expected("non-[] value", span));
                 return Expression::garbage(working_set, span);


### PR DESCRIPTION
# Description
Fixes: #13253

The issue is because nushell use `parse_value` to parse named args, but `parse_value` doesn't parse `OneOf` syntax shape.

# User-Facing Changes
`OneOf` in named args should works again.

# Tests + Formatting
I think it's hard to add a test, because nushell doesn't support `oneof` syntax in custom command yet.

# After Submitting
NaN