### PR TITLE
catch unwrap on panics with `polars collect`

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/mod.rs
@@ -55,16 +55,21 @@ impl NuLazyFrame {
     }
 
     pub fn collect(self, span: Span) -> Result<NuDataFrame, ShellError> {
-        self.to_polars()
-            .collect()
-            .map_err(|e| ShellError::GenericError {
-                error: "Error collecting lazy frame".into(),
-                msg: e.to_string(),
-                span: Some(span),
-                help: None,
-                inner: vec![],
-            })
-            .map(|df| NuDataFrame::new(true, df))
+        crate::handle_panic(
+            || {
+                self.to_polars()
+                    .collect()
+                    .map_err(|e| ShellError::GenericError {
+                        error: "Error collecting lazy frame".into(),
+                        msg: e.to_string(),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    })
+                    .map(|df| NuDataFrame::new(true, df))
+            },
+            span,
+        )
     }
 
     pub fn apply_with_expr<F>(self, expr: NuExpression, f: F) -> Self


### PR DESCRIPTION
# Description
This resurrects the work from #12866 and fixes #12732. 

Polars panics for a plethora or reasons. While handling panics is generally frowned upon, in cases like with `polars collect` a panic cause a lot of work to be lost.  Often you might have multiple dataframes in memory and you are trying one operation and lose all state. 

While it possible the panic can leave things a strange state, it is pretty unlikely as part of a polars pipeline. Most of the time polars objects are not manipulating dataframes in memory mutability, but rather creating a new dataframe the operations being applied.  This is always the case with a lazy pipeline. After the collect call, the original dataframes are  intact still and I haven't observed any side effects. 