### PR TITLE
Remove unused `same-file` workspace dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,7 +3134,6 @@ dependencies = [
  "roxmltree",
  "rstest",
  "rusqlite",
- "same-file",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,6 @@ roxmltree = "0.19"
 rstest = { version = "0.18", default-features = false }
 rusqlite = "0.31"
 rust-embed = "8.5.0"
-same-file = "1.0"
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0"
 serde_urlencoded = "0.7.1"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -77,7 +77,6 @@ regex = { workspace = true }
 roxmltree = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "backup", "chrono"], optional = true }
 rmp = { workspace = true }
-same-file = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_urlencoded = { workspace = true }


### PR DESCRIPTION
A small no-op change.  It was used in a two years old `mv` fix (848550771a, pre `uu_mv`).  But now it's redundant.