### PR TITLE
Make `SpanId` and `RegId` also use new ID struct

### DIFF
--- a/crates/nu-engine/src/compile/builder.rs
+++ b/crates/nu-engine/src/compile/builder.rs
@@ -58,9 +58,9 @@ impl BlockBuilder {
                 }
             })
         {
-            Ok(RegId(index as u32))
+            Ok(RegId::new(index as u32))
         } else if self.register_allocation_state.len() < (u32::MAX as usize - 2) {
-            let reg_id = RegId(self.register_allocation_state.len() as u32);
+            let reg_id = RegId::new(self.register_allocation_state.len() as u32);
             self.register_allocation_state.push(true);
             Ok(reg_id)
         } else {
@@ -73,13 +73,16 @@ impl BlockBuilder {
     /// Check if a register is initialized with a value.
     pub(crate) fn is_allocated(&self, reg_id: RegId) -> bool {
         self.register_allocation_state
-            .get(reg_id.0 as usize)
+            .get(reg_id.get() as usize)
             .is_some_and(|state| *state)
     }
 
     /// Mark a register as initialized.
     pub(crate) fn mark_register(&mut self, reg_id: RegId) -> Result<(), CompileError> {
-        if let Some(is_allocated) = self.register_allocation_state.get_mut(reg_id.0 as usize) {
+        if let Some(is_allocated) = self
+            .register_allocation_state
+            .get_mut(reg_id.get() as usize)
+        {
             *is_allocated = true;
             Ok(())
         } else {
@@ -92,7 +95,7 @@ impl BlockBuilder {
     /// Mark a register as empty, so that it can be used again by something else.
     #[track_caller]
     pub(crate) fn free_register(&mut self, reg_id: RegId) -> Result<(), CompileError> {
-        let index = reg_id.0 as usize;
+        let index = reg_id.get() as usize;
 
         if self
             .register_allocation_state

--- a/crates/nu-engine/src/compile/mod.rs
+++ b/crates/nu-engine/src/compile/mod.rs
@@ -18,7 +18,7 @@ use expression::compile_expression;
 use operator::*;
 use redirect::*;
 
-const BLOCK_INPUT: RegId = RegId(0);
+const BLOCK_INPUT: RegId = RegId::new(0);
 
 /// Compile Nushell pipeline abstract syntax tree (AST) to internal representation (IR) instructions
 /// for evaluation.

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -113,25 +113,28 @@ impl<'a> EvalContext<'a> {
     #[inline]
     fn put_reg(&mut self, reg_id: RegId, new_value: PipelineData) {
         // log::trace!("{reg_id} <- {new_value:?}");
-        self.registers[reg_id.0 as usize] = new_value;
+        self.registers[reg_id.get() as usize] = new_value;
     }
 
     /// Borrow the contents of a register.
     #[inline]
     fn borrow_reg(&self, reg_id: RegId) -> &PipelineData {
-        &self.registers[reg_id.0 as usize]
+        &self.registers[reg_id.get() as usize]
     }
 
     /// Replace the contents of a register with `Empty` and then return the value that it contained
     #[inline]
     fn take_reg(&mut self, reg_id: RegId) -> PipelineData {
         // log::trace!("<- {reg_id}");
-        std::mem::replace(&mut self.registers[reg_id.0 as usize], PipelineData::Empty)
+        std::mem::replace(
+            &mut self.registers[reg_id.get() as usize],
+            PipelineData::Empty,
+        )
     }
 
     /// Clone data from a register. Must be collected first.
     fn clone_reg(&mut self, reg_id: RegId, error_span: Span) -> Result<PipelineData, ShellError> {
-        match &self.registers[reg_id.0 as usize] {
+        match &self.registers[reg_id.get() as usize] {
             PipelineData::Empty => Ok(PipelineData::Empty),
             PipelineData::Value(val, meta) => Ok(PipelineData::Value(val.clone(), meta.clone())),
             _ => Err(ShellError::IrEvalError {

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -584,7 +584,7 @@ impl Expression {
         Expression {
             expr,
             span,
-            span_id: SpanId(0),
+            span_id: SpanId::new(0),
             ty,
             custom_completion: None,
         }

--- a/crates/nu-protocol/src/debugger/profiler.rs
+++ b/crates/nu-protocol/src/debugger/profiler.rs
@@ -259,7 +259,7 @@ impl Debugger for Profiler {
                     .or_else(|| {
                         instruction
                             .output_register()
-                            .map(|register| Ok(&registers[register.0 as usize]))
+                            .map(|register| Ok(&registers[register.get() as usize]))
                     })
                     .map(|result| format_result(&result, span))
             })

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -120,7 +120,7 @@ pub const ENV_VARIABLE_ID: VarId = VarId::new(2);
 // NOTE: If you add more to this list, make sure to update the > checks based on the last in the list
 
 // The first span is unknown span
-pub const UNKNOWN_SPAN_ID: SpanId = SpanId(0);
+pub const UNKNOWN_SPAN_ID: SpanId = SpanId::new(0);
 
 impl EngineState {
     pub fn new() -> Self {
@@ -1027,12 +1027,12 @@ impl EngineState {
     /// Add new span and return its ID
     pub fn add_span(&mut self, span: Span) -> SpanId {
         self.spans.push(span);
-        SpanId(self.num_spans() - 1)
+        SpanId::new(self.num_spans() - 1)
     }
 
     /// Find ID of a span (should be avoided if possible)
     pub fn find_span_id(&self, span: Span) -> Option<SpanId> {
-        self.spans.iter().position(|sp| sp == &span).map(SpanId)
+        self.spans.iter().position(|sp| sp == &span).map(SpanId::new)
     }
 }
 
@@ -1041,7 +1041,7 @@ impl<'a> GetSpan for &'a EngineState {
     fn get_span(&self, span_id: SpanId) -> Span {
         *self
             .spans
-            .get(span_id.0)
+            .get(span_id.get())
             .expect("internal error: missing span")
     }
 }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1032,7 +1032,10 @@ impl EngineState {
 
     /// Find ID of a span (should be avoided if possible)
     pub fn find_span_id(&self, span: Span) -> Option<SpanId> {
-        self.spans.iter().position(|sp| sp == &span).map(SpanId::new)
+        self.spans
+            .iter()
+            .position(|sp| sp == &span)
+            .map(SpanId::new)
     }
 }
 

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1037,20 +1037,20 @@ impl<'a> StateWorkingSet<'a> {
     pub fn add_span(&mut self, span: Span) -> SpanId {
         let num_permanent_spans = self.permanent_state.spans.len();
         self.delta.spans.push(span);
-        SpanId(num_permanent_spans + self.delta.spans.len() - 1)
+        SpanId::new(num_permanent_spans + self.delta.spans.len() - 1)
     }
 }
 
 impl<'a> GetSpan for &'a StateWorkingSet<'a> {
     fn get_span(&self, span_id: SpanId) -> Span {
         let num_permanent_spans = self.permanent_state.num_spans();
-        if span_id.0 < num_permanent_spans {
+        if span_id.get() < num_permanent_spans {
             self.permanent_state.get_span(span_id)
         } else {
             *self
                 .delta
                 .spans
-                .get(span_id.0 - num_permanent_spans)
+                .get(span_id.get() - num_permanent_spans)
                 .expect("internal error: missing span")
         }
     }

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -76,6 +76,8 @@ pub mod marker {
     pub struct File;
     #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct VirtualPath;
+    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct Span;
 }
 
 pub type VarId = Id<marker::Var>;
@@ -85,9 +87,7 @@ pub type ModuleId = Id<marker::Module>;
 pub type OverlayId = Id<marker::Overlay>;
 pub type FileId = Id<marker::File>;
 pub type VirtualPathId = Id<marker::VirtualPath>;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct SpanId(pub usize); // more robust ID style used in the new parser
+pub type SpanId = Id<marker::Span>;
 
 /// An ID for an [IR](crate::ir) register. `%n` is a common shorthand for `RegId(n)`.
 ///

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -1,45 +1,56 @@
 use std::any;
-use std::fmt::{Debug, Error, Formatter};
+use std::fmt::{Debug, Display, Error, Formatter};
 use std::marker::PhantomData;
 
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Id<T> {
-    inner: usize,
-    _phantom: PhantomData<T>,
+pub struct Id<M, V = usize> {
+    inner: V,
+    _phantom: PhantomData<M>,
 }
 
-impl<T> Id<T> {
+impl<M, V> Id<M, V> {
     /// Creates a new `Id`.
     ///
-    /// Using a distinct type like `Id` instead of `usize` helps us avoid mixing plain integers
+    /// Using a distinct type like `Id` instead of `usize` integer helps us avoid mixing plain integers
     /// with identifiers.
     #[inline]
-    pub const fn new(inner: usize) -> Self {
+    pub const fn new(inner: V) -> Self {
         Self {
             inner,
             _phantom: PhantomData,
         }
     }
+}
 
-    /// Returns the inner `usize` value.
+impl<M, V> Id<M, V>
+where
+    V: Copy,
+{
+    /// Returns the inner value.
     ///
     /// This requires an explicit call, ensuring we only use the raw value when intended.
     #[inline]
-    pub const fn get(self) -> usize {
+    pub const fn get(self) -> V {
         self.inner
     }
 }
 
-impl<T> Debug for Id<T> {
+impl<M, V> Debug for Id<M, V>
+where
+    V: Display,
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        let marker = any::type_name::<T>().split("::").last().expect("not empty");
+        let marker = any::type_name::<M>().split("::").last().expect("not empty");
         write!(f, "{marker}Id({})", self.inner)
     }
 }
 
-impl<T> Serialize for Id<T> {
+impl<M, V> Serialize for Id<M, V>
+where
+    V: Serialize,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -48,12 +59,15 @@ impl<T> Serialize for Id<T> {
     }
 }
 
-impl<'de, T> Deserialize<'de> for Id<T> {
+impl<'de, M, V> Deserialize<'de> for Id<M, V>
+where
+    V: Deserialize<'de>,
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        let inner = usize::deserialize(deserializer)?;
+        let inner = V::deserialize(deserializer)?;
         Ok(Self {
             inner,
             _phantom: PhantomData,
@@ -78,6 +92,8 @@ pub mod marker {
     pub struct VirtualPath;
     #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct Span;
+    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct Reg;
 }
 
 pub type VarId = Id<marker::Var>;
@@ -89,15 +105,15 @@ pub type FileId = Id<marker::File>;
 pub type VirtualPathId = Id<marker::VirtualPath>;
 pub type SpanId = Id<marker::Span>;
 
-/// An ID for an [IR](crate::ir) register. `%n` is a common shorthand for `RegId(n)`.
+/// An ID for an [IR](crate::ir) register.
+///
+/// `%n` is a common shorthand for `RegId(n)`.
 ///
 /// Note: `%0` is allocated with the block input at the beginning of a compiled block.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[repr(transparent)]
-pub struct RegId(pub u32);
+pub type RegId = Id<marker::Reg, u32>;
 
-impl std::fmt::Display for RegId {
+impl Display for RegId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "%{}", self.0)
+        write!(f, "%{}", self.get())
     }
 }

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -13,7 +13,7 @@ pub struct Id<M, V = usize> {
 impl<M, V> Id<M, V> {
     /// Creates a new `Id`.
     ///
-    /// Using a distinct type like `Id` instead of `usize` integer helps us avoid mixing plain integers
+    /// Using a distinct type like `Id` instead of `usize` helps us avoid mixing plain integers
     /// with identifiers.
     #[inline]
     pub const fn new(inner: V) -> Self {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
In the PR #13832 I used some newtypes for the old IDs. `SpanId` and `RegId` already used newtypes, to streamline the code, I made them into the same style as the other marker-based IDs.

Since `RegId` should be a bit smaller (it uses a `u32` instead of `usize`) according to @devyn, I made the `Id` type generic with `usize` as the default inner value.

The question still stands how `Display` should be implemented if even.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Users of the internal values of `RegId` or `SpanId` have breaking changes but who outside nushell itself even uses these?

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
The IDs will be streamlined and all type-safe.