### PR TITLE
Chang http post to permit a pure integer value as the body

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -342,6 +342,15 @@ pub fn send_request(
                         signals,
                     )
                 }
+                Value::Int { .. } if body_type == BodyType::Json => {
+                    let data = value_to_json_value(&body)?;
+                    send_cancellable_request(
+                        &request_url,
+                        Box::new(|| req.send_json(data)),
+                        span,
+                        signals,
+                    )
+                }
                 _ => Err(ShellErrorOrRequestError::ShellError(ShellError::IOError {
                     msg: "unsupported body input".into(),
                 })),


### PR DESCRIPTION
Closes  #13679

# Description
A simple change that permits http post requests to have an integer value as its body. Solves the issue of trying to deserialize JSON bytes through post requests.

![request](https://github.com/user-attachments/assets/32ef3640-075b-41e5-8958-c6141e15a9e0)

# User-Facing Changes
Permits int values as body of http post commands.
