### PR TITLE
update virtual terminal processing

### DIFF
--- a/crates/nu-utils/src/utils.rs
+++ b/crates/nu-utils/src/utils.rs
@@ -7,6 +7,7 @@ pub fn enable_vt_processing() -> Result<()> {
         use crossterm_winapi::{ConsoleMode, Handle};
 
         pub const ENABLE_PROCESSED_OUTPUT: u32 = 0x0001;
+        pub const ENABLE_VIRTUAL_TERMINAL_INPUT: u32 = 0x0200;
         pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
         let mask = ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
@@ -17,8 +18,12 @@ pub fn enable_vt_processing() -> Result<()> {
         // enable_processed_output and enable_virtual_terminal_processing should be used
 
         if old_mode & mask == 0 {
-            console_mode
-                .set_mode(old_mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING)?
+            console_mode.set_mode(
+                old_mode
+                    | ENABLE_PROCESSED_OUTPUT
+                    | ENABLE_VIRTUAL_TERMINAL_PROCESSING
+                    | ENABLE_VIRTUAL_TERMINAL_INPUT,
+            )?
         }
     }
     Ok(())


### PR DESCRIPTION
# Description

With Windows Terminal Canary 1.23.240826001-llm, this enables nushell to query the terminal and receive a response.

![image](https://github.com/user-attachments/assets/c4c43328-c431-47e4-b377-8b3a2bc12b74)

The red component here is
```nushell
❯ ("0c0c" | into int -r 16) / 256 | math round | fmt | get lowerhex
0xc
```

This example queries the background and the response is a r/g/b color. The response really should be
```
␛]11;1;rgb:0c0c/0c0c/0c0c
```
I'm not sure why nushell's input is eating the first part.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
