### PR TITLE
bump rust version to 1.79.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://www.nushell.sh"
 license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
-rust-version = "1.78.0"
+rust-version = "1.79.0"
 version = "0.97.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -992,7 +992,7 @@ fn get_name(psid: PSID) -> Option<(String, String)> {
 fn from_wide_ptr(ptr: *const u16) -> String {
     unsafe {
         assert!(!ptr.is_null());
-        let len = (0..std::isize::MAX)
+        let len = (0..isize::MAX)
             .position(|i| *ptr.offset(i) == 0)
             .unwrap_or_default();
         let slice = std::slice::from_raw_parts(ptr, len);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,4 +16,4 @@ profile = "default"
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 4 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.78.0"
+channel = "1.79.0"


### PR DESCRIPTION
# Description

This PR bumps our rust version from 1.78 to 1.79.0 due to the 1.81.0 release.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
