### PR TITLE
allow tab to be retained with `find`

### DIFF
--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -208,7 +208,7 @@ pub fn highlight_search_string(
         }
     };
     // strip haystack to remove existing ansi style
-    let stripped_haystack = nu_utils::strip_ansi_likely(haystack);
+    let stripped_haystack = nu_utils::strip_ansi_string_unlikely(haystack.to_string());
     let mut last_match_end = 0;
     let mut highlighted = String::new();
 

--- a/crates/nu-utils/src/deansi.rs
+++ b/crates/nu-utils/src/deansi.rs
@@ -54,7 +54,7 @@ pub fn strip_ansi_string_unlikely(string: String) -> String {
     if string
         .as_str()
         .bytes()
-        .any(|x| matches!(x, 0..=9 | 11..=31))
+        .any(|x| matches!(x, 0..=8 | 11..=31))
     {
         if let Ok(stripped) = String::from_utf8(strip_ansi_escapes::strip(&string)) {
             return stripped;


### PR DESCRIPTION
# Description

This PR allows the tab character to be retained when using `find`.

### Before
![image](https://github.com/user-attachments/assets/92d78f55-58fb-42f4-be8f-82992292c900)

### After
![image](https://github.com/user-attachments/assets/fbd8e47f-9806-4e30-89a1-6c88b12a612c)


closes #13846

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
