### PR TITLE
no deref in touch

### DIFF
--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -181,7 +181,11 @@ impl Command for Touch {
                 let result = if no_follow_symlinks {
                     filetime::set_symlink_file_times(
                         &path,
-                        FileTime::from_system_time(get_target_metadata()?.accessed()?),
+                        if change_atime {
+                            FileTime::from_system_time(atime)
+                        } else {
+                            FileTime::from_system_time(get_target_metadata()?.accessed()?)
+                        },
                         FileTime::from_system_time(mtime),
                     )
                 } else {
@@ -200,7 +204,11 @@ impl Command for Touch {
                     filetime::set_symlink_file_times(
                         &path,
                         FileTime::from_system_time(atime),
-                        FileTime::from_system_time(get_target_metadata()?.modified()?),
+                        if change_mtime {
+                            FileTime::from_system_time(mtime)
+                        } else {
+                            FileTime::from_system_time(get_target_metadata()?.modified()?)
+                        },
                     )
                 } else {
                     filetime::set_file_atime(&path, FileTime::from_system_time(atime))

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -51,7 +51,7 @@ impl Command for Touch {
             .switch(
                 "no-deref",
                 "do not follow symlinks",
-                Some('d')
+                Some('s')
             )
             .category(Category::FileSystem)
     }

--- a/crates/nu-command/tests/commands/touch.rs
+++ b/crates/nu-command/tests/commands/touch.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Local};
 use nu_test_support::fs::{files_exist_at, Stub};
 use nu_test_support::nu;
-use nu_test_support::playground::Playground;
+use nu_test_support::playground::{Dirs, Playground};
 
 // Use 1 instead of 0 because 0 has a special meaning in Windows
 const TIME_ONE: filetime::FileTime = filetime::FileTime::from_unix_time(1, 0);
@@ -525,5 +525,129 @@ fn reference_respects_cwd() {
 
         let path = dirs.test().join("dir/foo.txt");
         assert!(path.exists());
+    })
+}
+
+fn setup_symlink_fs(dirs: &Dirs, sandbox: &mut Playground<'_>) {
+    sandbox.mkdir("d");
+    sandbox.with_files(&[Stub::EmptyFile("f"), Stub::EmptyFile("d/f")]);
+    sandbox.symlink("f", "fs");
+    sandbox.symlink("d", "ds");
+    sandbox.symlink("d/f", "fds");
+
+    // sandbox.symlink does not handle symlinks to missing files well. It panics
+    // But they are useful, and they should be tested.
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(dirs.test().join("m"), dirs.test().join("fms")).unwrap();
+    }
+
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_file(dirs.test().join("m"), dirs.test().join("fms")).unwrap();
+    }
+
+    // Change the file times to a known "old" value for comparison
+    filetime::set_symlink_file_times(dirs.test().join("f"), TIME_ONE, TIME_ONE).unwrap();
+    filetime::set_symlink_file_times(dirs.test().join("d"), TIME_ONE, TIME_ONE).unwrap();
+    filetime::set_symlink_file_times(dirs.test().join("d/f"), TIME_ONE, TIME_ONE).unwrap();
+    filetime::set_symlink_file_times(dirs.test().join("ds"), TIME_ONE, TIME_ONE).unwrap();
+    filetime::set_symlink_file_times(dirs.test().join("fs"), TIME_ONE, TIME_ONE).unwrap();
+    filetime::set_symlink_file_times(dirs.test().join("fds"), TIME_ONE, TIME_ONE).unwrap();
+    filetime::set_symlink_file_times(dirs.test().join("fms"), TIME_ONE, TIME_ONE).unwrap();
+}
+
+fn get_times(path: &nu_path::AbsolutePath) -> (filetime::FileTime, filetime::FileTime) {
+    let metadata = path.symlink_metadata().unwrap();
+
+    (
+        filetime::FileTime::from_system_time(metadata.accessed().unwrap()),
+        filetime::FileTime::from_system_time(metadata.modified().unwrap()),
+    )
+}
+
+#[test]
+fn follow_symlinks() {
+    Playground::setup("touch_follows_symlinks", |dirs, sandbox| {
+        setup_symlink_fs(&dirs, sandbox);
+
+        let missing = dirs.test().join("m");
+        assert!(!missing.exists());
+
+        nu!(
+            cwd: dirs.test(),
+            "
+                touch fms
+                touch fds
+                touch ds
+                touch fs
+            "
+        );
+
+        // We created the missing symlink target
+        assert!(missing.exists());
+
+        // The timestamps for files and directories were changed from TIME_ONE
+        let file_times = get_times(&dirs.test().join("f"));
+        let dir_times = get_times(&dirs.test().join("d"));
+        let dir_file_times = get_times(&dirs.test().join("d/f"));
+
+        assert_ne!(file_times, (TIME_ONE, TIME_ONE));
+        assert_ne!(dir_times, (TIME_ONE, TIME_ONE));
+        assert_ne!(dir_file_times, (TIME_ONE, TIME_ONE));
+
+        // For symlinks, they remain the same
+        let file_symlink_times = get_times(&dirs.test().join("fs"));
+        let dir_symlink_times = get_times(&dirs.test().join("ds"));
+        let dir_file_symlink_times = get_times(&dirs.test().join("fds"));
+        let file_missing_symlink_times = get_times(&dirs.test().join("fms"));
+
+        assert_eq!(file_symlink_times, (TIME_ONE, TIME_ONE));
+        assert_eq!(dir_symlink_times, (TIME_ONE, TIME_ONE));
+        assert_eq!(dir_file_symlink_times, (TIME_ONE, TIME_ONE));
+        assert_eq!(file_missing_symlink_times, (TIME_ONE, TIME_ONE));
+    })
+}
+
+#[test]
+fn no_follow_symlinks() {
+    Playground::setup("touch_touches_symlinks", |dirs, sandbox| {
+        setup_symlink_fs(&dirs, sandbox);
+
+        let missing = dirs.test().join("m");
+        assert!(!missing.exists());
+
+        nu!(
+            cwd: dirs.test(),
+            "
+                touch fms -d
+                touch fds -d
+                touch ds -d
+                touch fs -d
+            "
+        );
+
+        // We did not create the missing symlink target
+        assert!(!missing.exists());
+
+        // The timestamps for files and directories remain the same
+        let file_times = get_times(&dirs.test().join("f"));
+        let dir_times = get_times(&dirs.test().join("d"));
+        let dir_file_times = get_times(&dirs.test().join("d/f"));
+
+        assert_eq!(file_times, (TIME_ONE, TIME_ONE));
+        assert_eq!(dir_times, (TIME_ONE, TIME_ONE));
+        assert_eq!(dir_file_times, (TIME_ONE, TIME_ONE));
+
+        // For symlinks, everything changed. (except their targets, and paths, and personality)
+        let file_symlink_times = get_times(&dirs.test().join("fs"));
+        let dir_symlink_times = get_times(&dirs.test().join("ds"));
+        let dir_file_symlink_times = get_times(&dirs.test().join("fds"));
+        let file_missing_symlink_times = get_times(&dirs.test().join("fms"));
+
+        assert_ne!(file_symlink_times, (TIME_ONE, TIME_ONE));
+        assert_ne!(dir_symlink_times, (TIME_ONE, TIME_ONE));
+        assert_ne!(dir_file_symlink_times, (TIME_ONE, TIME_ONE));
+        assert_ne!(file_missing_symlink_times, (TIME_ONE, TIME_ONE));
     })
 }

--- a/crates/nu-command/tests/commands/touch.rs
+++ b/crates/nu-command/tests/commands/touch.rs
@@ -596,16 +596,17 @@ fn follow_symlinks() {
         assert_ne!(dir_times, (TIME_ONE, TIME_ONE));
         assert_ne!(dir_file_times, (TIME_ONE, TIME_ONE));
 
-        // For symlinks, they remain the same
+        // For symlinks, they remain (mostly) the same
+        // We can't test accessed times, since to reach the target file, the symlink must be accessed!
         let file_symlink_times = get_times(&dirs.test().join("fs"));
         let dir_symlink_times = get_times(&dirs.test().join("ds"));
         let dir_file_symlink_times = get_times(&dirs.test().join("fds"));
         let file_missing_symlink_times = get_times(&dirs.test().join("fms"));
 
-        assert_eq!(file_symlink_times, (TIME_ONE, TIME_ONE));
-        assert_eq!(dir_symlink_times, (TIME_ONE, TIME_ONE));
-        assert_eq!(dir_file_symlink_times, (TIME_ONE, TIME_ONE));
-        assert_eq!(file_missing_symlink_times, (TIME_ONE, TIME_ONE));
+        assert_eq!(file_symlink_times.1, TIME_ONE);
+        assert_eq!(dir_symlink_times.1, TIME_ONE);
+        assert_eq!(dir_file_symlink_times.1, TIME_ONE);
+        assert_eq!(file_missing_symlink_times.1, TIME_ONE);
     })
 }
 

--- a/crates/nu-command/tests/commands/touch.rs
+++ b/crates/nu-command/tests/commands/touch.rs
@@ -621,10 +621,10 @@ fn no_follow_symlinks() {
         nu!(
             cwd: dirs.test(),
             "
-                touch fds -d
-                touch ds -d
-                touch fs -d
-                touch fms -d
+                touch fds -s
+                touch ds -s
+                touch fs -s
+                touch fms -s
             "
         );
 

--- a/crates/nu-command/tests/commands/touch.rs
+++ b/crates/nu-command/tests/commands/touch.rs
@@ -577,10 +577,10 @@ fn follow_symlinks() {
         nu!(
             cwd: dirs.test(),
             "
-                touch fms
                 touch fds
                 touch ds
                 touch fs
+                touch fms
             "
         );
 
@@ -620,10 +620,10 @@ fn no_follow_symlinks() {
         nu!(
             cwd: dirs.test(),
             "
-                touch fms -d
                 touch fds -d
                 touch ds -d
                 touch fs -d
+                touch fms -d
             "
         );
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Adds --no-deref flag to `touch`. Nice and backwards compatible, and I get to touch symlinks. I still don't get to set their dates directly, but maybe that'll come with utouch.

Some sadness in the implementation, since `set_symlink_file_times` doesn't take Option values and we call it twice with the old "read" values from reference (or now, if missing). This shouldn't be a big concern since `touch` already did two calls if you set both mtime and atime. Also, `--no-deref` applies both to the reference file, and to the target file. No splitting them up, because that's silly.

Can always bikeshed. I nicked `--no-deref` from the uutils flag, and made the short flag `-d` because it obviously can't be `-h`. I thought of `-S` like in `glob`, for the "negative/filter out" uppercase short letters. Ultimately I don't think it matters much.

Should fix #14212 since it's not really tied to uutils, besides the comment about setting a `datetime` value directly.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
New flag.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Maybe.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
