### PR TITLE
path expand should use the file's directory in const contexts

### DIFF
--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -46,6 +46,12 @@ impl Command for SubCommand {
         "Try to expand a path to its absolute form."
     }
 
+    fn extra_description(&self) -> &str {
+        r#"This command expands a path relative to the current working directory.
+It also works in const contexts, in which the path will be expanded relative to
+the directory containing the script or module."#
+    }
+
     fn is_const(&self) -> bool {
         true
     }

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -82,9 +82,13 @@ impl Command for SubCommand {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         #[allow(deprecated)]
+        let cwd = match working_set.files.top().and_then(|f| f.parent()) {
+            Some(file) => file.to_string_lossy().into_owned(),
+            None => current_dir_str_const(working_set)?,
+        };
         let args = Arguments {
             strict: call.has_flag_const(working_set, "strict")?,
-            cwd: current_dir_str_const(working_set)?,
+            cwd,
             not_follow_symlink: call.has_flag_const(working_set, "no-symlink")?,
         };
         // This doesn't match explicit nulls


### PR DESCRIPTION
Alternative solution to:
- #9776 
- #10626 
- #12195 

Related:
- #14101

# Description
Makes `path expand`'s const behavior more predictable and relative to the containing file, rather than the what `$env.PWD` was during parse time.

This removes the need for `$env.FILE_PWD`, as users can just use this:
```nushell
const file_pwd = "." | path expand
```
This can be used in modules, sourced files and scripts without any issue.

```nushell
def foo [] {
    const file_pwd = "." | path expand
}
```
Can be contained in command definitions and not leak even from a sourced file.

# Examples

```nushell
# ~/.config/nushell/scripts/foo.nu
export def main [] {
    const file_pwd_const = "." | path expand
    let file_pwd_runtime = "." | path expand
    {
        "const": $file_pwd_const
        "runtime": $file_pwd_runtime
    }
}
```

Previous behavior
```
> pwd
/home/user
> use foo.nu
> foo
╭─────────┬────────────╮
│ const   │ /home/user │
│ runtime │ /home/user │
╰─────────┴────────────╯
> cd Desktop
> foo
╭─────────┬────────────────────╮
│ const   │ /home/user         │
│ runtime │ /home/user/Desktop │
╰─────────┴────────────────────╯
```

New behavior
```
> pwd
/home/user
> use foo.nu
> foo
╭─────────┬────────────────────────────────────╮
│ const   │ /home/user/.config/nushell/scripts │
│ runtime │ /home/user                         │
╰─────────┴────────────────────────────────────╯
> cd Desktop
> foo
╭─────────┬────────────────────────────────────╮
│ const   │ /home/user/.config/nushell/scripts │
│ runtime │ /home/user/Desktop                 │
╰─────────┴────────────────────────────────────╯
```

# User-Facing Changes
`path parse`'s const behavior no longer depends on `$env.PWD`.