### PR TITLE
Update Nu for release workflow and fix build warning of musl targets

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -39,7 +39,7 @@ jobs:
         uses: hustcer/setup-nu@v3.13
         if: github.repository == 'nushell/nightly'
         with:
-          version: 0.95.0
+          version: 0.97.1
 
       # Synchronize the main branch of nightly repo with the main branch of Nushell official repo
       - name: Prepare for Nightly Release
@@ -136,7 +136,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3.13
       with:
-        version: 0.95.0
+        version: 0.97.1
 
     - name: Release Nu Binary
       id: nu
@@ -194,7 +194,7 @@ jobs:
       - name: Setup Nushell
         uses: hustcer/setup-nu@v3.13
         with:
-          version: 0.95.0
+          version: 0.97.1
 
       # Keep the last a few releases
       - name: Delete Older Releases

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -86,15 +86,15 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
         }
         'aarch64-unknown-linux-musl' => {
             aria2c https://musl.cc/aarch64-linux-musl-cross.tgz
-            tar -xf aarch64-linux-musl-cross.tgz
-            $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.PWD)/aarch64-linux-musl-cross/bin')
+            tar -xf aarch64-linux-musl-cross.tgz -C $env.HOME
+            $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.HOME)/aarch64-linux-musl-cross/bin')
             $env.CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = 'aarch64-linux-musl-gcc'
             cargo-build-nu
         }
         'armv7-unknown-linux-musleabihf' => {
             aria2c https://musl.cc/armv7r-linux-musleabihf-cross.tgz
-            tar -xf armv7r-linux-musleabihf-cross.tgz
-            $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.PWD)/armv7r-linux-musleabihf-cross/bin')
+            tar -xf armv7r-linux-musleabihf-cross.tgz -C $env.HOME
+            $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.HOME)/armv7r-linux-musleabihf-cross/bin')
             $env.CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER = 'armv7r-linux-musleabihf-gcc'
             cargo-build-nu
         }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3.13
       with:
-        version: 0.95.0
+        version: 0.97.1
 
     - name: Release Nu Binary
       id: nu


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

1. Update Nushell to v0.97.1 for release workflow
2. Fix musl targets cross compiling warning like: `warning: File system loop found: /home/runner/work/nightly/nightly/aarch64-linux-musl-cross/usr points to an ancestor /home/runner/work/nightly/nightly/aarch64-linux-musl-cross/`

Tested in https://github.com/nushell/nightly/actions/runs/10849647834/job/30109290106
