### PR TITLE
enable test_cp_recurse on macos

### DIFF
--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -615,9 +615,7 @@ static TEST_COPY_TO_FOLDER: &str = "hello_dir/";
 static TEST_COPY_TO_FOLDER_FILE: &str = "hello_dir/hello_world.txt";
 static TEST_COPY_FROM_FOLDER: &str = "hello_dir_with_file/";
 static TEST_COPY_FROM_FOLDER_FILE: &str = "hello_dir_with_file/hello_world.txt";
-#[cfg(not(target_os = "macos"))]
 static TEST_COPY_TO_FOLDER_NEW: &str = "hello_dir_new";
-#[cfg(not(target_os = "macos"))]
 static TEST_COPY_TO_FOLDER_NEW_FILE: &str = "hello_dir_new/hello_world.txt";
 
 #[test]
@@ -712,7 +710,6 @@ fn test_cp_multiple_files() {
 }
 
 #[test]
-#[cfg(not(target_os = "macos"))]
 fn test_cp_recurse() {
     Playground::setup("ucp_test_22", |dirs, sandbox| {
         // Create the relevant target directories


### PR DESCRIPTION
# Description

This PR enables some tests that were disabled on macos.

We shall see if the CI passes. (Update: CI has passed.)

# User-Facing Changes

Should be no user-facing changes as only a test-file is modified.

# Tests + Formatting

Test coverage should increase
