### PR TITLE
Fix --header-row description

### DIFF
--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -25,7 +25,7 @@ impl Command for Transpose {
             ])
             .switch(
                 "header-row",
-                "treat the first row as column names",
+                "treat the first column as the header-row (column names)",
                 Some('r'),
             )
             .switch(


### PR DESCRIPTION
# Description

The help description on `transpose --header-row/-r` appears to be wrong (and now that I understand that, it probably explains why it's confused me for so long).

It currently says:

```
 -r, --header-row - treat the first row as column names
```

This just looks wrong - The first **row** of the input data is not considered.  It's the first **column** that is used to create the header-row of the transposed table.

For example:

To record using `-dr`:

```nu
[[col-names         values ];
 [foo                  1   ]
 [bar                  5   ]
 [baz                  7   ]
 [cat                  -12 ]
] | transpose -dr

╭─────┬─────╮
│ foo │ 1   │
│ bar │ 5   │
│ baz │ 7   │
│ cat │ -12 │
╰─────┴─────╯
```

To table using `-r`:

```nu
[[col-names         values ];
 [foo                  1   ]
 [bar                  5   ]
 [baz                  7   ]
 [cat                  -12 ]
] | transpose -r

╭───┬─────┬─────┬─────┬─────╮
│ # │ foo │ bar │ baz │ cat │
├───┼─────┼─────┼─────┼─────┤
│ 0 │   1 │   5 │   7 │ -12 │
╰───┴─────┴─────┴─────┴─────╯
```

# User-Facing Changes

Updates the help description to:

```
-r, --header-row - use the first input column as the table header-row (or keynames when combined with --as-record)
```

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A