### PR TITLE
Added record key renaming for derive macros `IntoValue` and `FromValue`

### DIFF
--- a/crates/nu-derive-value/src/attributes.rs
+++ b/crates/nu-derive-value/src/attributes.rs
@@ -5,14 +5,14 @@ use crate::{error::DeriveError, HELPER_ATTRIBUTE};
 
 #[derive(Debug)]
 pub struct ContainerAttributes {
-    pub rename_all: Case,
+    pub rename_all: Option<Case>,
     pub type_name: Option<String>,
 }
 
 impl Default for ContainerAttributes {
     fn default() -> Self {
         Self {
-            rename_all: Case::Snake,
+            rename_all: None,
             type_name: None,
         }
     }
@@ -59,7 +59,7 @@ impl ContainerAttributes {
                                 return Ok(()); // We stored the err in `err`.
                             }
                         };
-                        container_attrs.rename_all = case;
+                        container_attrs.rename_all = Some(case);
                     }
                     "type_name" => {
                         let type_name: LitStr = meta.value()?.parse()?;

--- a/crates/nu-derive-value/src/attributes.rs
+++ b/crates/nu-derive-value/src/attributes.rs
@@ -3,19 +3,10 @@ use syn::{spanned::Spanned, Attribute, Fields, LitStr};
 
 use crate::{error::DeriveError, HELPER_ATTRIBUTE};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ContainerAttributes {
     pub rename_all: Option<Case>,
     pub type_name: Option<String>,
-}
-
-impl Default for ContainerAttributes {
-    fn default() -> Self {
-        Self {
-            rename_all: None,
-            type_name: None,
-        }
-    }
 }
 
 impl ContainerAttributes {

--- a/crates/nu-derive-value/src/from.rs
+++ b/crates/nu-derive-value/src/from.rs
@@ -70,7 +70,7 @@ fn derive_struct_from_value(
 ///
 /// This function constructs the `from_value` function for structs.
 /// The implementation is straightforward as most of the heavy lifting is handled by
-/// `parse_value_via_fields`, and this function only needs to construct the signature around it.
+/// [`parse_value_via_fields`], and this function only needs to construct the signature around it.
 ///
 /// For structs with named fields, this constructs a large return type where each field
 /// contains the implementation for that specific field.
@@ -511,7 +511,7 @@ fn enum_expected_type(attr_type_name: Option<&str>) -> Option<TokenStream2> {
 /// Parses a `Value` into self.
 ///
 /// This function handles the actual parsing of a `Value` into self.
-/// It takes two parameters: `fields` and `self_ident`.
+/// It takes three parameters: `fields`, `self_ident` and `rename_all`.
 /// The `fields` parameter determines the expected type of `Value`: named fields expect a
 /// `Value::Record`, unnamed fields expect a `Value::List`, and a unit expects `Value::Nothing`.
 ///
@@ -524,6 +524,10 @@ fn enum_expected_type(attr_type_name: Option<&str>) -> Option<TokenStream2> {
 /// The `self_ident` parameter is used to describe the identifier of the returned value.
 /// For structs, `Self` is usually sufficient, but for enums, `Self::Variant` may be needed in the
 /// future.
+/// 
+/// The `rename_all` parameter is provided through `#[nu_value(rename_all = "...")]` and describes 
+/// how, if passed, the field keys in the `Value` should be named.
+/// If this is `None`, we keep the names as they are in the struct.
 ///
 /// This function is more complex than the equivalent for `IntoValue` due to error handling
 /// requirements.

--- a/crates/nu-derive-value/src/from.rs
+++ b/crates/nu-derive-value/src/from.rs
@@ -524,8 +524,8 @@ fn enum_expected_type(attr_type_name: Option<&str>) -> Option<TokenStream2> {
 /// The `self_ident` parameter is used to describe the identifier of the returned value.
 /// For structs, `Self` is usually sufficient, but for enums, `Self::Variant` may be needed in the
 /// future.
-/// 
-/// The `rename_all` parameter is provided through `#[nu_value(rename_all = "...")]` and describes 
+///
+/// The `rename_all` parameter is provided through `#[nu_value(rename_all = "...")]` and describes
 /// how, if passed, the field keys in the `Value` should be named.
 /// If this is `None`, we keep the names as they are in the struct.
 ///

--- a/crates/nu-derive-value/src/into.rs
+++ b/crates/nu-derive-value/src/into.rs
@@ -50,9 +50,9 @@ pub fn derive_into_value(input: TokenStream2) -> Result<TokenStream2, DeriveErro
 /// For structs with unnamed fields, this generates a `Value::List` with each field in the list.
 /// For unit structs, this generates `Value::Nothing`, because there is no data.
 ///
-/// This function provides the signature and prepares the call to the [`fields_return_value`] 
+/// This function provides the signature and prepares the call to the [`fields_return_value`]
 /// function which does the heavy lifting of creating the `Value` calls.
-/// 
+///
 /// # Examples
 ///
 /// These examples show what the macro would generate.
@@ -219,12 +219,12 @@ fn enum_into_value(
 ///
 /// This function handles the construction of the final `Value` that the macro generates.
 /// It is currently only used for structs but may be used for enums in the future.
-/// The function takes three parameters: the `fields`, which allow iterating over each field of a 
+/// The function takes three parameters: the `fields`, which allow iterating over each field of a
 /// data type, the `accessor` and `rename_all`.
 /// The fields determine whether we need to generate a `Value::Record`, `Value::List`, or
 /// `Value::Nothing`.
 /// For named fields, they are also directly used to generate the record key.
-/// If `#[nu_value(rename_all = "...")]` is used and then passed in here via `rename_all`, the 
+/// If `#[nu_value(rename_all = "...")]` is used and then passed in here via `rename_all`, the
 /// named fields will be converted to the given case and then uses as the record key.
 ///
 /// The `accessor` parameter generalizes how the data is accessed.

--- a/crates/nu-derive-value/src/into.rs
+++ b/crates/nu-derive-value/src/into.rs
@@ -50,6 +50,9 @@ pub fn derive_into_value(input: TokenStream2) -> Result<TokenStream2, DeriveErro
 /// For structs with unnamed fields, this generates a `Value::List` with each field in the list.
 /// For unit structs, this generates `Value::Nothing`, because there is no data.
 ///
+/// This function provides the signature and prepares the call to the [`fields_return_value`] 
+/// function which does the heavy lifting of creating the `Value` calls.
+/// 
 /// # Examples
 ///
 /// These examples show what the macro would generate.
@@ -216,11 +219,13 @@ fn enum_into_value(
 ///
 /// This function handles the construction of the final `Value` that the macro generates.
 /// It is currently only used for structs but may be used for enums in the future.
-/// The function takes two parameters: the `fields`, which allow iterating over each field of a data
-/// type, and the `accessor`.
+/// The function takes three parameters: the `fields`, which allow iterating over each field of a 
+/// data type, the `accessor` and `rename_all`.
 /// The fields determine whether we need to generate a `Value::Record`, `Value::List`, or
 /// `Value::Nothing`.
 /// For named fields, they are also directly used to generate the record key.
+/// If `#[nu_value(rename_all = "...")]` is used and then passed in here via `rename_all`, the 
+/// named fields will be converted to the given case and then uses as the record key.
 ///
 /// The `accessor` parameter generalizes how the data is accessed.
 /// For named fields, this is usually the name of the fields preceded by `self` in a struct, and

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -43,7 +43,7 @@ use std::{
 /// This can be useful in situations where the default type name is not desired.
 ///
 /// ```
-/// # use nu_protocol::{FromValue, Value, ShellError, record};
+/// # use nu_protocol::{FromValue, Value, ShellError, record, Span};
 /// #
 /// # let span = Span::unknown();
 /// #
@@ -66,7 +66,7 @@ use std::{
 /// );
 ///
 ///
-/// #[derive(FromValue, PartialEq, Eq)]
+/// #[derive(FromValue, PartialEq, Eq, Debug)]
 /// #[nu_value(rename_all = "kebab-case")]
 /// struct Person {
 ///     first_name: String,

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -17,29 +17,36 @@ use std::{
 ///
 /// # Derivable
 /// This trait can be used with `#[derive]`.
+///
 /// When derived on structs with named fields, it expects a [`Value::Record`] where each field of
 /// the struct maps to a corresponding field in the record.
+/// You can customize the case conversion of these field names by using 
+/// `#[nu_value(rename_all = "...")]` on the struct.
+/// Supported case conversions include those provided by [`convert_case::Case`], such as 
+/// "snake_case", "kebab-case", "PascalCase", and others.
+/// Additionally, all values accepted by 
+/// [`#[serde(rename_all = "...")]`](https://serde.rs/container-attrs.html#rename_all) are valid here.
+/// If not set, the field names will match the original Rust field names as-is.
+///
 /// For structs with unnamed fields, it expects a [`Value::List`], and the fields are populated in
 /// the order they appear in the list.
-/// Unit structs expect  a [`Value::Nothing`], as they contain no data.
+/// Unit structs expect a [`Value::Nothing`], as they contain no data.
 /// Attempting to convert from a non-matching `Value` type will result in an error.
 ///
 /// Only enums with no fields may derive this trait.
 /// The expected value representation will be the name of the variant as a [`Value::String`].
 /// By default, variant names will be expected in ["snake_case"](convert_case::Case::Snake).
 /// You can customize the case conversion using `#[nu_value(rename_all = "kebab-case")]` on the enum.
-/// All deterministic and useful case conversions provided by [`convert_case::Case`] are supported
-/// by specifying the case name followed by "case".
-/// Also all values for
-/// [`#[serde(rename_all = "...")]`](https://serde.rs/container-attrs.html#rename_all) are valid
-/// here.
 ///
 /// Additionally, you can use `#[nu_value(type_name = "...")]` in the derive macro to set a custom type name
 /// for `FromValue::expected_type`. This will result in a `Type::Custom` with the specified type name.
 /// This can be useful in situations where the default type name is not desired.
-///
+/// 
 /// ```
-/// # use nu_protocol::{FromValue, Value, ShellError};
+/// # use nu_protocol::{FromValue, Value, ShellError, record};
+/// #
+/// # let span = Span::unknown();
+/// #
 /// #[derive(FromValue, Debug, PartialEq)]
 /// #[nu_value(rename_all = "COBOL-CASE", type_name = "birb")]
 /// enum Bird {
@@ -56,6 +63,30 @@ use std::{
 /// assert_eq!(
 ///     &Bird::expected_type().to_string(),
 ///     "birb"
+/// );
+/// 
+/// 
+/// #[derive(FromValue, PartialEq, Eq)]
+/// #[nu_value(rename_all = "kebab-case")]
+/// struct Person {
+///     first_name: String,
+///     last_name: String,
+///     age: u32,
+/// }
+///
+/// let value = Value::record(record! {
+///     "first-name" => Value::string("John", span),
+///     "last-name" => Value::string("Doe", span),
+///     "age" => Value::int(42, span),
+/// }, span);
+///
+/// assert_eq!(
+///     Person::from_value(value).unwrap(),
+///     Person {
+///         first_name: "John".into(),
+///         last_name: "Doe".into(),
+///         age: 42,
+///     }
 /// );
 /// ```
 pub trait FromValue: Sized {

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -20,11 +20,11 @@ use std::{
 ///
 /// When derived on structs with named fields, it expects a [`Value::Record`] where each field of
 /// the struct maps to a corresponding field in the record.
-/// You can customize the case conversion of these field names by using 
+/// You can customize the case conversion of these field names by using
 /// `#[nu_value(rename_all = "...")]` on the struct.
-/// Supported case conversions include those provided by [`convert_case::Case`], such as 
+/// Supported case conversions include those provided by [`convert_case::Case`], such as
 /// "snake_case", "kebab-case", "PascalCase", and others.
-/// Additionally, all values accepted by 
+/// Additionally, all values accepted by
 /// [`#[serde(rename_all = "...")]`](https://serde.rs/container-attrs.html#rename_all) are valid here.
 /// If not set, the field names will match the original Rust field names as-is.
 ///
@@ -41,7 +41,7 @@ use std::{
 /// Additionally, you can use `#[nu_value(type_name = "...")]` in the derive macro to set a custom type name
 /// for `FromValue::expected_type`. This will result in a `Type::Custom` with the specified type name.
 /// This can be useful in situations where the default type name is not desired.
-/// 
+///
 /// ```
 /// # use nu_protocol::{FromValue, Value, ShellError, record};
 /// #
@@ -64,8 +64,8 @@ use std::{
 ///     &Bird::expected_type().to_string(),
 ///     "birb"
 /// );
-/// 
-/// 
+///
+///
 /// #[derive(FromValue, PartialEq, Eq)]
 /// #[nu_value(rename_all = "kebab-case")]
 /// struct Person {

--- a/crates/nu-protocol/src/value/into_value.rs
+++ b/crates/nu-protocol/src/value/into_value.rs
@@ -10,6 +10,11 @@ use crate::{Record, ShellError, Span, Value};
 /// This trait can be used with `#[derive]`.
 /// When derived on structs with named fields, the resulting value representation will use
 /// [`Value::Record`], where each field of the record corresponds to a field of the struct.
+/// By default, field names will be kept as-is, but you can customize the case conversion
+/// for all fields in a struct by using `#[nu_value(rename_all = "kebab-case")]` on the struct.
+/// All useful case options from [`convert_case::Case`] are supported, as well as the
+/// values allowed by [`#[serde(rename_all)]`](https://serde.rs/container-attrs.html#rename_all).
+///
 /// For structs with unnamed fields, the value representation will be [`Value::List`], with all
 /// fields inserted into a list.
 /// Unit structs will be represented as [`Value::Nothing`] since they contain no data.
@@ -18,14 +23,12 @@ use crate::{Record, ShellError, Span, Value};
 /// The resulting value representation will be the name of the variant as a [`Value::String`].
 /// By default, variant names will be converted to ["snake_case"](convert_case::Case::Snake).
 /// You can customize the case conversion using `#[nu_value(rename_all = "kebab-case")]` on the enum.
-/// All deterministic and useful case conversions provided by [`convert_case::Case`] are supported
-/// by specifying the case name followed by "case".
-/// Also all values for
-/// [`#[serde(rename_all = "...")]`](https://serde.rs/container-attrs.html#rename_all) are valid
-/// here.
 ///
 /// ```
-/// # use nu_protocol::{IntoValue, Value, Span};
+/// # use nu_protocol::{IntoValue, Value, Span, record};
+/// #
+/// # let span = Span::unknown();
+/// #
 /// #[derive(IntoValue)]
 /// #[nu_value(rename_all = "COBOL-CASE")]
 /// enum Bird {
@@ -35,8 +38,30 @@ use crate::{Record, ShellError, Span, Value};
 /// }
 ///
 /// assert_eq!(
-///     Bird::RiverDuck.into_value(Span::unknown()),
+///     Bird::RiverDuck.into_value(span),
 ///     Value::test_string("RIVER-DUCK")
+/// );
+///
+///
+/// #[derive(IntoValue)]
+/// #[nu_value(rename_all = "kebab-case")]
+/// struct Person {
+///     first_name: String,
+///     last_name: String,
+///     age: u32,
+/// }
+///
+/// assert_eq!(
+///     Person {
+///         first_name: "John".into(),
+///         last_name: "Doe".into(),
+///         age: 42,
+///     }.into_value(span),
+///     Value::record(record! {
+///         "first-name" => Value::string("John", span),
+///         "last-name" => Value::string("Doe", span),
+///         "age" => Value::int(42, span),
+///     }, span)
 /// );
 /// ```
 pub trait IntoValue: Sized {

--- a/crates/nu-protocol/src/value/test_derive.rs
+++ b/crates/nu-protocol/src/value/test_derive.rs
@@ -384,62 +384,133 @@ fn enum_incorrect_type() {
     assert!(res.is_err());
 }
 
-// Generate the `Enum` from before but with all possible `rename_all` variants.
-macro_rules! enum_rename_all {
-    ($($ident:ident: $case:literal => [$a1:literal, $b2:literal, $c3:literal]),*) => {
-        $(
-            #[derive(Debug, PartialEq, IntoValue, FromValue)]
-            #[nu_value(rename_all = $case)]
-            enum $ident {
-                AlphaOne,
-                BetaTwo,
-                CharlieThree
-            }
+mod enum_rename_all {
+    use super::*;
+    use crate as nu_protocol;
 
-            impl $ident {
-                fn make() -> [Self; 3] {
-                    [Self::AlphaOne, Self::BetaTwo, Self::CharlieThree]
+    // Generate the `Enum` from before but with all possible `rename_all` variants.
+    macro_rules! enum_rename_all {
+        ($($ident:ident: $case:literal => [$a1:literal, $b2:literal, $c3:literal]),*) => {
+            $(
+                #[derive(Debug, PartialEq, IntoValue, FromValue)]
+                #[nu_value(rename_all = $case)]
+                enum $ident {
+                    AlphaOne,
+                    BetaTwo,
+                    CharlieThree
                 }
 
-                fn value() -> Value {
-                    Value::test_list(vec![
-                        Value::test_string($a1),
-                        Value::test_string($b2),
-                        Value::test_string($c3),
-                    ])
+                impl $ident {
+                    fn make() -> [Self; 3] {
+                        [Self::AlphaOne, Self::BetaTwo, Self::CharlieThree]
+                    }
+
+                    fn value() -> Value {
+                        Value::test_list(vec![
+                            Value::test_string($a1),
+                            Value::test_string($b2),
+                            Value::test_string($c3),
+                        ])
+                    }
                 }
-            }
-        )*
+            )*
 
-        #[test]
-        fn enum_rename_all_into_value() {$({
-            let expected = $ident::value();
-            let actual = $ident::make().into_test_value();
-            assert_eq!(expected, actual);
-        })*}
+            #[test]
+            fn into_value() {$({
+                let expected = $ident::value();
+                let actual = $ident::make().into_test_value();
+                assert_eq!(expected, actual);
+            })*}
 
-        #[test]
-        fn enum_rename_all_from_value() {$({
-            let expected = $ident::make();
-            let actual = <[$ident; 3]>::from_value($ident::value()).unwrap();
-            assert_eq!(expected, actual);
-        })*}
+            #[test]
+            fn from_value() {$({
+                let expected = $ident::make();
+                let actual = <[$ident; 3]>::from_value($ident::value()).unwrap();
+                assert_eq!(expected, actual);
+            })*}
+        }
+    }
+
+    enum_rename_all! {
+        Upper: "UPPER CASE" => ["ALPHA ONE", "BETA TWO", "CHARLIE THREE"],
+        Lower: "lower case" => ["alpha one", "beta two", "charlie three"],
+        Title: "Title Case" => ["Alpha One", "Beta Two", "Charlie Three"],
+        Camel: "camelCase" => ["alphaOne", "betaTwo", "charlieThree"],
+        Pascal: "PascalCase" => ["AlphaOne", "BetaTwo", "CharlieThree"],
+        Snake: "snake_case" => ["alpha_one", "beta_two", "charlie_three"],
+        UpperSnake: "UPPER_SNAKE_CASE" => ["ALPHA_ONE", "BETA_TWO", "CHARLIE_THREE"],
+        Kebab: "kebab-case" => ["alpha-one", "beta-two", "charlie-three"],
+        Cobol: "COBOL-CASE" => ["ALPHA-ONE", "BETA-TWO", "CHARLIE-THREE"],
+        Train: "Train-Case" => ["Alpha-One", "Beta-Two", "Charlie-Three"],
+        Flat: "flatcase" => ["alphaone", "betatwo", "charliethree"],
+        UpperFlat: "UPPERFLATCASE" => ["ALPHAONE", "BETATWO", "CHARLIETHREE"]
     }
 }
 
-enum_rename_all! {
-    Upper: "UPPER CASE" => ["ALPHA ONE", "BETA TWO", "CHARLIE THREE"],
-    Lower: "lower case" => ["alpha one", "beta two", "charlie three"],
-    Title: "Title Case" => ["Alpha One", "Beta Two", "Charlie Three"],
-    Camel: "camelCase" => ["alphaOne", "betaTwo", "charlieThree"],
-    Pascal: "PascalCase" => ["AlphaOne", "BetaTwo", "CharlieThree"],
-    Snake: "snake_case" => ["alpha_one", "beta_two", "charlie_three"],
-    UpperSnake: "UPPER_SNAKE_CASE" => ["ALPHA_ONE", "BETA_TWO", "CHARLIE_THREE"],
-    Kebab: "kebab-case" => ["alpha-one", "beta-two", "charlie-three"],
-    Cobol: "COBOL-CASE" => ["ALPHA-ONE", "BETA-TWO", "CHARLIE-THREE"],
-    Train: "Train-Case" => ["Alpha-One", "Beta-Two", "Charlie-Three"],
-    Flat: "flatcase" => ["alphaone", "betatwo", "charliethree"],
-    UpperFlat: "UPPERFLATCASE" => ["ALPHAONE", "BETATWO", "CHARLIETHREE"]
+mod named_fields_struct_rename_all {
+    use super::*;
+    use crate as nu_protocol;
+
+    macro_rules! named_fields_struct_rename_all {
+        ($($ident:ident: $case:literal => [$a1:literal, $b2:literal, $c3:literal]),*) => {
+            $(
+                #[derive(Debug, PartialEq, IntoValue, FromValue)]
+                #[nu_value(rename_all = $case)]
+                struct $ident {
+                    alpha_one: (),
+                    beta_two: (),
+                    charlie_three: (),
+                }
+
+                impl $ident {
+                    fn make() -> Self {
+                        Self {
+                            alpha_one: (),
+                            beta_two: (),
+                            charlie_three: (),
+                        }
+                    }
+
+                    fn value() -> Value {
+                        Value::test_record(record! {
+                            $a1 => Value::test_nothing(),
+                            $b2 => Value::test_nothing(),
+                            $c3 => Value::test_nothing(),
+                        })
+                    }
+                }
+            )*
+
+            #[test]
+            fn into_value() {$({
+                let expected = $ident::value();
+                let actual = $ident::make().into_test_value();
+                assert_eq!(expected, actual);
+            })*}
+
+            #[test]
+            fn from_value() {$({
+                let expected = $ident::make();
+                let actual = $ident::from_value($ident::value()).unwrap();
+                assert_eq!(expected, actual);
+            })*}
+        }
+    }
+
+    named_fields_struct_rename_all! {
+        Upper: "UPPER CASE" => ["ALPHA ONE", "BETA TWO", "CHARLIE THREE"],
+        Lower: "lower case" => ["alpha one", "beta two", "charlie three"],
+        Title: "Title Case" => ["Alpha One", "Beta Two", "Charlie Three"],
+        Camel: "camelCase" => ["alphaOne", "betaTwo", "charlieThree"],
+        Pascal: "PascalCase" => ["AlphaOne", "BetaTwo", "CharlieThree"],
+        Snake: "snake_case" => ["alpha_one", "beta_two", "charlie_three"],
+        UpperSnake: "UPPER_SNAKE_CASE" => ["ALPHA_ONE", "BETA_TWO", "CHARLIE_THREE"],
+        Kebab: "kebab-case" => ["alpha-one", "beta-two", "charlie-three"],
+        Cobol: "COBOL-CASE" => ["ALPHA-ONE", "BETA-TWO", "CHARLIE-THREE"],
+        Train: "Train-Case" => ["Alpha-One", "Beta-Two", "Charlie-Three"],
+        Flat: "flatcase" => ["alphaone", "betatwo", "charliethree"],
+        UpperFlat: "UPPERFLATCASE" => ["ALPHAONE", "BETATWO", "CHARLIETHREE"]
+    }
 }
 
 #[derive(IntoValue, FromValue, Debug, PartialEq)]


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Using derived `IntoValue` and `FromValue` implementations on structs with named fields currently produce `Value::Record`s where each key is the key of the Rust struct. For records like the `$nu` constant, that won't work as this record uses `kebab-case` for it's keys. To accomodate this, I upgraded the `#[nu_value(rename_all = "...")]` helper attribute to also work on structs with named fields which will rename the keys via the same case conversion as the enums already have.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Users of these macros may choose different key styles for their in `Value` representation.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
I added the same test suite as enums already have and updated the traits documentation with more examples that also pass the doc test.
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
I played around with the `$nu` constant but got stuck at the point that these keys are kebab-cased, with this, I can play around more with it.