### PR TITLE
Allow path relative-to to use parent directory symbols

### DIFF
--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -162,11 +162,12 @@ fn relative_to(path: &Path, span: Span, args: &Arguments) -> Value {
         }
     };
 
-    let mut path: String = differing_parent.iter().map(|_| "../").collect();
+    let mut path = PathBuf::new();
+    differing_parent.iter().for_each(|_| path.push(".."));
 
-    path.push_str(&differing_child.to_string_lossy());
+    path.push(&differing_child);
 
-    Value::string(path, span)
+    Value::string(path.to_string_lossy(), span)
 }
 #[cfg(test)]
 mod tests {

--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -113,6 +113,12 @@ path."#
                 example: r"'eggs\bacon\sausage\spam' | path relative-to 'eggs\bacon\sausage'",
                 result: Some(Value::test_string(r"spam")),
             },
+            Example {
+                description: "Find a relative path that requires parent directory symbols",
+                example: r"'a\b\c' | path relative-to 'a\d\e'",
+
+                result: Some(Value::test_string(r"..\..\b\c")),
+            },
         ]
     }
 

--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -165,7 +165,7 @@ fn relative_to(path: &Path, span: Span, args: &Arguments) -> Value {
     let mut path = PathBuf::new();
     differing_parent.iter().for_each(|_| path.push(".."));
 
-    path.push(&differing_child);
+    path.push(differing_child);
 
     Value::string(path.to_string_lossy(), span)
 }

--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -92,6 +92,30 @@ path."#
         )
     }
 
+    #[cfg(windows)]
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Find a relative path from two absolute paths",
+                example: r"'C:\Users\viking' | path relative-to 'C:\Users'",
+                result: Some(Value::test_string(r"viking")),
+            },
+            Example {
+                description: "Find a relative path from absolute paths in list",
+                example: r"[ C:\Users\viking, C:\Users\spam ] | path relative-to C:\Users",
+                result: Some(Value::test_list(vec![
+                    Value::test_string("viking"),
+                    Value::test_string("spam"),
+                ])),
+            },
+            Example {
+                description: "Find a relative path from two relative paths",
+                example: r"'eggs\bacon\sausage\spam' | path relative-to 'eggs\bacon\sausage'",
+                result: Some(Value::test_string(r"spam")),
+            },
+        ]
+    }
+
     #[cfg(not(windows))]
     fn examples(&self) -> Vec<Example> {
         vec![


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Addresses #13969. Allows `path relative-to` to generate relative paths that use the parent directory  `..` within them. Also changes the error type to be slightly more informative than the previous one.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Added test example:

- `'a/b/c' | path relative-to 'a/d/e'`

