### PR TITLE
Fix `LAST_EXIT_CODE` not being set for internal errors

### DIFF
--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -286,6 +286,8 @@ impl Stack {
     pub fn set_last_error(&mut self, error: &ShellError) {
         if let Some(code) = error.external_exit_code() {
             self.set_last_exit_code(code.item, code.span);
+        } else {
+            self.set_last_exit_code(1, Span::unknown());
         }
     }
 


### PR DESCRIPTION
# Description
Fixes #13949 where `$env.LAST_EXIT_CODE` was not being set for internal errors.

# Tests + Formatting
Cannot test due to limitations with the `nu_repl` test bin.
