### PR TITLE
remove deprecated warnings

### DIFF
--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -77,20 +77,6 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        if call.has_flag_const(working_set, "not")? {
-            nu_protocol::report_shell_error(
-                working_set.permanent(),
-                &ShellError::GenericError {
-                    error: "Deprecated option".into(),
-                    msg: "`str contains --not {string}` is deprecated and will be removed in 0.95."
-                        .into(),
-                    span: Some(call.head),
-                    help: Some("Please use the `not` operator instead.".into()),
-                    inner: vec![],
-                },
-            );
-        }
-
         let cell_paths: Vec<CellPath> = call.rest_const(working_set, 1)?;
         let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
         let args = Arguments {


### PR DESCRIPTION
# Description
While looking into nushell deprecated relative code, I found `str contains` have some warnings, but it should be removed.