### PR TITLE
Update merge example

### DIFF
--- a/crates/nu-command/src/filters/merge.rs
+++ b/crates/nu-command/src/filters/merge.rs
@@ -38,21 +38,21 @@ repeating this process with row 1, and so on."#
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "[a b c] | wrap name | merge ( [4 5 6] | wrap id )",
+                example: "[a b c] | wrap name | merge ( [47 512 618] | wrap id )",
                 description: "Add an 'id' column to the input table",
                 result: Some(Value::list(
                     vec![
                         Value::test_record(record! {
                             "name" => Value::test_string("a"),
-                            "id" => Value::test_int(4),
+                            "id" => Value::test_int(47),
                         }),
                         Value::test_record(record! {
                             "name" => Value::test_string("b"),
-                            "id" => Value::test_int(5),
+                            "id" => Value::test_int(512),
                         }),
                         Value::test_record(record! {
                             "name" => Value::test_string("c"),
-                            "id" => Value::test_int(6),
+                            "id" => Value::test_int(618),
                         }),
                     ],
                     Span::test_data(),

--- a/crates/nu-command/src/filters/merge.rs
+++ b/crates/nu-command/src/filters/merge.rs
@@ -38,21 +38,21 @@ repeating this process with row 1, and so on."#
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "[a b c] | wrap name | merge ( [1 2 3] | wrap index )",
-                description: "Add an 'index' column to the input table",
+                example: "[a b c] | wrap name | merge ( [4 5 6] | wrap id )",
+                description: "Add an 'id' column to the input table",
                 result: Some(Value::list(
                     vec![
                         Value::test_record(record! {
                             "name" => Value::test_string("a"),
-                            "index" => Value::test_int(1),
+                            "id" => Value::test_int(4),
                         }),
                         Value::test_record(record! {
                             "name" => Value::test_string("b"),
-                            "index" => Value::test_int(2),
+                            "id" => Value::test_int(5),
                         }),
                         Value::test_record(record! {
                             "name" => Value::test_string("c"),
-                            "index" => Value::test_int(3),
+                            "id" => Value::test_int(6),
                         }),
                     ],
                     Span::test_data(),


### PR DESCRIPTION
# Description

All credit to @AlifianK for suggesting this in the doc repo (https://github.com/nushell/nushell.github.io/pull/1571).

This updates the merge example to make it more clear by using a different set of numbers that can't easily be confused with an `index`.  Also changes the `index` to `id` to remove the "magic column name conversion". (#13780).

# User-Facing Changes

Help/Doc change only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A