### PR TITLE
Add `--locked` flag to Cargo install

### DIFF
--- a/crates/nu-parser/fuzz/README.md
+++ b/crates/nu-parser/fuzz/README.md
@@ -3,7 +3,7 @@
 - For detailed info, please look at [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz)
 
 # Quick start guide
-- Install cargo-fuzz by `cargo install cargo-fuzz`
+- Install cargo-fuzz by `cargo install cargo-fuzz --locked`
 - Run `gather_seeds.nu` for preparing the initial seeds corpus
 - Make output directory `mkdir out`
 - Run the fuzzer with `cargo fuzz run parse out seeds`

--- a/crates/nu-path/fuzz/README.md
+++ b/crates/nu-path/fuzz/README.md
@@ -3,6 +3,6 @@
 - For detailed info, please look at [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz)
 
 # Quick start guide
-- Install cargo-fuzz by `cargo install cargo-fuzz`
+- Install cargo-fuzz by `cargo install cargo-fuzz --locked`
 - Make output directory `mkdir out`
 - Run the fuzzer with `cargo fuzz run parse out`

--- a/crates/nu_plugin_gstat/README.md
+++ b/crates/nu_plugin_gstat/README.md
@@ -5,7 +5,7 @@ Note: this requires Nushell 0.60 or later
 To install:
 
 ```
-> cargo install --path .
+> cargo install --path . --locked
 ```
 
 To add the plugin (from inside Nushell):

--- a/crates/nu_plugin_inc/README.md
+++ b/crates/nu_plugin_inc/README.md
@@ -5,7 +5,7 @@ Note: this requires Nushell 0.60 or later
 To install:
 
 ```
-cargo install --path .
+cargo install --path . --locked
 ```
 
 To add the plugin (from inside Nushell):

--- a/crates/nu_plugin_query/README.md
+++ b/crates/nu_plugin_query/README.md
@@ -5,7 +5,7 @@ Note: this requires Nushell 0.60 or later
 To install:
 
 ```
-> cargo install --path .
+> cargo install --path . --locked
 ```
 
 To add the plugin (from inside Nushell):

--- a/devdocs/PLATFORM_SUPPORT.md
+++ b/devdocs/PLATFORM_SUPPORT.md
@@ -56,7 +56,7 @@ Help from the community to make sure they get tested and improved so they can be
 The Nushell team only provides a select few distribution sources and so far encourages community members to maintain the individual packages for particular package managers:
 
 We provide:
-- source code distribution via `crates.io` -> `cargo install nu`
+- source code distribution via `crates.io` -> `cargo install nu --locked`
 - GitHub builds with each release: (following the build matrix of the nightly builds)
 - the setup for `winget` packaging
 

--- a/scripts/coverage-local.nu
+++ b/scripts/coverage-local.nu
@@ -35,7 +35,7 @@ let start = (date now)
 #
 # Output: `lcov.info` file
 #
-# Relies on `cargo-llvm-cov`. Install via `cargo install cargo-llvm-cov`
+# Relies on `cargo-llvm-cov`. Install via `cargo install cargo-llvm-cov --locked`
 # https://github.com/taiki-e/cargo-llvm-cov
 
 # You probably have to run `cargo llvm-cov clean` once manually,

--- a/scripts/coverage-local.sh
+++ b/scripts/coverage-local.sh
@@ -7,7 +7,7 @@ REPO_ROOT=$(dirname $DIR)
 #
 # Output: `lcov.info` file
 #
-# Relies on `cargo-llvm-cov`. Install via `cargo install cargo-llvm-cov`
+# Relies on `cargo-llvm-cov`. Install via `cargo install cargo-llvm-cov --locked`
 # https://github.com/taiki-e/cargo-llvm-cov
 
 # You probably have to run `cargo llvm-cov clean` once manually,

--- a/scripts/install-all.ps1
+++ b/scripts/install-all.ps1
@@ -26,7 +26,7 @@ foreach ( $plugin in $NU_PLUGINS) {
     Write-Output "Install plugin $plugin from local..."
     Write-Output "----------------------------------------------"
     Set-Location crates/$plugin
-    cargo install --force --path .
+    cargo install --force --path . --locked
     Set-Location ../../
 }
 

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -30,5 +30,5 @@ do
     echo "----------------------------------------------"
     echo "Install plugin $plugin from local..."
     echo "----------------------------------------------"
-    cargo install --force --path "$REPO_ROOT/crates/$plugin"
+    cargo install --force --path "$REPO_ROOT/crates/$plugin" --locked
 done

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -373,7 +373,7 @@ def install-plugin [] {
     print $'(char nl)Installing ($plugin)'
     print '----------------------------'
 
-    ^cargo install --path $"crates/($plugin)"
+    ^cargo install --path $"crates/($plugin) --locked"
 }
 
 # install Nushell and features you want
@@ -461,7 +461,7 @@ def compute-coverage [] {
 #
 # Output: `lcov.info` file
 #
-# Relies on `cargo-llvm-cov`. Install via `cargo install cargo-llvm-cov`
+# Relies on `cargo-llvm-cov`. Install via `cargo install cargo-llvm-cov --locked`
 # https://github.com/taiki-e/cargo-llvm-cov
 #
 # You probably have to run `cargo llvm-cov clean` once manually,


### PR DESCRIPTION
Using the `--locked` flag prevents installation failures when dependencies have broken updates.

All references are replaced.

[nushell.github.io #1641](https://github.com/nushell/nushell.github.io/issues/1641), [#1642](https://github.com/nushell/nushell.github.io/issues/1642)  related.
