### PR TITLE
[str replace] add exemple for escaped regexes

### DIFF
--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -156,12 +156,17 @@ impl Command for SubCommand {
                 result: Some(Value::test_string("my_library.nu")),
             },
             Example {
-                description: "Find and replace all occurrences of find string using regular expression",
+                description: "Find and replace contents with capture group using regular expression, with escapes",
+                example: "'hello=world' | str replace -r '\\$?(?<varname>.*)=(?<value>.*)' '$$$varname = $value'",
+                result: Some(Value::test_string("$hello = world")),
+            },
+            Example {
+                description: "Find and replace all occurrences of found string using regular expression",
                 example: "'abc abc abc' | str replace --all --regex 'b' 'z'",
                 result: Some(Value::test_string("azc azc azc")),
             },
             Example {
-                description: "Find and replace all occurrences of find string in table using regular expression",
+                description: "Find and replace all occurrences of found string in table using regular expression",
                 example:
                     "[[ColA ColB ColC]; [abc abc ads]] | str replace --all --regex 'b' 'z' ColA ColC",
                 result: Some(Value::test_list (
@@ -173,7 +178,7 @@ impl Command for SubCommand {
                 )),
             },
             Example {
-                description: "Find and replace all occurrences of find string in record using regular expression",
+                description: "Find and replace all occurrences of found string in record using regular expression",
                 example:
                     "{ KeyA: abc, KeyB: abc, KeyC: ads } | str replace --all --regex 'b' 'z' KeyA KeyC",
                 result: Some(Value::test_record(record! {


### PR DESCRIPTION
 # Description

This is a follow-up of https://github.com/nushell/nushell.github.io/pull/1584

The goal is to provide the user understanding of how to escape strings

# User-Facing Changes
Nothing except documentation

# Tests + Formatting
 
 I don't know why but these two tests are failing on my system:

- `test_std_util path_add`
- `commands::umkdir::mkdir_umask_permission`

Since I hardly believe it is linked to my changes, I will let your CI check it. Meanwhile, I will check my system, highly likely that it is something something related to me recently switching shells, hacking my way through prompts environments, etc.


# After Submitting

Will check how to re-generate the [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged


