### PR TITLE
add version and path to plugin executable help

### DIFF
--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -655,6 +655,7 @@ fn print_help(plugin: &impl Plugin, encoder: impl PluginEncoder) {
 
     println!("Nushell Plugin");
     println!("Encoder: {}", encoder.name());
+    println!("Version: {}", plugin.version());
 
     let mut help = String::new();
     let help_style = HelpStyle::default();
@@ -662,7 +663,6 @@ fn print_help(plugin: &impl Plugin, encoder: impl PluginEncoder) {
     plugin.commands().into_iter().for_each(|command| {
         let signature = command.signature();
         let res = write!(help, "\nCommand: {}", command.name())
-            .and_then(|_| writeln!(help, "\nVersion: {}", plugin.version()))
             .and_then(|_| writeln!(help, "\nDescription:\n > {}", command.description()))
             .and_then(|_| {
                 if !command.extra_description().is_empty() {

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -657,6 +657,15 @@ fn print_help(plugin: &impl Plugin, encoder: impl PluginEncoder) {
     println!("Encoder: {}", encoder.name());
     println!("Version: {}", plugin.version());
 
+    // Determine the plugin name
+    let exe = std::env::current_exe().ok();
+    let plugin_name: String = exe
+        .as_ref()
+        // .and_then(|path| path.file_stem())
+        .map(|stem| stem.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "(unknown)".into());
+    println!("Plugin file path: {}", plugin_name);
+
     let mut help = String::new();
     let help_style = HelpStyle::default();
 

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -662,6 +662,7 @@ fn print_help(plugin: &impl Plugin, encoder: impl PluginEncoder) {
     plugin.commands().into_iter().for_each(|command| {
         let signature = command.signature();
         let res = write!(help, "\nCommand: {}", command.name())
+            .and_then(|_| writeln!(help, "\nVersion: {}", plugin.version()))
             .and_then(|_| writeln!(help, "\nDescription:\n > {}", command.description()))
             .and_then(|_| {
                 if !command.extra_description().is_empty() {

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -661,7 +661,6 @@ fn print_help(plugin: &impl Plugin, encoder: impl PluginEncoder) {
     let exe = std::env::current_exe().ok();
     let plugin_name: String = exe
         .as_ref()
-        // .and_then(|path| path.file_stem())
         .map(|stem| stem.to_string_lossy().into_owned())
         .unwrap_or_else(|| "(unknown)".into());
     println!("Plugin file path: {}", plugin_name);


### PR DESCRIPTION
# Description

This change allows one to see the version of their plugin file without trying to register it.

![image](https://github.com/user-attachments/assets/9f1ddbd7-f63f-47f7-87c8-0d839f5e4b1f)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
