### PR TITLE
Fix the order of preference for `VISUAL` and `EDITOR`

### DIFF
--- a/crates/nu-cmd-base/src/util.rs
+++ b/crates/nu-cmd-base/src/util.rs
@@ -78,10 +78,10 @@ pub fn get_editor(
         get_editor_commandline(&config.buffer_editor, "$env.config.buffer_editor")
     {
         Ok(buff_editor)
-    } else if let Some(value) = env_vars.get("EDITOR") {
-        get_editor_commandline(value, "$env.EDITOR")
     } else if let Some(value) = env_vars.get("VISUAL") {
         get_editor_commandline(value, "$env.VISUAL")
+    } else if let Some(value) = env_vars.get("EDITOR") {
+        get_editor_commandline(value, "$env.EDITOR")
     } else {
         Err(ShellError::GenericError {
             error: "No editor configured".into(),

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -238,7 +238,7 @@ $env.config = {
     color_config: $dark_theme # if you want a more interesting theme, you can replace the empty record with `$dark_theme`, `$light_theme` or another custom record
     footer_mode: 25 # always, never, number_of_rows, auto
     float_precision: 2 # the precision for displaying floats in tables
-    buffer_editor: null # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
+    buffer_editor: null # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.VISUAL and $env.EDITOR
     use_ansi_coloring: true
     bracketed_paste: true # enable bracketed paste, currently useless on windows
     edit_mode: emacs # emacs, vi


### PR DESCRIPTION
# Description

The order in which Nushell consulted `$env.EDITOR` and `$env.VISUAL` was wrong. Most other programs check `$env.VISUAL` first and then fall back to `$env.EDITOR` (for historic reasons).

References:

 * https://wiki.archlinux.org/title/Environment_variables#Default_programs
 * https://help.ubuntu.com/community/EnvironmentVariables#Preferred_application_variables
 * https://unix.stackexchange.com/a/4861
 * https://git-scm.com/docs/git-var

# User-Facing Changes

Users will now be able to use those preferences variables the same way they are used in other programs.

# Tests + Formatting

That part wasn't tested before, and I don't think it's necessary to test it now.

# After Submitting

PR to the docs repo is here: nushell/nushell.github.io#1621
