### PR TITLE
fixed issue with find not working with symbols that should be escaped

### DIFF
--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -193,7 +193,8 @@ pub fn highlight_search_string(
     string_style: &Style,
     highlight_style: &Style,
 ) -> Result<String, ShellError> {
-    let regex_string = format!("(?i){needle}");
+    let escaped_needle = regex::escape(needle);
+    let regex_string = format!("(?i){escaped_needle}");
     let regex = match Regex::new(&regex_string) {
         Ok(regex) => regex,
         Err(err) => {

--- a/crates/nu-command/tests/commands/find.rs
+++ b/crates/nu-command/tests/commands/find.rs
@@ -139,8 +139,6 @@ fn find_in_table_keeps_row_with_multiple_matched_and_keeps_other_columns() {
     assert!(actual.out.contains("60"));
 }
 
-// let data = [[d]; ["a?b"] ["a*b"] ["a{1}b"] ["a[]b"]]
-// let terms = ["?" "*" "{1}" "[]"]
 #[test]
 fn find_with_string_search_with_special_char_1() {
     let actual = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find '?' | to json -r");

--- a/crates/nu-command/tests/commands/find.rs
+++ b/crates/nu-command/tests/commands/find.rs
@@ -138,3 +138,65 @@ fn find_in_table_keeps_row_with_multiple_matched_and_keeps_other_columns() {
     assert!(actual.out.contains("bill"));
     assert!(actual.out.contains("60"));
 }
+
+// let data = [[d]; ["a?b"] ["a*b"] ["a{1}b"] ["a[]b"]]
+// let terms = ["?" "*" "{1}" "[]"]
+#[test]
+fn find_with_string_search_with_special_char_1() {
+    let actual = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find '?' | to json -r");
+
+    assert_eq!(
+        actual.out,
+        "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m?\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
+    );
+}
+
+#[test]
+fn find_with_string_search_with_special_char_2() {
+    let actual = nu!("[[d]; [a?b] [a*b] [a{1}b]] | find '*' | to json -r");
+
+    assert_eq!(
+        actual.out,
+        "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m*\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
+    );
+}
+
+#[test]
+fn find_with_string_search_with_special_char_3() {
+    let actual = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find '{1}' | to json -r");
+
+    assert_eq!(
+        actual.out,
+        "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m{1}\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
+    );
+}
+
+#[test]
+fn find_with_string_search_with_special_char_4() {
+    let actual = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find '[' | to json -r");
+
+    assert_eq!(
+        actual.out,
+        "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m[\\u001b[0m\\u001b[37m]b\\u001b[0m\"}]"
+    );
+}
+
+#[test]
+fn find_with_string_search_with_special_char_5() {
+    let actual = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find ']' | to json -r");
+
+    assert_eq!(
+        actual.out,
+        "[{\"d\":\"\\u001b[37ma[\\u001b[0m\\u001b[41;37m]\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
+    );
+}
+
+#[test]
+fn find_with_string_search_with_special_char_6() {
+    let actual = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find '[]' | to json -r");
+
+    assert_eq!(
+        actual.out,
+        "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m[]\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
+    );
+}


### PR DESCRIPTION
# Description

Thanks to @weirdan's suggestion, this now works.
![image](https://github.com/user-attachments/assets/34522c7b-b012-4f73-883d-9913142e85b9)

Closes #13789

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
