### PR TITLE
doc: fix broken doc links

### DIFF
--- a/crates/nu-command/src/charting/hashable_value.rs
+++ b/crates/nu-command/src/charting/hashable_value.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, FixedOffset};
 use nu_protocol::{ShellError, Span, Value};
 use std::hash::{Hash, Hasher};
 
-/// A subset of [`Value`](crate::Value), which is hashable.
+/// A subset of [`Value`], which is hashable.
 /// And it means that we can put the value into something like
 /// [`HashMap`](std::collections::HashMap) or [`HashSet`](std::collections::HashSet) for further
 /// usage like value statistics.

--- a/crates/nu-plugin/src/plugin/process.rs
+++ b/crates/nu-plugin/src/plugin/process.rs
@@ -79,7 +79,7 @@ impl PluginProcess {
         }
     }
 
-    /// Move the plugin process out of the foreground. See [`ForegroundGuard::reset`].
+    /// Move the plugin process out of the foreground. See [`ForegroundGuard`].
     ///
     /// This is a no-op if the plugin process was already in the background.
     pub(crate) fn exit_foreground(&self) -> Result<(), ShellError> {

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -376,7 +376,9 @@ pub enum PluginOption {
     /// Send `GcDisabled(true)` to stop the plugin from being automatically garbage collected, or
     /// `GcDisabled(false)` to enable it again.
     ///
-    /// See [`EngineInterface::set_gc_disabled`] for more information.
+    /// See [`EngineInterface::set_gc_disabled`][ei_sgd] for more information.
+    ///
+    /// [ei_sgd]: crate::plugin::EngineInterface::set_gc_disabled
     GcDisabled(bool),
 }
 

--- a/crates/nu-plugin/src/util/mutable_cow.rs
+++ b/crates/nu-plugin/src/util/mutable_cow.rs
@@ -1,5 +1,5 @@
-/// Like [`Cow`] but with a mutable reference instead. So not exactly clone-on-write, but can be
-/// made owned.
+/// Like [`Cow`](std::borrow::Cow) but with a mutable reference instead. So not exactly
+/// clone-on-write, but can be made owned.
 pub enum MutableCow<'a, T> {
     Borrowed(&'a mut T),
     Owned(T),

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -59,7 +59,7 @@ impl Stack {
     /// stdout and stderr will be set to [`OutDest::Inherit`]. So, if the last command is an external command,
     /// then its output will be forwarded to the terminal/stdio streams.
     ///
-    /// Use [`Stack::capture`] afterwards if you need to evaluate an expression to a [`Value`](crate::Value)
+    /// Use [`Stack::capture`] afterwards if you need to evaluate an expression to a [`Value`]
     /// (as opposed to a [`PipelineData`](crate::PipelineData)).
     pub fn new() -> Self {
         Self {

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -626,7 +626,7 @@ fn truncate_columns_by_columns(
     widths
 }
 
-/// The same as [`tabled::peaker::PriorityMax`] but prioritizes left columns first in case of equal width.
+/// Table setting that prioritizes left columns first in case of equal width.
 #[derive(Debug, Default, Clone)]
 pub struct PriorityMax;
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Quick PR to fix doc warnings I saw when compiling with `cargo doc --no-deps --document-private-items --workspace`

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

None

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Irrelevant

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

None