### PR TITLE
Added documentation explanation explaining how to select all columns with `polars col`

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/data/col.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/col.rs
@@ -1,7 +1,12 @@
-use crate::{dataframe::values::NuExpression, values::CustomValueSupport, PolarsPlugin};
+use crate::{
+    dataframe::values::NuExpression,
+    values::{Column, CustomValueSupport, NuDataFrame},
+    PolarsPlugin,
+};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    record, Category, Example, LabeledError, PipelineData, Signature, SyntaxShape, Type, Value,
+    record, Category, Example, LabeledError, PipelineData, Signature, Span, SyntaxShape, Type,
+    Value,
 };
 use polars::prelude::col;
 
@@ -24,21 +29,35 @@ impl PluginCommand for ExprCol {
             .required(
                 "column name",
                 SyntaxShape::String,
-                "Name of column to be used",
+                "Name of column to be used. '*' can be used for all columns.",
             )
             .input_output_type(Type::Any, Type::Custom("expression".into()))
             .category(Category::Custom("expression".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Creates a named column expression and converts it to a nu object",
-            example: "polars col a | polars into-nu",
-            result: Some(Value::test_record(record! {
-                "expr" =>  Value::test_string("column"),
-                "value" => Value::test_string("a"),
-            })),
-        }]
+        vec![
+            Example {
+                description: "Creates a named column expression and converts it to a nu object",
+                example: "polars col a | polars into-nu",
+                result: Some(Value::test_record(record! {
+                    "expr" =>  Value::test_string("column"),
+                    "value" => Value::test_string("a"),
+                })),
+            },
+            Example {
+                description: "Select all columns using the asterisk wildcard.",
+                example: "[[a b]; [x 1] [y 2] [z 3]] | polars into-df | polars select (polars col '*') | polars collect",
+                result: Some(
+                    NuDataFrame::try_from_columns(vec![
+                        Column::new("a".to_string(), vec![Value::test_string("x"), Value::test_string("y"), Value::test_string("z")]),
+                        Column::new("b".to_string(), vec![Value::test_int(1), Value::test_int(2), Value::test_int(3)]),
+                    ],None)
+                    .expect("should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
     }
 
     fn search_terms(&self) -> Vec<&str> {


### PR DESCRIPTION
# Description
Previously there were no examples or explanations that you can use '*' to select all columns. Updated description and added a new example.