### PR TITLE
Remove superfluous separator when there's no flag description/comment

### DIFF
--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -572,7 +572,9 @@ where
                 document_shape(arg)
             );
         }
-        let _ = write!(long_desc, " - {}", flag.desc);
+        if !flag.desc.is_empty() {
+            let _ = write!(long_desc, ": {}", flag.desc);
+        }
         if let Some(value) = &flag.default_value {
             let _ = write!(long_desc, " (default: {})", &value_formatter(value));
         }

--- a/tests/repl/test_help.rs
+++ b/tests/repl/test_help.rs
@@ -6,11 +6,11 @@ use rstest::rstest;
 #[case(": arga help")]
 #[case("argb help")]
 #[case("optional, default: 20")]
-#[case("- f1 switch")]
-#[case("- f2 named no default")]
-#[case("- f3 named default 3")]
+#[case(": f1 switch")]
+#[case(": f2 named no default")]
+#[case(": f3 named default 3")]
 #[case("default: 33")]
-#[case("--help - Display the help message")]
+#[case("--help: Display the help message")]
 fn can_get_help(#[case] exp_result: &str) -> TestResult {
     run_test(
         &format!(


### PR DESCRIPTION
# Description

Fixes a small side-issue in #10977 - If a command flag didn't have a comment/description, it would still show an unnecessary separator at the end of the line.

This fixes that, plus uses the `: ` (colon) to separate the flag from the description.  This aligns with the way that named parameters are handled.

# User-Facing Changes

Help/doc only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A