### PR TITLE
Expand multiple dots in path in completions 

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -57,7 +57,7 @@ pub fn complete_rec(
     let Ok(result) = built_path.read_dir() else {
         return completions;
     };
-
+    
     let mut entries = Vec::new();
     for entry in result.filter_map(|e| e.ok()) {
         let entry_name = entry.file_name().to_string_lossy().into_owned();
@@ -194,16 +194,11 @@ pub fn complete_item(
     match components.peek().cloned() {
         Some(c @ Component::Prefix(..)) => {
             // windows only by definition
-            components.next();
-            if let Some(Component::RootDir) = components.peek().cloned() {
-                components.next();
-            };
             cwd = [c, Component::RootDir].iter().collect();
             prefix_len = c.as_os_str().len();
             original_cwd = OriginalCwd::Prefix(c.as_os_str().to_string_lossy().into_owned());
         }
         Some(c @ Component::RootDir) => {
-            components.next();
             // This is kind of a hack. When joining an empty string with the rest,
             // we add the slash automagically
             cwd = PathBuf::from(c.as_os_str());
@@ -211,7 +206,6 @@ pub fn complete_item(
             original_cwd = OriginalCwd::Prefix(String::new());
         }
         Some(Component::Normal(home)) if home.to_string_lossy() == "~" => {
-            components.next();
             cwd = home_dir().map(Into::into).unwrap_or(cwd_pathbuf);
             prefix_len = 1;
             original_cwd = OriginalCwd::Home;

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -161,19 +161,19 @@ pub fn complete_item(
     let expanded_partial = expand_ndots(Path::new(&cleaned_partial));
     let mut partial = expanded_partial.to_string_lossy().to_string();
 
-    // Handle the trailing dot case
-    if cleaned_partial.ends_with("/.") {
-        partial.push_str("/.");
-    }
-
-    //let isdir = path.is_dir();
     #[cfg(unix)]
     let path_separator = SEP;
     #[cfg(windows)]
-    let path_separator = partial
+    let path_separator = cleaned_partial
         .chars()
         .rfind(|c: &char| is_separator(*c))
         .unwrap_or(SEP);
+
+    // Handle the trailing dot case
+    if cleaned_partial.ends_with(&format!("{path_separator}.")) {
+        partial.push_str(&format!("{path_separator}."));
+    }
+
     let cwd_pathbuf = Path::new(cwd).to_path_buf();
     let ls_colors = (engine_state.config.use_ls_colors_completions
         && engine_state.config.use_ansi_coloring)

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -496,7 +496,13 @@ fn partial_completions() {
     match_suggestions(&expected_paths, &suggestions);
 
     // Test completion where there is a sneaky `...` in the path
-    let dir_str = file(dir.join("par").join("...").join("par").join("fi").join("so"));
+    let dir_str = file(
+        dir.join("par")
+            .join("...")
+            .join("par")
+            .join("fi")
+            .join("so"),
+    );
     let target_dir = format!("rm {dir_str}");
     let suggestions = completer.complete(&target_dir, target_dir.len());
 
@@ -967,7 +973,7 @@ fn folder_with_directorycompletions_with_dots() {
         .into_os_string()
         .into_string()
         .unwrap();
-    
+
     // Instantiate a new completer
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
@@ -976,9 +982,12 @@ fn folder_with_directorycompletions_with_dots() {
     let suggestions = completer.complete(&target_dir, target_dir.len());
 
     // Create the expected values
-    let expected_paths: Vec<String> = vec![
-        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("folder_inside_folder")),
-    ];
+    let expected_paths: Vec<String> = vec![folder(
+        dir.join("directory_completion")
+            .join("folder_inside_folder")
+            .join("..")
+            .join("folder_inside_folder"),
+    )];
 
     #[cfg(windows)]
     {
@@ -1008,7 +1017,7 @@ fn folder_with_directorycompletions_with_three_trailing_dots() {
         .into_os_string()
         .into_string()
         .unwrap();
-    
+
     // Instantiate a new completer
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
@@ -1018,11 +1027,41 @@ fn folder_with_directorycompletions_with_three_trailing_dots() {
 
     // Create the expected values
     let expected_paths: Vec<String> = vec![
-        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("..").join("another")),
-        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("..").join("directory_completion")),
-        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("..").join("test_a")),
-        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("..").join("test_b")),
-        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("..").join(".hidden_folder")),
+        folder(
+            dir.join("directory_completion")
+                .join("folder_inside_folder")
+                .join("..")
+                .join("..")
+                .join("another"),
+        ),
+        folder(
+            dir.join("directory_completion")
+                .join("folder_inside_folder")
+                .join("..")
+                .join("..")
+                .join("directory_completion"),
+        ),
+        folder(
+            dir.join("directory_completion")
+                .join("folder_inside_folder")
+                .join("..")
+                .join("..")
+                .join("test_a"),
+        ),
+        folder(
+            dir.join("directory_completion")
+                .join("folder_inside_folder")
+                .join("..")
+                .join("..")
+                .join("test_b"),
+        ),
+        folder(
+            dir.join("directory_completion")
+                .join("folder_inside_folder")
+                .join("..")
+                .join("..")
+                .join(".hidden_folder"),
+        ),
     ];
 
     #[cfg(windows)]

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -958,6 +958,87 @@ fn folder_with_directorycompletions() {
 }
 
 #[test]
+fn folder_with_directorycompletions_with_dots() {
+    // Create a new engine
+    let (dir, _, engine, stack) = new_engine();
+    let dir_string = dir
+        .join("directory_completion")
+        .join("folder_inside_folder")
+        .into_os_string()
+        .into_string()
+        .unwrap();
+    
+    // Instantiate a new completer
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+
+    // Test completions for the current folder
+    let target_dir = format!("cd {dir_string}{MAIN_SEPARATOR}..{MAIN_SEPARATOR}");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    // Create the expected values
+    let expected_paths: Vec<String> = vec![
+        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("folder_inside_folder")),
+    ];
+
+    #[cfg(windows)]
+    {
+        let target_dir = format!("cd {dir_str}/");
+        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+
+        let expected_slash_paths: Vec<String> = expected_paths
+            .iter()
+            .map(|s| s.replace('\\', "/"))
+            .collect();
+
+        match_suggestions(&expected_slash_paths, &slash_suggestions);
+    }
+
+    // Match the results
+    match_suggestions(&expected_paths, &suggestions);
+}
+
+#[test]
+fn folder_with_directorycompletions_with_three_trailing_dots() {
+    // Create a new engine
+    let (dir, _, engine, stack) = new_engine();
+    let dir_string = dir
+        .join("directory_completion")
+        .join("folder_inside_folder")
+        .join(".../")
+        .into_os_string()
+        .into_string()
+        .unwrap();
+    
+    // Instantiate a new completer
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+
+    // Test completions for the current folder
+    let target_dir = format!("cd {dir_string}");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    // Create the expected values
+    let expected_paths: Vec<String> = vec![
+        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("..").join("completions")),
+    ];
+
+    #[cfg(windows)]
+    {
+        let target_dir = format!("cd {dir_str}/");
+        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+
+        let expected_slash_paths: Vec<String> = expected_paths
+            .iter()
+            .map(|s| s.replace('\\', "/"))
+            .collect();
+
+        match_suggestions(&expected_slash_paths, &slash_suggestions);
+    }
+
+    // Match the results
+    match_suggestions(&expected_paths, &suggestions);
+}
+
+#[test]
 fn variables_completions() {
     // Create a new engine
     let (dir, _, mut engine, mut stack) = new_engine();

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -544,32 +544,28 @@ fn partial_completion_with_dot_expansions() {
     let expected_paths: Vec<String> = vec![
         file(
             dir.join("partial")
-                .join("..")
-                .join("..")
+                .join("...")
                 .join("partial_completions")
                 .join("final_partial")
                 .join("somefile"),
         ),
         file(
             dir.join("partial-a")
-                .join("..")
-                .join("..")
+                .join("...")
                 .join("partial_completions")
                 .join("final_partial")
                 .join("somefile"),
         ),
         file(
             dir.join("partial-b")
-                .join("..")
-                .join("..")
+                .join("...")
                 .join("partial_completions")
                 .join("final_partial")
                 .join("somefile"),
         ),
         file(
             dir.join("partial-c")
-                .join("..")
-                .join("..")
+                .join("...")
                 .join("partial_completions")
                 .join("final_partial")
                 .join("somefile"),
@@ -1035,36 +1031,31 @@ fn folder_with_directorycompletions_with_three_trailing_dots() {
         folder(
             dir.join("directory_completion")
                 .join("folder_inside_folder")
-                .join("..")
-                .join("..")
+                .join("...")
                 .join("another"),
         ),
         folder(
             dir.join("directory_completion")
                 .join("folder_inside_folder")
-                .join("..")
-                .join("..")
+                .join("...")
                 .join("directory_completion"),
         ),
         folder(
             dir.join("directory_completion")
                 .join("folder_inside_folder")
-                .join("..")
-                .join("..")
+                .join("...")
                 .join("test_a"),
         ),
         folder(
             dir.join("directory_completion")
                 .join("folder_inside_folder")
-                .join("..")
-                .join("..")
+                .join("...")
                 .join("test_b"),
         ),
         folder(
             dir.join("directory_completion")
                 .join("folder_inside_folder")
-                .join("..")
-                .join("..")
+                .join("...")
                 .join(".hidden_folder"),
         ),
     ];

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -495,7 +495,41 @@ fn partial_completions() {
     // Match the results
     match_suggestions(&expected_paths, &suggestions);
 
-    // Test completion where there is a sneaky `...` in the path
+    // Test completion for all files under directories whose names begin with "pa"
+    let file_str = file(dir.join("partial-a").join("have"));
+    let target_file = format!("rm {file_str}");
+    let suggestions = completer.complete(&target_file, target_file.len());
+
+    // Create the expected values
+    let expected_paths: Vec<String> = vec![
+        file(dir.join("partial-a").join("have_ext.exe")),
+        file(dir.join("partial-a").join("have_ext.txt")),
+    ];
+
+    // Match the results
+    match_suggestions(&expected_paths, &suggestions);
+
+    // Test completion for all files under directories whose names begin with "pa"
+    let file_str = file(dir.join("partial-a").join("have_ext."));
+    let file_dir = format!("rm {file_str}");
+    let suggestions = completer.complete(&file_dir, file_dir.len());
+
+    // Create the expected values
+    let expected_paths: Vec<String> = vec![
+        file(dir.join("partial-a").join("have_ext.exe")),
+        file(dir.join("partial-a").join("have_ext.txt")),
+    ];
+
+    // Match the results
+    match_suggestions(&expected_paths, &suggestions);
+}
+
+#[test]
+fn partial_completion_with_dot_expansions() {
+    let (dir, _, engine, stack) = new_partial_engine();
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+
     let dir_str = file(
         dir.join("par")
             .join("...")
@@ -540,34 +574,6 @@ fn partial_completions() {
                 .join("final_partial")
                 .join("somefile"),
         ),
-    ];
-
-    // Match the results
-    match_suggestions(&expected_paths, &suggestions);
-
-    // Test completion for all files under directories whose names begin with "pa"
-    let file_str = file(dir.join("partial-a").join("have"));
-    let target_file = format!("rm {file_str}");
-    let suggestions = completer.complete(&target_file, target_file.len());
-
-    // Create the expected values
-    let expected_paths: Vec<String> = vec![
-        file(dir.join("partial-a").join("have_ext.exe")),
-        file(dir.join("partial-a").join("have_ext.txt")),
-    ];
-
-    // Match the results
-    match_suggestions(&expected_paths, &suggestions);
-
-    // Test completion for all files under directories whose names begin with "pa"
-    let file_str = file(dir.join("partial-a").join("have_ext."));
-    let file_dir = format!("rm {file_str}");
-    let suggestions = completer.complete(&file_dir, file_dir.len());
-
-    // Create the expected values
-    let expected_paths: Vec<String> = vec![
-        file(dir.join("partial-a").join("have_ext.exe")),
-        file(dir.join("partial-a").join("have_ext.txt")),
     ];
 
     // Match the results

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1136,7 +1136,7 @@ fn folder_with_directorycompletions_do_not_collapse_dots() {
 
     #[cfg(windows)]
     {
-        let target_dir = format!("cd {dir_str}/.../");
+        let target_dir = format!("cd {dir_str}/../../");
         let slash_suggestions = completer.complete(&target_dir, target_dir.len());
 
         let expected_slash_paths: Vec<String> = expected_paths

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -839,59 +839,6 @@ fn command_watch_with_filecompletion() {
     match_suggestions(&expected_paths, &suggestions)
 }
 
-#[test]
-fn command_stat_with_dot_expansion_completion() {
-    let (dir, _, mut engine, mut stack) = new_engine();
-
-    //change PWD env var
-    let dir_str = dir
-        .join("directory_completion")
-        .join("folder_inside_folder")
-        .clone()
-        .into_os_string()
-        .into_string()
-        .unwrap_or_default();
-
-    stack.add_env_var(
-        "PWD".to_string(),
-        nu_protocol::Value::string(dir_str.clone(), nu_protocol::Span::new(0, dir_str.len())),
-    );
-    engine.add_env_var(
-        "PWD".to_string(),
-        nu_protocol::Value::string(dir_str.clone(), nu_protocol::Span::new(0, dir_str.len())),
-    );
-
-    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
-
-    let target_dir = format!("stat {}", folder("..."));
-    let suggestions = completer.complete(&target_dir, target_dir.len());
-
-    #[cfg(windows)]
-    let expected_paths: Vec<String> = vec![
-        "..\\..\\another\\".to_string(),
-        "..\\..\\custom_completion.nu".to_string(),
-        "..\\..\\directory_completion\\".to_string(),
-        "..\\..\\nushell".to_string(),
-        "..\\..\\test_a\\".to_string(),
-        "..\\..\\test_b\\".to_string(),
-        "..\\..\\.hidden_file".to_string(),
-        "..\\..\\.hidden_folder\\".to_string(),
-    ];
-    #[cfg(not(windows))]
-    let expected_paths: Vec<String> = vec![
-        "../../another/".to_string(),
-        "../../custom_completion.nu".to_string(),
-        "../../directory_completion/".to_string(),
-        "../../nushell".to_string(),
-        "../../test_a/".to_string(),
-        "../../test_b/".to_string(),
-        "../../.hidden_file".to_string(),
-        "../../.hidden_folder/".to_string(),
-    ];
-
-    match_suggestions(&expected_paths, &suggestions)
-}
-
 #[rstest]
 fn subcommand_completions(mut subcommand_completer: NuCompleter) {
     let prefix = "foo br";

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -991,7 +991,7 @@ fn folder_with_directorycompletions_with_dots() {
 
     #[cfg(windows)]
     {
-        let target_dir = format!("cd {dir_str}/.../");
+        let target_dir = format!("cd {dir_str}/../");
         let slash_suggestions = completer.complete(&target_dir, target_dir.len());
 
         let expected_slash_paths: Vec<String> = expected_paths

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1018,7 +1018,11 @@ fn folder_with_directorycompletions_with_three_trailing_dots() {
 
     // Create the expected values
     let expected_paths: Vec<String> = vec![
-        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("..").join("completions")),
+        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("..").join("another")),
+        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("..").join("directory_completion")),
+        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("..").join("test_a")),
+        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("..").join("test_b")),
+        folder(dir.join("directory_completion").join("folder_inside_folder").join("..").join("..").join(".hidden_folder")),
     ];
 
     #[cfg(windows)]

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -495,6 +495,50 @@ fn partial_completions() {
     // Match the results
     match_suggestions(&expected_paths, &suggestions);
 
+    // Test completion where there is a sneaky `...` in the path
+    let dir_str = file(dir.join("par").join("...").join("par").join("fi").join("so"));
+    let target_dir = format!("rm {dir_str}");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    // Create the expected values
+    let expected_paths: Vec<String> = vec![
+        file(
+            dir.join("partial")
+                .join("..")
+                .join("..")
+                .join("partial_completions")
+                .join("final_partial")
+                .join("somefile"),
+        ),
+        file(
+            dir.join("partial-a")
+                .join("..")
+                .join("..")
+                .join("partial_completions")
+                .join("final_partial")
+                .join("somefile"),
+        ),
+        file(
+            dir.join("partial-b")
+                .join("..")
+                .join("..")
+                .join("partial_completions")
+                .join("final_partial")
+                .join("somefile"),
+        ),
+        file(
+            dir.join("partial-c")
+                .join("..")
+                .join("..")
+                .join("partial_completions")
+                .join("final_partial")
+                .join("somefile"),
+        ),
+    ];
+
+    // Match the results
+    match_suggestions(&expected_paths, &suggestions);
+
     // Test completion for all files under directories whose names begin with "pa"
     let file_str = file(dir.join("partial-a").join("have"));
     let target_file = format!("rm {file_str}");

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -863,8 +863,8 @@ fn command_stat_with_dot_expansion_completion() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
-    let target_dir = "stat .../";
-    let suggestions = completer.complete(target_dir, target_dir.len());
+    let target_dir = format!("stat {}", folder("..."));
+    let suggestions = completer.complete(&target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<String> = vec![

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -299,7 +299,7 @@ fn file_completions() {
     match_suggestions(&expected_paths, &suggestions);
 
     // Test completions for hidden files
-    let target_dir = format!("ls {}.", folder(dir.join(".hidden_folder")));
+    let target_dir = format!("ls {}", file(dir.join(".hidden_folder").join(".")));
     let suggestions = completer.complete(&target_dir, target_dir.len());
 
     let expected_paths: Vec<String> =

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -299,7 +299,7 @@ fn file_completions() {
     match_suggestions(&expected_paths, &suggestions);
 
     // Test completions for hidden files
-    let target_dir = format!("ls {}{MAIN_SEPARATOR}.", folder(dir.join(".hidden_folder")));
+    let target_dir = format!("ls {}.", folder(dir.join(".hidden_folder")));
     let suggestions = completer.complete(&target_dir, target_dir.len());
 
     let expected_paths: Vec<String> =

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1078,6 +1078,80 @@ fn folder_with_directorycompletions_with_three_trailing_dots() {
 }
 
 #[test]
+fn folder_with_directorycompletions_do_not_collapse_dots() {
+    // Create a new engine
+    let (dir, _, engine, stack) = new_engine();
+    let dir_str = dir
+        .join("directory_completion")
+        .join("folder_inside_folder")
+        .into_os_string()
+        .into_string()
+        .unwrap();
+
+    // Instantiate a new completer
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+
+    // Test completions for the current folder
+    let target_dir = format!("cd {dir_str}{MAIN_SEPARATOR}..{MAIN_SEPARATOR}..{MAIN_SEPARATOR}");
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+
+    // Create the expected values
+    let expected_paths: Vec<String> = vec![
+        folder(
+            dir.join("directory_completion")
+                .join("folder_inside_folder")
+                .join("..")
+                .join("..")
+                .join("another"),
+        ),
+        folder(
+            dir.join("directory_completion")
+                .join("folder_inside_folder")
+                .join("..")
+                .join("..")
+                .join("directory_completion"),
+        ),
+        folder(
+            dir.join("directory_completion")
+                .join("folder_inside_folder")
+                .join("..")
+                .join("..")
+                .join("test_a"),
+        ),
+        folder(
+            dir.join("directory_completion")
+                .join("folder_inside_folder")
+                .join("..")
+                .join("..")
+                .join("test_b"),
+        ),
+        folder(
+            dir.join("directory_completion")
+                .join("folder_inside_folder")
+                .join("..")
+                .join("..")
+                .join(".hidden_folder"),
+        ),
+    ];
+
+    #[cfg(windows)]
+    {
+        let target_dir = format!("cd {dir_str}/.../");
+        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+
+        let expected_slash_paths: Vec<String> = expected_paths
+            .iter()
+            .map(|s| s.replace('\\', "/"))
+            .collect();
+
+        match_suggestions(&expected_slash_paths, &slash_suggestions);
+    }
+
+    // Match the results
+    match_suggestions(&expected_paths, &suggestions);
+}
+
+#[test]
 fn variables_completions() {
     // Create a new engine
     let (dir, _, mut engine, mut stack) = new_engine();

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -967,7 +967,7 @@ fn folder_with_directorycompletions() {
 fn folder_with_directorycompletions_with_dots() {
     // Create a new engine
     let (dir, _, engine, stack) = new_engine();
-    let dir_string = dir
+    let dir_str = dir
         .join("directory_completion")
         .join("folder_inside_folder")
         .into_os_string()
@@ -978,7 +978,7 @@ fn folder_with_directorycompletions_with_dots() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     // Test completions for the current folder
-    let target_dir = format!("cd {dir_string}{MAIN_SEPARATOR}..{MAIN_SEPARATOR}");
+    let target_dir = format!("cd {dir_str}{MAIN_SEPARATOR}..{MAIN_SEPARATOR}");
     let suggestions = completer.complete(&target_dir, target_dir.len());
 
     // Create the expected values
@@ -991,7 +991,7 @@ fn folder_with_directorycompletions_with_dots() {
 
     #[cfg(windows)]
     {
-        let target_dir = format!("cd {dir_str}/");
+        let target_dir = format!("cd {dir_str}/.../");
         let slash_suggestions = completer.complete(&target_dir, target_dir.len());
 
         let expected_slash_paths: Vec<String> = expected_paths
@@ -1010,10 +1010,9 @@ fn folder_with_directorycompletions_with_dots() {
 fn folder_with_directorycompletions_with_three_trailing_dots() {
     // Create a new engine
     let (dir, _, engine, stack) = new_engine();
-    let dir_string = dir
+    let dir_str = dir
         .join("directory_completion")
         .join("folder_inside_folder")
-        .join(".../")
         .into_os_string()
         .into_string()
         .unwrap();
@@ -1022,7 +1021,7 @@ fn folder_with_directorycompletions_with_three_trailing_dots() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     // Test completions for the current folder
-    let target_dir = format!("cd {dir_string}");
+    let target_dir = format!("cd {dir_str}{MAIN_SEPARATOR}...{MAIN_SEPARATOR}");
     let suggestions = completer.complete(&target_dir, target_dir.len());
 
     // Create the expected values
@@ -1066,7 +1065,7 @@ fn folder_with_directorycompletions_with_three_trailing_dots() {
 
     #[cfg(windows)]
     {
-        let target_dir = format!("cd {dir_str}/");
+        let target_dir = format!("cd {dir_str}/.../");
         let slash_suggestions = completer.complete(&target_dir, target_dir.len());
 
         let expected_slash_paths: Vec<String> = expected_paths

--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -152,6 +152,17 @@ mod test_expand_ndots {
         };
         assert_path_eq!(expand_ndots(path), expected);
     }
+
+    #[test]
+    fn trailing_dots() {
+        let path = Path::new("/foo/bar/..");
+        let expected = if cfg!(windows) {
+            r"\foo\bar\.."
+        } else {
+            "/foo/bar/.."
+        };
+        assert_path_eq!(expand_ndots(path), expected);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description
This is my first PR, and I'm looking for feedback to help me improve! 

This PR fixes #13380 by expanding the path prior to parsing it.
Also I've removed some unused code in [completion_common.rs](https://github.com/Ancient77/nushell/blob/84e92bb02c78d4bb71a045fbbe73b9351ab8d16a/crates/nu-cli/src/completions/completion_common.rs
)
# User-Facing Changes

Auto-completion for "cd .../" now works by expanding to "cd ../../". 

# Tests + Formatting

Formatted and added 2 tests for triple dots in the middle of a path and at the end.
Also added a test for the expand_ndots() function.

