### PR TITLE
ensure toolkit is using external cargo command

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -17,14 +17,14 @@ export def fmt [
 
     if $check {
         try {
-            cargo fmt --all -- --check
+            ^cargo fmt --all -- --check
         } catch {
             error make --unspanned {
                 msg: $"\nplease run ('toolkit fmt' | pretty-format-command) to fix formatting!"
             }
         }
     } else {
-        cargo fmt --all
+        ^cargo fmt --all
     }
 }
 
@@ -41,11 +41,11 @@ export def clippy [
 
     # If changing these settings also change CI settings in .github/workflows/ci.yml
     try {(
-        cargo clippy
+        ^cargo clippy
             --workspace
             --exclude nu_plugin_*
             --features ($features | str join ",")
-        --
+            --
             -D warnings
             -D clippy::unwrap_used
             -D clippy::unchecked_duration_subtraction
@@ -56,12 +56,12 @@ export def clippy [
     }
     # In tests we don't have to deny unwrap
     (
-        cargo clippy
+        ^cargo clippy
             --tests
             --workspace
             --exclude nu_plugin_*
             --features ($features | str join ",")
-        --
+            --
             -D warnings
     )
 
@@ -69,9 +69,9 @@ export def clippy [
         print $"running ('toolkit clippy' | pretty-format-command) on plugins"
     }
     (
-        cargo clippy
+        ^cargo clippy
             --package nu_plugin_*
-        --
+            --
             -D warnings
             -D clippy::unwrap_used
             -D clippy::unchecked_duration_subtraction
@@ -92,15 +92,15 @@ export def test [
 ] {
     if $fast {
         if $workspace {
-            cargo nextest run --all
+            ^cargo nextest run --all
         } else {
-            cargo nextest run --features ($features | str join ",")
+            ^cargo nextest run --features ($features | str join ",")
         }
     } else {
         if $workspace {
-            cargo test --workspace
+            ^cargo test --workspace
         } else {
-            cargo test --features ($features | str join ",")
+            ^cargo test --features ($features | str join ",")
         }
     }
 }
@@ -109,7 +109,7 @@ export def test [
 export def "test stdlib" [
     --extra-args: string = ''
 ] {
-    cargo run -- --no-config-file -c $"
+    ^cargo run -- --no-config-file -c $"
         use crates/nu-std/testing.nu
         testing run-tests --path crates/nu-std ($extra_args)
     "
@@ -303,7 +303,7 @@ export def "check pr" [
 
 # run Nushell from source with a right indicator
 export def run [] {
-    cargo run -- ...[
+    ^cargo run -- ...[
         -e "$env.PROMPT_COMMAND_RIGHT = $'(ansi magenta_reverse)trying Nushell inside Cargo(ansi reset)'"
     ]
 }
@@ -325,7 +325,7 @@ def build-nushell [features: string] {
     print $'(char nl)Building nushell'
     print '----------------------------'
 
-    cargo build --features $features --locked
+    ^cargo build --features $features --locked
 }
 
 def build-plugin [] {
@@ -335,7 +335,7 @@ def build-plugin [] {
     print '----------------------------'
 
     cd $"crates/($plugin)"
-    cargo build
+    ^cargo build
 }
 
 # build Nushell and plugins with some features
@@ -373,7 +373,7 @@ def install-plugin [] {
     print $'(char nl)Installing ($plugin)'
     print '----------------------------'
 
-    cargo install --path $"crates/($plugin)"
+    ^cargo install --path $"crates/($plugin)"
 }
 
 # install Nushell and features you want
@@ -382,7 +382,7 @@ export def install [
     --all # install all plugins with Nushell
 ] {
     touch crates/nu-cmd-lang/build.rs # needed to make sure `version` has the correct `commit_hash`
-    cargo install --path . --features ($features | str join ",") --locked --force
+    ^cargo install --path . --features ($features | str join ",") --locked --force
     if not $all {
         return
     }
@@ -438,23 +438,23 @@ def compute-coverage [] {
     # show env outputs .ini/.toml style description of the variables
     # In order to use from toml, we need to make sure our string literals are single quoted
     # This is especially important when running on Windows since "C:\blah" is treated as an escape
-    cargo llvm-cov show-env | str replace (char dq) (char sq) -a | from toml | load-env
+    ^cargo llvm-cov show-env | str replace (char dq) (char sq) -a | from toml | load-env
 
     print "Cleaning up coverage data"
-    cargo llvm-cov clean --workspace
+    ^cargo llvm-cov clean --workspace
 
     print "Building with workspace and profile=ci"
     # Apparently we need to explicitly build the necessary parts
     # using the `--profile=ci` is basically `debug` build with unnecessary symbols stripped
     # leads to smaller binaries and potential savings when compiling and running
-    cargo build --workspace --profile=ci
+    ^cargo build --workspace --profile=ci
 
     print "Running tests with --workspace and profile=ci"
-    cargo test --workspace --profile=ci
+    ^cargo test --workspace --profile=ci
 
     # You need to provide the used profile to find the raw data
     print "Generating coverage report as lcov.info"
-    cargo llvm-cov report --lcov --output-path lcov.info --profile=ci
+    ^cargo llvm-cov report --lcov --output-path lcov.info --profile=ci
 }
 
 # Script to generate coverage locally
@@ -512,12 +512,12 @@ export def benchmark-compare [
     # benchmark the target revision
     print $'-- Running benchmarks for ($target)'
     git checkout $target
-    cargo export $tgt_bin_dir -- bench
+    ^cargo export $tgt_bin_dir -- bench
 
     # benchmark the comparison reference revision
     print $'-- Running benchmarks for ($reference)'
     git checkout $reference
-    cargo export $ref_bin_dir -- bench
+    ^cargo export $ref_bin_dir -- bench
 
     # return back to the whatever revision before benchmarking
     print '-- Done'
@@ -547,7 +547,7 @@ export def benchmark-log [
     if $target != $current {
         git checkout $target
     }
-    cargo export $bin_dir -- bench
+    ^cargo export $bin_dir -- bench
 
     # return back to the whatever revision before benchmarking
     print '-- Done'


### PR DESCRIPTION
# Description

@cptpiepmatz and I ran into a problem where `toolkit check pr` and `toolkit clippy --verbose` wouldn't work. I tracked it down to me using `cargo-completions.nu` out of the nu_scripts repo. It was redefining `cargo clippy`. The fix was to ensure that all `cargo` commands in `toolkit.nu` use the external `^cargo`.

Specifically, the problem with `cargo clippy` in `cargo-completions.nu` is it didn't seem to allow `-- -D blah` type parameters.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
