### PR TITLE
support table literal syntax in `join` right-table argument

### DIFF
--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -29,7 +29,7 @@ impl Command for Join {
         Signature::build("join")
             .required(
                 "right-table",
-                SyntaxShape::List(Box::new(SyntaxShape::Any)),
+                SyntaxShape::Table([].into()),
                 "The right table in the join.",
             )
             .required(

--- a/crates/nu-command/tests/commands/join.rs
+++ b/crates/nu-command/tests/commands/join.rs
@@ -355,7 +355,6 @@ fn do_cases_where_result_differs_between_join_types_with_different_join_keys(joi
     }
 }
 
-#[ignore]
 #[test]
 fn test_alternative_table_syntax() {
     let join_type = "--inner";


### PR DESCRIPTION
# Description

Makes `join` `right-table` support table literal notation instead of parsing the column list (treated as empty data):

```diff
[{a: 1}] | join [[a]; [1]] a | to nuon
-[]
+[[a]; [1]]
```

Fixes #13537, fixes #14134