### PR TITLE
Prefer process name over executable path

### DIFF
--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -115,12 +115,13 @@ fn run_ps(
                         help: None,
                         inner: vec![],
                     })?;
-                // If we can't get the start time, just use the current time
-                let proc_start = proc_stat
-                    .starttime()
-                    .get()
-                    .unwrap_or_else(|_| chrono::Local::now());
-                record.push("start_time", Value::date(proc_start.into(), span));
+                record.push(
+                    "start_time",
+                    match proc_stat.starttime().get() {
+                        Ok(ts) => Value::date(ts.into(), span),
+                        Err(_) => Value::nothing(span),
+                    },
+                );
                 record.push("user_id", Value::int(proc.curr_proc.owner() as i64, span));
                 // These work and may be helpful, but it just seemed crowded
                 // record.push("group_id", Value::int(proc_stat.pgrp as i64, span));
@@ -180,7 +181,5 @@ fn run_ps(
         output.push(Value::record(record, span));
     }
 
-    Ok(output
-        .into_iter()
-        .into_pipeline_data(span, engine_state.signals().clone()))
+    Ok(output.into_pipeline_data(span, engine_state.signals().clone()))
 }


### PR DESCRIPTION
# Description
Prefer process name over executable path. This in practice causes the `name` column to use just the base executable name.

Also set start_time to nothing on error, because why not.

# User-Facing Changes

Before:

> /opt/google/chrome/chrome

After:

> chrome

Also picks up changes due to `echo test-proc > /proc/$$/comm`.

# Tests + Formatting

No new coverage.