### PR TITLE
ignore without_timezone test for now

### DIFF
--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -507,7 +507,14 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn takes_a_date_format_without_timezone() {
+        // Ignoring this test for now because we changed the human-date-parser to use
+        // the users timezone instead of UTC. We may continue to tweak this behavior.
+        // Another hacky solution is to set the timezone to UTC in the test, which works
+        // on MacOS and Linux but hasn't been tested on Windows. Plus it kind of defeats
+        // the purpose of a "without_timezone" test.
+        // std::env::set_var("TZ", "UTC");
         let date_str = Value::test_string("16.11.1984 8:00 am");
         let fmt_options = Some(DatetimeFormat("%d.%m.%Y %H:%M %P".to_string()));
         let args = Arguments {


### PR DESCRIPTION
# Description

Since the human-date-parser was switched to use the users local timezone, this test may not be needed anymore. I've just ignored it for now and put a comment about why it's being ignored.

There are more discussions on this topic here https://github.com/nushell/nushell/pull/14266

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
