### PR TITLE
Load env when importing with `use std *`

### DIFF
--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -26,3 +26,14 @@ export module ./dirs {
     goto
   ]
 }
+
+# Workaround for #13403 to load export-env blocks from submodules
+export-env {
+    # log
+    $env.NU_LOG_FORMAT = $env.NU_LOG_FORMAT? | default "%ANSI_START%%DATE%|%LEVEL%|%MSG%%ANSI_STOP%"
+    $env.NU_LOG_DATE_FORMAT = $env.NU_LOG_DATE_FORMAT? | default "%Y-%m-%dT%H:%M:%S%.3f"
+    
+    # dirs
+    $env.DIRS_POSITION = 0
+    $env.DIRS_LIST = [($env.PWD | path expand)]
+}


### PR DESCRIPTION
# Description

After a `use std *`, the environment variables exported from the submodules' `export-env` blocks are not available because of #13403.  This causes failures in `log` (currently) and will cause issues in `dirs` once we stop autoloading it separately.

When the submodules are loaded separately (e.g., `use std/log`), everything already worked correctly.  While this is the preferred way of doing it, we also want `use std *` to work properly.

This is a workaround for the standard library submodules.  It is definitely not ideal, but it can be removed when and if #13403 is fixed.

For now, we need to duplicate any environment settings in both the submodules (when loaded with `use std/log`) and in the standard library itself (when loaded with `use std *`).  Again, this should not be necessary, but currently is because of #13403.

# User-Facing Changes

Bug fix

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A