### PR TITLE
Add a workflow to set milestone for a merged PR automatically

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -1,0 +1,18 @@
+# Description:
+#   - Update milestone of a merged PR
+
+name: Milestone Action
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  update-milestone:
+    runs-on: ubuntu-latest
+    name: Milestone Update
+    if: ${{github.event.pull_request.merged == true}}
+    steps:
+      - name: Set Milestone
+        uses: hustcer/milestone-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Add a workflow to set milestone for a merged PR automatically.

A example action run log looks like: https://github.com/hustcer/milestone-action/actions/runs/11320750633/job/31478761283

[`hustcer/milestone-action`](https://github.com/hustcer/milestone-action) is a Github action powered by `nushell`, and still in active development, so I will use `main` branch for easily to try new changes


