### PR TITLE
Fix padding issue with header_on_border

### DIFF
--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -272,6 +272,8 @@ fn set_indent(table: &mut Table, left: usize, right: usize) {
 }
 
 fn set_border_head(table: &mut Table, with_footer: bool, wctrl: TableWidthCtrl) {
+    let pad = wctrl.pad;
+
     if with_footer {
         let count_rows = table.count_rows();
         let last_row_index = count_rows - 1;
@@ -298,12 +300,14 @@ fn set_border_head(table: &mut Table, with_footer: bool, wctrl: TableWidthCtrl) 
                     first_row.1,
                     head_settings.1,
                     head_settings.2.clone(),
+                    pad,
                 ))
                 .with(SetLineHeaders::new(
                     last_row_index - 1,
                     last_row.1,
                     head_settings.1,
                     head_settings.2,
+                    pad,
                 )),
         );
     } else {
@@ -318,7 +322,7 @@ fn set_border_head(table: &mut Table, with_footer: bool, wctrl: TableWidthCtrl) 
                 .with(wctrl)
                 .with(StripColorFromRow(0))
                 .with(MoveRowNext::new(0, 0))
-                .with(SetLineHeaders::new(0, row.1, row_opts.1, row_opts.2)),
+                .with(SetLineHeaders::new(0, row.1, row_opts.1, row_opts.2, pad)),
         );
     }
 }
@@ -983,6 +987,7 @@ struct SetLineHeaders {
     columns: Vec<String>,
     alignment: AlignmentHorizontal,
     color: Option<Color>,
+    pad: usize,
 }
 
 impl SetLineHeaders {
@@ -991,12 +996,14 @@ impl SetLineHeaders {
         columns: Vec<String>,
         alignment: AlignmentHorizontal,
         color: Option<Color>,
+        pad: usize,
     ) -> Self {
         Self {
             line,
             columns,
             alignment,
             color,
+            pad,
         }
     }
 }
@@ -1013,7 +1020,7 @@ impl TableOption<NuRecords, ColoredConfig, CompleteDimensionVecRecords<'_>> for 
             Some(widths) => {
                 columns = columns
                     .into_iter()
-                    .zip(widths.iter().map(|w| w.checked_sub(2).unwrap_or(*w))) // exclude padding; which is generally 2
+                    .zip(widths.iter().map(|w| w - self.pad)) // it must be always safe to do
                     .map(|(s, width)| Truncate::truncate(&s, width).into_owned())
                     .collect();
             }


### PR DESCRIPTION
close #13803 

For your @amtoine  example we get

```
#┬c-a┬c-b┬c-c┬c-d─┬─c-e─
0│  1│ 12│123│1234│12345
─┴───┴───┴───┴────┴─────
```