### PR TITLE
add `from ndnuon` and `to ndnuon` to stdlib

### DIFF
--- a/crates/nu-std/std/formats/mod.nu
+++ b/crates/nu-std/std/formats/mod.nu
@@ -30,11 +30,11 @@ export def "to jsonl" []: any -> string {
 }
 
 # Convert from NDNUON, i.e. newline-delimited NUON, to structured
-def "from ndnuon" []: [string -> any] {
+export def "from ndnuon" []: [string -> any] {
     lines | each { from nuon }
 }
 
 # Convert structured data to NDNUON, i.e. newline-delimited NUON
-def "to ndnuon" []: [any -> string] {
+export def "to ndnuon" []: [any -> string] {
     each { to nuon --raw } | to text
 }

--- a/crates/nu-std/std/formats/mod.nu
+++ b/crates/nu-std/std/formats/mod.nu
@@ -28,3 +28,13 @@ export def "to ndjson" []: any -> string {
 export def "to jsonl" []: any -> string {
     each { to json --raw } | to text
 }
+
+# Convert from NDNUON, i.e. newline-delimited NUON, to structured
+def "from ndnuon" []: [string -> any] {
+    lines | each { from nuon }
+}
+
+# Convert structured data to NDNUON, i.e. newline-delimited NUON
+def "to ndnuon" []: [any -> string] {
+    each { to nuon --raw } | to text
+}

--- a/crates/nu-std/std/formats/mod.nu
+++ b/crates/nu-std/std/formats/mod.nu
@@ -29,7 +29,7 @@ export def "to jsonl" []: any -> string {
     each { to json --raw } | to text
 }
 
-# Convert from NDNUON, i.e. newline-delimited NUON, to structured
+# Convert from NDNUON (newline-delimited NUON), to structured data
 export def "from ndnuon" []: [string -> any] {
     lines | each { from nuon }
 }

--- a/crates/nu-std/tests/test_formats.nu
+++ b/crates/nu-std/tests/test_formats.nu
@@ -2,15 +2,26 @@
 use std/assert
 use std/formats *
 
-def test_data_multiline [] {
-  let lines = [
-    "{\"a\":1}",
-    "{\"a\":2}",
-    "{\"a\":3}",
-    "{\"a\":4}",
-    "{\"a\":5}",
-    "{\"a\":6}",
-  ]
+def test_data_multiline [--nuon] {
+  let lines = if $nuon {
+    [
+      "{a: 1}",
+      "{a: 2}",
+      "{a: 3}",
+      "{a: 4}",
+      "{a: 5}",
+      "{a: 6}",
+    ]
+  } else {
+    [
+      "{\"a\":1}",
+      "{\"a\":2}",
+      "{\"a\":3}",
+      "{\"a\":4}",
+      "{\"a\":5}",
+      "{\"a\":6}",
+    ]
+  }
 
   if $nu.os-info.name == "windows" {
     $lines | str join "\r\n"
@@ -87,14 +98,14 @@ def to_jsonl_single_object [] {
 
 #[test]
 def from_ndnuon_multiple_objects [] {
-  let result = test_data_multiline | formats from ndnuon
+  let result = test_data_multiline | from ndnuon
   let expect = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}]
   assert equal $result $expect "could not convert from NDNUON"
 }
 
 #[test]
 def from_ndnuon_single_object [] {
-  let result = '{a: 1}' | formats from ndnuon
+  let result = '{a: 1}' | from ndnuon
   let expect = [{a:1}]
   assert equal $result $expect "could not convert from NDNUON"
 }
@@ -106,14 +117,14 @@ def from_ndnuon_invalid_object [] {
 
 #[test]
 def to_ndnuon_multiple_objects [] {
-  let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | formats to ndnuon | str trim
-  let expect = test_data_multiline
+  let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | to ndnuon | str trim
+  let expect = test_data_multiline --nuon
   assert equal $result $expect "could not convert to NDNUON"
 }
 
 #[test]
 def to_ndnuon_single_object [] {
-  let result = [{a:1}] | formats to ndnuon | str trim
-  let expect = "{a:1}"
+  let result = [{a:1}] | to ndnuon | str trim
+  let expect = "{a: 1}"
   assert equal $result $expect "could not convert to NDNUON"
 }

--- a/crates/nu-std/tests/test_formats.nu
+++ b/crates/nu-std/tests/test_formats.nu
@@ -84,3 +84,22 @@ def to_jsonl_single_object [] {
   let expect = "{\"a\":1}"
   assert equal $result $expect "could not convert to JSONL"
 }
+
+#[test]
+def from_ndnuon_multiple_objects [] {
+  let result = test_data_multiline | formats from ndnuon
+  let expect = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}]
+  assert equal $result $expect "could not convert from NDNUON"
+}
+
+#[test]
+def from_ndnuon_single_object [] {
+  let result = '{a: 1}' | formats from ndnuon
+  let expect = [{a:1}]
+  assert equal $result $expect "could not convert from NDNUON"
+}
+
+#[test]
+def from_ndnuon_invalid_object [] {
+  assert error { '{"a":1' | formats from ndnuon }
+}

--- a/crates/nu-std/tests/test_formats.nu
+++ b/crates/nu-std/tests/test_formats.nu
@@ -103,3 +103,17 @@ def from_ndnuon_single_object [] {
 def from_ndnuon_invalid_object [] {
   assert error { '{"a":1' | formats from ndnuon }
 }
+
+#[test]
+def to_ndnuon_multiple_objects [] {
+  let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | formats to ndnuon | str trim
+  let expect = test_data_multiline
+  assert equal $result $expect "could not convert to NDNUON"
+}
+
+#[test]
+def to_ndnuon_single_object [] {
+  let result = [{a:1}] | formats to ndnuon | str trim
+  let expect = "{a:1}"
+  assert equal $result $expect "could not convert to NDNUON"
+}

--- a/crates/nu-std/tests/test_std_formats.nu
+++ b/crates/nu-std/tests/test_std_formats.nu
@@ -104,7 +104,6 @@ def from_ndnuon_invalid_object [] {
   assert error { '{"a":1' | formats from ndnuon }
 }
 
-
 #[test]
 def to_ndnuon_multiple_objects [] {
   let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | formats to ndnuon | str trim

--- a/crates/nu-std/tests/test_std_formats.nu
+++ b/crates/nu-std/tests/test_std_formats.nu
@@ -1,16 +1,27 @@
 # Test std/formats when importing `use std *`
 use std *
 
-def test_data_multiline [] {
+def test_data_multiline [--nuon] {
   use std *
-  let lines = [
-    "{\"a\":1}",
-    "{\"a\":2}",
-    "{\"a\":3}",
-    "{\"a\":4}",
-    "{\"a\":5}",
-    "{\"a\":6}",
-  ]
+  let lines = if $nuon {
+    [
+      "{a: 1}",
+      "{a: 2}",
+      "{a: 3}",
+      "{a: 4}",
+      "{a: 5}",
+      "{a: 6}",
+    ]
+  } else {
+    [
+      "{\"a\":1}",
+      "{\"a\":2}",
+      "{\"a\":3}",
+      "{\"a\":4}",
+      "{\"a\":5}",
+      "{\"a\":6}",
+    ]
+  }
 
   if $nu.os-info.name == "windows" {
     $lines | str join "\r\n"
@@ -107,13 +118,13 @@ def from_ndnuon_invalid_object [] {
 #[test]
 def to_ndnuon_multiple_objects [] {
   let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | formats to ndnuon | str trim
-  let expect = test_data_multiline
+  let expect = test_data_multiline --nuon
   assert equal $result $expect "could not convert to NDNUON"
 }
 
 #[test]
 def to_ndnuon_single_object [] {
   let result = [{a:1}] | formats to ndnuon | str trim
-  let expect = "{a:1}"
+  let expect = "{a: 1}"
   assert equal $result $expect "could not convert to NDNUON"
 }

--- a/crates/nu-std/tests/test_std_formats.nu
+++ b/crates/nu-std/tests/test_std_formats.nu
@@ -103,3 +103,18 @@ def from_ndnuon_single_object [] {
 def from_ndnuon_invalid_object [] {
   assert error { '{"a":1' | formats from ndnuon }
 }
+
+
+#[test]
+def to_ndnuon_multiple_objects [] {
+  let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | formats to ndnuon | str trim
+  let expect = test_data_multiline
+  assert equal $result $expect "could not convert to NDNUON"
+}
+
+#[test]
+def to_ndnuon_single_object [] {
+  let result = [{a:1}] | formats to ndnuon | str trim
+  let expect = "{a:1}"
+  assert equal $result $expect "could not convert to NDNUON"
+}

--- a/crates/nu-std/tests/test_std_formats.nu
+++ b/crates/nu-std/tests/test_std_formats.nu
@@ -84,3 +84,22 @@ def to_jsonl_single_object [] {
   let expect = "{\"a\":1}"
   assert equal $result $expect "could not convert to JSONL"
 }
+
+#[test]
+def from_ndnuon_multiple_objects [] {
+  let result = test_data_multiline | formats from ndnuon
+  let expect = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}]
+  assert equal $result $expect "could not convert from NDNUON"
+}
+
+#[test]
+def from_ndnuon_single_object [] {
+  let result = '{a: 1}' | formats from ndnuon
+  let expect = [{a:1}]
+  assert equal $result $expect "could not convert from NDNUON"
+}
+
+#[test]
+def from_ndnuon_invalid_object [] {
+  assert error { '{"a":1' | formats from ndnuon }
+}


### PR DESCRIPTION
# Description
i was playing with the NDNUON format and using local definitions of `from ndnuon` and `to ndnuon` but then i thought they could live in the standard library next to `from ndjson` and `to ndjson` :yum:

# User-Facing Changes
users can now add the following to their configs and get NDNUON ready to go
```nushell
use std formats ["from ndnuon" "to ndnuon"]
```

# Tests + Formatting
i did simply mimic the tests for `from ndjson` and `to ndjson`, i hope it's fine since the recent big change to the standard library

# After Submitting
