### PR TITLE
Remove `system-clipboard` from the default build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,6 @@ jobs:
       fail-fast: true
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-20.04]
-        include:
-          - default-flags: ""
-          # linux CI cannot handle clipboard feature
-          - platform: ubuntu-20.04
-            default-flags: "--no-default-features --features=default-no-clipboard"
 
     runs-on: ${{ matrix.platform }}
 
@@ -72,7 +67,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
 
       - name: Tests
-        run: cargo test --workspace --profile ci --exclude nu_plugin_* ${{ matrix.default-flags }}
+        run: cargo test --workspace --profile ci --exclude nu_plugin_*
       - name: Check for clean repo
         shell: bash
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,10 +250,8 @@ plugin = [
   "nu-protocol/plugin",
   "nu-engine/plugin",
 ]
-default = ["default-no-clipboard", "system-clipboard"]
-# Enables convenient omitting of the system-clipboard feature, as it leads to problems in ci on linux
-# See https://github.com/nushell/nushell/pull/11535
-default-no-clipboard = [
+
+default = [
   "plugin",
   "trash-support",
   "sqlite",
@@ -267,6 +265,8 @@ stable = ["default"]
 static-link-openssl = ["dep:openssl", "nu-cmd-lang/static-link-openssl"]
 
 mimalloc = ["nu-cmd-lang/mimalloc", "dep:mimalloc"]
+# Optional system clipboard support in `reedline`, this behavior has problematic compatibility with some systems.
+# Missing X server/ Wayland can cause issues
 system-clipboard = [
   "reedline/system_clipboard",
   "nu-cli/system-clipboard",

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -854,8 +854,6 @@ $env.config = {
         }
         # The following bindings with `*system` events require that Nushell has
         # been compiled with the `system-clipboard` feature.
-        # This should be the case for Windows, macOS, and most Linux distributions
-        # Not available for example on Android (termux)
         # If you want to use the system clipboard for visual selection or to
         # paste directly, uncomment the respective lines and replace the version
         # using the internal clipboard.


### PR DESCRIPTION
# Description
This feature tried to connect reedline with the system clipboard for three special bindings.
To do so it uses the `arboard` crate with heavy dependencies for the system X or Wayland server or the Windows APIs. We had issues in the headless CI with it and builds with musl seem to stall.

Removing it from the default build should negatively impact only a small subset of users aware of the extra bindings. You can still use the internal clipboard for binding based selection and the terminals extra bindings to copy arbitrary content into the system clipboard.  

For all other users it removes potential sources of failure and a whole 1 MB of release mode binary size (> 2% reduction). Furthermore a potentially substantial attack surface for Nushell is gone for default builds.

- Should resolve #13019
- Work in the spirit of #13603


# User-Facing Changes

The `edit` entries `copyselectionsystem`/`copyselectionsystem`/`pastesystem` for keybindings are gone in the default build

If you strictly depend on this behavior, you can still build with the addition of `--features system-clipboard`



