### PR TITLE
Turn compile errors into fatal errors

### DIFF
--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -74,7 +74,7 @@ pub fn evaluate_commands(
 
         if let Some(err) = working_set.compile_errors.first() {
             report_compile_error(&working_set, err);
-            // Not a fatal error, for now
+            std::process::exit(1);
         }
 
         (output, working_set.render())

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -89,7 +89,7 @@ pub fn evaluate_file(
 
     if let Some(err) = working_set.compile_errors.first() {
         report_compile_error(&working_set, err);
-        // Not a fatal error, for now
+        std::process::exit(1);
     }
 
     // Look for blocks whose name starts with "main" and replace it with the filename.

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -296,7 +296,7 @@ fn evaluate_source(
 
         if let Some(err) = working_set.compile_errors.first() {
             report_compile_error(&working_set, err);
-            // Not a fatal error, for now
+            return Ok(true);
         }
 
         (output, working_set.render())


### PR DESCRIPTION
# Description

Because the IR compiler was previously optional, compile errors were not treated as fatal errors, and were just logged like parse warnings are. This unfortunately meant that if a user encountered a compile error, they would see "Can't evaluate block in IR mode" as the actual error in addition to (hopefully) logging the compile error.

This changes compile errors to be treated like parse errors so that they show up as the last error, helping users understand what's wrong a little bit more easily.

Fixes #14333.

# User-Facing Changes
- Shouldn't see "Can't evaluate block in IR mode"
- Should only see compile error
- No evaluation should happen

# Tests + Formatting
Didn't add any tests specifically for this, but it might be good to have at least one that checks to ensure the compile error shows up and the "can't evaluate" error does not.
