### PR TITLE
fix error when exporting constants with type signatures in modules

### DIFF
--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -1,10 +1,11 @@
 use nu_test_support::nu;
+use rstest::rstest;
 
-#[test]
-fn let_name_builtin_var() {
-    let actual = nu!("let in = 3");
-
-    assert!(actual
+#[rstest]
+#[case("let in = 3")]
+#[case("let in: int = 3")]
+fn let_name_builtin_var(#[case] assignment: &str) {
+    assert!(nu!(assignment)
         .err
         .contains("'in' is the name of a builtin Nushell variable"));
 }

--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -1,4 +1,5 @@
 use nu_test_support::nu;
+use rstest::rstest;
 
 #[test]
 fn mut_variable() {
@@ -7,11 +8,11 @@ fn mut_variable() {
     assert_eq!(actual.out, "4");
 }
 
-#[test]
-fn mut_name_builtin_var() {
-    let actual = nu!("mut in = 3");
-
-    assert!(actual
+#[rstest]
+#[case("mut in = 3")]
+#[case("mut in: int = 3")]
+fn mut_name_builtin_var(#[case] assignment: &str) {
+    assert!(nu!(assignment)
         .err
         .contains("'in' is the name of a builtin Nushell variable"));
 }

--- a/tests/repl/test_modules.rs
+++ b/tests/repl/test_modules.rs
@@ -117,6 +117,10 @@ fn export_consts() -> TestResult {
     run_test(
         r#"module spam { export const b = 3; }; use spam b; $b"#,
         "3",
+    )?;
+    run_test(
+        r#"module spam { export const b: int = 3; }; use spam b; $b"#,
+        "3",
     )
 }
 


### PR DESCRIPTION
Fixes #14023

# Description

- Prevents "failed to find added variable" when modules export constants
  with type signatures:

```nushell
> module foo { export const bar: int = 2 }
Error: nu::parser::unknown_state

  × Internal error.
   ╭─[entry #1:1:21]
 1 │ module foo { export const bar: int = 2 }
   ·                     ─────────┬────────
   ·                              ╰── failed to find added variable
```

- Returns `name_is_builtin_var` errors for names with type signatures:

```nushell
> let env: string = "";
Error: nu::parser::name_is_builtin_var

  × `env` used as variable name.
   ╭─[entry #1:1:5]
 1 │ let env: string = "";
   ·     ─┬─
   ·      ╰── already a builtin variable
```