### PR TITLE
Fix: Make Commands Respect Generate (i.e. ListStream)

### DIFF
--- a/crates/nu-command/src/filters/drop/drop_.rs
+++ b/crates/nu-command/src/filters/drop/drop_.rs
@@ -1,4 +1,39 @@
+use itertools::{Itertools, MultiPeek};
 use nu_engine::command_prelude::*;
+
+// Drops the specified numbers of rows from the end of the iterator.
+struct DropIterator<Item, Iter: Iterator<Item = Item>> {
+    iter: MultiPeek<Iter>,
+    rows: usize,
+}
+
+impl<Item, Iter> DropIterator<Item, Iter>
+where
+    Iter: Iterator<Item = Item>,
+{
+    fn new(iter: Iter, rows: usize) -> Self {
+        DropIterator {
+            iter: iter.multipeek(),
+            rows,
+        }
+    }
+}
+
+impl<Item, Iter> Iterator for DropIterator<Item, Iter>
+where
+    Iter: Iterator<Item = Item>,
+{
+    type Item = Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for _ in 0..(self.rows + 1) {
+            if self.iter.peek().is_none() {
+                return None;
+            }
+        }
+        self.iter.next()
+    }
+}
 
 #[derive(Clone)]
 pub struct Drop;
@@ -78,21 +113,18 @@ impl Command for Drop {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         let metadata = input.metadata();
-        let rows: Option<Spanned<i64>> = call.opt(engine_state, stack, 0)?;
-        let mut values = input.into_iter_strict(head)?.collect::<Vec<_>>();
+        let rows: usize = call.opt(engine_state, stack, 0)?.or(Some(1)).unwrap();
 
-        let rows_to_drop = if let Some(rows) = rows {
-            if rows.item < 0 {
-                return Err(ShellError::NeedsPositiveValue { span: rows.span });
-            } else {
-                rows.item as usize
-            }
-        } else {
-            1
-        };
-
-        values.truncate(values.len().saturating_sub(rows_to_drop));
-        Ok(Value::list(values, head).into_pipeline_data_with_metadata(metadata))
+        input
+            .into_iter_strict(head)
+            .map(|iter| DropIterator::new(iter, rows))
+            .map(|iter| {
+                iter.into_pipeline_data_with_metadata(
+                    head,
+                    engine_state.signals().clone(),
+                    metadata,
+                )
+            })
     }
 }
 

--- a/crates/nu-std/std/iter.nu
+++ b/crates/nu-std/std/iter.nu
@@ -31,7 +31,7 @@ export def find [ # -> any | null
     fn: closure          # the closure used to perform the search 
 ] {
     try {
-       filter $fn | get 0?
+       filter $fn | first
     } catch {
        null
     }
@@ -60,20 +60,7 @@ export def find [ # -> any | null
 export def find-index [ # -> int
     fn: closure                # the closure used to perform the search
 ] {
-    let matches = (
-        enumerate
-        | each {|it|
-            if (do $fn $it.item) {
-                $it.index
-            }
-        }
-    )
-
-    if ($matches | is-empty) {
-        -1
-    } else {
-        $matches | first
-    }
+    enumerate | find {|it| do $fn $it.item} | get index? | default (-1)
 }
 
 # Returns a new list with the separator between adjacent
@@ -89,13 +76,7 @@ export def find-index [ # -> int
 export def intersperse [ # -> list<any>
     separator: any              # the separator to be used
 ] {
-    reduce --fold [] {|it, acc|
-         $acc ++ [$it, $separator]
-    } 
-    | match $in {
-         [] => [],
-         $xs => ($xs | take (($xs | length) - 1 ))
-    }
+    each {|it| [$it, $separator]} | flatten | drop
 }
 
 # Returns a list of intermediate steps performed by `reduce`


### PR DESCRIPTION
# Description
Changes the way `PipelineData::ListStream`/iterators are handled in various commands to avoid unnecessarily consuming the iterator, thus allowing the `generate` command to be properly operated on.

## Examples


# User-Facing Changes
TL;DR: Bug fixes, shouldn't be considered breaking.
- [x] A numeric cell path will now only iterate to the exact index of `generate`/iterator. This fixes commands that were consuming the iterator because of cell paths (e.g. `get`, `std iter find`, etc.).
- [x] `drop` now only looks ahead in the `generate`/iterator by the number of rows to be dropped + 1.
- [x] `std iter find-index` now stops after finding the index of the matching value from a `generate`/iterator.
- [x] `std iter intersperse` no longer reduces the `generate`/iterator so it is `generate` friendly.
- [x] `select` no longer iterates over the entire `generate`/iterator, but instead it operates on each item individually, so it is `generate` friendly.
- [ ] `group-by`
- [ ] `join`
- [ ] `range`
- [ ] `reject`
- [ ] ~`insert` will no longer iterate up to the index at which to insert, but rather insert it at the index when the iterator reaches that point.~ This unfortunately was a lot more difficult than I anticipated. I had created an `InsertAtIndexIterator` and it's implementation worked, but it ended up causing a lifetime parameter to be needed on `ListStream`, which caused a lifetime spiral that thoroughly confused me and would've required modifying a significant amount of the codebase. Seems not worth it unless someone knows a way around that.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Tests pass. No new tests added. Should I add tests for these?

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
I don't think that the documentation needs to be updated unless we want to add examples using `generate` to commands that support it.