### PR TITLE
support filesize arguments in `random` `binary`/`chars`

### DIFF
--- a/crates/nu-command/src/random/binary.rs
+++ b/crates/nu-command/src/random/binary.rs
@@ -14,7 +14,11 @@ impl Command for SubCommand {
         Signature::build("random binary")
             .input_output_types(vec![(Type::Nothing, Type::Binary)])
             .allow_variants_without_examples(true)
-            .required("length", SyntaxShape::Int, "Length of the output binary.")
+            .required(
+                "length",
+                SyntaxShape::OneOf(vec![SyntaxShape::Int, SyntaxShape::Filesize]),
+                "Length of the output binary.",
+            )
             .category(Category::Random)
     }
 
@@ -43,11 +47,18 @@ impl Command for SubCommand {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Generate 16 random bytes",
-            example: "random binary 16",
-            result: None,
-        }]
+        vec![
+            Example {
+                description: "Generate 16 random bytes",
+                example: "random binary 16",
+                result: None,
+            },
+            Example {
+                description: "Generate 1 random kilobyte",
+                example: "random binary 1kb",
+                result: None,
+            },
+        ]
     }
 }
 

--- a/crates/nu-command/src/random/chars.rs
+++ b/crates/nu-command/src/random/chars.rs
@@ -21,7 +21,7 @@ impl Command for SubCommand {
             .allow_variants_without_examples(true)
             .named(
                 "length",
-                SyntaxShape::Int,
+                SyntaxShape::OneOf(vec![SyntaxShape::Int, SyntaxShape::Filesize]),
                 "Number of chars (default 25)",
                 Some('l'),
             )
@@ -56,6 +56,11 @@ impl Command for SubCommand {
             Example {
                 description: "Generate random chars with specified length",
                 example: "random chars --length 20",
+                result: None,
+            },
+            Example {
+                description: "Generate one kilobyte of random chars",
+                example: "random chars --length 1kb",
                 result: None,
             },
         ]

--- a/crates/nu-command/tests/commands/random/binary.rs
+++ b/crates/nu-command/tests/commands/random/binary.rs
@@ -1,0 +1,21 @@
+use nu_test_support::nu;
+
+#[test]
+fn generates_bytes_of_specified_length() {
+    let actual = nu!(r#"
+        random binary 16 | bytes length
+        "#);
+
+    let result = actual.out;
+    assert_eq!(result, "16");
+}
+
+#[test]
+fn generates_bytes_of_specified_filesize() {
+    let actual = nu!(r#"
+        random binary 1kb | bytes length
+        "#);
+
+    let result = actual.out;
+    assert_eq!(result, "1000");
+}

--- a/crates/nu-command/tests/commands/random/chars.rs
+++ b/crates/nu-command/tests/commands/random/chars.rs
@@ -9,3 +9,13 @@ fn generates_chars_of_specified_length() {
     let result = actual.out;
     assert_eq!(result, "15");
 }
+
+#[test]
+fn generates_chars_of_specified_filesize() {
+    let actual = nu!(r#"
+        random chars --length 1kb | str stats | get bytes
+        "#);
+
+    let result = actual.out;
+    assert_eq!(result, "1000");
+}

--- a/crates/nu-command/tests/commands/random/mod.rs
+++ b/crates/nu-command/tests/commands/random/mod.rs
@@ -1,3 +1,4 @@
+mod binary;
 mod bool;
 mod chars;
 mod dice;


### PR DESCRIPTION
Closes #13920

# User-Facing Changes

`random binary` and `random chars` now support filesize arguments:

```nushell
random binary 1kb
random chars --length 1kb
```