### PR TITLE
Removed CustomValue portion of CustomValue type name strings. 

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/custom_value.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/custom_value.rs
@@ -27,7 +27,7 @@ impl CustomValue for NuDataFrameCustomValue {
     }
 
     fn type_name(&self) -> String {
-        "NuDataFrameCustomValue".into()
+        "NuDataFrame".into()
     }
 
     fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/custom_value.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/custom_value.rs
@@ -27,7 +27,7 @@ impl CustomValue for NuLazyFrameCustomValue {
     }
 
     fn type_name(&self) -> String {
-        "NuLazyFrameCustomValue".into()
+        "NuLazyFrame".into()
     }
 
     fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_lazygroupby/custom_value.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_lazygroupby/custom_value.rs
@@ -19,7 +19,7 @@ impl CustomValue for NuLazyGroupByCustomValue {
     }
 
     fn type_name(&self) -> String {
-        "NuLazyGroupByCustomValue".into()
+        "NuLazyGroupBy".into()
     }
 
     fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_when/custom_value.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_when/custom_value.rs
@@ -20,7 +20,7 @@ impl CustomValue for NuWhenCustomValue {
     }
 
     fn type_name(&self) -> String {
-        "NuWhenCustomValue".into()
+        "NuWhen".into()
     }
 
     fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {


### PR DESCRIPTION
#Description

This changes the names returned by CustomValue::name() of the various custom value structs to just say the name of the thing they represent. For instance "DataFrameCustomValue" is not just "DataFrame". 

# User-Facing Changes
- Places such as  or errors where NuDataFrameCustomValue would be seen, now just shows as NuDataFrame.

