### PR TITLE
Allow using function keys F21-F35 for keybindings

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -862,10 +862,10 @@ fn add_parsed_keybinding(
             c if c.starts_with('f') => c[1..]
                 .parse()
                 .ok()
-                .filter(|num| (1..=20).contains(num))
+                .filter(|num| (1..=35).contains(num))
                 .map(KeyCode::F)
                 .ok_or(ShellError::InvalidValue {
-                    valid: "'f1', 'f2', ..., or 'f20'".into(),
+                    valid: "'f1', 'f2', ..., or 'f35'".into(),
                     actual: format!("'{keycode}'"),
                     span: keybinding.keycode.span(),
                 })?,


### PR DESCRIPTION
I feel like the limitations on what can be bound are too strict.

I'm a fan of using MacOs keybindings [0] in terminal applications. Since not every app I use supports the Kitty keyboard protocol, I have bound these to a sequence of bytes so that:

* if an app doesn't support the Kitty keyboard protocol (Zsh, iPython...) I can remap this sequence of bytes to the desired action.
* if an app _does_ support the Kitty keyboard protocol (Neovim, Reedline), I can map the function keys (F27-F35 as listed below).

<details>
<summary>kitty.conf</summary>

```kitty
# F27
map cmd+z           send_text all \x1b[57390u
# F28
map cmd+left        send_text all \x1b[57391u
# F29
map cmd+right       send_text all \x1b[57392u
# F30
map cmd+backspace   send_text all \x1b[57393u
# F31
map cmd+delete      send_text all \x1b[57394u
# F32
map alt+left        send_text all \x1b[57395u
# F33
map alt+right       send_text all \x1b[57396u
# F34
map alt+backspace   send_text all \x1b[57397u
# F35
map alt+delete      send_text all \x1b[57398u
```

</details>

In Reedline everything works perfectly. The issue is for some reason we limit the keys that can be bound in Nushell, so I am unable to do that.

(Also, there's no way to bind a sequence of bytes in Reedline so I can't fall back to the dumb method).

Thank you!

[0] like `(alt|cmd)+backspace` for deleting a word|line or `(alt|cmd)+(left|right)` for jumping back/forward