### PR TITLE
Update `fill.rs` to fix last example given with help

### DIFF
--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -108,7 +108,7 @@ impl Command for Fill {
             },
             Example {
                 description:
-                    "Fill a filesize on the left side to a width of 5 with the character '0'",
+                    "Fill a filesize on both sides to a width of 10 with the character '0'",
                 example: "1kib | fill --alignment middle --character '0' --width 10",
                 result: Some(Value::string("0001024000", Span::test_data())),
             },


### PR DESCRIPTION
Original stated it filled on the left to a width of 5 while showing the command and output to fill on both sides to a width of 10. Changed wording of description to match effect of example and displayed result.
