### PR TITLE
Fix binary example and add one for text uploads

### DIFF
--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -128,8 +128,13 @@ impl Command for SubCommand {
                 result: None,
             },
             Example {
-                description: "Upload a file to example.com",
-                example: "http post --content-type multipart/form-data https://www.example.com { file: (open -r file.mp3 | into binary) }",
+                description: "Upload a binary file to example.com",
+                example: "http post --content-type multipart/form-data https://www.example.com { file: (open -r file.mp3) }",
+                result: None,
+            },
+            Example {
+                description: "Convert a text file into binary and upload it to example.com",
+                example: "http post --content-type multipart/form-data https://www.example.com { file: (open -r file.txt | into binary) }",
                 result: None,
             },
         ]


### PR DESCRIPTION
# Description

In #14291, I misunderstood the use-case for `into binary` with `http post`.  Thanks again to @weirdan for steering me straight on that.  This reverts the example that I changed and adds a new one for uploading text files.

# User-Facing Changes

Doc-only

# Tests + Formatting



# After Submitting

N/A