### PR TITLE
Set proc/env cwd to engine_state value

### DIFF
--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -320,6 +320,10 @@ impl EngineState {
             }
         }
 
+        let cwd = self.cwd(Some(stack))?;
+        // TODO: better error
+        std::env::set_current_dir(cwd)?;
+
         if let Some(config) = stack.config.take() {
             // If config was updated in the stack, replace it.
             self.config = config;


### PR DESCRIPTION
# Description

Fixes #14000 by once again calling `set_current_dir()`, but doing so with the `cwd` from the current state, rather than the (previously removed) argument to `merge_env()`.

# User-Facing Changes

Bug fix

# Tests + Formatting

If this looks good, I'll look at adding a test case for it.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A