### PR TITLE
Change --max-time arg for http commands to use `Duration` type

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -525,7 +525,7 @@ pub fn request_set_timeout(
     mut request: Request,
 ) -> Result<Request, ShellError> {
     if let Some(timeout) = timeout {
-        let val = timeout.as_i64()?;
+        let val = timeout.as_duration()?;
         if val.is_negative() || val < 1 {
             return Err(ShellError::TypeMismatch {
                 err_message: "Timeout value must be an int and larger than 0".to_string(),
@@ -533,7 +533,7 @@ pub fn request_set_timeout(
             });
         }
 
-        request = request.timeout(Duration::from_secs(val as u64));
+        request = request.timeout(Duration::from_nanos(val as u64));
     }
 
     Ok(request)

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -43,8 +43,8 @@ impl Command for SubCommand {
             )
             .named(
                 "max-time",
-                SyntaxShape::Int,
-                "timeout period in seconds",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
                 Some('m'),
             )
             .named(

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -38,8 +38,8 @@ impl Command for SubCommand {
             )
             .named(
                 "max-time",
-                SyntaxShape::Int,
-                "timeout period in seconds",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
                 Some('m'),
             )
             .named(

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -38,8 +38,8 @@ impl Command for SubCommand {
             )
             .named(
                 "max-time",
-                SyntaxShape::Int,
-                "timeout period in seconds",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
                 Some('m'),
             )
             .named(

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -37,8 +37,8 @@ impl Command for SubCommand {
             )
             .named(
                 "max-time",
-                SyntaxShape::Int,
-                "timeout period in seconds",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
                 Some('m'),
             )
             .named(

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -39,8 +39,8 @@ impl Command for SubCommand {
             )
             .named(
                 "max-time",
-                SyntaxShape::Int,
-                "timeout period in seconds",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
                 Some('m'),
             )
             .named(

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -39,8 +39,8 @@ impl Command for SubCommand {
             )
             .named(
                 "max-time",
-                SyntaxShape::Int,
-                "timeout period in seconds",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
                 Some('m'),
             )
             .named(

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -39,8 +39,8 @@ impl Command for SubCommand {
             )
             .named(
                 "max-time",
-                SyntaxShape::Int,
-                "timeout period in seconds",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
                 Some('m'),
             )
             .named(


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #14222
- fixes #14222

you can also mention related issues, PRs or discussions!
-->
- fixes #14222

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
The ability to set duration unit for `--max-time` when using the `http` command util.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
