### PR TITLE
fix --ide-ast when there are errors

### DIFF
--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -130,7 +130,7 @@ impl Span {
     }
 
     pub fn contains_span(&self, span: Self) -> bool {
-        self.start <= span.start && span.end <= self.end
+        self.start <= span.start && span.end <= self.end && span.end != 0
     }
 
     /// Point to the space just past this span, useful for missing values

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -642,8 +642,8 @@ pub fn ast(engine_state: &mut EngineState, file_path: &str) {
                 {
                     "type": "ast",
                     "span": {
-                        "start": span.start - offset,
-                        "end": span.end - offset,
+                        "start": span.start.checked_sub(offset),
+                        "end": span.end.checked_sub(offset),
                     },
                     "shape": shape.to_string(),
                     "content": content // may not be necessary, but helpful for debugging


### PR DESCRIPTION
# Description

This PR fixes #13732. However, I don't think it's a proper fix.
1. It doesn't really show what the problem is.
2. It kind of side-steps the error entirely.

I do think the change in span.rs may be valid because I don't think span.end should ever be 0. In the example in 13732 the span end was always 0 and so that made contains_span() return true, which seems like a false positive.

The `checked_sub()` in ide.rs kind of just stops it from failing outloud.

I'll leave it to smarter folks than me to land this if they think it's worthy.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
