### PR TITLE
Fix `do -p` not waiting for external commands

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -169,7 +169,7 @@ impl Command for Do {
                     && !matches!(caller_stack.stdout(), OutDest::Pipe | OutDest::Capture) =>
             {
                 if let ByteStreamSource::Child(child) = stream.source_mut() {
-                    child.set_exit_code(0)
+                    child.ignore_error();
                 }
                 Ok(PipelineData::ByteStream(stream, metadata))
             }

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -73,3 +73,10 @@ fn run_closure_with_it_using() {
     assert!(actual.err.is_empty());
     assert_eq!(actual.out, "3");
 }
+
+#[test]
+fn waits_for_external() {
+    let actual = nu!(r#"do -p { nu -c 'sleep 1sec; print before; exit 1'}; print after"#);
+    assert!(actual.err.is_empty());
+    assert_eq!(actual.out, "beforeafter");
+}

--- a/crates/nu-protocol/src/process/exit_status.rs
+++ b/crates/nu-protocol/src/process/exit_status.rs
@@ -20,10 +20,12 @@ impl ExitStatus {
         }
     }
 
-    pub fn check_ok(self, span: Span) -> Result<(), ShellError> {
+    pub fn check_ok(self, ignore_error: bool, span: Span) -> Result<(), ShellError> {
         match self {
             ExitStatus::Exited(exit_code) => {
-                if let Ok(exit_code) = exit_code.try_into() {
+                if ignore_error {
+                    Ok(())
+                } else if let Ok(exit_code) = exit_code.try_into() {
                     Err(ShellError::NonZeroExitCode { exit_code, span })
                 } else {
                     Ok(())
@@ -38,7 +40,7 @@ impl ExitStatus {
 
                 let sig = Signal::try_from(signal);
 
-                if sig == Ok(Signal::SIGPIPE) {
+                if sig == Ok(Signal::SIGPIPE) || (ignore_error && !core_dumped) {
                     // Processes often exit with SIGPIPE, but this is not an error condition.
                     Ok(())
                 } else {


### PR DESCRIPTION
# Description
Similar to #13870 (thanks @WindSoilder), this PR adds a boolean which determines whether to ignore any errors from an external command. This is in order to fix #13876. I.e., `do -p` does not wait for externals to complete before continuing.

# User-Facing Changes
Bug fix.

# Tests + Formatting
Added a test.
