### PR TITLE
Remove unnecessary sort in `explore` search fn

### DIFF
--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -860,10 +860,8 @@ fn search_pattern(data: impl Iterator<Item = String>, pat: &str, rev: bool) -> V
         }
     }
 
-    if !rev {
-        matches.sort();
-    } else {
-        matches.sort_by(|a, b| b.cmp(a));
+    if rev {
+        matches.reverse();
     }
 
     matches


### PR DESCRIPTION
Noticed when playing with the `stable_sort_primitive` lint that the elements from `enumerate` are already sorted.
