### PR TITLE
Try to add aarch64-unknown-linux-musl and armv7-unknown-linux-musleabihf release target

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -78,7 +78,9 @@ jobs:
         - x86_64-unknown-linux-gnu
         - x86_64-unknown-linux-musl
         - aarch64-unknown-linux-gnu
+        - aarch64-unknown-linux-musl
         - armv7-unknown-linux-gnueabihf
+        - armv7-unknown-linux-musleabihf
         - riscv64gc-unknown-linux-gnu
         extra: ['bin']
         include:
@@ -104,7 +106,11 @@ jobs:
           os: ubuntu-22.04
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-22.04
+        - target: aarch64-unknown-linux-musl
+          os: ubuntu-22.04
         - target: armv7-unknown-linux-gnueabihf
+          os: ubuntu-22.04
+        - target: armv7-unknown-linux-musleabihf
           os: ubuntu-22.04
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-latest

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -84,6 +84,20 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
             $env.CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER = 'arm-linux-gnueabihf-gcc'
             cargo-build-nu
         }
+        'aarch64-unknown-linux-musl' => {
+            aria2c https://musl.cc/aarch64-linux-musl-cross.tgz
+            tar -xf aarch64-linux-musl-cross.tgz
+            $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.PWD)/aarch64-linux-musl-cross/bin')
+            $env.CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = 'aarch64-linux-musl-gcc'
+            cargo-build-nu
+        }
+        'armv7-unknown-linux-musleabihf' => {
+            aria2c https://musl.cc/armv7r-linux-musleabihf-cross.tgz
+            tar -xf armv7r-linux-musleabihf-cross.tgz
+            $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.PWD)/armv7r-linux-musleabihf-cross/bin')
+            $env.CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER = 'armv7r-linux-musleabihf-gcc'
+            cargo-build-nu
+        }
         _ => {
             # musl-tools to fix 'Failed to find tool. Is `musl-gcc` installed?'
             # Actually just for x86_64-unknown-linux-musl target


### PR DESCRIPTION
Related: https://github.com/nushell/nushell/issues/10444

<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
Try to add `aarch64-unknown-linux-musl` and `armv7-unknown-linux-musleabihf` release target
I will test these two new targets in the nightly workflow, It should work: https://github.com/nushell/nightly/actions/runs/10692449465/job/29640875827, 
and check the release binaries. If everything goes well we can add the `musl` targets in the next release
