### PR TITLE
Improve #12008 UX, clear scrollback by default on `clear`

### DIFF
--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -57,7 +57,7 @@ impl Command for Clear {
                 result: None,
             },
             Example {
-                description: "Clear the terminal without its scroll-back history",
+                description: "Clear the terminal but not its scroll-back history",
                 example: "clear -k",
                 result: None,
             },

--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -24,9 +24,9 @@ impl Command for Clear {
             .category(Category::Platform)
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .switch(
-                "all",
-                "Clear the terminal and its scroll-back history",
-                Some('a'),
+                "keep-scrollback",
+                "Do not clear the scrollback history",
+                Some('k'),
             )
     }
 
@@ -37,9 +37,9 @@ impl Command for Clear {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let clear_type: ClearType = match call.has_flag(engine_state, stack, "all")? {
-            true => ClearType::Purge,
-            _ => ClearType::All,
+        let clear_type: ClearType = match call.has_flag(engine_state, stack, "keep-scrollback")? {
+            true => ClearType::All,
+            _ => ClearType::Purge,
         };
         std::io::stdout()
             .queue(ClearCommand(clear_type))?
@@ -57,8 +57,8 @@ impl Command for Clear {
                 result: None,
             },
             Example {
-                description: "Clear the terminal and its scroll-back history",
-                example: "clear --all",
+                description: "Clear the terminal without its scroll-back history",
+                example: "clear -k",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -19,6 +19,10 @@ impl Command for Clear {
         "Clear the terminal."
     }
 
+    fn extra_description(&self) -> &str {
+        "By default clears the current screen and the off-screen scrollback buffer."
+    }
+
     fn signature(&self) -> Signature {
         Signature::build("clear")
             .category(Category::Platform)
@@ -57,7 +61,7 @@ impl Command for Clear {
                 result: None,
             },
             Example {
-                description: "Clear the terminal but not its scroll-back history",
+                description: "Clear the terminal but not its scrollback history",
                 example: "clear -k",
                 result: None,
             },

--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -62,7 +62,7 @@ impl Command for Clear {
             },
             Example {
                 description: "Clear the terminal but not its scrollback history",
-                example: "clear -k",
+                example: "clear --keep-scrollback",
                 result: None,
             },
         ]


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Related to #11693. It looks like there is no reason for Nu shell's `clear` to behave differently than other shells' `clear`. To improve the UX and fulfill the user expectations, the default has been adjusted to work the same as in other shells by clearing the scrollback buffer. For edge cases where someone depends on the current behavior of keeping the scrollback, a `-k` option has been added.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

- Improve the UX of `clear` by changing the default behavior to the same as other popular shells, i.e clear scrollback by default.
- Remove `-a --all` flag, make it the default behavior to clear the scrollback
- Add `-k --keep-scrollback` flag for backward compat to keep the scrollback buffer

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

This is a simple change flipping the flag and default behavior, no tests should be needed.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

- [ ] update the `clear` command docs