### PR TITLE
Use `heck` instead of `convert_case` for `nu-derive-value`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,15 +934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,7 +3211,7 @@ dependencies = [
 name = "nu-derive-value"
 version = "0.97.2"
 dependencies = [
- "convert_case",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3424,7 +3415,6 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-humanize",
- "convert_case",
  "dirs",
  "dirs-sys",
  "fancy-regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3418,6 +3418,7 @@ dependencies = [
  "dirs",
  "dirs-sys",
  "fancy-regex",
+ "heck",
  "indexmap",
  "log",
  "lru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,6 @@ chardetng = "0.1.17"
 chrono = { default-features = false, version = "0.4.34" }
 chrono-humanize = "0.2.3"
 chrono-tz = "0.8"
-convert_case = "0.6"
 crossbeam-channel = "0.5.8"
 crossterm = "0.27"
 csv = "1.3"

--- a/crates/nu-derive-value/Cargo.toml
+++ b/crates/nu-derive-value/Cargo.toml
@@ -18,4 +18,4 @@ proc-macro2 = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }
 proc-macro-error = { workspace = true }
-convert_case = { workspace = true }
+heck = { workspace = true }

--- a/crates/nu-derive-value/src/case.rs
+++ b/crates/nu-derive-value/src/case.rs
@@ -1,0 +1,72 @@
+use heck::*;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Case {
+    // directly supported by heck
+    Pascal,
+    Camel,
+    Snake,
+    Kebab,
+    ScreamingSnake,
+    Title,
+    Cobol,
+    Train,
+
+    // custom variants
+    Upper,
+    Lower,
+    Flat,
+    ScreamingFlat,
+}
+
+impl Case {
+    pub fn from_str(s: impl AsRef<str>) -> Option<Self> {
+        match s.as_ref() {
+            // The matched case are all useful variants from `convert_case` with aliases
+            // that `serde` uses.
+            "PascalCase" | "UpperCamelCase" => Case::Pascal,
+            "camelCase" | "lowerCamelCase" => Case::Camel,
+            "snake_case" => Case::Snake,
+            "kebab-case" => Case::Kebab,
+            "SCREAMING_SNAKE_CASE" | "UPPER_SNAKE_CASE" | "SHOUTY_SNAKE_CASE" => {
+                Case::ScreamingSnake
+            }
+            "Title Case" => Case::Title,
+            "COBOL-CASE" | "SCREAMING-KEBAB-CASE" | "UPPER-KEBAB-CASE" => Case::Cobol,
+            "Train-Case" => Case::Train,
+
+            "UPPER CASE" | "UPPER WITH SPACES CASE" => Case::Upper,
+            "lower case" | "lower with spaces case" => Case::Lower,
+            "flatcase" | "lowercase" => Case::Flat,
+            "SCREAMINGFLATCASE" | "UPPERFLATCASE" | "UPPERCASE" => Case::ScreamingFlat,
+
+            _ => return None,
+        }
+        .into()
+    }
+}
+
+pub trait Casing {
+    fn to_case(&self, case: Case) -> String;
+}
+
+impl<T: AsRef<str>> Casing for T {
+    fn to_case(&self, case: Case) -> String {
+        let s = self.as_ref();
+        match case {
+            Case::Pascal => s.to_upper_camel_case(),
+            Case::Camel => s.to_lower_camel_case(),
+            Case::Snake => s.to_snake_case(),
+            Case::Kebab => s.to_kebab_case(),
+            Case::ScreamingSnake => s.to_shouty_snake_case(),
+            Case::Title => s.to_title_case(),
+            Case::Cobol => s.to_shouty_kebab_case(),
+            Case::Train => s.to_train_case(),
+
+            Case::Upper => s.to_shouty_snake_case().replace('_', " "),
+            Case::Lower => s.to_snake_case().replace('_', " "),
+            Case::Flat => s.to_snake_case().replace('_', ""),
+            Case::ScreamingFlat => s.to_shouty_snake_case().replace('_', ""),
+        }
+    }
+}

--- a/crates/nu-derive-value/src/from.rs
+++ b/crates/nu-derive-value/src/from.rs
@@ -1,4 +1,3 @@
-use convert_case::{Case, Casing};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
 use syn::{
@@ -6,7 +5,10 @@ use syn::{
     Type,
 };
 
-use crate::attributes::{self, ContainerAttributes};
+use crate::{
+    attributes::{self, ContainerAttributes},
+    case::{Case, Casing},
+};
 
 #[derive(Debug)]
 pub struct FromValue;

--- a/crates/nu-derive-value/src/from.rs
+++ b/crates/nu-derive-value/src/from.rs
@@ -395,7 +395,7 @@ fn derive_enum_from_value(
 /// all possible variants.
 /// The input value is expected to be a `Value::String` containing the name of the variant formatted
 /// as defined by the `#[nu_value(rename_all = "...")]` attribute.
-/// If no attribute is given, [`convert_case::Case::Snake`] is expected.
+/// If no attribute is given, [`snake_case`](heck::ToSnakeCase) is expected.
 ///
 /// If no matching variant is found, `ShellError::CantConvert` is returned.
 ///

--- a/crates/nu-derive-value/src/into.rs
+++ b/crates/nu-derive-value/src/into.rs
@@ -1,4 +1,3 @@
-use convert_case::{Case, Casing};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
 use syn::{
@@ -6,7 +5,10 @@ use syn::{
     Index,
 };
 
-use crate::attributes::{self, ContainerAttributes};
+use crate::{
+    attributes::{self, ContainerAttributes},
+    case::{Case, Casing},
+};
 
 #[derive(Debug)]
 pub struct IntoValue;

--- a/crates/nu-derive-value/src/lib.rs
+++ b/crates/nu-derive-value/src/lib.rs
@@ -32,6 +32,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use proc_macro_error::{proc_macro_error, Diagnostic};
 
 mod attributes;
+mod case;
 mod error;
 mod from;
 mod into;

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -23,7 +23,6 @@ bytes = { workspace = true }
 byte-unit = { version = "5.1", features = [ "serde" ] }
 chrono = { workspace = true, features = [ "serde", "std", "unstable-locales" ], default-features = false }
 chrono-humanize = { workspace = true }
-convert_case = { workspace = true }
 dirs = { workspace = true }
 fancy-regex = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -25,6 +25,7 @@ chrono = { workspace = true, features = [ "serde", "std", "unstable-locales" ], 
 chrono-humanize = { workspace = true }
 dirs = { workspace = true }
 fancy-regex = { workspace = true }
+heck = { workspace = true }
 indexmap = { workspace = true }
 lru = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-backtrace"] }

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -22,7 +22,7 @@ use std::{
 /// the struct maps to a corresponding field in the record.
 /// You can customize the case conversion of these field names by using
 /// `#[nu_value(rename_all = "...")]` on the struct.
-/// Supported case conversions include those provided by [`convert_case::Case`], such as
+/// Supported case conversions include those provided by [`heck`], such as
 /// "snake_case", "kebab-case", "PascalCase", and others.
 /// Additionally, all values accepted by
 /// [`#[serde(rename_all = "...")]`](https://serde.rs/container-attrs.html#rename_all) are valid here.
@@ -35,7 +35,7 @@ use std::{
 ///
 /// Only enums with no fields may derive this trait.
 /// The expected value representation will be the name of the variant as a [`Value::String`].
-/// By default, variant names will be expected in ["snake_case"](convert_case::Case::Snake).
+/// By default, variant names will be expected in ["snake_case"](heck::ToSnakeCase).
 /// You can customize the case conversion using `#[nu_value(rename_all = "kebab-case")]` on the enum.
 ///
 /// Additionally, you can use `#[nu_value(type_name = "...")]` in the derive macro to set a custom type name

--- a/crates/nu-protocol/src/value/into_value.rs
+++ b/crates/nu-protocol/src/value/into_value.rs
@@ -12,7 +12,7 @@ use crate::{Record, ShellError, Span, Value};
 /// [`Value::Record`], where each field of the record corresponds to a field of the struct.
 /// By default, field names will be kept as-is, but you can customize the case conversion
 /// for all fields in a struct by using `#[nu_value(rename_all = "kebab-case")]` on the struct.
-/// All case options from [`heck`] are supported, as well as the values allowed by 
+/// All case options from [`heck`] are supported, as well as the values allowed by
 /// [`#[serde(rename_all)]`](https://serde.rs/container-attrs.html#rename_all).
 ///
 /// For structs with unnamed fields, the value representation will be [`Value::List`], with all

--- a/crates/nu-protocol/src/value/into_value.rs
+++ b/crates/nu-protocol/src/value/into_value.rs
@@ -12,8 +12,8 @@ use crate::{Record, ShellError, Span, Value};
 /// [`Value::Record`], where each field of the record corresponds to a field of the struct.
 /// By default, field names will be kept as-is, but you can customize the case conversion
 /// for all fields in a struct by using `#[nu_value(rename_all = "kebab-case")]` on the struct.
-/// All useful case options from [`convert_case::Case`] are supported, as well as the
-/// values allowed by [`#[serde(rename_all)]`](https://serde.rs/container-attrs.html#rename_all).
+/// All case options from [`heck`] are supported, as well as the values allowed by 
+/// [`#[serde(rename_all)]`](https://serde.rs/container-attrs.html#rename_all).
 ///
 /// For structs with unnamed fields, the value representation will be [`Value::List`], with all
 /// fields inserted into a list.
@@ -21,7 +21,7 @@ use crate::{Record, ShellError, Span, Value};
 ///
 /// Only enums with no fields may derive this trait.
 /// The resulting value representation will be the name of the variant as a [`Value::String`].
-/// By default, variant names will be converted to ["snake_case"](convert_case::Case::Snake).
+/// By default, variant names will be converted to ["snake_case"](heck::ToSnakeCase).
 /// You can customize the case conversion using `#[nu_value(rename_all = "kebab-case")]` on the enum.
 ///
 /// ```


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
@sholderbach mentioned that I introduced `convert_case` as a dependency while we already had `heck` for case conversion. So in this PR replaced the use `convert_case` with `heck`. Mostly I rebuilt the `convert_case` API with `heck` to work with it as I like the API of `convert_case` more than `heck`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Nothing changed, the use of `convert_case` wasn't exposed anywhere and all case conversions are still available.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
No new tests required but my tests in `test_derive` captured some errors I made while developing this change, (hurray, tests work 🎉)
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
