### PR TITLE
Bump shadow-rs from 0.34 to 0.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5714,9 +5714,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fe0bac8a8752586a618a1c80d01d8ca5d40fce4f6077fbc851e48dcbdb90df"
+checksum = "fca0e9bdc073d7173ba993fb7886477af5df75588b57afcb4b96f21911ab0bfa"
 dependencies = [
  "const_format",
  "is_debug",

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -21,10 +21,10 @@ nu-protocol = { path = "../nu-protocol", version = "0.97.2" }
 nu-utils = { path = "../nu-utils", version = "0.97.2" }
 
 itertools = { workspace = true }
-shadow-rs = { version = "0.34", default-features = false }
+shadow-rs = { version = "0.35", default-features = false }
 
 [build-dependencies]
-shadow-rs = { version = "0.34", default-features = false }
+shadow-rs = { version = "0.35", default-features = false }
 
 [features]
 mimalloc = []


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Updates the shadow-rs dependency in the nu-cmd-lang crate. This is needed due to packaging issues, since rustc introduced a breaking change. Please merge this, and make a release as soon as possible. See https://github.com/NixOS/nixpkgs/pull/341647.

