### PR TITLE
Fix issue with `ls | explore` coloring of file names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3245,6 +3245,7 @@ dependencies = [
  "nu-engine",
  "nu-json",
  "nu-parser",
+ "nu-path",
  "nu-pretty-hex",
  "nu-protocol",
  "nu-table",

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 nu-protocol = { path = "../nu-protocol", version = "0.98.1" }
 nu-parser = { path = "../nu-parser", version = "0.98.1" }
+nu-path = { path = "../nu-path", version = "0.98.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.98.1" }
 nu-engine = { path = "../nu-engine", version = "0.98.1" }
 nu-table = { path = "../nu-table", version = "0.98.1" }

--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -72,6 +72,9 @@ impl Command for Explore {
         explore_config.table.separator_style = lookup_color(&style_computer, "separator");
 
         let lscolors = create_lscolors(engine_state, stack);
+        let cwd = engine_state.cwd(Some(stack)).map_or(String::new(), |path| {
+            path.to_str().unwrap_or("").to_string()
+        });
 
         let config = PagerConfig::new(
             &nu_config,
@@ -80,6 +83,7 @@ impl Command for Explore {
             &lscolors,
             peek_value,
             tail,
+            &cwd,
         );
 
         let result = run_pager(engine_state, &mut stack.clone(), input, config);

--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -143,6 +143,8 @@ pub struct PagerConfig<'a> {
     // If true, when quitting output the value of the cell the cursor was on
     pub peek_value: bool,
     pub tail: bool,
+    // Just a cached dir we are working in used for color manipulations
+    pub cwd: String,
 }
 
 impl<'a> PagerConfig<'a> {
@@ -153,6 +155,7 @@ impl<'a> PagerConfig<'a> {
         lscolors: &'a LsColors,
         peek_value: bool,
         tail: bool,
+        cwd: &str,
     ) -> Self {
         Self {
             nu_config,
@@ -161,6 +164,7 @@ impl<'a> PagerConfig<'a> {
             lscolors,
             peek_value,
             tail,
+            cwd: cwd.to_string(),
         }
     }
 }
@@ -371,6 +375,7 @@ fn create_view_config<'a>(pager: &'a Pager<'_>) -> ViewConfig<'a> {
         cfg.explore_config,
         cfg.style_computer,
         cfg.lscolors,
+        &pager.config.cwd,
     )
 }
 
@@ -419,12 +424,7 @@ fn run_command(
         Command::View { mut cmd, stackable } => {
             // what we do we just replace the view.
             let value = view_stack.curr_view.as_mut().and_then(|p| p.view.exit());
-            let view_cfg = ViewConfig::new(
-                pager.config.nu_config,
-                pager.config.explore_config,
-                pager.config.style_computer,
-                pager.config.lscolors,
-            );
+            let view_cfg = create_view_config(pager);
 
             let new_view = cmd.spawn(engine_state, stack, value, &view_cfg)?;
             if let Some(view) = view_stack.curr_view.take() {

--- a/crates/nu-explore/src/views/mod.rs
+++ b/crates/nu-explore/src/views/mod.rs
@@ -58,6 +58,7 @@ pub struct ViewConfig<'a> {
     pub explore_config: &'a ExploreConfig,
     pub style_computer: &'a StyleComputer<'a>,
     pub lscolors: &'a LsColors,
+    pub cwd: &'a str,
 }
 
 impl<'a> ViewConfig<'a> {
@@ -66,12 +67,14 @@ impl<'a> ViewConfig<'a> {
         explore_config: &'a ExploreConfig,
         style_computer: &'a StyleComputer<'a>,
         lscolors: &'a LsColors,
+        cwd: &'a str,
     ) -> Self {
         Self {
             nu_config,
             explore_config,
             style_computer,
             lscolors,
+            cwd,
         }
     }
 }

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -127,7 +127,7 @@ impl RecordView {
         if layer.record_text.is_none() {
             let mut data =
                 convert_records_to_string(&layer.record_values, cfg.nu_config, cfg.style_computer);
-            lscolorize(&layer.column_names, &mut data, cfg.lscolors);
+            lscolorize(&layer.column_names, &mut data, cfg.cwd, cfg.lscolors);
 
             layer.record_text = Some(data);
         }


### PR DESCRIPTION
close #13936

The fix seem to be exactly what you've @fdncred  described.
But I'd recheck that everything is good.

![image](https://github.com/user-attachments/assets/5d9ce02b-9545-4a96-9718-b19d2e5810b8)

Take care.
Have a great week.