### PR TITLE
error when closure param lists aren't terminated by `|`

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4603,7 +4603,7 @@ pub fn parse_closure_expression(
                 } = token.1
                 {
                     end_span = Some(span);
-                    amt_to_skip = token.0;
+                    amt_to_skip += token.0;
                     break;
                 }
             }
@@ -4611,6 +4611,7 @@ pub fn parse_closure_expression(
             let end_point = if let Some(span) = end_span {
                 span.end
             } else {
+                working_set.error(ParseError::Unclosed("|".into(), Span::new(end, end)));
                 end
             };
 

--- a/tests/repl/test_signatures.rs
+++ b/tests/repl/test_signatures.rs
@@ -1,4 +1,5 @@
 use crate::repl::tests::{fail_test, run_test, TestResult};
+use rstest::rstest;
 
 #[test]
 fn list_annotations() -> TestResult {
@@ -374,4 +375,13 @@ fn table_annotations_with_extra_characters() -> TestResult {
     let input = "def run [t: table<int>extra] {$t | length}; run [[int]; [8]]";
     let expected = "Extra characters in the parameter name";
     fail_test(input, expected)
+}
+
+#[rstest]
+#[case("{ |a $a }")]
+#[case("{ |a, b $a + $b }")]
+#[case("do { |a $a } 1")]
+#[case("do { |a $a } 1 2")]
+fn closure_param_list_not_terminated(#[case] input: &str) -> TestResult {
+    fail_test(input, "unclosed |")
 }


### PR DESCRIPTION
Fixes #13757, fixes #9562

# User-Facing Changes

- `unclosed |` is returned for malformed closure parameters:

```
{ |a }
```

- Parameter list closing pipes are highlighted as part of the closure