### PR TITLE
Add split cell-path

### DIFF
--- a/crates/nu-command/src/conversions/mod.rs
+++ b/crates/nu-command/src/conversions/mod.rs
@@ -1,5 +1,7 @@
 mod fill;
 pub(crate) mod into;
+mod split_cell_path;
 
 pub use fill::Fill;
 pub use into::*;
+pub use split_cell_path::SubCommand as SplitCellPath;

--- a/crates/nu-command/src/conversions/split_cell_path.rs
+++ b/crates/nu-command/src/conversions/split_cell_path.rs
@@ -11,15 +11,12 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![
-                (Type::CellPath, Type::List(Box::new(Type::Any))),
-                (
-                    Type::CellPath,
-                    Type::List(Box::new(Type::Record(
-                        [("value".into(), Type::Any), ("optional".into(), Type::Bool)].into(),
-                    ))),
-                ),
-            ])
+            .input_output_type(
+                Type::CellPath,
+                Type::List(Box::new(Type::Record(
+                    [("value".into(), Type::Any), ("optional".into(), Type::Bool)].into(),
+                ))),
+            )
             .category(Category::Conversions)
             .allow_variants_without_examples(true)
     }

--- a/crates/nu-command/src/conversions/split_cell_path.rs
+++ b/crates/nu-command/src/conversions/split_cell_path.rs
@@ -11,12 +11,15 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_type(
-                Type::CellPath,
-                Type::List(Box::new(Type::Record(
-                    [("value".into(), Type::Any), ("optional".into(), Type::Bool)].into(),
-                ))),
-            )
+            .input_output_types(vec![
+                (Type::CellPath, Type::List(Box::new(Type::Any))),
+                (
+                    Type::CellPath,
+                    Type::List(Box::new(Type::Record(
+                        [("value".into(), Type::Any), ("optional".into(), Type::Bool)].into(),
+                    ))),
+                ),
+            ])
             .category(Category::Conversions)
             .allow_variants_without_examples(true)
     }

--- a/crates/nu-command/src/conversions/split_cell_path.rs
+++ b/crates/nu-command/src/conversions/split_cell_path.rs
@@ -66,6 +66,51 @@ impl Command for SubCommand {
             PipelineData::Empty => Err(ShellError::PipelineEmpty { dst_span: head }),
         }
     }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Split a cell-path into its components",
+                example: "$.5?.c | split cell-path",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "value" => Value::test_int(5),
+                        "optional" => Value::test_bool(true),
+                    }),
+                    Value::test_record(record! {
+                        "value" => Value::test_string("c"),
+                        "optional" => Value::test_bool(false),
+                    }),
+                ])),
+            },
+            Example {
+                description: "Split a complex cell-path",
+                example: r#"$.a.b?.1."2"."c.d" | split cell-path"#,
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "value" => Value::test_string("a"),
+                        "optional" => Value::test_bool(false),
+                    }),
+                    Value::test_record(record! {
+                        "value" => Value::test_string("b"),
+                        "optional" => Value::test_bool(true),
+                    }),
+                    Value::test_record(record! {
+                        "value" => Value::test_int(1),
+                        "optional" => Value::test_bool(false),
+                    }),
+                    Value::test_record(record! {
+                        "value" => Value::test_string("2"),
+                        "optional" => Value::test_bool(false),
+                    }),
+                    Value::test_record(record! {
+                        "value" => Value::test_string("c.d"),
+                        "optional" => Value::test_bool(false),
+                    }),
+                ])),
+            },
+        ]
+    }
 }
 
 fn split_cell_path(val: CellPath, span: Span) -> Result<Value, ShellError> {
@@ -103,8 +148,21 @@ fn split_cell_path(val: CellPath, span: Span) -> Result<Value, ShellError> {
             })
         })
         .collect();
+
     Ok(Value::List {
         vals: members,
         internal_span: span,
     })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
 }

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -327,6 +327,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             IntoString,
             IntoGlob,
             IntoValue,
+            SplitCellPath,
         };
 
         // Env


### PR DESCRIPTION
this PR should close #12168

# Description
Add `split cell-path`, inverse of `into cell-path`.

# User-Facing Changes
Currently there is no way to make use of cell-path values as a user, other than passing them to builtin commands. This PR makes more use cases possible.