### PR TITLE
Add Debian Dockerfile

### DIFF
--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -1,0 +1,56 @@
+# syntax=docker/dockerfile:latest
+
+# Git: git version 2.46.0
+# /etc/os-release: Debian GNU/Linux 12 (bookworm)
+# Kernel: Linux 8aa16b289a9f 5.15.153.1-microsoft-standard-WSL2 #1 SMP Fri Mar 29 23:14:13 UTC 2024 x86_64 GNU/Linux
+# Build cmd: docker build --no-cache --file debian.Dockerfile . -t nushell:latest
+# Other tags: nushell:latest-debian
+FROM debian:bookworm-slim
+
+ARG TARGETARCH
+ARG ARCH=${TARGETARCH/arm64/aarch64}
+ARG ARCH=${ARCH/arm/armv7}
+ARG ARCH=${ARCH/amd64/x86_64}
+
+ARG BUILD_REF
+ARG BUILD_DATE
+LABEL maintainer="The Nushell Project Developers" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.title="Nushell" \
+    org.opencontainers.image.created=$BUILD_DATE \
+    org.opencontainers.image.revision=$BUILD_REF \
+    org.opencontainers.image.authors="The Nushell Project Developers" \
+    org.opencontainers.image.vendor="Nushell Project" \
+    org.opencontainers.image.description="A new type of shell" \
+    org.opencontainers.image.source="https://github.com/nushell/nushell" \
+    org.opencontainers.image.documentation="https://www.nushell.sh/book/"
+
+RUN apt update && apt install -y wget \
+    && cd /tmp \
+    && wget -qO - https://api.github.com/repos/nushell/nushell/releases/latest \
+    | grep browser_download_url \
+    | cut -d '"' -f 4 \
+    | grep ${ARCH}-unknown-linux-gnu \
+    | xargs -I{} wget -q {} \
+    && mkdir nu-latest && tar xvf nu-*.tar.gz --directory=nu-latest \
+    && cp -aR nu-latest/**/* /usr/bin/ \
+    #  Setup nushell user
+    && echo '/usr/bin/nu' >> /etc/shells \
+    && useradd -p '' -s /usr/bin/nu nushell \
+    && mkdir -p /home/nushell/.config/nushell/ \
+    # Setup default config file for nushell
+    && cd /home/nushell/.config/nushell \
+    && chmod +x /usr/bin/nu \
+    && chown -R nushell:nushell /home/nushell/.config/nushell \
+    # Reset Nushell config to default
+    && su -c 'config reset -w' nushell \
+    && ls /usr/bin/nu_plugin* \
+    | xargs -I{} su -c 'plugin add {}' nushell \
+    && rm -rf /tmp/* \
+    && rm -rf /var/lib/apt/lists/*
+
+USER nushell
+
+WORKDIR /home/nushell
+
+ENTRYPOINT ["nu"]


### PR DESCRIPTION
# Description

Add Dockerfile for Debian/Ubuntu images.
Related to #14171 and PR #14191

This is largely similar to the Alpine version, however there are some minor differences:
- I've specially added Debian Bookworm here to provide some stability when new major versions are released. We can bump the (LTS only perhaps) versions supported as needed.
- I moved the creation of the nushell user until later to avoid a warning about the nu binary not (yet) being available.
- Debian doesn't come with wget or curl. I've added wget to be similar to Alpine. I tried creating a multi-layer version to avoid installing wget (reduced attack surface) but the image was bigger due to the extra layer, so didn't seem worth being different.

I can transfer the relevant changes to the Alpine image if we want to keep them easily diffable?

# User-Facing Changes

While this provides a Debian image by default. An Ubuntu image can be created from this by changing to `FROM ubuntu:noble`. We could later supply that as an optional argument from the build workflow to be able to build different distros and supported versions.

# Tests + Formatting

The images produced for Debian/Ubuntu are ~75Mb bigger as listed in `docker images`:

```
REPOSITORY                                       TAG             IMAGE ID       CREATED        SIZE
nu-alpine                                        latest          71c0216eddd9   44 years ago   167MB
nu-debian                                        latest          cce3d91fc77c   44 years ago   243MB
nu-ubuntu                                        latest          ce90497da806   44 years ago   240MB
```

I've tested a few nu commands, including polars. It seems to work okay. It makes sense to add some container-based tests once the workflows are available. I'll probably pick that up later when @hustcer has completed the migration of his workflows. Perhaps invoking a nushell-based test suite if one is available. The toolkit seems to rely on cargo and the source being available, which of course won't work here.
