### PR TITLE
allow bools to be type checked with each other

### DIFF
--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -480,6 +480,7 @@ pub fn math_result_type(
                 (Type::Duration, Type::Duration) => (Type::Bool, None),
                 (Type::Date, Type::Date) => (Type::Bool, None),
                 (Type::Filesize, Type::Filesize) => (Type::Bool, None),
+                (Type::Bool, Type::Bool) => (Type::Bool, None),
 
                 (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
                 (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
@@ -530,6 +531,7 @@ pub fn math_result_type(
                 (Type::Duration, Type::Duration) => (Type::Bool, None),
                 (Type::Date, Type::Date) => (Type::Bool, None),
                 (Type::Filesize, Type::Filesize) => (Type::Bool, None),
+                (Type::Bool, Type::Bool) => (Type::Bool, None),
 
                 (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
                 (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
@@ -580,6 +582,7 @@ pub fn math_result_type(
                 (Type::Duration, Type::Duration) => (Type::Bool, None),
                 (Type::Date, Type::Date) => (Type::Bool, None),
                 (Type::Filesize, Type::Filesize) => (Type::Bool, None),
+                (Type::Bool, Type::Bool) => (Type::Bool, None),
 
                 (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
                 (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
@@ -630,6 +633,7 @@ pub fn math_result_type(
                 (Type::Duration, Type::Duration) => (Type::Bool, None),
                 (Type::Date, Type::Date) => (Type::Bool, None),
                 (Type::Filesize, Type::Filesize) => (Type::Bool, None),
+                (Type::Bool, Type::Bool) => (Type::Bool, None),
 
                 (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
                 (Type::Custom(a), _) => (Type::Custom(a.clone()), None),


### PR DESCRIPTION
# Description

This PR allows bools to be type checked against each other.

![image](https://github.com/user-attachments/assets/64dc36f8-59bc-4e66-8380-6b693c77a2d3)

I looked for test and maybe we don't have any for type checked math stuff. I didn't see any.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
