### PR TITLE
add `start_time` to `ps -l` on macos

### DIFF
--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -1,3 +1,4 @@
+use chrono::{Local, TimeZone};
 #[cfg(windows)]
 use itertools::Itertools;
 use nu_engine::command_prelude::*;
@@ -175,6 +176,10 @@ fn run_ps(
             #[cfg(target_os = "macos")]
             {
                 record.push("cwd", Value::string(proc.cwd(), span));
+                let timestamp = Local
+                    .timestamp_nanos(proc.start_time * 1_000_000_000)
+                    .into();
+                record.push("start_time", Value::date(timestamp, span));
             }
         }
 

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "macos")]
 use chrono::{Local, TimeZone};
 #[cfg(windows)]
 use itertools::Itertools;

--- a/crates/nu-system/src/macos.rs
+++ b/crates/nu-system/src/macos.rs
@@ -25,6 +25,7 @@ pub struct ProcessInfo {
     pub curr_res: Option<RUsageInfoV2>,
     pub prev_res: Option<RUsageInfoV2>,
     pub interval: Duration,
+    pub start_time: i64,
 }
 
 pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> {
@@ -94,6 +95,7 @@ pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> 
         let curr_time = Instant::now();
         let interval = curr_time.saturating_duration_since(prev_time);
         let ppid = curr_task.pbsd.pbi_ppid as i32;
+        let start_time = curr_task.pbsd.pbi_start_tvsec as i64;
 
         let proc = ProcessInfo {
             pid,
@@ -107,6 +109,7 @@ pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> 
             curr_res,
             prev_res,
             interval,
+            start_time,
         };
 
         ret.push(proc);


### PR DESCRIPTION
# Description

This PR adds `start_time` to the MacOS `ps -l` command. Was requested in discord. `start_time` is displayed in `Local` time.

![image](https://github.com/user-attachments/assets/b3743cde-af43-4756-9e2a-54689104fb25)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

/cc @cablehead 