### PR TITLE
Add mac and IP address entries to `sys net`

### DIFF
--- a/crates/nu-command/src/system/sys/net.rs
+++ b/crates/nu-command/src/system/sys/net.rs
@@ -44,8 +44,29 @@ fn net(span: Span) -> Value {
     let networks = Networks::new_with_refreshed_list()
         .iter()
         .map(|(iface, data)| {
+            let ip_addresses = data
+                .ip_networks()
+                .iter()
+                .map(|ip| {
+                    let protocol = match ip.addr {
+                        std::net::IpAddr::V4(_) => "ipv4",
+                        std::net::IpAddr::V6(_) => "ipv6",
+                    };
+                    Value::record(
+                        record! {
+                            "address" => Value::string(ip.addr.to_string(), span),
+                            "protocol" => Value::string(protocol, span),
+                            "loop" => Value::bool(ip.addr.is_loopback(), span),
+                            "multicast" => Value::bool(ip.addr.is_multicast(), span),
+                        },
+                        span,
+                    )
+                })
+                .collect();
             let record = record! {
                 "name" => Value::string(trim_cstyle_null(iface), span),
+                "mac" => Value::string(data.mac_address().to_string(), span),
+                "ip" => Value::list(ip_addresses, span),
                 "sent" => Value::filesize(data.total_transmitted() as i64, span),
                 "recv" => Value::filesize(data.total_received() as i64, span),
             };


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

What it says on the tin, this change adds the `mac` and `ip` columns to the `sys net` command, where `mac` is the interface mac address and `ip` is a record containing ipv4 and ipv6 addresses as well as whether or not the address is loopback and multicast. I thought it might be useful to have this information available in Nushell. This change basically just pulls extra information out of the underlying structs in the `sysinfo::Networks` struct. Here's a screenshot from my system:

![Screenshot from 2024-11-19 11-59-54](https://github.com/user-attachments/assets/92c2d72c-b0d0-49c0-8167-9e1ce853acf1)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

- Adds `mac` and `ip` columns to the `sys net` command, where `mac` contains the interface's mac address and `ip` contains information extracted from the `std::net::IpAddr` struct, including address, protocol, whether or not the address is loopback, and whether or not it's multicast

# Tests + Formatting
Didn't add any tests specifically, didn't seem like there were any relevant tests. Ran existing tests and formatting.

<!--
Don't forget to add tests that cover your changes. 

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->