### PR TITLE
#7190 Added sort_by config to ls configs (Fixes #7190)

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -263,7 +263,23 @@ fn setup_and_sort_by_config(
         Span::unknown(),
         sort_by_config.ignore_case,
         sort_by_config.natural,
-    )?;
+    )
+    .map_err(|err| {
+        let ShellError::CantFindColumn {
+            col_name,
+            span,
+            src_span,
+        } = err
+        else {
+            return err;
+        };
+
+        ShellError::CantFindColumn {
+            col_name: format!("{} (from the ls configuration)", col_name),
+            span,
+            src_span,
+        }
+    })?;
 
     if sort_by_config.reverse {
         comparator_vals.reverse();

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -489,13 +489,13 @@ fn ls_for_one_pattern(
                     } else {
                         Some(path.to_string_lossy().to_string())
                     }
-                        .ok_or_else(|| ShellError::GenericError {
-                            error: format!("Invalid file name: {:}", path.to_string_lossy()),
-                            msg: "invalid file name".into(),
-                            span: Some(call_span),
-                            help: None,
-                            inner: vec![],
-                        });
+                    .ok_or_else(|| ShellError::GenericError {
+                        error: format!("Invalid file name: {:}", path.to_string_lossy()),
+                        msg: "invalid file name".into(),
+                        span: Some(call_span),
+                        help: None,
+                        inner: vec![],
+                    });
 
                     match display_name {
                         Ok(name) => {
@@ -530,13 +530,13 @@ fn ls_for_one_pattern(
                 })
             })
     })
-        .map_err(|err| ShellError::GenericError {
-            error: "Unable to create a rayon pool".into(),
-            msg: err.to_string(),
-            span: Some(call_span),
-            help: None,
-            inner: vec![],
-        })?;
+    .map_err(|err| ShellError::GenericError {
+        error: "Unable to create a rayon pool".into(),
+        msg: err.to_string(),
+        span: Some(call_span),
+        help: None,
+        inner: vec![],
+    })?;
 
     Ok(rx
         .into_iter()
@@ -668,7 +668,7 @@ pub(crate) fn dir_entry_dict(
                                         .expect("already check the filename have a parent"),
                                     true,
                                 )
-                                    .to_string_lossy(),
+                                .to_string_lossy(),
                                 span,
                             )
                         } else {
@@ -1019,7 +1019,7 @@ fn read_dir(
     f: &Path,
     span: Span,
     use_threads: bool,
-) -> Result<Box<dyn Iterator<Item=Result<PathBuf, ShellError>> + Send>, ShellError> {
+) -> Result<Box<dyn Iterator<Item = Result<PathBuf, ShellError>> + Send>, ShellError> {
     let items = f
         .read_dir()
         .map_err(|error| {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -355,10 +355,7 @@ fn ls_for_one_pattern(
                 nu_path::expand_path_with(pat.item.as_ref(), &cwd, pat.item.is_expand());
             // Avoid checking and pushing "*" to the path when directory (do not show contents) flag is true
             if !directory && tmp_expanded.is_dir() {
-                if read_dir(&tmp_expanded, p_tag)?
-                    .next()
-                    .is_none()
-                {
+                if read_dir(&tmp_expanded, p_tag)?.next().is_none() {
                     return Ok(Value::test_nothing().into_pipeline_data());
                 }
                 just_read_dir = !(pat.item.is_expand() && pat.item.as_ref().contains(GLOB_CHARS));

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -287,7 +287,7 @@ fn handle_err_sort_by_config(
 ) -> Option<ShellError> {
     let ShellError::CantFindColumn {
         col_name,
-        span,
+        span: _,
         src_span,
     } = err
     else {
@@ -312,7 +312,7 @@ fn handle_err_sort_by_config(
             "{} (from the ls configuration{} Will ignore that misconfigured sort.)",
             col_name, list_column_names_names
         ),
-        span,
+        span: None,
         src_span,
     };
 

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -1,5 +1,5 @@
 use super::util::get_rest_for_glob_pattern;
-use crate::{math, sort_utils, Comparator, DirBuilder, DirInfo};
+use crate::{sort_utils, Comparator, DirBuilder, DirInfo};
 use chrono::{DateTime, Local, LocalResult, TimeZone, Utc};
 use nu_engine::glob_from;
 #[allow(deprecated)]
@@ -162,7 +162,7 @@ impl Command for Ls {
         if stack.get_config(engine_state).ls.sort_by.is_empty() {
             Ok(result)
         } else {
-            apply_post_sorting(engine_state, &stack, call, result)
+            apply_post_sorting(engine_state, stack, call, result)
         }
     }
 
@@ -236,7 +236,7 @@ fn apply_post_sorting(
     let mut comparator_vals: Vec<Value> = result.into_iter().collect();
 
     for sort_by_config in sort_by_configs {
-         setup_and_sort_by_config(&mut comparator_vals, &sort_by_config)?;
+        setup_and_sort_by_config(&mut comparator_vals, sort_by_config)?;
     }
 
     let val = Value::list(comparator_vals, call.head);
@@ -556,7 +556,6 @@ fn path_contains_hidden_folder(path: &Path, folders: &[PathBuf]) -> bool {
     false
 }
 
-use nix::libc::printf;
 use nu_protocol::ast::PathMember;
 #[cfg(unix)]
 use std::os::unix::fs::FileTypeExt;

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -553,7 +553,7 @@ fn lists_regular_sort_by_name_reversed_size_type() {
 
 #[test]
 fn lists_regular_sort_by_no_files() {
-    Playground::setup("ls_test_sort_by_no_files", |dirs, sandbox| {
+    Playground::setup("ls_test_sort_by_no_files", |dirs, _| {
         let inp = &[
             "$env.config = { \
                 ls: { \

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -436,28 +436,6 @@ fn lists_files_including_starting_with_dot() {
 }
 
 #[test]
-fn lists_regular_files_using_question_mark_wildcard_asdsad() {
-    Playground::setup("ls_test_3", |dirs, sandbox| {
-        sandbox.with_files(&[
-            EmptyFile("yehuda.10.txt"),
-            EmptyFile("jt.10.txt"),
-            EmptyFile("andres.10.txt"),
-            EmptyFile("chicken_not_to_be_picked_up.100.txt"),
-        ]);
-
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                ls *.??.txt
-                | length
-            "
-        ));
-
-        assert_eq!(actual.out, "3");
-    })
-}
-
-#[test]
 fn list_all_columns() {
     Playground::setup("ls_test_all_columns", |dirs, sandbox| {
         sandbox.with_files(&[

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -838,27 +838,3 @@ fn list_symlink_with_full_path() {
         );
     })
 }
-
-#[test]
-fn consistent_list_order() {
-    Playground::setup("ls_test_order", |dirs, sandbox| {
-        sandbox.with_files(&[
-            EmptyFile("los.txt"),
-            EmptyFile("tres.txt"),
-            EmptyFile("amigos.txt"),
-            EmptyFile("arepas.clu"),
-        ]);
-
-        let no_arg = nu!(
-            cwd: dirs.test(), pipeline(
-            "ls"
-        ));
-
-        let with_arg = nu!(
-            cwd: dirs.test(), pipeline(
-            "ls ."
-        ));
-
-        assert_eq!(no_arg.out, with_arg.out);
-    })
-}

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -436,6 +436,28 @@ fn lists_files_including_starting_with_dot() {
 }
 
 #[test]
+fn lists_regular_files_using_question_mark_wildcard_asdsad() {
+    Playground::setup("ls_test_3", |dirs, sandbox| {
+        sandbox.with_files(&[
+            EmptyFile("yehuda.10.txt"),
+            EmptyFile("jt.10.txt"),
+            EmptyFile("andres.10.txt"),
+            EmptyFile("chicken_not_to_be_picked_up.100.txt"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            "
+                ls *.??.txt
+                | length
+            "
+        ));
+
+        assert_eq!(actual.out, "3");
+    })
+}
+
+#[test]
 fn list_all_columns() {
     Playground::setup("ls_test_all_columns", |dirs, sandbox| {
         sandbox.with_files(&[

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -43,7 +43,7 @@ fn lists_regular_sort_by_files_name_order() {
             nu_repl_code(inp)
         );
 
-        let expected_sorted_order_by_name = vec![
+        let mut expected_sorted_order_by_name = vec![
             "2_small_natural.txt",
             "10_small_natural.txt",
             "A_DIRECTORY",
@@ -59,9 +59,17 @@ fn lists_regular_sort_by_files_name_order() {
             "b_medium.txt",
             "b_small.txt",
         ];
+        handle_case_insentive_os(&mut expected_sorted_order_by_name);
         let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
         assert_eq!(actual_output, expected_sorted_order_by_name);
     })
+}
+
+fn handle_case_insentive_os(expected_sorted_order_by_name: &mut Vec<&str>) {
+    if cfg!(target_os = "macos") {
+        expected_sorted_order_by_name
+            .retain(|x| ["A_DIRECTORY", "A_LARGE.TXT", "A_MEDIUM.TXT", "A_SMALL.TXT"].contains(x));
+    }
 }
 
 #[test]
@@ -87,7 +95,7 @@ fn lists_regular_sort_by_files_name_order_reversed() {
                 nu_repl_code(inp)
             );
 
-            let expected_sorted_order_by_name = vec![
+            let mut expected_sorted_order_by_name = vec![
                 "b_small.txt",
                 "b_medium.txt",
                 "b_large.txt",
@@ -103,6 +111,7 @@ fn lists_regular_sort_by_files_name_order_reversed() {
                 "10_small_natural.txt",
                 "2_small_natural.txt",
             ];
+            handle_case_insentive_os(&mut expected_sorted_order_by_name);
             let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
             assert_eq!(actual_output, expected_sorted_order_by_name);
         },
@@ -132,7 +141,7 @@ fn lists_regular_sort_by_files_name_order_dont_ignore_case() {
                 nu_repl_code(inp)
             );
 
-            let expected_sorted_order_by_name = vec![
+            let mut expected_sorted_order_by_name = vec![
                 "2_small_natural.txt",
                 "10_small_natural.txt",
                 "A_DIRECTORY",
@@ -148,6 +157,7 @@ fn lists_regular_sort_by_files_name_order_dont_ignore_case() {
                 "b_medium.txt",
                 "b_small.txt",
             ];
+            handle_case_insentive_os(&mut expected_sorted_order_by_name);
             let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
             assert_eq!(actual_output, expected_sorted_order_by_name);
         },
@@ -178,7 +188,7 @@ fn lists_regular_sort_by_files_name_order_dont_ignore_case_not_natural() {
                 nu_repl_code(inp)
             );
 
-            let expected_sorted_order_by_name = vec![
+            let mut expected_sorted_order_by_name = vec![
                 "10_small_natural.txt",
                 "2_small_natural.txt",
                 "A_DIRECTORY",
@@ -194,6 +204,7 @@ fn lists_regular_sort_by_files_name_order_dont_ignore_case_not_natural() {
                 "b_medium.txt",
                 "b_small.txt",
             ];
+            handle_case_insentive_os(&mut expected_sorted_order_by_name);
             let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
             assert_eq!(actual_output, expected_sorted_order_by_name);
         },
@@ -220,7 +231,7 @@ fn lists_regular_sorty_by_type() {
             nu_repl_code(inp)
         );
 
-        let expected_sorted_order_by_name = vec![
+        let mut expected_sorted_order_by_name = vec![
             "A_DIRECTORY",
             "a_directory",
             "b_directory",
@@ -236,6 +247,7 @@ fn lists_regular_sorty_by_type() {
             "b_medium.txt",
             "b_small.txt",
         ];
+        handle_case_insentive_os(&mut expected_sorted_order_by_name);
         let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
         assert_eq!(actual_output, expected_sorted_order_by_name);
     })
@@ -262,7 +274,7 @@ fn lists_regular_sorty_by_type_reversed() {
             nu_repl_code(inp)
         );
 
-        let expected_sorted_order_by_name = vec![
+        let mut expected_sorted_order_by_name = vec![
             "b_small.txt",
             "b_medium.txt",
             "b_large.txt",
@@ -278,6 +290,7 @@ fn lists_regular_sorty_by_type_reversed() {
             "a_directory",
             "A_DIRECTORY",
         ];
+        handle_case_insentive_os(&mut expected_sorted_order_by_name);
         let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
         assert_eq!(actual_output, expected_sorted_order_by_name);
     })
@@ -308,7 +321,7 @@ fn lists_regular_sort_by_type_reversed_no_effect_natural_and_case() {
                 nu_repl_code(inp)
             );
 
-            let expected_sorted_order_by_name = vec![
+            let mut expected_sorted_order_by_name = vec![
                 "b_small.txt",
                 "b_medium.txt",
                 "b_large.txt",
@@ -324,6 +337,7 @@ fn lists_regular_sort_by_type_reversed_no_effect_natural_and_case() {
                 "a_directory",
                 "A_DIRECTORY",
             ];
+            handle_case_insentive_os(&mut expected_sorted_order_by_name);
             let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
             assert_eq!(actual_output, expected_sorted_order_by_name);
         },
@@ -350,7 +364,7 @@ fn lists_regular_sort_by_size() {
             nu_repl_code(inp)
         );
 
-        let expected_sorted_order_by_name = vec![
+        let mut expected_sorted_order_by_name = vec![
             "10_small_natural.txt",
             "2_small_natural.txt",
             "A_SMALL.TXT",
@@ -366,6 +380,7 @@ fn lists_regular_sort_by_size() {
             "a_directory",
             "b_directory",
         ];
+        handle_case_insentive_os(&mut expected_sorted_order_by_name);
         let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
         assert_eq!(actual_output, expected_sorted_order_by_name);
     })
@@ -392,7 +407,7 @@ fn lists_regular_sort_by_size_reversed() {
             nu_repl_code(inp)
         );
 
-        let expected_sorted_order_by_name = vec![
+        let mut expected_sorted_order_by_name = vec![
             "b_directory",
             "a_directory",
             "A_DIRECTORY",
@@ -408,6 +423,7 @@ fn lists_regular_sort_by_size_reversed() {
             "2_small_natural.txt",
             "10_small_natural.txt",
         ];
+        handle_case_insentive_os(&mut expected_sorted_order_by_name);
         let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
         assert_eq!(actual_output, expected_sorted_order_by_name);
     })
@@ -438,7 +454,7 @@ fn lists_regular_sort_by_size_reversed_no_effect_natural_and_case() {
                 nu_repl_code(inp)
             );
 
-            let expected_sorted_order_by_name = vec![
+            let mut expected_sorted_order_by_name = vec![
                 "b_directory",
                 "a_directory",
                 "A_DIRECTORY",
@@ -454,6 +470,7 @@ fn lists_regular_sort_by_size_reversed_no_effect_natural_and_case() {
                 "2_small_natural.txt",
                 "10_small_natural.txt",
             ];
+            handle_case_insentive_os(&mut expected_sorted_order_by_name);
             let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
             assert_eq!(actual_output, expected_sorted_order_by_name);
         },
@@ -481,7 +498,7 @@ fn lists_regular_sort_by_modified() {
             nu_repl_code(inp)
         );
 
-        let expected_sorted_order_by_name = vec![
+        let mut expected_sorted_order_by_name = vec![
             "10_small_natural.txt",
             "2_small_natural.txt",
             "A_DIRECTORY",
@@ -497,6 +514,7 @@ fn lists_regular_sort_by_modified() {
             "b_medium.txt",
             "b_small.txt",
         ];
+        handle_case_insentive_os(&mut expected_sorted_order_by_name);
         let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
         assert_eq!(actual_output, expected_sorted_order_by_name);
     })
@@ -529,7 +547,7 @@ fn lists_regular_sort_by_name_reversed_size_type() {
                 nu_repl_code(inp)
             );
 
-            let expected_sorted_order_by_name = vec![
+            let mut expected_sorted_order_by_name = vec![
                 "b_directory",
                 "a_directory",
                 "A_DIRECTORY",
@@ -545,6 +563,57 @@ fn lists_regular_sort_by_name_reversed_size_type() {
                 "a_large.txt",
                 "A_LARGE.TXT",
             ];
+            handle_case_insentive_os(&mut expected_sorted_order_by_name);
+            let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
+            assert_eq!(actual_output, expected_sorted_order_by_name);
+        },
+    )
+}
+
+#[test]
+fn lists_regular_sort_by_name_reversed_size_type_with_l_flag() {
+    Playground::setup(
+        "ls_test_sort_by_name_reversed_size_type",
+        |dirs, sandbox| {
+            setup_files_to_test_ls_sortby_config(sandbox);
+            let inp = &[
+                "$env.config = { \
+                ls: { \
+                    sort_by: [{ \
+                        column: \"name\", \
+                        reverse: true, \
+                    },{ \
+                        column: \"size\", \
+                    },{ \
+                        column: \"type\", \
+                    }] \
+                } \
+            }",
+                "ls -l",
+            ];
+
+            let actual = nu!(
+                cwd: dirs.test(),
+                nu_repl_code(inp)
+            );
+
+            let mut expected_sorted_order_by_name = vec![
+                "b_directory",
+                "a_directory",
+                "A_DIRECTORY",
+                "b_small.txt",
+                "a_small.txt",
+                "A_SMALL.TXT",
+                "10_small_natural.txt",
+                "2_small_natural.txt",
+                "b_medium.txt",
+                "a_medium.txt",
+                "A_MEDIUM.TXT",
+                "b_large.txt",
+                "a_large.txt",
+                "A_LARGE.TXT",
+            ];
+            handle_case_insentive_os(&mut expected_sorted_order_by_name);
             let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
             assert_eq!(actual_output, expected_sorted_order_by_name);
         },
@@ -599,7 +668,7 @@ fn lists_regular_sort_by_unknown_column() {
             nu_repl_code(inp)
         );
 
-        let expected_sorted_order_by_name = vec![
+        let mut expected_sorted_order_by_name = vec![
             "10_small_natural.txt",
             "2_small_natural.txt",
             "A_DIRECTORY",
@@ -615,12 +684,14 @@ fn lists_regular_sort_by_unknown_column() {
             "b_medium.txt",
             "b_small.txt",
         ];
+        handle_case_insentive_os(&mut expected_sorted_order_by_name);
         let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
         assert_eq!(actual_output, expected_sorted_order_by_name);
 
         // Technically this is a warning and not an error.
         let error_message = actual.err.as_str();
-        assert!(error_message.contains("cannot find column 'unknown_column (from the ls configuration, possible columns are name, type, size, modified. Will ignore that misconfigured sort.)'"));
+        assert!(error_message.contains("Cannot find column 'unknown_column"));
+        assert!(error_message.contains("name, type, size, modified"));
     })
 }
 
@@ -681,7 +752,7 @@ fn lists_regular_sort_by_files_name_order_not_natural() {
                 nu_repl_code(inp)
             );
 
-            let expected_sorted_order_by_name = vec![
+            let mut expected_sorted_order_by_name = vec![
                 "10_small_natural.txt",
                 "2_small_natural.txt",
                 "A_DIRECTORY",
@@ -697,6 +768,7 @@ fn lists_regular_sort_by_files_name_order_not_natural() {
                 "b_medium.txt",
                 "b_small.txt",
             ];
+            handle_case_insentive_os(&mut expected_sorted_order_by_name);
             let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
             assert_eq!(actual_output, expected_sorted_order_by_name);
         },
@@ -713,22 +785,26 @@ fn get_file_order_by_name_for_ls_sorby_config(actual: &Outcome) -> Vec<&str> {
 }
 
 fn setup_files_to_test_ls_sortby_config(sandbox: &mut Playground) {
-    let files = [
+    let mut files = vec![
         FileWithContent("a_small.txt", "small"),
-        FileWithContent("A_SMALL.TXT", "small"),
         FileWithContent("b_small.txt", "small"),
         FileWithContent("a_medium.txt", "medium"),
-        FileWithContent("A_MEDIUM.TXT", "medium"),
         FileWithContent("b_medium.txt", "medium"),
         FileWithContent("a_large.txt", "largelargelarge"),
-        FileWithContent("A_LARGE.TXT", "largelargelarge"),
         FileWithContent("b_large.txt", "largelargelarge"),
         FileWithContent("10_small_natural.txt", "small"),
         FileWithContent("2_small_natural.txt", "small"),
     ];
+
+    // Add case-sensitive files and directories for OSs that can handle them
+    if !cfg!(target_os = "macos") {
+        files.push(FileWithContent("A_SMALL.TXT", "small"));
+        files.push(FileWithContent("A_MEDIUM.TXT", "medium"));
+        files.push(FileWithContent("A_LARGE.TXT", "largelargelarge"));
+        sandbox.mkdir("A_DIRECTORY");
+    }
     sandbox.with_files(&files);
     sandbox.mkdir("a_directory");
-    sandbox.mkdir("A_DIRECTORY");
     sandbox.mkdir("b_directory");
 }
 

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -68,7 +68,7 @@ fn lists_regular_sort_by_files_name_order() {
 fn handle_case_insentive_os(expected_sorted_order_by_name: &mut Vec<&str>) {
     if cfg!(target_os = "macos") {
         expected_sorted_order_by_name
-            .retain(|x| ["A_DIRECTORY", "A_LARGE.TXT", "A_MEDIUM.TXT", "A_SMALL.TXT"].contains(x));
+            .retain(|x| !["A_DIRECTORY", "A_LARGE.TXT", "A_MEDIUM.TXT", "A_SMALL.TXT"].contains(x));
     }
 }
 

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -599,12 +599,28 @@ fn lists_regular_sort_by_unknown_column() {
             nu_repl_code(inp)
         );
 
-        let expected_sorted_order_by_name: Vec<String> = vec![];
+        let expected_sorted_order_by_name = vec![
+            "10_small_natural.txt",
+            "2_small_natural.txt",
+            "A_DIRECTORY",
+            "A_LARGE.TXT",
+            "A_MEDIUM.TXT",
+            "A_SMALL.TXT",
+            "a_directory",
+            "a_large.txt",
+            "a_medium.txt",
+            "a_small.txt",
+            "b_directory",
+            "b_large.txt",
+            "b_medium.txt",
+            "b_small.txt",
+        ];
         let actual_output = get_file_order_by_name_for_ls_sorby_config(&actual);
         assert_eq!(actual_output, expected_sorted_order_by_name);
 
+        // Technically this is a warning and not an error.
         let error_message = actual.err.as_str();
-        assert!(error_message.contains("cannot find column 'unknown_column (from the ls configuration, possible columns are name, type, size, modified.)'"));
+        assert!(error_message.contains("cannot find column 'unknown_column (from the ls configuration, possible columns are name, type, size, modified. Will ignore that misconfigured sort.)'"));
     })
 }
 

--- a/crates/nu-protocol/src/config/helper.rs
+++ b/crates/nu-protocol/src/config/helper.rs
@@ -105,6 +105,26 @@ impl UpdateFromValue for usize {
     }
 }
 
+impl UpdateFromValue for Vec<String> {
+    fn update(&mut self, value: &Value, path: &mut ConfigPath, errors: &mut ConfigErrors) {
+        if let Ok(val) = value.as_list() {
+            *self = val
+                .iter()
+                .map(|val| {
+                    if let Ok(val) = val.as_str() {
+                        val.into()
+                    } else {
+                        errors.type_mismatch(path, Type::String, val);
+                        "".into()
+                    }
+                })
+                .collect();
+        } else {
+            errors.type_mismatch(path, Type::String, value);
+        }
+    }
+}
+
 impl UpdateFromValue for String {
     fn update(&mut self, value: &Value, path: &mut ConfigPath, errors: &mut ConfigErrors) {
         if let Ok(val) = value.as_str() {

--- a/crates/nu-protocol/src/config/helper.rs
+++ b/crates/nu-protocol/src/config/helper.rs
@@ -105,26 +105,6 @@ impl UpdateFromValue for usize {
     }
 }
 
-impl UpdateFromValue for Vec<String> {
-    fn update(&mut self, value: &Value, path: &mut ConfigPath, errors: &mut ConfigErrors) {
-        if let Ok(val) = value.as_list() {
-            *self = val
-                .iter()
-                .map(|val| {
-                    if let Ok(val) = val.as_str() {
-                        val.into()
-                    } else {
-                        errors.type_mismatch(path, Type::String, val);
-                        "".into()
-                    }
-                })
-                .collect();
-        } else {
-            errors.type_mismatch(path, Type::String, value);
-        }
-    }
-}
-
 impl UpdateFromValue for String {
     fn update(&mut self, value: &Value, path: &mut ConfigPath, errors: &mut ConfigErrors) {
         if let Ok(val) = value.as_str() {

--- a/crates/nu-protocol/src/config/ls.rs
+++ b/crates/nu-protocol/src/config/ls.rs
@@ -65,7 +65,12 @@ impl Default for LsConfig {
         Self {
             use_ls_colors: true,
             clickable_links: true,
-            sort_by: vec![],
+            sort_by: vec![LsConfigSortConfig {
+                column: "name".to_string(),
+                reverse: false,
+                ignore_case: true,
+                natural: true,
+            }],
         }
     }
 }

--- a/crates/nu-protocol/src/config/ls.rs
+++ b/crates/nu-protocol/src/config/ls.rs
@@ -1,11 +1,64 @@
 use super::prelude::*;
 use crate as nu_protocol;
+use crate::config::helper::ConfigPathScope;
+use crate::Record;
 
 #[derive(Clone, Debug, IntoValue, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LsConfig {
     pub use_ls_colors: bool,
     pub clickable_links: bool,
-    pub sort_by: Vec<String>,
+    pub sort_by: Vec<LsConfigSortConfig>,
+}
+
+#[derive(Clone, Debug, IntoValue, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LsConfigSortConfig {
+    pub column: String,
+    pub reverse: bool,
+    pub ignore_case: bool,
+    pub natural: bool,
+}
+
+impl UpdateFromValue for Vec<LsConfigSortConfig> {
+    fn update<'a>(
+        &mut self,
+        value: &'a Value,
+        path: &mut ConfigPath<'a>,
+        errors: &mut ConfigErrors,
+    ) {
+        if let Ok(value_list) = value.as_list() {
+            *self = value_list
+                .iter()
+                .map(|value_record| {
+                    let Value::Record { val: record, .. } = value_record else {
+                        errors.type_mismatch(path, Type::record(), value_record);
+                        return None;
+                    };
+
+                    let mut ls_config_sort_config = LsConfigSortConfig::default();
+
+                    for (col, val) in record.iter() {
+                        let path = &mut path.push(col);
+                        match col.as_str() {
+                            "column" => ls_config_sort_config.column.update(val, path, errors),
+                            "reverse" => ls_config_sort_config.reverse.update(val, path, errors),
+                            "ignore_case" => ls_config_sort_config.ignore_case.update(val, path, errors),
+                            "natural" => ls_config_sort_config.natural.update(val, path, errors),
+                            _ => errors.unknown_option(path, val),
+                        }
+                    }
+
+                    if ls_config_sort_config.column.is_empty() {
+                        errors.missing_column(path, "column", value_record.span());
+                    }
+
+                    Some(ls_config_sort_config)
+                })
+                .filter_map(|x| x)
+                .collect();
+        } else {
+            errors.type_mismatch(path, Type::list(Type::record()), value);
+        }
+    }
 }
 
 impl Default for LsConfig {
@@ -14,6 +67,17 @@ impl Default for LsConfig {
             use_ls_colors: true,
             clickable_links: true,
             sort_by: vec![],
+        }
+    }
+}
+
+impl Default for LsConfigSortConfig {
+    fn default() -> Self {
+        Self {
+            column: "".to_string(),
+            reverse: false,
+            ignore_case: false,
+            natural: false,
         }
     }
 }

--- a/crates/nu-protocol/src/config/ls.rs
+++ b/crates/nu-protocol/src/config/ls.rs
@@ -1,7 +1,5 @@
 use super::prelude::*;
 use crate as nu_protocol;
-use crate::config::helper::ConfigPathScope;
-use crate::Record;
 
 #[derive(Clone, Debug, IntoValue, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LsConfig {
@@ -28,7 +26,7 @@ impl UpdateFromValue for Vec<LsConfigSortConfig> {
         if let Ok(value_list) = value.as_list() {
             *self = value_list
                 .iter()
-                .map(|value_record| {
+                .filter_map(|value_record| {
                     let Value::Record { val: record, .. } = value_record else {
                         errors.type_mismatch(path, Type::record(), value_record);
                         return None;
@@ -41,7 +39,9 @@ impl UpdateFromValue for Vec<LsConfigSortConfig> {
                         match col.as_str() {
                             "column" => ls_config_sort_config.column.update(val, path, errors),
                             "reverse" => ls_config_sort_config.reverse.update(val, path, errors),
-                            "ignore_case" => ls_config_sort_config.ignore_case.update(val, path, errors),
+                            "ignore_case" => {
+                                ls_config_sort_config.ignore_case.update(val, path, errors)
+                            }
                             "natural" => ls_config_sort_config.natural.update(val, path, errors),
                             _ => errors.unknown_option(path, val),
                         }
@@ -53,7 +53,6 @@ impl UpdateFromValue for Vec<LsConfigSortConfig> {
 
                     Some(ls_config_sort_config)
                 })
-                .filter_map(|x| x)
                 .collect();
         } else {
             errors.type_mismatch(path, Type::list(Type::record()), value);

--- a/crates/nu-protocol/src/config/ls.rs
+++ b/crates/nu-protocol/src/config/ls.rs
@@ -65,12 +65,7 @@ impl Default for LsConfig {
         Self {
             use_ls_colors: true,
             clickable_links: true,
-            sort_by: vec![LsConfigSortConfig {
-                column: "name".to_string(),
-                reverse: false,
-                ignore_case: true,
-                natural: true,
-            }],
+            sort_by: vec![LsConfigSortConfig::default()],
         }
     }
 }
@@ -78,10 +73,10 @@ impl Default for LsConfig {
 impl Default for LsConfigSortConfig {
     fn default() -> Self {
         Self {
-            column: "".to_string(),
+            column: "name".to_string(),
             reverse: false,
-            ignore_case: false,
-            natural: false,
+            ignore_case: true,
+            natural: true,
         }
     }
 }

--- a/crates/nu-protocol/src/config/ls.rs
+++ b/crates/nu-protocol/src/config/ls.rs
@@ -1,10 +1,11 @@
 use super::prelude::*;
 use crate as nu_protocol;
 
-#[derive(Clone, Copy, Debug, IntoValue, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, IntoValue, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LsConfig {
     pub use_ls_colors: bool,
     pub clickable_links: bool,
+    pub sort_by: Vec<String>,
 }
 
 impl Default for LsConfig {
@@ -12,6 +13,7 @@ impl Default for LsConfig {
         Self {
             use_ls_colors: true,
             clickable_links: true,
+            sort_by: vec![],
         }
     }
 }
@@ -33,6 +35,7 @@ impl UpdateFromValue for LsConfig {
             match col.as_str() {
                 "use_ls_colors" => self.use_ls_colors.update(val, path, errors),
                 "clickable_links" => self.clickable_links.update(val, path, errors),
+                "sort_by" => self.sort_by.update(val, path, errors),
                 _ => errors.unknown_option(path, val),
             }
         }

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -16,6 +16,7 @@ pub use helper::extract_value;
 pub use history::{HistoryConfig, HistoryFileFormat};
 pub use hooks::Hooks;
 pub use ls::LsConfig;
+pub use ls::LsConfigSortConfig;
 pub use output::ErrorStyle;
 pub use plugin_gc::{PluginGcConfig, PluginGcConfigs};
 pub use reedline::{CursorShapeConfig, EditBindings, NuCursorShape, ParsedKeybinding, ParsedMenu};

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -152,6 +152,7 @@ $env.config = {
     ls: {
         use_ls_colors: true # use the LS_COLORS environment variable to colorize output
         clickable_links: true # enable or disable clickable links. Your terminal has to support links.
+        sort_by: [] # Adds sorting on the output of ls, Example: sort_by: ['name reverse natural', 'type'] would be similar to `ls | | sort-by name -rn | sort-by type`
     }
 
     rm: {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -152,7 +152,6 @@ $env.config = {
     ls: {
         use_ls_colors: true # use the LS_COLORS environment variable to colorize output
         clickable_links: true # enable or disable clickable links. Your terminal has to support links.
-        sort_by: [] # Adds sorting on the output of ls, Example: sort_by: ['name reverse natural', 'type'] would be similar to `ls | | sort-by name -rn | sort-by type`
     }
 
     rm: {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -152,6 +152,13 @@ $env.config = {
     ls: {
         use_ls_colors: true # use the LS_COLORS environment variable to colorize output
         clickable_links: true # enable or disable clickable links. Your terminal has to support links.
+        sort_by: [
+            {
+                column: "name",
+                natural: true,
+                ignore_case: true,
+            },
+        ]
     }
 
     rm: {


### PR DESCRIPTION
# Description
- This PR closes #7190 

First of, first PR and I have some questions about missing pieces. I do not know if this is the best way to communicate it so please direct me. I added a questions section at the end. 

# User-Facing Changes
I am quite sure I solely use new code and beside adding the `sort_by`-configs then there should not be any other changes. 

# Tests + Formatting

```                                                                                            
~/Projects/nushell> cd tests/fixtures/completions/          
~/Projects/nushell/tests/fixtures/completions> ls      
╭───┬──────────────────────┬──────┬─────────┬────────────╮
│ # │         name         │ type │  size   │  modified  │
├───┼──────────────────────┼──────┼─────────┼────────────┤
│ 0 │ another              │ dir  │ 4.0 KiB │ 2 days ago │
│ 1 │ custom_completion.nu │ file │   100 B │ 2 days ago │
│ 2 │ directory_completion │ dir  │ 4.0 KiB │ 2 days ago │
│ 3 │ nushell              │ file │     0 B │ 2 days ago │
│ 4 │ test_a               │ dir  │ 4.0 KiB │ 2 days ago │
│ 5 │ test_b               │ dir  │ 4.0 KiB │ 2 days ago │
╰───┴──────────────────────┴──────┴─────────┴────────────╯

# Add `sort_by: ['name reverse natural', 'type']` to ls in `config.nu` and source. 
~/Projects/nushell/tests/fixtures/completions> ls                 
╭───┬──────────────────────┬──────┬─────────┬────────────╮
│ # │         name         │ type │  size   │  modified  │
├───┼──────────────────────┼──────┼─────────┼────────────┤
│ 0 │ test_b               │ dir  │ 4.0 KiB │ 2 days ago │
│ 1 │ test_a               │ dir  │ 4.0 KiB │ 2 days ago │
│ 2 │ directory_completion │ dir  │ 4.0 KiB │ 2 days ago │
│ 3 │ another              │ dir  │ 4.0 KiB │ 2 days ago │
│ 4 │ nushell              │ file │     0 B │ 2 days ago │
│ 5 │ custom_completion.nu │ file │   100 B │ 2 days ago │
╰───┴──────────────────────┴──────┴─────────┴────────────╯

# Remove the line again and source again (ERROR, it does not reset)
~/Projects/nushell/tests/fixtures/completions> ls                 
╭───┬──────────────────────┬──────┬─────────┬────────────╮
│ # │         name         │ type │  size   │  modified  │
├───┼──────────────────────┼──────┼─────────┼────────────┤
│ 0 │ test_b               │ dir  │ 4.0 KiB │ 2 days ago │
│ 1 │ test_a               │ dir  │ 4.0 KiB │ 2 days ago │
│ 2 │ directory_completion │ dir  │ 4.0 KiB │ 2 days ago │
│ 3 │ another              │ dir  │ 4.0 KiB │ 2 days ago │
│ 4 │ nushell              │ file │     0 B │ 2 days ago │
│ 5 │ custom_completion.nu │ file │   100 B │ 2 days ago │
╰───┴──────────────────────┴──────┴─────────┴────────────╯     

# Add `sort_by: []` to ls in `config.nu` and source. (Now it resets)
~/Projects/nushell/tests/fixtures/completions> ls      
╭───┬──────────────────────┬──────┬─────────┬────────────╮
│ # │         name         │ type │  size   │  modified  │
├───┼──────────────────────┼──────┼─────────┼────────────┤
│ 0 │ another              │ dir  │ 4.0 KiB │ 2 days ago │
│ 1 │ custom_completion.nu │ file │   100 B │ 2 days ago │
│ 2 │ directory_completion │ dir  │ 4.0 KiB │ 2 days ago │
│ 3 │ nushell              │ file │     0 B │ 2 days ago │
│ 4 │ test_a               │ dir  │ 4.0 KiB │ 2 days ago │
│ 5 │ test_b               │ dir  │ 4.0 KiB │ 2 days ago │
╰───┴──────────────────────┴──────┴─────────┴────────────╯
```  


# I did run the following 
- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library


# After Submitting
I need to update [the documentation](https://github.com/nushell/nushell.github.io) and I will prepare that while waiting for this MR to get some comments. 

# Questions 

1. Is there a better way of parsing the config than the new `setup_and_sort_by_config`-method? I kept it super naive just to be able to test the setup.  I were thinking that maybe there is already some parsing logic that parses strings into sort setup? Please direct me to some example code if that is the case. 
2. If that is not the case: Should I just keep it simple and have the fully written out flags? Because writing a parser that checks for `-in` as an example is fine but adds complexity. 
3. I were not able to find any existing automatic tests for `ls`, please direct me to them because I want to add some automatic tests for this feature. 
4. In general I did hack this together so I am very open for input about better architecture. I were keeping it simple so I could share quick and then get good feedback. 
5. Is it a general sourcing error that a config is not overwritten by default value if it is removed? As shown in the test. 
6. Is it okay that I removed the `Copy`-trait from `LsConfig`? 