### PR TITLE
Add `Filesize` type

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/into.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/into.rs
@@ -203,7 +203,7 @@ pub fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
             Value::string(raw_string.trim(), span)
         }
         Value::Int { val, .. } => convert_to_smallest_number_type(*val, span),
-        Value::Filesize { val, .. } => convert_to_smallest_number_type(*val, span),
+        Value::Filesize { val, .. } => convert_to_smallest_number_type(val.get(), span),
         Value::Duration { val, .. } => convert_to_smallest_number_type(*val, span),
         Value::String { val, .. } => {
             let raw_bytes = val.as_bytes();

--- a/crates/nu-cmd-extra/src/extra/conversions/fmt.rs
+++ b/crates/nu-cmd-extra/src/extra/conversions/fmt.rs
@@ -66,7 +66,7 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
     match input {
         Value::Float { val, .. } => fmt_it_64(*val, span),
         Value::Int { val, .. } => fmt_it(*val, span),
-        Value::Filesize { val, .. } => fmt_it(*val, span),
+        Value::Filesize { val, .. } => fmt_it(val.get(), span),
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(

--- a/crates/nu-command/src/charting/hashable_value.rs
+++ b/crates/nu-command/src/charting/hashable_value.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, FixedOffset};
-use nu_protocol::{ShellError, Span, Value};
+use nu_protocol::{Filesize, ShellError, Span, Value};
 use std::hash::{Hash, Hasher};
 
 /// A subset of [`Value`], which is hashable.
@@ -30,7 +30,7 @@ pub enum HashableValue {
         span: Span,
     },
     Filesize {
-        val: i64,
+        val: Filesize,
         span: Span,
     },
     Duration {
@@ -198,7 +198,10 @@ mod test {
             (Value::int(1, span), HashableValue::Int { val: 1, span }),
             (
                 Value::filesize(1, span),
-                HashableValue::Filesize { val: 1, span },
+                HashableValue::Filesize {
+                    val: 1.into(),
+                    span,
+                },
             ),
             (
                 Value::duration(1, span),

--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -167,7 +167,7 @@ fn fill(
 fn action(input: &Value, args: &Arguments, span: Span) -> Value {
     match input {
         Value::Int { val, .. } => fill_int(*val, args, span),
-        Value::Filesize { val, .. } => fill_int(*val, args, span),
+        Value::Filesize { val, .. } => fill_int(val.get(), args, span),
         Value::Float { val, .. } => fill_float(*val, args, span),
         Value::String { val, .. } => fill_string(val, args, span),
         // Propagate errors by explicitly matching them before the final case.

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -147,7 +147,7 @@ pub fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
         Value::Binary { .. } => input.clone(),
         Value::Int { val, .. } => Value::binary(val.to_ne_bytes().to_vec(), span),
         Value::Float { val, .. } => Value::binary(val.to_ne_bytes().to_vec(), span),
-        Value::Filesize { val, .. } => Value::binary(val.to_ne_bytes().to_vec(), span),
+        Value::Filesize { val, .. } => Value::binary(val.get().to_ne_bytes().to_vec(), span),
         Value::String { val, .. } => Value::binary(val.as_bytes().to_vec(), span),
         Value::Bool { val, .. } => Value::binary(i64::from(*val).to_ne_bytes().to_vec(), span),
         Value::Duration { val, .. } => Value::binary(val.to_ne_bytes().to_vec(), span),

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -253,7 +253,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
                 convert_int(input, span, radix)
             }
         }
-        Value::Filesize { val, .. } => Value::int(*val, span),
+        Value::Filesize { val, .. } => Value::int(val.get(), span),
         Value::Float { val, .. } => Value::int(
             {
                 if radix == 10 {

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -421,7 +421,7 @@ pub fn value_to_sql(value: Value) -> Result<Box<dyn rusqlite::ToSql>, ShellError
         Value::Bool { val, .. } => Box::new(val),
         Value::Int { val, .. } => Box::new(val),
         Value::Float { val, .. } => Box::new(val),
-        Value::Filesize { val, .. } => Box::new(val),
+        Value::Filesize { val, .. } => Box::new(val.get()),
         Value::Duration { val, .. } => Box::new(val),
         Value::Date { val, .. } => Box::new(val),
         Value::String { val, .. } => Box::new(val),

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -109,7 +109,7 @@ pub fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
     let span = v.span();
     Ok(match v {
         Value::Bool { val, .. } => nu_json::Value::Bool(*val),
-        Value::Filesize { val, .. } => nu_json::Value::I64(*val),
+        Value::Filesize { val, .. } => nu_json::Value::I64(val.get()),
         Value::Duration { val, .. } => nu_json::Value::I64(*val),
         Value::Date { val, .. } => nu_json::Value::String(val.to_string()),
         Value::Float { val, .. } => nu_json::Value::F64(*val),

--- a/crates/nu-command/src/formats/to/msgpack.rs
+++ b/crates/nu-command/src/formats/to/msgpack.rs
@@ -168,7 +168,7 @@ pub(crate) fn write_value(
             mp::write_f64(out, *val).err_span(span)?;
         }
         Value::Filesize { val, .. } => {
-            mp::write_sint(out, *val).err_span(span)?;
+            mp::write_sint(out, val.get()).err_span(span)?;
         }
         Value::Duration { val, .. } => {
             mp::write_sint(out, *val).err_span(span)?;

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -47,7 +47,7 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
     Ok(match &v {
         Value::Bool { val, .. } => toml::Value::Boolean(*val),
         Value::Int { val, .. } => toml::Value::Integer(*val),
-        Value::Filesize { val, .. } => toml::Value::Integer(*val),
+        Value::Filesize { val, .. } => toml::Value::Integer(val.get()),
         Value::Duration { val, .. } => toml::Value::String(val.to_string()),
         Value::Date { val, .. } => toml::Value::Datetime(to_toml_datetime(val)),
         Value::Range { .. } => toml::Value::String("<Range>".to_string()),

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -44,7 +44,9 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
     Ok(match &v {
         Value::Bool { val, .. } => serde_yaml::Value::Bool(*val),
         Value::Int { val, .. } => serde_yaml::Value::Number(serde_yaml::Number::from(*val)),
-        Value::Filesize { val, .. } => serde_yaml::Value::Number(serde_yaml::Number::from(*val)),
+        Value::Filesize { val, .. } => {
+            serde_yaml::Value::Number(serde_yaml::Number::from(val.get()))
+        }
         Value::Duration { val, .. } => serde_yaml::Value::String(val.to_string()),
         Value::Date { val, .. } => serde_yaml::Value::String(val.to_string()),
         Value::Range { .. } => serde_yaml::Value::Null,

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -90,7 +90,7 @@ pub fn average(values: &[Value], span: Span, head: Span) -> Result<Value, ShellE
     let total = &sum(Value::int(0, head), values.to_vec(), span, head)?;
     let span = total.span();
     match total {
-        Value::Filesize { val, .. } => Ok(Value::filesize(val / values.len() as i64, span)),
+        Value::Filesize { val, .. } => Ok(Value::filesize(val.get() / values.len() as i64, span)),
         Value::Duration { val, .. } => Ok(Value::duration(val / values.len() as i64, span)),
         _ => total.div(head, &Value::int(values.len() as i64, head), head),
     }

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -142,9 +142,10 @@ pub fn mode(values: &[Value], _span: Span, head: Span) -> Result<Value, ShellErr
             Value::Float { val, .. } => {
                 Ok(HashableType::new(val.to_ne_bytes(), NumberTypes::Float))
             }
-            Value::Filesize { val, .. } => {
-                Ok(HashableType::new(val.to_ne_bytes(), NumberTypes::Filesize))
-            }
+            Value::Filesize { val, .. } => Ok(HashableType::new(
+                val.get().to_ne_bytes(),
+                NumberTypes::Filesize,
+            )),
             Value::Error { error, .. } => Err(*error.clone()),
             other => Err(ShellError::UnsupportedInput {
                 msg: "Unable to give a result with this input".to_string(),

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -141,7 +141,7 @@ fn reject_rows_with_list_spread() {
     let actual = nu!("let arg = [2 0]; [[name type size];[Cargo.toml file 10mb] [Cargo.lock file 10mb] [src dir 100mb]] | reject ...$arg | to nuon");
     assert_eq!(
         actual.out,
-        r#"[[name, type, size]; ["Cargo.lock", file, 10000000b]]"#
+        r#"[[name, type, size]; ["Cargo.lock", file, 10000000B]]"#
     );
 }
 
@@ -150,7 +150,7 @@ fn reject_mixed_with_list_spread() {
     let actual = nu!("let arg = [type 2]; [[name type size];[Cargp.toml file 10mb] [ Cargo.lock file 10mb] [src dir 100mb]] | reject ...$arg | to nuon");
     assert_eq!(
         actual.out,
-        r#"[[name, size]; ["Cargp.toml", 10000000b], ["Cargo.lock", 10000000b]]"#
+        r#"[[name, size]; ["Cargp.toml", 10000000B], ["Cargo.lock", 10000000B]]"#
     );
 }
 

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -141,7 +141,7 @@ fn reject_rows_with_list_spread() {
     let actual = nu!("let arg = [2 0]; [[name type size];[Cargo.toml file 10mb] [Cargo.lock file 10mb] [src dir 100mb]] | reject ...$arg | to nuon");
     assert_eq!(
         actual.out,
-        r#"[[name, type, size]; ["Cargo.lock", file, 10000000B]]"#
+        r#"[[name, type, size]; ["Cargo.lock", file, 10000000b]]"#
     );
 }
 
@@ -150,7 +150,7 @@ fn reject_mixed_with_list_spread() {
     let actual = nu!("let arg = [type 2]; [[name type size];[Cargp.toml file 10mb] [ Cargo.lock file 10mb] [src dir 100mb]] | reject ...$arg | to nuon");
     assert_eq!(
         actual.out,
-        r#"[[name, size]; ["Cargp.toml", 10000000B], ["Cargo.lock", 10000000B]]"#
+        r#"[[name, size]; ["Cargp.toml", 10000000b], ["Cargo.lock", 10000000b]]"#
     );
 }
 

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -211,7 +211,7 @@ fn to_nuon_filesize() {
         "#
     ));
 
-    assert_eq!(actual.out, "1024B");
+    assert_eq!(actual.out, "1024b");
 }
 
 #[test]

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -5,9 +5,9 @@ fn to_nuon_correct_compaction() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            open appveyor.yml 
-            | to nuon 
-            | str length 
+            open appveyor.yml
+            | to nuon
+            | str length
             | $in > 500
         "#
     ));
@@ -211,7 +211,7 @@ fn to_nuon_filesize() {
         "#
     ));
 
-    assert_eq!(actual.out, "1024b");
+    assert_eq!(actual.out, "1024B");
 }
 
 #[test]

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -11,9 +11,9 @@ use itertools::Itertools;
 use log::trace;
 use nu_engine::DIR_VAR_PARSER_INFO;
 use nu_protocol::{
-    ast::*, engine::StateWorkingSet, eval_const::eval_constant, BlockId, DeclId, DidYouMean, Flag,
-    ParseError, PositionalArg, Signature, Span, Spanned, SyntaxShape, Type, VarId, ENV_VARIABLE_ID,
-    IN_VARIABLE_ID,
+    ast::*, engine::StateWorkingSet, eval_const::eval_constant, BlockId, DeclId, DidYouMean,
+    FilesizeUnit, Flag, ParseError, PositionalArg, Signature, Span, Spanned, SyntaxShape, Type,
+    VarId, ENV_VARIABLE_ID, IN_VARIABLE_ID,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -2572,19 +2572,67 @@ pub fn parse_unit_value<'res>(
 }
 
 pub const FILESIZE_UNIT_GROUPS: &[UnitGroup] = &[
-    (Unit::Kilobyte, "KB", Some((Unit::Byte, 1000))),
-    (Unit::Megabyte, "MB", Some((Unit::Kilobyte, 1000))),
-    (Unit::Gigabyte, "GB", Some((Unit::Megabyte, 1000))),
-    (Unit::Terabyte, "TB", Some((Unit::Gigabyte, 1000))),
-    (Unit::Petabyte, "PB", Some((Unit::Terabyte, 1000))),
-    (Unit::Exabyte, "EB", Some((Unit::Petabyte, 1000))),
-    (Unit::Kibibyte, "KIB", Some((Unit::Byte, 1024))),
-    (Unit::Mebibyte, "MIB", Some((Unit::Kibibyte, 1024))),
-    (Unit::Gibibyte, "GIB", Some((Unit::Mebibyte, 1024))),
-    (Unit::Tebibyte, "TIB", Some((Unit::Gibibyte, 1024))),
-    (Unit::Pebibyte, "PIB", Some((Unit::Tebibyte, 1024))),
-    (Unit::Exbibyte, "EIB", Some((Unit::Pebibyte, 1024))),
-    (Unit::Byte, "B", None),
+    (
+        Unit::Filesize(FilesizeUnit::KB),
+        "KB",
+        Some((Unit::Filesize(FilesizeUnit::B), 1000)),
+    ),
+    (
+        Unit::Filesize(FilesizeUnit::MB),
+        "MB",
+        Some((Unit::Filesize(FilesizeUnit::KB), 1000)),
+    ),
+    (
+        Unit::Filesize(FilesizeUnit::GB),
+        "GB",
+        Some((Unit::Filesize(FilesizeUnit::MB), 1000)),
+    ),
+    (
+        Unit::Filesize(FilesizeUnit::TB),
+        "TB",
+        Some((Unit::Filesize(FilesizeUnit::GB), 1000)),
+    ),
+    (
+        Unit::Filesize(FilesizeUnit::PB),
+        "PB",
+        Some((Unit::Filesize(FilesizeUnit::TB), 1000)),
+    ),
+    (
+        Unit::Filesize(FilesizeUnit::EB),
+        "EB",
+        Some((Unit::Filesize(FilesizeUnit::PB), 1000)),
+    ),
+    (
+        Unit::Filesize(FilesizeUnit::KiB),
+        "KIB",
+        Some((Unit::Filesize(FilesizeUnit::B), 1024)),
+    ),
+    (
+        Unit::Filesize(FilesizeUnit::MiB),
+        "MIB",
+        Some((Unit::Filesize(FilesizeUnit::KiB), 1024)),
+    ),
+    (
+        Unit::Filesize(FilesizeUnit::GiB),
+        "GIB",
+        Some((Unit::Filesize(FilesizeUnit::MiB), 1024)),
+    ),
+    (
+        Unit::Filesize(FilesizeUnit::TiB),
+        "TIB",
+        Some((Unit::Filesize(FilesizeUnit::GiB), 1024)),
+    ),
+    (
+        Unit::Filesize(FilesizeUnit::PiB),
+        "PIB",
+        Some((Unit::Filesize(FilesizeUnit::TiB), 1024)),
+    ),
+    (
+        Unit::Filesize(FilesizeUnit::EiB),
+        "EIB",
+        Some((Unit::Filesize(FilesizeUnit::EiB), 1024)),
+    ),
+    (Unit::Filesize(FilesizeUnit::B), "B", None),
 ];
 
 pub const DURATION_UNIT_GROUPS: &[UnitGroup] = &[

--- a/crates/nu-protocol/src/ast/unit.rs
+++ b/crates/nu-protocol/src/ast/unit.rs
@@ -1,24 +1,9 @@
-use crate::{ShellError, Span, Value};
+use crate::{Filesize, FilesizeUnit, IntoValue, ShellError, Span, Value};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Unit {
-    // Filesize units: metric
-    Byte,
-    Kilobyte,
-    Megabyte,
-    Gigabyte,
-    Terabyte,
-    Petabyte,
-    Exabyte,
-
-    // Filesize units: ISO/IEC 80000
-    Kibibyte,
-    Mebibyte,
-    Gibibyte,
-    Tebibyte,
-    Pebibyte,
-    Exbibyte,
+    Filesize(FilesizeUnit),
 
     // Duration units
     Nanosecond,
@@ -34,33 +19,19 @@ pub enum Unit {
 impl Unit {
     pub fn build_value(self, size: i64, span: Span) -> Result<Value, ShellError> {
         match self {
-            Unit::Byte => Ok(Value::filesize(size, span)),
-            Unit::Kilobyte => Ok(Value::filesize(size * 1000, span)),
-            Unit::Megabyte => Ok(Value::filesize(size * 1000 * 1000, span)),
-            Unit::Gigabyte => Ok(Value::filesize(size * 1000 * 1000 * 1000, span)),
-            Unit::Terabyte => Ok(Value::filesize(size * 1000 * 1000 * 1000 * 1000, span)),
-            Unit::Petabyte => Ok(Value::filesize(
-                size * 1000 * 1000 * 1000 * 1000 * 1000,
-                span,
-            )),
-            Unit::Exabyte => Ok(Value::filesize(
-                size * 1000 * 1000 * 1000 * 1000 * 1000 * 1000,
-                span,
-            )),
-
-            Unit::Kibibyte => Ok(Value::filesize(size * 1024, span)),
-            Unit::Mebibyte => Ok(Value::filesize(size * 1024 * 1024, span)),
-            Unit::Gibibyte => Ok(Value::filesize(size * 1024 * 1024 * 1024, span)),
-            Unit::Tebibyte => Ok(Value::filesize(size * 1024 * 1024 * 1024 * 1024, span)),
-            Unit::Pebibyte => Ok(Value::filesize(
-                size * 1024 * 1024 * 1024 * 1024 * 1024,
-                span,
-            )),
-            Unit::Exbibyte => Ok(Value::filesize(
-                size * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
-                span,
-            )),
-
+            Unit::Filesize(unit) => {
+                if let Some(filesize) = Filesize::from_unit(size, unit) {
+                    Ok(filesize.into_value(span))
+                } else {
+                    Err(ShellError::GenericError {
+                        error: "filesize too large".into(),
+                        msg: "filesize too large".into(),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    })
+                }
+            }
             Unit::Nanosecond => Ok(Value::duration(size, span)),
             Unit::Microsecond => Ok(Value::duration(size * 1000, span)),
             Unit::Millisecond => Ok(Value::duration(size * 1000 * 1000, span)),

--- a/crates/nu-protocol/src/ir/mod.rs
+++ b/crates/nu-protocol/src/ir/mod.rs
@@ -1,13 +1,11 @@
-use std::{fmt, sync::Arc};
-
 use crate::{
     ast::{CellPath, Expression, Operator, Pattern, RangeInclusion},
     engine::EngineState,
-    BlockId, DeclId, RegId, Span, Value, VarId,
+    BlockId, DeclId, Filesize, RegId, Span, Value, VarId,
 };
-
 use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize};
+use std::{fmt, sync::Arc};
 
 mod call;
 mod display;
@@ -397,7 +395,7 @@ pub enum Literal {
     Bool(bool),
     Int(i64),
     Float(f64),
-    Filesize(i64),
+    Filesize(Filesize),
     Duration(i64),
     Binary(DataSlice),
     Block(BlockId),

--- a/crates/nu-protocol/src/value/filesize.rs
+++ b/crates/nu-protocol/src/value/filesize.rs
@@ -1,7 +1,281 @@
-use crate::Config;
+use crate::{Config, FromValue, IntoValue, ShellError, Span, Type, Value};
 use byte_unit::UnitType;
 use nu_utils::get_system_locale;
 use num_format::ToFormattedString;
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt,
+    iter::{Product, Sum},
+    ops::{Add, Div, Mul, Neg, Rem, Sub},
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(transparent)]
+#[serde(transparent)]
+pub struct Filesize(i64);
+
+impl Filesize {
+    pub const ZERO: Self = Self(0);
+
+    pub const fn new(bytes: i64) -> Self {
+        Self(bytes)
+    }
+
+    pub const fn get(&self) -> i64 {
+        self.0
+    }
+
+    pub const fn from_unit(value: i64, unit: FilesizeUnit) -> Option<Self> {
+        if let Some(bytes) = value.checked_mul(unit.as_bytes() as i64) {
+            Some(Self(bytes))
+        } else {
+            None
+        }
+    }
+}
+
+impl From<i64> for Filesize {
+    fn from(value: i64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Filesize> for i64 {
+    fn from(filesize: Filesize) -> Self {
+        filesize.0
+    }
+}
+
+impl TryFrom<u64> for Filesize {
+    type Error = <u64 as TryInto<i64>>::Error;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        value.try_into().map(Self)
+    }
+}
+
+impl TryFrom<Filesize> for u64 {
+    type Error = <i64 as TryInto<u64>>::Error;
+
+    fn try_from(filesize: Filesize) -> Result<Self, Self::Error> {
+        filesize.0.try_into()
+    }
+}
+
+macro_rules! impl_from {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl From<$ty> for Filesize {
+                #[inline]
+                fn from(value: $ty) -> Self {
+                    Self(value.into())
+                }
+            }
+
+            impl TryFrom<Filesize> for $ty {
+                type Error = <i64 as TryInto<$ty>>::Error;
+
+                #[inline]
+                fn try_from(filesize: Filesize) -> Result<Self, Self::Error> {
+                    filesize.0.try_into()
+                }
+            }
+        )*
+    };
+}
+
+impl_from!(u8, i8, u16, i16, u32, i32);
+
+impl FromValue for Filesize {
+    fn from_value(value: Value) -> Result<Self, ShellError> {
+        value.as_filesize()
+    }
+
+    fn expected_type() -> Type {
+        Type::Filesize
+    }
+}
+
+impl IntoValue for Filesize {
+    fn into_value(self, span: Span) -> Value {
+        Value::filesize(self.0, span)
+    }
+}
+
+impl Add for Filesize {
+    type Output = Option<Self>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        self.0.checked_add(rhs.0).map(Self)
+    }
+}
+
+impl Sub for Filesize {
+    type Output = Option<Self>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.0.checked_sub(rhs.0).map(Self)
+    }
+}
+
+impl Mul for Filesize {
+    type Output = Option<Self>;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        self.0.checked_mul(rhs.0).map(Self)
+    }
+}
+
+impl Div for Filesize {
+    type Output = Option<Self>;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        self.0.checked_div(rhs.0).map(Self)
+    }
+}
+
+impl Rem for Filesize {
+    type Output = Option<Self>;
+
+    fn rem(self, rhs: Self) -> Self::Output {
+        self.0.checked_rem(rhs.0).map(Self)
+    }
+}
+
+impl Neg for Filesize {
+    type Output = Option<Self>;
+
+    fn neg(self) -> Self::Output {
+        self.0.checked_neg().map(Self)
+    }
+}
+
+impl Sum<Filesize> for Option<Filesize> {
+    fn sum<I: Iterator<Item = Filesize>>(iter: I) -> Self {
+        let mut sum = Filesize::ZERO;
+        for filesize in iter {
+            sum = (sum + filesize)?;
+        }
+        Some(sum)
+    }
+}
+
+impl Product<Filesize> for Option<Filesize> {
+    fn product<I: Iterator<Item = Filesize>>(iter: I) -> Self {
+        let mut product = Filesize::ZERO;
+        for filesize in iter {
+            product = (product * filesize)?;
+        }
+        Some(product)
+    }
+}
+
+impl fmt::Display for Filesize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        format_filesize(self.0, "auto", Some(false)).fmt(f)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FilesizeUnit {
+    B,
+    KB,
+    MB,
+    GB,
+    TB,
+    PB,
+    EB,
+    KiB,
+    MiB,
+    GiB,
+    TiB,
+    PiB,
+    EiB,
+}
+
+impl FilesizeUnit {
+    pub const fn as_bytes(&self) -> u64 {
+        match self {
+            Self::B => 1,
+            Self::KB => 10_u64.pow(3),
+            Self::MB => 10_u64.pow(6),
+            Self::GB => 10_u64.pow(9),
+            Self::TB => 10_u64.pow(12),
+            Self::PB => 10_u64.pow(15),
+            Self::EB => 10_u64.pow(18),
+            Self::KiB => 1 << 10,
+            Self::MiB => 1 << 20,
+            Self::GiB => 1 << 30,
+            Self::TiB => 1 << 40,
+            Self::PiB => 1 << 50,
+            Self::EiB => 1 << 60,
+        }
+    }
+
+    pub const fn as_filesize(&self) -> Filesize {
+        Filesize::new(self.as_bytes() as i64)
+    }
+
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::B => "B",
+            Self::KB => "KB",
+            Self::MB => "MB",
+            Self::GB => "GB",
+            Self::TB => "TB",
+            Self::PB => "PB",
+            Self::EB => "EB",
+            Self::KiB => "KiB",
+            Self::MiB => "MiB",
+            Self::GiB => "GiB",
+            Self::TiB => "TiB",
+            Self::PiB => "PiB",
+            Self::EiB => "EiB",
+        }
+    }
+
+    pub const fn is_decimal(&self) -> bool {
+        match self {
+            FilesizeUnit::B
+            | FilesizeUnit::KB
+            | FilesizeUnit::MB
+            | FilesizeUnit::GB
+            | FilesizeUnit::TB
+            | FilesizeUnit::PB
+            | FilesizeUnit::EB => true,
+            FilesizeUnit::KiB
+            | FilesizeUnit::MiB
+            | FilesizeUnit::GiB
+            | FilesizeUnit::TiB
+            | FilesizeUnit::PiB
+            | FilesizeUnit::EiB => false,
+        }
+    }
+
+    pub const fn is_binary(&self) -> bool {
+        match self {
+            FilesizeUnit::KB
+            | FilesizeUnit::MB
+            | FilesizeUnit::GB
+            | FilesizeUnit::TB
+            | FilesizeUnit::PB
+            | FilesizeUnit::EB => false,
+            FilesizeUnit::B
+            | FilesizeUnit::KiB
+            | FilesizeUnit::MiB
+            | FilesizeUnit::GiB
+            | FilesizeUnit::TiB
+            | FilesizeUnit::PiB
+            | FilesizeUnit::EiB => true,
+        }
+    }
+}
+
+impl fmt::Display for FilesizeUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
 
 pub fn format_filesize_from_conf(num_bytes: i64, config: &Config) -> String {
     // We need to take into account config.filesize_metric so, if someone asks for KB

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -252,9 +252,7 @@ impl FromValue for i64 {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         match v {
             Value::Int { val, .. } => Ok(val),
-            Value::Filesize { val, .. } => Ok(val),
             Value::Duration { val, .. } => Ok(val),
-
             v => Err(ShellError::CantConvert {
                 to_type: Self::expected_type().to_string(),
                 from_type: v.get_type().to_string(),
@@ -308,9 +306,7 @@ macro_rules! impl_from_value_for_uint {
                 let span = v.span();
                 const MAX: i64 = $max;
                 match v {
-                    Value::Int { val, .. }
-                    | Value::Filesize { val, .. }
-                    | Value::Duration { val, .. } => {
+                    Value::Int { val, .. } | Value::Duration { val, .. } => {
                         match val {
                             i64::MIN..=-1 => Err(ShellError::NeedsPositiveValue { span }),
                             0..=MAX => Ok(val as $type),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -301,9 +301,9 @@ impl Value {
     }
 
     /// Returns the inner `i64` filesize value or an error if this `Value` is not a filesize
-    pub fn as_filesize(&self) -> Result<i64, ShellError> {
+    pub fn as_filesize(&self) -> Result<Filesize, ShellError> {
         if let Value::Filesize { val, .. } = self {
-            Ok(*val)
+            Ok(Filesize::new(*val))
         } else {
             self.cant_convert_to("filesize")
         }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -83,7 +83,7 @@ pub enum Value {
         internal_span: Span,
     },
     Filesize {
-        val: i64,
+        val: Filesize,
         // note: spans are being refactored out of Value
         // please use .span() instead of matching this span value
         #[serde(rename = "span")]
@@ -303,7 +303,7 @@ impl Value {
     /// Returns the inner `i64` filesize value or an error if this `Value` is not a filesize
     pub fn as_filesize(&self) -> Result<Filesize, ShellError> {
         if let Value::Filesize { val, .. } = self {
-            Ok(Filesize::new(*val))
+            Ok(*val)
         } else {
             self.cant_convert_to("filesize")
         }
@@ -1819,9 +1819,9 @@ impl Value {
         }
     }
 
-    pub fn filesize(val: i64, span: Span) -> Value {
+    pub fn filesize(val: impl Into<Filesize>, span: Span) -> Value {
         Value::Filesize {
-            val,
+            val: val.into(),
             internal_span: span,
         }
     }
@@ -1938,7 +1938,7 @@ impl Value {
 
     /// Note: Only use this for test data, *not* live data, as it will point into unknown source
     /// when used in errors.
-    pub fn test_filesize(val: i64) -> Value {
+    pub fn test_filesize(val: impl Into<Filesize>) -> Value {
         Value::filesize(val, Span::test_data())
     }
 
@@ -2478,7 +2478,7 @@ impl Value {
                 }
             }
             (Value::Filesize { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
-                if let Some(val) = lhs.checked_add(*rhs) {
+                if let Some(val) = *lhs + *rhs {
                     Ok(Value::filesize(val, span))
                 } else {
                     Err(ShellError::OperatorOverflow {
@@ -2599,7 +2599,7 @@ impl Value {
                 }
             }
             (Value::Filesize { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
-                if let Some(val) = lhs.checked_sub(*rhs) {
+                if let Some(val) = *lhs - *rhs {
                     Ok(Value::filesize(val, span))
                 } else {
                     Err(ShellError::OperatorOverflow {
@@ -2647,16 +2647,48 @@ impl Value {
                 Ok(Value::float(lhs * rhs, span))
             }
             (Value::Int { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
-                Ok(Value::filesize(*lhs * *rhs, span))
+                if let Some(val) = *lhs * *rhs {
+                    Ok(Value::filesize(val, span))
+                } else {
+                    Err(ShellError::OperatorOverflow {
+                        msg: "multiply operation overflowed".into(),
+                        span,
+                        help: None,
+                    })
+                }
             }
             (Value::Filesize { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
-                Ok(Value::filesize(*lhs * *rhs, span))
+                if let Some(val) = *lhs * *rhs {
+                    Ok(Value::filesize(val, span))
+                } else {
+                    Err(ShellError::OperatorOverflow {
+                        msg: "multiply operation overflowed".into(),
+                        span,
+                        help: None,
+                    })
+                }
             }
             (Value::Float { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
-                Ok(Value::filesize((*lhs * *rhs as f64) as i64, span))
+                if let Some(val) = *lhs * *rhs {
+                    Ok(Value::filesize(val, span))
+                } else {
+                    Err(ShellError::OperatorOverflow {
+                        msg: "multiply operation overflowed".into(),
+                        span,
+                        help: None,
+                    })
+                }
             }
             (Value::Filesize { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
-                Ok(Value::filesize((*lhs as f64 * *rhs) as i64, span))
+                if let Some(val) = *lhs * *rhs {
+                    Ok(Value::filesize(val, span))
+                } else {
+                    Err(ShellError::OperatorOverflow {
+                        msg: "multiply operation overflowed".into(),
+                        span,
+                        help: None,
+                    })
+                }
             }
             (Value::Int { val: lhs, .. }, Value::Duration { val: rhs, .. }) => {
                 Ok(Value::duration(*lhs * *rhs, span))
@@ -2714,14 +2746,14 @@ impl Value {
                 }
             }
             (Value::Filesize { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
-                if *rhs == 0 {
+                if *rhs == Filesize::ZERO {
                     Err(ShellError::DivisionByZero { span: op })
                 } else {
-                    Ok(Value::float(*lhs as f64 / *rhs as f64, span))
+                    Ok(Value::float(lhs.get() as f64 / rhs.get() as f64, span))
                 }
             }
             (Value::Filesize { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
-                if let Some(val) = lhs.checked_div(*rhs) {
+                if let Some(val) = lhs.get().checked_div(*rhs) {
                     Ok(Value::filesize(val, span))
                 } else if *rhs == 0 {
                     Err(ShellError::DivisionByZero { span: op })
@@ -2735,9 +2767,8 @@ impl Value {
             }
             (Value::Filesize { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
                 if *rhs != 0.0 {
-                    let val = *lhs as f64 / rhs;
-                    if i64::MIN as f64 <= val && val <= i64::MAX as f64 {
-                        Ok(Value::filesize(val as i64, span))
+                    if let Ok(val) = Filesize::try_from(lhs.get() as f64 / rhs) {
+                        Ok(Value::filesize(val, span))
                     } else {
                         Err(ShellError::OperatorOverflow {
                             msg: "division operation overflowed".into(),
@@ -2787,163 +2818,6 @@ impl Value {
             }
             (Value::Custom { val: lhs, .. }, rhs) => {
                 lhs.operation(self.span(), Operator::Math(Math::Divide), op, rhs)
-            }
-
-            _ => Err(ShellError::OperatorMismatch {
-                op_span: op,
-                lhs_ty: self.get_type().to_string(),
-                lhs_span: self.span(),
-                rhs_ty: rhs.get_type().to_string(),
-                rhs_span: rhs.span(),
-            }),
-        }
-    }
-
-    pub fn modulo(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
-        // Based off the unstable `div_floor` function in the std library.
-        fn checked_mod_i64(dividend: i64, divisor: i64) -> Option<i64> {
-            let remainder = dividend.checked_rem(divisor)?;
-            if (remainder > 0 && divisor < 0) || (remainder < 0 && divisor > 0) {
-                // Note that `remainder + divisor` cannot overflow, because `remainder` and
-                // `divisor` have opposite signs.
-                Some(remainder + divisor)
-            } else {
-                Some(remainder)
-            }
-        }
-
-        fn checked_mod_f64(dividend: f64, divisor: f64) -> Option<f64> {
-            if divisor == 0.0 {
-                None
-            } else {
-                let remainder = dividend % divisor;
-                if (remainder > 0.0 && divisor < 0.0) || (remainder < 0.0 && divisor > 0.0) {
-                    Some(remainder + divisor)
-                } else {
-                    Some(remainder)
-                }
-            }
-        }
-
-        match (self, rhs) {
-            (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
-                if let Some(val) = checked_mod_i64(*lhs, *rhs) {
-                    Ok(Value::int(val, span))
-                } else if *rhs == 0 {
-                    Err(ShellError::DivisionByZero { span: op })
-                } else {
-                    Err(ShellError::OperatorOverflow {
-                        msg: "modulo operation overflowed".into(),
-                        span,
-                        help: None,
-                    })
-                }
-            }
-            (Value::Int { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
-                if let Some(val) = checked_mod_f64(*lhs as f64, *rhs) {
-                    Ok(Value::float(val, span))
-                } else {
-                    Err(ShellError::DivisionByZero { span: op })
-                }
-            }
-            (Value::Float { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
-                if let Some(val) = checked_mod_f64(*lhs, *rhs as f64) {
-                    Ok(Value::float(val, span))
-                } else {
-                    Err(ShellError::DivisionByZero { span: op })
-                }
-            }
-            (Value::Float { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
-                if let Some(val) = checked_mod_f64(*lhs, *rhs) {
-                    Ok(Value::float(val, span))
-                } else {
-                    Err(ShellError::DivisionByZero { span: op })
-                }
-            }
-            (Value::Filesize { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
-                if let Some(val) = checked_mod_i64(*lhs, *rhs) {
-                    Ok(Value::filesize(val, span))
-                } else if *rhs == 0 {
-                    Err(ShellError::DivisionByZero { span: op })
-                } else {
-                    Err(ShellError::OperatorOverflow {
-                        msg: "modulo operation overflowed".into(),
-                        span,
-                        help: None,
-                    })
-                }
-            }
-            (Value::Filesize { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
-                if let Some(val) = checked_mod_i64(*lhs, *rhs) {
-                    Ok(Value::filesize(val, span))
-                } else if *rhs == 0 {
-                    Err(ShellError::DivisionByZero { span: op })
-                } else {
-                    Err(ShellError::OperatorOverflow {
-                        msg: "modulo operation overflowed".into(),
-                        span,
-                        help: None,
-                    })
-                }
-            }
-            (Value::Filesize { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
-                if let Some(val) = checked_mod_f64(*lhs as f64, *rhs) {
-                    if i64::MIN as f64 <= val && val <= i64::MAX as f64 {
-                        Ok(Value::filesize(val as i64, span))
-                    } else {
-                        Err(ShellError::OperatorOverflow {
-                            msg: "modulo operation overflowed".into(),
-                            span,
-                            help: None,
-                        })
-                    }
-                } else {
-                    Err(ShellError::DivisionByZero { span: op })
-                }
-            }
-            (Value::Duration { val: lhs, .. }, Value::Duration { val: rhs, .. }) => {
-                if let Some(val) = checked_mod_i64(*lhs, *rhs) {
-                    Ok(Value::duration(val, span))
-                } else if *rhs == 0 {
-                    Err(ShellError::DivisionByZero { span: op })
-                } else {
-                    Err(ShellError::OperatorOverflow {
-                        msg: "division operation overflowed".into(),
-                        span,
-                        help: None,
-                    })
-                }
-            }
-            (Value::Duration { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
-                if let Some(val) = checked_mod_i64(*lhs, *rhs) {
-                    Ok(Value::duration(val, span))
-                } else if *rhs == 0 {
-                    Err(ShellError::DivisionByZero { span: op })
-                } else {
-                    Err(ShellError::OperatorOverflow {
-                        msg: "division operation overflowed".into(),
-                        span,
-                        help: None,
-                    })
-                }
-            }
-            (Value::Duration { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
-                if let Some(val) = checked_mod_f64(*lhs as f64, *rhs) {
-                    if i64::MIN as f64 <= val && val <= i64::MAX as f64 {
-                        Ok(Value::duration(val as i64, span))
-                    } else {
-                        Err(ShellError::OperatorOverflow {
-                            msg: "division operation overflowed".into(),
-                            span,
-                            help: None,
-                        })
-                    }
-                } else {
-                    Err(ShellError::DivisionByZero { span: op })
-                }
-            }
-            (Value::Custom { val: lhs, .. }, rhs) => {
-                lhs.operation(span, Operator::Math(Math::Modulo), op, rhs)
             }
 
             _ => Err(ShellError::OperatorMismatch {
@@ -3017,9 +2891,9 @@ impl Value {
                 }
             }
             (Value::Filesize { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
-                if let Some(val) = checked_div_floor_i64(*lhs, *rhs) {
+                if let Some(val) = checked_div_floor_i64(lhs.get(), rhs.get()) {
                     Ok(Value::int(val, span))
-                } else if *rhs == 0 {
+                } else if *rhs == Filesize::ZERO {
                     Err(ShellError::DivisionByZero { span: op })
                 } else {
                     Err(ShellError::OperatorOverflow {
@@ -3030,7 +2904,7 @@ impl Value {
                 }
             }
             (Value::Filesize { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
-                if let Some(val) = checked_div_floor_i64(*lhs, *rhs) {
+                if let Some(val) = checked_div_floor_i64(lhs.get(), *rhs) {
                     Ok(Value::filesize(val, span))
                 } else if *rhs == 0 {
                     Err(ShellError::DivisionByZero { span: op })
@@ -3043,9 +2917,9 @@ impl Value {
                 }
             }
             (Value::Filesize { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
-                if let Some(val) = checked_div_floor_f64(*lhs as f64, *rhs) {
-                    if i64::MIN as f64 <= val && val <= i64::MAX as f64 {
-                        Ok(Value::filesize(val as i64, span))
+                if let Some(val) = checked_div_floor_f64(lhs.get() as f64, *rhs) {
+                    if let Ok(val) = Filesize::try_from(val) {
+                        Ok(Value::filesize(val, span))
                     } else {
                         Err(ShellError::OperatorOverflow {
                             msg: "division operation overflowed".into(),
@@ -3101,6 +2975,163 @@ impl Value {
             (Value::Custom { val: lhs, .. }, rhs) => {
                 lhs.operation(self.span(), Operator::Math(Math::Divide), op, rhs)
             }
+            _ => Err(ShellError::OperatorMismatch {
+                op_span: op,
+                lhs_ty: self.get_type().to_string(),
+                lhs_span: self.span(),
+                rhs_ty: rhs.get_type().to_string(),
+                rhs_span: rhs.span(),
+            }),
+        }
+    }
+
+    pub fn modulo(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
+        // Based off the unstable `div_floor` function in the std library.
+        fn checked_mod_i64(dividend: i64, divisor: i64) -> Option<i64> {
+            let remainder = dividend.checked_rem(divisor)?;
+            if (remainder > 0 && divisor < 0) || (remainder < 0 && divisor > 0) {
+                // Note that `remainder + divisor` cannot overflow, because `remainder` and
+                // `divisor` have opposite signs.
+                Some(remainder + divisor)
+            } else {
+                Some(remainder)
+            }
+        }
+
+        fn checked_mod_f64(dividend: f64, divisor: f64) -> Option<f64> {
+            if divisor == 0.0 {
+                None
+            } else {
+                let remainder = dividend % divisor;
+                if (remainder > 0.0 && divisor < 0.0) || (remainder < 0.0 && divisor > 0.0) {
+                    Some(remainder + divisor)
+                } else {
+                    Some(remainder)
+                }
+            }
+        }
+
+        match (self, rhs) {
+            (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
+                if let Some(val) = checked_mod_i64(*lhs, *rhs) {
+                    Ok(Value::int(val, span))
+                } else if *rhs == 0 {
+                    Err(ShellError::DivisionByZero { span: op })
+                } else {
+                    Err(ShellError::OperatorOverflow {
+                        msg: "modulo operation overflowed".into(),
+                        span,
+                        help: None,
+                    })
+                }
+            }
+            (Value::Int { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
+                if let Some(val) = checked_mod_f64(*lhs as f64, *rhs) {
+                    Ok(Value::float(val, span))
+                } else {
+                    Err(ShellError::DivisionByZero { span: op })
+                }
+            }
+            (Value::Float { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
+                if let Some(val) = checked_mod_f64(*lhs, *rhs as f64) {
+                    Ok(Value::float(val, span))
+                } else {
+                    Err(ShellError::DivisionByZero { span: op })
+                }
+            }
+            (Value::Float { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
+                if let Some(val) = checked_mod_f64(*lhs, *rhs) {
+                    Ok(Value::float(val, span))
+                } else {
+                    Err(ShellError::DivisionByZero { span: op })
+                }
+            }
+            (Value::Filesize { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
+                if let Some(val) = checked_mod_i64(lhs.get(), rhs.get()) {
+                    Ok(Value::filesize(val, span))
+                } else if *rhs == Filesize::ZERO {
+                    Err(ShellError::DivisionByZero { span: op })
+                } else {
+                    Err(ShellError::OperatorOverflow {
+                        msg: "modulo operation overflowed".into(),
+                        span,
+                        help: None,
+                    })
+                }
+            }
+            (Value::Filesize { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
+                if let Some(val) = checked_mod_i64(lhs.get(), *rhs) {
+                    Ok(Value::filesize(val, span))
+                } else if *rhs == 0 {
+                    Err(ShellError::DivisionByZero { span: op })
+                } else {
+                    Err(ShellError::OperatorOverflow {
+                        msg: "modulo operation overflowed".into(),
+                        span,
+                        help: None,
+                    })
+                }
+            }
+            (Value::Filesize { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
+                if let Some(val) = checked_mod_f64(lhs.get() as f64, *rhs) {
+                    if let Ok(val) = Filesize::try_from(val) {
+                        Ok(Value::filesize(val, span))
+                    } else {
+                        Err(ShellError::OperatorOverflow {
+                            msg: "modulo operation overflowed".into(),
+                            span,
+                            help: None,
+                        })
+                    }
+                } else {
+                    Err(ShellError::DivisionByZero { span: op })
+                }
+            }
+            (Value::Duration { val: lhs, .. }, Value::Duration { val: rhs, .. }) => {
+                if let Some(val) = checked_mod_i64(*lhs, *rhs) {
+                    Ok(Value::duration(val, span))
+                } else if *rhs == 0 {
+                    Err(ShellError::DivisionByZero { span: op })
+                } else {
+                    Err(ShellError::OperatorOverflow {
+                        msg: "division operation overflowed".into(),
+                        span,
+                        help: None,
+                    })
+                }
+            }
+            (Value::Duration { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
+                if let Some(val) = checked_mod_i64(*lhs, *rhs) {
+                    Ok(Value::duration(val, span))
+                } else if *rhs == 0 {
+                    Err(ShellError::DivisionByZero { span: op })
+                } else {
+                    Err(ShellError::OperatorOverflow {
+                        msg: "division operation overflowed".into(),
+                        span,
+                        help: None,
+                    })
+                }
+            }
+            (Value::Duration { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
+                if let Some(val) = checked_mod_f64(*lhs as f64, *rhs) {
+                    if i64::MIN as f64 <= val && val <= i64::MAX as f64 {
+                        Ok(Value::duration(val as i64, span))
+                    } else {
+                        Err(ShellError::OperatorOverflow {
+                            msg: "division operation overflowed".into(),
+                            span,
+                            help: None,
+                        })
+                    }
+                } else {
+                    Err(ShellError::DivisionByZero { span: op })
+                }
+            }
+            (Value::Custom { val: lhs, .. }, rhs) => {
+                lhs.operation(span, Operator::Math(Math::Modulo), op, rhs)
+            }
+
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
                 lhs_ty: self.get_type().to_string(),

--- a/crates/nu_plugin_formats/src/to/plist.rs
+++ b/crates/nu_plugin_formats/src/to/plist.rs
@@ -1,10 +1,8 @@
-use std::time::SystemTime;
-
+use crate::FormatCmdsPlugin;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand, SimplePluginCommand};
 use nu_protocol::{Category, Example, LabeledError, Record, Signature, Span, Value as NuValue};
-use plist::{Integer, Value as PlistValue};
-
-use crate::FormatCmdsPlugin;
+use plist::Value as PlistValue;
+use std::time::SystemTime;
 
 pub(crate) struct IntoPlist;
 
@@ -68,7 +66,7 @@ fn convert_nu_value(nu_val: &NuValue) -> Result<PlistValue, LabeledError> {
         NuValue::String { val, .. } => Ok(PlistValue::String(val.to_owned())),
         NuValue::Bool { val, .. } => Ok(PlistValue::Boolean(*val)),
         NuValue::Float { val, .. } => Ok(PlistValue::Real(*val)),
-        NuValue::Int { val, .. } => Ok(PlistValue::Integer(Into::<Integer>::into(*val))),
+        NuValue::Int { val, .. } => Ok(PlistValue::Integer((*val).into())),
         NuValue::Binary { val, .. } => Ok(PlistValue::Data(val.to_owned())),
         NuValue::Record { val, .. } => convert_nu_dict(val),
         NuValue::List { vals, .. } => Ok(PlistValue::Array(
@@ -77,7 +75,7 @@ fn convert_nu_value(nu_val: &NuValue) -> Result<PlistValue, LabeledError> {
                 .collect::<Result<_, _>>()?,
         )),
         NuValue::Date { val, .. } => Ok(PlistValue::Date(SystemTime::from(val.to_owned()).into())),
-        NuValue::Filesize { val, .. } => Ok(PlistValue::Integer(Into::<Integer>::into(*val))),
+        NuValue::Filesize { val, .. } => Ok(PlistValue::Integer(val.get().into())),
         _ => Err(build_label_error(
             format!("{:?} is not convertible", nu_val),
             span,

--- a/crates/nuon/src/lib.rs
+++ b/crates/nuon/src/lib.rs
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn filesize() {
-        nuon_end_to_end("1024B", Some(Value::test_filesize(1024)));
+        nuon_end_to_end("1024b", Some(Value::test_filesize(1024)));
         assert_eq!(from_nuon("1kib", None).unwrap(), Value::test_filesize(1024));
     }
 

--- a/crates/nuon/src/lib.rs
+++ b/crates/nuon/src/lib.rs
@@ -154,8 +154,8 @@ mod tests {
 
     #[test]
     fn filesize() {
-        nuon_end_to_end("1024b", Some(Value::test_filesize(1024)));
-        assert_eq!(from_nuon("1kib", None).unwrap(), Value::test_filesize(1024),);
+        nuon_end_to_end("1024B", Some(Value::test_filesize(1024)));
+        assert_eq!(from_nuon("1kib", None).unwrap(), Value::test_filesize(1024));
     }
 
     #[test]

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -110,7 +110,7 @@ fn value_to_string(
         // Propagate existing errors
         Value::Error { error, .. } => Err(*error.clone()),
         // FIXME: make filesizes use the shortest lossless representation.
-        Value::Filesize { val, .. } => Ok(format!("{}B", val.get())),
+        Value::Filesize { val, .. } => Ok(format!("{}b", val.get())),
         Value::Float { val, .. } => {
             // This serialises these as 'nan', 'inf' and '-inf', respectively.
             if &val.round() == val && val.is_finite() {

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -39,7 +39,7 @@ pub enum ToStyle {
 ///
 // WARNING: please leave the following two trailing spaces, they matter for the documentation
 // formatting
-/// > **Note**  
+/// > **Note**
 /// > a [`Span`] can be passed to [`to_nuon`] if there is context available to the caller, e.g. when
 /// > using this function in a command implementation such as [`to nuon`](https://www.nushell.sh/commands/docs/to_nuon.html).
 ///
@@ -110,7 +110,7 @@ fn value_to_string(
         // Propagate existing errors
         Value::Error { error, .. } => Err(*error.clone()),
         // FIXME: make filesizes use the shortest lossless representation.
-        Value::Filesize { val, .. } => Ok(format!("{}b", *val)),
+        Value::Filesize { val, .. } => Ok(format!("{}B", val.get())),
         Value::Float { val, .. } => {
             // This serialises these as 'nan', 'inf' and '-inf', respectively.
             if &val.round() == val && val.is_finite() {


### PR DESCRIPTION
# Description
Adds a new `Filesize` type so that `FromValue` can be used to convert a `Value::Filesize` to a `Filesize`. Currently, to extract a filesize from a `Value` using `FromValue`, you have to extract an `i64` which coerces `Value::Int`, `Value::Duration`, and `Value::Filesize` to an `i64`.

Having a separate type also allows us to enforce checked math to catch overflows. Similarly, it allows us to specify other trait implementations like `Display` in a common place.

# User-Facing Changes
Multiplication with filesizes now error on overflow. Should not be a breaking change for plugins (i.e., serialization) since `Filesize` is marked with `serde(transparent)`.

# Tests + Formatting
Updated some tests.