### PR TITLE
Add ls colors to cjs and mjs files

### DIFF
--- a/crates/nu-command/src/viewers/icons.rs
+++ b/crates/nu-command/src/viewers/icons.rs
@@ -201,6 +201,7 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "cc" => '\u{e61d}',             // 
             "cert" => '\u{eafa}',           // 
             "cfg" => '\u{e615}',            // 
+            "cjs" => '\u{e74e}',            // 
             "class" => '\u{e256}',          // 
             "clj" => '\u{e768}',            // 
             "cljs" => '\u{e76a}',           // 

--- a/crates/nu-utils/src/utils.rs
+++ b/crates/nu-utils/src/utils.rs
@@ -155,6 +155,8 @@ pub fn get_ls_colors(lscolors_env_string: Option<String>) -> LsColors {
                 "*.rb=0;38;5;48",
                 "*.md=0;38;5;185",
                 "*.js=0;38;5;48",
+                "*.cjs=0;38;5;48",
+                "*.mjs=0;38;5;48",
                 "*.go=0;38;5;48",
                 "*.vb=0;38;5;48",
                 "*.hi=0;38;5;243",


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Add ls color highlighting for *.cjs and *.mjs files in line with regular *.js files
Add an icon to *.cjs files in line with *.js and *.mjs files