### PR TITLE
Remove unneeded `serde` feature on `byte-unit` dep

### DIFF
--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -23,7 +23,7 @@ nu-derive-value = { path = "../nu-derive-value", version = "0.97.2" }
 
 brotli = { workspace = true, optional = true }
 bytes = { workspace = true }
-byte-unit = { version = "5.1", features = [ "serde" ] }
+byte-unit = { version = "5.1" }
 chrono = { workspace = true, features = [ "serde", "std", "unstable-locales" ], default-features = false }
 chrono-humanize = { workspace = true }
 dirs = { workspace = true }


### PR DESCRIPTION
removing the `std` feature as well would drop some dependencies tied to
`rust_decimal` from the `Cargo.lock` but unclear to me what the actual
impact on compile times is.

We may want to consider dropping the `byte-unit` dependency altogether
as we have a significant fraction of our own logic to support the byte
units with 1024 and 1000 prefixes. Not sure which fraction is covered by
us or the dependency.
