### PR TITLE
IR: Don't generate instructions for `def` and `export def`.

### DIFF
--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -318,7 +318,7 @@ fn export_def_recursive_func_should_work() {
     let actual = nu!(r#"
 export def recursive [c: int] {
     if ($c == 0) { return }
-    if ($c mod 2 > 0) {
+    if ($c mod 1 > 0) {
         $in | recursive ($c - 1)
     } else {
         recursive ($c - 1)

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -318,7 +318,7 @@ fn export_def_recursive_func_should_work() {
     let actual = nu!(r#"
 export def recursive [c: int] {
     if ($c == 0) { return }
-    if ($c mod 1 > 0) {
+    if ($c mod 2 > 0) {
         $in | recursive ($c - 1)
     } else {
         recursive ($c - 1)

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -292,3 +292,37 @@ fn def_env_wrapped_no_help() {
     let actual = nu!("def --wrapped foo [...rest] { echo $rest }; foo -h | to json --raw");
     assert_eq!(actual.out, r#"["-h"]"#);
 }
+
+#[test]
+fn def_recursive_func_should_work() {
+    let actual = nu!("def bar [] { let x = 1; ($x | foo) }; def foo [] { foo }");
+    assert!(actual.err.is_empty());
+
+    let actual = nu!(r#"
+def recursive [c: int] {
+    if ($c == 0) { return }
+    if ($c mod 2 > 0) {
+        $in | recursive ($c - 1)
+    } else {
+        recursive ($c - 1)
+    }
+}"#);
+    assert!(actual.err.is_empty());
+}
+
+#[test]
+fn export_def_recursive_func_should_work() {
+    let actual = nu!("export def bar [] { let x = 1; ($x | foo) }; export def foo [] { foo }");
+    assert!(actual.err.is_empty());
+
+    let actual = nu!(r#"
+export def recursive [c: int] {
+    if ($c == 0) { return }
+    if ($c mod 2 > 0) {
+        $in | recursive ($c - 1)
+    } else {
+        recursive ($c - 1)
+    }
+}"#);
+    assert!(actual.err.is_empty());
+}

--- a/crates/nu-engine/src/compile/call.rs
+++ b/crates/nu-engine/src/compile/call.rs
@@ -71,6 +71,7 @@ pub(crate) fn compile_call(
             "return" => {
                 return compile_return(working_set, builder, call, redirect_modes, io_reg);
             }
+            "def" | "export def" => return Ok(()),
             _ => (),
         }
     }

--- a/crates/nu-engine/src/compile/call.rs
+++ b/crates/nu-engine/src/compile/call.rs
@@ -71,7 +71,9 @@ pub(crate) fn compile_call(
             "return" => {
                 return compile_return(working_set, builder, call, redirect_modes, io_reg);
             }
-            "def" | "export def" => return Ok(()),
+            "def" | "export def" => {
+                return builder.load_empty(io_reg);
+            }
             _ => (),
         }
     }


### PR DESCRIPTION
# Description
Fixes: #14110
Fixes: #14087

I think it's ok to not generating instruction to `def` and `export def` call.  Because they just return `PipelineData::Empty` without doing anything.

If nushell generates instructions for `def` and `export def`, nushell will try to capture variables for these block.  It's not the  time to do this.

# User-Facing Changes
```
nu -c "
def bar [] {
    let x = 1
    ($x | foo)
}
def foo [] {
    foo
}
" 
```
Will no longer raise error.

# Tests + Formatting
Added 4 tests
