### PR TITLE
Only ask to create config files the first time nu is started

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -26,6 +26,13 @@ pub(crate) fn run_commands(
     let mut stack = Stack::new();
     let start_time = std::time::Instant::now();
 
+    let ask_to_create_config = if let Some(mut config_path) = nu_path::config_dir() {
+        config_path.push(NUSHELL_FOLDER);
+        !config_path.exists()
+    } else {
+        false
+    };
+
     if stack.has_env_var(engine_state, "NU_USE_IR") {
         stack.use_ir = true;
     }
@@ -49,6 +56,7 @@ pub(crate) fn run_commands(
                 &mut stack,
                 parsed_nu_cli_args.env_file,
                 true,
+                ask_to_create_config,
             );
         } else {
             config_files::read_default_env_file(engine_state, &mut stack)
@@ -57,6 +65,13 @@ pub(crate) fn run_commands(
         perf!("read env.nu", start_time, use_color);
 
         let start_time = std::time::Instant::now();
+        let ask_to_create_config = if let Some(mut config_path) = nu_path::config_dir() {
+            config_path.push(NUSHELL_FOLDER);
+            !config_path.exists()
+        } else {
+            false
+        };
+
         // If we have a config file parameter *OR* we have a login shell parameter, read the config file
         if parsed_nu_cli_args.config_file.is_some() || parsed_nu_cli_args.login_shell.is_some() {
             config_files::read_config_file(
@@ -64,6 +79,7 @@ pub(crate) fn run_commands(
                 &mut stack,
                 parsed_nu_cli_args.config_file,
                 false,
+                ask_to_create_config,
             );
         }
 
@@ -126,6 +142,12 @@ pub(crate) fn run_file(
     // if the --no-config-file(-n) flag is passed, do not load plugin, env, or config files
     if parsed_nu_cli_args.no_config_file.is_none() {
         let start_time = std::time::Instant::now();
+        let ask_to_create_config = if let Some(mut config_path) = nu_path::config_dir() {
+            config_path.push(NUSHELL_FOLDER);
+            !config_path.exists()
+        } else {
+            false
+        };
         #[cfg(feature = "plugin")]
         read_plugin_file(engine_state, parsed_nu_cli_args.plugin_file, NUSHELL_FOLDER);
         perf!("read plugins", start_time, use_color);
@@ -138,6 +160,7 @@ pub(crate) fn run_file(
                 &mut stack,
                 parsed_nu_cli_args.env_file,
                 true,
+                ask_to_create_config,
             );
         } else {
             config_files::read_default_env_file(engine_state, &mut stack)
@@ -151,6 +174,7 @@ pub(crate) fn run_file(
                 &mut stack,
                 parsed_nu_cli_args.config_file,
                 false,
+                ask_to_create_config,
             );
         }
         perf!("read config.nu", start_time, use_color);

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "plugin")]
 use crate::{
     command,
     config_files::{self, setup_config, NUSHELL_FOLDER},
@@ -65,7 +64,7 @@ pub(crate) fn run_commands(
 
         let start_time = std::time::Instant::now();
         let ask_to_create_config = if let Some(mut config_path) = nu_path::config_dir() {
-            config_path.push(NUSHELL_FOLDER);
+            config_path.push(config_files::NUSHELL_FOLDER);
             !config_path.exists()
         } else {
             false
@@ -142,7 +141,7 @@ pub(crate) fn run_file(
     if parsed_nu_cli_args.no_config_file.is_none() {
         let start_time = std::time::Instant::now();
         let ask_to_create_config = if let Some(mut config_path) = nu_path::config_dir() {
-            config_path.push(NUSHELL_FOLDER);
+            config_path.push(config_files::NUSHELL_FOLDER);
             !config_path.exists()
         } else {
             false
@@ -231,7 +230,7 @@ pub(crate) fn run_repl(
     let ret_val = evaluate_repl(
         engine_state,
         stack,
-        config_files::NUSHELL_FOLDER,
+        NUSHELL_FOLDER,
         parsed_nu_cli_args.execute,
         parsed_nu_cli_args.no_std_lib,
         entire_start_time,

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,8 +1,7 @@
 #[cfg(feature = "plugin")]
-use crate::config_files::NUSHELL_FOLDER;
 use crate::{
     command,
-    config_files::{self, setup_config},
+    config_files::{self, setup_config, NUSHELL_FOLDER},
 };
 use log::trace;
 #[cfg(feature = "plugin")]


### PR DESCRIPTION
# Description

Implements #13669

When nu is started for the first time, the directory represented by `$nu.default-config-dir` typically will not exist.  In this case, Nushell will create the directory.  It will then detect that either or both `config.nu`/`env.nu` don't exist and offer to create them.

(Existing behavior) If the user declines, the directory will still be created (since the history file lives there as well).  The `default_config.nu` and `default_env.nu` will be loaded.

On subsequent launches, as long as the config directory continues to exist, the user will not be prompted to recreate the config files.  Nushell will behave as if the user answered "N" to the prompt in that `default_config.nu` and `default_env.nu` will be used.

The user can still create a `config.nu` or `env.nu` at any point, and that will be used.  In that case, `default_config.nu` and/or `default_env.nu` will no longer be loaded (unless and until #13671 is implemented).

# User-Facing Changes

User will no longer be prompted to create config files if they are missing so long as the config directory exists.

## Before this change:

1. Nushell starts for the first time
2. The directory where config files are stored does not exist
3. The config files do not exist
   * User is asked whether they want to create `env.nu`
     - User says, "Y", `default_env.nu` is copied to the directory as `env.nu` (and directory is created if needed)
     - User says, "n", `default_env.nu` is loaded, but no file on the filesystem is created.
 
   * User is asked whether they want to create `config.nu`
     - User says, "Y", `default_config.nu` is copied to the directory as `config.nu` (and directory is created if needed)
     - User says, "n", `default_config.nu` is loaded, but no file on the filesystem is created.

4. The next time `nu` is run, if either file is missing, the user will be prompted again for that file.

## After this change:

Steps 1 - 3 remains the same.

4. The next time `nu` is run, we check if the directory exists.  If so:
5. Do not prompt user to create any missing files **(New Behavior)**
6. `$nu.default-config-dir/env.nu` exists?
   * Yes? Use it. (Normal behavior)
   * No?  Evaluate `default_env.nu`.  (Normal behavior)
   * No file is created on the filesystem

7. `$nu.default-config-dir/config.nu` exists?
   * Yes? Use it. (Normal behavior)
   * No?  Evaluate `default_config.nu` (Normal behavior)
   * No file is created on the filesystem

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

This behavior isn't currently mentioned in the configuration doc.  I'll probably hold off on changing anything in the doc until #13671 is implemented.  Regardless, given the timing, this won't make it into a release for at least 4 weeks.