### PR TITLE
FIX : Only home dir path in pwd will be replaced with `~` in  in titlebar

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -914,7 +914,7 @@ fn run_shell_integration_osc2(
             let home_dir_str = p.as_path().display().to_string();
             if path.starts_with(&home_dir_str) {
                 path.replacen(&home_dir_str, "~", 1)
-            }else {
+            } else {
                 path
             }
         } else {


### PR DESCRIPTION
# Description :
- This pull request addresses issue #13594  where any substring of the path that matches the home directory is replaced with `~` in the title bar. This was problematic because partial matches within the path were also being replaced.

# Changes Made :

   - Changes has been made in [nushell/crates/nu-cli/src/repl.rs](https://github.com/nushell/nushell/blob/983014cc40e6a96548c731b7de26e3a1a70d6426/crates/nu-cli/src/repl.rs#L914) file.
   - Conditional Replacement Logic: The code now checks if the current path (`path`) starts with the home directory path (`home_dir_str`). This ensures that only paths that genuinely begin with the home directory will be considered for replacement with `~`.
   - Controlled Substitution: If the path starts with the home directory path, only the first occurrence is replaced with `~`. Otherwise, the original path is returned without any modification. This prevents accidental replacement of partial matches within the path, ensuring more accurate and predictable behavior. 


 