### PR TITLE
Add RELEASE_QUERY_API build arg for Dockerfiles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ ARG ARCH=${ARCH/amd64/x86_64}
 
 ARG BUILD_REF
 ARG BUILD_DATE
+ARG RELEASE_QUERY_API="https://api.github.com/repos/nushell/nushell/releases/latest"
+
 LABEL maintainer="The Nushell Project Developers" \
     org.opencontainers.image.licenses="MIT" \
     org.opencontainers.image.title="Nushell" \
@@ -29,7 +31,7 @@ RUN echo '/usr/bin/nu' >> /etc/shells \
     && adduser -D -s /usr/bin/nu nushell \
     && mkdir -p /home/nushell/.config/nushell/ \
     && cd /tmp \
-    && wget -qO - https://api.github.com/repos/nushell/nushell/releases/latest \
+    && wget -qO - ${RELEASE_QUERY_API} \
     | grep browser_download_url \
     | cut -d '"' -f 4 \
     | grep ${ARCH}-unknown-linux-musl \

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -14,6 +14,8 @@ ARG ARCH=${ARCH/amd64/x86_64}
 
 ARG BUILD_REF
 ARG BUILD_DATE
+ARG RELEASE_QUERY_API="https://api.github.com/repos/nushell/nushell/releases/latest"
+
 LABEL maintainer="The Nushell Project Developers" \
     org.opencontainers.image.licenses="MIT" \
     org.opencontainers.image.title="Nushell" \
@@ -27,7 +29,7 @@ LABEL maintainer="The Nushell Project Developers" \
 
 RUN apt update && apt install -y wget \
     && cd /tmp \
-    && wget -qO - https://api.github.com/repos/nushell/nushell/releases/latest \
+    && wget -qO - ${RELEASE_QUERY_API} \
     | grep browser_download_url \
     | cut -d '"' -f 4 \
     | grep ${ARCH}-unknown-linux-gnu \


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Add `RELEASE_QUERY_API` build arg for all Dockerfiles, with default value set to `https://api.github.com/repos/nushell/nushell/releases/latest`, So that we can build the nightly images with the same Dockerfile but a different  `RELEASE_QUERY_API` build arg.

A nightly image build with the new Dockerfile could be found here: https://github.com/orgs/nushell/packages/container/nushell/297473460?tag=nightly

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

The default behavior keep the same as before

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

Those who want to build a docker image with the nushell nightly release installed could run:
```nu
let queryApi = http get https://api.github.com/repos/nushell/nightly/releases | sort-by -r created_at | get 0.url
docker buildx build --build-arg $'RELEASE_QUERY_API=($queryApi)' ...
```
