### PR TITLE
Fallback to extension-based content type detection when parsing `Content-Type` header fails

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -561,6 +561,9 @@ fn transform_response_using_content_type(
     content_type: &str,
 ) -> Result<PipelineData, ShellError> {
     let content_type = mime::Mime::from_str(content_type)
+        // there are invalid content types in the wild, so we try to recover
+        // Example: `Content-Type: "text/plain"; charset="utf8"` (note the quotes)
+        .or_else(|_| mime::Mime::from_str(&content_type.replace('"', "")))
         .or_else(|_| mime::Mime::from_str("text/plain"))
         .expect("Failed to parse content type, and failed to default to text/plain");
 

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -273,3 +273,25 @@ fn http_get_self_signed_override() {
     let actual = nu!("http get --insecure https://self-signed.badssl.com/");
     assert!(actual.out.contains("<html>"));
 }
+
+#[test]
+fn http_get_with_invalid_mime_type() {
+    let mut server = Server::new();
+
+    let _mock = server
+        .mock("GET", "/foo.nuon")
+        .with_status(200)
+        .with_header("content-type", r#""what/ever""#)
+        .with_body("[1 2 3]")
+        .create();
+
+    let actual = nu!(pipeline(
+        format!(
+            r#"http get {url}/foo.nuon | to json --raw"#,
+            url = server.url()
+        )
+        .as_str()
+    ));
+
+    assert_eq!(actual.out, "[1,2,3]");
+}


### PR DESCRIPTION
# Description

Previously when nushell failed to parse the content type header, it would emit an error instead of returning the response. Now it will fall back to `text/plain` (which, in turn, will trigger type detection based on file extension).

May fix (potentially) nushell/nushell#11927

Refs: https://discord.com/channels/601130461678272522/614593951969574961/1272895236489613366

Supercedes: #13609 

# User-Facing Changes

It's now possible to fetch content even if the server returns an invalid content type header. Users may need to parse the response manually, but it's still better than not getting the response at all.

# Tests + Formatting

Added a test for the new behaviour.

# After Submitting
