### PR TITLE
update folder_depth algorithm for glob command

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -173,8 +173,10 @@ impl Command for Glob {
             depth
         } else if glob_pattern.contains("**") {
             usize::MAX
+        } else if glob_pattern.contains(std::path::MAIN_SEPARATOR) {
+            glob_pattern.split(std::path::MAIN_SEPARATOR).count() + 1
         } else {
-            1usize
+            1
         };
 
         let (prefix, glob) = match WaxGlob::new(&glob_pattern) {

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -171,8 +171,10 @@ impl Command for Glob {
 
         let folder_depth = if let Some(depth) = depth {
             depth
-        } else {
+        } else if glob_pattern.contains("**") {
             usize::MAX
+        } else {
+            1usize
         };
 
         let (prefix, glob) = match WaxGlob::new(&glob_pattern) {


### PR DESCRIPTION
# Description

This PR updates the `folder_depth` algorithm in order to make `glob` a bit faster. The algorithm works like this. Since `folder_depth` is always used we need to set it to a value. If the glob pattern contains `**` then make `folder_depth` `usize::MAX`. If `--depth` is not provided, make it 1, otherwise use the provided value.

closes #13914

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
