### PR TITLE
command/http/client use CRLF for headers join instead of LF

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -376,7 +376,7 @@ fn send_multipart_request(
                         format!("Content-Length: {}", val.len()),
                     ];
                     builder
-                        .add(&mut Cursor::new(val), &headers.join("\n"))
+                        .add(&mut Cursor::new(val), &headers.join("\r\n"))
                         .map_err(err)?;
                 } else {
                     let headers = format!(r#"Content-Disposition: form-data; name="{}""#, col);


### PR DESCRIPTION
# Description
Apparently it should be joint CRLF for the EOL marker

https://www.rfc-editor.org/rfc/rfc2616#section-2.2

Plain LF isn't particularly standardized and many backends don't recognize it. Tested on `starlette`

# User-Facing Changes
None

# Tests + Formatting
It's two characters; everything passes

# After Submitting
Not needed