### PR TITLE
Add parse-time constant `$NU_CURRENT_FILE`

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -74,18 +74,6 @@ pub fn evaluate_file(
         .expect("internal error: missing filename");
 
     let mut working_set = StateWorkingSet::new(engine_state);
-
-    let current_file = working_set.add_variable(
-        b"$NU_CURRENT_FILE".into(),
-        Span::unknown(),
-        nu_protocol::Type::String,
-        false,
-    );
-    working_set.set_variable_const_val(
-        current_file,
-        Value::string(file_path.to_string_lossy(), Span::unknown()),
-    );
-
     trace!("parsing file: {}", file_path_str);
     let block = parse(&mut working_set, Some(file_path_str), &file, false);
 

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -76,7 +76,7 @@ pub fn evaluate_file(
     let mut working_set = StateWorkingSet::new(engine_state);
 
     let current_file = working_set.add_variable(
-        b"$current_file".into(),
+        b"$NU_CURRENT_FILE".into(),
         Span::unknown(),
         nu_protocol::Type::String,
         false,

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -74,6 +74,18 @@ pub fn evaluate_file(
         .expect("internal error: missing filename");
 
     let mut working_set = StateWorkingSet::new(engine_state);
+
+    let current_file = working_set.add_variable(
+        b"$current_file".into(),
+        Span::unknown(),
+        nu_protocol::Type::String,
+        false,
+    );
+    working_set.set_variable_const_val(
+        current_file,
+        Value::string(file_path.to_string_lossy(), Span::unknown()),
+    );
+
     trace!("parsing file: {}", file_path_str);
     let block = parse(&mut working_set, Some(file_path_str), &file, false);
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1719,6 +1719,16 @@ pub fn parse_module_block(
 ) -> (Block, Module, Vec<Span>) {
     working_set.enter_scope();
 
+    if let Some(file) = working_set
+        .files
+        .top()
+        .map(|f| f.to_string_lossy().into_owned())
+    {
+        let current_file =
+            working_set.add_variable(b"$current_file".into(), span, Type::String, false);
+        working_set.set_variable_const_val(current_file, Value::string(file, span));
+    };
+
     let source = working_set.get_span_contents(span);
 
     let (output, err) = lex(source, span.start, &[], &[], false);

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3525,17 +3525,6 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                             return garbage_pipeline(working_set, spans);
                         }
 
-                        let new_file = working_set.add_variable(
-                            b"$NU_CURRENT_FILE".into(),
-                            Span::concat(&spans[1..]),
-                            Type::String,
-                            false,
-                        );
-                        working_set.set_variable_const_val(
-                            new_file,
-                            Value::test_string(path.clone().path().to_string_lossy()),
-                        );
-
                         // This will load the defs from the file into the
                         // working set, if it was a successful parse.
                         let block = parse(
@@ -3547,29 +3536,6 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
 
                         // Remove the file from the stack of files being processed.
                         working_set.files.pop();
-
-                        // Restore `$current_size` to previous file
-                        let current_file = working_set.add_variable(
-                            b"$NU_CURRENT_FILE".into(),
-                            Span::unknown(),
-                            Type::String,
-                            false,
-                        );
-                        if let Some(file) = working_set
-                            .files
-                            .top()
-                            .map(|f| f.to_string_lossy().into_owned())
-                        {
-                            working_set.set_variable_const_val(
-                                current_file,
-                                Value::string(file, Span::unknown()),
-                            );
-                        } else {
-                            working_set.set_variable_const_val(
-                                current_file,
-                                Value::nothing(Span::unknown()),
-                            )
-                        };
 
                         // Save the block into the working set
                         let block_id = working_set.add_block(block);

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1725,7 +1725,7 @@ pub fn parse_module_block(
         .map(|f| f.to_string_lossy().into_owned())
     {
         let current_file =
-            working_set.add_variable(b"$current_file".into(), span, Type::String, false);
+            working_set.add_variable(b"$NU_CURRENT_FILE".into(), span, Type::String, false);
         working_set.set_variable_const_val(current_file, Value::string(file, span));
     };
 
@@ -3526,7 +3526,7 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                         }
 
                         let new_file = working_set.add_variable(
-                            b"$current_file".into(),
+                            b"$NU_CURRENT_FILE".into(),
                             Span::concat(&spans[1..]),
                             Type::String,
                             false,
@@ -3550,7 +3550,7 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
 
                         // Restore `$current_size` to previous file
                         let current_file = working_set.add_variable(
-                            b"$current_file".into(),
+                            b"$NU_CURRENT_FILE".into(),
                             Span::unknown(),
                             Type::String,
                             false,


### PR DESCRIPTION
Addresses
- #12195 

The other approach:
- #14303

# Description
Adds `$NU_CURRENT_FILE`, a parse-time constant that is the absolute path of the source file containing it.

- Useful for any script or module that makes use of non nuscript files.
- Removes the need for `$env.CURRENT_FILE` and `$env.FILE_PWD`.
- Can be used in modules, sourced files or scripts.

<!-- -->

- Requires changes in the parser

# Examples

The following example is written with the assumption that `path expand` can not run during parse-time.

```nushell
# ~/.config/nushell/scripts/foo.nu
const paths = {
    self: $NU_CURRENT_FILE,
    dir: ($NU_CURRENT_FILE | path dirname),
    sibling: ($NU_CURRENT_FILE | path basename -r "sibling")
    parent_dir: ($NU_CURRENT_FILE | path dirname --num-levels 2)
    cousin: ($NU_CURRENT_FILE | path dirname --num-levels 2 | path join "cousin")
}

export def main [] {
    $paths
}
```

```nushell
> use foo.nu
> foo
╭────────────┬────────────────────────────────────────────╮
│ self       │ /home/user/.config/nushell/scripts/foo.nu  │
│ dir        │ /home/user/.config/nushell/scripts         │
│ sibling    │ /home/user/.config/nushell/scripts/sibling │
│ parent_dir │ /home/user/.config/nushell                 │
│ cousin     │ /home/user/.config/nushell/cousin          │
╰────────────┴────────────────────────────────────────────╯
```

# Comparison with #14303 
# Pros
- More intuitive, easier to understand at a glance and similar to the existing `$env.CURRENT_FILE`
# Cons
- Requires changes in the parser 
- Small scoping issues, as there is no way to un-define a variable or constant, other than overwriting it with `null`.