### PR TITLE
Bump rustix from 0.38.34 to 0.38.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5433,9 +5433,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",


### PR DESCRIPTION
Notable this gets https://github.com/bytecodealliance/rustix/pull/1147 which makes things work on Android again.

Without this update latest `0.98.0` release gets stuck in a loop outputting the below error due to the `TCGETS2` usage:

> Error: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }

