### PR TITLE
Fix Docker image build failure

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,13 +7,25 @@ FROM alpine
 
 LABEL maintainer=nushell
 
-RUN echo '/usr/bin/nu' >> /etc/shells \
+ARG TARGETARCH
+
+RUN set -eux; \
+    if [ "${TARGETARCH}" = "amd64" ] || [ "${TARGETARCH}" = "x86_64" ]; then \
+        echo "Downloading x86_64 binary for ${TARGETARCH}..."; \
+        arch_path="x86_64"; \
+    elif [ "${TARGETARCH}" = "arm64" ] || [ "${TARGETARCH}" = "aarch64"]; then \
+        echo "Downloading aarch64 binary for ${TARGETARCH}..."; \
+        arch_path="aarch64"; \
+    else \
+        arch_path=""; \
+    fi; \
+    echo '/usr/bin/nu' >> /etc/shells \
     && adduser -D -s /usr/bin/nu nushell \
     && mkdir -p /home/nushell/.config/nushell/ \
     && cd /tmp \
     && wget -qO - https://api.github.com/repos/nushell/nushell/releases/latest \
     | grep browser_download_url \
-    | grep musl.tar.gz \
+    | grep "${arch_path}.*.musl.tar.gz" \
     | cut -f4 -d '"' \
     | xargs -I{} wget {} \
     && tar -xzf nu* \


### PR DESCRIPTION
## Description
While building the docker image under `nushell/docker` directory, following build failure observed.

![nushell-docker-error](https://github.com/user-attachments/assets/972048d7-b001-4325-b947-93e95b98f4d1)

The problem here is the following lines of code that decide which `nushell` binary to download, extract, and install
https://github.com/nushell/nushell/blob/main/docker/Dockerfile#L16-L19

The issue is especially with wildcard asterisk (*) which downloads both `amd64` and `arm64` binary while building.

## Fix
Introduced build arg `TARGETARCH` which will be populated implicitly by docker `build/buildx` which will help us to decide which binary to download. 

## User-Facing Changes
None. 

## Testing Details
Tested building docker image on both `amd64` and `arm64` systems.
**amd64/x86_64**
![nushell-docker-amd64](https://github.com/user-attachments/assets/ea30b7e3-0664-4a5b-bb13-4c18cdae2a31)

**arm64**
![nushell-docker-arm64](https://github.com/user-attachments/assets/54e47051-1ee7-4695-bc6c-1e211532a545)

