### PR TITLE
Cut down unnecessary lint allows

### DIFF
--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -30,30 +30,21 @@ pub(crate) const TRANSIENT_PROMPT_MULTILINE_INDICATOR: &str =
 pub(crate) const PRE_PROMPT_MARKER: &str = "\x1b]133;A\x1b\\";
 pub(crate) const POST_PROMPT_MARKER: &str = "\x1b]133;B\x1b\\";
 pub(crate) const PRE_EXECUTION_MARKER: &str = "\x1b]133;C\x1b\\";
-#[allow(dead_code)]
 pub(crate) const POST_EXECUTION_MARKER_PREFIX: &str = "\x1b]133;D;";
-#[allow(dead_code)]
 pub(crate) const POST_EXECUTION_MARKER_SUFFIX: &str = "\x1b\\";
 
 // OSC633 is the same as OSC133 but specifically for VSCode
 pub(crate) const VSCODE_PRE_PROMPT_MARKER: &str = "\x1b]633;A\x1b\\";
 pub(crate) const VSCODE_POST_PROMPT_MARKER: &str = "\x1b]633;B\x1b\\";
-#[allow(dead_code)]
 pub(crate) const VSCODE_PRE_EXECUTION_MARKER: &str = "\x1b]633;C\x1b\\";
-#[allow(dead_code)]
 //"\x1b]633;D;{}\x1b\\"
 pub(crate) const VSCODE_POST_EXECUTION_MARKER_PREFIX: &str = "\x1b]633;D;";
-#[allow(dead_code)]
 pub(crate) const VSCODE_POST_EXECUTION_MARKER_SUFFIX: &str = "\x1b\\";
-#[allow(dead_code)]
 //"\x1b]633;E;{}\x1b\\"
 pub(crate) const VSCODE_COMMANDLINE_MARKER_PREFIX: &str = "\x1b]633;E;";
-#[allow(dead_code)]
 pub(crate) const VSCODE_COMMANDLINE_MARKER_SUFFIX: &str = "\x1b\\";
-#[allow(dead_code)]
 // "\x1b]633;P;Cwd={}\x1b\\"
 pub(crate) const VSCODE_CWD_PROPERTY_MARKER_PREFIX: &str = "\x1b]633;P;Cwd=";
-#[allow(dead_code)]
 pub(crate) const VSCODE_CWD_PROPERTY_MARKER_SUFFIX: &str = "\x1b\\";
 
 pub(crate) const RESET_APPLICATION_MODE: &str = "\x1b[?1l";

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -711,7 +711,6 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
     }
     for keybinding in parsed_keybindings {
         add_keybinding(
-            &keybinding.name,
             &keybinding.mode,
             keybinding,
             config,
@@ -730,9 +729,7 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
     }
 }
 
-#[allow(clippy::only_used_in_recursion)]
 fn add_keybinding(
-    name: &Option<Value>,
     mode: &Value,
     keybinding: &ParsedKeybinding,
     config: &Config,
@@ -755,7 +752,6 @@ fn add_keybinding(
         Value::List { vals, .. } => {
             for inner_mode in vals {
                 add_keybinding(
-                    name,
                     inner_mode,
                     keybinding,
                     config,

--- a/crates/nu-command/src/progress_bar.rs
+++ b/crates/nu-command/src/progress_bar.rs
@@ -45,11 +45,6 @@ impl NuProgressBar {
         self.pb.set_position(bytes_processed);
     }
 
-    #[allow(dead_code)]
-    pub fn finished_msg(&self, msg: String) {
-        self.pb.finish_with_message(msg);
-    }
-
     pub fn abandoned_msg(&self, msg: String) {
         self.pb.abandon_with_message(msg);
     }

--- a/crates/nu-command/src/strings/guess_width.rs
+++ b/crates/nu-command/src/strings/guess_width.rs
@@ -291,42 +291,39 @@ fn positions_helper(blanks: &[usize], min_lines: usize) -> Vec<usize> {
     pos
 }
 
-// to_rows returns rows separated by columns.
-#[allow(dead_code)]
-fn to_rows(lines: Vec<String>, pos: Vec<usize>, trim_space: bool) -> Vec<Vec<String>> {
-    let mut rows: Vec<Vec<String>> = Vec::with_capacity(lines.len());
-    for line in lines {
-        let columns = split(&line, &pos, trim_space);
-        rows.push(columns);
-    }
-    rows
-}
-
-// to_table parses a slice of lines and returns a table.
-#[allow(dead_code)]
-pub fn to_table(lines: Vec<String>, header: usize, trim_space: bool) -> Vec<Vec<String>> {
-    let pos = positions(&lines, header, 2);
-    to_rows(lines, pos, trim_space)
-}
-
-// to_table_n parses a slice of lines and returns a table, but limits the number of splits.
-#[allow(dead_code)]
-pub fn to_table_n(
-    lines: Vec<String>,
-    header: usize,
-    num_split: usize,
-    trim_space: bool,
-) -> Vec<Vec<String>> {
-    let mut pos = positions(&lines, header, 2);
-    if pos.len() > num_split {
-        pos.truncate(num_split);
-    }
-    to_rows(lines, pos, trim_space)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{to_table, to_table_n, GuessWidth};
+    use super::*;
+
+    /// to_rows returns rows separated by columns.
+    fn to_rows(lines: Vec<String>, pos: Vec<usize>, trim_space: bool) -> Vec<Vec<String>> {
+        let mut rows: Vec<Vec<String>> = Vec::with_capacity(lines.len());
+        for line in lines {
+            let columns = split(&line, &pos, trim_space);
+            rows.push(columns);
+        }
+        rows
+    }
+
+    /// to_table parses a slice of lines and returns a table.
+    pub fn to_table(lines: Vec<String>, header: usize, trim_space: bool) -> Vec<Vec<String>> {
+        let pos = positions(&lines, header, 2);
+        to_rows(lines, pos, trim_space)
+    }
+
+    /// to_table_n parses a slice of lines and returns a table, but limits the number of splits.
+    pub fn to_table_n(
+        lines: Vec<String>,
+        header: usize,
+        num_split: usize,
+        trim_space: bool,
+    ) -> Vec<Vec<String>> {
+        let mut pos = positions(&lines, header, 2);
+        if pos.len() > num_split {
+            pos.truncate(num_split);
+        }
+        to_rows(lines, pos, trim_space)
+    }
 
     #[test]
     fn test_guess_width_ps_trim() {

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -471,7 +471,6 @@ unsafe fn null_terminated_wchar_to_string(slice: &[u16]) -> String {
     }
 }
 
-// #[allow(clippy::uninit_vec)]
 unsafe fn get_process_data(
     handle: HANDLE,
     ptr: *const c_void,
@@ -518,7 +517,6 @@ unsafe fn get_region_size(handle: HANDLE, ptr: *const c_void) -> Result<usize, &
     Ok((meminfo.RegionSize as isize - ptr.offset_from(meminfo.BaseAddress)) as usize)
 }
 
-// #[allow(clippy::uninit_vec)]
 unsafe fn ph_query_process_variable_size(
     process_handle: HANDLE,
     process_information_class: PROCESSINFOCLASS,

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -471,7 +471,7 @@ unsafe fn null_terminated_wchar_to_string(slice: &[u16]) -> String {
     }
 }
 
-#[allow(clippy::uninit_vec)]
+// #[allow(clippy::uninit_vec)]
 unsafe fn get_process_data(
     handle: HANDLE,
     ptr: *const c_void,
@@ -518,7 +518,7 @@ unsafe fn get_region_size(handle: HANDLE, ptr: *const c_void) -> Result<usize, &
     Ok((meminfo.RegionSize as isize - ptr.offset_from(meminfo.BaseAddress)) as usize)
 }
 
-#[allow(clippy::uninit_vec)]
+// #[allow(clippy::uninit_vec)]
 unsafe fn ph_query_process_variable_size(
     process_handle: HANDLE,
     process_information_class: PROCESSINFOCLASS,


### PR DESCRIPTION
Trying to reduce lint allows either by checking if they are former false positives or by fixing the underlying warning.

- **Remove dead `allow(dead_code)`**
- **Remove recursive dead code**
- **Remove dead code**
- **Move test only functions to test module**
  The unit tests that use them, themselves are somewhat sus in that they
mock the usage and not test specificly used methods of the
implementation, so there is a risk for divergence
- **Remove `clippy::uninit_vec` allow.**
  May have been a false positive, or the impl has changed somewhat.
We certainly want to look at the unsafe code here to vet for
correctness.
