### PR TITLE
Add parse error for external commands used in assignment without caret

### DIFF
--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -312,23 +312,29 @@ fn append_assign_takes_pipeline() -> TestResult {
 }
 
 #[test]
-fn assign_bare_external_fails() -> TestResult {
-    fail_test("$env.FOO = nu --testbin cococo", "must be explicit")
+fn assign_bare_external_fails() {
+    let result = nu!("$env.FOO = nu --testbin cococo");
+    assert!(!result.status.success());
+    assert!(result.err.contains("must be explicit"));
 }
 
 #[test]
-fn assign_bare_external_with_caret() -> TestResult {
-    run_test("$env.FOO = ^nu --testbin cococo", "")
+fn assign_bare_external_with_caret() {
+    let result = nu!("$env.FOO = ^nu --testbin cococo");
+    assert!(result.status.success());
 }
 
 #[test]
-fn assign_backtick_quoted_external_fails() -> TestResult {
-    fail_test("$env.FOO = `nu` --testbin cococo", "must be explicit")
+fn assign_backtick_quoted_external_fails() {
+    let result = nu!("$env.FOO = `nu` --testbin cococo");
+    assert!(!result.status.success());
+    assert!(result.err.contains("must be explicit"));
 }
 
 #[test]
-fn assign_backtick_quoted_external_with_caret() -> TestResult {
-    run_test("$env.FOO = ^`nu` --testbin cococo", "")
+fn assign_backtick_quoted_external_with_caret() {
+    let result = nu!("$env.FOO = ^`nu` --testbin cococo");
+    assert!(result.status.success());
 }
 
 #[test]

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -312,6 +312,26 @@ fn append_assign_takes_pipeline() -> TestResult {
 }
 
 #[test]
+fn assign_bare_external_fails() -> TestResult {
+    fail_test("$env.FOO = nu --testbin cococo", "must be explicit")
+}
+
+#[test]
+fn assign_bare_external_with_caret() -> TestResult {
+    run_test("$env.FOO = ^nu --testbin cococo", "")
+}
+
+#[test]
+fn assign_backtick_quoted_external_fails() -> TestResult {
+    fail_test("$env.FOO = `nu` --testbin cococo", "must be explicit")
+}
+
+#[test]
+fn assign_backtick_quoted_external_with_caret() -> TestResult {
+    run_test("$env.FOO = ^`nu` --testbin cococo", "")
+}
+
+#[test]
 fn string_interpolation_paren_test() -> TestResult {
     run_test(r#"$"('(')(')')""#, "()")
 }


### PR DESCRIPTION
# Description

As per our Wednesday meeting, this adds a parse error when something that would be parsed as an external call is present at the top level, unless the head of the external call begins with a caret (to make it explicit).

I tried to make the error quite descriptive about what should be done.

# User-Facing Changes
These now cause a parse error:

```nushell
$foo = bar
$foo = `bar`
```

These would have been interpreted as strings before this version, but now they'd be interpreted as external calls. This behavior is consistent with `let`/`mut` (which is unaffected by this change).

Here is an example of the error:

```
Error:   × External command calls must be explicit in assignments
   ╭─[entry #3:1:8]
 1 │ $foo = bar
   ·        ─┬─
   ·         ╰── add a caret (^) before the command name if you intended to run and capture its output
   ╰────
  help: the parsing of assignments was changed in 0.97.0, and this would have previously been treated as a string.
        Alternatively, quote the string with single or double quotes to avoid it being interpreted as a command name. This
        restriction may be removed in a future release.
```

# Tests + Formatting

Tests added to cover the change. Note made about it being temporary.
