### PR TITLE
fix(group-by): re #14337, normalize `--to-table` output column names

### DIFF
--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -184,8 +184,8 @@ impl Command for GroupBy {
     | group-by lang year --to-table"#,
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
-                        "lang" => Value::test_string("rb"),
-                        "year" => Value::test_string("2019"),
+                        "group0" => Value::test_string("rb"),
+                        "group1" => Value::test_string("2019"),
                         "items" => Value::test_list(vec![
                             Value::test_record(record! {
                                 "name" => Value::test_string("andres"),
@@ -195,8 +195,8 @@ impl Command for GroupBy {
                         ]),
                     }),
                     Value::test_record(record! {
-                        "lang" => Value::test_string("rs"),
-                        "year" => Value::test_string("2019"),
+                        "group0" => Value::test_string("rs"),
+                        "group1" => Value::test_string("2019"),
                         "items" => Value::test_list(vec![
                             Value::test_record(record! {
                                 "name" => Value::test_string("jt"),
@@ -206,8 +206,8 @@ impl Command for GroupBy {
                         ]),
                     }),
                     Value::test_record(record! {
-                        "lang" => Value::test_string("rs"),
-                        "year" => Value::test_string("2021"),
+                        "group0" => Value::test_string("rs"),
+                        "group1" => Value::test_string("2021"),
                         "items" => Value::test_list(vec![
                             Value::test_record(record! {
                                 "name" => Value::test_string("storm"),

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -306,7 +306,6 @@ fn group_closure(
 }
 
 struct Grouped {
-    grouper: Option<String>,
     groups: Tree,
 }
 
@@ -325,7 +324,6 @@ impl Grouped {
         }
 
         Self {
-            grouper: Some("group".into()),
             groups: Tree::Leaf(groups),
         }
     }
@@ -350,9 +348,7 @@ impl Grouped {
                 })
             }
         };
-        let grouper = grouper.as_cell_path().ok().map(CellPath::to_column_name);
         Ok(Self {
-            grouper,
             groups: Tree::Leaf(groups),
         })
     }
@@ -393,7 +389,7 @@ impl Grouped {
     }
 
     fn _into_table(self, head: Span, index: usize) -> Vec<Record> {
-        let grouper = self.grouper.unwrap_or_else(|| format!("group{index}"));
+        let grouper = format!("group{index}");
         match self.groups {
             Tree::Leaf(leaf) => leaf
                 .into_iter()

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -101,7 +101,7 @@ impl Command for GroupBy {
                 example: "['1' '3' '1' '3' '2' '1' '1'] | group-by --to-table",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
-                        "group" => Value::test_string("1"),
+                        "group0" => Value::test_string("1"),
                         "items" => Value::test_list(vec![
                             Value::test_string("1"),
                             Value::test_string("1"),
@@ -110,14 +110,14 @@ impl Command for GroupBy {
                         ]),
                     }),
                     Value::test_record(record! {
-                        "group" => Value::test_string("3"),
+                        "group0" => Value::test_string("3"),
                         "items" => Value::test_list(vec![
                             Value::test_string("3"),
                             Value::test_string("3"),
                         ]),
                     }),
                     Value::test_record(record! {
-                        "group" => Value::test_string("2"),
+                        "group0" => Value::test_string("2"),
                         "items" => Value::test_list(vec![Value::test_string("2")]),
                     }),
                 ])),

--- a/crates/nu-std/testing.nu
+++ b/crates/nu-std/testing.nu
@@ -79,7 +79,7 @@ def create-test-record [] nothing -> record<before-each: string, after-each: str
         | group-by --to-table annotation
         | update items {|x|
             $x.items.function_name
-            | if $x.annotation in ["test", "test-skip"] {
+            | if $x.group0 in ["test", "test-skip"] {
                 $in
             } else {
                 get 0


### PR DESCRIPTION
Follow up to #14337, pointed out [here](https://github.com/nushell/nushell/pull/14337#issuecomment-2480392373) that using `grouper` arguments to name output columns may cause naming conflicts such as
- input having a column named "items" and using `group-by items`, output will have a single `items` column, which actually contains group names.
- (Unlikely) having grouper arguments `{ ... } group0`, where a cell-path `grouper` results in the same column name as the closure `grouper`.

I wanted to keep that naming scheme as I find it more intuitive, however it is most likely better to not name columns after `grouper` arguments. Also we can always use `rename` right after.

Before:
```nushell
> $data | group-by lang year --to-table
╭─#─┬─lang─┬─year─┬────────────items─────────────╮
│ 0 │ rb   │ 2019 │ ╭─#─┬──name──┬─lang─┬─year─╮ │
│   │      │      │ │ 0 │ andres │ rb   │ 2019 │ │
│   │      │      │ ╰─#─┴──name──┴─lang─┴─year─╯ │
│ 1 │ rs   │ 2019 │ ╭─#─┬─name─┬─lang─┬─year─╮   │
│   │      │      │ │ 0 │ jt   │ rs   │ 2019 │   │
│   │      │      │ ╰─#─┴─name─┴─lang─┴─year─╯   │
│ 2 │ rs   │ 2021 │ ╭─#─┬─name──┬─lang─┬─year─╮  │
│   │      │      │ │ 0 │ storm │ rs   │ 2021 │  │
│   │      │      │ ╰─#─┴─name──┴─lang─┴─year─╯  │
╰─#─┴─lang─┴─year─┴────────────items─────────────╯
```

After:
```nushell
> $data | group-by lang year --to-table
╭─#─┬─group0─┬─group1─┬────────────items─────────────╮
│ 0 │ rb     │ 2019   │ ╭─#─┬──name──┬─lang─┬─year─╮ │
│   │        │        │ │ 0 │ andres │ rb   │ 2019 │ │
│   │        │        │ ╰─#─┴──name──┴─lang─┴─year─╯ │
│ 1 │ rs     │ 2019   │ ╭─#─┬─name─┬─lang─┬─year─╮   │
│   │        │        │ │ 0 │ jt   │ rs   │ 2019 │   │
│   │        │        │ ╰─#─┴─name─┴─lang─┴─year─╯   │
│ 2 │ rs     │ 2021   │ ╭─#─┬─name──┬─lang─┬─year─╮  │
│   │        │        │ │ 0 │ storm │ rs   │ 2021 │  │
│   │        │        │ ╰─#─┴─name──┴─lang─┴─year─╯  │
╰─#─┴─group0─┴─group1─┴────────────items─────────────╯
```