### PR TITLE
Improve `CellPath` display output

### DIFF
--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -223,7 +223,7 @@ fn test_computable_style_closure_basic() {
         ];
         let actual_repl = nu!(cwd: dirs.test(), nu_repl_code(&inp));
         assert_eq!(actual_repl.err, "");
-        assert_eq!(actual_repl.out, "[bell.obj, book.obj, candle.obj]");
+        assert_eq!(actual_repl.out, r#"["bell.obj", "book.obj", "candle.obj"]"#);
     });
 }
 

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -157,7 +157,7 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
             let mut inner_table = None;
 
             for (column_index, (column, value)) in val.into_owned().into_iter().enumerate() {
-                let column_requested = columns.iter().find(|c| c.to_string() == column);
+                let column_requested = columns.iter().find(|c| c.to_column_name() == column);
                 let need_flatten = { columns.is_empty() || column_requested.is_some() };
                 let span = value.span();
 

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -240,7 +240,7 @@ fn select(
                                 //FIXME: improve implementation to not clone
                                 match input_val.clone().follow_cell_path(&path.members, false) {
                                     Ok(fetcher) => {
-                                        record.push(path.to_string(), fetcher);
+                                        record.push(path.to_column_name(), fetcher);
                                         if !columns_with_value.contains(&path) {
                                             columns_with_value.push(path);
                                         }
@@ -271,7 +271,7 @@ fn select(
                             // FIXME: remove clone
                             match v.clone().follow_cell_path(&cell_path.members, false) {
                                 Ok(result) => {
-                                    record.push(cell_path.to_string(), result);
+                                    record.push(cell_path.to_column_name(), result);
                                 }
                                 Err(e) => return Err(e),
                             }
@@ -295,7 +295,7 @@ fn select(
                         //FIXME: improve implementation to not clone
                         match x.clone().follow_cell_path(&path.members, false) {
                             Ok(value) => {
-                                record.push(path.to_string(), value);
+                                record.push(path.to_column_name(), value);
                             }
                             Err(e) => return Err(e),
                         }

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -130,7 +130,10 @@ fn reject_optional_row() {
 #[test]
 fn reject_columns_with_list_spread() {
     let actual = nu!("let arg = [type size]; [[name type size];[Cargo.toml file 10mb] [Cargo.lock file 10mb] [src dir 100mb]] | reject ...$arg | to nuon");
-    assert_eq!(actual.out, "[[name]; [Cargo.toml], [Cargo.lock], [src]]");
+    assert_eq!(
+        actual.out,
+        r#"[[name]; ["Cargo.toml"], ["Cargo.lock"], [src]]"#
+    );
 }
 
 #[test]
@@ -138,7 +141,7 @@ fn reject_rows_with_list_spread() {
     let actual = nu!("let arg = [2 0]; [[name type size];[Cargo.toml file 10mb] [Cargo.lock file 10mb] [src dir 100mb]] | reject ...$arg | to nuon");
     assert_eq!(
         actual.out,
-        "[[name, type, size]; [Cargo.lock, file, 10000000b]]"
+        r#"[[name, type, size]; ["Cargo.lock", file, 10000000b]]"#
     );
 }
 
@@ -147,7 +150,7 @@ fn reject_mixed_with_list_spread() {
     let actual = nu!("let arg = [type 2]; [[name type size];[Cargp.toml file 10mb] [ Cargo.lock file 10mb] [src dir 100mb]] | reject ...$arg | to nuon");
     assert_eq!(
         actual.out,
-        "[[name, size]; [Cargp.toml, 10000000b], [Cargo.lock, 10000000b]]"
+        r#"[[name, size]; ["Cargp.toml", 10000000b], ["Cargo.lock", 10000000b]]"#
     );
 }
 

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -166,7 +166,7 @@ fn select_ignores_errors_successfully1() {
 fn select_ignores_errors_successfully2() {
     let actual = nu!("[{a: 1} {a: 2} {a: 3}] | select b? | to nuon");
 
-    assert_eq!(actual.out, "[[b?]; [null], [null], [null]]".to_string());
+    assert_eq!(actual.out, "[[b]; [null], [null], [null]]".to_string());
     assert!(actual.err.is_empty());
 }
 
@@ -174,7 +174,7 @@ fn select_ignores_errors_successfully2() {
 fn select_ignores_errors_successfully3() {
     let actual = nu!("{foo: bar} | select invalid_key? | to nuon");
 
-    assert_eq!(actual.out, "{invalid_key?: null}".to_string());
+    assert_eq!(actual.out, "{invalid_key: null}".to_string());
     assert!(actual.err.is_empty());
 }
 
@@ -184,10 +184,7 @@ fn select_ignores_errors_successfully4() {
         r#""key val\na 1\nb 2\n" | lines | split column --collapse-empty " " | select foo? | to nuon"#
     );
 
-    assert_eq!(
-        actual.out,
-        r#"[[foo?]; [null], [null], [null]]"#.to_string()
-    );
+    assert_eq!(actual.out, r#"[[foo]; [null], [null], [null]]"#.to_string());
     assert!(actual.err.is_empty());
 }
 
@@ -237,7 +234,7 @@ fn ignore_errors_works() {
         [{}] | select -i $path | to nuon
         "#);
 
-    assert_eq!(actual.out, "[[foo?]; [null]]");
+    assert_eq!(actual.out, "[[foo]; [null]]");
 }
 
 #[test]

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -59,6 +59,7 @@ serde_json = { workspace = true }
 strum = "0.26"
 strum_macros = "0.26"
 nu-test-support = { path = "../nu-test-support", version = "0.99.2" }
+nu-utils = { path = "../nu-utils", version = "0.99.2" }
 pretty_assertions = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -174,6 +174,27 @@ impl CellPath {
             member.make_optional();
         }
     }
+
+    // Formats the cell-path as a column name, i.e. without quoting and optional markers ('?').
+    pub fn to_column_name(&self) -> String {
+        let mut s = String::new();
+
+        for member in &self.members {
+            match member {
+                PathMember::Int { val, .. } => {
+                    s += &val.to_string();
+                }
+                PathMember::String { val, .. } => {
+                    s += val;
+                }
+            }
+
+            s.push('.');
+        }
+
+        s.pop(); // Easier than checking whether to insert the '.' on every iteration.
+        s
+    }
 }
 
 impl Display for CellPath {

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -1,5 +1,6 @@
 use super::Expression;
 use crate::Span;
+use nu_utils::{escape_quote_string, needs_quoting};
 use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, fmt::Display};
 
@@ -177,18 +178,21 @@ impl CellPath {
 
 impl Display for CellPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (idx, elem) in self.members.iter().enumerate() {
-            if idx > 0 {
-                write!(f, ".")?;
-            }
-            match elem {
+        write!(f, "$")?;
+        for member in self.members.iter() {
+            match member {
                 PathMember::Int { val, optional, .. } => {
                     let question_mark = if *optional { "?" } else { "" };
-                    write!(f, "{val}{question_mark}")?
+                    write!(f, ".{val}{question_mark}")?
                 }
                 PathMember::String { val, optional, .. } => {
                     let question_mark = if *optional { "?" } else { "" };
-                    write!(f, "{val}{question_mark}")?
+                    let val = if needs_quoting(val) {
+                        &escape_quote_string(val)
+                    } else {
+                        val
+                    };
+                    write!(f, ".{val}{question_mark}")?
                 }
             }
         }

--- a/crates/nu-utils/src/quoting.rs
+++ b/crates/nu-utils/src/quoting.rs
@@ -2,12 +2,12 @@ use fancy_regex::Regex;
 use std::sync::LazyLock;
 
 // This hits, in order:
-// • Any character of []:`{}#'";()|$,
+// • Any character of []:`{}#'";()|$,.
 // • Any digit (\d)
 // • Any whitespace (\s)
 // • Case-insensitive sign-insensitive float "keywords" inf, infinity and nan.
 static NEEDS_QUOTING_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"[\[\]:`\{\}#'";\(\)\|\$,\d\s]|(?i)^[+\-]?(inf(inity)?|nan)$"#)
+    Regex::new(r#"[\[\]:`\{\}#'";\(\)\|\$,\.\d\s]|(?i)^[+\-]?(inf(inity)?|nan)$"#)
         .expect("internal error: NEEDS_QUOTING_REGEX didn't compile")
 });
 

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -97,7 +97,7 @@ fn value_to_string(
                 Ok("false".to_string())
             }
         }
-        Value::CellPath { val, .. } => Ok(format!("$.{}", val)),
+        Value::CellPath { val, .. } => Ok(val.to_string()),
         Value::Custom { .. } => Err(ShellError::UnsupportedInput {
             msg: "custom values are currently not nuon-compatible".to_string(),
             input: "value originates from here".into(),
@@ -116,10 +116,10 @@ fn value_to_string(
             if &val.round() == val && val.is_finite() {
                 Ok(format!("{}.0", *val))
             } else {
-                Ok(format!("{}", *val))
+                Ok(val.to_string())
             }
         }
-        Value::Int { val, .. } => Ok(format!("{}", *val)),
+        Value::Int { val, .. } => Ok(val.to_string()),
         Value::List { vals, .. } => {
             let headers = get_columns(vals);
             if !headers.is_empty() && vals.iter().all(|x| x.columns().eq(headers.iter())) {

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -177,7 +177,7 @@ fn spread_args_type() -> TestResult {
 fn explain_spread_args() -> TestResult {
     run_test(
         r#"(explain { || echo ...[1 2] }).cmd_args.0 | select arg_type name type | to nuon"#,
-        r#"[[arg_type, name, type]; [spread, "[1 2]", list<int>]]"#,
+        r#"[["$.arg_type", "$.name", "$.type"]; [spread, "[1 2]", list<int>]]"#,
     )
 }
 

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -30,7 +30,7 @@ fn not_spread() -> TestResult {
     run_test(r#"def ... [x] { $x }; ... ..."#, "...").unwrap();
     run_test(
         r#"let a = 4; [... $a ... [1] ... (5) ...bare ...] | to nuon"#,
-        "[..., 4, ..., [1], ..., 5, ...bare, ...]",
+        r#"["...", 4, "...", [1], "...", 5, "...bare", "..."]"#,
     )
 }
 
@@ -177,7 +177,7 @@ fn spread_args_type() -> TestResult {
 fn explain_spread_args() -> TestResult {
     run_test(
         r#"(explain { || echo ...[1 2] }).cmd_args.0 | select arg_type name type | to nuon"#,
-        r#"[["$.arg_type", "$.name", "$.type"]; [spread, "[1 2]", list<int>]]"#,
+        r#"[[arg_type, name, type]; [spread, "[1 2]", list<int>]]"#,
     )
 }
 

--- a/tests/repl/test_table_operations.rs
+++ b/tests/repl/test_table_operations.rs
@@ -248,7 +248,7 @@ fn get() -> TestResult {
 #[test]
 fn select_1() -> TestResult {
     run_test(
-        r#"([[name, age]; [a, 1], [b, 2]]) | select name | get 1 | get name"#,
+        r#"([[name, age]; [a, 1], [b, 2]]) | select name | get 1 | get '$.name'"#,
         "b",
     )
 }
@@ -256,7 +256,7 @@ fn select_1() -> TestResult {
 #[test]
 fn select_2() -> TestResult {
     run_test(
-        r#"[[name, age]; [a, 1] [b, 2]] | get 1 | select age | get age"#,
+        r#"[[name, age]; [a, 1] [b, 2]] | get 1 | select age | get '$.age'"#,
         "2",
     )
 }

--- a/tests/repl/test_table_operations.rs
+++ b/tests/repl/test_table_operations.rs
@@ -248,7 +248,7 @@ fn get() -> TestResult {
 #[test]
 fn select_1() -> TestResult {
     run_test(
-        r#"([[name, age]; [a, 1], [b, 2]]) | select name | get 1 | get '$.name'"#,
+        r#"([[name, age]; [a, 1], [b, 2]]) | select name | get 1 | get name"#,
         "b",
     )
 }
@@ -256,7 +256,7 @@ fn select_1() -> TestResult {
 #[test]
 fn select_2() -> TestResult {
     run_test(
-        r#"[[name, age]; [a, 1] [b, 2]] | get 1 | select age | get '$.age'"#,
+        r#"[[name, age]; [a, 1] [b, 2]] | get 1 | select age | get age"#,
         "2",
     )
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Fixes: #13362

This PR fixes the `Display` impl for `CellPath`, as laid out in #13362 and #14090:

```nushell
> $.0."0"
$.0."0"

> $."foo.bar".baz
$."foo.bar".baz
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Cell-paths are now printed using the same `$.` notation that is used to create them, and ambiguous column names are properly quoted.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
