### PR TITLE
Add loongarch64-unknown-linux-gnu-gcc build target

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -82,6 +82,7 @@ jobs:
         - armv7-unknown-linux-gnueabihf
         - armv7-unknown-linux-musleabihf
         - riscv64gc-unknown-linux-gnu
+        - loongarch64-unknown-linux-gnu
         extra: ['bin']
         include:
         - target: aarch64-apple-darwin
@@ -113,6 +114,8 @@ jobs:
         - target: armv7-unknown-linux-musleabihf
           os: ubuntu-22.04
         - target: riscv64gc-unknown-linux-gnu
+          os: ubuntu-latest
+        - target: loongarch64-unknown-linux-gnu
           os: ubuntu-latest
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -116,7 +116,7 @@ jobs:
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-latest
         - target: loongarch64-unknown-linux-gnu
-          os: ubuntu-latest
+          os: ubuntu-22.04
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -99,8 +99,8 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
             cargo-build-nu
         }
         'loongarch64-unknown-linux-gnu' => {
-            aria2c https://github.com/loongson/build-tools/releases/download/2023.08.08/CLFS-loongarch64-8.1-x86_64-cross-tools-gcc-glibc.tar.xz
-            tar xf CLFS-loongarch64-8.1-x86_64-cross-tools-gcc-glibc.tar.xz
+            aria2c https://github.com/loongson/build-tools/releases/download/2024.08.08/x86_64-cross-tools-loongarch64-binutils_2.43-gcc_14.2.0-glibc_2.40.tar.xz
+            tar xf x86_64-cross-tools-loongarch64-binutils_2.43-gcc_14.2.0-glibc_2.40.tar.xz
             $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.PWD)/cross-tools/bin')
             $env.CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER = 'loongarch64-unknown-linux-gnu-gcc'
             cargo-build-nu

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -100,7 +100,7 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
         }
         'loongarch64-unknown-linux-gnu' => {
             aria2c https://github.com/loongson/build-tools/releases/download/2023.08.08/CLFS-loongarch64-8.1-x86_64-cross-tools-gcc-glibc.tar.xz
-            tar xf CLFS-loongarch64-8.1.1-x86_64-cross-tools-gcc-libc.tar.xz
+            tar xf CLFS-loongarch64-8.1-x86_64-cross-tools-gcc-glibc.tar.xz
             $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.PWD)/cross-tools/bin')
             $env.CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER = 'loongarch64-unknown-linux-gnu-gcc'
             cargo-build-nu

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -99,7 +99,7 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
             cargo-build-nu
         }
         'loongarch64-unknown-linux-gnu' => {
-            aria2c https://github.com/sunhaiyong1978/CLFS-for-LoongArch/releases/download/8.1/CLFS-loongarch64-8.1.1-x86_64-cross-tools-gcc-libc.tar.xz
+            aria2c https://github.com/loongson/build-tools/releases/download/2023.08.08/CLFS-loongarch64-8.1-x86_64-cross-tools-gcc-glibc.tar.xz
             tar xf CLFS-loongarch64-8.1.1-x86_64-cross-tools-gcc-libc.tar.xz
             $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.PWD)/cross-tools/bin')
             $env.CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER = 'loongarch64-unknown-linux-gnu-gcc'

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -100,7 +100,7 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
         }
         'loongarch64-unknown-linux-gnu' => {
             aria2c https://github.com/loongson/build-tools/releases/download/2024.08.08/x86_64-cross-tools-loongarch64-binutils_2.43-gcc_14.2.0-glibc_2.40.tar.xz
-            tar xf x86_64-cross-tools-loongarch64-binutils_2.43-gcc_14.2.0-glibc_2.40.tar.xz
+            tar xf x86_64-cross-tools-loongarch64-*.tar.xz
             $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.PWD)/cross-tools/bin')
             $env.CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER = 'loongarch64-unknown-linux-gnu-gcc'
             cargo-build-nu

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -98,6 +98,13 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
             $env.CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER = 'armv7r-linux-musleabihf-gcc'
             cargo-build-nu
         }
+        'loongarch64-unknown-linux-gnu' => {
+            aria2c https://github.com/sunhaiyong1978/CLFS-for-LoongArch/releases/download/8.1/CLFS-loongarch64-8.1.1-x86_64-cross-tools-gcc-libc.tar.xz
+            tar xf CLFS-loongarch64-8.1.1-x86_64-cross-tools-gcc-libc.tar.xz
+            $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.PWD)/cross-tools/bin')
+            $env.CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER = 'loongarch64-unknown-linux-gnu-gcc'
+            cargo-build-nu
+        }
         _ => {
             # musl-tools to fix 'Failed to find tool. Is `musl-gcc` installed?'
             # Actually just for x86_64-unknown-linux-musl target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   standard:
-    name: Std
+    name: Nu
 
     strategy:
       fail-fast: false
@@ -32,6 +32,7 @@ jobs:
         - armv7-unknown-linux-gnueabihf
         - armv7-unknown-linux-musleabihf
         - riscv64gc-unknown-linux-gnu
+        - loongarch64-unknown-linux-gnu
         extra: ['bin']
         include:
         - target: aarch64-apple-darwin
@@ -63,12 +64,14 @@ jobs:
         - target: armv7-unknown-linux-musleabihf
           os: ubuntu-22.04
         - target: riscv64gc-unknown-linux-gnu
-          os: ubuntu-latest
+          os: ubuntu-22.04
+        - target: loongarch64-unknown-linux-gnu
+          os: ubuntu-22.04
 
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v4.1.7
+    - uses: actions/checkout@v4
 
     - name: Update Rust Toolchain Target
       run: |
@@ -82,9 +85,9 @@ jobs:
         rustflags: ''
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3.13
+      uses: hustcer/setup-nu@v3
       with:
-        version: 0.97.1
+        version: 0.98.0
 
     - name: Release Nu Binary
       id: nu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   standard:
-    name: Nu
+    name: Std
 
     strategy:
       fail-fast: false
@@ -64,14 +64,14 @@ jobs:
         - target: armv7-unknown-linux-musleabihf
           os: ubuntu-22.04
         - target: riscv64gc-unknown-linux-gnu
-          os: ubuntu-22.04
+          os: ubuntu-latest
         - target: loongarch64-unknown-linux-gnu
           os: ubuntu-22.04
 
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.1.7
 
     - name: Update Rust Toolchain Target
       run: |
@@ -85,9 +85,9 @@ jobs:
         rustflags: ''
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3
+      uses: hustcer/setup-nu@v3.13
       with:
-        version: 0.98.0
+        version: 0.97.1
 
     - name: Release Nu Binary
       id: nu


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

Add `loongarch64-unknown-linux-gnu-gcc` build target
A test release could be found here: https://github.com/nushell/nightly/releases/tag/v0.98.1
Loongarch64 workflow build result: https://github.com/nushell/nightly/actions/runs/10973523602/job/30471006104
