### PR TITLE
nu-table/ Fix footer truncation in case of head_on_border

### DIFF
--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -296,9 +296,9 @@ fn set_border_head(table: &mut Table, with_footer: bool, wctrl: TableWidthCtrl) 
             Settings::default()
                 .with(StripColorFromRow(0))
                 .with(StripColorFromRow(count_rows - 1))
+                .with(wctrl)
                 .with(MoveRowNext::new(0, 0))
                 .with(MoveRowPrev::new(last_row_index - 1, last_row_index))
-                .with(wctrl)
                 .with(SetLineHeaders::new(0, head, alignment, head_color))
                 .with(SetLineHeaders::new(
                     last_row_index - 1,
@@ -317,8 +317,8 @@ fn set_border_head(table: &mut Table, with_footer: bool, wctrl: TableWidthCtrl) 
         table.with(
             Settings::default()
                 .with(StripColorFromRow(0))
-                .with(MoveRowNext::new(0, 0))
                 .with(wctrl)
+                .with(MoveRowNext::new(0, 0))
                 .with(SetLineHeaders::new(0, row.1, row_opts.1, row_opts.2)),
         );
     }
@@ -1109,6 +1109,10 @@ impl TableOption<NuRecords, ColoredConfig, CompleteDimensionVecRecords<'_>> for 
     ) {
         row_shift_next(recs, cfg, self.row, self.line);
     }
+
+    fn hint_change(&self) -> Option<Entity> {
+        None
+    }
 }
 
 impl TableOption<NuRecords, ColoredConfig, CompleteDimensionVecRecords<'_>> for MoveRowPrev {
@@ -1119,6 +1123,10 @@ impl TableOption<NuRecords, ColoredConfig, CompleteDimensionVecRecords<'_>> for 
         _: &mut CompleteDimensionVecRecords<'_>,
     ) {
         row_shift_prev(recs, cfg, self.row, self.line);
+    }
+
+    fn hint_change(&self) -> Option<Entity> {
+        None
     }
 }
 

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -294,18 +294,18 @@ fn set_border_head(table: &mut Table, with_footer: bool, wctrl: TableWidthCtrl) 
 
         table.with(
             Settings::default()
-                .with(wctrl)
                 .with(StripColorFromRow(0))
                 .with(StripColorFromRow(count_rows - 1))
                 .with(MoveRowNext::new(0, 0))
                 .with(MoveRowPrev::new(last_row_index - 1, last_row_index))
+                .with(wctrl)
+                .with(SetLineHeaders::new(0, head, alignment, head_color))
                 .with(SetLineHeaders::new(
                     last_row_index - 1,
                     footer,
                     alignment,
                     footer_color,
-                ))
-                .with(SetLineHeaders::new(0, head, alignment, head_color)),
+                )),
         );
     } else {
         let mut row = GetRow(0, Vec::new());
@@ -316,9 +316,9 @@ fn set_border_head(table: &mut Table, with_footer: bool, wctrl: TableWidthCtrl) 
 
         table.with(
             Settings::default()
-                .with(wctrl)
                 .with(StripColorFromRow(0))
                 .with(MoveRowNext::new(0, 0))
+                .with(wctrl)
                 .with(SetLineHeaders::new(0, row.1, row_opts.1, row_opts.2)),
         );
     }
@@ -466,10 +466,9 @@ fn trim_as_header(
 
     // even though it's safe to trim columns by header there might be left unused space
     // so we do use it if possible prioritizing left columns
-
+    let mut widths = vec![0; headers_widths.len()];
     for (i, head_width) in headers_widths.into_iter().enumerate() {
-        let head_width = head_width - trim.pad;
-        let column_width = trim.width[i] - trim.pad; // safe to assume width is bigger then paddding
+        let column_width = trim.width[i]; // safe to assume width is bigger then paddding
 
         let mut use_width = head_width;
         if free_width > 0 {
@@ -481,15 +480,45 @@ fn trim_as_header(
             use_width += additional_width;
         }
 
+        widths[i] = use_width;
+    }
+
+    // make sure we are fit in;
+    // which is might not be the case where we need to truncate columns furter then a column head width
+    let expected_width = get_total_width2(&widths, cfg);
+    if expected_width > trim.width_max {
+        let mut diff = expected_width - trim.width_max;
+        'out: loop {
+            let (biggest_column, &value) = widths
+                .iter()
+                .enumerate()
+                .max_by_key(|(_, &value)| value)
+                .expect("ok");
+            if value <= trim.pad {
+                unreachable!("theoretically must never happen at this point")
+            }
+
+            widths[biggest_column] -= 1;
+            diff -= 1;
+
+            if diff == 0 {
+                break 'out;
+            }
+        }
+    }
+
+    for (i, width) in widths.iter().cloned().enumerate() {
+        let width = width - trim.pad;
+
         match &trim.strategy {
             TrimStrategy::Wrap { try_to_keep_words } => {
-                let wrap = Width::wrap(use_width).keep_words(*try_to_keep_words);
+                let wrap = Width::wrap(width).keep_words(*try_to_keep_words);
 
                 let opt = Modify::new(Columns::single(i)).with(wrap);
                 TableOption::<VecRecords<Text<String>>, _, _>::change(opt, recs, cfg, dims);
             }
             TrimStrategy::Truncate { suffix } => {
-                let mut truncate = Width::truncate(use_width);
+                let mut truncate = Width::truncate(width);
                 if let Some(suffix) = suffix {
                     truncate = truncate.suffix(suffix).suffix_try_color(true);
                 }
@@ -499,6 +528,8 @@ fn trim_as_header(
             }
         }
     }
+
+    TableOption::change(SetDimensions(widths), recs, cfg, dims);
 }
 
 fn align_table(
@@ -979,6 +1010,8 @@ impl TableOption<NuRecords, ColoredConfig, CompleteDimensionVecRecords<'_>>
     }
 }
 
+// It's laverages a use of guuaranted cached widths before hand
+// to speed up things a bit.
 struct SetLineHeaders {
     line: usize,
     columns: Vec<String>,
@@ -1011,8 +1044,6 @@ impl TableOption<NuRecords, ColoredConfig, CompleteDimensionVecRecords<'_>> for 
     ) {
         let mut columns = self.columns;
 
-        println!("----> {:?}", dims.get_widths());
-
         match dims.get_widths() {
             Some(widths) => {
                 columns = columns
@@ -1026,6 +1057,8 @@ impl TableOption<NuRecords, ColoredConfig, CompleteDimensionVecRecords<'_>> for 
                 // which means we are OK to leave columns as they are.
                 //
                 // but we actually always have to have widths at this point
+
+                unreachable!("must never be the case");
             }
         };
 
@@ -1038,6 +1071,10 @@ impl TableOption<NuRecords, ColoredConfig, CompleteDimensionVecRecords<'_>> for 
             self.alignment,
             self.color,
         )
+    }
+
+    fn hint_change(&self) -> Option<Entity> {
+        None
     }
 }
 

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -484,7 +484,7 @@ fn trim_as_header(
     }
 
     // make sure we are fit in;
-    // which is might not be the case where we need to truncate columns furter then a column head width
+    // which is might not be the case where we need to truncate columns further then a column head width
     let expected_width = get_total_width2(&widths, cfg);
     if expected_width > trim.width_max {
         let mut diff = expected_width - trim.width_max;


### PR DESCRIPTION
Hi there;

I do think it must be fixed.

I also did improve performance for a fraction in case of header on border.
I want to believe :) I didn't bench it.
But we didn't cached the width in this code branch before.
Which was causing all data reestimation.

close #13966
cc: @fdncred 