### PR TITLE
fix path exists on a non-directory file

### DIFF
--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -39,7 +39,8 @@ impl Command for SubCommand {
 
     fn extra_description(&self) -> &str {
         r#"This only checks if it is possible to either `open` or `cd` to the given path.
-If you need to distinguish dirs and files, please use `path type`."#
+If you need to distinguish dirs and files, please use `path type`.
+Also note that if you don't have a permission to a directory of a path, false will be returned"#
     }
 
     fn is_const(&self) -> bool {
@@ -147,7 +148,7 @@ fn exists(path: &Path, span: Span, args: &Arguments) -> Value {
             |_| Ok(true),
         )
     } else {
-        path.try_exists()
+        Ok(path.exists())
     };
     Value::bool(
         match exists {

--- a/crates/nu-command/tests/commands/path/exists.rs
+++ b/crates/nu-command/tests/commands/path/exists.rs
@@ -65,6 +65,18 @@ fn const_path_exists() {
 }
 
 #[test]
+fn path_exists_under_a_non_directory() {
+    Playground::setup("path_exists_6", |dirs, _| {
+        let actual = nu!(
+                cwd: dirs.test(),
+                "touch test_file; 'test_file/aaa' | path exists"
+        );
+        assert_eq!(actual.out, "false");
+        assert!(actual.err.is_empty());
+    })
+}
+
+#[test]
 fn test_check_symlink_exists() {
     use nu_test_support::{nu, playground::Playground};
 


### PR DESCRIPTION
# Description
Fixes:  #13460

The issue is caused by `try_exists` method on path, it will return `Err(NotADirectory)` if user tried to check for a path under a regular file.
To fix it, I think it's ok to use `exists` rather than `try_exists`, although [Path::exists()](https://doc.rust-lang.org/std/path/struct.Path.html#method.exists) only checks whether or not a path was both found and readable.  I think it's ok, and we can add this information under `extra_description`.

# User-Facing Changes
The following code will no longer raise error:
```
touch a; 'a/b' | path exists
```

# Tests + Formatting
Added 1 test.
