### PR TITLE
Revert "update virtual terminal processing"

### DIFF
--- a/crates/nu-utils/src/utils.rs
+++ b/crates/nu-utils/src/utils.rs
@@ -7,7 +7,6 @@ pub fn enable_vt_processing() -> Result<()> {
         use crossterm_winapi::{ConsoleMode, Handle};
 
         pub const ENABLE_PROCESSED_OUTPUT: u32 = 0x0001;
-        pub const ENABLE_VIRTUAL_TERMINAL_INPUT: u32 = 0x0200;
         pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
         let mask = ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
@@ -18,12 +17,8 @@ pub fn enable_vt_processing() -> Result<()> {
         // enable_processed_output and enable_virtual_terminal_processing should be used
 
         if old_mode & mask == 0 {
-            console_mode.set_mode(
-                old_mode
-                    | ENABLE_PROCESSED_OUTPUT
-                    | ENABLE_VIRTUAL_TERMINAL_PROCESSING
-                    | ENABLE_VIRTUAL_TERMINAL_INPUT,
-            )?
+            console_mode
+                .set_mode(old_mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING)?
         }
     }
     Ok(())


### PR DESCRIPTION
Reverts nushell/nushell#13710

Let's revert this to see if it fixes https://github.com/nushell/nushell/issues/11950. I've tested and the latest Windows Terminal Preview still works the way I need it to without this code.