### PR TITLE
Making nushell works better with external args which surrounded by backtick quotes

### DIFF
--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1021,6 +1021,11 @@ pub fn test_external_call_head_interpolated_string(
     r#"{a:1,b:c,c:d}"#,
     "value with single quote and double quote"
 )]
+#[case(
+    r#"^foo `hello world`"#,
+    r#"hello world"#,
+    "value is surrounded by backtick quote"
+)]
 pub fn test_external_call_arg_glob(#[case] input: &str, #[case] expected: &str, #[case] tag: &str) {
     test_external_call(input, tag, |name, args| {
         match &name.expr {
@@ -1114,6 +1119,16 @@ pub fn test_external_call_arg_raw_string(
     r#"^foo "foo\\external call""#,
     r#"foo\external call"#,
     "double quote with backslash"
+)]
+#[case(
+    r#"^foo `"hello world"`"#,
+    r#"hello world"#,
+    "value is surrounded by backtick quote, with inner double quote"
+)]
+#[case(
+    r#"^foo `'hello world'`"#,
+    r#"hello world"#,
+    "value is surrounded by backtick quote, with inner single quote"
 )]
 pub fn test_external_call_arg_string(
     #[case] input: &str,


### PR DESCRIPTION
# Description
Fixes: #13431
Fixes: #13578

The issue happened because nushell thinks external program name and external arg with totally same rule.  But actually they are a little bit different.
When parsing external program name, backtick is a thing and it should be keeped.
But when parsing external args, backtick is just a mark that it's a **bareword which may contain space**.  So in this context, it's already useless.

# User-Facing Changes
After the pr, the following command will work as intended.
```nushell
> ^echo `"hello"`
hello
```

# Tests + Formatting
Added 3 test cases.