### PR TITLE
Empty rest args match should be an empty list

### DIFF
--- a/crates/nu-command/tests/commands/match_.rs
+++ b/crates/nu-command/tests/commands/match_.rs
@@ -65,6 +65,12 @@ fn match_list_rest() {
 }
 
 #[test]
+fn match_list_rest_empty() {
+    let actual = nu!(r#"match [1] { [1 ..$rest] => { $rest == [] } }"#);
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
 fn match_constant_1() {
     let actual = nu!(
         r#"match 2 { 1 => { print "failure"}, 2 => { print "success" }, 3 => { print "failure" }}"#

--- a/crates/nu-protocol/src/engine/pattern_match.rs
+++ b/crates/nu-protocol/src/engine/pattern_match.rs
@@ -48,13 +48,14 @@ impl Matcher for Pattern {
             Pattern::List(items) => match &value {
                 Value::List { vals, .. } => {
                     if items.len() > vals.len() {
-                        // The only we we allow this is to have a rest pattern in the n+1 position
+                        // We only allow this is to have a rest pattern in the n+1 position
                         if items.len() == (vals.len() + 1) {
                             match &items[vals.len()].pattern {
                                 Pattern::IgnoreRest => {}
-                                Pattern::Rest(var_id) => {
-                                    matches.push((*var_id, Value::nothing(items[vals.len()].span)))
-                                }
+                                Pattern::Rest(var_id) => matches.push((
+                                    *var_id,
+                                    Value::list(Vec::new(), items[vals.len()].span),
+                                )),
                                 _ => {
                                     // There is a pattern which can't skip missing values, so we fail
                                     return false;


### PR DESCRIPTION
Fixes #14145 

# User-Facing Changes
An empty rest match would be `null` previously. Now it will be an empty list.
This is a breaking change for any scripts relying on the old behavior.

Example script:
```nu
match [1] {
  [_ ..$rest] => {
    match $rest {
      null => { "old" }
      [] => { "new" }
    }
  } 
}
```
This expression would evaluate to "old" on current nu versions and "new" with this patch.


