### PR TITLE
Removes more quotes on external command arguments

### DIFF
--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -996,6 +996,31 @@ pub fn test_external_call_head_interpolated_string(
     r"foo\external call",
     "backtick quote with backslash"
 )]
+#[case(
+    r#"^foo --flag="value""#,
+    r#"--flag=value"#,
+    "flag value with double quote"
+)]
+#[case(
+    r#"^foo --flag='value'"#,
+    r#"--flag=value"#,
+    "flag value with single quote"
+)]
+#[case(
+    r#"^foo {a:1,b:'c',c:'d'}"#,
+    r#"{a:1,b:c,c:d}"#,
+    "value with many inner single quotes"
+)]
+#[case(
+    r#"^foo {a:1,b:"c",c:"d"}"#,
+    r#"{a:1,b:c,c:d}"#,
+    "value with many double quotes"
+)]
+#[case(
+    r#"^foo {a:1,b:'c',c:"d"}"#,
+    r#"{a:1,b:c,c:d}"#,
+    "value with single quote and double quote"
+)]
 pub fn test_external_call_arg_glob(#[case] input: &str, #[case] expected: &str, #[case] tag: &str) {
     test_external_call(input, tag, |name, args| {
         match &name.expr {


### PR DESCRIPTION
# Description
Fixes: #13662

I don't think nushell need to parse and keep nested quote on external command arguments.  Some nested quote is safe to removed.  After the pr, nushell will behave more likely to bash.

# User-Facing Changes
#### Before
```
> ^echo {a:1,b:'c',c:'d'}
{a:1,b:c',c:'d} 
```
#### After
```
> ^echo {a:1,b:'c',c:'d'}
{a:1,b:c',c:'d} 
```

# Tests + Formatting
Added some tests to cover the behavior