### PR TITLE
Switch to unicase's to_folded_case

### DIFF
--- a/crates/nu-utils/src/casing.rs
+++ b/crates/nu-utils/src/casing.rs
@@ -9,11 +9,6 @@ pub trait IgnoreCaseExt {
     /// language-invariant and consistent. Case folded text should be used
     /// solely for processing and generally should not be stored or displayed.
     ///
-    /// Note: this method might only do [`str::to_lowercase`] instead of a
-    /// full case fold, depending on how Nu is compiled. You should still
-    /// prefer using this method for generating case-insensitive strings,
-    /// though, as it expresses intent much better than `to_lowercase`.
-    ///
     /// [case folded]: <https://unicode.org/faq/casemap_charprop.html#2>
     fn to_folded_case(&self) -> String;
 
@@ -40,9 +35,7 @@ pub trait IgnoreCaseExt {
 
 impl IgnoreCaseExt for str {
     fn to_folded_case(&self) -> String {
-        // we only do to_lowercase, as unicase doesn't expose its case fold yet
-        // (seanmonstar/unicase#61) and we don't want to pull in another table
-        self.to_lowercase()
+        UniCase::new(self).to_folded_case()
     }
 
     fn eq_ignore_case(&self, other: &str) -> bool {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
Switch `to_folded_case` to a proper case fold instead of `str::to_lowercase` now that unicase exposes its `to_folded_case` method.

Rel: #10884, https://github.com/seanmonstar/unicase/issues/61

# User-Facing Changes

Case insensitive sorts now do proper case folding.

Old behavior:

```nushell
[dreißig DREISSIG] | sort -i
# => ╭───┬──────────╮
# => │ 0 │ DREISSIG │
# => │ 1 │ dreißig  │
# => ╰───┴──────────╯
```

New behavior:

```nushell
[dreißig DREISSIG] | sort -i
# => ╭───┬──────────╮
# => │ 0 │ dreißig  │
# => │ 1 │ DREISSIG │
# => ╰───┴──────────╯
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

N/A