### PR TITLE
make `FooterMode::Auto` work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,6 +3493,7 @@ dependencies = [
  "nu-utils",
  "once_cell",
  "tabled",
+ "terminal_size",
 ]
 
 [[package]]

--- a/crates/nu-protocol/src/config/table.rs
+++ b/crates/nu-protocol/src/config/table.rs
@@ -58,7 +58,7 @@ pub enum FooterMode {
     Always,
     /// Only show the footer if there are more than RowCount rows
     RowCount(u64),
-    /// Calculate the screen height, calculate row count, if display will be bigger than screen, add the footer
+    /// Calculate the screen height and row count, if screen height is larger than row count, don't show footer
     Auto,
 }
 

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -22,6 +22,7 @@ nu-ansi-term = { workspace = true }
 once_cell = { workspace = true }
 fancy-regex = { workspace = true }
 tabled = { workspace = true, features = ["ansi"], default-features = false }
+terminal_size = { workspace = true }
 
 [dev-dependencies]
 # nu-test-support = { path="../nu-test-support", version = "0.98.1"  }

--- a/crates/nu-table/src/common.rs
+++ b/crates/nu-table/src/common.rs
@@ -202,18 +202,14 @@ fn need_footer(config: &Config, count_records: u64) -> bool {
         FooterMode::Always => true,
         // Never show the footer
         FooterMode::Never => false,
-        // Calculate the screen height, calculate row count, if display will be bigger than screen, add the footer
+        // Calculate the screen height and row count, if screen height is larger than row count, don't show footer
         FooterMode::Auto => {
             let (_width, height) = match terminal_size() {
                 Some((w, h)) => (Width(w.0).0 as u64, Height(h.0).0 as u64),
                 None => (Width(0).0 as u64, Height(0).0 as u64),
             };
 
-            if height > count_records {
-                false
-            } else {
-                true
-            }
+            height <= count_records
         }
     }
 }

--- a/crates/nu-table/src/common.rs
+++ b/crates/nu-table/src/common.rs
@@ -3,6 +3,7 @@ use crate::{
 };
 use nu_color_config::{Alignment, StyleComputer, TextStyle};
 use nu_protocol::{Config, FooterMode, ShellError, Span, TableMode, TrimStrategy, Value};
+use terminal_size::{terminal_size, Height, Width};
 
 pub type NuText = (String, TextStyle);
 pub type TableResult = Result<Option<TableOutput>, ShellError>;
@@ -194,6 +195,25 @@ fn with_footer(config: &Config, with_header: bool, count_records: usize) -> bool
 }
 
 fn need_footer(config: &Config, count_records: u64) -> bool {
-    matches!(config.footer_mode, FooterMode::RowCount(limit) if count_records > limit)
-        || matches!(config.footer_mode, FooterMode::Always)
+    match config.footer_mode {
+        // Only show the footer if there are more than RowCount rows
+        FooterMode::RowCount(limit) => count_records > limit,
+        // Always show the footer
+        FooterMode::Always => true,
+        // Never show the footer
+        FooterMode::Never => false,
+        // Calculate the screen height, calculate row count, if display will be bigger than screen, add the footer
+        FooterMode::Auto => {
+            let (_width, height) = match terminal_size() {
+                Some((w, h)) => (Width(w.0).0 as u64, Height(h.0).0 as u64),
+                None => (Width(0).0 as u64, Height(0).0 as u64),
+            };
+
+            if height > count_records {
+                false
+            } else {
+                true
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Description

@Yethal discovered that `FooterMode::Auto` in the config as `$env.config.footer_mode = auto` did not work. This PR attempts to fix that problem by implementing the auto algorithm that was already supposed to work.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
