### PR TITLE
view source: add content_type metadata

### DIFF
--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::Config;
+use nu_protocol::{Config, DataSource, PipelineMetadata};
 
 use std::fmt::Write;
 
@@ -32,7 +32,7 @@ impl Command for ViewSource {
         let arg: Value = call.req(engine_state, stack, 0)?;
         let arg_span = arg.span();
 
-        match arg {
+        let source = match arg {
             Value::String { val, .. } => {
                 if let Some(decl_id) = engine_state.find_decl(val.as_bytes(), &[]) {
                     // arg is a command
@@ -193,7 +193,13 @@ impl Command for ViewSource {
                     })
                 }
             }
-        }
+        };
+        source.map(|x| {
+            x.set_metadata(Some(PipelineMetadata {
+                data_source: DataSource::None,
+                content_type: Some("application/x-nuscript".into()),
+            }))
+        })
     }
 
     fn examples(&self) -> Vec<Example> {


### PR DESCRIPTION
# Description
Add content type metadata to the output of `view source`.

I've gone along with the mime type used [here][xdg], but this shouldn't be merged until there is consensus #13858.

`to nuon`'s output has content type `application/x-nuon`

[xdg]: https://gitlab.freedesktop.org/xdg/shared-mime-info/-/merge_requests/231

# User-Facing Changes
Combined with `metadata access`, allows richer display_output hooks.
Might be useful with other commands that make use of content_type like the `http` commands.