### PR TITLE
Update wrap example

### DIFF
--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -57,31 +57,34 @@ impl Command for Wrap {
         vec![
             Example {
                 description: "Wrap a list into a table with a given column name",
-                example: "[1 2 3] | wrap num",
+                example: "[ Pachisi Mahjong Catan Carcassonne ] | wrap game",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
-                        "num" => Value::test_int(1),
+                        "game" => Value::test_string("Pachisi"),
                     }),
                     Value::test_record(record! {
-                        "num" => Value::test_int(2),
+                        "game" => Value::test_string("Mahjong"),
                     }),
                     Value::test_record(record! {
-                        "num" => Value::test_int(3),
+                        "game" => Value::test_string("Catan"),
+                    }),
+                    Value::test_record(record! {
+                        "game" => Value::test_string("Carcassonne"),
                     }),
                 ])),
             },
             Example {
                 description: "Wrap a range into a table with a given column name",
-                example: "1..3 | wrap num",
+                example: "4..6 | wrap num",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
-                        "num" => Value::test_int(1),
+                        "num" => Value::test_int(4),
                     }),
                     Value::test_record(record! {
-                        "num" => Value::test_int(2),
+                        "num" => Value::test_int(5),
                     }),
                     Value::test_record(record! {
-                        "num" => Value::test_int(3),
+                        "num" => Value::test_int(6),
                     }),
                 ])),
             },


### PR DESCRIPTION
# Description

As with #13985, credit to @AlifianK for suggesting this in https://github.com/nushell/nushell.github.io/pull/1572

Updates the example in `wrap` to not use 1-based, sequential numbers.

# User-Facing Changes

Help/doc only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A
