### PR TITLE
Respect `$env.config.use_kitty_protocol` in `input listen`

### DIFF
--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -100,6 +100,7 @@ There are 4 `key_type` variants:
             // * [neovim text editor](https://github.com/neovim/neovim/pull/18181)
             // * [kakoune text editor](https://github.com/mawww/kakoune/issues/4103)
             // * [dte text editor](https://gitlab.com/craigbarnes/dte/-/issues/138)
+            //[ghostty terminal](https://github.com/ghostty-org/ghostty/pull/317)
             //
             // Refer to https://sw.kovidgoyal.net/kitty/keyboard-protocol/ if you're curious.
             let _ = execute!(

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -100,7 +100,7 @@ There are 4 `key_type` variants:
             // * [neovim text editor](https://github.com/neovim/neovim/pull/18181)
             // * [kakoune text editor](https://github.com/mawww/kakoune/issues/4103)
             // * [dte text editor](https://gitlab.com/craigbarnes/dte/-/issues/138)
-            //[ghostty terminal](https://github.com/ghostty-org/ghostty/pull/317)
+            // * [ghostty terminal](https://github.com/ghostty-org/ghostty/pull/317)
             //
             // Refer to https://sw.kovidgoyal.net/kitty/keyboard-protocol/ if you're curious.
             let _ = execute!(

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -2,7 +2,7 @@ use crossterm::event::{
     DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
     EnableMouseCapture, KeyCode, KeyEventKind, KeyModifiers, MouseEvent, MouseEventKind,
 };
-use crossterm::terminal;
+use crossterm::{execute, terminal};
 use nu_engine::command_prelude::*;
 
 use num_traits::AsPrimitive;
@@ -81,8 +81,35 @@ There are 4 `key_type` variants:
         let head = call.head;
         let event_type_filter = get_event_type_filter(engine_state, stack, call, head)?;
         let add_raw = call.has_flag(engine_state, stack, "raw")?;
+        let config = engine_state.get_config();
 
         terminal::enable_raw_mode()?;
+
+        if config.use_kitty_protocol {
+            if let Ok(false) = crossterm::terminal::supports_keyboard_enhancement() {
+                println!("WARN: The terminal doesn't support use_kitty_protocol config.\r");
+            }
+
+            // enable kitty protocol
+            //
+            // Note that, currently, only the following support this protocol:
+            // * [kitty terminal](https://sw.kovidgoyal.net/kitty/)
+            // * [foot terminal](https://codeberg.org/dnkl/foot/issues/319)
+            // * [WezTerm terminal](https://wezfurlong.org/wezterm/config/lua/config/enable_kitty_keyboard.html)
+            // * [notcurses library](https://github.com/dankamongmen/notcurses/issues/2131)
+            // * [neovim text editor](https://github.com/neovim/neovim/pull/18181)
+            // * [kakoune text editor](https://github.com/mawww/kakoune/issues/4103)
+            // * [dte text editor](https://gitlab.com/craigbarnes/dte/-/issues/138)
+            //
+            // Refer to https://sw.kovidgoyal.net/kitty/keyboard-protocol/ if you're curious.
+            let _ = execute!(
+                stdout(),
+                crossterm::event::PushKeyboardEnhancementFlags(
+                    crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                )
+            );
+        }
+
         let console_state = event_type_filter.enable_events()?;
         loop {
             let event = crossterm::event::read().map_err(|_| ShellError::GenericError {
@@ -95,6 +122,13 @@ There are 4 `key_type` variants:
             let event = parse_event(head, &event, &event_type_filter, add_raw);
             if let Some(event) = event {
                 terminal::disable_raw_mode()?;
+                if config.use_kitty_protocol {
+                    let _ = execute!(
+                        std::io::stdout(),
+                        crossterm::event::PopKeyboardEnhancementFlags
+                    );
+                }
+
                 console_state.restore();
                 return Ok(event.into_pipeline_data());
             }


### PR DESCRIPTION
Fixes nushell/nushell#13891

# Description

`input listen` now respects `$env.config.use_kitty_protocol`
This is essentially a copy-paste from `keybindings listen` where it was already implemented.

# User-Facing Changes

`input listen` now respects `$env.config.use_kitty_protocol`

# Tests + Formatting

# After Submitting
