### PR TITLE
Add slice as a search term on `range`

### DIFF
--- a/crates/nu-command/src/filters/range.rs
+++ b/crates/nu-command/src/filters/range.rs
@@ -25,7 +25,7 @@ impl Command for Range {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["filter", "head", "tail"]
+        vec!["filter", "head", "tail", "slice"]
     }
 
     fn examples(&self) -> Vec<Example> {


### PR DESCRIPTION
Not to be confused with `seq` which is similar to our range type,
`range` does a slice based on a range.
