### PR TITLE
Fix ignored `into datetime` test

### DIFF
--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -185,11 +185,13 @@ impl Command for SubCommand {
                 example: "'16.11.1984 8:00 am' | into datetime --format '%d.%m.%Y %H:%M %P'",
                 #[allow(clippy::inconsistent_digit_grouping)]
                 result: Some(Value::date(
-                    DateTime::from_naive_utc_and_offset(
-                        NaiveDateTime::parse_from_str("16.11.1984 8:00 am", "%d.%m.%Y %H:%M %P")
-                        .expect("date calculation should not fail in test"),
-                        *Local::now().offset(),
-                    ),
+                    Local
+                        .from_local_datetime(
+                            &NaiveDateTime::parse_from_str("16.11.1984 8:00 am", "%d.%m.%Y %H:%M %P")
+                                .expect("date calculation should not fail in test"),
+                        )
+                        .unwrap()
+                        .with_timezone(Local::now().offset()),
                     Span::test_data(),
                 )),
             },
@@ -517,12 +519,16 @@ mod tests {
         };
         let actual = action(&date_str, &args, Span::test_data());
         let expected = Value::date(
-            DateTime::from_naive_utc_and_offset(
-                NaiveDateTime::parse_from_str("16.11.1984 8:00 am", "%d.%m.%Y %H:%M %P").unwrap(),
-                *Local::now().offset(),
-            ),
+            Local
+                .from_local_datetime(
+                    &NaiveDateTime::parse_from_str("16.11.1984 8:00 am", "%d.%m.%Y %H:%M %P")
+                        .unwrap(),
+                )
+                .unwrap()
+                .with_timezone(Local::now().offset()),
             Span::test_data(),
         );
+
         assert_eq!(actual, expected)
     }
 


### PR DESCRIPTION
# Description

Fixes test which was ignored in #14297.  Also fixes related example.

Tests now use local timezone to match actual result.

More discussion in #14266

# User-Facing Changes

Tests-only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A