### PR TITLE
add `-l` flag to du

### DIFF
--- a/crates/nu-command/src/filesystem/du.rs
+++ b/crates/nu-command/src/filesystem/du.rs
@@ -15,6 +15,7 @@ pub struct DuArgs {
     path: Option<Spanned<NuGlob>>,
     all: bool,
     deref: bool,
+    long: bool,
     exclude: Option<Spanned<NuGlob>>,
     #[serde(rename = "max-depth")]
     max_depth: Option<Spanned<i64>>,
@@ -49,6 +50,11 @@ impl Command for Du {
                 "deref",
                 "Dereference symlinks to their targets for size",
                 Some('r'),
+            )
+            .switch(
+                "long",
+                "Get underlying directories and files for each entry",
+                Some('l'),
             )
             .named(
                 "exclude",
@@ -97,6 +103,7 @@ impl Command for Du {
         }
         let all = call.has_flag(engine_state, stack, "all")?;
         let deref = call.has_flag(engine_state, stack, "deref")?;
+        let long = call.has_flag(engine_state, stack, "long")?;
         let exclude = call.get_flag(engine_state, stack, "exclude")?;
         #[allow(deprecated)]
         let current_dir = current_dir(engine_state, stack)?;
@@ -114,6 +121,7 @@ impl Command for Du {
                     path: None,
                     all,
                     deref,
+                    long,
                     exclude,
                     max_depth,
                     min_size,
@@ -130,6 +138,7 @@ impl Command for Du {
                         path: Some(p),
                         all,
                         deref,
+                        long,
                         exclude: exclude.clone(),
                         max_depth,
                         min_size,
@@ -200,6 +209,7 @@ fn du_for_one_pattern(
 
     let all = args.all;
     let deref = args.deref;
+    let long = args.long;
     let max_depth = args.max_depth.map(|f| f.item as u64);
     let min_size = args.min_size.map(|f| f.item as u64);
 
@@ -209,6 +219,7 @@ fn du_for_one_pattern(
         deref,
         exclude,
         all,
+        long,
     };
 
     let mut output: Vec<Value> = vec![];
@@ -217,7 +228,7 @@ fn du_for_one_pattern(
             Ok(a) => {
                 if a.is_dir() {
                     output.push(DirInfo::new(a, &params, max_depth, span, signals)?.into());
-                } else if let Ok(v) = FileInfo::new(a, deref, span) {
+                } else if let Ok(v) = FileInfo::new(a, deref, span, params.long) {
                     output.push(v.into());
                 }
             }

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -666,7 +666,7 @@ pub(crate) fn dir_entry_dict(
 
             if md.is_dir() {
                 if du {
-                    let params = DirBuilder::new(Span::new(0, 2), None, false, None, false);
+                    let params = DirBuilder::new(Span::new(0, 2), None, false, None, false, false);
                     let dir_size = DirInfo::new(filename, &params, None, span, signals)?.get_size();
 
                     Value::filesize(dir_size as i64, span)

--- a/crates/nu-command/tests/commands/du.rs
+++ b/crates/nu-command/tests/commands/du.rs
@@ -100,3 +100,17 @@ fn du_with_multiple_path() {
     let actual = nu!(cwd: "tests/fixtures", "du ...[] | length");
     assert_eq!(actual.out, "0");
 }
+
+#[test]
+fn test_du_output_columns() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        "du -m 1 | columns | str join ','"
+    );
+    assert_eq!(actual.out, "path,apparent,physical");
+    let actual = nu!(
+        cwd: "tests/fixtures/formats",
+        "du -m 1 -l | columns | str join ','"
+    );
+    assert_eq!(actual.out, "path,apparent,physical,directories,files");
+}


### PR DESCRIPTION
# Description
Closes:  #14387 
To make it happen, just need to added `-l` flag to `du`, and pass it to `DirBuilder`, `DirInfo`, `FileInfo`
Then tweak `impl From<DirInfo> for Value` and `impl From<FileInfo> for Value` impl.

# User-Facing Changes
`du` is no longer output `directories` and `file` columns by default, added `-l` flag will show these columns.
```nushell
> du nushell
╭───┬────────────────────────────────────┬──────────┬──────────╮
│ # │                path                │ apparent │ physical │
├───┼────────────────────────────────────┼──────────┼──────────┤
│ 0 │ /home/windsoilder/projects/nushell │ 34.6 GiB │ 34.7 GiB │
├───┼────────────────────────────────────┼──────────┼──────────┤
│ # │                path                │ apparent │ physical │
╰───┴────────────────────────────────────┴──────────┴──────────╯
> du nushell -l  # It outputs two more columns, `directories` and `files`, but the output is too long to paste here.
```
# Tests + Formatting
Added 1 test

# After Submitting
NaN
