### PR TITLE
Add `run-internal` command

### DIFF
--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -1,5 +1,6 @@
 use nu_engine::command_prelude::*;
 use nu_protocol::ByteStreamSource;
+use nu_protocol::{DataSource, PipelineMetadata};
 
 #[derive(Clone)]
 pub struct Print;
@@ -57,15 +58,22 @@ Since this command has no output, there is no point in piping it with other comm
         let no_newline = call.has_flag(engine_state, stack, "no-newline")?;
         let to_stderr = call.has_flag(engine_state, stack, "stderr")?;
         let raw = call.has_flag(engine_state, stack, "raw")?;
+        let metadata = match input.metadata() {
+            Some(md) => md,
+            None => PipelineMetadata {
+                data_source: DataSource::Ls,
+                content_type: None,
+            },
+        };
 
         // This will allow for easy printing of pipelines as well
         if !args.is_empty() {
             for arg in args {
                 if raw {
-                    arg.into_pipeline_data()
+                    arg.into_pipeline_data_with_metadata(metadata.clone())
                         .print_raw(engine_state, no_newline, to_stderr)?;
                 } else {
-                    arg.into_pipeline_data()
+                    arg.into_pipeline_data_with_metadata(metadata.clone())
                         .print(engine_state, stack, no_newline, to_stderr)?;
                 }
             }

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -116,6 +116,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
         bind_command! {
             Complete,
             External,
+            Internal,
             Exec,
             NuCheck,
             Sys,

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -14,6 +14,7 @@ mod ps;
 #[cfg(windows)]
 mod registry_query;
 mod run_external;
+mod run_internal;
 mod sys;
 mod uname;
 mod which_;
@@ -34,6 +35,7 @@ pub use ps::Ps;
 #[cfg(windows)]
 pub use registry_query::RegistryQuery;
 pub use run_external::{command_not_found, eval_arguments_from_call, which, External};
+pub use run_internal::Internal;
 pub use sys::*;
 pub use uname::UName;
 pub use which_::Which;

--- a/crates/nu-command/src/system/run_internal.rs
+++ b/crates/nu-command/src/system/run_internal.rs
@@ -1,4 +1,3 @@
-use log::info;
 use nu_engine::command_prelude::*;
 use nu_engine::{convert_env_values, eval_block};
 use nu_parser::parse;
@@ -54,7 +53,7 @@ impl Command for Internal {
         let config = engine_state.get_config();
         let table_mode = config.table.mode.into_value(call.head);
         let error_style = config.error_style.into_value(call.head);
-        let no_newline = false;
+        // let no_newline = false;
         let commands: Spanned<String> = call.req(engine_state, stack, 0)?;
         // let _ = evaluate_commands(
         //     &commands,
@@ -76,7 +75,7 @@ impl Command for Internal {
             EvaluateCommandsOpts {
                 table_mode: Some(table_mode),
                 error_style: Some(error_style),
-                no_newline,
+                // no_newline,
             },
         )
     }
@@ -88,7 +87,7 @@ impl Command for Internal {
 pub struct EvaluateCommandsOpts {
     pub table_mode: Option<Value>,
     pub error_style: Option<Value>,
-    pub no_newline: bool,
+    // pub no_newline: bool,
 }
 
 /// Run a command (or commands) given to us by the user
@@ -102,7 +101,7 @@ pub fn evaluate_commands(
     let EvaluateCommandsOpts {
         table_mode,
         error_style,
-        no_newline,
+        // no_newline: _,
     } = opts;
 
     // Handle the configured error style early

--- a/crates/nu-command/src/system/run_internal.rs
+++ b/crates/nu-command/src/system/run_internal.rs
@@ -56,7 +56,19 @@ impl Command for Internal {
         let error_style = config.error_style.into_value(call.head);
         let no_newline = false;
         let commands: Spanned<String> = call.req(engine_state, stack, 0)?;
-        let _ = evaluate_commands(
+        // let _ = evaluate_commands(
+        //     &commands,
+        //     &mut engine_state.clone(),
+        //     &mut stack.clone(),
+        //     input,
+        //     EvaluateCommandsOpts {
+        //         table_mode: Some(table_mode),
+        //         error_style: Some(error_style),
+        //         no_newline,
+        //     },
+        // );
+        // Ok(PipelineData::Empty)
+        evaluate_commands(
             &commands,
             &mut engine_state.clone(),
             &mut stack.clone(),
@@ -66,8 +78,7 @@ impl Command for Internal {
                 error_style: Some(error_style),
                 no_newline,
             },
-        );
-        Ok(PipelineData::Empty)
+        )
     }
 }
 
@@ -87,7 +98,7 @@ pub fn evaluate_commands(
     stack: &mut Stack,
     input: PipelineData,
     opts: EvaluateCommandsOpts,
-) -> Result<(), ShellError> {
+) -> Result<PipelineData, ShellError> {
     let EvaluateCommandsOpts {
         table_mode,
         error_style,
@@ -146,22 +157,23 @@ pub fn evaluate_commands(
     engine_state.merge_delta(delta)?;
 
     // Run the block
-    let pipeline = eval_block::<WithoutDebug>(engine_state, stack, &block, input)?;
+    // let pipeline = eval_block::<WithoutDebug>(engine_state, stack, &block, input)?;
+    eval_block::<WithoutDebug>(engine_state, stack, &block, input)
 
-    if let PipelineData::Value(Value::Error { error, .. }, ..) = pipeline {
-        return Err(*error);
-    }
+    // if let PipelineData::Value(Value::Error { error, .. }, ..) = pipeline {
+    //     return Err(*error);
+    // }
 
-    if let Some(t_mode) = table_mode {
-        Arc::make_mut(&mut engine_state.config).table.mode =
-            t_mode.coerce_str()?.parse().unwrap_or_default();
-    }
+    // if let Some(t_mode) = table_mode {
+    //     Arc::make_mut(&mut engine_state.config).table.mode =
+    //         t_mode.coerce_str()?.parse().unwrap_or_default();
+    // }
 
-    pipeline.print(engine_state, stack, no_newline, false)?;
+    // pipeline.print(engine_state, stack, no_newline, false)?;
 
-    info!("evaluate {}:{}:{}", file!(), line!(), column!());
+    // info!("evaluate {}:{}:{}", file!(), line!(), column!());
 
-    Ok(())
+    // Ok(())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/system/run_internal.rs
+++ b/crates/nu-command/src/system/run_internal.rs
@@ -1,0 +1,179 @@
+use log::info;
+use nu_engine::command_prelude::*;
+use nu_engine::{convert_env_values, eval_block};
+use nu_parser::parse;
+use nu_protocol::{
+    cli_error::report_compile_error,
+    debugger::WithoutDebug,
+    engine::{EngineState, Stack, StateWorkingSet},
+    report_parse_error, report_parse_warning, IntoValue, PipelineData, ShellError, Spanned, Value,
+};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct Internal;
+
+impl Command for Internal {
+    fn name(&self) -> &str {
+        "run-internal"
+    }
+
+    fn description(&self) -> &str {
+        "Runs internal command."
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build(self.name())
+            .input_output_types(vec![(Type::Any, Type::Any)])
+            .required("command", SyntaxShape::String, "Internal command to run.")
+            .category(Category::System)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Run an internal command",
+                example: r#"run-internal "ls""#,
+                result: None,
+            },
+            Example {
+                description: "Run a pipeline",
+                example: r#"run-internal "print (ls | first 5);print (ps | first 5)"#,
+                result: None,
+            },
+        ]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let config = engine_state.get_config();
+        let table_mode = config.table.mode.into_value(call.head);
+        let error_style = config.error_style.into_value(call.head);
+        let no_newline = false;
+        let commands: Spanned<String> = call.req(engine_state, stack, 0)?;
+        let _ = evaluate_commands(
+            &commands,
+            &mut engine_state.clone(),
+            &mut stack.clone(),
+            input,
+            EvaluateCommandsOpts {
+                table_mode: Some(table_mode),
+                error_style: Some(error_style),
+                no_newline,
+            },
+        );
+        Ok(PipelineData::Empty)
+    }
+}
+
+// This code is ripped off from nu-cli. It's duplicated here because I didn't
+// want to add a dependency on nu-cli in nu-command.
+#[derive(Default)]
+pub struct EvaluateCommandsOpts {
+    pub table_mode: Option<Value>,
+    pub error_style: Option<Value>,
+    pub no_newline: bool,
+}
+
+/// Run a command (or commands) given to us by the user
+pub fn evaluate_commands(
+    commands: &Spanned<String>,
+    engine_state: &mut EngineState,
+    stack: &mut Stack,
+    input: PipelineData,
+    opts: EvaluateCommandsOpts,
+) -> Result<(), ShellError> {
+    let EvaluateCommandsOpts {
+        table_mode,
+        error_style,
+        no_newline,
+    } = opts;
+
+    // Handle the configured error style early
+    if let Some(e_style) = error_style {
+        match e_style.coerce_str()?.parse() {
+            Ok(e_style) => {
+                Arc::make_mut(&mut engine_state.config).error_style = e_style;
+            }
+            Err(err) => {
+                return Err(ShellError::GenericError {
+                    error: "Invalid value for `--error-style`".into(),
+                    msg: err.into(),
+                    span: Some(e_style.span()),
+                    help: None,
+                    inner: vec![],
+                });
+            }
+        }
+    }
+
+    // Translate environment variables from Strings to Values
+    convert_env_values(engine_state, stack)?;
+
+    // Parse the source code
+    let (block, delta) = {
+        if let Some(ref t_mode) = table_mode {
+            Arc::make_mut(&mut engine_state.config).table.mode =
+                t_mode.coerce_str()?.parse().unwrap_or_default();
+        }
+
+        let mut working_set = StateWorkingSet::new(engine_state);
+
+        let output = parse(&mut working_set, None, commands.item.as_bytes(), false);
+        if let Some(warning) = working_set.parse_warnings.first() {
+            report_parse_warning(&working_set, warning);
+        }
+
+        if let Some(err) = working_set.parse_errors.first() {
+            report_parse_error(&working_set, err);
+            std::process::exit(1);
+        }
+
+        if let Some(err) = working_set.compile_errors.first() {
+            report_compile_error(&working_set, err);
+            // Not a fatal error, for now
+        }
+
+        (output, working_set.render())
+    };
+
+    // Update permanent state
+    engine_state.merge_delta(delta)?;
+
+    // Run the block
+    let pipeline = eval_block::<WithoutDebug>(engine_state, stack, &block, input)?;
+
+    if let PipelineData::Value(Value::Error { error, .. }, ..) = pipeline {
+        return Err(*error);
+    }
+
+    if let Some(t_mode) = table_mode {
+        Arc::make_mut(&mut engine_state.config).table.mode =
+            t_mode.coerce_str()?.parse().unwrap_or_default();
+    }
+
+    pipeline.print(engine_state, stack, no_newline, false)?;
+
+    info!("evaluate {}:{}:{}", file!(), line!(), column!());
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    // use super::*;
+    // use nu_test_support::{fs::Stub, playground::Playground};
+
+    // #[test]
+    // fn test_some_test() {
+    // }
+
+    // #[test]
+    // fn test_some_other_test() {
+    // }
+}

--- a/crates/nu-command/src/system/run_internal.rs
+++ b/crates/nu-command/src/system/run_internal.rs
@@ -141,7 +141,7 @@ pub fn evaluate_commands(
 
         if let Some(err) = working_set.parse_errors.first() {
             report_parse_error(&working_set, err);
-            std::process::exit(1);
+            //std::process::exit(1);
         }
 
         if let Some(err) = working_set.compile_errors.first() {


### PR DESCRIPTION
# Description

I'm not sure if this is "eval" or just "eval-adjacent". Let's talk about it. I wonder if it's safe enough since it doesn't return a value. Or maybe it can be made safer somehow? (also, there's a hack to pass metadata for ls through).

This PR adds the ability to run internal commands similar to how you run external commands. All it really does is call the same exact code as when you do `nu -c "blah"`.

![image](https://github.com/user-attachments/assets/32e3de5c-6228-45ba-b8de-5f7a4dffde84)

![image](https://github.com/user-attachments/assets/1e88cf81-5360-460f-8160-3cf96e859b40)

## Update:

It returns values now. Will need to clean up code.

Also will need to fix this problem that Kubouch found. unknown flag has an error and exits nushell to zsh in my case in the screenshot.
![image](https://github.com/user-attachments/assets/b174475d-bb45-4279-9d17-6c41841fcc9a)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
