### PR TITLE
No longer load `default_env.nu` by default when running with `-c` or `<script.nu>`

### DIFF
--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -1,5 +1,5 @@
 use log::info;
-use nu_engine::{convert_env_values, eval_block};
+use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_protocol::{
     cli_error::report_compile_error,
@@ -49,9 +49,6 @@ pub fn evaluate_commands(
             }
         }
     }
-
-    // Translate environment variables from Strings to Values
-    convert_env_values(engine_state, stack)?;
 
     // Parse the source code
     let (block, delta) = {

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -1,6 +1,6 @@
 use crate::util::{eval_source, print_pipeline};
 use log::{info, trace};
-use nu_engine::{convert_env_values, eval_block};
+use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_path::canonicalize_with;
 use nu_protocol::{
@@ -22,9 +22,6 @@ pub fn evaluate_file(
     stack: &mut Stack,
     input: PipelineData,
 ) -> Result<(), ShellError> {
-    // Convert environment variables from Strings to Values and store them in the engine state.
-    convert_env_values(engine_state, stack)?;
-
     let cwd = engine_state.cwd_as_string(Some(stack))?;
 
     let file_path =

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -398,6 +398,16 @@ fn ensure_path(scope: &mut HashMap<String, Value>, env_path_name: &str) -> Optio
                 });
             }
         }
+    } else {
+        error = error.or_else(|| {
+            Some(ShellError::GenericError {
+                error: format!("{env_path_name} not found"),
+                msg: format!("{env_path_name} was not found"),
+                span: None,
+                help: None,
+                inner: vec![],
+            })
+        });
     }
 
     error

--- a/crates/nu-utils/src/default_files/default_env.nu
+++ b/crates/nu-utils/src/default_files/default_env.nu
@@ -40,13 +40,6 @@ $env.PROMPT_COMMAND_RIGHT = {||
     ([$last_exit_code, (char space), $time_segment] | str join)
 }
 
-$env.ENV_CONVERSIONS = {
-    "PATH": {
-        from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
-        to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
-    }
-}
-
 $env.NU_LIB_DIRS = [
     ($nu.default-config-dir | path join 'scripts') # add <nushell-config-dir>/scripts
     ($nu.data-dir | path join 'completions') # default home for nushell completions

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -157,30 +157,6 @@ pub(crate) fn read_loginshell_file(engine_state: &mut EngineState, stack: &mut S
     }
 }
 
-pub(crate) fn read_default_env_file(engine_state: &mut EngineState, stack: &mut Stack) {
-    let config_file = get_default_env();
-    eval_source(
-        engine_state,
-        stack,
-        config_file.as_bytes(),
-        "default_env.nu",
-        PipelineData::empty(),
-        false,
-    );
-
-    warn!(
-        "read_default_env_file() env_file_contents: {config_file} {}:{}:{}",
-        file!(),
-        line!(),
-        column!()
-    );
-
-    // Merge the environment in case env vars changed in the config
-    if let Err(e) = engine_state.merge_env(stack) {
-        report_shell_error(engine_state, &e);
-    }
-}
-
 /// Get files sorted lexicographically
 ///
 /// uses `impl Ord for String`

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -51,18 +51,6 @@ pub(crate) fn read_config_file(
             use_color
         );
     } else {
-        let start_time = std::time::Instant::now();
-        let config = engine_state.get_config();
-        let use_color = config.use_ansi_coloring;
-        if let Err(e) = convert_env_values(engine_state, stack) {
-            report_shell_error(engine_state, &e);
-        }
-        perf!(
-            "translate env vars before default_config.nu",
-            start_time,
-            use_color
-        );
-
         eval_default_config(engine_state, stack, get_default_config(), is_env_config);
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,17 +276,6 @@ fn main() -> Result<()> {
     gather_parent_env_vars(&mut engine_state, init_cwd.as_ref());
     perf!("gather env vars", start_time, use_color);
 
-    start_time = std::time::Instant::now();
-    let stack = Stack::new();
-    let config = engine_state.get_config();
-    let use_color = config.use_ansi_coloring;
-    // First pass of this will essentially convert Path-only
-    if let Err(e) = convert_env_values(&mut engine_state, &stack) {
-        report_shell_error(&engine_state, &e);
-    }
-
-    perf!("translate path env", start_time, use_color);
-
     engine_state.add_env_var(
         "NU_VERSION".to_string(),
         Value::string(env!("CARGO_PKG_VERSION"), Span::unknown()),
@@ -353,6 +342,17 @@ fn main() -> Result<()> {
             .expect("set_current_dir() should succeed");
     }
     perf!("run test_bins", start_time, use_color);
+
+    start_time = std::time::Instant::now();
+    let stack = Stack::new();
+    let config = engine_state.get_config();
+    let use_color = config.use_ansi_coloring;
+    // First pass of this will essentially convert Path-only
+    if let Err(e) = convert_env_values(&mut engine_state, &stack) {
+        report_shell_error(&engine_state, &e);
+    }
+
+    perf!("translate path env", start_time, use_color);
 
     start_time = std::time::Instant::now();
     let input = if let Some(redirect_stdin) = &parsed_nu_cli_args.redirect_stdin {

--- a/src/run.rs
+++ b/src/run.rs
@@ -48,10 +48,7 @@ pub(crate) fn run_commands(
                 true,
                 create_scaffold,
             );
-        } else {
-            config_files::read_default_env_file(engine_state, &mut stack)
         }
-
         perf!("read env.nu", start_time, use_color);
 
         let start_time = std::time::Instant::now();
@@ -138,8 +135,6 @@ pub(crate) fn run_file(
                 true,
                 create_scaffold,
             );
-        } else {
-            config_files::read_default_env_file(engine_state, &mut stack)
         }
         perf!("read env.nu", start_time, use_color);
 

--- a/tests/repl/test_config.rs
+++ b/tests/repl/test_config.rs
@@ -1,4 +1,5 @@
 use crate::repl::tests::{fail_test, run_test, run_test_std, TestResult};
+use nu_test_support::nu;
 
 #[test]
 fn mutate_nu_config() -> TestResult {
@@ -167,4 +168,19 @@ fn mutate_nu_config_plugin_gc_plugins() -> TestResult {
         "#,
         "0sec",
     )
+}
+
+#[test]
+fn env_is_not_loaded_by_commandstring() {
+    // Neither default_env.nu nor user's env.nu should be loaded
+    // when using `nu -c`
+    let nu = nu_test_support::fs::executable_path().display().to_string();
+    let cmd = format!(
+        r#"
+            {nu} -c "view files | where filename =~ 'env\\.nu$' | length"
+        "#
+    );
+    let actual = nu!(cmd);
+
+    assert_eq!(actual.out, "0");
 }


### PR DESCRIPTION
# Description

* Before:  When running `nu` with a script file or using `nu -c`, we always loaded a `env.nu` (whether one specified by `--env-config <file>` or the `default_env.nu` otherwise.
* After:  Only load the configs when the user requests it with `--env-config <file>`.  In that case (as with all others after #14249) we load `default_env.nu` then the user-specified one.

There doesn't seem to be anything in the `default_env.nu` that would ever be required for a script or commandstring.  `$env.NU_LIB_DIRS` and `$env.PLUGIN_DIRS` are populated by `main.rs` regardless, and that's the only thing I could see being useful.  All tests still pass after this.

# User-Facing Changes

Running with `-c` or a script is just under a millisecond (on my system) faster.  Certain environment variables like `$env.PROMPT_COMMAND` may be empty, but it's unlikely they would be used in a `-c` or script anyway.

# Tests + Formatting

All tests green locally.

Added test to make sure no `env.nu` (or `default_env.nu` is loaded when running with `-c`.

# After Submitting

Found as part of documentation update.  Will document new behavior for 0.101 along with the other changes in #14249.