### PR TITLE
Improve the example carapace completer

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -142,7 +142,22 @@ let light_theme = {
 
 # External completer example
 # let carapace_completer = {|spans|
-#     carapace $spans.0 nushell ...$spans | from json
+#     # carapace doesn't give completions if you don't give it any additional
+#     # args
+#     mut spans = $spans
+#     if ($spans | is-empty) {
+#         $spans = [""]
+#     }
+#     
+#     carapace $spans.0 nushell ...$spans | from json 
+#         # sort by color
+#         | sort-by {
+#             let fg = $in | get -i style.fg
+#             let attr = $in | get -i style.attr
+#             
+#             # the ~ there to make "empty" results appear at the end
+#             $"($fg)~($attr)"
+#         }
 # }
 
 # The default config record. This is where much of your global configuration is setup.


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Currently the example completer doesn't return anything if you haven't typed anything. So it do do, for example "git <tab>", you get nothing. Since carapace only gives completions when you pass a arg. By passing "" we get completions in this case too. 

The output is also not sorted by color, so it looks something like this

![image](https://github.com/user-attachments/assets/d32960e4-ff7e-4135-a047-f55e2eb14985)

Instead sort the output by color 

![image](https://github.com/user-attachments/assets/ab6775ea-dd8a-475b-92d9-2da03cd5791d)