### PR TITLE
Correct wording from previous PR

### DIFF
--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -25,7 +25,7 @@ impl Command for Transpose {
             ])
             .switch(
                 "header-row",
-                "treat the first column as the header-row (column names)",
+                "use the first input column as the table header-row (or keynames when combined with --as-record)",
                 Some('r'),
             )
             .switch(


### PR DESCRIPTION
# Description

Apologies - The updated wording I used in the last PR *description* was not what I actually pushed.  I failed to commit and push the last update.  This PR fixes the code to reflect what was described in #14065:

```
-r, --header-row - use the first input column as the table header-row (or keynames when combined with --as-record)
```

# User-Facing Changes

Help/doc only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

(And visually confirmed help changes ;-))

# After Submitting

N/A