### PR TITLE
Fix namespace collision in std and nupm

### DIFF
--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -4,21 +4,21 @@
 export use lib *
 
 # std submodules
-export module assert
-export module bench
-export module dt
-export module formats
-export module help
-export module input
-export module iter
-export module log
-export module math
-export module xml
+export module ./assert
+export module ./bench
+export module ./dt
+export module ./formats
+export module ./help
+export module ./input
+export module ./iter
+export module ./log
+export module ./math
+export module ./xml
 
 # Load main dirs command and all subcommands
-export use dirs main
-export module dirs {
-  export use dirs [
+export use ./dirs main
+export module ./dirs {
+  export use ./dirs [
     add
     drop
     next


### PR DESCRIPTION
# Description

Fxes https://github.com/nushell/nupm/issues/102

Not loading `std` at startup has caused an issue with nupm and std where the `dirs` module name clashes and nupm won't load.  This was technically a preexisting bug that was previously masked. This could have been fixed (and also should be) by changing the import statement in nupm, but the potential for collision would remain in other (user) modules.

This PR explicitly sets the relative path for the import statements in `std/mod.nu` so that there are no collisions.

# User-Facing Changes

Bugfix

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A