### PR TITLE
Add hardlink flag to cp

### DIFF
--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -89,7 +89,6 @@ fn copies_a_file_with_hardlink_impl(progress: bool) {
     });
 }
 
-
 #[test]
 fn copies_the_file_inside_directory_if_path_to_copy_is_directory() {
     copies_the_file_inside_directory_if_path_to_copy_is_directory_impl(false);
@@ -810,7 +809,8 @@ fn test_cp_recurse_with_hardlink_flag() {
         // Since we're using a hardlink, the updated hashes should be the same.
         let src_hash_modified = get_file_hash(src.display());
         assert_ne!(src_hash, src_hash_modified);
-        let after_cp_hash_modified = get_file_hash(dirs.test().join(TEST_COPY_TO_FOLDER_NEW_FILE).display());
+        let after_cp_hash_modified =
+            get_file_hash(dirs.test().join(TEST_COPY_TO_FOLDER_NEW_FILE).display());
         assert_eq!(src_hash_modified, after_cp_hash_modified);
     });
 }

--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -615,9 +615,7 @@ static TEST_COPY_TO_FOLDER: &str = "hello_dir/";
 static TEST_COPY_TO_FOLDER_FILE: &str = "hello_dir/hello_world.txt";
 static TEST_COPY_FROM_FOLDER: &str = "hello_dir_with_file/";
 static TEST_COPY_FROM_FOLDER_FILE: &str = "hello_dir_with_file/hello_world.txt";
-#[cfg(not(target_os = "macos"))]
 static TEST_COPY_TO_FOLDER_NEW: &str = "hello_dir_new";
-#[cfg(not(target_os = "macos"))]
 static TEST_COPY_TO_FOLDER_NEW_FILE: &str = "hello_dir_new/hello_world.txt";
 
 #[test]
@@ -712,7 +710,6 @@ fn test_cp_multiple_files() {
 }
 
 #[test]
-#[cfg(not(target_os = "macos"))]
 fn test_cp_recurse() {
     Playground::setup("ucp_test_22", |dirs, sandbox| {
         // Create the relevant target directories


### PR DESCRIPTION
Add flag to `cp` builtin to enable creating hardlinks.

This make use of the `-l`/`--links` flag from coreutils' cp command.
See https://uutils.github.io/coreutils/docs/utils/cp.html

# User-Facing Changes

Should add extra flag to `cp`.
Default behavior of `cp` should not change

# Tests + Formatting
Added some unit tests

TODO:
- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
