### PR TITLE
Change stack variable from vector to hashmap

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/collect.rs
+++ b/crates/nu-cmd-lang/src/core_commands/collect.rs
@@ -84,14 +84,14 @@ is particularly large, this can cause high memory usage."#
                 redirect_env(engine_state, stack, &stack_captures);
                 // for when we support `data | let x = $in;`
                 // remove the variables added earlier
-                for (var_id, _) in closure.captures {
+                for (var_id, _) in closure.captures.into_iter() {
                     stack_captures.remove_var(var_id);
                 }
                 if let Some(u) = saved_positional {
                     stack_captures.remove_var(u);
                 }
                 // add any new variables to the stack
-                stack.vars.extend(stack_captures.vars);
+                stack.vars.extend(*stack_captures.vars);
             }
         } else {
             result = Ok(input.into_pipeline_data_with_metadata(metadata));

--- a/crates/nu-command/src/charting/hashable_value.rs
+++ b/crates/nu-command/src/charting/hashable_value.rs
@@ -185,7 +185,7 @@ mod test {
         engine::Closure,
         BlockId,
     };
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn from_value() {
@@ -246,7 +246,7 @@ mod test {
             Value::closure(
                 Closure {
                     block_id: BlockId::new(0),
-                    captures: Vec::new(),
+                    captures: Box::new(HashMap::new()),
                 },
                 span,
             ),

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -920,7 +920,13 @@ impl Eval for EvalRuntime {
             })
             .collect::<Result<_, _>>()?;
 
-        Ok(Value::closure(Closure { block_id, captures }, span))
+        Ok(Value::closure(
+            Closure {
+                block_id,
+                captures: Box::new(captures),
+            },
+            span,
+        ))
     }
 
     fn eval_overlay(engine_state: &EngineState, span: Span) -> Result<Value, ShellError> {

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -827,11 +827,11 @@ fn literal_value(
                 .captures
                 .iter()
                 .map(|var_id| get_var(ctx, *var_id, span).map(|val| (*var_id, val)))
-                .collect::<Result<Vec<_>, ShellError>>()?;
+                .collect::<Result<_, ShellError>>()?;
             Value::closure(
                 Closure {
                     block_id: *block_id,
-                    captures,
+                    captures: Box::new(captures),
                 },
                 span,
             )

--- a/crates/nu-plugin-core/src/util/with_custom_values_in.rs
+++ b/crates/nu-plugin-core/src/util/with_custom_values_in.rs
@@ -39,12 +39,12 @@ fn find_custom_values() {
             Value::test_int(4),
         ]),
         "closure" => Value::test_closure({
-            let mut capture = Box::new(HashMap::new());
-            capture.insert(VarId::new(0), cv.clone());
-            capture.insert(VarId::new(1), Value::test_string("foo"));
+            let mut captures = Box::new(HashMap::new());
+            captures.insert(VarId::new(0), cv.clone());
+            captures.insert(VarId::new(1), Value::test_string("foo"));
             Closure {
                 block_id: BlockId::new(0),
-                captures: capture
+                captures
             }
     }),
     });

--- a/crates/nu-plugin-core/src/util/with_custom_values_in.rs
+++ b/crates/nu-plugin-core/src/util/with_custom_values_in.rs
@@ -28,6 +28,7 @@ where
 fn find_custom_values() {
     use nu_plugin_protocol::test_util::test_plugin_custom_value;
     use nu_protocol::{engine::Closure, record};
+    use std::collections::HashMap;
 
     let mut cv = Value::test_custom_value(Box::new(test_plugin_custom_value()));
 
@@ -37,12 +38,15 @@ fn find_custom_values() {
             cv.clone(),
             Value::test_int(4),
         ]),
-        "closure" => Value::test_closure(
+        "closure" => Value::test_closure({
+            let mut capture = Box::new(HashMap::new());
+            capture.insert(VarId::new(0), cv.clone());
+            capture.insert(VarId::new(1), Value::test_string("foo"));
             Closure {
                 block_id: BlockId::new(0),
-                captures: vec![(VarId::new(0), cv.clone()), (VarId::new(1), Value::test_string("foo"))]
+                captures: capture
             }
-        ),
+    }),
     });
 
     // Do with_custom_values_in, and count the number of custom values found

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -23,6 +23,7 @@ use nu_protocol::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashMap,
     sync::{mpsc, Arc},
     time::Duration,
 };
@@ -432,7 +433,7 @@ fn manager_consume_engine_call_forwards_to_subscriber_with_pipeline_data() -> Re
             closure: Spanned {
                 item: Closure {
                     block_id: BlockId::new(0),
-                    captures: vec![],
+                    captures: Box::new(HashMap::new()),
                 },
                 span: Span::test_data(),
             },

--- a/crates/nu-plugin-engine/src/plugin_custom_value_with_source/tests.rs
+++ b/crates/nu-plugin-engine/src/plugin_custom_value_with_source/tests.rs
@@ -137,7 +137,7 @@ fn add_source_in_nested_closure() -> Result<(), ShellError> {
     captures.insert(VarId::new(1), orig_custom_val.clone());
     let mut val = Value::test_closure(Closure {
         block_id: BlockId::new(0),
-        captures: captures,
+        captures,
     });
     let source = Arc::new(PluginSource::new_fake("foo"));
     PluginCustomValueWithSource::add_source_in(&mut val, &source)?;

--- a/crates/nu-plugin-protocol/src/plugin_custom_value/tests.rs
+++ b/crates/nu-plugin-protocol/src/plugin_custom_value/tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash::Hash};
+use std::collections::HashMap;
 
 use crate::test_util::{expected_test_custom_value, test_plugin_custom_value, TestCustomValue};
 

--- a/crates/nu-plugin-protocol/src/plugin_custom_value/tests.rs
+++ b/crates/nu-plugin-protocol/src/plugin_custom_value/tests.rs
@@ -163,7 +163,7 @@ fn serialize_in_closure() -> Result<(), ShellError> {
     captures.insert(VarId::new(1), orig_custom_val.clone());
     let mut val = Value::test_closure(Closure {
         block_id: BlockId::new(0),
-        captures: captures,
+        captures,
     });
     PluginCustomValue::serialize_custom_values_in(&mut val)?;
 
@@ -253,7 +253,7 @@ fn deserialize_in_closure() -> Result<(), ShellError> {
     captures.insert(VarId::new(1), orig_custom_val.clone());
     let mut val = Value::test_closure(Closure {
         block_id: BlockId::new(0),
-        captures: captures,
+        captures,
     });
     PluginCustomValue::deserialize_custom_values_in(&mut val)?;
 

--- a/crates/nu-plugin/src/plugin/interface/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/tests.rs
@@ -1036,14 +1036,14 @@ fn interface_eval_closure_with_stream() -> Result<(), ShellError> {
         EngineCallResponse::PipelineData(PipelineData::Value(Value::test_int(2), None))
     });
 
-    let mut capture = Box::new(HashMap::new());
-    capture.insert(VarId::new(0), Value::test_int(5));
+    let mut captures = Box::new(HashMap::new());
+    captures.insert(VarId::new(0), Value::test_int(5));
     let result = interface
         .eval_closure_with_stream(
             &Spanned {
                 item: Closure {
                     block_id: BlockId::new(42),
-                    captures: capture,
+                    captures,
                 },
                 span: Span::test_data(),
             },

--- a/crates/nu-plugin/src/plugin/interface/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/tests.rs
@@ -9,13 +9,11 @@ use nu_plugin_protocol::{
     PluginCustomValue, PluginInput, PluginOutput, Protocol, ProtocolInfo, StreamData,
 };
 use nu_protocol::{
-    engine::Closure, BlockId, ByteStreamType, Config, CustomValue, Id,
-    IntoInterruptiblePipelineData, LabeledError, PipelineData, PluginSignature, ShellError,
-    Signals, Span, Spanned, Value, VarId,
+    engine::Closure, BlockId, ByteStreamType, Config, CustomValue, IntoInterruptiblePipelineData,
+    LabeledError, PipelineData, PluginSignature, ShellError, Signals, Span, Spanned, Value, VarId,
 };
 use std::{
     collections::HashMap,
-    hash::Hash,
     sync::{
         mpsc::{self, TryRecvError},
         Arc,

--- a/crates/nu-protocol/src/engine/capture_block.rs
+++ b/crates/nu-protocol/src/engine/capture_block.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{BlockId, Value, VarId};
 
 use serde::{Deserialize, Serialize};
@@ -5,5 +7,5 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Closure {
     pub block_id: BlockId,
-    pub captures: Vec<(VarId, Value)>,
+    pub captures: Box<HashMap<VarId, Value>>,
 }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -37,6 +37,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
     cmp::Ordering,
+    collections::HashMap,
     fmt::{Debug, Display, Write},
     ops::Bound,
     path::PathBuf,
@@ -2030,7 +2031,7 @@ impl Value {
             Value::test_list(Vec::new()),
             Value::test_closure(Closure {
                 block_id: BlockId::new(0),
-                captures: Vec::new(),
+                captures: Box::new(HashMap::new()),
             }),
             Value::test_nothing(),
             Value::error(

--- a/crates/nuon/src/lib.rs
+++ b/crates/nuon/src/lib.rs
@@ -8,6 +8,8 @@ pub use to::ToStyle;
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use chrono::DateTime;
     use nu_protocol::{
         ast::{CellPath, PathMember, RangeInclusion},
@@ -176,7 +178,7 @@ mod tests {
         assert!(to_nuon(
             &Value::test_closure(Closure {
                 block_id: BlockId::new(0),
-                captures: vec![]
+                captures: Box::new(HashMap::new())
             }),
             ToStyle::Raw,
             None,


### PR DESCRIPTION
# Description
This PR updates the variable stack in the Nu engine to use a HashMap. Previously, searching, adding, or removing a variable required looping through the entire vector, which was inefficient. By switching to a HashMap, we improve time complexity. The following tables show the benchmark between the old and new versions using [Hyperfine](https://github.com/sharkdp/hyperfine) on the release mode.
| Script |  Old | New |
| -------- | -------- | -------- |
| [fibonaci-recursive](https://github.com/nushell/nu_scripts/blob/main/benchmarks/fibonacci-recursive.nu) | 3.431 s ±  0.150 s     | 3.313 s ±  0.129 s |
| [fibonaci](https://github.com/nushell/nu_scripts/blob/main/benchmarks/fibonacci.nu)               |854.7 ms ±  37.7 ms     |  818.5 ms ±   7.6 ms |
| [gradient_benchmark_no_check](https://github.com/nushell/nu_scripts/blob/main/benchmarks/gradient_benchmark_no_check.nu) |251.6 ms ±   3.2 ms s | 237.8 ms ±   3.1 ms |
| [turtle](https://github.com/nushell/nu_scripts/blob/main/benchmarks/turtle.nu)                  |25.0 ms ±   0.8 ms     | 24.7 ms ±   0.8 ms |

I believe we can further optimize by switching from the standard HashMap to [FxHashMap](https://github.com/cbreeden/fxhash). If this PR looks good, I can create a follow-up PR.


