### PR TITLE
fix(group-by): re #14337 name collision prevention

### DIFF
--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -246,63 +246,68 @@ pub fn group_by(
     };
 
     let value = if to_table {
-        let mut closure_idx: usize = 0;
-
-        let grouper_names = groupers.iter().map(|grouper| {
-            grouper.as_ref().map(move |item| match item {
-                Grouper::CellPath { val } => val.to_column_name(),
-                Grouper::Closure { .. } => {
-                    closure_idx += 1;
-                    format!("closure_{}", closure_idx - 1)
-                }
-            })
-        });
-
-        let mut name_set: Vec<Spanned<String>> = Vec::with_capacity(grouper_names.len());
-
-        for name in grouper_names {
-            if name.item == "items" {
-                return Err(ShellError::GenericError {
-                    error: "grouper arguments can't be named `items`".into(),
-                    msg: "here".into(),
-                    span: Some(name.span),
-                    help: Some("instead of a cell-path, try using a closure: { get items }".into()),
-                    inner: vec![],
-                });
-            }
-
-            if let Some(conflicting_name) = name_set
-                .iter()
-                .find(|elem| elem.as_ref().item == name.item.as_str())
-            {
-                return Err(ShellError::GenericError {
-                    error: "grouper arguments result in colliding column names".into(),
-                    msg: "duplicate column names".into(),
-                    span: Some(conflicting_name.span.append(name.span)),
-                    help: Some("instead of a cell-path, try using a closure or renaming columns".into()),
-                    inner: vec![ShellError::ColumnDefinedTwice {
-                        col_name: conflicting_name.item.clone(),
-                        first_use: conflicting_name.span,
-                        second_use: name.span,
-                    }],
-                });
-            }
-
-            name_set.push(name);
-        }
-
-        let column_names: Vec<String> = name_set
-            .into_iter()
-            .map(|elem| elem.item)
-            .chain(["items".into()])
-            .collect();
-
+        let column_names = groupers_to_column_names(&groupers)?;
         grouped.into_table(&column_names, head)
     } else {
         grouped.into_record(head)
     };
 
     Ok(value.into_pipeline_data())
+}
+
+fn groupers_to_column_names(groupers: &[Spanned<Grouper>]) -> Result<Vec<String>, ShellError> {
+    let mut closure_idx: usize = 0;
+    let grouper_names = groupers.iter().map(|grouper| {
+        grouper.as_ref().map(move |item| match item {
+            Grouper::CellPath { val } => val.to_column_name(),
+            Grouper::Closure { .. } => {
+                closure_idx += 1;
+                format!("closure_{}", closure_idx - 1)
+            }
+        })
+    });
+
+    let mut name_set: Vec<Spanned<String>> = Vec::with_capacity(grouper_names.len());
+
+    for name in grouper_names {
+        if name.item == "items" {
+            return Err(ShellError::GenericError {
+                error: "grouper arguments can't be named `items`".into(),
+                msg: "here".into(),
+                span: Some(name.span),
+                help: Some("instead of a cell-path, try using a closure: { get items }".into()),
+                inner: vec![],
+            });
+        }
+
+        if let Some(conflicting_name) = name_set
+            .iter()
+            .find(|elem| elem.as_ref().item == name.item.as_str())
+        {
+            return Err(ShellError::GenericError {
+                error: "grouper arguments result in colliding column names".into(),
+                msg: "duplicate column names".into(),
+                span: Some(conflicting_name.span.append(name.span)),
+                help: Some(
+                    "instead of a cell-path, try using a closure or renaming columns".into(),
+                ),
+                inner: vec![ShellError::ColumnDefinedTwice {
+                    col_name: conflicting_name.item.clone(),
+                    first_use: conflicting_name.span,
+                    second_use: name.span,
+                }],
+            });
+        }
+
+        name_set.push(name);
+    }
+
+    let column_names: Vec<String> = name_set
+        .into_iter()
+        .map(|elem| elem.item)
+        .chain(["items".into()])
+        .collect();
+    Ok(column_names)
 }
 
 fn group_cell_path(

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -256,6 +256,10 @@ pub fn group_by(
 }
 
 fn groupers_to_column_names(groupers: &[Spanned<Grouper>]) -> Result<Vec<String>, ShellError> {
+    if groupers.is_empty() {
+        return Ok(vec!["group".into(), "items".into()]);
+    }
+
     let mut closure_idx: usize = 0;
     let grouper_names = groupers.iter().map(|grouper| {
         grouper.as_ref().map(move |item| match item {

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -238,16 +238,16 @@ pub fn group_by(
         return Ok(Value::record(Record::new(), head).into_pipeline_data());
     }
 
-    let mut groupers = groupers.into_iter();
 
-    let grouped = if let Some(grouper) = groupers.next() {
-        let mut groups = Grouped::new(&grouper, values, config, engine_state, stack)?;
-        for grouper in groupers {
-            groups.subgroup(&grouper, config, engine_state, stack)?;
+    let grouped = match &groupers[..] {
+        [first, rest @ ..] => {
+            let mut grouped = Grouped::new(first, values, config, engine_state, stack)?;
+            for grouper in rest {
+                grouped.subgroup(grouper, config, engine_state, stack)?;
+            }
+            grouped
         }
-        groups
-    } else {
-        Grouped::empty(values, config)
+        [] => Grouped::empty(values, config),
     };
 
     let value = if to_table {

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -12,10 +12,6 @@ impl Command for GroupBy {
 
     fn signature(&self) -> Signature {
         Signature::build("group-by")
-            // TODO: It accepts Table also, but currently there is no Table
-            // example. Perhaps Table should be a subtype of List, in which case
-            // the current signature would suffice even when a Table example
-            // exists.
             .input_output_types(vec![(Type::List(Box::new(Type::Any)), Type::Any)])
             .switch(
                 "to-table",

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -262,7 +262,7 @@ fn groupers_to_column_names(groupers: &[Spanned<Grouper>]) -> Result<Vec<String>
 
     let mut closure_idx: usize = 0;
     let grouper_names = groupers.iter().map(|grouper| {
-        grouper.as_ref().map(move |item| match item {
+        grouper.as_ref().map(|item| match item {
             Grouper::CellPath { val } => val.to_column_name(),
             Grouper::Closure { .. } => {
                 closure_idx += 1;

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -240,9 +240,9 @@ pub fn group_by(
 
     let grouped = match &groupers[..] {
         [first, rest @ ..] => {
-            let mut grouped = Grouped::new(first, values, config, engine_state, stack)?;
+            let mut grouped = Grouped::new(first.as_ref(), values, config, engine_state, stack)?;
             for grouper in rest {
-                grouped.subgroup(grouper, config, engine_state, stack)?;
+                grouped.subgroup(grouper.as_ref(), config, engine_state, stack)?;
             }
             grouped
         }
@@ -352,11 +352,15 @@ impl Grouped {
         engine_state: &EngineState,
         stack: &mut Stack,
     ) -> Result<Self, ShellError> {
-        let groups = match grouper {
-            Grouper::CellPath { val, .. } => group_cell_path(val, values, config)?,
-            Grouper::Closure { val, span, .. } => {
-                group_closure(values, *span, Closure::clone(val), engine_state, stack)?
-            }
+        let groups = match grouper.item {
+            Grouper::CellPath { val } => group_cell_path(val, values, config)?,
+            Grouper::Closure { val } => group_closure(
+                values,
+                grouper.span,
+                Closure::clone(val),
+                engine_state,
+                stack,
+            )?,
         };
         Ok(Self {
             groups: Tree::Leaf(groups),


### PR DESCRIPTION
A more involved solution to the issue pointed out [here](https://github.com/nushell/nushell/pull/14337#issuecomment-2480392373)

# Description

With `--to-table`
- cell-path groupers are used to create column names, similar to `select`
- closure groupers result in columns named `closure_{i}` where `i` is the index of argument, with regards to other closures i.e. first closure grouper results in a column named `closure_0`

  Previously
  - `group-by foo {...} {...}` => `table<foo, group1, group2, items>`
  - `group-by {...} foo {...}` => `table<group0, foo, group2, items>`
  
  With this PR
  - `group-by foo {...} {...}` => `table<foo, closure_0, closure_1, items>`
  - `group-by {...} foo {...}` => `table<closure_0, foo, closure_1, items>` 
- no grouper argument results in a `table<group, items>` as previously

On naming conflicts caused by cell-path groupers named `items` or `closure_{i}`, an error is thrown, suggesting to use a closure in place of a cell-path.

```nushell
❯ ls | rename items | group-by items --to-table 
Error:   × grouper arguments can't be named `items`
   ╭─[entry #3:1:29]
 1 │ ls | rename items | group-by items --to-table 
   ·                             ────────┬────────
   ·                                     ╰── contains `items`
   ╰────
  help: instead of a cell-path, try using a closure
```
And following the suggestion:
```nushell
❯ ls | rename items | group-by { get items } --to-table 
╭─#──┬──────closure_0──────┬───────────────────────────items────────────────────────────╮
│ 0  │ CITATION.cff        │ ╭─#─┬────items─────┬─type─┬─size──┬───modified───╮         │
│    │                     │ │ 0 │ CITATION.cff │ file │ 812 B │ 3 months ago │         │
│    │                     │ ╰─#─┴────items─────┴─type─┴─size──┴───modified───╯         │
│ 1  │ CODE_OF_CONDUCT.md  │ ╭─#─┬───────items────────┬─type─┬──size───┬───modified───╮ │
...
```