### PR TITLE
Expression support for `polars strftime`

### DIFF
--- a/crates/nu_plugin_polars/Cargo.toml
+++ b/crates/nu_plugin_polars/Cargo.toml
@@ -73,6 +73,7 @@ features = [
 	"strings",
 	"string_to_integer",
 	"streaming",
+	"temporal",
 	"to_dummies",
 ]
 optional = false


### PR DESCRIPTION
# Description
Allows `polars strftime` to be used as an expression:
<img width="849" alt="Screenshot 2024-09-03 at 13 14 11" src="https://github.com/user-attachments/assets/2a987fdf-cf00-4c57-b6e1-0b706c594c20">

# User-Facing Changes
- `polars strftime` can now be used as an expression.