### PR TITLE
update to reedline 5e556bfd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5147,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.35.0"
-source = "git+https://github.com/nushell/reedline?branch=main#871075e62b5703cfc584e4e02b14c2473f5b0b63"
+source = "git+https://github.com/nushell/reedline?branch=main#5e556bfd2855420e782e1753da13a4fcb798f2c7"
 dependencies = [
  "arboard",
  "chrono",


### PR DESCRIPTION
# Description

This PR updates nushell to the latest commit 5e556bfd.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
