### PR TITLE
allow ps1 files to be executed without pwsh/powershell -c file.ps1

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -1,6 +1,6 @@
 use nu_cmd_base::hook::eval_hook;
 use nu_engine::{command_prelude::*, env_to_strings, get_eval_expression};
-use nu_path::{dots::expand_ndots, expand_tilde};
+use nu_path::{canonicalize_with, dots::expand_ndots, expand_tilde};
 use nu_protocol::{did_you_mean, process::ChildProcess, ByteStream, NuGlob, OutDest, Signals};
 use nu_system::ForegroundChild;
 use nu_utils::IgnoreCaseExt;
@@ -131,7 +131,7 @@ impl Command for External {
             // Determine the PATH to be used and then use `which` to find it - though this has no
             // effect if it's an absolute path already
             let paths = nu_engine::env::path_str(engine_state, stack, call.head)?;
-            let Some(executable) = which(expanded_name, &paths, cwd.as_ref()) else {
+            let Some(executable) = which(expanded_name.clone(), &paths, cwd.as_ref()) else {
                 return Err(command_not_found(&name_str, call.head, engine_state, stack));
             };
             executable
@@ -155,14 +155,21 @@ impl Command for External {
             // The /D flag disables execution of AutoRun commands from registry.
             // The /C flag followed by a command name instructs CMD to execute
             // that command and quit.
-            command.args(["/D", "/C", &name_str]);
+            command.args(["/D", "/C", &expanded_name.to_string_lossy()]);
             for arg in &args {
                 command.raw_arg(escape_cmd_argument(arg)?);
             }
         } else if potential_powershell_script {
+            // canonicalize the path to the script so that tests pass
+            let canon_path = if let Ok(cwd) = engine_state.cwd_as_string(None) {
+                canonicalize_with(&expanded_name, cwd)?
+            } else {
+                // If we can't get the current working directory, just provide the expanded name
+                expanded_name
+            };
             // The -Command flag followed by a script name instructs PowerShell to
             // execute that script and quit.
-            command.args(["-Command", &name_str]);
+            command.args(["-Command", &canon_path.to_string_lossy()]);
             for arg in &args {
                 command.raw_arg(arg.item.clone());
             }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -125,7 +125,7 @@ impl Command for External {
             // Determine the PATH to be used and then use `which` to find it - though this has no
             // effect if it's an absolute path already
             let paths = nu_engine::env::path_str(engine_state, stack, call.head)?;
-            let Some(executable) = which(expanded_name.clone(), &paths, cwd.as_ref()) else {
+            let Some(executable) = which(&expanded_name, &paths, cwd.as_ref()) else {
                 return Err(command_not_found(&name_str, call.head, engine_state, stack));
             };
             executable

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -1,6 +1,6 @@
 use nu_cmd_base::hook::eval_hook;
 use nu_engine::{command_prelude::*, env_to_strings, get_eval_expression};
-use nu_path::{canonicalize_with, dots::expand_ndots, expand_tilde};
+use nu_path::{dots::expand_ndots, expand_tilde};
 use nu_protocol::{did_you_mean, process::ChildProcess, ByteStream, NuGlob, OutDest, Signals};
 use nu_system::ForegroundChild;
 use nu_utils::IgnoreCaseExt;
@@ -160,6 +160,8 @@ impl Command for External {
                 command.raw_arg(escape_cmd_argument(arg)?);
             }
         } else if potential_powershell_script {
+            use nu_path::canonicalize_with;
+
             // canonicalize the path to the script so that tests pass
             let canon_path = if let Ok(cwd) = engine_state.cwd_as_string(None) {
                 canonicalize_with(&expanded_name, cwd)?

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -355,9 +355,9 @@ fn external_command_receives_raw_binary_data() {
 
 #[cfg(windows)]
 #[test]
-fn can_run_batch_files() {
+fn can_run_cmd_files() {
     use nu_test_support::fs::Stub::FileWithContent;
-    Playground::setup("run a Windows batch file", |dirs, sandbox| {
+    Playground::setup("run a Windows cmd file", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "foo.cmd",
             r#"
@@ -373,10 +373,28 @@ fn can_run_batch_files() {
 
 #[cfg(windows)]
 #[test]
+fn can_run_batch_files() {
+    use nu_test_support::fs::Stub::FileWithContent;
+    Playground::setup("run a Windows batch file", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContent(
+            "foo.bat",
+            r#"
+                @echo off
+                echo Hello World
+            "#,
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), pipeline("foo.bat"));
+        assert!(actual.out.contains("Hello World"));
+    });
+}
+
+#[cfg(windows)]
+#[test]
 fn can_run_batch_files_without_cmd_extension() {
     use nu_test_support::fs::Stub::FileWithContent;
     Playground::setup(
-        "run a Windows batch file without specifying the extension",
+        "run a Windows cmd file without specifying the extension",
         |dirs, sandbox| {
             sandbox.with_files(&[FileWithContent(
                 "foo.cmd",
@@ -438,5 +456,22 @@ fn redirect_combine() {
 
         // Lines are collapsed in the nu! macro
         assert_eq!(actual.out, "FooBar");
+    });
+}
+
+#[cfg(windows)]
+#[test]
+fn can_run_ps1_files() {
+    use nu_test_support::fs::Stub::FileWithContent;
+    Playground::setup("run_a_windows_ps_file", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContent(
+            "foo.ps1",
+            r#"
+                Write-Host Hello World
+            "#,
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), pipeline("foo.ps1"));
+        assert!(actual.out.contains("Hello World"));
     });
 }


### PR DESCRIPTION
# Description

This PR allows nushell to run powershell scripts easier. You can already do `powershell -c script.ps1` but this PR takes it a step further by doing the `powershell -c` part for you. So, if you have script.ps1 you can execute it by running it in the command position of the repl.
![image](https://github.com/user-attachments/assets/0661a746-27d9-4d21-b576-c244ff7fab2b)

or once it's in json, just consume it with nushell.
![image](https://github.com/user-attachments/assets/38f5c5d8-3659-41f0-872b-91a14909760b)


# User-Facing Changes
Easier to run powershell scripts. It should work on Windows with powershell.exe and mac/linux if you have pwsh.exe installed. More testing is needed.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
