### PR TITLE
Consolidate uses of `test-case` to `rstest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3025,7 +3025,6 @@ dependencies = [
  "rstest",
  "sysinfo 0.32.0",
  "tempfile",
- "test-case",
  "unicode-segmentation",
  "uuid",
  "which",
@@ -6241,39 +6240,6 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
-
-[[package]]
-name = "test-case"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
-dependencies = [
- "test-case-macros",
-]
-
-[[package]]
-name = "test-case-core"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.75",
-]
-
-[[package]]
-name = "test-case-macros"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.75",
- "test-case-core",
-]
 
 [[package]]
 name = "textwrap"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -16,7 +16,6 @@ nu-command = { path = "../nu-command", version = "0.99.2" }
 nu-test-support = { path = "../nu-test-support", version = "0.99.2" }
 rstest = { workspace = true, default-features = false }
 tempfile = { workspace = true }
-test-case = "3.3.1"
 
 [dependencies]
 nu-cmd-base = { path = "../nu-cmd-base", version = "0.99.2" }

--- a/crates/nu-cli/src/commands/history/history_import.rs
+++ b/crates/nu-cli/src/commands/history/history_import.rs
@@ -283,7 +283,7 @@ fn backup(path: &Path) -> Result<Option<PathBuf>, ShellError> {
 #[cfg(test)]
 mod tests {
     use chrono::DateTime;
-    use test_case::case;
+    use rstest::rstest;
 
     use super::*;
 
@@ -378,14 +378,11 @@ mod tests {
         Value::record(rec, span)
     }
 
-    #[case(&["history.dat"], "history.dat.bak"; "no_backup")]
-    #[case(&["history.dat", "history.dat.bak"], "history.dat.bak.1"; "backup_exists")]
-    #[case(
-        &["history.dat", "history.dat.bak", "history.dat.bak.1"],
-        "history.dat.bak.2";
-        "multiple_backups_exists"
-    )]
-    fn test_find_backup_path(existing: &[&str], want: &str) {
+    #[rstest]
+    #[case::no_backup(&["history.dat"], "history.dat.bak")]
+    #[case::backup_exists(&["history.dat", "history.dat.bak"], "history.dat.bak.1")]
+    #[case::multiple_backups_exists( &["history.dat", "history.dat.bak", "history.dat.bak.1"], "history.dat.bak.2")]
+    fn test_find_backup_path(#[case] existing: &[&str], #[case] want: &str) {
         let dir = tempfile::tempdir().unwrap();
         for name in existing {
             std::fs::File::create_new(dir.path().join(name)).unwrap();

--- a/crates/nu-cli/tests/commands/history_import.rs
+++ b/crates/nu-cli/tests/commands/history_import.rs
@@ -4,8 +4,8 @@ use reedline::{
     FileBackedHistory, History, HistoryItem, HistoryItemId, ReedlineError, SearchQuery,
     SqliteBackedHistory,
 };
+use rstest::rstest;
 use tempfile::TempDir;
-use test_case::case;
 
 struct Test {
     cfg_dir: TempDir,
@@ -251,9 +251,10 @@ fn to_empty_sqlite() {
     .run()
 }
 
-#[case(HistoryFileFormat::Plaintext; "plaintext")]
-#[case(HistoryFileFormat::Sqlite; "sqlite")]
-fn to_existing(dst_format: HistoryFileFormat) {
+#[rstest]
+#[case::plaintext(HistoryFileFormat::Plaintext)]
+#[case::sqlite(HistoryFileFormat::Sqlite)]
+fn to_existing(#[case] dst_format: HistoryFileFormat) {
     TestCase {
         dst_format,
         dst_history: vec![


### PR DESCRIPTION
With #14083 a dependency on `test-case` was introduced, we already
depend on the more exp(a/e)nsive `rstest` for our macro-based test case
generation (with fixtures on top)

To save on some compilation for proc macros unify to `rstest`
