### PR TITLE
add table params support to `url join` and `url build-query`

### DIFF
--- a/crates/nu-command/src/network/url/build_query.rs
+++ b/crates/nu-command/src/network/url/build_query.rs
@@ -1,6 +1,6 @@
 use nu_engine::command_prelude::*;
 
-use super::query::record_to_query_string;
+use super::query::{record_to_query_string, table_to_query_string};
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -14,7 +14,10 @@ impl Command for SubCommand {
         Signature::build("url build-query")
             .input_output_types(vec![
                 (Type::record(), Type::String),
-                (Type::table(), Type::String),
+                (
+                    Type::Table([("key".into(), Type::Any), ("value".into(), Type::Any)].into()),
+                    Type::String,
+                ),
             ])
             .category(Category::Network)
     }
@@ -35,11 +38,6 @@ impl Command for SubCommand {
                 result: Some(Value::test_string("mode=normal&userid=31415")),
             },
             Example {
-                description: "Outputs a query string representing the contents of this 1-row table",
-                example: r#"[[foo bar]; ["1" "2"]] | url build-query"#,
-                result: Some(Value::test_string("foo=1&bar=2")),
-            },
-            Example {
                 description: "Outputs a query string representing the contents of this record, with a value that needs to be url-encoded",
                 example: r#"{a:"AT&T", b: "AT T"} | url build-query"#,
                 result: Some(Value::test_string("a=AT%26T&b=AT+T")),
@@ -48,6 +46,11 @@ impl Command for SubCommand {
                 description: "Outputs a query string representing the contents of this record, \"exploding\" the list into multiple parameters",
                 example: r#"{a: ["one", "two"], b: "three"} | url build-query"#,
                 result: Some(Value::test_string("a=one&a=two&b=three")),
+            },
+            Example {
+                description: "Outputs a query string representing the contents of this table containing key-value pairs",
+                example: r#"[[key, value]; [a, one], [a, two], [b, three], [a, four]] | url build-query"#,
+                result: Some(Value::test_string("a=one&a=two&b=three&a=four")),
             },
         ]
     }
@@ -60,30 +63,23 @@ impl Command for SubCommand {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        to_url(input, head)
+        let input_span = input.span().unwrap_or(head);
+        let value = input.into_value(input_span)?;
+        let span = value.span();
+        let output = match value {
+            Value::Record { ref val, .. } => record_to_query_string(val, span, head),
+            Value::List { ref vals, .. } => table_to_query_string(vals, span, head),
+            // Propagate existing errors
+            Value::Error { error, .. } => Err(*error),
+            other => Err(ShellError::UnsupportedInput {
+                msg: "Expected a record or table from pipeline".to_string(),
+                input: "value originates from here".into(),
+                msg_span: head,
+                input_span: other.span(),
+            }),
+        };
+        Ok(Value::string(output?, head).into_pipeline_data())
     }
-}
-
-fn to_url(input: PipelineData, head: Span) -> Result<PipelineData, ShellError> {
-    let output: Result<String, ShellError> = input
-        .into_iter()
-        .map(move |value| {
-            let span = value.span();
-            match value {
-                Value::Record { ref val, .. } => record_to_query_string(val, span, head),
-                // Propagate existing errors
-                Value::Error { error, .. } => Err(*error),
-                other => Err(ShellError::UnsupportedInput {
-                    msg: "Expected a table from pipeline".to_string(),
-                    input: "value originates from here".into(),
-                    msg_span: head,
-                    input_span: other.span(),
-                }),
-            }
-        })
-        .collect();
-
-    Ok(Value::string(output?, head).into_pipeline_data())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -112,7 +112,7 @@ impl Command for SubCommand {
                             .into_owned()
                             .into_iter()
                             .try_fold(UrlComponents::new(), |url, (k, v)| {
-                                url.add_component(k, v, span, engine_state)
+                                url.add_component(k, v, head, engine_state)
                             });
 
                         url_components?.to_url(span)
@@ -155,7 +155,7 @@ impl UrlComponents {
         self,
         key: String,
         value: Value,
-        span: Span,
+        head: Span,
         engine_state: &EngineState,
     ) -> Result<Self, ShellError> {
         let value_span = value.span();
@@ -293,7 +293,7 @@ impl UrlComponents {
                     &ShellError::GenericError {
                         error: format!("'{key}' is not a valid URL field"),
                         msg: format!("remove '{key}' col from input record"),
-                        span: Some(span),
+                        span: Some(value_span),
                         help: None,
                         inner: vec![],
                     },

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -1,6 +1,6 @@
 use nu_engine::command_prelude::*;
 
-use super::query::record_to_query_string;
+use super::query::{record_to_query_string, table_to_query_string};
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -194,40 +194,41 @@ impl UrlComponents {
         }
 
         if key == "params" {
-            return match value {
-                Value::Record { ref val, .. } => {
-                    let mut qs = record_to_query_string(val, value_span, span)?;
-
-                    qs = if !qs.trim().is_empty() {
-                        format!("?{qs}")
-                    } else {
-                        qs
-                    };
-
-                    if let Some(q) = self.query {
-                        if q != qs {
-                            // if query is present it means that also query_span is set.
-                            return Err(ShellError::IncompatibleParameters {
-                                left_message: format!("Mismatch, qs from params is: {qs}"),
-                                left_span: value_span,
-                                right_message: format!("instead query is: {q}"),
-                                right_span: self.query_span.unwrap_or(Span::unknown()),
-                            });
-                        }
-                    }
-
-                    Ok(Self {
-                        query: Some(qs),
-                        params_span: Some(value_span),
-                        ..self
+            let mut qs = match value {
+                Value::Record { ref val, .. } => record_to_query_string(val, value_span, head)?,
+                Value::List { ref vals, .. } => table_to_query_string(vals, value_span, head)?,
+                Value::Error { error, .. } => return Err(*error),
+                other => {
+                    return Err(ShellError::IncompatibleParametersSingle {
+                        msg: String::from("Key params has to be a record or a table"),
+                        span: other.span(),
                     })
                 }
-                Value::Error { error, .. } => Err(*error),
-                other => Err(ShellError::IncompatibleParametersSingle {
-                    msg: String::from("Key params has to be a record"),
-                    span: other.span(),
-                }),
             };
+
+            qs = if !qs.trim().is_empty() {
+                format!("?{qs}")
+            } else {
+                qs
+            };
+
+            if let Some(q) = self.query {
+                if q != qs {
+                    // if query is present it means that also query_span is set.
+                    return Err(ShellError::IncompatibleParameters {
+                        left_message: format!("Mismatch, qs from params is: {qs}"),
+                        left_span: value_span,
+                        right_message: format!("instead query is: {q}"),
+                        right_span: self.query_span.unwrap_or(Span::unknown()),
+                    });
+                }
+            }
+
+            return Ok(Self {
+                query: Some(qs),
+                params_span: Some(value_span),
+                ..self
+            });
         }
 
         // apart from port and params all other keys are strings.

--- a/crates/nu-command/tests/commands/url/join.rs
+++ b/crates/nu-command/tests/commands/url/join.rs
@@ -201,7 +201,9 @@ fn url_join_with_invalid_params() {
             "#
     ));
 
-    assert!(actual.err.contains("Key params has to be a record or a table"));
+    assert!(actual
+        .err
+        .contains("Key params has to be a record or a table"));
 }
 
 #[test]
@@ -422,5 +424,7 @@ fn url_join_with_params_invalid_table() {
     ));
 
     assert!(actual.err.contains("expected a table"));
-    assert!(actual.err.contains("not a table, contains non-record values"));
+    assert!(actual
+        .err
+        .contains("not a table, contains non-record values"));
 }


### PR DESCRIPTION
Add `table<key, value>` support to `url join` for the `params` field, and as input to `url build-query` #14162

# Description
```nushell
{
    "scheme": "http",
    "username": "usr",
    "password": "pwd",
    "host": "localhost",
    "params": [
        ["key", "value"];
        ["par_1", "aaa"],
        ["par_2", "bbb"],
        ["par_1", "ccc"],
        ["par_2", "ddd"],
    ],
    "port": "1234",
} | url join
```
```
http://usr:pwd@localhost:1234?par_1=aaa&par_2=bbb&par_1=ccc&par_2=ddd
```

---

```nushell
[
    ["key", "value"];
    ["par_1", "aaa"],
    ["par_2", "bbb"],
    ["par_1", "ccc"],
    ["par_2", "ddd"],
] | url build-query
```
```
par_1=aaa&par_2=bbb&par_1=ccc&par_2=ddd
```

# User-Facing Changes

## `url build-query`

- can no longer accept one row table input as if it were a record