### PR TITLE
Incrementing the eager dataframe cache value before returning it

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/lazy/collect.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/collect.rs
@@ -76,7 +76,7 @@ impl PluginCommand for LazyCollect {
             }
             PolarsPluginObject::NuDataFrame(df) => {
                 // This should just increment the cache value.
-                // We can return a value back without incrementing the 
+                // We can return a value back without incrementing the
                 // cache value or the value will be dropped (issue #12828)
                 let _ = plugin.cache.get(&df.id, true)?;
 

--- a/crates/nu_plugin_polars/src/dataframe/lazy/collect.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/collect.rs
@@ -75,6 +75,11 @@ impl PluginCommand for LazyCollect {
                 ))
             }
             PolarsPluginObject::NuDataFrame(df) => {
+                // This should just increment the cache value.
+                // We can return a value back without incrementing the 
+                // cache value or the value will be dropped (issue #12828)
+                let _ = plugin.cache.get(&df.id, true)?;
+
                 // just return the dataframe, add to cache again to be safe
                 Ok(PipelineData::Value(
                     df.cache(plugin, engine, call.head)?.into_value(call.head),


### PR DESCRIPTION
# Description

Fixes issue [12828](https://github.com/nushell/nushell/issues/12828).

When attempting a `polars collect` on an eager dataframe, we return dataframe as is. However, before this fix I failed to increment the internal cache reference count. This caused the value to be dropped from the internal cache when the references were decremented again. 

This fix adds a call to cache.get to increment the value before returning.
