### PR TITLE
Tests: add a test to make sure that function can't use mutable variable

### DIFF
--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -143,7 +143,7 @@ fn mut_raw_string() {
 }
 
 #[test]
-fn mut_should_not_be_allowed_outside_func() {
+fn def_should_not_mutate_mut() {
     let actual = nu!("mut a = 3; def foo [] { $a = 4}");
     assert!(actual.err.contains("capture of mutable variable"));
     assert!(!actual.status.success())

--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -141,3 +141,10 @@ fn mut_raw_string() {
     let actual = nu!(r#"mut x = r#'abc'#; $x"#);
     assert_eq!(actual.out, "abc");
 }
+
+#[test]
+fn mut_should_not_be_allowed_outside_func() {
+    let actual = nu!("mut a = 3; def foo [] { $a = 4}");
+    assert!(actual.err.contains("capture of mutable variable"));
+    assert!(!actual.status.success())
+}


### PR DESCRIPTION
@sholderbach suggested that we need to have a test for a function can't use mutable variable.

https://github.com/nushell/nushell/pull/14311#issuecomment-2470035194

So this pr is going to add a case for it.