### PR TITLE
Fix multipart/form-data post example

### DIFF
--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -129,7 +129,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Upload a file to example.com",
-                example: "http post --content-type multipart/form-data https://www.example.com { audio: (open -r file.mp3) }",
+                example: "http post --content-type multipart/form-data https://www.example.com { file: (open -r file.mp3 | into binary) }",
                 result: None,
             },
         ]


### PR DESCRIPTION
# Description

Thanks to @weirdan [in Discord](https://discord.com/channels/601130461678272522/614593951969574961/1304508148207583345) for pointing out that correct syntax for `http post --content-type multipart/form-data`.

The existing example was incomplete, so I've updated it.

# User-Facing Changes

Doc-only

# Tests + Formatting

`toolkit test` currently seems to be broken, so relying on CI

# After Submitting

N/A