### PR TITLE
Add `NU_REPL_PREV_ERROR` env variable

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -121,7 +121,7 @@ fn bench_eval_source(
             let mut engine = engine.clone();
             let fname: &str = &fname.clone();
             let source: &[u8] = &source.clone();
-            black_box(eval_source(
+            let _ = black_box(eval_source(
                 &mut engine,
                 &mut stack,
                 source,

--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -299,7 +299,8 @@ pub fn migrate_old_plugin_file(engine_state: &EngineState, storage_path: &str) -
         &old_plugin_file_path.to_string_lossy(),
         PipelineData::Empty,
         false,
-    ) != 0
+    )
+    .is_err()
     {
         return false;
     }

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -155,7 +155,9 @@ pub(crate) fn read_loginshell_file(engine_state: &mut EngineState, stack: &mut S
 
 pub(crate) fn read_default_env_file(engine_state: &mut EngineState, stack: &mut Stack) {
     let config_file = get_default_env();
-    eval_source(
+
+    // TODO: ignore this error?
+    let _ = eval_source(
         engine_state,
         stack,
         config_file.as_bytes(),
@@ -236,7 +238,8 @@ fn eval_default_config(
         &config_file, is_env_config
     );
     // Just use the contents of "default_config.nu" or "default_env.nu"
-    eval_source(
+    // TODO: ignore this error?
+    let _ = eval_source(
         engine_state,
         stack,
         config_file.as_bytes(),


### PR DESCRIPTION
# Description
This PR adds `$env.NU_REPL_PREV_ERROR`. It is set only in the REPL and only if the previous entry/command failed. If present, it contains an error record like the one passed to `catch` closures. For example:

```nu
# parse error
> let err =
Error: nu::parser::keyword_missing_arg

  × Missing argument to `=`.
   ╭─[entry #1:1:10]
 1 │ let err =
   ╰────

> $env.NU_REPL_PREV_ERROR
╭───────┬────────────────────────────────────────────────────────────────────────────╮
│ msg   │ Missing argument to `=`.                                                   │
│ debug │ KeywordMissingArgument("variable", "=", Span { start: 92421, end: 92421 }) │
╰───────┴────────────────────────────────────────────────────────────────────────────╯
```
```nu
# external error
> ^false
> $env.NU_REPL_PREV_ERROR
╭───────────┬───────────────────────────────────────────────────────────────────────────╮
│ msg       │ External command had a non-zero exit code                                 │
│ debug     │ NonZeroExitCode { exit_code: 1, span: Span { start: 92436, end: 92441 } } │
│ raw       │ NonZeroExitCode { exit_code: 1, span: Span { start: 92436, end: 92441 } } │
│ exit_code │ 1                                                                         │
╰───────────┴───────────────────────────────────────────────────────────────────────────╯
```
```nu
# internal error
> error make { msg: "error" }
Error:   × error
   ╭─[entry #5:1:1]
 1 │ error make { msg: "error" }
   · ─────┬────
   ·      ╰── originates from here
   ╰────

> $env.NU_REPL_PREV_ERROR
╭───────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ msg   │ error                                                                                                                              │
│ debug │ GenericError { error: "error", msg: "originates from here", span: Some(Span { start: 92464, end: 92474 }), help: None, inner: [] } │
│ raw   │ GenericError { error: "error", msg: "originates from here", span: Some(Span { start: 92464, end: 92474 }), help: None, inner: [] } │
╰───────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
```nu
# no error
> ^true
> $env.NU_REPL_PREV_ERROR? # does not exist

```

As opposed to `$env.LAST_EXIT_CODE`, `$env.NU_REPL_PREV_ERROR` is only set after a REPL entry finishes/errors, so there is no need to worry about accidentally overwriting `$env.LAST_EXIT_CODE` when running an external command in your prompt command.


# Tests + Formatting
Cannot test due to limitations with `nu_repl` test bin.
