### PR TITLE
remove cfg_atter tarpaulin

### DIFF
--- a/crates/nu-system/src/macos.rs
+++ b/crates/nu-system/src/macos.rs
@@ -27,7 +27,6 @@ pub struct ProcessInfo {
     pub interval: Duration,
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut ret = Vec::new();
@@ -116,7 +115,6 @@ pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> 
     ret
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_arg_max() -> size_t {
     let mut mib: [c_int; 2] = [libc::CTL_KERN, libc::KERN_ARGMAX];
     let mut arg_max = 0i32;
@@ -144,14 +142,12 @@ pub struct PathInfo {
     pub cwd: PathBuf,
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 unsafe fn get_unchecked_str(cp: *mut u8, start: *mut u8) -> String {
     let len = (cp as usize).saturating_sub(start as usize);
     let part = std::slice::from_raw_parts(start, len);
     String::from_utf8_unchecked(part.to_vec())
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_path_info(pid: i32, mut size: size_t) -> Option<PathInfo> {
     let mut proc_args = Vec::with_capacity(size);
     let ptr: *mut u8 = proc_args.as_mut_slice().as_mut_ptr();
@@ -252,7 +248,6 @@ fn get_path_info(pid: i32, mut size: size_t) -> Option<PathInfo> {
     }
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn clone_task_all_info(src: &TaskAllInfo) -> TaskAllInfo {
     let pbsd = BSDInfo {
         pbi_flags: src.pbsd.pbi_flags,

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -109,7 +109,6 @@ pub struct CpuInfo {
     pub curr_user: u64,
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut ret = Vec::new();
@@ -257,7 +256,6 @@ pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> 
     ret
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn set_privilege() -> bool {
     unsafe {
         let handle = GetCurrentProcess();
@@ -284,7 +282,6 @@ fn set_privilege() -> bool {
     }
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_pids() -> Vec<i32> {
     let dword_size = size_of::<u32>();
     let mut pids: Vec<u32> = Vec::with_capacity(10192);
@@ -307,7 +304,6 @@ fn get_pids() -> Vec<i32> {
     pids.iter().map(|x| *x as i32).collect()
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_ppid_threads() -> (HashMap<i32, i32>, HashMap<i32, i32>) {
     let mut ppids = HashMap::new();
     let mut threads = HashMap::new();
@@ -332,7 +328,6 @@ fn get_ppid_threads() -> (HashMap<i32, i32>, HashMap<i32, i32>) {
     (ppids, threads)
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_handle(pid: i32) -> Option<HANDLE> {
     if pid == 0 {
         return None;
@@ -353,7 +348,6 @@ fn get_handle(pid: i32) -> Option<HANDLE> {
     }
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_times(handle: HANDLE) -> Option<(u64, u64, u64, u64)> {
     unsafe {
         let mut start: FILETIME = zeroed();
@@ -382,7 +376,6 @@ fn get_times(handle: HANDLE) -> Option<(u64, u64, u64, u64)> {
     }
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_memory_info(handle: HANDLE) -> Option<MemoryInfo> {
     unsafe {
         let mut pmc: PROCESS_MEMORY_COUNTERS_EX = zeroed();
@@ -413,7 +406,6 @@ fn get_memory_info(handle: HANDLE) -> Option<MemoryInfo> {
     }
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_command(handle: HANDLE) -> Option<String> {
     unsafe {
         let mut exe_buf = [0u16; MAX_PATH as usize + 1];
@@ -780,7 +772,6 @@ fn get_cwd<T: RtlUserProcessParameters>(params: &T, handle: HANDLE) -> PathBuf {
     }
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_io(handle: HANDLE) -> Option<(u64, u64)> {
     unsafe {
         let mut io: IO_COUNTERS = zeroed();
@@ -801,7 +792,6 @@ pub struct SidName {
     pub domainname: Option<String>,
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_user(handle: HANDLE) -> Option<SidName> {
     unsafe {
         let mut token: HANDLE = zeroed();
@@ -854,7 +844,6 @@ fn get_user(handle: HANDLE) -> Option<SidName> {
     }
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_groups(handle: HANDLE) -> Option<Vec<SidName>> {
     unsafe {
         let mut token: HANDLE = zeroed();
@@ -914,7 +903,6 @@ fn get_groups(handle: HANDLE) -> Option<Vec<SidName>> {
     }
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_sid(psid: PSID) -> Vec<u64> {
     unsafe {
         let mut ret = Vec::new();
@@ -945,7 +933,6 @@ thread_local!(
         RefCell::new(HashMap::new());
 );
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_name_cached(psid: PSID) -> Option<(String, String)> {
     NAME_CACHE.with(|c| {
         let mut c = c.borrow_mut();
@@ -959,7 +946,6 @@ fn get_name_cached(psid: PSID) -> Option<(String, String)> {
     })
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_name(psid: PSID) -> Option<(String, String)> {
     unsafe {
         let mut cc_name = 0;
@@ -1003,7 +989,6 @@ fn get_name(psid: PSID) -> Option<(String, String)> {
     }
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn from_wide_ptr(ptr: *const u16) -> String {
     unsafe {
         assert!(!ptr.is_null());
@@ -1015,7 +1000,6 @@ fn from_wide_ptr(ptr: *const u16) -> String {
     }
 }
 
-#[cfg_attr(tarpaulin, ignore)]
 fn get_priority(handle: HANDLE) -> u32 {
     unsafe { GetPriorityClass(handle) }
 }


### PR DESCRIPTION
# Description

Remove the `#[cfg_attr(tarpaulin, ignore)]` code coverage attributes to get rid warnings when compiling plugins with a more recent rust version than nushell.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
