### PR TITLE
fix unknown_command when parsing certain strings with equal signs

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2927,6 +2927,10 @@ pub fn parse_string_strict(working_set: &mut StateWorkingSet, span: Span) -> Exp
             working_set.error(ParseError::Unclosed("\'".into(), span));
             return garbage(working_set, span);
         }
+        if bytes.starts_with(b"r#") && (bytes.len() == 1 || !bytes.ends_with(b"#")) {
+            working_set.error(ParseError::Unclosed("r#".into(), span));
+            return garbage(working_set, span);
+        }
     }
 
     let (bytes, quoted) = if (bytes.starts_with(b"\"") && bytes.ends_with(b"\"") && bytes.len() > 1)
@@ -5380,10 +5384,12 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
 
             let starting_error_count = working_set.parse_errors.len();
 
-            let lhs = parse_string_strict(
-                working_set,
-                Span::new(spans[pos].start, spans[pos].start + point - 1),
-            );
+            let lhs_span = Span::new(spans[pos].start, spans[pos].start + point - 1);
+            if !is_identifier(working_set.get_span_contents(lhs_span)) {
+                break;
+            }
+
+            let lhs = parse_string_strict(working_set, lhs_span);
             let rhs = if spans[pos].start + point < spans[pos].end {
                 let rhs_span = Span::new(spans[pos].start + point, spans[pos].end);
 

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -176,7 +176,14 @@ fn bad_var_name() -> TestResult {
 
 #[test]
 fn bad_var_name2() -> TestResult {
-    fail_test(r#"let $foo-bar = 4"#, "valid variable")
+    fail_test(r#"let $foo-bar = 4"#, "valid variable")?;
+    fail_test(r#"foo-bar=4 true"#, "Command `foo-bar=4` not found")
+}
+
+#[test]
+fn bad_var_name3() -> TestResult {
+    fail_test(r#"let $=foo = 4"#, "valid variable")?;
+    fail_test(r#"=foo=4 true"#, "Command `=foo=4` not found")
 }
 
 #[test]
@@ -265,6 +272,34 @@ fn string_interp_with_equals() -> TestResult {
         r#"let query_prefix = $"https://api.github.com/search/issues?q=repo:nushell/"; $query_prefix"#,
         "https://api.github.com/search/issues?q=repo:nushell/",
     )
+}
+
+#[test]
+fn raw_string_with_equals() -> TestResult {
+    run_test(
+        r#"let query_prefix = r#'https://api.github.com/search/issues?q=repo:nushell/'#; $query_prefix"#,
+        "https://api.github.com/search/issues?q=repo:nushell/",
+    )
+}
+
+#[test]
+fn list_quotes_with_equals() -> TestResult {
+    run_test(
+        r#"["https://api.github.com/search/issues?q=repo:nushell/"] | get 0"#,
+        "https://api.github.com/search/issues?q=repo:nushell/",
+    )
+}
+
+#[test]
+fn record_quotes_with_equals() -> TestResult {
+    run_test(r#"{"a=":b} | get a="#, "b")?;
+    run_test(r#"{"=a":b} | get =a"#, "b")?;
+
+    run_test(r#"{a:"=b"} | get a"#, "=b")?;
+    run_test(r#"{a:"b="} | get a"#, "b=")?;
+
+    run_test(r#"{a:b,"=c":d} | get =c"#, "d")?;
+    run_test(r#"{a:b,"c=":d} | get c="#, "d")
 }
 
 #[test]


### PR DESCRIPTION
# Description

Prevents errors when `=` is used before the end of:

- strings in lists/records (with a symbol adjacent to the quotes)
- raw strings

```
> ["=a"]
Error: nu::parser::unknown_command

  × Unknown command.
   ╭─[entry #9:1:1]
 1 │ ["=a"]
   · ───┬──
   ·    ╰── unknown command
   ╰────
```

```
> r#'=a'#
Error: nu::parser::unknown_command

  × Unknown command.
   ╭─[entry #5:1:1]
 1 │ r#'=a'#
   · ───┬───
   ·    ╰── unknown command
   ╰────
```

Closes #13902, closes #13901, closes #9879, closes #6401, closes #5806

# User-Facing Changes

Variable names in environment shorthand assignments must satisfy `is_identifier`.