### PR TITLE
Make the math commands const

### DIFF
--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -34,6 +34,10 @@ impl Command for SubCommand {
         vec!["absolute", "modulus", "positive", "distance"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -43,6 +47,16 @@ impl Command for SubCommand {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         input.map(move |value| abs_helper(value, head), engine_state.signals())
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
+            let head = call.head;
+            input.map(move |value| abs_helper(value, head), working_set.permanent().signals())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -50,13 +50,16 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
-            let head = call.head;
-            input.map(move |value| abs_helper(value, head), working_set.permanent().signals())
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        input.map(
+            move |value| abs_helper(value, head),
+            working_set.permanent().signals(),
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -53,11 +53,11 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
+        &self,
+        _working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, average)
     }
 

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -38,6 +38,10 @@ impl Command for SubCommand {
         vec!["average", "mean", "statistics"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,
@@ -45,6 +49,15 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        run_with_function(call, input, average)
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, average)
     }
 

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -49,17 +49,20 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty { dst_span: head });            
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        input.map(move |value| operate(value, head), working_set.permanent().signals())
+        input.map(
+            move |value| operate(value, head),
+            working_set.permanent().signals(),
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -29,6 +29,10 @@ impl Command for SubCommand {
         vec!["ceiling", "round up", "rounding", "integer"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -42,6 +46,20 @@ impl Command for SubCommand {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| operate(value, head), engine_state.signals())
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        // This doesn't match explicit nulls
+        if matches!(input, PipelineData::Empty) {
+            return Err(ShellError::PipelineEmpty { dst_span: head });            
+        }
+        input.map(move |value| operate(value, head), working_set.permanent().signals())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -29,6 +29,10 @@ impl Command for SubCommand {
         vec!["round down", "rounding", "integer"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -42,6 +46,20 @@ impl Command for SubCommand {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| operate(value, head), engine_state.signals())
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        // This doesn't match explicit nulls
+        if matches!(input, PipelineData::Empty) {
+            return Err(ShellError::PipelineEmpty { dst_span: head });
+        }
+        input.map(move |value| operate(value, head), working_set.permanent().signals())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -49,17 +49,20 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        input.map(move |value| operate(value, head), working_set.permanent().signals())
+        input.map(
+            move |value| operate(value, head),
+            working_set.permanent().signals(),
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -34,6 +34,10 @@ impl Command for SubCommand {
         vec!["base", "exponent", "inverse", "euler"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -60,6 +64,34 @@ impl Command for SubCommand {
         input.map(
             move |value| operate(value, head, base),
             engine_state.signals(),
+        )
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        let base: Spanned<f64> = call.req_const(working_set, 0)?;
+
+        if base.item <= 0.0f64 {
+            return Err(ShellError::UnsupportedInput {
+                msg: "Base has to be greater 0".into(),
+                input: "value originates from here".into(),
+                msg_span: head,
+                input_span: base.span,
+            });
+        }
+            // This doesn't match explicit nulls
+        if matches!(input, PipelineData::Empty) {
+            return Err(ShellError::PipelineEmpty { dst_span: head });
+        }
+        let base = base.item;
+        input.map(
+            move |value| operate(value, head, base),
+            working_set.permanent().signals(),
         )
     }
 

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -68,11 +68,11 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         let base: Spanned<f64> = call.req_const(working_set, 0)?;
 
@@ -84,7 +84,7 @@ impl Command for SubCommand {
                 input_span: base.span,
             });
         }
-            // This doesn't match explicit nulls
+        // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -35,6 +35,10 @@ impl Command for SubCommand {
         vec!["maximum", "largest"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,
@@ -42,6 +46,15 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        run_with_function(call, input, maximum)
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, maximum)
     }
 

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -51,7 +51,7 @@ impl Command for SubCommand {
 
     fn run_const(
             &self,
-            working_set: &StateWorkingSet,
+            _working_set: &StateWorkingSet,
             call: &Call,
             input: PipelineData,
         ) -> Result<PipelineData, ShellError> {

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -50,11 +50,11 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            _working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
+        &self,
+        _working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, maximum)
     }
 

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -48,7 +48,7 @@ impl Command for SubCommand {
 
     fn run_const(
             &self,
-            working_set: &StateWorkingSet,
+            _working_set: &StateWorkingSet,
             call: &Call,
             input: PipelineData,
         ) -> Result<PipelineData, ShellError> {

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -32,6 +32,10 @@ impl Command for SubCommand {
         vec!["middle", "statistics"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,
@@ -39,6 +43,15 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        run_with_function(call, input, median)
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, median)
     }
 

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -47,11 +47,11 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            _working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
+        &self,
+        _working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, median)
     }
 

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -51,7 +51,7 @@ impl Command for SubCommand {
 
     fn run_const(
             &self,
-            working_set: &StateWorkingSet,
+            _working_set: &StateWorkingSet,
             call: &Call,
             input: PipelineData,
         ) -> Result<PipelineData, ShellError> {

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -50,11 +50,11 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            _working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
+        &self,
+        _working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, minimum)
     }
 

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -35,6 +35,10 @@ impl Command for SubCommand {
         vec!["minimum", "smallest"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,
@@ -42,6 +46,15 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        run_with_function(call, input, minimum)
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, minimum)
     }
 

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -77,11 +77,11 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            _working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
+        &self,
+        _working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, mode)
     }
 

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -62,6 +62,10 @@ impl Command for SubCommand {
         vec!["common", "often"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,
@@ -69,6 +73,15 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        run_with_function(call, input, mode)
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, mode)
     }
 

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -78,7 +78,7 @@ impl Command for SubCommand {
 
     fn run_const(
             &self,
-            working_set: &StateWorkingSet,
+            _working_set: &StateWorkingSet,
             call: &Call,
             input: PipelineData,
         ) -> Result<PipelineData, ShellError> {

--- a/crates/nu-command/src/math/product.rs
+++ b/crates/nu-command/src/math/product.rs
@@ -48,7 +48,7 @@ impl Command for SubCommand {
 
     fn run_const(
             &self,
-            working_set: &StateWorkingSet,
+            _working_set: &StateWorkingSet,
             call: &Call,
             input: PipelineData,
         ) -> Result<PipelineData, ShellError> {

--- a/crates/nu-command/src/math/product.rs
+++ b/crates/nu-command/src/math/product.rs
@@ -47,11 +47,11 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            _working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
+        &self,
+        _working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, product)
     }
 

--- a/crates/nu-command/src/math/product.rs
+++ b/crates/nu-command/src/math/product.rs
@@ -32,6 +32,10 @@ impl Command for SubCommand {
         vec!["times", "multiply", "x", "*"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,
@@ -39,6 +43,15 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        run_with_function(call, input, product)
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, product)
     }
 

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -59,11 +59,11 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
         let precision_param: Option<i64> = call.get_flag_const(working_set, "precision")?;
         let head = call.head;
         // This doesn't match explicit nulls

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -41,6 +41,10 @@ impl Command for SubCommand {
         ]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -49,6 +53,16 @@ impl Command for SubCommand {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let sample = call.has_flag(engine_state, stack, "sample")?;
+        run_with_function(call, input, compute_stddev(sample))
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
+        let sample = call.has_flag_const(working_set, "sample")?;
         run_with_function(call, input, compute_stddev(sample))
     }
 

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -57,11 +57,11 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
         let sample = call.has_flag_const(working_set, "sample")?;
         run_with_function(call, input, compute_stddev(sample))
     }

--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -50,7 +50,7 @@ impl Command for SubCommand {
 
     fn run_const(
             &self,
-            working_set: &StateWorkingSet,
+            _working_set: &StateWorkingSet,
             call: &Call,
             input: PipelineData,
         ) -> Result<PipelineData, ShellError> {

--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -49,11 +49,11 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            _working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
+        &self,
+        _working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, summation)
     }
 

--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -34,6 +34,10 @@ impl Command for SubCommand {
         vec!["plus", "add", "total", "+"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,
@@ -41,6 +45,15 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        run_with_function(call, input, summation)
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
         run_with_function(call, input, summation)
     }
 

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -33,6 +33,10 @@ impl Command for SubCommand {
         vec!["deviation", "dispersion", "variation", "statistics"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -41,6 +45,16 @@ impl Command for SubCommand {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let sample = call.has_flag(engine_state, stack, "sample")?;
+        run_with_function(call, input, compute_variance(sample))
+    }
+
+    fn run_const(
+            &self,
+            working_set: &StateWorkingSet,
+            call: &Call,
+            input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
+        let sample = call.has_flag_const(working_set, "sample")?;
         run_with_function(call, input, compute_variance(sample))
     }
 

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -49,11 +49,11 @@ impl Command for SubCommand {
     }
 
     fn run_const(
-            &self,
-            working_set: &StateWorkingSet,
-            call: &Call,
-            input: PipelineData,
-        ) -> Result<PipelineData, ShellError> {
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
         let sample = call.has_flag_const(working_set, "sample")?;
         run_with_function(call, input, compute_variance(sample))
     }

--- a/crates/nu-command/tests/commands/math/abs.rs
+++ b/crates/nu-command/tests/commands/math/abs.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn const_abs(){
+    let actual = nu!("const ABS = -5.5 | math abs; $ABS");
+    assert_eq!(actual.out, "5.5");
+}

--- a/crates/nu-command/tests/commands/math/abs.rs
+++ b/crates/nu-command/tests/commands/math/abs.rs
@@ -1,7 +1,7 @@
 use nu_test_support::nu;
 
 #[test]
-fn const_abs(){
+fn const_abs() {
     let actual = nu!("const ABS = -5.5 | math abs; $ABS");
     assert_eq!(actual.out, "5.5");
 }

--- a/crates/nu-command/tests/commands/math/avg.rs
+++ b/crates/nu-command/tests/commands/math/avg.rs
@@ -22,7 +22,7 @@ fn can_average_bytes() {
 }
 
 #[test]
-fn const_avg(){
+fn const_avg() {
     let actual = nu!("const AVG = [1 3 5] | math avg; $AVG");
     assert_eq!(actual.out, "3");
 }

--- a/crates/nu-command/tests/commands/math/avg.rs
+++ b/crates/nu-command/tests/commands/math/avg.rs
@@ -20,3 +20,9 @@ fn can_average_bytes() {
 
     assert_eq!(actual.out, "34985870");
 }
+
+#[test]
+fn const_avg(){
+    let actual = nu!("const AVG = [1 3 5] | math avg; $AVG");
+    assert_eq!(actual.out, "3");
+}

--- a/crates/nu-command/tests/commands/math/ceil.rs
+++ b/crates/nu-command/tests/commands/math/ceil.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn const_ceil(){
+    let actual = nu!("const CEIL = 1.5 | math ceil; $CEIL");
+    assert_eq!(actual.out, "2");
+}

--- a/crates/nu-command/tests/commands/math/ceil.rs
+++ b/crates/nu-command/tests/commands/math/ceil.rs
@@ -1,7 +1,7 @@
 use nu_test_support::nu;
 
 #[test]
-fn const_ceil(){
+fn const_ceil() {
     let actual = nu!("const CEIL = 1.5 | math ceil; $CEIL");
     assert_eq!(actual.out, "2");
 }

--- a/crates/nu-command/tests/commands/math/floor.rs
+++ b/crates/nu-command/tests/commands/math/floor.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn const_floor(){
+    let actual = nu!("const FLOOR = 15.5 | math floor; $FLOOR");
+    assert_eq!(actual.out, "15");
+}

--- a/crates/nu-command/tests/commands/math/floor.rs
+++ b/crates/nu-command/tests/commands/math/floor.rs
@@ -1,7 +1,7 @@
 use nu_test_support::nu;
 
 #[test]
-fn const_floor(){
+fn const_floor() {
     let actual = nu!("const FLOOR = 15.5 | math floor; $FLOOR");
     assert_eq!(actual.out, "15");
 }

--- a/crates/nu-command/tests/commands/math/log.rs
+++ b/crates/nu-command/tests/commands/math/log.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn const_log(){
+    let actual = nu!("const LOG = 16 | math log 2; $LOG");
+    assert_eq!(actual.out, "4");
+}

--- a/crates/nu-command/tests/commands/math/log.rs
+++ b/crates/nu-command/tests/commands/math/log.rs
@@ -1,7 +1,7 @@
 use nu_test_support::nu;
 
 #[test]
-fn const_log(){
+fn const_log() {
     let actual = nu!("const LOG = 16 | math log 2; $LOG");
     assert_eq!(actual.out, "4");
 }

--- a/crates/nu-command/tests/commands/math/max.rs
+++ b/crates/nu-command/tests/commands/math/max.rs
@@ -1,7 +1,7 @@
 use nu_test_support::nu;
 
 #[test]
-fn const_max(){
+fn const_max() {
     let actual = nu!("const MAX = [1 3 5] | math max; $MAX");
     assert_eq!(actual.out, "5");
 }

--- a/crates/nu-command/tests/commands/math/max.rs
+++ b/crates/nu-command/tests/commands/math/max.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn const_max(){
+    let actual = nu!("const MAX = [1 3 5] | math max; $MAX");
+    assert_eq!(actual.out, "5");
+}

--- a/crates/nu-command/tests/commands/math/median.rs
+++ b/crates/nu-command/tests/commands/math/median.rs
@@ -35,3 +35,9 @@ fn median_mixed_numbers() {
 
     assert_eq!(actual.out, "-11.5")
 }
+
+#[test]
+fn const_median(){
+    let actual = nu!("const MEDIAN = [1 3 5] | math median; $MEDIAN");
+    assert_eq!(actual.out, "3");
+}

--- a/crates/nu-command/tests/commands/math/median.rs
+++ b/crates/nu-command/tests/commands/math/median.rs
@@ -37,7 +37,7 @@ fn median_mixed_numbers() {
 }
 
 #[test]
-fn const_median(){
+fn const_median() {
     let actual = nu!("const MEDIAN = [1 3 5] | math median; $MEDIAN");
     assert_eq!(actual.out, "3");
 }

--- a/crates/nu-command/tests/commands/math/min.rs
+++ b/crates/nu-command/tests/commands/math/min.rs
@@ -1,7 +1,7 @@
 use nu_test_support::nu;
 
 #[test]
-fn const_min(){
+fn const_min() {
     let actual = nu!("const MIN = [1 3 5] | math min; $MIN");
     assert_eq!(actual.out, "1");
 }

--- a/crates/nu-command/tests/commands/math/min.rs
+++ b/crates/nu-command/tests/commands/math/min.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn const_min(){
+    let actual = nu!("const MIN = [1 3 5] | math min; $MIN");
+    assert_eq!(actual.out, "1");
+}

--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -1,8 +1,18 @@
+mod abs;
 mod avg;
+mod ceil;
+mod floor;
+mod log;
+mod max;
 mod median;
+mod min;
+mod mode;
+mod product;
 mod round;
 mod sqrt;
+mod stddev;
 mod sum;
+mod variance;
 
 use nu_test_support::{nu, pipeline};
 

--- a/crates/nu-command/tests/commands/math/mode.rs
+++ b/crates/nu-command/tests/commands/math/mode.rs
@@ -1,7 +1,7 @@
 use nu_test_support::nu;
 
 #[test]
-fn const_avg(){
+fn const_avg() {
     let actual = nu!("const MODE = [1 3 3 5] | math mode; $MODE");
     assert_eq!(actual.out, "╭───┬───╮│ 0 │ 3 │╰───┴───╯");
 }

--- a/crates/nu-command/tests/commands/math/mode.rs
+++ b/crates/nu-command/tests/commands/math/mode.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn const_avg(){
+    let actual = nu!("const MODE = [1 3 3 5] | math mode; $MODE");
+    assert_eq!(actual.out, "╭───┬───╮│ 0 │ 3 │╰───┴───╯");
+}

--- a/crates/nu-command/tests/commands/math/product.rs
+++ b/crates/nu-command/tests/commands/math/product.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn const_product(){
+    let actual = nu!("const PROD = [1 3 5] | math product; $PROD");
+    assert_eq!(actual.out, "15");
+}

--- a/crates/nu-command/tests/commands/math/product.rs
+++ b/crates/nu-command/tests/commands/math/product.rs
@@ -1,7 +1,7 @@
 use nu_test_support::nu;
 
 #[test]
-fn const_product(){
+fn const_product() {
     let actual = nu!("const PROD = [1 3 5] | math product; $PROD");
     assert_eq!(actual.out, "15");
 }

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -34,3 +34,9 @@ fn fails_with_wrong_input_type() {
 
     assert!(actual.err.contains("command doesn't support"))
 }
+
+#[test]
+fn const_round(){
+    let actual = nu!("const ROUND = 18.345 | math round; $ROUND");
+    assert_eq!(actual.out, "18");
+}

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -36,7 +36,7 @@ fn fails_with_wrong_input_type() {
 }
 
 #[test]
-fn const_round(){
+fn const_round() {
     let actual = nu!("const ROUND = 18.345 | math round; $ROUND");
     assert_eq!(actual.out, "18");
 }

--- a/crates/nu-command/tests/commands/math/sqrt.rs
+++ b/crates/nu-command/tests/commands/math/sqrt.rs
@@ -22,7 +22,7 @@ fn can_sqrt_perfect_square() {
 }
 
 #[test]
-fn const_sqrt(){
+fn const_sqrt() {
     let actual = nu!("const SQRT = 4 | math sqrt; $SQRT");
     assert_eq!(actual.out, "2");
 }

--- a/crates/nu-command/tests/commands/math/sqrt.rs
+++ b/crates/nu-command/tests/commands/math/sqrt.rs
@@ -20,3 +20,9 @@ fn can_sqrt_perfect_square() {
 
     assert_eq!(actual.out, "2");
 }
+
+#[test]
+fn const_sqrt(){
+    let actual = nu!("const SQRT = 4 | math sqrt; $SQRT");
+    assert_eq!(actual.out, "2");
+}

--- a/crates/nu-command/tests/commands/math/stddev.rs
+++ b/crates/nu-command/tests/commands/math/stddev.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn const_avg(){
+    let actual = nu!("const SDEV = [1 2] | math stddev; $SDEV");
+    assert_eq!(actual.out, "0.5");
+}

--- a/crates/nu-command/tests/commands/math/stddev.rs
+++ b/crates/nu-command/tests/commands/math/stddev.rs
@@ -1,7 +1,7 @@
 use nu_test_support::nu;
 
 #[test]
-fn const_avg(){
+fn const_avg() {
     let actual = nu!("const SDEV = [1 2] | math stddev; $SDEV");
     assert_eq!(actual.out, "0.5");
 }

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -79,7 +79,7 @@ fn sum_of_a_row_containing_a_table_is_an_error() {
 }
 
 #[test]
-fn const_sum(){
+fn const_sum() {
     let actual = nu!("const SUM = [1 3] | math sum; $SUM");
     assert_eq!(actual.out, "4");
 }

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -77,3 +77,9 @@ fn sum_of_a_row_containing_a_table_is_an_error() {
         .err
         .contains("Attempted to compute the sum of a value that cannot be summed"));
 }
+
+#[test]
+fn const_sum(){
+    let actual = nu!("const SUM = [1 3] | math sum; $SUM");
+    assert_eq!(actual.out, "4");
+}

--- a/crates/nu-command/tests/commands/math/variance.rs
+++ b/crates/nu-command/tests/commands/math/variance.rs
@@ -1,7 +1,7 @@
 use nu_test_support::nu;
 
 #[test]
-fn const_variance(){
+fn const_variance() {
     let actual = nu!("const VAR = [1 2 3 4 5] | math variance; $VAR");
     assert_eq!(actual.out, "2");
 }

--- a/crates/nu-command/tests/commands/math/variance.rs
+++ b/crates/nu-command/tests/commands/math/variance.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn const_variance(){
+    let actual = nu!("const VAR = [1 2 3 4 5] | math variance; $VAR");
+    assert_eq!(actual.out, "2");
+}


### PR DESCRIPTION
This PR closes [Issue #13482](https://github.com/nushell/nushell/issues/13482)

# Description
This PR tend to make all math function to be constant. 

# User-Facing Changes
The math commands now can be used as constant methods.

### Some Example
```
> const MODE = [3 3 9 12 12 15] | math mode
> $MODE
╭───┬────╮
│ 0 │  3 │
│ 1 │ 12 │
╰───┴────╯

> const LOG = [16 8 4] | math log 2
> $LOG
╭───┬──────╮
│ 0 │ 4.00 │
│ 1 │ 3.00 │
│ 2 │ 2.00 │
╰───┴──────╯

> const VAR = [1 3 5] | math variance
> $VAR
2.6666666666666665
```

# Tests + Formatting
Tests are added for all of the math command to test there constant behavior.

I mostly focused on the actual user experience, not the correctness of the methods and algorithms.

# After Submitting
I think  this change don't require any additional documentation. Feel free to correct me in this topic please.
