### PR TITLE
Show `?` for optional entries when displaying `CellPath`s

### DIFF
--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -166,7 +166,7 @@ fn select_ignores_errors_successfully1() {
 fn select_ignores_errors_successfully2() {
     let actual = nu!("[{a: 1} {a: 2} {a: 3}] | select b? | to nuon");
 
-    assert_eq!(actual.out, "[[b]; [null], [null], [null]]".to_string());
+    assert_eq!(actual.out, "[[b?]; [null], [null], [null]]".to_string());
     assert!(actual.err.is_empty());
 }
 
@@ -174,7 +174,7 @@ fn select_ignores_errors_successfully2() {
 fn select_ignores_errors_successfully3() {
     let actual = nu!("{foo: bar} | select invalid_key? | to nuon");
 
-    assert_eq!(actual.out, "{invalid_key: null}".to_string());
+    assert_eq!(actual.out, "{invalid_key?: null}".to_string());
     assert!(actual.err.is_empty());
 }
 
@@ -184,7 +184,10 @@ fn select_ignores_errors_successfully4() {
         r#""key val\na 1\nb 2\n" | lines | split column --collapse-empty " " | select foo? | to nuon"#
     );
 
-    assert_eq!(actual.out, r#"[[foo]; [null], [null], [null]]"#.to_string());
+    assert_eq!(
+        actual.out,
+        r#"[[foo?]; [null], [null], [null]]"#.to_string()
+    );
     assert!(actual.err.is_empty());
 }
 
@@ -234,7 +237,7 @@ fn ignore_errors_works() {
         [{}] | select -i $path | to nuon
         "#);
 
-    assert_eq!(actual.out, "[[foo]; [null]]");
+    assert_eq!(actual.out, "[[foo?]; [null]]");
 }
 
 #[test]

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -182,8 +182,14 @@ impl Display for CellPath {
                 write!(f, ".")?;
             }
             match elem {
-                PathMember::Int { val, .. } => write!(f, "{val}")?,
-                PathMember::String { val, .. } => write!(f, "{val}")?,
+                PathMember::Int { val, optional, .. } => {
+                    let question_mark = if *optional { "?" } else { "" };
+                    write!(f, "{val}{question_mark}")?
+                }
+                PathMember::String { val, optional, .. } => {
+                    let question_mark = if *optional { "?" } else { "" };
+                    write!(f, "{val}{question_mark}")?
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR makes the `Display` implementation for `CellPath` show a `?` suffix on every optional entry, which makes the output consistent with the language syntax.

Before this PR, the printing of cell paths was confusing, e.g. `$.x` and `$.x?` were both printed as `x`. Now, the second one is printed as `x?`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

The formatting of cell paths now matches the syntax used to create them, reducing confusion.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

All tests pass, including `stdlib` tests.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
