### PR TITLE
Fixup `serde` feature selection in `nu-protocol`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ roxmltree = "0.19"
 rstest = { version = "0.18", default-features = false }
 rusqlite = "0.31"
 rust-embed = "8.5.0"
-serde = { version = "1.0", default-features = false }
+serde = { version = "1.0" }
 serde_json = "1.0"
 serde_urlencoded = "0.7.1"
 serde_yaml = "0.9"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -34,7 +34,7 @@ lru = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-backtrace"] }
 num-format = { workspace = true }
 rmp-serde = { workspace = true, optional = true }
-serde = { workspace = true, features = ["default"] }
+serde = { workspace = true }
 thiserror = "1.0"
 typetag = "0.2"
 os_pipe = { workspace = true, features = ["io_safety"] }

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -34,7 +34,7 @@ lru = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-backtrace"] }
 num-format = { workspace = true }
 rmp-serde = { workspace = true, optional = true }
-serde = { workspace = true, default-features = false }
+serde = { workspace = true, features = ["default"] }
 thiserror = "1.0"
 typetag = "0.2"
 os_pipe = { workspace = true, features = ["io_safety"] }

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -12,7 +12,7 @@ bench = false
 [dependencies]
 nu-plugin = { path = "../nu-plugin", version = "0.97.2" }
 nu-protocol = { path = "../nu-protocol", version = "0.97.2", features = ["plugin"] }
-serde = { workspace = true, default-features = false }
+serde = { workspace = true }
 typetag = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Discovered by @cptpiepmatz that #13749 broke the standalone check for
`nu-protocol`

Explicit use of the feature as workspace root also disables all features
for `serde`. Alternatively we could reconsider this there.
