### PR TITLE
Add aarch64-unknown-linux-musl and armv7-unknown-linux-musleabihf targets to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,9 @@ jobs:
         - x86_64-unknown-linux-gnu
         - x86_64-unknown-linux-musl
         - aarch64-unknown-linux-gnu
+        - aarch64-unknown-linux-musl
         - armv7-unknown-linux-gnueabihf
+        - armv7-unknown-linux-musleabihf
         - riscv64gc-unknown-linux-gnu
         extra: ['bin']
         include:
@@ -54,7 +56,11 @@ jobs:
           os: ubuntu-22.04
         - target: aarch64-unknown-linux-gnu
           os: ubuntu-22.04
+        - target: aarch64-unknown-linux-musl
+          os: ubuntu-22.04
         - target: armv7-unknown-linux-gnueabihf
+          os: ubuntu-22.04
+        - target: armv7-unknown-linux-musleabihf
           os: ubuntu-22.04
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-latest


### PR DESCRIPTION

# Description

Add aarch64-unknown-linux-musl and armv7-unknown-linux-musleabihf targets to release workflow. This PR and https://github.com/nushell/nushell/pull/13775 will close: https://github.com/nushell/nushell/issues/10444

It works well here: https://github.com/nushell/nightly/releases/tag/nightly-2d360fd


