### PR TITLE
Fix `try` printing when it is not the last pipeline element 

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -63,7 +63,7 @@ impl Command for Try {
         let eval_block = get_eval_block(engine_state);
 
         let result = eval_block(engine_state, stack, try_block, input)
-            .and_then(|pipeline| pipeline.drain_if_end(engine_state, stack));
+            .and_then(|pipeline| pipeline.drain_to_out_dest(engine_state, stack));
 
         match result {
             Err(err) => run_catch(err, head, catch_block, engine_state, stack, eval_block),

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -63,7 +63,7 @@ impl Command for Try {
         let eval_block = get_eval_block(engine_state);
 
         let result = eval_block(engine_state, stack, try_block, input)
-            .and_then(|pipeline| pipeline.write_to_out_dests(engine_state, stack));
+            .and_then(|pipeline| pipeline.drain_if_end(engine_state, stack));
 
         match result {
             Err(err) => run_catch(err, head, catch_block, engine_state, stack, eval_block),

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -63,7 +63,7 @@ impl Command for Try {
         let eval_block = get_eval_block(engine_state);
 
         let result = eval_block(engine_state, stack, try_block, input)
-            .and_then(|pipeline| pipeline.drain_to_out_dest(engine_state, stack));
+            .and_then(|pipeline| pipeline.drain_to_out_dests(engine_state, stack));
 
         match result {
             Err(err) => run_catch(err, head, catch_block, engine_state, stack, eval_block),

--- a/crates/nu-command/src/filters/tee.rs
+++ b/crates/nu-command/src/filters/tee.rs
@@ -163,7 +163,7 @@ use it in your pipeline."#
                                     Ok(None)
                                 }
                                 OutDest::Null => copy_on_thread(tee, io::sink(), &info).map(Some),
-                                OutDest::Inherit => {
+                                OutDest::Print | OutDest::Inherit => {
                                     copy_on_thread(tee, io::stderr(), &info).map(Some)
                                 }
                                 OutDest::File(file) => {
@@ -181,7 +181,9 @@ use it in your pipeline."#
                                     Ok(())
                                 }
                                 OutDest::Null => copy_pipe(stdout, io::sink(), &info),
-                                OutDest::Inherit => copy_pipe(stdout, io::stdout(), &info),
+                                OutDest::Print | OutDest::Inherit => {
+                                    copy_pipe(stdout, io::stdout(), &info)
+                                }
                                 OutDest::File(file) => copy_pipe(stdout, file.as_ref(), &info),
                             }?;
                         }
@@ -198,7 +200,7 @@ use it in your pipeline."#
                                 OutDest::Null => {
                                     copy_pipe_on_thread(stderr, io::sink(), &info).map(Some)
                                 }
-                                OutDest::Inherit => {
+                                OutDest::Print | OutDest::Inherit => {
                                     copy_pipe_on_thread(stderr, io::stderr(), &info).map(Some)
                                 }
                                 OutDest::File(file) => {
@@ -218,7 +220,7 @@ use it in your pipeline."#
                                     Ok(())
                                 }
                                 OutDest::Null => copy(tee, io::sink(), &info),
-                                OutDest::Inherit => copy(tee, io::stdout(), &info),
+                                OutDest::Print | OutDest::Inherit => copy(tee, io::stdout(), &info),
                                 OutDest::File(file) => copy(tee, file.as_ref(), &info),
                             }?;
                         }

--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -117,3 +117,10 @@ fn try_catches_exit_code_in_expr() {
     let actual = nu!("print (try { nu -c 'exit 42' } catch { |e| $e.exit_code })");
     assert_eq!(actual.out, "42");
 }
+
+#[test]
+
+fn try_prints_only_if_last_pipeline() {
+    let actual = nu!("try { 'should not print' }; 'last value'");
+    assert_eq!(actual.out, "last value");
+}

--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -107,20 +107,22 @@ fn exit_code_available_in_catch() {
 }
 
 #[test]
-fn try_catches_exit_code_in_assignment() {
+fn catches_exit_code_in_assignment() {
     let actual = nu!("let x = try { nu -c 'exit 42' } catch { |e| $e.exit_code }; $x");
     assert_eq!(actual.out, "42");
 }
 
 #[test]
-fn try_catches_exit_code_in_expr() {
+fn catches_exit_code_in_expr() {
     let actual = nu!("print (try { nu -c 'exit 42' } catch { |e| $e.exit_code })");
     assert_eq!(actual.out, "42");
 }
 
 #[test]
-
-fn try_prints_only_if_last_pipeline() {
+fn prints_only_if_last_pipeline() {
     let actual = nu!("try { 'should not print' }; 'last value'");
+    assert_eq!(actual.out, "last value");
+
+    let actual = nu!("try { ['should not print'] | every 1 }; 'last value'");
     assert_eq!(actual.out, "last value");
 }

--- a/crates/nu-engine/src/compile/builder.rs
+++ b/crates/nu-engine/src/compile/builder.rs
@@ -205,7 +205,7 @@ impl BlockBuilder {
             Instruction::Span { src_dst } => allocate(&[*src_dst], &[*src_dst]),
             Instruction::Drop { src } => allocate(&[*src], &[]),
             Instruction::Drain { src } => allocate(&[*src], &[]),
-            Instruction::WriteToOutDests { src } => allocate(&[*src], &[]),
+            Instruction::DrainIfEnd { src } => allocate(&[*src], &[]),
             Instruction::LoadVariable { dst, var_id: _ } => allocate(&[], &[*dst]),
             Instruction::StoreVariable { var_id: _, src } => allocate(&[*src], &[]),
             Instruction::DropVariable { var_id: _ } => Ok(()),

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -473,7 +473,7 @@ pub(crate) fn compile_try(
     if let Some(mode) = redirect_modes.err {
         builder.push(mode.map(|mode| Instruction::RedirectErr { mode }))?;
     }
-    builder.push(Instruction::WriteToOutDests { src: io_reg }.into_spanned(call.head))?;
+    builder.push(Instruction::DrainIfEnd { src: io_reg }.into_spanned(call.head))?;
     builder.push(Instruction::PopErrorHandler.into_spanned(call.head))?;
 
     // Jump over the failure case

--- a/crates/nu-engine/src/compile/redirect.rs
+++ b/crates/nu-engine/src/compile/redirect.rs
@@ -151,7 +151,8 @@ pub(crate) fn out_dest_to_redirect_mode(
             OutDest::PipeSeparate => Ok(RedirectMode::PipeSeparate),
             OutDest::Value => Ok(RedirectMode::Value),
             OutDest::Null => Ok(RedirectMode::Null),
-            OutDest::Inherit => Ok(RedirectMode::Inherit),
+            OutDest::Print => Ok(RedirectMode::Print),
+            OutDest::Inherit => Err(CompileError::InvalidRedirectMode { span }),
             OutDest::File(_) => Err(CompileError::InvalidRedirectMode { span }),
         })
         .transpose()

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -328,7 +328,7 @@ fn eval_instruction<D: DebugContext>(
                 let stack = &mut ctx
                     .stack
                     .push_redirection(ctx.redirect_out.clone(), ctx.redirect_err.clone());
-                data.drain_if_end(ctx.engine_state, stack)?
+                data.drain_to_out_dest(ctx.engine_state, stack)?
             };
             ctx.put_reg(*src, res);
             Ok(Continue)
@@ -1426,6 +1426,7 @@ fn eval_redirection(
         RedirectMode::Value => Ok(Some(Redirection::Pipe(OutDest::Value))),
         RedirectMode::Null => Ok(Some(Redirection::Pipe(OutDest::Null))),
         RedirectMode::Inherit => Ok(Some(Redirection::Pipe(OutDest::Inherit))),
+        RedirectMode::Print => Ok(Some(Redirection::Pipe(OutDest::Print))),
         RedirectMode::File { file_num } => {
             let file = ctx
                 .files

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -322,13 +322,13 @@ fn eval_instruction<D: DebugContext>(
             let data = ctx.take_reg(*src);
             drain(ctx, data)
         }
-        Instruction::WriteToOutDests { src } => {
+        Instruction::DrainIfEnd { src } => {
             let data = ctx.take_reg(*src);
             let res = {
                 let stack = &mut ctx
                     .stack
                     .push_redirection(ctx.redirect_out.clone(), ctx.redirect_err.clone());
-                data.write_to_out_dests(ctx.engine_state, stack)?
+                data.drain_if_end(ctx.engine_state, stack)?
             };
             ctx.put_reg(*src, res);
             Ok(Continue)
@@ -507,14 +507,19 @@ fn eval_instruction<D: DebugContext>(
                     msg: format!("Tried to write to file #{file_num}, but it is not open"),
                     span: Some(*span),
                 })?;
-            let result = {
-                let mut stack = ctx
-                    .stack
-                    .push_redirection(Some(Redirection::File(file)), None);
-                src.write_to_out_dests(ctx.engine_state, &mut stack)?
+            let is_external = if let PipelineData::ByteStream(stream, ..) = &src {
+                matches!(stream.source(), ByteStreamSource::Child(..))
+            } else {
+                false
             };
-            // Abort execution if there's an exit code from a failed external
-            drain(ctx, result)
+            if let Err(err) = src.write_to(file.as_ref()) {
+                if is_external {
+                    ctx.stack.set_last_error(&err);
+                }
+                Err(err)?
+            } else {
+                Ok(Continue)
+            }
         }
         Instruction::CloseFile { file_num } => {
             if ctx.files[*file_num as usize].take().is_some() {

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -328,7 +328,7 @@ fn eval_instruction<D: DebugContext>(
                 let stack = &mut ctx
                     .stack
                     .push_redirection(ctx.redirect_out.clone(), ctx.redirect_err.clone());
-                data.drain_to_out_dest(ctx.engine_state, stack)?
+                data.drain_to_out_dests(ctx.engine_state, stack)?
             };
             ctx.put_reg(*src, res);
             Ok(Continue)

--- a/crates/nu-protocol/src/engine/stack_out_dest.rs
+++ b/crates/nu-protocol/src/engine/stack_out_dest.rs
@@ -62,8 +62,8 @@ pub(crate) struct StackOutDest {
 impl StackOutDest {
     pub(crate) fn new() -> Self {
         Self {
-            pipe_stdout: None,
-            pipe_stderr: None,
+            pipe_stdout: Some(OutDest::Print),
+            pipe_stderr: Some(OutDest::Print),
             stdout: OutDest::Inherit,
             stderr: OutDest::Inherit,
             parent_stdout: None,

--- a/crates/nu-protocol/src/ir/display.rs
+++ b/crates/nu-protocol/src/ir/display.rs
@@ -312,6 +312,7 @@ impl fmt::Display for RedirectMode {
             RedirectMode::Value => write!(f, "value"),
             RedirectMode::Null => write!(f, "null"),
             RedirectMode::Inherit => write!(f, "inherit"),
+            RedirectMode::Print => write!(f, "print"),
             RedirectMode::File { file_num } => write!(f, "file({file_num})"),
             RedirectMode::Caller => write!(f, "caller"),
         }

--- a/crates/nu-protocol/src/ir/display.rs
+++ b/crates/nu-protocol/src/ir/display.rs
@@ -92,8 +92,8 @@ impl<'a> fmt::Display for FmtInstruction<'a> {
             Instruction::Drain { src } => {
                 write!(f, "{:WIDTH$} {src}", "drain")
             }
-            Instruction::WriteToOutDests { src } => {
-                write!(f, "{:WIDTH$} {src}", "write-to-out-dests")
+            Instruction::DrainIfEnd { src } => {
+                write!(f, "{:WIDTH$} {src}", "drain-if-end")
             }
             Instruction::LoadVariable { dst, var_id } => {
                 let var = FmtVar::new(self.engine_state, *var_id);

--- a/crates/nu-protocol/src/ir/mod.rs
+++ b/crates/nu-protocol/src/ir/mod.rs
@@ -123,9 +123,9 @@ pub enum Instruction {
     /// code, and invokes any available error handler with Empty, or if not available, returns an
     /// exit-code-only stream, leaving the block.
     Drain { src: RegId },
-    /// Write to the output destinations in the stack
+    /// Drain the value/stream in a register and discard only if this is the last pipeline element.
     // TODO: see if it's possible to remove this
-    WriteToOutDests { src: RegId },
+    DrainIfEnd { src: RegId },
     /// Load the value of a variable into the `dst` register
     LoadVariable { dst: RegId, var_id: VarId },
     /// Store the value of a variable from the `src` register
@@ -290,7 +290,7 @@ impl Instruction {
             Instruction::Span { src_dst } => Some(src_dst),
             Instruction::Drop { .. } => None,
             Instruction::Drain { .. } => None,
-            Instruction::WriteToOutDests { .. } => None,
+            Instruction::DrainIfEnd { .. } => None,
             Instruction::LoadVariable { dst, .. } => Some(dst),
             Instruction::StoreVariable { .. } => None,
             Instruction::DropVariable { .. } => None,

--- a/crates/nu-protocol/src/ir/mod.rs
+++ b/crates/nu-protocol/src/ir/mod.rs
@@ -450,6 +450,7 @@ pub enum RedirectMode {
     Value,
     Null,
     Inherit,
+    Print,
     /// Use the given numbered file.
     File {
         file_num: u32,

--- a/crates/nu-protocol/src/pipeline/out_dest.rs
+++ b/crates/nu-protocol/src/pipeline/out_dest.rs
@@ -25,10 +25,16 @@ pub enum OutDest {
     ///
     /// This will forward output to the null device for the platform.
     Null,
-    /// Output to nushell's stdout or stderr.
+    /// Output to nushell's stdout or stderr (only for external commands).
     ///
-    /// This causes external commands to inherit nushell's stdout or stderr.
+    /// This causes external commands to inherit nushell's stdout or stderr. This also causes
+    /// [`ListStream`](crate::ListStream)s to be drained, but not to be printed.
     Inherit,
+    /// Print to nushell's stdout or stderr.
+    ///
+    /// This is just like `Inherit`, except that [`ListStream`](crate::ListStream)s and
+    /// [`Value`](crate::Value)s are also printed.
+    Print,
     /// Redirect output to a file.
     File(Arc<File>), // Arc<File>, since we sometimes need to clone `OutDest` into iterators, etc.
 }
@@ -52,7 +58,7 @@ impl TryFrom<&OutDest> for Stdio {
         match out_dest {
             OutDest::Pipe | OutDest::PipeSeparate | OutDest::Value => Ok(Self::piped()),
             OutDest::Null => Ok(Self::null()),
-            OutDest::Inherit => Ok(Self::inherit()),
+            OutDest::Print | OutDest::Inherit => Ok(Self::inherit()),
             OutDest::File(file) => Ok(file.try_clone()?.into()),
         }
     }

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -196,7 +196,7 @@ impl PipelineData {
     /// as is. For [`OutDest::Value`], this will collect into a value and return it. For
     /// [`OutDest::Print`], the [`PipelineData`] is drained and printed. Otherwise, the
     /// [`PipelineData`] is drained, but only printed if it is the output of an external command.
-    pub fn drain_to_out_dest(
+    pub fn drain_to_out_dests(
         self,
         engine_state: &EngineState,
         stack: &mut Stack,

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -165,6 +165,9 @@ impl PipelineData {
         }
     }
 
+    /// Drain and write this [`PipelineData`] to `dest`.
+    ///
+    /// Values are converted to bytes and separated by newlines if this is a `ListStream`.
     pub fn write_to(self, mut dest: impl Write) -> Result<(), ShellError> {
         match self {
             PipelineData::Empty => Ok(()),


### PR DESCRIPTION
# Description

Fixes #13991. This was done by more clearly separating the case when a pipeline is drained vs when it is being written (to a file).

I also added an `OutDest::Print` case which might not be strictly necessary, but is a helpful addition.

# User-Facing Changes

Bug fix.

# Tests + Formatting

Added a test.

# After Submitting

There are still a few redirection bugs that I found, but they require larger code changes, so I'll leave them until after the release.