### PR TITLE
Fix encode/decode todo's

### DIFF
--- a/crates/nu-command/src/strings/base/hex.rs
+++ b/crates/nu-command/src/strings/base/hex.rs
@@ -53,7 +53,7 @@ impl Command for DecodeHex {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        todo!()
+        super::decode(data_encoding::HEXLOWER_PERMISSIVE, call.span(), input)
     }
 }
 

--- a/crates/nu-command/src/strings/base/mod.rs
+++ b/crates/nu-command/src/strings/base/mod.rs
@@ -54,14 +54,17 @@ fn get_string(input: PipelineData, call_span: Span) -> Result<(String, Span), Sh
             match val {
                 Value::String { val, .. } => Ok((val, span)),
 
-                _ => {
-                    todo!("Invalid type")
-                }
+                value => Err(ShellError::TypeMismatch {
+                    err_message: "binary or string".to_owned(),
+                    span: call_span,
+                }),
             }
         }
-        PipelineData::ListStream(..) => {
-            todo!()
-        }
+        PipelineData::ListStream(list, ..) => Err(ShellError::PipelineMismatch {
+            exp_input_type: "binary or string".to_owned(),
+            dst_span: call_span,
+            src_span: list.span(),
+        }),
         PipelineData::ByteStream(stream, ..) => {
             let span = stream.span();
             Ok((stream.into_string()?, span))
@@ -80,20 +83,23 @@ fn get_binary(input: PipelineData, call_span: Span) -> Result<(Vec<u8>, Span), S
                 Value::Binary { val, .. } => Ok((val, span)),
                 Value::String { val, .. } => Ok((val.into_bytes(), span)),
 
-                _ => {
-                    todo!("Invalid type")
-                }
+                value => Err(ShellError::TypeMismatch {
+                    err_message: "binary or string".to_owned(),
+                    span: call_span,
+                }),
             }
         }
-        PipelineData::ListStream(..) => {
-            todo!()
-        }
+        PipelineData::ListStream(list, ..) => Err(ShellError::PipelineMismatch {
+            exp_input_type: "binary or string".to_owned(),
+            dst_span: call_span,
+            src_span: list.span(),
+        }),
         PipelineData::ByteStream(stream, ..) => {
             let span = stream.span();
             Ok((stream.into_bytes()?, span))
         }
-        PipelineData::Empty => {
-            todo!("Can't have empty data");
-        }
+        PipelineData::Empty => Err(ShellError::PipelineEmpty {
+            dst_span: call_span,
+        }),
     }
 }

--- a/crates/nu-command/tests/commands/base/base32.rs
+++ b/crates/nu-command/tests/commands/base/base32.rs
@@ -2,16 +2,14 @@ use nu_test_support::nu;
 
 #[test]
 fn canonical() {
-    for value in super::random_bytes() {
-        let outcome = nu!("{} | encode base32 | decode base32 | to nuon", value);
-        assert_eq!(outcome.out, value);
+    super::test_canonical("base32");
+    super::test_canonical("base32 --nopad");
+}
 
-        let outcome = nu!(
-            "{} | encode base32 --nopad | decode base32 --nopad | to nuon",
-            value
-        );
-        assert_eq!(outcome.out, value);
-    }
+#[test]
+fn const_() {
+    super::test_const("base32");
+    super::test_const("base32 --nopad");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/base/base32hex.rs
+++ b/crates/nu-command/tests/commands/base/base32hex.rs
@@ -2,16 +2,14 @@ use nu_test_support::nu;
 
 #[test]
 fn canonical() {
-    for value in super::random_bytes() {
-        let outcome = nu!("{} | encode base32hex | decode base32hex | to nuon", value);
-        assert_eq!(outcome.out, value);
+    super::test_canonical("base32hex");
+    super::test_canonical("base32hex --nopad");
+}
 
-        let outcome = nu!(
-            "{} | encode base32hex --nopad | decode base32hex --nopad | to nuon",
-            value
-        );
-        assert_eq!(outcome.out, value);
-    }
+#[test]
+fn const_() {
+    super::test_const("base32hex");
+    super::test_const("base32hex --nopad");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/base/base64.rs
+++ b/crates/nu-command/tests/commands/base/base64.rs
@@ -2,31 +2,18 @@ use nu_test_support::nu;
 
 #[test]
 fn canonical() {
-    for value in super::random_bytes() {
-        let outcome = nu!(
-            "{} | encode new-base64 | decode new-base64 | to nuon",
-            value
-        );
-        assert_eq!(outcome.out, value);
+    super::test_canonical("new-base64");
+    super::test_canonical("new-base64 --url");
+    super::test_canonical("new-base64 --nopad");
+    super::test_canonical("new-base64 --url --nopad");
+}
 
-        let outcome = nu!(
-            "{} | encode new-base64 --url | decode new-base64 --url | to nuon",
-            value
-        );
-        assert_eq!(outcome.out, value);
-
-        let outcome = nu!(
-            "{} | encode new-base64 --nopad | decode new-base64 --nopad | to nuon",
-            value
-        );
-        assert_eq!(outcome.out, value);
-
-        let outcome = nu!(
-            "{} | encode new-base64 --url --nopad | decode new-base64 --url --nopad | to nuon",
-            value
-        );
-        assert_eq!(outcome.out, value);
-    }
+#[test]
+fn const_() {
+    super::test_const("new-base64");
+    super::test_const("new-base64 --url");
+    super::test_const("new-base64 --nopad");
+    super::test_const("new-base64 --url --nopad");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/base/hex.rs
+++ b/crates/nu-command/tests/commands/base/hex.rs
@@ -2,10 +2,12 @@ use nu_test_support::nu;
 
 #[test]
 fn canonical() {
-    for value in super::random_bytes() {
-        let outcome = nu!("{} | encode hex | decode hex | to nuon", value);
-        assert_eq!(outcome.out, value);
-    }
+    super::test_canonical("hex");
+}
+
+#[test]
+fn const_() {
+    super::test_const("hex");
 }
 
 #[test]


### PR DESCRIPTION
Mistakes have been made.  I forgot about a bunch of `todo`s in the helper functions.  So, this PR replaces them with proper errors.  It also adds tests for parse-time evaluation, because one `todo` I missed was in a `run_const` function.