### PR TITLE
Respect user-defined `$env.NU_LOG_FORMAT` and `$env.NU_LOG_DATE_FORMAT`

### DIFF
--- a/crates/nu-std/std/log.nu
+++ b/crates/nu-std/std/log.nu
@@ -36,8 +36,8 @@ export def log-short-prefix [] {
     }
 }
 export-env {
-    $env.NU_LOG_FORMAT = $"%ANSI_START%%DATE%|%LEVEL%|%MSG%%ANSI_STOP%"
-    $env.NU_LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%.3f"
+    $env.NU_LOG_FORMAT = $env.NU_LOG_FORMAT? | default "%ANSI_START%%DATE%|%LEVEL%|%MSG%%ANSI_STOP%"
+    $env.NU_LOG_DATE_FORMAT = $env.NU_LOG_DATE_FORMAT | default "%Y-%m-%dT%H:%M:%S%.3f"
 }
 
 def log-types [] {

--- a/crates/nu-std/std/log.nu
+++ b/crates/nu-std/std/log.nu
@@ -37,7 +37,7 @@ export def log-short-prefix [] {
 }
 export-env {
     $env.NU_LOG_FORMAT = $env.NU_LOG_FORMAT? | default "%ANSI_START%%DATE%|%LEVEL%|%MSG%%ANSI_STOP%"
-    $env.NU_LOG_DATE_FORMAT = $env.NU_LOG_DATE_FORMAT | default "%Y-%m-%dT%H:%M:%S%.3f"
+    $env.NU_LOG_DATE_FORMAT = $env.NU_LOG_DATE_FORMAT? | default "%Y-%m-%dT%H:%M:%S%.3f"
 }
 
 def log-types [] {

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -143,7 +143,7 @@ macro_rules! nu_with_std {
         cwd: $value:expr,
         $($rest:tt)*
     ) => {
-        nu!(@options [ $($options)* cwd => $crate::fs::in_directory($value) ; ] $($rest)*)
+        nu_with_std!(@options [ $($options)* cwd => $crate::fs::in_directory($value) ; ] $($rest)*)
     };
     // For all other options, we call `.into()` on the `$value` and hope for the best. ;)
     (
@@ -151,7 +151,7 @@ macro_rules! nu_with_std {
         $field:ident : $value:expr,
         $($rest:tt)*
     ) => {
-        nu!(@options [ $($options)* $field => $value.into() ; ] $($rest)*)
+        nu_with_std!(@options [ $($options)* $field => $value.into() ; ] $($rest)*)
     };
 
     // When the `$field: $value,` pairs are all parsed, the next tokens are the `$path` and any
@@ -163,11 +163,11 @@ macro_rules! nu_with_std {
         $(,)*
     ) => {{
         // Here we parse the options into a `NuOpts` struct
-        let opts = nu!(@nu_opts $($options)*);
+        let opts = nu_with_std!(@nu_opts $($options)*);
         // and format the `$path` using the `$part`s
-        let path = nu!(@format_path $path, $($part),*);
+        let path = nu_with_std!(@format_path $path, $($part),*);
         // Then finally we go to the `@main` phase, where the actual work is done.
-        nu!(@main opts, path)
+        nu_with_std!(@main opts, path)
     }};
 
     // Create the NuOpts struct from the `field => value ;` pairs
@@ -196,7 +196,7 @@ macro_rules! nu_with_std {
 
     // This is the entrypoint for this macro.
     ($($token:tt)*) => {{
-        nu!(@options [ ] $($token)*)
+        nu_with_std!(@options [ ] $($token)*)
     }};
 }
 


### PR DESCRIPTION
Fixes nushell/nushell#13689

# Description

Respect user-defined `$env.NU_LOG_FORMAT` and `$env.NU_LOG_DATE_FORMAT`

Additionally I fixed `nu_with_std!()` macro (it was not working correctly)

# User-Facing Changes

Users now may set `$env.NU_LOG_FORMAT` and `$env.NU_LOG_DATE_FORMAT` in `env.nu` and it will work even if `use std` is used after that.

# Tests + Formatting

Added a couple of tests for the new functionality.

# After Submitting
