### PR TITLE
allow != for polars

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/between_values.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/between_values.rs
@@ -334,6 +334,10 @@ pub(super) fn compute_series_single_value(
             Value::Float { val, .. } => {
                 compare_series_float(&lhs, *val, ChunkedArray::not_equal, lhs_span)
             }
+            Value::String { val, .. } => {
+                let equal_pattern = format!("^{}$", fancy_regex::escape(val));
+                contains_series_pat(&lhs, &equal_pattern, lhs_span)
+            }
             Value::Date { val, .. } => compare_series_i64(
                 &lhs,
                 val.timestamp_millis(),


### PR DESCRIPTION
# Description

This PR fixes a problem where not equal in polars wasn't working with strings.

## Before
```nushell
let a = ls | polars into-df
$a.type != "dir"
Error: nu::shell::type_mismatch

  × Type mismatch during operation.
   ╭─[entry #16:1:1]
 1 │ $a.type != "dir"
   · ─┬      ─┬ ──┬──
   ·  │       │   ╰── string
   ·  │       ╰── type mismatch for operator
   ·  ╰── NuDataFrame
   ╰────
```

## After
```nushell
let a = ls | polars into-df
$a.type != "dir"
╭──#──┬─type──╮
│ 0   │ false │
│ 1   │ false │
│ 2   │ false │
...
```

/cc @ayax79 to make sure I did this right.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
