### PR TITLE
[umkdir][tests] get umask instead of assuming it

### DIFF
--- a/crates/nu-command/tests/commands/umkdir.rs
+++ b/crates/nu-command/tests/commands/umkdir.rs
@@ -12,12 +12,6 @@ fn get_umask() -> u32 {
     mode::get_umask()
 }
 
-#[cfg(test)]
-#[cfg(windows)]
-fn get_umask() -> u32 {
-    0
-}
-
 #[test]
 fn creates_directory() {
     Playground::setup("mkdir_test_1", |dirs, _| {

--- a/crates/nu-command/tests/commands/umkdir.rs
+++ b/crates/nu-command/tests/commands/umkdir.rs
@@ -1,14 +1,18 @@
 use nu_test_support::fs::files_exist_at;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
+
+#[cfg(test)]
 #[cfg(not(windows))]
 use uucore::mode;
 
+#[cfg(test)]
 #[cfg(not(windows))]
 fn get_umask() -> u32 {
     mode::get_umask()
 }
 
+#[cfg(test)]
 #[cfg(windows)]
 fn get_umask() -> u32 {
     0

--- a/crates/nu-command/tests/commands/umkdir.rs
+++ b/crates/nu-command/tests/commands/umkdir.rs
@@ -2,15 +2,8 @@ use nu_test_support::fs::files_exist_at;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
-#[cfg(test)]
 #[cfg(not(windows))]
 use uucore::mode;
-
-#[cfg(test)]
-#[cfg(not(windows))]
-fn get_umask() -> u32 {
-    mode::get_umask()
-}
 
 #[test]
 fn creates_directory() {
@@ -155,7 +148,7 @@ fn mkdir_umask_permission() {
             .permissions()
             .mode();
 
-        let umask = get_umask();
+        let umask = mode::get_umask();
         let default_mode = 0o40777;
         let expected: u32 = default_mode & !umask;
 

--- a/crates/nu-command/tests/commands/umkdir.rs
+++ b/crates/nu-command/tests/commands/umkdir.rs
@@ -1,7 +1,18 @@
 use nu_test_support::fs::files_exist_at;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
+#[cfg(not(windows))]
 use uucore::mode;
+
+#[cfg(not(windows))]
+fn get_umask() -> u32 {
+    mode::get_umask()
+}
+
+#[cfg(windows)]
+fn get_umask() -> u32 {
+    0
+}
 
 #[test]
 fn creates_directory() {
@@ -146,7 +157,7 @@ fn mkdir_umask_permission() {
             .permissions()
             .mode();
 
-        let umask = mode::get_umask();
+        let umask = get_umask();
         let default_mode = 0o40777;
         let expected: u32 = default_mode & !umask;
 

--- a/crates/nu-command/tests/commands/umkdir.rs
+++ b/crates/nu-command/tests/commands/umkdir.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::files_exist_at;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
+use uucore::mode;
 
 #[test]
 fn creates_directory() {
@@ -145,10 +146,13 @@ fn mkdir_umask_permission() {
             .permissions()
             .mode();
 
+        let umask = mode::get_umask();
+        let default_mode = 0o40777;
+        let expected: u32 = default_mode & !umask;
+
         assert_eq!(
-            actual, 0o40755,
-            "Most *nix systems have 0o00022 as the umask. \
-            So directory permission should be 0o40755 = 0o40777 & (!0o00022)"
+            actual, expected,
+            "Umask should have been applied to created folder"
         );
     })
 }


### PR DESCRIPTION
# Description

Contributors to this projects will have a test failure if their `umask` is not set to `0022`.

Apparently on Debian (at least on my install), it is set to `0002` which makes my test fail. While `0022` is safer than the value I have, I want to reduce the amount if issue new contributors could have.

I am making this test not assuming anything and instead, reading the user umask.

# Related discussion

 I see that the `umask` command implementation has been discussed in #12256 . We could use this and enforce a umask for tests who rely on this. I believe however (let me know what you think) that hard coded values are harder to read in the test.



# User-Facing Changes
N/A

# Tests + Formatting
All green on my side after this MR :+1: 


# After Submitting
Documentation is not impacted
