### PR TITLE
Updated warning message for old dirs/shells

### DIFF
--- a/crates/nu-std/std/deprecated_dirs.nu
+++ b/crates/nu-std/std/deprecated_dirs.nu
@@ -26,7 +26,7 @@ print -e $"
 (ansi red)Warning:(ansi reset) The 'std dirs' module will no longer automatically
 be loaded in the next release. To continue using the Shells
 feature, and to remove this warning, please add the following
-to your config.nu:
+to your startup configuration (typically env.nu or config.nu):
 
 use std/dirs shells-aliases *
 


### PR DESCRIPTION
# Description

@kubouch noticed that the warning message from #13842 when using a "Shells" alias mentioned `config.nu`, but he's using it in the prompt which means loading it in `env.nu`.  Updated the warning message to:

> ... feature, and to remove this warning, please add the following
> to your startup configuration (typically env.nu or config.nu):

# User-Facing Changes

No change in functionality - More clear instructions, hopefully.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

Doc and release notes still to be updated for #13842 