### PR TITLE
Revert "Show `?` for optional entries when displaying `CellPath`s"

### DIFF
--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -166,7 +166,7 @@ fn select_ignores_errors_successfully1() {
 fn select_ignores_errors_successfully2() {
     let actual = nu!("[{a: 1} {a: 2} {a: 3}] | select b? | to nuon");
 
-    assert_eq!(actual.out, "[[b?]; [null], [null], [null]]".to_string());
+    assert_eq!(actual.out, "[[b]; [null], [null], [null]]".to_string());
     assert!(actual.err.is_empty());
 }
 
@@ -174,7 +174,7 @@ fn select_ignores_errors_successfully2() {
 fn select_ignores_errors_successfully3() {
     let actual = nu!("{foo: bar} | select invalid_key? | to nuon");
 
-    assert_eq!(actual.out, "{invalid_key?: null}".to_string());
+    assert_eq!(actual.out, "{invalid_key: null}".to_string());
     assert!(actual.err.is_empty());
 }
 
@@ -184,10 +184,7 @@ fn select_ignores_errors_successfully4() {
         r#""key val\na 1\nb 2\n" | lines | split column --collapse-empty " " | select foo? | to nuon"#
     );
 
-    assert_eq!(
-        actual.out,
-        r#"[[foo?]; [null], [null], [null]]"#.to_string()
-    );
+    assert_eq!(actual.out, r#"[[foo]; [null], [null], [null]]"#.to_string());
     assert!(actual.err.is_empty());
 }
 
@@ -237,7 +234,7 @@ fn ignore_errors_works() {
         [{}] | select -i $path | to nuon
         "#);
 
-    assert_eq!(actual.out, "[[foo?]; [null]]");
+    assert_eq!(actual.out, "[[foo]; [null]]");
 }
 
 #[test]

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -182,14 +182,8 @@ impl Display for CellPath {
                 write!(f, ".")?;
             }
             match elem {
-                PathMember::Int { val, optional, .. } => {
-                    let question_mark = if *optional { "?" } else { "" };
-                    write!(f, "{val}{question_mark}")?
-                }
-                PathMember::String { val, optional, .. } => {
-                    let question_mark = if *optional { "?" } else { "" };
-                    write!(f, "{val}{question_mark}")?
-                }
+                PathMember::Int { val, .. } => write!(f, "{val}")?,
+                PathMember::String { val, .. } => write!(f, "{val}")?,
             }
         }
         Ok(())


### PR DESCRIPTION
Reverts nushell/nushell#14042

Staging this revert because of @hustcer's comment in the original PR.

------

I think it's actually a breaking change:

### Before this PR the following line works:
```nushell
http get https://api.github.com/repos/nushell/nushell/releases/latest | select -i tag_name assets?.id? | flatten | rename -c {'assets.id': id}
```
### After this PR the above line will broken and should be changed to:
```nushell
http get https://api.github.com/repos/nushell/nushell/releases/latest | select -i tag_name assets?.id? | flatten | rename -c {'assets?.id?': id}
```
It's weird that after this change the column names will have a ? suffix if `select` with `-i`, it may be unacceptable?: 
```nushell
[[version name]; ['0.1.0' nushell] ['0.1.1' fish] ['0.2.0' zsh]] | select -i version name | columns
 0   version? 
 1   name? 
```