### PR TITLE
Consistent default key bindings for ide_completion_menu

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -36,6 +36,41 @@ const DEFAULT_COMPLETION_MENU: &str = r#"
   }
 }"#;
 
+const DEFAULT_IDE_COMPLETION_MENU: &str = r#"
+{
+  name: ide_completion_menu
+  only_buffer_difference: false
+  marker: "| "
+  type: {
+    layout: ide
+    min_completion_width: 0,
+    max_completion_width: 50,
+    max_completion_height: 10, # will be limited by the available lines in the terminal
+    padding: 0,
+    border: true,
+    cursor_offset: 0,
+    description_mode: "prefer_right"
+    min_description_width: 0
+    max_description_width: 50
+    max_description_height: 10
+    description_offset: 1
+    # If true, the cursor pos will be corrected, so the suggestions match up with the typed text
+    #
+    # C:\> str
+    #      str join
+    #      str trim
+    #      str split
+    correct_cursor_pos: false
+  }
+  style: {
+    text: green
+    selected_text: { attr: r }
+    description_text: yellow
+    match_text: { attr: u }
+    selected_match_text: { attr: ur }
+  }
+}"#;
+
 const DEFAULT_HISTORY_MENU: &str = r#"
 {
   name: history_menu
@@ -95,6 +130,7 @@ pub(crate) fn add_menus(
     // Checking if the default menus have been added from the config file
     let default_menus = [
         ("completion_menu", DEFAULT_COMPLETION_MENU),
+        ("ide_completion_menu", DEFAULT_IDE_COMPLETION_MENU),
         ("history_menu", DEFAULT_HISTORY_MENU),
         ("help_menu", DEFAULT_HELP_MENU),
     ];
@@ -624,6 +660,16 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
         KeyCode::Tab,
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::Menu("completion_menu".to_string()),
+            ReedlineEvent::MenuNext,
+            ReedlineEvent::Edit(vec![EditCommand::Complete]),
+        ]),
+    );
+
+    keybindings.add_binding(
+        KeyModifiers::CONTROL,
+        KeyCode::Char(' '),
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::Menu("ide_completion_menu".to_string()),
             ReedlineEvent::MenuNext,
             ReedlineEvent::Edit(vec![EditCommand::Complete]),
         ]),

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -413,28 +413,13 @@ $env.config = {
         {
             name: ide_completion_menu
             modifier: control
-            keycode: char_n
+            keycode: space
             mode: [emacs vi_normal vi_insert]
             event: {
                 until: [
                     { send: menu name: ide_completion_menu }
                     { send: menunext }
                     { edit: complete }
-                    { send: down }
-                ]
-            }
-        }
-        {
-            name: move_up
-            modifier: control
-            keycode: char_p
-            mode: [emacs vi_normal vi_insert]
-            event: {
-                until: [
-                    { send: menu name: ide_completion_menu }
-                    { send: menuprevious }
-                    { edit: complete }
-                    { send: up }
                 ]
             }
         }
@@ -632,6 +617,30 @@ $env.config = {
             keycode: end
             mode: [emacs, vi_normal, vi_insert]
             event: { edit: movetolineend }
+        }
+        {
+            name: move_down
+            modifier: control
+            keycode: char_n
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    { send: menudown }
+                    { send: down }
+                ]
+            }
+        }
+        {
+            name: move_up
+            modifier: control
+            keycode: char_p
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    { send: menuup }
+                    { send: up }
+                ]
+            }
         }
         {
             name: delete_one_character_backward

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -404,6 +404,13 @@ $env.config = {
             }
         }
         {
+            name: completion_previous_menu
+            modifier: shift
+            keycode: backtab
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: menuprevious }
+        }
+        {
             name: ide_completion_menu
             modifier: control
             keycode: char_n
@@ -413,6 +420,21 @@ $env.config = {
                     { send: menu name: ide_completion_menu }
                     { send: menunext }
                     { edit: complete }
+                    { send: down }
+                ]
+            }
+        }
+        {
+            name: move_up
+            modifier: control
+            keycode: char_p
+            mode: [emacs vi_normal vi_insert]
+            event: {
+                until: [
+                    { send: menu name: ide_completion_menu }
+                    { send: menuprevious }
+                    { edit: complete }
+                    { send: up }
                 ]
             }
         }
@@ -429,13 +451,6 @@ $env.config = {
             keycode: f1
             mode: [emacs, vi_insert, vi_normal]
             event: { send: menu name: help_menu }
-        }
-        {
-            name: completion_previous_menu
-            modifier: shift
-            keycode: backtab
-            mode: [emacs, vi_normal, vi_insert]
-            event: { send: menuprevious }
         }
         {
             name: next_page_menu
@@ -617,30 +632,6 @@ $env.config = {
             keycode: end
             mode: [emacs, vi_normal, vi_insert]
             event: { edit: movetolineend }
-        }
-        {
-            name: move_up
-            modifier: control
-            keycode: char_p
-            mode: [emacs, vi_normal, vi_insert]
-            event: {
-                until: [
-                    { send: menuup }
-                    { send: up }
-                ]
-            }
-        }
-        {
-            name: move_down
-            modifier: control
-            keycode: char_t
-            mode: [emacs, vi_normal, vi_insert]
-            event: {
-                until: [
-                    { send: menudown }
-                    { send: down }
-                ]
-            }
         }
         {
             name: delete_one_character_backward


### PR DESCRIPTION
Updates Ctrl+p to open the ide_completion menu and otherwise advance to the "previous" menu item.

Ctrl+n opens the ide_completion_menu and subsequently advances to the "next" menu item. Ctrl+p should share this behavior for the "previous" menu item. See nushell/nushell#13946 for detailed discussion.

Tested by building and running nushell without a custom config, falling back to this default config.
