### PR TITLE
Config: change ctrl-k to `cuttolineend` event

### DIFF
--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -524,6 +524,14 @@ impl Value {
                         *value = config.color_config.clone().into_value(span);
                     }
                 }
+                "use_grid_icons" => {
+                    // TODO: delete it after 0.99
+                    report_invalid_value(
+                        "`use_grid_icons` is deleted, you should delete the key, and use `grid -i` in such case.",
+                        span,
+                        &mut errors
+                    );
+                }
                 "footer_mode" => {
                     process_string_enum(
                         &mut config.footer_mode,

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -748,7 +748,7 @@ $env.config = {
             modifier: control
             keycode: char_k
             mode: emacs
-            event: { edit: cuttoend }
+            event: { edit: cuttolineend }
         }
         {
             name: cut_line_from_start


### PR DESCRIPTION
# Description
According to emacs doc, I think `ctrl-k` should map to `cuttolineend`.

# User-Facing Changes
`ctrl-k` will no longer cut to the end of buffer