### PR TITLE
Make `polars save` return an empty pipeline

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
@@ -236,7 +236,7 @@ pub fn unknown_file_save_error(span: Span) -> ShellError {
 #[cfg(test)]
 pub(crate) mod test {
     use nu_plugin_test_support::PluginTest;
-    use nu_protocol::{Span, Value};
+    use nu_protocol::{PipelineData, Span, Value};
     use uuid::Uuid;
 
     use crate::PolarsPlugin;
@@ -260,15 +260,9 @@ pub(crate) mod test {
                 Span::test_data(),
             ),
         );
-        let pipeline_data = plugin_test.eval(&cmd)?;
+        let _pipeline_data = plugin_test.eval(&cmd)?;
 
         assert!(tmp_file.exists());
-
-        let value = pipeline_data.into_value(Span::test_data())?;
-        let list = value.as_list()?;
-        assert_eq!(list.len(), 1);
-        let msg = list.first().expect("should have a value").as_str()?;
-        assert!(msg.contains("saved"));
 
         Ok(())
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
@@ -236,7 +236,7 @@ pub fn unknown_file_save_error(span: Span) -> ShellError {
 #[cfg(test)]
 pub(crate) mod test {
     use nu_plugin_test_support::PluginTest;
-    use nu_protocol::{PipelineData, Span, Value};
+    use nu_protocol::{Span, Value};
     use uuid::Uuid;
 
     use crate::PolarsPlugin;

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
@@ -15,7 +15,7 @@ use nu_path::expand_path_with;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Type, Value,
+    SyntaxShape, Type,
 };
 use polars::error::PolarsError;
 
@@ -209,12 +209,8 @@ fn command(
             span: spanned_file.span,
         }),
     }?;
-    let file_value = Value::string(format!("saved {:?}", &file_path), file_span);
 
-    Ok(PipelineData::Value(
-        Value::list(vec![file_value], call.head),
-        None,
-    ))
+    Ok(PipelineData::empty())
 }
 
 pub(crate) fn polars_file_save_error(e: PolarsError, span: Span) -> ShellError {
@@ -290,19 +286,4 @@ pub(crate) mod test {
             extension,
         )
     }
-
-    //     #[test]
-    //     pub fn test_to_ipc() -> Result<(), Box<dyn std::error::Error>> {
-    //         test_sink("ipc")
-    //     }
-    //
-    //     #[test]
-    //     pub fn test_to_csv() -> Result<(), Box<dyn std::error::Error>> {
-    //         test_sink("csv")
-    //     }
-    //
-    //     #[test]
-    //     pub fn test_to_json() -> Result<(), Box<dyn std::error::Error>> {
-    //         test_sink("ndjson")
-    //     }
 }


### PR DESCRIPTION
# Description
In order to be more consistent with it's nu counterpart, `polars save` now returns an empty pipeline instead of a message of the saved file.

# User-Facing Changes
- `polars save` no longer displays a save message, making it consistent with `save` behavior.