### PR TITLE
Try harder to surface variable alternatives with non-names

### DIFF
--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -3,6 +3,7 @@ use std::{
     str::{from_utf8, Utf8Error},
 };
 
+use crate::engine::StateWorkingSet;
 use crate::{ast::RedirectionSource, did_you_mean, Span, Type};
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
@@ -622,6 +623,13 @@ fn did_you_mean_impl(possibilities_bytes: &[&[u8]], input_bytes: &[u8]) -> Optio
 impl DidYouMean {
     pub fn new(possibilities_bytes: &[&[u8]], input_bytes: &[u8]) -> DidYouMean {
         DidYouMean(did_you_mean_impl(possibilities_bytes, input_bytes))
+    }
+
+    pub fn look_for_suggestion(working_set: &StateWorkingSet, input_bytes: &[u8]) -> DidYouMean {
+        DidYouMean::new(&working_set.list_variables(), input_bytes)
+    }
+    pub fn has_suggestion(&self) -> bool {
+        self.0.is_some()
     }
 }
 


### PR DESCRIPTION
Fixes #10815 

When someone accidentally does `$foo-bar` instead of `$foo_bar`, there are two parse errors:

- "this is not a variable name" (beacuse of the hyphen)
- "did you mean $foo_bar" (through our suggestion system)

Unfortunately, many places in the system only will display the first parse error. So this change will place the suggestion first in this case (if there is a suggestion in the first place).

---

What this looks like in practice:
```
[1] % cargo run -- script.nu
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.19s
     Running `target/debug/nu script.nu`
Error: nu::parser::variable_not_found

  × Variable not found.
   ╭─[/Users/rtpg/proj/nushell/script.nu:2:3]
 1 │ def foo [--hi-there] {
 2 │   $hi-there
   ·   ────┬────
   ·       ╰── variable not found. Did you mean '$hi_there'?
 3 │ }
   ╰────
```

There's  work to be done to make sure that places that look at `parse_errors` (grep for `parse_errors.first()`) try harder to report multiple errors, if possible, instead of just the first/last/whatever.

The underlying issue in this case was in `crates/nu-cli/src/eval_file.rs`:

```
    // If any parse errors were found, report the first error and exit.
    if let Some(err) = working_set.parse_errors.first() {
        report_parse_error(&working_set, err);
        std::process::exit(1);
    }
```

^ there's probably an easy win there of reporting the first N errors and then failing out. But based off of what I've seen just on parsing variables, I don't know how well the parser as a whole would handle that, so am uncomfortable sending in that change.
