### PR TITLE
fix ls_colors coloring in grid and ls

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -631,7 +631,7 @@ mod test {
             .into_string()
             .unwrap();
 
-        // parsing config.nu breaks without PWD set, so set a valid path
+        // set the PWD environment variable as it's required now
         engine_state.add_env_var("PWD".into(), Value::string(cwd, Span::test_data()));
 
         let mut buf = vec![];

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -623,8 +623,16 @@ mod test {
 
     #[test]
     fn test_write_pipeline_data() {
-        let engine_state = EngineState::new();
+        let mut engine_state = EngineState::new();
         let stack = Stack::new();
+        let cwd = std::env::current_dir()
+            .unwrap()
+            .into_os_string()
+            .into_string()
+            .unwrap();
+
+        // parsing config.nu breaks without PWD set, so set a valid path
+        engine_state.add_env_var("PWD".into(), Value::string(cwd, Span::test_data()));
 
         let mut buf = vec![];
         let input = PipelineData::Empty;

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -237,7 +237,9 @@ fn create_grid_output(
                     cell.alignment = Alignment::Left;
                     grid.add(cell);
                 } else {
-                    let style = ls_colors.style_for_path(value.clone());
+                    let no_ansi = nu_utils::strip_ansi_unlikely(&value);
+                    let path = cwd.join(no_ansi.as_ref());
+                    let style = ls_colors.style_for_path(path.clone());
                     let ansi_style = style.map(Style::to_nu_ansi_term_style).unwrap_or_default();
                     let mut cell = Cell::from(ansi_style.paint(value).to_string());
                     cell.alignment = Alignment::Left;

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -5,6 +5,7 @@
 use lscolors::{LsColors, Style};
 use nu_color_config::{color_from_hex, StyleComputer, TextStyle};
 use nu_engine::{command_prelude::*, env_to_string};
+use nu_path::form::Absolute;
 use nu_pretty_hex::HexConfig;
 use nu_protocol::{
     ByteStream, Config, DataSource, ListStream, PipelineMetadata, Signals, TableMode, ValueIterator,
@@ -125,7 +126,7 @@ impl Command for Table {
             let val = Value::list(supported_table_modes(), Span::test_data());
             return Ok(val.into_pipeline_data());
         }
-
+        let cwd = engine_state.cwd(Some(stack))?;
         let cfg = parse_table_config(call, engine_state, stack)?;
         let input = CmdInput::new(engine_state, stack, call, input);
 
@@ -135,7 +136,7 @@ impl Command for Table {
             let _ = nu_utils::enable_vt_processing();
         }
 
-        handle_table_command(input, cfg)
+        handle_table_command(input, cfg, cwd)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -367,6 +368,7 @@ impl<'a> CmdInput<'a> {
 fn handle_table_command(
     mut input: CmdInput<'_>,
     cfg: TableConfig,
+    cwd: nu_path::PathBuf<Absolute>,
 ) -> Result<PipelineData, ShellError> {
     let span = input.data.span().unwrap_or(input.call.head);
     match input.data {
@@ -389,11 +391,11 @@ fn handle_table_command(
             let stream = ListStream::new(vals.into_iter(), span, signals);
             input.data = PipelineData::Empty;
 
-            handle_row_stream(input, cfg, stream, metadata)
+            handle_row_stream(input, cfg, stream, metadata, cwd)
         }
         PipelineData::ListStream(stream, metadata) => {
             input.data = PipelineData::Empty;
-            handle_row_stream(input, cfg, stream, metadata)
+            handle_row_stream(input, cfg, stream, metadata, cwd)
         }
         PipelineData::Value(Value::Record { val, .. }, ..) => {
             input.data = PipelineData::Empty;
@@ -413,7 +415,7 @@ fn handle_table_command(
             let stream =
                 ListStream::new(val.into_range_iter(span, Signals::empty()), span, signals);
             input.data = PipelineData::Empty;
-            handle_row_stream(input, cfg, stream, metadata)
+            handle_row_stream(input, cfg, stream, metadata, cwd)
         }
         x => Ok(x),
     }
@@ -605,6 +607,7 @@ fn handle_row_stream(
     cfg: TableConfig,
     stream: ListStream,
     metadata: Option<PipelineMetadata>,
+    cwd: nu_path::PathBuf<Absolute>,
 ) -> Result<PipelineData, ShellError> {
     let stream = match metadata.as_ref() {
         // First, `ls` sources:
@@ -634,7 +637,9 @@ fn handle_row_stream(
                     if let Some(value) = record.to_mut().get_mut("name") {
                         let span = value.span();
                         if let Value::String { val, .. } = value {
-                            if let Some(val) = render_path_name(val, &config, &ls_colors, span) {
+                            if let Some(val) =
+                                render_path_name(val, &config, &ls_colors, cwd.clone(), span)
+                            {
                                 *value = val;
                             }
                         }
@@ -1008,15 +1013,16 @@ fn render_path_name(
     path: &str,
     config: &Config,
     ls_colors: &LsColors,
+    cwd: nu_path::PathBuf<Absolute>,
     span: Span,
 ) -> Option<Value> {
     if !config.ls.use_ls_colors {
         return None;
     }
 
+    let fullpath = cwd.join(path);
     let stripped_path = nu_utils::strip_ansi_unlikely(path);
-
-    let metadata = std::fs::symlink_metadata(stripped_path.as_ref());
+    let metadata = std::fs::symlink_metadata(fullpath);
     let has_metadata = metadata.is_ok();
     let style =
         ls_colors.style_for_path_with_metadata(stripped_path.as_ref(), metadata.ok().as_ref());


### PR DESCRIPTION
# Description

After PR https://github.com/nushell/nushell/pull/12953, LS_COLORS coloring broke in the `grid` and `ls` commands because the full path to the files were not available. This PR restores the coloring.


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
