### PR TITLE
Defensive handling of errors when transposing

### DIFF
--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -176,10 +176,9 @@ pub fn transpose(
     let metadata = input.metadata();
     let input: Vec<_> = input.into_iter().collect();
     // Ensure error values are propagated
-    for x in input.iter() {
-        match x {
-            Value::Error {..} => return Ok(x.clone().into_pipeline_data_with_metadata(metadata)),
-            _ => {}
+    for i in input.iter() {
+        if let Value::Error { .. } = i {
+            return Ok(i.clone().into_pipeline_data_with_metadata(metadata));
         }
     }
 

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -175,6 +175,13 @@ pub fn transpose(
 
     let metadata = input.metadata();
     let input: Vec<_> = input.into_iter().collect();
+    // Ensure error values are propagated
+    for x in input.iter() {
+        match x {
+            Value::Error {..} => return Ok(x.clone().into_pipeline_data_with_metadata(metadata)),
+            _ => {}
+        }
+    }
 
     let descs = get_columns(&input);
 

--- a/crates/nu-command/tests/commands/transpose.rs
+++ b/crates/nu-command/tests/commands/transpose.rs
@@ -25,7 +25,10 @@ fn row_but_all() {
 fn throw_inner_error() {
     let error_msg = "This message should show up";
     let error = format!("(error make {{ msg: \"{}\" }})", error_msg);
-    let actual = nu!(format!("[[key value]; [foo 1] [foo 2] [{} 3]] | transpose", error));
+    let actual = nu!(format!(
+        "[[key value]; [foo 1] [foo 2] [{} 3]] | transpose",
+        error
+    ));
 
     assert!(actual.err.contains(error.as_str()));
 }

--- a/crates/nu-command/tests/commands/transpose.rs
+++ b/crates/nu-command/tests/commands/transpose.rs
@@ -20,3 +20,12 @@ fn row_but_all() {
 
     assert!(actual.out.contains("foo: [1, 2]"));
 }
+
+#[test]
+fn throw_inner_error() {
+    let error_msg = "This message should show up";
+    let error = format!("(error make {{ msg: \"{}\" }})", error_msg);
+    let actual = nu!(format!("[[key value]; [foo 1] [foo 2] [{} 3]] | transpose", error));
+
+    assert!(actual.err.contains(error.as_str()));
+}


### PR DESCRIPTION
# Description
This PR aims to close #14027, in which it was noticed that the transpose command "swallows" error messages.

*Note that in exploring the linked issue, [other situations were identified](https://github.com/nushell/nushell/issues/14027#issuecomment-2414602880) which also produce inconsistent behaviour. These have knowingly been omitted from this PR, to minimize its scope, and since they seem to have a different cause. It's probably best to make a separate issue/PR in which to tackle a broader scan of error handling, with a suspected relation to streams.*

# User-Facing Changes
The user will see errors from deeper in the pipeline, in case the errors originated there.

# Tests + Formatting
Toolkit PR check was run successfully.

One test was added, covering this exact situation, in order to prevent regressions.
The bug is relatively obscure, so it may be prone to reappear during refactorings.
