### PR TITLE
Add type signature example for def command

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -70,6 +70,11 @@ impl Command for Def {
                 example: r#"def --wrapped my-echo [...rest] { ^echo ...$rest }; my-echo -e 'spam\tspam'"#,
                 result: Some(Value::test_string("spam\tspam")),
             },
+            Example {
+                description: "Define a custom command with a type signature. Passing a non-int value will result in an error",
+                example: r#"def only_int []: int -> int { $in }; 42 | only_int"#,
+                result: Some(Value::test_int(42)),
+            },
         ]
     }
 }


### PR DESCRIPTION
# Description

By popular demand (a.k.a. https://github.com/nushell/nushell.github.io/issues/1035), provide an example of a type signature in the `def` help.

# User-Facing Changes

Help/Doc

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib

# After Submitting

N/A