### PR TITLE
Add support for converting polars decimal values to nushell values

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
@@ -1201,6 +1201,18 @@ fn series_to_values(
 
             Ok(values)
         }
+        DataType::Decimal(_precision, _scale) => {
+            let casted = series
+                .cast(&DataType::Float64)
+                .map_err(|e| ShellError::GenericError {
+                    error: "Errors casting decimal column to float".into(),
+                    msg: "".into(),
+                    span: None,
+                    help: Some(e.to_string()),
+                    inner: vec![],
+                })?;
+            series_to_values(&casted, maybe_from_row, maybe_size, span)
+        }
         e => Err(ShellError::GenericError {
             error: "Error creating Dataframe".into(),
             msg: "".to_string(),


### PR DESCRIPTION
Adds support for converting from polars decimal type to nushell values.

This fix works by first converting a polars decimal series to an f64 series, then converting to Value::Float
