### PR TITLE
add `name` to `$env.config.keybindings`

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -711,6 +711,7 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
     }
     for keybinding in parsed_keybindings {
         add_keybinding(
+            &keybinding.name,
             &keybinding.mode,
             keybinding,
             config,
@@ -729,7 +730,9 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
     }
 }
 
+#[allow(clippy::only_used_in_recursion)]
 fn add_keybinding(
+    name: &Option<Value>,
     mode: &Value,
     keybinding: &ParsedKeybinding,
     config: &Config,
@@ -752,6 +755,7 @@ fn add_keybinding(
         Value::List { vals, .. } => {
             for inner_mode in vals {
                 add_keybinding(
+                    name,
                     inner_mode,
                     keybinding,
                     config,

--- a/crates/nu-protocol/src/config/reedline.rs
+++ b/crates/nu-protocol/src/config/reedline.rs
@@ -5,6 +5,7 @@ use crate::{engine::Closure, FromValue};
 /// Definition of a parsed keybinding from the config object
 #[derive(Clone, Debug, FromValue, IntoValue, Serialize, Deserialize)]
 pub struct ParsedKeybinding {
+    pub name: Option<Value>,
     pub modifier: Value,
     pub keycode: Value,
     pub event: Value,


### PR DESCRIPTION
# Description

This PR adds the `name` column back to keybindings.
![image](https://github.com/user-attachments/assets/63d884c9-80af-4d27-a37f-b7861f1b81a7)

This may be considered a hack since the reedline keybinding has no spot for name, but it seems to work.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
