### PR TITLE
Make contributor image wider

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Please submit an issue or PR to be added to this list.
 See [Contributing](CONTRIBUTING.md) for details. Thanks to all the people who already contributed!
 
 <a href="https://github.com/nushell/nushell/graphs/contributors">
-  <img src="https://contributors-img.web.app/image?repo=nushell/nushell&max=750" />
+  <img src="https://contributors-img.web.app/image?repo=nushell/nushell&max=750&columns=25" />
 </a>
 
 ## License

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Please submit an issue or PR to be added to this list.
 See [Contributing](CONTRIBUTING.md) for details. Thanks to all the people who already contributed!
 
 <a href="https://github.com/nushell/nushell/graphs/contributors">
-  <img src="https://contributors-img.web.app/image?repo=nushell/nushell&max=750&columns=25" />
+  <img src="https://contributors-img.web.app/image?repo=nushell/nushell&max=750&columns=20" />
 </a>
 
 ## License


### PR DESCRIPTION
With this many contributors you otherwise have to scroll really far to get down to the license info. 

The alternative would be to limit the number of faces we show, but it is cool to have them all (as long as the generated svg doesn't take too long to load or generate)

