### PR TITLE
since windows allows slash or backslash, allow both instead of MAIN_SEPARATOR

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -169,12 +169,16 @@ impl Command for Glob {
             });
         }
 
+        // below we have to check / and \\ because windows allows both
+        // so we can't assume MAIN_SEPARATOR will be the only separator
         let folder_depth = if let Some(depth) = depth {
             depth
         } else if glob_pattern.contains("**") {
             usize::MAX
-        } else if glob_pattern.contains(std::path::MAIN_SEPARATOR) {
-            glob_pattern.split(std::path::MAIN_SEPARATOR).count() + 1
+        } else if glob_pattern.contains('/') {
+            glob_pattern.split('/').count() + 1
+        } else if glob_pattern.contains('\\') {
+            glob_pattern.split('\\').count() + 1
         } else {
             1
         };

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -169,16 +169,14 @@ impl Command for Glob {
             });
         }
 
-        // below we have to check / and \\ because windows allows both
-        // so we can't assume MAIN_SEPARATOR will be the only separator
+        // below we have to check / instead of MAIN_SEPARATOR because glob uses / as separator
+        // using a glob like **\*.rs should fail because it's not a valid glob pattern
         let folder_depth = if let Some(depth) = depth {
             depth
         } else if glob_pattern.contains("**") {
             usize::MAX
         } else if glob_pattern.contains('/') {
             glob_pattern.split('/').count() + 1
-        } else if glob_pattern.contains('\\') {
-            glob_pattern.split('\\').count() + 1
         } else {
             1
         };


### PR DESCRIPTION
# Description

I mean't to do this small change the other day but forgot. We probably shouldn't be using MAIN_SEPARATOR because **\\*.rs is an illegal glob. So, update this to just use slash.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
