### PR TITLE
raise ParseError if assign to a non-variable or non-mutable-variable

### DIFF
--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -150,7 +150,7 @@ fn def_should_not_mutate_mut() {
 }
 
 #[test]
-fn mut_with_bad_syntax_raises_parse_error() {
+fn assign_to_non_mut_variable_raises_parse_error() {
     let actual = nu!("let x = 3; $x = 4");
     assert!(actual
         .err

--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -148,3 +148,14 @@ fn def_should_not_mutate_mut() {
     assert!(actual.err.contains("capture of mutable variable"));
     assert!(!actual.status.success())
 }
+
+#[test]
+fn mut_with_bad_syntax_raises_parse_error() {
+    let actual = nu!("let x = 3; $x = 4");
+    assert!(actual
+        .err
+        .contains("parser::assignment_requires_mutable_variable"));
+
+    let actual = nu!("mut x = 3; x = 5");
+    assert!(actual.err.contains("parser::assignment_requires_variable"));
+}

--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -515,6 +515,30 @@ pub enum ParseError {
         help("To spread arguments, the command needs to define a multi-positional parameter in its signature, such as ...rest")
     )]
     UnexpectedSpreadArg(String, #[label = "unexpected spread argument"] Span),
+
+    /// Invalid assignment left-hand side
+    ///
+    /// ## Resolution
+    ///
+    /// Assignment requires that you assign to a mutable variable or cell path.
+    #[error("Assignment to an immutable variable.")]
+    #[diagnostic(
+        code(nu::parser::assignment_requires_mutable_variable),
+        help("declare the variable with `mut`, or shadow it again with `let`")
+    )]
+    AssignmentRequiresMutableVar(#[label("needs to be a mutable variable")] Span),
+
+    /// Invalid assignment left-hand side
+    ///
+    /// ## Resolution
+    ///
+    /// Assignment requires that you assign to a variable or variable cell path.
+    #[error("Assignment operations require a variable.")]
+    #[diagnostic(
+        code(nu::parser::assignment_requires_variable),
+        help("try assigning to a variable or a cell path of a variable")
+    )]
+    AssignmentRequiresVar(#[label("needs to be a variable")] Span),
 }
 
 impl ParseError {
@@ -603,6 +627,8 @@ impl ParseError {
             ParseError::RedirectingBuiltinCommand(_, s, _) => *s,
             ParseError::UnexpectedSpreadArg(_, s) => *s,
             ParseError::ExtraTokensAfterClosingDelimiter(s) => *s,
+            ParseError::AssignmentRequiresVar(s) => *s,
+            ParseError::AssignmentRequiresMutableVar(s) => *s,
         }
     }
 }


### PR DESCRIPTION
# Description
While reviewing #14388, I think we can make some improvement on parser.

For the following code:
```nushell
let a = 3
a = 10   # should be error
$a = 10 # another error
```
I think they can raise `ParseError`, so nushell doesn't need to move forward compiling IR block.

# User-Facing Changes
```nushell
let a = 3
a = 10
```
Will raise parse error instead of compile error.

# Tests + Formatting
Added 1 test.
