### PR TITLE
doc: fix broken doc links

### DIFF
--- a/crates/nu-command/src/charting/hashable_value.rs
+++ b/crates/nu-command/src/charting/hashable_value.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, FixedOffset};
 use nu_protocol::{ShellError, Span, Value};
 use std::hash::{Hash, Hasher};
 
-/// A subset of [`Value`](crate::Value), which is hashable.
+/// A subset of [`Value`], which is hashable.
 /// And it means that we can put the value into something like
 /// [`HashMap`](std::collections::HashMap) or [`HashSet`](std::collections::HashSet) for further
 /// usage like value statistics.

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -506,7 +506,7 @@ pub fn which(name: impl AsRef<OsStr>, paths: &str, cwd: &Path) -> Option<PathBuf
 }
 
 /// Returns true if `name` is a (somewhat useful) CMD internal command. The full
-/// list can be found at https://ss64.com/nt/syntax-internal.html
+/// list can be found at <https://ss64.com/nt/syntax-internal.html>
 fn is_cmd_internal_command(name: &str) -> bool {
     const COMMANDS: &[&str] = &[
         "ASSOC", "CLS", "ECHO", "FTYPE", "MKLINK", "PAUSE", "START", "VER", "VOL",

--- a/crates/nu-engine/src/compile/mod.rs
+++ b/crates/nu-engine/src/compile/mod.rs
@@ -43,8 +43,8 @@ pub fn compile(working_set: &StateWorkingSet, block: &Block) -> Result<IrBlock, 
 }
 
 /// Compiles a [`Block`] in-place into an IR block. This can be used in a nested manner, for example
-/// by [`compile_if()`], where the instructions for the blocks for the if/else are inlined into the
-/// top-level IR block.
+/// by [`compile_if()`][keyword::compile_if], where the instructions for the blocks for the if/else
+/// are inlined into the top-level IR block.
 fn compile_block(
     working_set: &StateWorkingSet,
     builder: &mut BlockBuilder,

--- a/crates/nu-plugin-engine/src/process.rs
+++ b/crates/nu-plugin-engine/src/process.rs
@@ -79,7 +79,7 @@ impl PluginProcess {
         }
     }
 
-    /// Move the plugin process out of the foreground. See [`ForegroundGuard::reset`].
+    /// Move the plugin process out of the foreground. See [`ForegroundGuard`].
     ///
     /// This is a no-op if the plugin process was already in the background.
     pub(crate) fn exit_foreground(&self) -> Result<(), ShellError> {

--- a/crates/nu-plugin-engine/src/source.rs
+++ b/crates/nu-plugin-engine/src/source.rs
@@ -11,7 +11,7 @@ pub struct PluginSource {
     /// A weak reference to the persistent plugin that might hold an interface to the plugin.
     ///
     /// This is weak to avoid cyclic references, but it does mean we might fail to upgrade if
-    /// the engine state lost the [`PersistentPlugin`] at some point.
+    /// the engine state lost the [`PersistentPlugin`][crate::PersistentPlugin] at some point.
     pub(crate) persistent: Weak<dyn GetPlugin>,
 }
 

--- a/crates/nu-plugin-engine/src/util/mutable_cow.rs
+++ b/crates/nu-plugin-engine/src/util/mutable_cow.rs
@@ -1,5 +1,5 @@
-/// Like [`Cow`] but with a mutable reference instead. So not exactly clone-on-write, but can be
-/// made owned.
+/// Like [`Cow`][std::borrow::Cow] but with a mutable reference instead. So not exactly
+/// clone-on-write, but can be made owned.
 pub enum MutableCow<'a, T> {
     Borrowed(&'a mut T),
     Owned(T),

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -68,7 +68,7 @@ impl Stack {
     /// stdout and stderr will be set to [`OutDest::Inherit`]. So, if the last command is an external command,
     /// then its output will be forwarded to the terminal/stdio streams.
     ///
-    /// Use [`Stack::capture`] afterwards if you need to evaluate an expression to a [`Value`](crate::Value)
+    /// Use [`Stack::capture`] afterwards if you need to evaluate an expression to a [`Value`]
     /// (as opposed to a [`PipelineData`](crate::PipelineData)).
     pub fn new() -> Self {
         Self {

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -847,7 +847,8 @@ fn truncate_columns_by_head(
     widths
 }
 
-/// The same as [`tabled::peaker::PriorityMax`] but prioritizes left columns first in case of equal width.
+/// The same as [`tabled::settings::peaker::PriorityMax`] but prioritizes left columns first in case
+/// of equal width.
 #[derive(Debug, Default, Clone)]
 pub struct PriorityMax;
 


### PR DESCRIPTION
Some broken doc links I saw when compiling with `cargo +stable doc --no-deps --document-private-items --workspace --open`