### PR TITLE
add is_const to `help commands` and `scope commands`

### DIFF
--- a/crates/nu-command/src/help/help_commands.rs
+++ b/crates/nu-command/src/help/help_commands.rs
@@ -220,6 +220,7 @@ fn build_help_commands(engine_state: &EngineState, span: Span) -> Vec<Value> {
             "params" => param_table,
             "input_output" => input_output_table,
             "search_terms" => Value::string(search_terms.join(", "), span),
+            "is_const" => Value::bool(decl.is_const(), span),
         };
 
         found_cmds_vec.push(Value::record(record, span));

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -113,6 +113,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                     "examples" => Value::list(examples, span),
                     "type" => Value::string(decl.command_type().to_string(), span),
                     "is_sub" => Value::bool(decl.is_sub(), span),
+                    "is_const" => Value::bool(decl.is_const(), span),
                     "creates_scope" => Value::bool(signature.creates_scope, span),
                     "extra_description" => Value::string(decl.extra_description(), span),
                     "search_terms" => Value::string(decl.search_terms().join(", "), span),


### PR DESCRIPTION
# Description

This PR adds `is_const` to `help commands` and `scope commands` so we can see which commands are const commands.

![image](https://github.com/user-attachments/assets/f2269f9d-5042-40e4-b506-34d69096fcd1)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
