### PR TITLE
error when a closure is used as `def` body

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -18,7 +18,7 @@ impl Command for Def {
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .required("def_name", SyntaxShape::String, "Command name.")
             .required("params", SyntaxShape::Signature, "Parameters.")
-            .required("block", SyntaxShape::Closure(None), "Body of the definition.")
+            .required("block", SyntaxShape::Block(false), "Body of the definition.")
             .switch("env", "keep the environment defined inside the command", None)
             .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/export_def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_def.rs
@@ -18,7 +18,7 @@ impl Command for ExportDef {
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .required("def_name", SyntaxShape::String, "Command name.")
             .required("params", SyntaxShape::Signature, "Parameters.")
-            .required("block", SyntaxShape::Block, "Body of the definition.")
+            .required("block", SyntaxShape::Block(false), "Body of the definition.")
             .switch("env", "keep the environment defined inside the command", None)
             .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/export_module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_module.rs
@@ -20,7 +20,7 @@ impl Command for ExportModule {
             .required("module", SyntaxShape::String, "Module name or module path.")
             .optional(
                 "block",
-                SyntaxShape::Block,
+                SyntaxShape::Block(true),
                 "Body of the module if 'module' parameter is not a path.",
             )
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -27,7 +27,7 @@ impl Command for For {
                 SyntaxShape::Keyword(b"in".to_vec(), Box::new(SyntaxShape::Any)),
                 "Range of the loop.",
             )
-            .required("block", SyntaxShape::Block, "The block to run.")
+            .required("block", SyntaxShape::Block(true), "The block to run.")
             .creates_scope()
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/if_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/if_.rs
@@ -24,7 +24,7 @@ impl Command for If {
             .required("cond", SyntaxShape::MathExpression, "Condition to check.")
             .required(
                 "then_block",
-                SyntaxShape::Block,
+                SyntaxShape::Block(true),
                 "Block to run if check succeeds.",
             )
             .optional(
@@ -32,7 +32,7 @@ impl Command for If {
                 SyntaxShape::Keyword(
                     b"else".to_vec(),
                     Box::new(SyntaxShape::OneOf(vec![
-                        SyntaxShape::Block,
+                        SyntaxShape::Block(true),
                         SyntaxShape::Expression,
                     ])),
                 ),

--- a/crates/nu-cmd-lang/src/core_commands/loop_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/loop_.rs
@@ -17,7 +17,7 @@ impl Command for Loop {
         Signature::build("loop")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("block", SyntaxShape::Block, "Block to loop.")
+            .required("block", SyntaxShape::Block(true), "Block to loop.")
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/module.rs
@@ -20,7 +20,7 @@ impl Command for Module {
             .required("module", SyntaxShape::String, "Module name or module path.")
             .optional(
                 "block",
-                SyntaxShape::Block,
+                SyntaxShape::Block(true),
                 "Body of the module if 'module' parameter is not a module path.",
             )
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -16,7 +16,7 @@ impl Command for Try {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("try")
             .input_output_types(vec![(Type::Any, Type::Any)])
-            .required("try_block", SyntaxShape::Block, "Block to run.")
+            .required("try_block", SyntaxShape::Block(true), "Block to run.")
             .optional(
                 "catch_closure",
                 SyntaxShape::Keyword(

--- a/crates/nu-cmd-lang/src/core_commands/while_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/while_.rs
@@ -20,7 +20,7 @@ impl Command for While {
             .required("cond", SyntaxShape::MathExpression, "Condition to check.")
             .required(
                 "block",
-                SyntaxShape::Block,
+                SyntaxShape::Block(true),
                 "Block to loop if check succeeds.",
             )
             .category(Category::Core)

--- a/crates/nu-command/src/env/export_env.rs
+++ b/crates/nu-command/src/env/export_env.rs
@@ -14,7 +14,7 @@ impl Command for ExportEnv {
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .required(
                 "block",
-                SyntaxShape::Block,
+                SyntaxShape::Block(true),
                 "The block to run to set the environment.",
             )
             .category(Category::Env)

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -462,10 +462,9 @@ pub fn parse_def(
                         let block = working_set.get_block_mut(*block_id);
                         block.signature = Box::new(sig.clone());
                     }
-                    _ => working_set.error(ParseError::Expected(
-                        "definition body closure { ... }",
-                        arg.span,
-                    )),
+                    _ => {
+                        working_set.error(ParseError::Expected("definition body { ... }", arg.span))
+                    }
                 }
             }
 

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1991,7 +1991,7 @@ mod input_types {
                 .input_output_types(vec![(Type::Nothing, Type::Nothing)])
                 .required("def_name", SyntaxShape::String, "definition name")
                 .required("params", SyntaxShape::Signature, "parameters")
-                .required("body", SyntaxShape::Closure(None), "body of the definition")
+                .required("body", SyntaxShape::Block(false), "body of the definition")
                 .category(Category::Core)
         }
 
@@ -2228,7 +2228,7 @@ mod input_types {
                 .required("cond", SyntaxShape::MathExpression, "condition to check")
                 .required(
                     "then_block",
-                    SyntaxShape::Block,
+                    SyntaxShape::Block(true),
                     "block to run if check succeeds",
                 )
                 .optional(
@@ -2236,7 +2236,7 @@ mod input_types {
                     SyntaxShape::Keyword(
                         b"else".to_vec(),
                         Box::new(SyntaxShape::OneOf(vec![
-                            SyntaxShape::Block,
+                            SyntaxShape::Block(true),
                             SyntaxShape::Expression,
                         ])),
                     ),

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -18,7 +18,8 @@ pub enum SyntaxShape {
     Binary,
 
     /// A block is allowed, eg `{start this thing}`
-    Block,
+    /// `bool`: capture mutable variables
+    Block(bool),
 
     /// A boolean value, eg `true` or `false`
     Boolean,
@@ -143,7 +144,7 @@ impl SyntaxShape {
 
         match self {
             SyntaxShape::Any => Type::Any,
-            SyntaxShape::Block => Type::Block,
+            SyntaxShape::Block(_) => Type::Block,
             SyntaxShape::Closure(_) => Type::Closure,
             SyntaxShape::Binary => Type::Binary,
             SyntaxShape::CellPath => Type::Any,
@@ -209,7 +210,7 @@ impl Display for SyntaxShape {
             SyntaxShape::Directory => write!(f, "directory"),
             SyntaxShape::GlobPattern => write!(f, "glob"),
             SyntaxShape::ImportPattern => write!(f, "import"),
-            SyntaxShape::Block => write!(f, "block"),
+            SyntaxShape::Block(_) => write!(f, "block"),
             SyntaxShape::Closure(args) => {
                 if let Some(args) = args {
                     let arg_vec: Vec<_> = args.iter().map(|x| x.to_string()).collect();

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -109,7 +109,7 @@ impl Type {
             Type::Range => SyntaxShape::Range,
             Type::Bool => SyntaxShape::Boolean,
             Type::String => SyntaxShape::String,
-            Type::Block => SyntaxShape::Block, // FIXME needs more accuracy
+            Type::Block => SyntaxShape::Block(true), // FIXME needs more accuracy
             Type::Closure => SyntaxShape::Closure(None), // FIXME needs more accuracy
             Type::CellPath => SyntaxShape::CellPath,
             Type::Duration => SyntaxShape::Duration,

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -931,8 +931,10 @@ fn record_missing_value() -> TestResult {
 }
 
 #[test]
-fn def_requires_body_closure() -> TestResult {
-    fail_test("def a [] (echo 4)", "expected definition body closure")
+fn def_requires_body_block() -> TestResult {
+    fail_test("def a [] (echo 4)", "expected definition body")?;
+    fail_test("def a [] {|| }", "expected definition body")?;
+    fail_test("def a [] {|b: int| echo $b }", "expected definition body")
 }
 
 #[test]


### PR DESCRIPTION
Closes #9737

# User-Facing Changes

`def` now errors instead of silently ignoring closure blocks:

```nushell
> def foo [] {|bar| }
Error: nu::parser::parse_mismatch

  × Parse mismatch during operation.
   ╭─[entry #1:1:12]
 1 │ def foo [] {|bar| }
   ·            ────┬───
   ·                ╰── expected definition body { ... }
   ╰────
```