### PR TITLE
Use Ctrl+s for ide_completion_menu

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -404,14 +404,20 @@ $env.config = {
             }
         }
         {
+            name: completion_previous_menu
+            modifier: shift
+            keycode: backtab
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: menuprevious }
+        }
+        {
             name: ide_completion_menu
             modifier: control
-            keycode: char_n
+            keycode: char_s
             mode: [emacs vi_normal vi_insert]
             event: {
                 until: [
                     { send: menu name: ide_completion_menu }
-                    { send: menunext }
                     { edit: complete }
                 ]
             }
@@ -429,13 +435,6 @@ $env.config = {
             keycode: f1
             mode: [emacs, vi_insert, vi_normal]
             event: { send: menu name: help_menu }
-        }
-        {
-            name: completion_previous_menu
-            modifier: shift
-            keycode: backtab
-            mode: [emacs, vi_normal, vi_insert]
-            event: { send: menuprevious }
         }
         {
             name: next_page_menu
@@ -633,7 +632,7 @@ $env.config = {
         {
             name: move_down
             modifier: control
-            keycode: char_t
+            keycode: char_n
             mode: [emacs, vi_normal, vi_insert]
             event: {
                 until: [


### PR DESCRIPTION
Avoids overriding Ctrl+n for "next" menu item and down, as commonly used for Emacs style bindings, as well as the defaults for Reedline.

Also updates the move_down binding to use Ctrl+n instead of Ctrl+t, for consistency with the Emacs and Reedline defaults mentioned above.

Fixes nushell/nushell#13946.

Tested by building and running nushell without a custom config, falling back to this default config.