### PR TITLE
make a user friendly message when `use_grid_icons` is used in config

### DIFF
--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -524,6 +524,14 @@ impl Value {
                         *value = config.color_config.clone().into_value(span);
                     }
                 }
+                "use_grid_icons" => {
+                    // TODO: delete it after 0.99
+                    report_invalid_value(
+                        "`use_grid_icons` is deleted, you should delete the key, and use `grid -i` in such case.",
+                        span,
+                        &mut errors
+                    );
+                }
                 "footer_mode" => {
                     process_string_enum(
                         &mut config.footer_mode,


### PR DESCRIPTION
# Description
After merging #13788, I get an error message which says that `use_grid_icons` is invalid.

I think it's good to report the specific error, and guide user to delete it.