### PR TITLE
Add tests to test the `--max-age` arg in http commands

### DIFF
--- a/crates/nu-command/tests/commands/network/http/patch.rs
+++ b/crates/nu-command/tests/commands/network/http/patch.rs
@@ -1,3 +1,5 @@
+use std::{thread, time::Duration};
+
 use mockito::Server;
 use nu_test_support::{nu, pipeline};
 
@@ -161,4 +163,26 @@ fn http_patch_redirect_mode_error() {
     assert!(&actual.err.contains(
         "Redirect encountered when redirect handling mode was 'error' (301 Moved Permanently)"
     ));
+}
+
+#[test]
+fn http_patch_timeout() {
+    let mut server = Server::new();
+    let _mock = server
+        .mock("PATCH", "/")
+        .with_chunked_body(|w| {
+            thread::sleep(Duration::from_secs(1));
+            w.write_all(b"Delayed response!")
+        })
+        .create();
+
+    let actual = nu!(pipeline(
+        format!(
+            "http patch --max-time 500ms {url} patchbody",
+            url = server.url()
+        )
+        .as_str()
+    ));
+
+    assert!(&actual.err.contains("nu::shell::io_error"));
 }

--- a/crates/nu-command/tests/commands/network/http/put.rs
+++ b/crates/nu-command/tests/commands/network/http/put.rs
@@ -1,3 +1,5 @@
+use std::{thread, time::Duration};
+
 use mockito::Server;
 use nu_test_support::{nu, pipeline};
 
@@ -161,4 +163,26 @@ fn http_put_redirect_mode_error() {
     assert!(&actual.err.contains(
         "Redirect encountered when redirect handling mode was 'error' (301 Moved Permanently)"
     ));
+}
+
+#[test]
+fn http_put_timeout() {
+    let mut server = Server::new();
+    let _mock = server
+        .mock("PUT", "/")
+        .with_chunked_body(|w| {
+            thread::sleep(Duration::from_secs(1));
+            w.write_all(b"Delayed response!")
+        })
+        .create();
+
+    let actual = nu!(pipeline(
+        format!(
+            "http put --max-time 500ms {url} putbody",
+            url = server.url()
+        )
+        .as_str()
+    ));
+
+    assert!(&actual.err.contains("nu::shell::io_error"));
 }


### PR DESCRIPTION
- fixes #14241
