### PR TITLE
Add metadata on `open --raw` with bytestreams

### DIFF
--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -146,10 +146,16 @@ impl Command for Open {
                         }
                     };
 
-                    let content_type = path
-                        .extension()
-                        .map(|ext| ext.to_string_lossy().to_string())
-                        .and_then(|ref s| detect_content_type(s));
+                    // Assigning content type should only happen in raw mode. Otherwise, the content
+                    // will potentially be in one of the built-in nushell `from xxx` formats and therefore
+                    // cease to be in the original content-type.... or so I'm told. :)
+                    let content_type = if raw {
+                        path.extension()
+                            .map(|ext| ext.to_string_lossy().to_string())
+                            .and_then(|ref s| detect_content_type(s))
+                    } else {
+                        None
+                    };
 
                     let stream = PipelineData::ByteStream(
                         ByteStream::file(file, call_span, engine_state.signals().clone()),

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -146,13 +146,10 @@ impl Command for Open {
                         }
                     };
 
-                    let content_type = if raw {
-                        path.extension()
-                            .map(|ext| ext.to_string_lossy().to_string())
-                            .and_then(|ref s| detect_content_type(s))
-                    } else {
-                        None
-                    };
+                    let content_type = path
+                        .extension()
+                        .map(|ext| ext.to_string_lossy().to_string())
+                        .and_then(|ref s| detect_content_type(s));
 
                     let stream = PipelineData::ByteStream(
                         ByteStream::file(file, call_span, engine_state.signals().clone()),
@@ -283,6 +280,9 @@ fn detect_content_type(extension: &str) -> Option<String> {
     match extension {
         // Per RFC-9512, application/yaml should be used
         "yaml" | "yml" => Some("application/yaml".to_string()),
+        "nu" => Some("application/x-nuscript".to_string()),
+        "json" | "jsonl" | "ndjson" => Some("application/json".to_string()),
+        "nuon" => Some("application/x-nuon".to_string()),
         _ => mime_guess::from_ext(extension)
             .first()
             .map(|mime| mime.to_string()),

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -383,23 +383,23 @@ fn open_files_inside_glob_metachars_dir() {
 #[test]
 fn test_content_types_with_open_raw() {
     Playground::setup("open_files_content_type_test", |dirs, _| {
-        let result = nu!(cwd: dirs.formats(), "open --raw random_numbers.csv | metadata");
+        let result = nu!(cwd: dirs.formats(), "open random_numbers.csv | metadata");
         assert!(result.out.contains("text/csv"));
-        let result = nu!(cwd: dirs.formats(), "open --raw caco3_plastics.tsv | metadata");
+        let result = nu!(cwd: dirs.formats(), "open caco3_plastics.tsv | metadata");
         assert!(result.out.contains("text/tab-separated-values"));
-        let result = nu!(cwd: dirs.formats(), "open --raw sample-simple.json | metadata");
+        let result = nu!(cwd: dirs.formats(), "open sample-simple.json | metadata");
         assert!(result.out.contains("application/json"));
-        let result = nu!(cwd: dirs.formats(), "open --raw sample.ini | metadata");
+        let result = nu!(cwd: dirs.formats(), "open sample.ini | metadata");
         assert!(result.out.contains("text/plain"));
-        let result = nu!(cwd: dirs.formats(), "open --raw sample_data.xlsx | metadata");
+        let result = nu!(cwd: dirs.formats(), "open -r sample_data.xlsx | metadata");
         assert!(result.out.contains("vnd.openxmlformats-officedocument"));
-        let result = nu!(cwd: dirs.formats(), "open --raw sample_def.nu | metadata");
-        assert!(!result.out.contains("content_type"));
-        let result = nu!(cwd: dirs.formats(), "open --raw sample.eml | metadata");
+        let result = nu!(cwd: dirs.formats(), "open sample_def.nu | metadata");
+        assert!(result.out.contains("application/x-nuscript"));
+        let result = nu!(cwd: dirs.formats(), "open sample.eml | metadata");
         assert!(result.out.contains("message/rfc822"));
-        let result = nu!(cwd: dirs.formats(), "open --raw cargo_sample.toml | metadata");
+        let result = nu!(cwd: dirs.formats(), "open cargo_sample.toml | metadata");
         assert!(result.out.contains("text/x-toml"));
-        let result = nu!(cwd: dirs.formats(), "open --raw appveyor.yml | metadata");
+        let result = nu!(cwd: dirs.formats(), "open appveyor.yml | metadata");
         assert!(result.out.contains("application/yaml"));
     })
 }

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -383,23 +383,23 @@ fn open_files_inside_glob_metachars_dir() {
 #[test]
 fn test_content_types_with_open_raw() {
     Playground::setup("open_files_content_type_test", |dirs, _| {
-        let result = nu!(cwd: dirs.formats(), "open random_numbers.csv | metadata");
+        let result = nu!(cwd: dirs.formats(), "open --raw random_numbers.csv | metadata");
         assert!(result.out.contains("text/csv"));
-        let result = nu!(cwd: dirs.formats(), "open caco3_plastics.tsv | metadata");
+        let result = nu!(cwd: dirs.formats(), "open --raw caco3_plastics.tsv | metadata");
         assert!(result.out.contains("text/tab-separated-values"));
-        let result = nu!(cwd: dirs.formats(), "open sample-simple.json | metadata");
+        let result = nu!(cwd: dirs.formats(), "open --raw sample-simple.json | metadata");
         assert!(result.out.contains("application/json"));
-        let result = nu!(cwd: dirs.formats(), "open sample.ini | metadata");
+        let result = nu!(cwd: dirs.formats(), "open --raw sample.ini | metadata");
         assert!(result.out.contains("text/plain"));
-        let result = nu!(cwd: dirs.formats(), "open -r sample_data.xlsx | metadata");
+        let result = nu!(cwd: dirs.formats(), "open --raw sample_data.xlsx | metadata");
         assert!(result.out.contains("vnd.openxmlformats-officedocument"));
-        let result = nu!(cwd: dirs.formats(), "open sample_def.nu | metadata");
+        let result = nu!(cwd: dirs.formats(), "open --raw sample_def.nu | metadata");
         assert!(result.out.contains("application/x-nuscript"));
-        let result = nu!(cwd: dirs.formats(), "open sample.eml | metadata");
+        let result = nu!(cwd: dirs.formats(), "open --raw sample.eml | metadata");
         assert!(result.out.contains("message/rfc822"));
-        let result = nu!(cwd: dirs.formats(), "open cargo_sample.toml | metadata");
+        let result = nu!(cwd: dirs.formats(), "open --raw cargo_sample.toml | metadata");
         assert!(result.out.contains("text/x-toml"));
-        let result = nu!(cwd: dirs.formats(), "open appveyor.yml | metadata");
+        let result = nu!(cwd: dirs.formats(), "open --raw appveyor.yml | metadata");
         assert!(result.out.contains("application/yaml"));
     })
 }

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -41,10 +41,7 @@ impl ByteStreamSource {
 
     /// Source is a `Child` or `File`, rather than `Read`. Currently affects trimming
     fn is_external(&self) -> bool {
-        matches!(
-            self,
-            ByteStreamSource::File(..) | ByteStreamSource::Child(..)
-        )
+        matches!(self, ByteStreamSource::Child(..))
     }
 }
 


### PR DESCRIPTION
# Description

This PR closes #14137 and allows the display hook to be set on byte streams. So, with a hook like this below.
```nushell
display_output: {
    metadata access {|meta| match $meta.content_type? {
        "application/x-nuscript" | "application/x-nuon" | "text/x-nushell" => { nu-highlight },
        "application/json" => { ^bat --language=json --color=always --style=plain --paging=never },
        _ => {},
        }
    } | table
}
```
You could type `open toolkit.nu` and the text of toolkit.nu would be highlighted by nu-highlight. This PR also changes the way content-type is assigned with `open`. Previously it would only assign it if `--raw` was specified.

Lastly, it changes the `is_external()` function to only say `ByteStreamSource::Child`'s are external instead of both Child and `ByteStreamSource::File`. Again, this was to allow the hook to function properly. I'm not sure what negative ramifications changing `is_external()` could have, but there may be some?

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
