### PR TITLE
Fix panic if tokens are placed after a redirection

### DIFF
--- a/crates/nu-parser/src/lite_parser.rs
+++ b/crates/nu-parser/src/lite_parser.rs
@@ -136,11 +136,15 @@ impl LiteCommand {
     }
 
     pub fn parts_including_redirection(&self) -> impl Iterator<Item = Span> + '_ {
-        self.parts.iter().copied().chain(
-            self.redirection
-                .iter()
-                .flat_map(|redirection| redirection.spans()),
-        )
+        self.parts
+            .iter()
+            .copied()
+            .chain(
+                self.redirection
+                    .iter()
+                    .flat_map(|redirection| redirection.spans()),
+            )
+            .sorted_unstable_by_key(|a| (a.start, a.end))
     }
 }
 

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1229,6 +1229,18 @@ fn test_nothing_comparison_eq() {
 }
 
 #[rstest]
+#[case(b"let a o> file = 1")]
+#[case(b"mut a o> file = 1")]
+fn test_redirection_inside_letmut_no_panic(#[case] phase: &[u8]) {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+    working_set.add_decl(Box::new(Let));
+    working_set.add_decl(Box::new(Mut));
+
+    parse(&mut working_set, None, phase, true);
+}
+
+#[rstest]
 #[case(b"let a = 1 err> /dev/null")]
 #[case(b"let a = 1 out> /dev/null")]
 #[case(b"let a = 1 out+err> /dev/null")]


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
fixes #13835

The `concat` function from `span.rs` assumes that two consecutive span intervals must overlap. But when parsing `let` and `mut` expressions, we call `parts_including_redirection` which chains two slices of span and leads to the above condition not holding. So my solution here is to sort them after chaining.


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
