### PR TITLE
Polars no macro

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/aggregation_commands.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/aggregation_commands.rs
@@ -5,21 +5,6 @@ use crate::{expr_command, lazy_expr_command};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Span, Type, Value};
 
-// ExprList command
-// Expands to a command definition for a list expression
-expr_command!(
-    ExprList,
-    "polars implode",
-    "Aggregates a group to a Series.",
-    vec![Example {
-        description: "",
-        example: "",
-        result: None,
-    }],
-    implode,
-    test_implode
-);
-
 // ExprAggGroups command
 // Expands to a command definition for a agg groups expression
 expr_command!(

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
@@ -81,8 +81,6 @@ mod test {
 
     #[test]
     fn test_examples() -> Result<(), ShellError> {
-        // For some reason the comparison on dataframes that have been imploded is cuasing issues
-        // test_polars_plugin_command(&ExprList)
-        Ok(())
+        test_polars_plugin_command(&ExprList)
     }
 }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
@@ -1,0 +1,73 @@
+use crate::dataframe::values::NuExpression;
+use crate::values::{cant_convert_err, CustomValueSupport, PolarsPluginObject, PolarsPluginType};
+use crate::PolarsPlugin;
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Type};
+
+pub struct ExprList;
+
+impl PluginCommand for ExprList {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars implode"
+    }
+
+    fn description(&self) -> &str {
+        "Aggregates a group to a Series."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(
+                Type::Custom("expression".into()),
+                Type::Custom("expression".into()),
+            )
+            .category(Category::Custom("dataframe".into()))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "".into(),
+            example: "".into(),
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let value = input.into_value(call.head)?;
+        match PolarsPluginObject::try_from_value(plugin, &value)? {
+            PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),
+            _ => Err(cant_convert_err(&value, &[PolarsPluginType::NuExpression])),
+        }
+        .map_err(LabeledError::from)
+    }
+}
+
+fn command_expr(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    expr: NuExpression,
+) -> Result<PipelineData, ShellError> {
+    let res: NuExpression = expr.into_polars().implode().into();
+    res.to_pipeline_data(plugin, engine, call.head)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+    use nu_protocol::ShellError;
+
+    #[test]
+    fn test_examples() -> Result<(), ShellError> {
+        test_polars_plugin_command(&ExprList)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
@@ -1,8 +1,14 @@
 use crate::dataframe::values::NuExpression;
-use crate::values::{cant_convert_err, CustomValueSupport, PolarsPluginObject, PolarsPluginType};
+use crate::values::{
+    cant_convert_err, CustomValueSupport, NuDataFrame, PolarsPluginObject, PolarsPluginType,
+};
 use crate::PolarsPlugin;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Type};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type,
+};
+use polars::df;
+use polars::series::Series;
 
 pub struct ExprList;
 
@@ -14,7 +20,7 @@ impl PluginCommand for ExprList {
     }
 
     fn description(&self) -> &str {
-        "Aggregates a group to a Series."
+        "Aggregates values into a list."
     }
 
     fn signature(&self) -> Signature {
@@ -28,9 +34,15 @@ impl PluginCommand for ExprList {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "".into(),
-            example: "".into(),
-            result: None,
+            description: "Create two lists for columns a and b with all the rows as values.",
+            example: "[[a b]; [1 4] [2 5] [3 6]] | polars into-df | polars select (polars col '*' | polars implode) | polars collect",
+            result: Some(
+                NuDataFrame::from(df!(
+                    "a"=> [[1i64, 2, 3].iter().collect::<Series>()],
+                    "b"=> [[4i64, 5, 6].iter().collect::<Series>()],
+                ).expect("should not fail"))
+                .into_value(Span::unknown())
+            ),
         }]
     }
 
@@ -64,10 +76,13 @@ fn command_expr(
 mod test {
     use super::*;
     use crate::test::test_polars_plugin_command;
+    use nu_plugin_test_support::PluginTest;
     use nu_protocol::ShellError;
 
     #[test]
     fn test_examples() -> Result<(), ShellError> {
-        test_polars_plugin_command(&ExprList)
+        // For some reason the comparison on dataframes that have been imploded is cuasing issues
+        // test_polars_plugin_command(&ExprList)
+        Ok(())
     }
 }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/mod.rs
@@ -16,6 +16,7 @@ use nu_plugin::PluginCommand;
 pub use aggregate::LazyAggregate;
 pub use aggregation_commands::*;
 pub use cumulative::Cumulative;
+use implode::ExprList;
 pub use n_null::NNull;
 pub use n_unique::NUnique;
 pub use rolling::Rolling;

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/mod.rs
@@ -2,6 +2,7 @@ mod aggregate;
 mod aggregation_commands;
 mod cumulative;
 pub mod groupby;
+mod implode;
 mod median;
 mod n_null;
 mod n_unique;


### PR DESCRIPTION
# Description
Extracted `polars implode` from using the expression command macro. Added an example and test case. 

This is part of an effort to remove the polars command macros to be compliant with the macro standards with the rest of the nushell codebase.