### PR TITLE
Add search terms to `into value`

### DIFF
--- a/crates/nu-command/src/conversions/into/value.rs
+++ b/crates/nu-command/src/conversions/into/value.rs
@@ -32,7 +32,11 @@ impl Command for IntoValue {
     }
 
     fn description(&self) -> &str {
-        "Infer nushell datatype for each cell."
+        "Infer Nushell datatype for each cell."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "conversion"]
     }
 
     fn examples(&self) -> Vec<Example> {


### PR DESCRIPTION
# Description

From [Discord today](https://discord.com/channels/601130461678272522/729071784321876040/1286904159047778316), `into value` isn't classified with `conversions` like the other `into ...` subcommands.  I think this is correct, since it's a `table->table` operation, so it's a filter that has the side effect of (potentially) converting (via inference) cell values.

But we should at least have some search terms that help here, so this PR adds *"conversion"* and *"convert"* to the command.

# User-Facing Changes

`help -f conversion` will return `into value`

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A