### PR TITLE
update osc_633 string escaping

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -131,16 +131,13 @@ pub fn evaluate_repl(
         // escape a few things because this says so
         // https://code.visualstudio.com/docs/terminal/shell-integration#_vs-code-custom-sequences-osc-633-st
         let cmd_text = line_editor.current_buffer_contents().to_string();
+        let len = cmd_text.len();
+        let mut cmd_text_chars = cmd_text[0..len].chars();
+        let mut replaced_cmd_text = String::with_capacity(len);
 
-        let replaced_cmd_text = cmd_text
-            .chars()
-            .map(|c| match c {
-                '\n' => '\x0a',
-                '\r' => '\x0d',
-                '\x1b' => '\x1b',
-                _ => c,
-            })
-            .collect();
+        while let Some(c) = unescape_for_vscode(&mut cmd_text_chars) {
+            replaced_cmd_text.push(c);
+        }
 
         run_shell_integration_osc633(
             engine_state,
@@ -222,6 +219,28 @@ pub fn evaluate_repl(
     }
 
     Ok(())
+}
+
+fn unescape_for_vscode(text: &mut std::str::Chars) -> Option<char> {
+    match text.next() {
+        Some('\\') => match text.next() {
+            Some('0') => Some('\x00'),  // NUL '\0' (null character)
+            Some('a') => Some('\x07'),  // BEL '\a' (bell)
+            Some('b') => Some('\x08'),  // BS  '\b' (backspace)
+            Some('t') => Some('\x09'),  // HT  '\t' (horizontal tab)
+            Some('n') => Some('\x0a'),  // LF  '\n' (new line)
+            Some('v') => Some('\x0b'),  // VT  '\v' (vertical tab)
+            Some('f') => Some('\x0c'),  // FF  '\f' (form feed)
+            Some('r') => Some('\x0d'),  // CR  '\r' (carriage ret)
+            Some(';') => Some('\x3b'),  // semi-colon
+            Some('\\') => Some('\x5c'), // backslash
+            Some('e') => Some('\x1b'),  // escape
+            Some(c) => Some(c),
+            None => None,
+        },
+        Some(c) => Some(c),
+        None => None,
+    }
 }
 
 fn get_line_editor(


### PR DESCRIPTION
# Description

VSCode OSC 633 needs particular string escaping to function properly. I missed some escapes during my initial implementation. This PR should cover the escapes I missed originally.
 
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
