### PR TITLE
add the `alt+enter` keybinding for `insert_newline` into default config

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -903,13 +903,6 @@ $env.config = {
         # }
         {
             name: insert_newline
-            modifier: none
-            keycode: char_o
-            mode: [vi_normal]
-            event: { edit: insertnewline }
-        }
-        {
-            name: insert_newline
             modifier: control
             keycode: char_j
             mode: [emacs]

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -692,13 +692,6 @@ $env.config = {
             event: { send: enter }
         }
         {
-            name: insert_newline
-            modifier: alt
-            keycode: enter
-            mode: [emacs vi_normal vi_insert]
-            event: { edit: insertnewline }
-        }
-        {
             name: move_left
             modifier: control
             keycode: char_b

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -896,7 +896,7 @@ $env.config = {
         # So please feel free to uncomment and try the keybindings that will work for you.
         # {
         #     name: insert_newline
-        #     modifier: alt
+        #     modifier: alt     # In case of problems, check if the control or shift modifier works for you
         #     keycode: enter
         #     mode: [emacs vi_normal vi_insert]
         #     event: { edit: insertnewline }

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -901,19 +901,19 @@ $env.config = {
         #     mode: [emacs vi_normal vi_insert]
         #     event: { edit: insertnewline }
         # }
-        # {
-        #     name: insert_newline
-        #     modifier: none
-        #     keycode: char_o
-        #     mode: [vi_normal]
-        #     event: { edit: insertnewline }
-        # }
-        # {
-        #     name: insert_newline
-        #     modifier: control
-        #     keycode: char_j
-        #     mode: [emacs]
-        #     event: { edit: insertnewline }
-        # }
+        {
+            name: insert_newline
+            modifier: none
+            keycode: char_o
+            mode: [vi_normal]
+            event: { edit: insertnewline }
+        }
+        {
+            name: insert_newline
+            modifier: control
+            keycode: char_j
+            mode: [emacs]
+            event: { edit: insertnewline }
+        }
     ]
 }

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -889,5 +889,26 @@ $env.config = {
             mode: emacs
             event: { edit: selectall }
         }
+        # {
+        #     name: insert_newline
+        #     modifier: alt
+        #     keycode: enter
+        #     mode: [emacs vi_normal vi_insert]
+        #     event: { edit: insertnewline }
+        # }
+        # {
+        #     name: insert_newline
+        #     modifier: none
+        #     keycode: char_o
+        #     mode: [vi_normal]
+        #     event: { edit: insertnewline }
+        # }
+        # {
+        #     name: insert_newline
+        #     modifier: control
+        #     keycode: char_j
+        #     mode: [emacs]
+        #     event: { edit: insertnewline }
+        # }
     ]
 }

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -692,6 +692,13 @@ $env.config = {
             event: { send: enter }
         }
         {
+            name: insert_newline
+            modifier: alt
+            keycode: enter
+            mode: [emacs vi_normal vi_insert]
+            event: { edit: insertnewline }
+        }
+        {
             name: move_left
             modifier: control
             keycode: char_b

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -889,6 +889,11 @@ $env.config = {
             mode: emacs
             event: { edit: selectall }
         }
+        # Users frequently request a keybinding to add new lines in code
+        # while using REPL. The only reason those keybindings were never shipped
+        # with the initial reedline set is that those combinations of modifiers
+        # with Enter have somewhat spotty support across different platforms/terminals.
+        # So please feel free to uncomment and try the keybindings that will work for you.
         # {
         #     name: insert_newline
         #     modifier: alt


### PR DESCRIPTION
# Description

I propose adding a keybinding for `alt+enter` to insert new lines in the REPL. I believe it is a common need and a known shortcut (please let me know if it conflicts with other common practices that I might not be aware of).