### PR TITLE
Replace `IncorrectValue` with `InvalidValue`

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -130,13 +130,13 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
 
             if bits > input_num_type.num_bits() {
                 return Value::error(
-                    ShellError::IncorrectValue {
-                        msg: format!(
-                            "Trying to rotate by more than the available bits ({})",
+                    ShellError::InvalidValue {
+                        valid: format!(
+                            "an integer less than or equal to the available number of bits ({})",
                             input_num_type.num_bits()
                         ),
-                        val_span: bits_span,
-                        call_span: span,
+                        actual: bits.to_string(),
+                        span: bits_span,
                     },
                     span,
                 );
@@ -171,16 +171,16 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             Value::int(int, span)
         }
         Value::Binary { val, .. } => {
-            let len = val.len();
-            if bits > len * 8 {
+            let max_bits = val.len() * 8;
+            if bits > max_bits {
                 return Value::error(
-                    ShellError::IncorrectValue {
-                        msg: format!(
-                            "Trying to rotate by more than the available bits ({})",
-                            len * 8
+                    ShellError::InvalidValue {
+                        valid: format!(
+                            "an integer less than or equal to the available number of bits ({})",
+                            max_bits
                         ),
-                        val_span: bits_span,
-                        call_span: span,
+                        actual: bits.to_string(),
+                        span: bits_span,
                     },
                     span,
                 );

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -134,13 +134,13 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
 
             if bits > input_num_type.num_bits() {
                 return Value::error(
-                    ShellError::IncorrectValue {
-                        msg: format!(
-                            "Trying to rotate by more than the available bits ({})",
+                    ShellError::InvalidValue {
+                        valid: format!(
+                            "an integer less than or equal to the available number of bits ({})",
                             input_num_type.num_bits()
                         ),
-                        val_span: bits_span,
-                        call_span: span,
+                        actual: bits.to_string(),
+                        span: bits_span,
                     },
                     span,
                 );
@@ -175,16 +175,16 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             Value::int(int, span)
         }
         Value::Binary { val, .. } => {
-            let len = val.len();
-            if bits > len * 8 {
+            let max_bits = val.len() * 8;
+            if bits > max_bits {
                 return Value::error(
-                    ShellError::IncorrectValue {
-                        msg: format!(
-                            "Trying to rotate by more than the available bits ({})",
-                            len * 8
+                    ShellError::InvalidValue {
+                        valid: format!(
+                            "an integer less than or equal to the available number of bits ({})",
+                            max_bits
                         ),
-                        val_span: bits_span,
-                        call_span: span,
+                        actual: bits.to_string(),
+                        span: bits_span,
                     },
                     span,
                 );

--- a/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
@@ -145,13 +145,13 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             let input_num_type = get_input_num_type(val, signed, number_size);
             if !input_num_type.is_permitted_bit_shift(bits) {
                 return Value::error(
-                    ShellError::IncorrectValue {
-                        msg: format!(
-                            "Trying to shift by more than the available bits (permitted < {})",
+                    ShellError::InvalidValue {
+                        valid: format!(
+                            "an integer less than or equal to the available number of bits ({})",
                             input_num_type.num_bits()
                         ),
-                        val_span: bits_span,
-                        call_span: span,
+                        actual: bits.to_string(),
+                        span: bits_span,
                     },
                     span,
                 );
@@ -188,24 +188,25 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             Value::int(int, span)
         }
         Value::Binary { val, .. } => {
-            let byte_shift = bits / 8;
-            let bit_shift = bits % 8;
-
             // This is purely for symmetry with the int case and the fact that the
             // shift right implementation in its current form panicked with an overflow
-            if bits > val.len() * 8 {
+            let max_bits = val.len() * 8;
+            if bits > max_bits {
                 return Value::error(
-                    ShellError::IncorrectValue {
-                        msg: format!(
-                            "Trying to shift by more than the available bits ({})",
-                            val.len() * 8
+                    ShellError::InvalidValue {
+                        valid: format!(
+                            "an integer less than or equal to the available number of bits ({})",
+                            max_bits
                         ),
-                        val_span: bits_span,
-                        call_span: span,
+                        actual: bits.to_string(),
+                        span: bits_span,
                     },
                     span,
                 );
             }
+            let byte_shift = bits / 8;
+            let bit_shift = bits % 8;
+
             let bytes = if bit_shift == 0 {
                 shift_bytes_left(val, byte_shift)
             } else {

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -132,13 +132,13 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
 
             if !input_num_type.is_permitted_bit_shift(bits) {
                 return Value::error(
-                    ShellError::IncorrectValue {
-                        msg: format!(
-                            "Trying to shift by more than the available bits (permitted < {})",
+                    ShellError::InvalidValue {
+                        valid: format!(
+                            "an integer less than or equal to the available number of bits ({})",
                             input_num_type.num_bits()
                         ),
-                        val_span: bits_span,
-                        call_span: span,
+                        actual: bits.to_string(),
+                        span: bits_span,
                     },
                     span,
                 );
@@ -157,26 +157,26 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             Value::int(int, span)
         }
         Value::Binary { val, .. } => {
-            let byte_shift = bits / 8;
-            let bit_shift = bits % 8;
-
-            let len = val.len();
             // This check is done for symmetry with the int case and the previous
             // implementation would overflow byte indices leading to unexpected output
             // lengths
-            if bits > len * 8 {
+            let max_bits = val.len() * 8;
+            if bits > max_bits {
                 return Value::error(
-                    ShellError::IncorrectValue {
-                        msg: format!(
-                            "Trying to shift by more than the available bits ({})",
-                            len * 8
+                    ShellError::InvalidValue {
+                        valid: format!(
+                            "an integer less than or equal to the available number of bits ({})",
+                            max_bits
                         ),
-                        val_span: bits_span,
-                        call_span: span,
+                        actual: bits.to_string(),
+                        span: bits_span,
                     },
                     span,
                 );
             }
+            let byte_shift = bits / 8;
+            let bit_shift = bits % 8;
+
             let bytes = if bit_shift == 0 {
                 shift_bytes_right(val, byte_shift)
             } else {

--- a/crates/nu-command/src/bytes/build_.rs
+++ b/crates/nu-command/src/bytes/build_.rs
@@ -55,10 +55,10 @@ impl Command for BytesBuild {
             match val {
                 Value::Binary { mut val, .. } => output.append(&mut val),
                 Value::Int { val, .. } => {
-                    let byte: u8 = val.try_into().map_err(|_| ShellError::IncorrectValue {
-                        msg: format!("{val} is out of range for byte"),
-                        val_span,
-                        call_span: call.head,
+                    let byte: u8 = val.try_into().map_err(|_| ShellError::InvalidValue {
+                        valid: "an integer in the range [0, 255]".into(),
+                        actual: val.to_string(),
+                        span: val_span,
                     })?;
                     output.push(byte);
                 }

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -141,13 +141,10 @@ fn into_record(call: &Call, input: PipelineData) -> Result<PipelineData, ShellEr
                             let (val, key) = vals.pop().zip(vals.pop()).expect("length is < 2");
                             record.insert(key.coerce_into_string()?, val);
                         } else {
-                            return Err(ShellError::IncorrectValue {
-                                msg: format!(
-                                    "expected inner list with two elements, but found {} element(s)",
-                                    vals.len()
-                                ),
-                                val_span: span,
-                                call_span: call.head,
+                            return Err(ShellError::InvalidValue {
+                                valid: "a list with 2 elements".into(),
+                                actual: format!("a list with {} element(s)", vals.len()),
+                                span,
                             });
                         }
                         expected_type = Some(ExpectedType::Pair);

--- a/crates/nu-command/src/debug/view_ir.rs
+++ b/crates/nu-command/src/debug/view_ir.rs
@@ -84,17 +84,23 @@ the declaration may not be in scope.
             }
             // Decl by ID - IR dump always shows name of decl, but sometimes it isn't in scope
             Value::Int { val, .. } if is_decl_id => {
-                let decl_id = val
-                    .try_into()
-                    .ok()
-                    .map(DeclId::new)
-                    .filter(|id| id.get() < engine_state.num_decls())
-                    .ok_or_else(|| ShellError::IncorrectValue {
-                        msg: "not a valid decl id".into(),
-                        val_span: target.span(),
-                        call_span: call.head,
-                    })?;
-                let decl = engine_state.get_decl(decl_id);
+                let decl_id = val.try_into().map_err(|_| ShellError::InvalidValue {
+                    valid: "a non-negative integer".into(),
+                    actual: val.to_string(),
+                    span: target.span(),
+                })?;
+
+                if decl_id >= engine_state.num_decls() {
+                    return Err(ShellError::GenericError {
+                        error: format!("Unknown decl ID: {decl_id}"),
+                        msg: "ensure the decl ID is correct and try again".into(),
+                        span: Some(target.span()),
+                        help: None,
+                        inner: vec![],
+                    });
+                };
+
+                let decl = engine_state.get_decl(DeclId::new(decl_id));
                 decl.block_id().ok_or_else(|| ShellError::GenericError {
                     error: format!("Can't view IR for `{}`", decl.name()),
                     msg: "not a custom command".into(),
@@ -107,10 +113,10 @@ the declaration may not be in scope.
             Value::Int { val, .. } => {
                 val.try_into()
                     .map(BlockId::new)
-                    .map_err(|_| ShellError::IncorrectValue {
-                        msg: "not a valid block id".into(),
-                        val_span: target.span(),
-                        call_span: call.head,
+                    .map_err(|_| ShellError::InvalidValue {
+                        valid: "a non-negative interger".into(),
+                        actual: val.to_string(),
+                        span: target.span(),
                     })?
             }
             // Pass through errors

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -148,16 +148,16 @@ impl Command for Glob {
             }
         };
 
-        let glob_pattern =
-            match glob_pattern_input {
-                Value::String { val, .. } | Value::Glob { val, .. } => val,
-                _ => return Err(ShellError::IncorrectValue {
-                    msg: "Incorrect glob pattern supplied to glob. Please use string or glob only."
-                        .to_string(),
-                    val_span: call.head,
-                    call_span: glob_span,
-                }),
-            };
+        let glob_pattern = match glob_pattern_input {
+            Value::String { val, .. } | Value::Glob { val, .. } => val,
+            val => {
+                return Err(ShellError::RuntimeTypeMismatch {
+                    expected: Type::custom("string or glob"),
+                    actual: val.get_type(),
+                    span: val.span(),
+                });
+            }
+        };
 
         if glob_pattern.is_empty() {
             return Err(ShellError::GenericError {

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -100,10 +100,10 @@ pub fn to_delimited_data(
             .with_content_type(content_type),
     );
 
-    let separator = u8::try_from(separator.item).map_err(|_| ShellError::IncorrectValue {
-        msg: "separator must be an ASCII character".into(),
-        val_span: separator.span,
-        call_span: head,
+    let separator = u8::try_from(separator.item).map_err(|_| ShellError::InvalidValue {
+        valid: "an ASCII character".into(),
+        actual: separator.item.to_string(),
+        span: separator.span,
     })?;
 
     // Check to ensure the input is likely one of our supported types first. We can't check a stream

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -313,11 +313,13 @@ fn send_form_request(
     match body {
         Value::List { ref vals, .. } => {
             if vals.len() % 2 != 0 {
-                return Err(ShellErrorOrRequestError::ShellError(ShellError::IncorrectValue {
-                    msg: "Body type 'list' for form requests requires paired values. E.g.: [foo, 10]".into(),
-                    val_span: body.span(),
-                    call_span: span,
-                }));
+                return Err(ShellErrorOrRequestError::ShellError(
+                    ShellError::InvalidValue {
+                        valid: "a list with an even number of elements".into(),
+                        actual: format!("a list with {} elements", vals.len()),
+                        span: body.span(),
+                    },
+                ));
             }
 
             let data = vals

--- a/crates/nu-command/src/strings/base/mod.rs
+++ b/crates/nu-command/src/strings/base/mod.rs
@@ -24,10 +24,13 @@ pub fn decode(
     let output = match encoding.decode(input_str.as_bytes()) {
         Ok(output) => output,
         Err(err) => {
-            return Err(ShellError::IncorrectValue {
+            // TODO: convert/map each possible `DecodeError` case.
+            return Err(ShellError::GenericError {
+                error: "Failed to decode".into(),
                 msg: err.to_string(),
-                val_span: input_span,
-                call_span,
+                span: Some(call_span),
+                help: None,
+                inner: Vec::new(),
             });
         }
     };

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -249,9 +249,8 @@ fn action(
                     false => "",
                 };
                 let regex_string = flags.to_string() + find_str;
-                let regex = Regex::new(&regex_string);
 
-                match regex {
+                match Regex::new(&regex_string) {
                     Ok(re) => {
                         if *all {
                             Value::string(
@@ -278,10 +277,12 @@ fn action(
                         }
                     }
                     Err(e) => Value::error(
-                        ShellError::IncorrectValue {
-                            msg: format!("Regex error: {e}"),
-                            val_span: find.span,
-                            call_span: head,
+                        ShellError::GenericError {
+                            error: "Failed to create regex".into(),
+                            msg: e.to_string(),
+                            span: Some(find.span),
+                            help: None,
+                            inner: Vec::new(),
                         },
                         find.span,
                     ),

--- a/crates/nu-protocol/src/errors/shell_error.rs
+++ b/crates/nu-protocol/src/errors/shell_error.rs
@@ -135,21 +135,6 @@ pub enum ShellError {
         span: Span,
     },
 
-    /// A command received an argument with correct type but incorrect value.
-    ///
-    /// ## Resolution
-    ///
-    /// Correct the argument value before passing it in or change the command.
-    #[error("Incorrect value.")]
-    #[diagnostic(code(nu::shell::incorrect_value))]
-    IncorrectValue {
-        msg: String,
-        #[label = "{msg}"]
-        val_span: Span,
-        #[label = "encountered here"]
-        call_span: Span,
-    },
-
     /// This value cannot be used with this operator.
     ///
     /// ## Resolution

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/avro.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/avro.rs
@@ -17,10 +17,10 @@ fn get_compression(call: &EvaluatedCall) -> Result<Option<AvroCompression>, Shel
         match compression.as_ref() {
             "snappy" => Ok(Some(AvroCompression::Snappy)),
             "deflate" => Ok(Some(AvroCompression::Deflate)),
-            _ => Err(ShellError::IncorrectValue {
-                msg: "compression must be one of deflate or snappy".to_string(),
-                val_span: span,
-                call_span: span,
+            _ => Err(ShellError::InvalidValue {
+                valid: "'deflate' or 'snappy'".into(),
+                actual: format!("'{compression}'"),
+                span,
             }),
         }
     } else {


### PR DESCRIPTION
# Description
Follow up to #13802. This PR replaces usages of `ShellError::IncorrectValue` with `InvalidValue` or other appropriate error cases.

# User-Facing Changes
None, some errors messages may be different.