### PR TITLE
Fix doc and code comment typos

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -76,7 +76,7 @@ impl Command for External {
         // believe the user wants to use the windows association to run the script. The only
         // easy way to do this is to run cmd.exe with the script as an argument.
         let potential_nuscript_in_windows = if cfg!(windows) {
-            // let's make sure it's a .nu scrtipt
+            // let's make sure it's a .nu script
             if let Some(executable) = which(&expanded_name, "", cwd.as_ref()) {
                 let ext = executable
                     .extension()

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/agg_groups.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/agg_groups.rs
@@ -34,7 +34,7 @@ impl PluginCommand for ExprAggGroups {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Get the groiup index of the group by operations.",
+            description: "Get the group index of the group by operations.",
             example: r#"[[group value]; [one 94] [one 95] [one 96] [two 97] [two 98] [two 99]] 
                 | polars into-df 
                 | polars group-by group

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/value_counts.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/value_counts.rs
@@ -28,7 +28,7 @@ impl PluginCommand for ValueCount {
             .named(
                 "column",
                 SyntaxShape::String,
-                "Provide a custom name for the coutn column",
+                "Provide a custom name for the count column",
                 Some('c'),
             )
             .switch("sort", "Whether or not values should be sorted", Some('s'))


### PR DESCRIPTION
# User-Facing Changes

* Fixes `polars value-counts --column` help text typo
* Fixes `polars agg-groups` help text typo
