### PR TITLE
Add `#[nu_value(rename = "...")]` as helper attribute on members for derive macros

### DIFF
--- a/crates/nu-derive-value/src/attributes.rs
+++ b/crates/nu-derive-value/src/attributes.rs
@@ -4,10 +4,10 @@ use crate::{case::Case, error::DeriveError, HELPER_ATTRIBUTE};
 
 pub trait ParseAttrs: Default {
     fn parse_attrs<'a, M>(
-        iter: impl Iterator<Item = &'a Attribute>,
+        iter: impl IntoIterator<Item = &'a Attribute>,
     ) -> Result<Self, DeriveError<M>> {
         let mut attrs = Self::default();
-        for attr in filter(iter) {
+        for attr in filter(iter.into_iter()) {
             // This is a container to allow returning derive errors inside the parse_nested_meta fn.
             let mut err = Ok(());
             let _ = attr.parse_nested_meta(|meta| {

--- a/crates/nu-derive-value/src/case.rs
+++ b/crates/nu-derive-value/src/case.rs
@@ -47,12 +47,16 @@ impl Case {
 }
 
 pub trait Casing {
-    fn to_case(&self, case: Case) -> String;
+    fn to_case(&self, case: impl Into<Option<Case>>) -> String;
 }
 
-impl<T: AsRef<str>> Casing for T {
-    fn to_case(&self, case: Case) -> String {
-        let s = self.as_ref();
+impl<T: ToString> Casing for T {
+    fn to_case(&self, case: impl Into<Option<Case>>) -> String {
+        let s = self.to_string();
+        let Some(case) = case.into() else {
+            return s.to_string();
+        };
+
         match case {
             Case::Pascal => s.to_upper_camel_case(),
             Case::Camel => s.to_lower_camel_case(),

--- a/crates/nu-derive-value/src/error.rs
+++ b/crates/nu-derive-value/src/error.rs
@@ -30,6 +30,12 @@ pub enum DeriveError<M> {
     },
 }
 
+impl<M> From<syn::parse::Error> for DeriveError<M> {
+    fn from(value: syn::parse::Error) -> Self {
+        Self::Syn(value)
+    }
+}
+
 impl<M> From<DeriveError<M>> for Diagnostic {
     fn from(value: DeriveError<M>) -> Self {
         let derive_name = any::type_name::<M>().split("::").last().expect("not empty");

--- a/crates/nu-derive-value/src/error.rs
+++ b/crates/nu-derive-value/src/error.rs
@@ -30,8 +30,8 @@ pub enum DeriveError<M> {
     },
 
     /// Two keys or variants are called the same name breaking bidirectionality.
-    NonUniqueName { 
-        name: String, 
+    NonUniqueName {
+        name: String,
         first: Span,
         second: Span,
     },
@@ -91,12 +91,14 @@ impl<M> From<DeriveError<M>> for Diagnostic {
                     ))
             }
 
-            DeriveError::NonUniqueName { name, first, second } => {
-                Diagnostic::new(Level::Error, format!("non-unique name {name:?} found"))
+            DeriveError::NonUniqueName {
+                name,
+                first,
+                second,
+            } => Diagnostic::new(Level::Error, format!("non-unique name {name:?} found"))
                 .span_error(first, "first occurence found here".to_string())
                 .span_error(second, "second occurence found here".to_string())
-                .help("use `#[nu_value(rename = \"...\")]` to ensure unique names".to_string()) 
-            }
+                .help("use `#[nu_value(rename = \"...\")]` to ensure unique names".to_string()),
         }
     }
 }

--- a/crates/nu-derive-value/src/error.rs
+++ b/crates/nu-derive-value/src/error.rs
@@ -28,6 +28,13 @@ pub enum DeriveError<M> {
         value_span: Span,
         value: Box<dyn Debug>,
     },
+
+    /// Two keys or variants are called the same name breaking bidirectionality.
+    NonUniqueName { 
+        name: String, 
+        first: Span,
+        second: Span,
+    },
 }
 
 impl<M> From<syn::parse::Error> for DeriveError<M> {
@@ -82,6 +89,13 @@ impl<M> From<DeriveError<M>> for Diagnostic {
                     .help(format!(
                         "check documentation for `{derive_name}` for valid attribute values"
                     ))
+            }
+
+            DeriveError::NonUniqueName { name, first, second } => {
+                Diagnostic::new(Level::Error, format!("non-unique name {name:?} found"))
+                .span_error(first, "first occurence found here".to_string())
+                .span_error(second, "second occurence found here".to_string())
+                .help("use `#[nu_value(rename = \"...\")]` to ensure unique names".to_string()) 
             }
         }
     }

--- a/crates/nu-derive-value/src/error.rs
+++ b/crates/nu-derive-value/src/error.rs
@@ -96,8 +96,8 @@ impl<M> From<DeriveError<M>> for Diagnostic {
                 first,
                 second,
             } => Diagnostic::new(Level::Error, format!("non-unique name {name:?} found"))
-                .span_error(first, "first occurence found here".to_string())
-                .span_error(second, "second occurence found here".to_string())
+                .span_error(first, "first occurrence found here".to_string())
+                .span_error(second, "second occurrence found here".to_string())
                 .help("use `#[nu_value(rename = \"...\")]` to ensure unique names".to_string()),
         }
     }

--- a/crates/nu-derive-value/src/from.rs
+++ b/crates/nu-derive-value/src/from.rs
@@ -327,7 +327,8 @@ fn struct_expected_type(
             for field in fields.named.iter() {
                 let member_attrs = MemberAttributes::parse_attrs(&field.attrs)?;
                 let ident = field.ident.as_ref().expect("named has idents");
-                let ident_s = name_resolver.resolve_ident(ident, container_attrs, &member_attrs, None)?;
+                let ident_s =
+                    name_resolver.resolve_ident(ident, container_attrs, &member_attrs, None)?;
                 let ty = &field.ty;
                 fields_ts.push(quote! {(
                     std::string::ToString::to_string(#ident_s),
@@ -407,7 +408,7 @@ fn derive_enum_from_value(
 /// This function checks that every field is a unit variant and constructs a match statement over
 /// all possible variants.
 /// The input value is expected to be a `Value::String` containing the name of the variant.
-/// That string is defined by the [`NameResolver::resolve_ident`] method with the `default` value 
+/// That string is defined by the [`NameResolver::resolve_ident`] method with the `default` value
 /// being [`Case::Snake`].
 ///
 /// If no matching variant is found, `ShellError::CantConvert` is returned.
@@ -452,7 +453,8 @@ fn enum_from_value(data: &DataEnum, attrs: &[Attribute]) -> Result {
         .map(|variant| {
             let member_attrs = MemberAttributes::parse_attrs(&variant.attrs)?;
             let ident = &variant.ident;
-            let ident_s = name_resolver.resolve_ident(ident, &container_attrs, &member_attrs, Case::Snake)?;
+            let ident_s =
+                name_resolver.resolve_ident(ident, &container_attrs, &member_attrs, Case::Snake)?;
             match &variant.fields {
                 Fields::Named(fields) => Err(DeriveError::UnsupportedEnums {
                     fields_span: fields.span(),
@@ -534,13 +536,13 @@ fn enum_expected_type(attr_type_name: Option<&str>) -> Option<TokenStream2> {
 ///   - A unit struct expects `Value::Nothing`.
 ///
 /// For named fields, each field in the record is matched to a struct field.
-/// The name matching uses the identifiers resolved by 
+/// The name matching uses the identifiers resolved by
 /// [`NameResolver`](NameResolver::resolve_ident) with `default` being `None`.
 ///
 /// The `self_ident` parameter is used to specify the identifier for the returned value.
 /// For most structs, `Self` is sufficient, but `Self::Variant` may be needed for enum variants.
 ///
-/// The `container_attrs` parameters, provided through `#[nu_value]` on the container, defines 
+/// The `container_attrs` parameters, provided through `#[nu_value]` on the container, defines
 /// global rules for the `FromValue` implementation.
 /// This is used for the [`NameResolver`] to resolve the correct ident in the `Value`.
 ///
@@ -565,7 +567,8 @@ fn parse_value_via_fields(
             for field in fields.named.iter() {
                 let member_attrs = MemberAttributes::parse_attrs(&field.attrs)?;
                 let ident = field.ident.as_ref().expect("named has idents");
-                let ident_s = name_resolver.resolve_ident(ident, container_attrs, &member_attrs, None)?;
+                let ident_s =
+                    name_resolver.resolve_ident(ident, container_attrs, &member_attrs, None)?;
                 let ty = &field.ty;
                 fields_ts.push(match type_is_option(ty) {
                     true => quote! {

--- a/crates/nu-derive-value/src/from.rs
+++ b/crates/nu-derive-value/src/from.rs
@@ -6,7 +6,7 @@ use syn::{
 };
 
 use crate::{
-    attributes::{self, ContainerAttributes},
+    attributes::{self, ContainerAttributes, ParseAttrs},
     case::{Case, Casing},
 };
 

--- a/crates/nu-derive-value/src/into.rs
+++ b/crates/nu-derive-value/src/into.rs
@@ -152,10 +152,10 @@ fn struct_into_value(
 /// This function implements the derive macro `IntoValue` for enums.
 /// Currently, only unit enum variants are supported as it is not clear how other types of enums
 /// should be represented in a `Value`.
-/// For simple enums, we represent the enum as a `Value::String`. 
+/// For simple enums, we represent the enum as a `Value::String`.
 /// For other types of variants, we return an error.
 ///
-/// The variant name used in the `Value::String` is resolved by the 
+/// The variant name used in the `Value::String` is resolved by the
 /// [`NameResolver`](NameResolver::resolve_ident) with the `default` being [`Case::Snake`].
 /// The implementation matches over all variants, uses the appropriate variant name, and constructs
 /// a `Value::String`.
@@ -194,7 +194,12 @@ fn enum_into_value(
         .map(|variant| {
             let member_attrs = MemberAttributes::parse_attrs(variant.attrs.iter())?;
             let ident = variant.ident;
-            let ident_s = name_resolver.resolve_ident(&ident, &container_attrs, &member_attrs, Case::Snake)?;
+            let ident_s = name_resolver.resolve_ident(
+                &ident,
+                &container_attrs,
+                &member_attrs,
+                Case::Snake,
+            )?;
             match &variant.fields {
                 // In the future we can implement more complex enums here.
                 Fields::Named(fields) => Err(DeriveError::UnsupportedEnums {
@@ -227,11 +232,11 @@ fn enum_into_value(
 /// This function handles the construction of the final `Value` that the macro generates, primarily
 /// for structs.
 /// It takes three parameters: `fields`, which allows iterating over each field of a data type,
-/// `accessor`, which generalizes data access, and `container_attrs`, which is used for the 
+/// `accessor`, which generalizes data access, and `container_attrs`, which is used for the
 /// [`NameResolver`].
 ///
 /// - **Field Keys**:
-///   The field key is field name of the input struct and resolved the 
+///   The field key is field name of the input struct and resolved the
 ///   [`NameResolver`](NameResolver::resolve_ident).
 ///
 /// - **Fields Type**:
@@ -260,7 +265,8 @@ fn fields_return_value(
             for (field, accessor) in fields.named.iter().zip(accessor) {
                 let member_attrs = MemberAttributes::parse_attrs(field.attrs.iter())?;
                 let ident = field.ident.as_ref().expect("named has idents");
-                let field = name_resolver.resolve_ident(ident, &container_attrs, &member_attrs, None)?;
+                let field =
+                    name_resolver.resolve_ident(ident, container_attrs, &member_attrs, None)?;
                 items.push(quote!(#field => nu_protocol::IntoValue::into_value(#accessor, span)));
             }
             Ok(quote! {

--- a/crates/nu-derive-value/src/into.rs
+++ b/crates/nu-derive-value/src/into.rs
@@ -6,7 +6,7 @@ use syn::{
 };
 
 use crate::{
-    attributes::{self, ContainerAttributes},
+    attributes::{self, ContainerAttributes, ParseAttrs},
     case::{Case, Casing},
 };
 

--- a/crates/nu-derive-value/src/lib.rs
+++ b/crates/nu-derive-value/src/lib.rs
@@ -36,6 +36,7 @@ mod case;
 mod error;
 mod from;
 mod into;
+mod names;
 #[cfg(test)]
 mod tests;
 

--- a/crates/nu-derive-value/src/names.rs
+++ b/crates/nu-derive-value/src/names.rs
@@ -1,0 +1,51 @@
+use proc_macro2::Span;
+use std::collections::HashMap;
+use syn::Ident;
+
+use crate::attributes::{ContainerAttributes, MemberAttributes};
+use crate::case::{Case, Casing};
+use crate::error::DeriveError;
+
+#[derive(Debug, Default)]
+pub struct NameResolver {
+    seen_names: HashMap<String, Span>,
+}
+
+impl NameResolver {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolve identifier with attributes.
+    /// 
+    /// This method resolves the name that should be used in the `Value`.
+    /// By remembering which idents came before, we can check that every ident is unique.
+    /// If that is not the case, we return a [`DeriveError::NonUniqueName`].
+    pub fn resolve_ident<M>(
+        &mut self,
+        ident: &'_ Ident,
+        container_attrs: &'_ ContainerAttributes,
+        member_attrs: &'_ MemberAttributes,
+        default: impl Into<Option<Case>>,
+    ) -> Result<String, DeriveError<M>> {
+        let span = ident.span();
+        let rename_all = container_attrs.rename_all;
+        let rename = member_attrs.rename.as_ref();
+        let ident = match (rename, rename_all) {
+            (Some(rename), _) => rename.to_string(),
+            (None, Some(case)) => ident.to_case(case),
+            (None, None) => ident.to_case(default),
+        };
+
+        if let Some(seen) = self.seen_names.get(&ident) {
+            return Err(DeriveError::NonUniqueName { 
+                name: ident.to_string(), 
+                first: *seen, 
+                second: span 
+            });
+        }
+
+        self.seen_names.insert(ident.clone(), span);
+        Ok(ident)
+    }
+}

--- a/crates/nu-derive-value/src/names.rs
+++ b/crates/nu-derive-value/src/names.rs
@@ -19,16 +19,16 @@ impl NameResolver {
     /// Resolves an identifier using attributes and ensures its uniqueness.
     ///
     /// The identifier is transformed according to these rules:
-    /// - If [`MemberAttributes::rename`] is set, this explicitly renamed value is used. 
+    /// - If [`MemberAttributes::rename`] is set, this explicitly renamed value is used.
     ///   The value is defined by the helper attribute `#[nu_value(rename = "...")]` on a member.
-    /// - If the above is not set but [`ContainerAttributes::rename_all`] is, the identifier 
-    ///   undergoes case conversion as specified by the helper attribute 
+    /// - If the above is not set but [`ContainerAttributes::rename_all`] is, the identifier
+    ///   undergoes case conversion as specified by the helper attribute
     ///   `#[nu_value(rename_all = "...")]` on the container (struct or enum).
-    /// - If neither renaming attribute is set, the function applies the case conversion provided 
+    /// - If neither renaming attribute is set, the function applies the case conversion provided
     ///   by the `default` parameter.
     ///   If `default` is `None`, the identifier remains unchanged.
     ///
-    /// This function checks the transformed identifier against previously seen identifiers to 
+    /// This function checks the transformed identifier against previously seen identifiers to
     /// ensure it is unique.
     /// If a duplicate identifier is detected, it returns [`DeriveError::NonUniqueName`].
     pub fn resolve_ident<M>(
@@ -48,10 +48,10 @@ impl NameResolver {
         };
 
         if let Some(seen) = self.seen_names.get(&ident) {
-            return Err(DeriveError::NonUniqueName { 
-                name: ident.to_string(), 
-                first: *seen, 
-                second: span 
+            return Err(DeriveError::NonUniqueName {
+                name: ident.to_string(),
+                first: *seen,
+                second: span,
             });
         }
 

--- a/crates/nu-derive-value/src/names.rs
+++ b/crates/nu-derive-value/src/names.rs
@@ -16,11 +16,21 @@ impl NameResolver {
         Self::default()
     }
 
-    /// Resolve identifier with attributes.
-    /// 
-    /// This method resolves the name that should be used in the `Value`.
-    /// By remembering which idents came before, we can check that every ident is unique.
-    /// If that is not the case, we return a [`DeriveError::NonUniqueName`].
+    /// Resolves an identifier using attributes and ensures its uniqueness.
+    ///
+    /// The identifier is transformed according to these rules:
+    /// - If [`MemberAttributes::rename`] is set, this explicitly renamed value is used. 
+    ///   The value is defined by the helper attribute `#[nu_value(rename = "...")]` on a member.
+    /// - If the above is not set but [`ContainerAttributes::rename_all`] is, the identifier 
+    ///   undergoes case conversion as specified by the helper attribute 
+    ///   `#[nu_value(rename_all = "...")]` on the container (struct or enum).
+    /// - If neither renaming attribute is set, the function applies the case conversion provided 
+    ///   by the `default` parameter.
+    ///   If `default` is `None`, the identifier remains unchanged.
+    ///
+    /// This function checks the transformed identifier against previously seen identifiers to 
+    /// ensure it is unique.
+    /// If a duplicate identifier is detected, it returns [`DeriveError::NonUniqueName`].
     pub fn resolve_ident<M>(
         &mut self,
         ident: &'_ Ident,

--- a/crates/nu-derive-value/src/tests.rs
+++ b/crates/nu-derive-value/src/tests.rs
@@ -190,3 +190,53 @@ fn invalid_attribute_value() {
         into_res
     );
 }
+
+#[test]
+fn non_unique_struct_keys() {
+    let input = quote! {
+        struct DuplicateStruct {
+            #[nu_value(rename = "field")]
+            some_field: (),
+            field: (),
+        }
+    };
+
+    let from_res = derive_from_value(input.clone());
+    assert!(
+        matches!(from_res, Err(DeriveError::NonUniqueName { .. })),
+        "expected `DeriveError::NonUniqueName`, got {:?}",
+        from_res
+    );
+
+    let into_res = derive_into_value(input);
+    assert!(
+        matches!(into_res, Err(DeriveError::NonUniqueName { .. })),
+        "expected `DeriveError::NonUniqueName`, got {:?}",
+        into_res
+    );
+}
+
+#[test]
+fn non_unique_enum_variants() {
+    let input = quote! {
+        enum DuplicateEnum {
+            #[nu_value(rename = "variant")]
+            SomeVariant,
+            Variant
+        }
+    };
+
+    let from_res = derive_from_value(input.clone());
+    assert!(
+        matches!(from_res, Err(DeriveError::NonUniqueName { .. })),
+        "expected `DeriveError::NonUniqueName`, got {:?}",
+        from_res
+    );
+
+    let into_res = derive_into_value(input);
+    assert!(
+        matches!(into_res, Err(DeriveError::NonUniqueName { .. })),
+        "expected `DeriveError::NonUniqueName`, got {:?}",
+        into_res
+    );
+}

--- a/crates/nu-derive-value/src/tests.rs
+++ b/crates/nu-derive-value/src/tests.rs
@@ -136,6 +136,32 @@ fn unexpected_attribute_on_enum_variant() {
 }
 
 #[test]
+fn invalid_attribute_position_in_tuple_struct() {
+    let input = quote! {
+        struct SimpleTupleStruct(
+            #[nu_value(what)]
+            i32,
+            String,
+        );
+    };
+
+    let from_res = derive_from_value(input.clone());
+    assert!(
+        matches!(from_res, Err(DeriveError::InvalidAttributePosition { attribute_span: _ })),
+        "expected `DeriveError::InvalidAttributePosition`, got {:?}",
+        from_res
+    );
+
+    let into_res = derive_into_value(input);
+    assert!(
+        matches!(into_res, Err(DeriveError::InvalidAttributePosition { attribute_span: _ })),
+        "expected `DeriveError::InvalidAttributePosition`, got {:?}",
+        into_res
+    );
+}
+
+
+#[test]
 fn invalid_attribute_value() {
     let input = quote! {
         #[nu_value(rename_all = "CrazY-CasE")]

--- a/crates/nu-derive-value/src/tests.rs
+++ b/crates/nu-derive-value/src/tests.rs
@@ -147,19 +147,24 @@ fn invalid_attribute_position_in_tuple_struct() {
 
     let from_res = derive_from_value(input.clone());
     assert!(
-        matches!(from_res, Err(DeriveError::InvalidAttributePosition { attribute_span: _ })),
+        matches!(
+            from_res,
+            Err(DeriveError::InvalidAttributePosition { attribute_span: _ })
+        ),
         "expected `DeriveError::InvalidAttributePosition`, got {:?}",
         from_res
     );
 
     let into_res = derive_into_value(input);
     assert!(
-        matches!(into_res, Err(DeriveError::InvalidAttributePosition { attribute_span: _ })),
+        matches!(
+            into_res,
+            Err(DeriveError::InvalidAttributePosition { attribute_span: _ })
+        ),
         "expected `DeriveError::InvalidAttributePosition`, got {:?}",
         into_res
     );
 }
-
 
 #[test]
 fn invalid_attribute_value() {

--- a/crates/nu-derive-value/src/tests.rs
+++ b/crates/nu-derive-value/src/tests.rs
@@ -86,26 +86,51 @@ fn unexpected_attribute() {
 }
 
 #[test]
-#[ignore = "we allow some field attributes now"]
-fn deny_attribute_on_fields() {
+fn unexpected_attribute_on_struct_field() {
     let input = quote! {
-        struct SomeStruct {
-            #[nu_value]
-            field: ()
+        struct SimpleStruct {
+            #[nu_value(what)]
+            field_a: i32,
+            field_b: String,
         }
     };
 
     let from_res = derive_from_value(input.clone());
     assert!(
-        matches!(from_res, Err(DeriveError::InvalidAttributePosition { .. })),
-        "expected `DeriveError::InvalidAttributePosition`, got {:?}",
+        matches!(from_res, Err(DeriveError::UnexpectedAttribute { .. })),
+        "expected `DeriveError::UnexpectedAttribute`, got {:?}",
         from_res
     );
 
     let into_res = derive_into_value(input);
     assert!(
-        matches!(into_res, Err(DeriveError::InvalidAttributePosition { .. })),
-        "expected `DeriveError::InvalidAttributePosition`, got {:?}",
+        matches!(into_res, Err(DeriveError::UnexpectedAttribute { .. })),
+        "expected `DeriveError::UnexpectedAttribute`, got {:?}",
+        into_res
+    );
+}
+
+#[test]
+fn unexpected_attribute_on_enum_variant() {
+    let input = quote! {
+        enum SimpleEnum {
+            #[nu_value(what)]
+            A,
+            B,
+        }
+    };
+
+    let from_res = derive_from_value(input.clone());
+    assert!(
+        matches!(from_res, Err(DeriveError::UnexpectedAttribute { .. })),
+        "expected `DeriveError::UnexpectedAttribute`, got {:?}",
+        from_res
+    );
+
+    let into_res = derive_into_value(input);
+    assert!(
+        matches!(into_res, Err(DeriveError::UnexpectedAttribute { .. })),
+        "expected `DeriveError::UnexpectedAttribute`, got {:?}",
         into_res
     );
 }

--- a/crates/nu-derive-value/src/tests.rs
+++ b/crates/nu-derive-value/src/tests.rs
@@ -86,6 +86,7 @@ fn unexpected_attribute() {
 }
 
 #[test]
+#[ignore = "we allow some field attributes now"]
 fn deny_attribute_on_fields() {
     let input = quote! {
         struct SomeStruct {

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -20,13 +20,17 @@ use std::{
 ///
 /// When derived on structs with named fields, it expects a [`Value::Record`] where each field of
 /// the struct maps to a corresponding field in the record.
-/// You can customize the case conversion of these field names by using
-/// `#[nu_value(rename_all = "...")]` on the struct.
+///
+/// - If `#[nu_value(rename = "...")]` is applied to a field, that name will be used as the key in
+///   the record.
+/// - If `#[nu_value(rename_all = "...")]` is applied on the container (struct) the key of the
+///   field will be case-converted accordingly.
+/// - If neither attribute is applied, the field name is used as is.
+///
 /// Supported case conversions include those provided by [`heck`], such as
 /// "snake_case", "kebab-case", "PascalCase", and others.
 /// Additionally, all values accepted by
 /// [`#[serde(rename_all = "...")]`](https://serde.rs/container-attrs.html#rename_all) are valid here.
-/// If not set, the field names will match the original Rust field names as-is.
 ///
 /// For structs with unnamed fields, it expects a [`Value::List`], and the fields are populated in
 /// the order they appear in the list.
@@ -35,13 +39,18 @@ use std::{
 ///
 /// Only enums with no fields may derive this trait.
 /// The expected value representation will be the name of the variant as a [`Value::String`].
-/// By default, variant names will be expected in ["snake_case"](heck::ToSnakeCase).
-/// You can customize the case conversion using `#[nu_value(rename_all = "kebab-case")]` on the enum.
+///
+/// - If `#[nu_value(rename = "...")]` is applied to a variant, that name will be used.
+/// - If `#[nu_value(rename_all = "...")]` is applied on the enum container, the name of variant
+///   will be case-converted accordingly.
+/// - If neither attribute is applied, the variant name will default to
+///   ["snake_case"](heck::ToSnakeCase).
 ///
 /// Additionally, you can use `#[nu_value(type_name = "...")]` in the derive macro to set a custom type name
 /// for `FromValue::expected_type`. This will result in a `Type::Custom` with the specified type name.
 /// This can be useful in situations where the default type name is not desired.
 ///
+/// # Enum Example
 /// ```
 /// # use nu_protocol::{FromValue, Value, ShellError, record, Span};
 /// #
@@ -52,11 +61,17 @@ use std::{
 /// enum Bird {
 ///     MountainEagle,
 ///     ForestOwl,
+///     #[nu_value(rename = "RIVER-QUACK")]
 ///     RiverDuck,
 /// }
 ///
 /// assert_eq!(
-///     Bird::from_value(Value::test_string("RIVER-DUCK")).unwrap(),
+///     Bird::from_value(Value::string("FOREST-OWL", span)).unwrap(),
+///     Bird::ForestOwl
+/// );
+///
+/// assert_eq!(
+///     Bird::from_value(Value::string("RIVER-QUACK", span)).unwrap(),
 ///     Bird::RiverDuck
 /// );
 ///
@@ -64,14 +79,21 @@ use std::{
 ///     &Bird::expected_type().to_string(),
 ///     "birb"
 /// );
+/// ```
 ///
-///
+/// # Struct Example
+/// ```
+/// # use nu_protocol::{FromValue, Value, ShellError, record, Span};
+/// #
+/// # let span = Span::unknown();
+/// #
 /// #[derive(FromValue, PartialEq, Eq, Debug)]
 /// #[nu_value(rename_all = "kebab-case")]
 /// struct Person {
 ///     first_name: String,
 ///     last_name: String,
-///     age: u32,
+///     #[nu_value(rename = "age")]
+///     age_years: u32,
 /// }
 ///
 /// let value = Value::record(record! {
@@ -85,7 +107,7 @@ use std::{
 ///     Person {
 ///         first_name: "John".into(),
 ///         last_name: "Doe".into(),
-///         age: 42,
+///         age_years: 42,
 ///     }
 /// );
 /// ```

--- a/crates/nu-protocol/src/value/test_derive.rs
+++ b/crates/nu-protocol/src/value/test_derive.rs
@@ -587,19 +587,83 @@ fn enum_type_name_attr() {
     assert_eq!(TypeNameEnum::expected_type().to_string().as_str(), "enum");
 }
 
-// TODO: do a better test here
-#[test]
-fn struct_rename_field() {
-    #[derive(Debug, Default, IntoValue)]
-    struct SomeStruct {
-        #[nu_value(rename = "field")]
-        some_field: (),
-    }
+#[derive(IntoValue, FromValue, Default, Debug, PartialEq)]
+struct RenamedFieldStruct {
+    #[nu_value(rename = "renamed")]
+    field: (),
+}
 
-    assert!(SomeStruct::default()
-        .into_test_value()
-        .into_record()
+impl RenamedFieldStruct {
+    fn value() -> Value {
+        Value::test_record(record! {
+            "renamed" => Value::test_nothing(),
+        })
+    }
+}
+
+#[test]
+fn renamed_field_struct_into_value() {
+    let expected = RenamedFieldStruct::value();
+    let actual = RenamedFieldStruct::default().into_test_value();
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn renamed_field_struct_from_value() {
+    let expected = RenamedFieldStruct::default();
+    let actual = RenamedFieldStruct::from_value(RenamedFieldStruct::value()).unwrap();
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn renamed_field_struct_roundtrip() {
+    let expected = RenamedFieldStruct::default();
+    let actual = RenamedFieldStruct::from_value(RenamedFieldStruct::default().into_test_value()).unwrap();
+    assert_eq!(expected, actual);
+
+    let expected = RenamedFieldStruct::value();
+    let actual = RenamedFieldStruct::from_value(RenamedFieldStruct::value())
         .unwrap()
-        .get("field")
-        .is_some());
+        .into_test_value();
+    assert_eq!(expected, actual);
+}
+
+#[derive(IntoValue, FromValue, Default, Debug, PartialEq)]
+enum RenamedVariantEnum {
+    #[default]
+    #[nu_value(rename = "renamed")]
+    Variant
+}
+
+impl RenamedVariantEnum {
+    fn value() -> Value {
+        Value::test_string("renamed")
+    }
+}
+
+#[test]
+fn renamed_variant_enum_into_value() {
+    let expected = RenamedVariantEnum::value();
+    let actual = RenamedVariantEnum::default().into_test_value();
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn renamed_variant_enum_from_value() {
+    let expected = RenamedVariantEnum::default();
+    let actual = RenamedVariantEnum::from_value(RenamedVariantEnum::value()).unwrap();
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn renamed_variant_enum_roundtrip() {
+    let expected = RenamedVariantEnum::default();
+    let actual = RenamedVariantEnum::from_value(RenamedVariantEnum::default().into_test_value()).unwrap();
+    assert_eq!(expected, actual);
+
+    let expected = RenamedVariantEnum::value();
+    let actual = RenamedVariantEnum::from_value(RenamedVariantEnum::value())
+        .unwrap()
+        .into_test_value();
+    assert_eq!(expected, actual);
 }

--- a/crates/nu-protocol/src/value/test_derive.rs
+++ b/crates/nu-protocol/src/value/test_derive.rs
@@ -618,7 +618,8 @@ fn renamed_field_struct_from_value() {
 #[test]
 fn renamed_field_struct_roundtrip() {
     let expected = RenamedFieldStruct::default();
-    let actual = RenamedFieldStruct::from_value(RenamedFieldStruct::default().into_test_value()).unwrap();
+    let actual =
+        RenamedFieldStruct::from_value(RenamedFieldStruct::default().into_test_value()).unwrap();
     assert_eq!(expected, actual);
 
     let expected = RenamedFieldStruct::value();
@@ -632,7 +633,7 @@ fn renamed_field_struct_roundtrip() {
 enum RenamedVariantEnum {
     #[default]
     #[nu_value(rename = "renamed")]
-    Variant
+    Variant,
 }
 
 impl RenamedVariantEnum {
@@ -658,7 +659,8 @@ fn renamed_variant_enum_from_value() {
 #[test]
 fn renamed_variant_enum_roundtrip() {
     let expected = RenamedVariantEnum::default();
-    let actual = RenamedVariantEnum::from_value(RenamedVariantEnum::default().into_test_value()).unwrap();
+    let actual =
+        RenamedVariantEnum::from_value(RenamedVariantEnum::default().into_test_value()).unwrap();
     assert_eq!(expected, actual);
 
     let expected = RenamedVariantEnum::value();

--- a/crates/nu-protocol/src/value/test_derive.rs
+++ b/crates/nu-protocol/src/value/test_derive.rs
@@ -586,3 +586,20 @@ fn enum_type_name_attr() {
 
     assert_eq!(TypeNameEnum::expected_type().to_string().as_str(), "enum");
 }
+
+// TODO: do a better test here
+#[test]
+fn struct_rename_field() {
+    #[derive(Debug, Default, IntoValue)]
+    struct SomeStruct {
+        #[nu_value(rename = "field")]
+        some_field: (),
+    }
+
+    assert!(SomeStruct::default()
+        .into_test_value()
+        .into_record()
+        .unwrap()
+        .get("field")
+        .is_some());
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR allows the helper attribute `nu_value(rename = "...")` to be used on struct fields and enum variants. This allows renaming keys and variants just like [`#[serde(rename = "name")]`](https://serde.rs/field-attrs.html#rename). This has no singular variants for `IntoValue` or `FromValue`, both need to use the same (but I think this shouldn't be an issue for now).

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Users of the derive macros `IntoValue` and `FromValue` may now use `#[nu_value(rename = "...")]` to rename single fields, but no already existing code will break.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
I added some more tests and updated the docs accordingly.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
