### PR TITLE
Add support for formatting integers as binary or hexadecimal using `into string`

### DIFF
--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
+use pretty_assertions::assert_eq;
 
 #[test]
 fn from_range() {
@@ -218,4 +219,34 @@ fn int_into_string_decimals_respects_system_locale_en() {
     );
 
     assert_eq!(actual.out, "10.0");
+}
+
+#[test]
+fn into_string_hex_zero() {
+    let actual = nu!("0 | into string -x");
+    assert_eq!(actual.out, "0x0")
+}
+
+#[test]
+fn into_string_hex_negative() {
+    let actual = nu!("-2748 | into string -x");
+    assert_eq!(actual.out, "-0xabc")
+}
+
+#[test]
+fn into_string_bin_zero() {
+    let actual = nu!("0 | into string -b");
+    assert_eq!(actual.out, "0b0")
+}
+
+#[test]
+fn into_string_bin_negative() {
+    let actual = nu!("-10 | into string -b");
+    assert_eq!(actual.out, "-0b1010")
+}
+
+#[test]
+fn into_string_invalid_param_combination() {
+    let actual = nu!("0 | into string -b -x");
+    assert!(actual.err.contains("Incompatible parameters."))
 }


### PR DESCRIPTION
# Description
Added flags `--hexadecimal` and `--binary` to command `into string`, which formats integers in a signed hexadecimal and binary format.

```nushell
~> into string --help
...
Flags:
  -x, --hexadecimal - format numbers as hexadecimal
  -b, --binary - format numbers as binary
...
Examples:
  convert int to string as a hexadecimal number
  > 53509 | into string --hexadecimal
  0xd105

  convert int to string as a binary number
  > 42 | into string --binary
  0b101010
```

Numbers are formatted as signed, so `-10 | into string -x` evaluates as `-0xa`, not what the two's complement of -10 would be in hex. 

Using both switches results in an error:
```nushell
~> 10 | into string -x -b
Error: nu::shell::incompatible_parameters

  × Incompatible parameters.
   ╭─[entry #3:1:18]
 1 │ 10 | into string -x -b
   ·                  ─┬ ─┬
   ·                   │  ╰── This formats the number as binary
   ·                   ╰── This formats the number as hexadecimal
   ╰────


```

# User-Facing Changes
Two new switches on the command `into string` are added, no existing code should be affected.

# Possible extensions

- Type `number` is currently not formatted as hexadecimal nor binary, should the formatting be extended to these, eg `0xab.cd`? In my opinion, this is unnecessary.
- Should I add `--upper` switch to format the hexadecimal numbers with uppercase letters, e.g. `0xABC`?