### PR TITLE
`use` command: Don't create a variable with empty record if it doesn't define any constants

### DIFF
--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -274,8 +274,6 @@ impl Command for UCp {
 
         if let Err(error) = uu_cp::copy(&sources, &target_path, &options) {
             match error {
-                // code should still be EXIT_ERR as does GNU cp
-                uu_cp::Error::NotAllFilesCopied => {}
                 _ => {
                     return Err(ShellError::GenericError {
                         error: format!("{}", error),

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -274,6 +274,8 @@ impl Command for UCp {
 
         if let Err(error) = uu_cp::copy(&sources, &target_path, &options) {
             match error {
+                // code should still be EXIT_ERR as does GNU cp
+                uu_cp::Error::NotAllFilesCopied => {}
                 _ => {
                     return Err(ShellError::GenericError {
                         error: format!("{}", error),

--- a/crates/nu-protocol/src/module.rs
+++ b/crates/nu-protocol/src/module.rs
@@ -161,20 +161,25 @@ impl Module {
             }
 
             let span = self.span.unwrap_or(backup_span);
-            let const_record = Value::record(
-                const_rows
-                    .into_iter()
-                    .map(|(name, val)| (String::from_utf8_lossy(&name).to_string(), val))
-                    .collect(),
-                span,
-            );
+
+            // only needs to bring `$module` with a record value if it defines any constants.
+            let constants = if const_rows.is_empty() {
+                vec![]
+            } else {
+                vec![(
+                    final_name.clone(),
+                    Value::record(
+                        const_rows
+                            .into_iter()
+                            .map(|(name, val)| (String::from_utf8_lossy(&name).to_string(), val))
+                            .collect(),
+                        span,
+                    ),
+                )]
+            };
 
             return (
-                ResolvedImportPattern::new(
-                    decls,
-                    vec![(final_name.clone(), self_id)],
-                    vec![(final_name, const_record)],
-                ),
+                ResolvedImportPattern::new(decls, vec![(final_name.clone(), self_id)], constants),
                 errors,
             );
         };

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -244,6 +244,27 @@ fn complex_const_export() {
 }
 
 #[test]
+fn only_nested_module_have_const() {
+    let setup = r#"
+        module spam {
+            export module eggs {
+                export module bacon {
+                    export const viking = 'eats'
+                    export module none {}
+                }
+            }
+        }
+    "#;
+    let inp = &[setup, "use spam", "$spam.eggs.bacon.viking"];
+    let actual = nu!(&inp.join("; "));
+    assert_eq!(actual.out, "eats");
+
+    let inp = &[setup, "use spam", "'none' in $spam.eggs.bacon"];
+    let actual = nu!(&inp.join("; "));
+    assert_eq!(actual.out, "false");
+}
+
+#[test]
 fn complex_const_glob_export() {
     let inp = &[MODULE_SETUP, "use spam *", "$X"];
     let actual = nu!(&inp.join("; "));

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -238,13 +238,9 @@ fn complex_const_export() {
     let actual = nu!(&inp.join("; "));
     assert_eq!(actual.out, "eats");
 
-    let inp = &[
-        MODULE_SETUP,
-        "use spam",
-        "($spam.eggs.bacon.none | is-empty)",
-    ];
+    let inp = &[MODULE_SETUP, "use spam", "'none' in $spam.eggs.bacon"];
     let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "true");
+    assert_eq!(actual.out, "false");
 }
 
 #[test]
@@ -261,20 +257,16 @@ fn complex_const_glob_export() {
     let actual = nu!(&inp.join("; "));
     assert_eq!(actual.out, "eats");
 
-    let inp = &[MODULE_SETUP, "use spam *", "($eggs.bacon.none | is-empty)"];
+    let inp = &[MODULE_SETUP, "use spam *", "'none' in $eggs.bacon"];
     let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "true");
+    assert_eq!(actual.out, "false");
 }
 
 #[test]
 fn complex_const_drill_export() {
-    let inp = &[
-        MODULE_SETUP,
-        "use spam eggs bacon none",
-        "($none | is-empty)",
-    ];
+    let inp = &[MODULE_SETUP, "use spam eggs bacon none", "$none"];
     let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "true");
+    assert!(actual.err.contains("variable not found"));
 }
 
 #[test]

--- a/tests/repl/test_modules.rs
+++ b/tests/repl/test_modules.rs
@@ -121,6 +121,11 @@ fn export_consts() -> TestResult {
 }
 
 #[test]
+fn dont_export_module_name_as_a_variable() -> TestResult {
+    fail_test(r#"module spam { }; use spam; $spam"#, "variable not found")
+}
+
+#[test]
 fn func_use_consts() -> TestResult {
     run_test(
         r#"module spam { const b = 3; export def c [] { $b } }; use spam; spam c"#,


### PR DESCRIPTION
# Description
Fixes: #13967

The key changes lays in `nu-protocol/src/module.rs`, when resolving import pattern, nushell only needs to bring `$module` with a record value if it defines any constants.

# User-Facing Changes
```nushell
module spam {}
use spam
```
Will no longer create a `$spam` variable with an empty record.

# Tests + Formatting
Adjusted some tests and added some tests.