### PR TITLE
Be explicit about `reduce` args and input

### DIFF
--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -120,7 +120,8 @@ impl Command for Reduce {
             engine_state.signals().check(head)?;
             acc = closure
                 .add_arg(value)
-                .run_with_value(acc)?
+                .add_arg(acc.clone())
+                .run_with_input(PipelineData::Value(acc, None))?
                 .into_value(head)?;
         }
 


### PR DESCRIPTION
# Description

`run_with_value` is meant for running simple closures with one arg. Using `run_with_value` after `add_arg` is slightly confusing.