### PR TITLE
Add milestone to a closed issue that has a merged PR fix automatically

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -1,8 +1,11 @@
 # Description:
-#   - Update milestone of a merged PR
+#   - Add milestone to a merged PR automatically
+#   - Add milestone to a closed issue that has a merged PR fix (if any)
 
 name: Milestone Action
 on:
+  issues:
+    types: [closed]
   pull_request_target:
     types: [closed]
 
@@ -10,9 +13,18 @@ jobs:
   update-milestone:
     runs-on: ubuntu-latest
     name: Milestone Update
-    if: ${{github.event.pull_request.merged == true}}
     steps:
-      - name: Set Milestone
+      - name: Set Milestone for PR
         uses: hustcer/milestone-action@main
+        if: github.event.pull_request.merged == true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Bind milestone to closed issue that has a merged PR fix
+      - name: Set Milestone for Issue
+        uses: hustcer/milestone-action@main
+        if: github.event.issue.state == 'closed'
+        with:
+          action: bind-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

Use https://github.com/marketplace/actions/milestone-action to add milestone to a closed issue that has a merged PR fix automatically
