### PR TITLE
fix the ability to add a plugin by name instead of path

### DIFF
--- a/crates/nu-cmd-plugin/src/commands/plugin/add.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/add.rs
@@ -30,7 +30,7 @@ impl Command for PluginAdd {
             )
             .required(
                 "filename",
-                SyntaxShape::Filepath,
+                SyntaxShape::String,
                 "Path to the executable for the plugin",
             )
             .category(Category::Plugin)
@@ -81,15 +81,12 @@ apparent the next time `nu` is next launched with that plugin registry file.
         let filename: Spanned<String> = call.req(engine_state, stack, 0)?;
         let shell: Option<Spanned<String>> = call.get_flag(engine_state, stack, "shell")?;
         let cwd = engine_state.cwd(Some(stack))?;
-        let just_the_fn = match std::path::PathBuf::from(&filename.item).file_name() {
-            Some(f) => f.to_string_lossy().to_string(),
-            None => filename.item.clone(),
-        };
 
         // Check the current directory, or fall back to NU_PLUGIN_DIRS
-        let filename_expanded =
-            nu_path::locate_in_dirs(just_the_fn, &cwd, || get_plugin_dirs(engine_state, stack))
-                .err_span(filename.span)?;
+        let filename_expanded = nu_path::locate_in_dirs(&filename.item, &cwd, || {
+            get_plugin_dirs(engine_state, stack)
+        })
+        .err_span(filename.span)?;
 
         let shell_expanded = shell
             .as_ref()


### PR DESCRIPTION
# Description

This plugin fixes the ability to do `plugin add nu_plugin_polars` and have nushell look in NU_PLUGINS_DIR to find the plugin and add it.

closes #13040

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
