### PR TITLE
Expose flag truncate-ragged-lines in `polars open`

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
@@ -97,7 +97,7 @@ impl PluginCommand for OpenDataFrame {
                 r#"Polars Schema in format [{name: str}]. CSV, JSON, and JSONL files"#,
                 Some('s')
             )
-            .switch("truncate-ragged-lines", "Truncate ragged lines. CSV file", None)
+            .switch("truncate-ragged-lines", "Truncate lines that are longer than the schema. CSV file", None)
             .input_output_type(Type::Any, Type::Custom("dataframe".into()))
             .category(Category::Custom("dataframe".into()))
     }


### PR DESCRIPTION
# Description
Introduces a new flag `--truncate-ragged-lines` for `polars open` that will truncate lines that are longer than the schema.

# User-Facing Changes
- Introduction of the flag `--truncate-ragged-lines` for `polars open`