### PR TITLE
create a better error message for bad glob patterns

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -148,40 +148,41 @@ impl Command for Glob {
             }
         };
 
-        let glob_pattern = match glob_pattern_input {
-            Value::String { val, .. } => {
-                if val.is_empty() {
-                    return Err(ShellError::GenericError {
-                        error: "glob pattern must not be empty".into(),
-                        msg: "glob pattern is empty".into(),
-                        span: Some(glob_span),
-                        help: Some("add characters to the glob pattern".into()),
-                        inner: vec![],
-                    });
-                } else {
-                    val
+        let glob_pattern =
+            match glob_pattern_input {
+                Value::String { val, .. } => {
+                    if val.is_empty() {
+                        return Err(ShellError::GenericError {
+                            error: "glob pattern must not be empty".into(),
+                            msg: "glob pattern is empty".into(),
+                            span: Some(glob_span),
+                            help: Some("add characters to the glob pattern".into()),
+                            inner: vec![],
+                        });
+                    } else {
+                        val
+                    }
                 }
-            }
-            Value::Glob { val, .. } => {
-                if val.is_empty() {
-                    return Err(ShellError::GenericError {
-                        error: "glob pattern must not be empty".into(),
-                        msg: "glob pattern is empty".into(),
-                        span: Some(glob_span),
-                        help: Some("add characters to the glob pattern".into()),
-                        inner: vec![],
-                    });
-                } else {
-                    val
+                Value::Glob { val, .. } => {
+                    if val.is_empty() {
+                        return Err(ShellError::GenericError {
+                            error: "glob pattern must not be empty".into(),
+                            msg: "glob pattern is empty".into(),
+                            span: Some(glob_span),
+                            help: Some("add characters to the glob pattern".into()),
+                            inner: vec![],
+                        });
+                    } else {
+                        val
+                    }
                 }
-            }
-            _ => {
-                return Err(ShellError::IncompatibleParametersSingle {
-                    msg: "Incorrect parameter type".to_string(),
-                    span: glob_span,
-                })
-            }
-        };
+                _ => return Err(ShellError::IncorrectValue {
+                    msg: "Incorrect glob pattern supplied to glob. Please use string or glob only."
+                        .to_string(),
+                    val_span: call.head,
+                    call_span: glob_span,
+                }),
+            };
 
         let folder_depth = if let Some(depth) = depth {
             depth


### PR DESCRIPTION
# Description

@sholderbach pointed out that I could've made this error message better. So, here's my attempt to make it better.

This should work. I had a hard time figuring out how to trigger the error anyway because the type checker doesn't allow "bad" parameters to begin with.

### Before
![image](https://github.com/user-attachments/assets/ac60ce27-4b9a-49ca-910c-74422ae31bc4)


### After
![image](https://github.com/user-attachments/assets/fe939339-67df-4d30-a8dd-5ce3fe623a95)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
