### PR TITLE
Move the `http` commands to a plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3743,6 +3743,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu_plugin_http"
+version = "0.100.1"
+dependencies = [
+ "base64",
+ "mimalloc",
+ "mime",
+ "multipart-rs",
+ "native-tls",
+ "nu-json",
+ "nu-plugin",
+ "nu-plugin-test-support",
+ "nu-protocol",
+ "serde",
+ "serde_json",
+ "ureq",
+ "url",
+]
+
+[[package]]
 name = "nu_plugin_inc"
 version = "0.100.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ members = [
   "crates/nu_plugin_formats",
   "crates/nu_plugin_polars",
   "crates/nu_plugin_stress_internals",
+  "crates/nu_plugin_http",
   "crates/nu-std",
   "crates/nu-table",
   "crates/nu-term-grid",
@@ -110,7 +111,7 @@ miette = "7.2"
 mime = "0.3.17"
 mime_guess = "2.0"
 mockito = { version = "1.6", default-features = false }
-multipart-rs = "0.1.11"
+multipart-rs = "= 0.1.11"
 native-tls = "0.2"
 nix = { version = "0.29", default-features = false }
 notify-debouncer-full = { version = "0.3", default-features = false }

--- a/crates/nu_plugin_http/Cargo.toml
+++ b/crates/nu_plugin_http/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+authors = ["The Nushell Project Developers"]
+description = "A Nushell plugin for performing HTTP methods."
+edition = "2021"
+license = "MIT"
+name = "nu_plugin_http"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_http"
+version = "0.100.1"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[[bin]]
+name = "nu_plugin_http"
+bench = false
+
+[lib]
+bench = false
+
+[dependencies]
+nu-protocol = { path = "../nu-protocol", version = "0.100.1" }
+nu-plugin = { path = "../nu-plugin", version = "0.100.1" }
+nu-json = { version = "0.100.1", path = "../nu-json" }
+
+mimalloc = { version = "0.1.42" }
+serde = { version = "1.0", features = ["derive"] }
+url.workspace = true
+base64.workspace = true
+multipart-rs = "= 0.1.11"
+ureq.workspace = true
+serde_json.workspace = true
+native-tls = "0.2.12"
+mime.workspace = true
+
+[dev-dependencies]
+nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.100.1" }

--- a/crates/nu_plugin_http/Cargo.toml
+++ b/crates/nu_plugin_http/Cargo.toml
@@ -22,12 +22,12 @@ nu-plugin = { path = "../nu-plugin", version = "0.100.1" }
 nu-json = { version = "0.100.1", path = "../nu-json" }
 
 mimalloc = { version = "0.1.42" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 url.workspace = true
-base64.workspace = true
+base64 = "0.22.1"
 multipart-rs = "= 0.1.11"
-ureq.workspace = true
-serde_json.workspace = true
+ureq = { version = "2.10.0", default-features = false, features = ["charset", "gzip", "json", "native-tls"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
 native-tls = "0.2.12"
 mime.workspace = true
 

--- a/crates/nu_plugin_http/LICENSE
+++ b/crates/nu_plugin_http/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 The Nushell Project Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/nu_plugin_http/src/commands/client.rs
+++ b/crates/nu_plugin_http/src/commands/client.rs
@@ -1,0 +1,925 @@
+use base64::{
+    alphabet,
+    engine::{general_purpose::PAD, GeneralPurpose},
+    Engine,
+};
+use multipart_rs::MultipartWriter;
+use nu_plugin::{EngineInterface, EvaluatedCall};
+use nu_protocol::{
+    ast::PathMember, record, ByteStream, ByteStreamType, IntoPipelineData, LabeledError,
+    PipelineData, ShellError, Signals, Span, Spanned, Type, Value,
+};
+use serde_json::Value as JsonValue;
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    str::FromStr,
+    sync::mpsc::{self, RecvTimeoutError},
+    time::Duration,
+};
+use ureq::{Error, ErrorKind, Request, Response};
+use url::Url;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum BodyType {
+    Json,
+    Form,
+    Multipart,
+    Unknown(Option<String>),
+}
+
+impl From<Option<String>> for BodyType {
+    fn from(content_type: Option<String>) -> Self {
+        match content_type {
+            Some(it) if it.contains("application/json") => BodyType::Json,
+            Some(it) if it.contains("application/x-www-form-urlencoded") => BodyType::Form,
+            Some(it) if it.contains("multipart/form-data") => BodyType::Multipart,
+            Some(it) => BodyType::Unknown(Some(it)),
+            None => BodyType::Unknown(None),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum RedirectMode {
+    Follow,
+    Error,
+    Manual,
+}
+
+pub fn http_client(
+    allow_insecure: bool,
+    redirect_mode: RedirectMode,
+    engine: &EngineInterface,
+) -> Result<ureq::Agent, LabeledError> {
+    let tls = native_tls::TlsConnector::builder()
+        .danger_accept_invalid_certs(allow_insecure)
+        .build()
+        .map_err(|e| LabeledError::new(format!("Failed to build network tls: {e}")))?;
+
+    let mut agent_builder = ureq::builder()
+        .user_agent("nushell")
+        .tls_connector(std::sync::Arc::new(tls));
+
+    if let RedirectMode::Manual | RedirectMode::Error = redirect_mode {
+        agent_builder = agent_builder.redirects(0);
+    }
+
+    if let Some(http_proxy) = retrieve_http_proxy_from_env(engine)? {
+        if let Ok(proxy) = ureq::Proxy::new(http_proxy) {
+            agent_builder = agent_builder.proxy(proxy);
+        }
+    };
+
+    Ok(agent_builder.build())
+}
+
+pub fn http_parse_url(span: Span, raw_url: Value) -> Result<(String, Url), ShellError> {
+    let requested_url = raw_url.coerce_into_string()?;
+    let url = url::Url::parse(&requested_url).map_err(|_| ShellError::InvalidValue {
+        valid: "a valid URL".into(),
+        actual: requested_url.clone(),
+        span,
+    })?;
+    Ok((requested_url, url))
+}
+
+pub fn http_parse_redirect_mode(mode: Option<Spanned<String>>) -> Result<RedirectMode, ShellError> {
+    mode.map_or(Ok(RedirectMode::Follow), |v| match v.item.as_str() {
+        "follow" | "f" => Ok(RedirectMode::Follow),
+        "error" | "e" => Ok(RedirectMode::Error),
+        "manual" | "m" => Ok(RedirectMode::Manual),
+        s => Err(ShellError::InvalidValue {
+            valid: "'follow', 'f', 'error', 'e', 'manual', or 'm'".into(),
+            actual: s.into(),
+            span: v.span,
+        }),
+    })
+}
+
+pub fn response_to_buffer(
+    response: Response,
+    engine_state: &EngineInterface,
+    span: Span,
+) -> PipelineData {
+    // Try to get the size of the file to be downloaded.
+    // This is helpful to show the progress of the stream.
+    let buffer_size = match response.header("content-length") {
+        Some(content_length) => {
+            let content_length = content_length.parse::<u64>().unwrap_or_default();
+
+            if content_length == 0 {
+                None
+            } else {
+                Some(content_length)
+            }
+        }
+        _ => None,
+    };
+
+    // Try to guess whether the response is definitely intended to binary or definitely intended to
+    // be UTF-8 text. Otherwise specify `None` and just guess. This doesn't have to be thorough.
+    let content_type_lowercase = response.header("content-type").map(|s| s.to_lowercase());
+    let response_type = match content_type_lowercase.as_deref() {
+        Some("application/octet-stream") => ByteStreamType::Binary,
+        Some(h) if h.contains("charset=utf-8") => ByteStreamType::String,
+        _ => ByteStreamType::Unknown,
+    };
+
+    let reader = response.into_reader();
+
+    PipelineData::ByteStream(
+        ByteStream::read(reader, span, engine_state.signals().clone(), response_type)
+            .with_known_size(buffer_size),
+        None,
+    )
+}
+
+pub fn request_add_authorization_header(
+    user: Option<String>,
+    password: Option<String>,
+    mut request: Request,
+) -> Request {
+    let base64_engine = GeneralPurpose::new(&alphabet::STANDARD, PAD);
+
+    let login = match (user, password) {
+        (Some(user), Some(password)) => {
+            let mut enc_str = String::new();
+            base64_engine.encode_string(format!("{user}:{password}"), &mut enc_str);
+            Some(enc_str)
+        }
+        (Some(user), _) => {
+            let mut enc_str = String::new();
+            base64_engine.encode_string(format!("{user}:"), &mut enc_str);
+            Some(enc_str)
+        }
+        (_, Some(password)) => {
+            let mut enc_str = String::new();
+            base64_engine.encode_string(format!(":{password}"), &mut enc_str);
+            Some(enc_str)
+        }
+        _ => None,
+    };
+
+    if let Some(login) = login {
+        request = request.set("Authorization", &format!("Basic {login}"));
+    }
+
+    request
+}
+
+#[allow(clippy::large_enum_variant)]
+pub enum LabeledOrRequestError {
+    LabeledError(LabeledError),
+    RequestError(String, Box<Error>),
+}
+
+impl From<LabeledError> for LabeledOrRequestError {
+    fn from(error: LabeledError) -> Self {
+        LabeledOrRequestError::LabeledError(error)
+    }
+}
+
+impl From<ShellError> for LabeledOrRequestError {
+    fn from(error: ShellError) -> Self {
+        LabeledOrRequestError::LabeledError(error.into())
+    }
+}
+
+#[derive(Debug)]
+pub enum HttpBody {
+    Value(Value),
+    ByteStream(ByteStream),
+    None,
+}
+
+// remove once all commands have been migrated
+pub fn send_request(
+    request: Request,
+    http_body: HttpBody,
+    content_type: Option<String>,
+    span: Span,
+    signals: &Signals,
+) -> Result<Response, LabeledOrRequestError> {
+    let request_url = request.url().to_string();
+
+    match http_body {
+        HttpBody::None => {
+            send_cancellable_request(&request_url, Box::new(|| request.call()), span, signals)
+        }
+        HttpBody::ByteStream(byte_stream) => {
+            let req = if let Some(content_type) = content_type {
+                request.set("Content-Type", &content_type)
+            } else {
+                request
+            };
+
+            send_cancellable_request_bytes(&request_url, req, byte_stream, span, signals)
+        }
+        HttpBody::Value(body) => {
+            let body_type = BodyType::from(content_type);
+
+            // We should set the content_type if there is one available
+            // when the content type is unknown
+            let req = if let BodyType::Unknown(Some(content_type)) = &body_type {
+                request.clone().set("Content-Type", content_type)
+            } else {
+                request
+            };
+
+            match body_type {
+                BodyType::Json => send_json_request(&request_url, body, req, span, signals),
+                BodyType::Form => send_form_request(&request_url, body, req, span, signals),
+                BodyType::Multipart => {
+                    send_multipart_request(&request_url, body, req, span, signals)
+                }
+                BodyType::Unknown(_) => {
+                    send_default_request(&request_url, body, req, span, signals)
+                }
+            }
+        }
+    }
+}
+
+fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
+    let span = v.span();
+    Ok(match v {
+        Value::Bool { val, .. } => nu_json::Value::Bool(*val),
+        Value::Filesize { val, .. } => nu_json::Value::I64(*val),
+        Value::Duration { val, .. } => nu_json::Value::I64(*val),
+        Value::Date { val, .. } => nu_json::Value::String(val.to_string()),
+        Value::Float { val, .. } => nu_json::Value::F64(*val),
+        Value::Int { val, .. } => nu_json::Value::I64(*val),
+        Value::Nothing { .. } => nu_json::Value::Null,
+        Value::String { val, .. } => nu_json::Value::String(val.to_string()),
+        Value::Glob { val, .. } => nu_json::Value::String(val.to_string()),
+        Value::CellPath { val, .. } => nu_json::Value::Array(
+            val.members
+                .iter()
+                .map(|x| match &x {
+                    PathMember::String { val, .. } => nu_json::Value::String(val.clone()),
+                    PathMember::Int { val, .. } => nu_json::Value::U64(*val as u64),
+                })
+                .collect(),
+        ),
+
+        Value::List { vals, .. } => nu_json::Value::Array(json_list(vals)?),
+        Value::Error { error, .. } => return Err(*error.clone()),
+        Value::Closure { .. } | Value::Range { .. } => nu_json::Value::Null,
+        Value::Binary { val, .. } => {
+            nu_json::Value::Array(val.iter().map(|x| nu_json::Value::U64(*x as u64)).collect())
+        }
+        Value::Record { val, .. } => {
+            let mut m = nu_json::Map::new();
+            for (k, v) in &**val {
+                m.insert(k.clone(), value_to_json_value(v)?);
+            }
+            nu_json::Value::Object(m)
+        }
+        Value::Custom { val, .. } => {
+            let collected = val.to_base_value(span)?;
+            value_to_json_value(&collected)?
+        }
+    })
+}
+
+fn json_list(input: &[Value]) -> Result<Vec<nu_json::Value>, ShellError> {
+    let mut out = vec![];
+
+    for value in input {
+        out.push(value_to_json_value(value)?);
+    }
+
+    Ok(out)
+}
+
+fn send_json_request(
+    request_url: &str,
+    body: Value,
+    req: Request,
+    span: Span,
+    signals: &Signals,
+) -> Result<Response, LabeledOrRequestError> {
+    match body {
+        Value::Int { .. } | Value::Float { .. } | Value::List { .. } | Value::Record { .. } => {
+            let data = value_to_json_value(&body)?;
+            send_cancellable_request(request_url, Box::new(|| req.send_json(data)), span, signals)
+        }
+        // If the body type is string, assume it is string json content.
+        // If parsing fails, just send the raw string
+        Value::String { val: s, .. } => {
+            if let Ok(jvalue) = serde_json::from_str::<JsonValue>(&s) {
+                send_cancellable_request(
+                    request_url,
+                    Box::new(|| req.send_json(jvalue)),
+                    span,
+                    signals,
+                )
+            } else {
+                let data = serde_json::from_str(&s).unwrap_or_else(|_| nu_json::Value::String(s));
+                send_cancellable_request(
+                    request_url,
+                    Box::new(|| req.send_json(data)),
+                    span,
+                    signals,
+                )
+            }
+        }
+        _ => Err(ShellError::RuntimeTypeMismatch {
+            expected: Type::custom("int, float, list, string, or record"),
+            actual: body.get_type(),
+            span: body.span(),
+        })?,
+    }
+}
+
+fn send_form_request(
+    request_url: &str,
+    body: Value,
+    req: Request,
+    span: Span,
+    signals: &Signals,
+) -> Result<Response, LabeledOrRequestError> {
+    let build_request_fn = |data: Vec<(String, String)>| {
+        // coerce `data` into a shape that send_form() is happy with
+        let data = data
+            .iter()
+            .map(|(a, b)| (a.as_str(), b.as_str()))
+            .collect::<Vec<(&str, &str)>>();
+        req.send_form(&data)
+    };
+
+    match body {
+        Value::List { ref vals, .. } => {
+            if vals.len() % 2 != 0 {
+                return Err(LabeledError::new(
+                    "Body type 'list' for form requests requires paired values. E.g.: [foo, 10].",
+                )
+                .with_label("takes lists with an even number of elements", span)
+                .with_label("has an odd number of elements", body.span()))?;
+            }
+
+            let data = vals
+                .chunks(2)
+                .map(|it| Ok((it[0].coerce_string()?, it[1].coerce_string()?)))
+                .collect::<Result<Vec<_>, ShellError>>()?;
+
+            let request_fn = Box::new(|| build_request_fn(data));
+            send_cancellable_request(request_url, request_fn, span, signals)
+        }
+        Value::Record { val, .. } => {
+            let mut data: Vec<(String, String)> = Vec::with_capacity(val.len());
+
+            for (col, val) in val.into_owned() {
+                data.push((col, val.coerce_into_string()?))
+            }
+
+            let request_fn = Box::new(|| build_request_fn(data));
+            send_cancellable_request(request_url, request_fn, span, signals)
+        }
+        _ => Err(ShellError::RuntimeTypeMismatch {
+            expected: Type::custom("list or record"),
+            actual: body.get_type(),
+            span: body.span(),
+        })?,
+    }
+}
+
+fn send_multipart_request(
+    request_url: &str,
+    body: Value,
+    req: Request,
+    span: Span,
+    signals: &Signals,
+) -> Result<Response, LabeledOrRequestError> {
+    let request_fn = match body {
+        Value::Record { val, .. } => {
+            let mut builder = MultipartWriter::new();
+
+            for (col, val) in val.into_owned() {
+                if let Value::Binary { val, .. } = val {
+                    let headers = [
+                        "Content-Type: application/octet-stream".to_string(),
+                        "Content-Transfer-Encoding: binary".to_string(),
+                        format!(
+                            "Content-Disposition: form-data; name=\"{}\"; filename=\"{}\"",
+                            col, col
+                        ),
+                        format!("Content-Length: {}", val.len()),
+                    ];
+                    builder
+                        .add(val.as_slice(), &headers.join("\r\n"))
+                        .expect("reading from a Vec cannot fail");
+                } else {
+                    let headers = format!(r#"Content-Disposition: form-data; name="{}""#, col);
+                    builder
+                        .add(val.coerce_into_string()?.as_bytes(), &headers)
+                        .expect("reading from a Vec cannot fail");
+                }
+            }
+            builder.finish();
+
+            let (boundary, data) = (builder.boundary, builder.data);
+            let content_type = format!("multipart/form-data; boundary={}", boundary);
+
+            move || req.set("Content-Type", &content_type).send_bytes(&data)
+        }
+        _ => Err(ShellError::RuntimeTypeMismatch {
+            expected: Type::record(),
+            actual: body.get_type(),
+            span: body.span(),
+        })?,
+    };
+    send_cancellable_request(request_url, Box::new(request_fn), span, signals)
+}
+
+fn send_default_request(
+    request_url: &str,
+    body: Value,
+    req: Request,
+    span: Span,
+    signals: &Signals,
+) -> Result<Response, LabeledOrRequestError> {
+    match body {
+        Value::Binary { val, .. } => send_cancellable_request(
+            request_url,
+            Box::new(move || req.send_bytes(&val)),
+            span,
+            signals,
+        ),
+        Value::String { val, .. } => send_cancellable_request(
+            request_url,
+            Box::new(move || req.send_string(&val)),
+            span,
+            signals,
+        ),
+        _ => Err(ShellError::RuntimeTypeMismatch {
+            expected: Type::custom("binary or string"),
+            actual: body.get_type(),
+            span: body.span(),
+        })?,
+    }
+}
+
+// Helper method used to make blocking HTTP request calls cancellable with ctrl+c
+// ureq functions can block for a long time (default 30s?) while attempting to make an HTTP connection
+fn send_cancellable_request(
+    request_url: &str,
+    request_fn: Box<dyn FnOnce() -> Result<Response, Error> + Sync + Send>,
+    span: Span,
+    signals: &Signals,
+) -> Result<Response, LabeledOrRequestError> {
+    let (tx, rx) = mpsc::channel::<Result<Response, Error>>();
+
+    // Make the blocking request on a background thread...
+    std::thread::Builder::new()
+        .name("HTTP requester".to_string())
+        .spawn(move || {
+            let ret = request_fn();
+            let _ = tx.send(ret); // may fail if the user has cancelled the operation
+        })
+        .map_err(ShellError::from)?;
+
+    // ...and poll the channel for responses
+    loop {
+        signals.check(span)?;
+
+        // 100ms wait time chosen arbitrarily
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(result) => {
+                return result
+                    .map_err(|e| LabeledOrRequestError::RequestError(request_url.into(), e.into()))
+            }
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => panic!("http response channel disconnected"),
+        }
+    }
+}
+
+// Helper method used to make blocking HTTP request calls cancellable with ctrl+c
+// ureq functions can block for a long time (default 30s?) while attempting to make an HTTP connection
+fn send_cancellable_request_bytes(
+    request_url: &str,
+    request: Request,
+    byte_stream: ByteStream,
+    span: Span,
+    signals: &Signals,
+) -> Result<Response, LabeledOrRequestError> {
+    let (tx, rx) = mpsc::channel::<Result<Response, LabeledOrRequestError>>();
+    let request_url_string = request_url.to_string();
+
+    // Make the blocking request on a background thread...
+    std::thread::Builder::new()
+        .name("HTTP requester".to_string())
+        .spawn(move || {
+            let ret = byte_stream
+                .reader()
+                .ok_or_else(|| {
+                    LabeledOrRequestError::LabeledError(LabeledError::new("Got empty byte stream."))
+                })
+                .and_then(|reader| {
+                    request.send(reader).map_err(|e| {
+                        LabeledOrRequestError::RequestError(request_url_string, Box::new(e))
+                    })
+                });
+
+            // may fail if the user has cancelled the operation
+            let _ = tx.send(ret);
+        })
+        .map_err(ShellError::from)?;
+
+    // ...and poll the channel for responses
+    loop {
+        signals.check(span)?;
+
+        // 100ms wait time chosen arbitrarily
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(result) => return result,
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => panic!("http response channel disconnected"),
+        }
+    }
+}
+
+pub fn request_set_timeout(
+    timeout: Option<Value>,
+    mut request: Request,
+) -> Result<Request, ShellError> {
+    if let Some(timeout) = timeout {
+        let val = timeout.as_duration()?;
+        if val < 1 {
+            return Err(ShellError::InvalidValue {
+                valid: "a positive duration".into(),
+                actual: val.to_string(),
+                span: timeout.span(),
+            });
+        }
+
+        request = request.timeout(Duration::from_nanos(val as u64));
+    }
+
+    Ok(request)
+}
+
+pub fn request_add_custom_headers(
+    headers: Option<Value>,
+    mut request: Request,
+) -> Result<Request, ShellError> {
+    if let Some(headers) = headers {
+        let mut custom_headers: HashMap<String, Value> = HashMap::new();
+
+        match &headers {
+            Value::Record { val, .. } => {
+                for (k, v) in &**val {
+                    custom_headers.insert(k.to_string(), v.clone());
+                }
+            }
+
+            Value::List { vals: table, .. } => {
+                if table.len() == 1 {
+                    // single row([key1 key2]; [val1 val2])
+                    match &table[0] {
+                        Value::Record { val, .. } => {
+                            for (k, v) in &**val {
+                                custom_headers.insert(k.to_string(), v.clone());
+                            }
+                        }
+
+                        x => {
+                            return Err(ShellError::CantConvert {
+                                to_type: "string list or single row".into(),
+                                from_type: x.get_type().to_string(),
+                                span: headers.span(),
+                                help: None,
+                            });
+                        }
+                    }
+                } else {
+                    // primitive values ([key1 val1 key2 val2])
+                    for row in table.chunks(2) {
+                        if row.len() == 2 {
+                            custom_headers.insert(row[0].coerce_string()?, row[1].clone());
+                        }
+                    }
+                }
+            }
+
+            x => {
+                return Err(ShellError::CantConvert {
+                    to_type: "string list or single row".into(),
+                    from_type: x.get_type().to_string(),
+                    span: headers.span(),
+                    help: None,
+                });
+            }
+        };
+
+        for (k, v) in custom_headers {
+            if let Ok(s) = v.coerce_into_string() {
+                request = request.set(&k, &s);
+            }
+        }
+    }
+
+    Ok(request)
+}
+
+fn handle_response_error(span: Span, requested_url: &str, response_err: Error) -> LabeledError {
+    let msg = match response_err {
+        Error::Status(301, _) => "301 resource moved permanently".into(),
+        Error::Status(400, _) => "400 bad request".into(),
+        Error::Status(403, _) => "403 access forbidden".into(),
+        Error::Status(404, _) => "404 not found".into(),
+        Error::Status(408, _) => "408 request timed out".into(),
+        Error::Status(code, _) => format!("failed with status code {code}"),
+        Error::Transport(t) if t.kind() == ErrorKind::ConnectionFailed => {
+            format!("failed to establish a connection")
+        }
+        Error::Transport(t) => t.to_string(),
+    };
+    LabeledError::new(format!("Request to {requested_url} failed.")).with_label(msg, span)
+}
+
+pub struct RequestFlags {
+    pub allow_errors: bool,
+    pub raw: bool,
+    pub full: bool,
+}
+
+fn transform_response_using_content_type(
+    engine: &EngineInterface,
+    span: Span,
+    requested_url: &str,
+    flags: &RequestFlags,
+    resp: Response,
+    content_type: &str,
+) -> Result<PipelineData, LabeledError> {
+    let content_type = mime::Mime::from_str(content_type)
+        // there are invalid content types in the wild, so we try to recover
+        // Example: `Content-Type: "text/plain"; charset="utf8"` (note the quotes)
+        .or_else(|_| mime::Mime::from_str(&content_type.replace('"', "")))
+        .unwrap_or(mime::TEXT_PLAIN);
+
+    let ext = match (content_type.type_(), content_type.subtype()) {
+        (mime::TEXT, mime::PLAIN) => {
+            let path_extension = url::Url::parse(requested_url)
+                .map_err(|err| {
+                    LabeledError::new(err.to_string())
+                        .with_help("cannot parse")
+                        .with_label(
+                            format!("Cannot parse URL: {requested_url}"),
+                            Span::unknown(),
+                        )
+                })?
+                .path_segments()
+                .and_then(|segments| segments.last())
+                .and_then(|name| if name.is_empty() { None } else { Some(name) })
+                .and_then(|name| {
+                    PathBuf::from(name)
+                        .extension()
+                        .map(|name| name.to_string_lossy().to_string())
+                });
+            path_extension
+        }
+        _ => Some(content_type.subtype().to_string()),
+    };
+
+    let output = response_to_buffer(resp, engine, span);
+    if flags.raw {
+        Ok(output)
+    } else if let Some(ext) = ext {
+        match engine.find_decl(format!("from {ext}"))? {
+            Some(id) => Ok(engine.call_decl(id, EvaluatedCall::new(span), output, true, false)?),
+            None => Ok(output),
+        }
+    } else {
+        Ok(output)
+    }
+}
+
+pub fn check_response_redirection(
+    redirect_mode: RedirectMode,
+    span: Span,
+    response: &Result<Response, LabeledOrRequestError>,
+) -> Result<(), LabeledError> {
+    if let Ok(resp) = response {
+        if RedirectMode::Error == redirect_mode && (300..400).contains(&resp.status()) {
+            return Err(LabeledError::new(
+                "Redirect encountered when redirect handling mode was 'error'.",
+            )
+            .with_label(
+                format!(
+                    "failed with status code {} {}",
+                    resp.status(),
+                    resp.status_text()
+                ),
+                span,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn request_handle_response_content(
+    engine: &EngineInterface,
+    span: Span,
+    requested_url: &str,
+    flags: RequestFlags,
+    resp: Response,
+    request: Request,
+) -> Result<PipelineData, LabeledError> {
+    // #response_to_buffer moves "resp" making it impossible to read headers later.
+    // Wrapping it into a closure to call when needed
+    let consume_response_body = |response: Response| {
+        let content_type = response.header("content-type").map(|s| s.to_owned());
+
+        match content_type {
+            Some(content_type) => transform_response_using_content_type(
+                engine,
+                span,
+                requested_url,
+                &flags,
+                response,
+                &content_type,
+            ),
+            None => Ok(response_to_buffer(response, engine, span)),
+        }
+    };
+
+    if flags.full {
+        let response_status = resp.status();
+        let request_headers_value = headers_to_nu(&extract_request_headers(&request), span);
+        let response_headers_value = headers_to_nu(&extract_response_headers(&resp), span);
+        let headers = record! {
+            "request" => request_headers_value,
+            "response" => response_headers_value,
+        };
+
+        let body = consume_response_body(resp)?.into_value(span)?;
+
+        let full_response = Value::record(
+            record! {
+                "headers" => Value::record(headers, span),
+                "body" => body,
+                "status" => Value::int(response_status as i64, span),
+            },
+            span,
+        );
+
+        Ok(full_response.into_pipeline_data())
+    } else {
+        Ok(consume_response_body(resp)?)
+    }
+}
+
+pub fn request_handle_response(
+    engine: &EngineInterface,
+    span: Span,
+    requested_url: &str,
+    flags: RequestFlags,
+    response: Result<Response, LabeledOrRequestError>,
+    request: Request,
+) -> Result<PipelineData, LabeledError> {
+    match response {
+        Ok(resp) => {
+            request_handle_response_content(engine, span, requested_url, flags, resp, request)
+        }
+        Err(e) => match e {
+            LabeledOrRequestError::LabeledError(e) => Err(e),
+            LabeledOrRequestError::RequestError(_, e) => {
+                if flags.allow_errors {
+                    if let Error::Status(_, resp) = *e {
+                        Ok(request_handle_response_content(
+                            engine,
+                            span,
+                            requested_url,
+                            flags,
+                            resp,
+                            request,
+                        )?)
+                    } else {
+                        Err(handle_response_error(span, requested_url, *e))
+                    }
+                } else {
+                    Err(handle_response_error(span, requested_url, *e))
+                }
+            }
+        },
+    }
+}
+
+type Headers = HashMap<String, Vec<String>>;
+
+fn extract_request_headers(request: &Request) -> Headers {
+    request
+        .header_names()
+        .iter()
+        .map(|name| {
+            (
+                name.clone(),
+                request.all(name).iter().map(|e| e.to_string()).collect(),
+            )
+        })
+        .collect()
+}
+
+fn extract_response_headers(response: &Response) -> Headers {
+    response
+        .headers_names()
+        .iter()
+        .map(|name| {
+            (
+                name.clone(),
+                response.all(name).iter().map(|e| e.to_string()).collect(),
+            )
+        })
+        .collect()
+}
+
+fn headers_to_nu(headers: &Headers, span: Span) -> Value {
+    let mut vals = Vec::with_capacity(headers.len());
+
+    for (name, values) in headers {
+        let is_duplicate = vals.iter().any(|val| {
+            if let Value::Record { val, .. } = val {
+                if let Some((
+                    _col,
+                    Value::String {
+                        val: header_name, ..
+                    },
+                )) = val.get_index(0)
+                {
+                    return name == header_name;
+                }
+            }
+            false
+        });
+        if !is_duplicate {
+            // A single header can hold multiple values
+            // This interface is why we needed to check if we've already parsed this header name.
+            for str_value in values {
+                let record = record! {
+                    "name" => Value::string(name, span),
+                    "value" => Value::string(str_value, span),
+                };
+                vals.push(Value::record(record, span));
+            }
+        }
+    }
+
+    Value::list(vals, span)
+}
+
+pub fn request_handle_response_headers(
+    span: Span,
+    response: Result<Response, LabeledOrRequestError>,
+) -> Result<Value, LabeledError> {
+    match response {
+        Ok(resp) => Ok(headers_to_nu(&extract_response_headers(&resp), span)),
+        Err(e) => match e {
+            LabeledOrRequestError::LabeledError(e) => Err(e),
+            LabeledOrRequestError::RequestError(requested_url, e) => {
+                Err(handle_response_error(span, &requested_url, *e))
+            }
+        },
+    }
+}
+
+fn retrieve_http_proxy_from_env(engine: &EngineInterface) -> Result<Option<String>, ShellError> {
+    engine
+        .get_env_var("http_proxy")?
+        .or(engine.get_env_var("HTTP_PROXY")?)
+        .or(engine.get_env_var("https_proxy")?)
+        .or(engine.get_env_var("HTTPS_PROXY")?)
+        .or(engine.get_env_var("ALL_PROXY")?)
+        .map(Value::coerce_into_string)
+        .transpose()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_body_type_from_content_type() {
+        let json = Some("application/json".to_string());
+        assert_eq!(BodyType::Json, BodyType::from(json));
+
+        // while the charset wont' be passed as we are allowing serde and the library to control
+        // this, it still shouldn't be missed as json if passed in.
+        let json_with_charset = Some("application/json; charset=utf-8".to_string());
+        assert_eq!(BodyType::Json, BodyType::from(json_with_charset));
+
+        let form = Some("application/x-www-form-urlencoded".to_string());
+        assert_eq!(BodyType::Form, BodyType::from(form));
+
+        let multipart = Some("multipart/form-data".to_string());
+        assert_eq!(BodyType::Multipart, BodyType::from(multipart));
+
+        let unknown = Some("application/octet-stream".to_string());
+        assert_eq!(BodyType::Unknown(unknown.clone()), BodyType::from(unknown));
+
+        let none = None;
+        assert_eq!(BodyType::Unknown(none.clone()), BodyType::from(none));
+    }
+}

--- a/crates/nu_plugin_http/src/commands/client.rs
+++ b/crates/nu_plugin_http/src/commands/client.rs
@@ -352,7 +352,7 @@ fn send_form_request(
     match body {
         Value::List { ref vals, .. } => {
             if vals.len() % 2 != 0 {
-                return Err(LabeledError::new(
+                Err(LabeledError::new(
                     "Body type 'list' for form requests requires paired values. E.g.: [foo, 10].",
                 )
                 .with_label("takes lists with an even number of elements", span)
@@ -633,7 +633,7 @@ fn handle_response_error(span: Span, requested_url: &str, response_err: Error) -
         Error::Status(408, _) => "408 request timed out".into(),
         Error::Status(code, _) => format!("failed with status code {code}"),
         Error::Transport(t) if t.kind() == ErrorKind::ConnectionFailed => {
-            format!("failed to establish a connection")
+            "failed to establish a connection".into()
         }
         Error::Transport(t) => t.to_string(),
     };

--- a/crates/nu_plugin_http/src/commands/client.rs
+++ b/crates/nu_plugin_http/src/commands/client.rs
@@ -77,7 +77,7 @@ pub fn http_client(
 pub fn http_parse_url(span: Span, raw_url: Value) -> Result<(String, Url), ShellError> {
     let requested_url = raw_url.coerce_into_string()?;
     let url = url::Url::parse(&requested_url).map_err(|_| ShellError::InvalidValue {
-        valid: "a valid URL".into(),
+        valid: "a valid, fully formed URL with protocol (e.g., 'https://www.example.com')".into(),
         actual: requested_url.clone(),
         span,
     })?;

--- a/crates/nu_plugin_http/src/commands/delete.rs
+++ b/crates/nu_plugin_http/src/commands/delete.rs
@@ -1,0 +1,245 @@
+use super::client::{
+    check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
+    request_add_authorization_header, request_add_custom_headers, request_handle_response,
+    request_set_timeout, send_request, HttpBody, RequestFlags,
+};
+use crate::HttpPlugin;
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, Signature, Spanned, SyntaxShape, Type, Value,
+};
+
+#[derive(Clone)]
+pub struct Delete;
+
+impl PluginCommand for Delete {
+    type Plugin = HttpPlugin;
+
+    fn name(&self) -> &str {
+        "http delete"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("http delete")
+            .input_output_types(vec![(Type::Any, Type::Any)])
+            .allow_variants_without_examples(true)
+            .required(
+                "URL",
+                SyntaxShape::String,
+                "The URL to fetch the contents from.",
+            )
+            .named(
+                "user",
+                SyntaxShape::Any,
+                "the username when authenticating",
+                Some('u'),
+            )
+            .named(
+                "password",
+                SyntaxShape::Any,
+                "the password when authenticating",
+                Some('p'),
+            )
+            .named("data", SyntaxShape::Any, "the content to post", Some('d'))
+            .named(
+                "content-type",
+                SyntaxShape::Any,
+                "the MIME type of content to post",
+                Some('t'),
+            )
+            .named(
+                "max-time",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
+                Some('m'),
+            )
+            .named(
+                "headers",
+                SyntaxShape::Any,
+                "custom headers you want to add ",
+                Some('H'),
+            )
+            .switch(
+                "raw",
+                "fetch contents as text rather than a table",
+                Some('r'),
+            )
+            .switch(
+                "insecure",
+                "allow insecure server connections when using SSL",
+                Some('k'),
+            )
+            .switch(
+                "full",
+                "returns the full response instead of only the body",
+                Some('f'),
+            )
+            .switch(
+                "allow-errors",
+                "do not fail if the server returns an error code",
+                Some('e'),
+            ).named(
+                "redirect-mode",
+                SyntaxShape::String,
+                "What to do when encountering redirects. Default: 'follow'. Valid options: 'follow' ('f'), 'manual' ('m'), 'error' ('e').",
+                Some('R')
+            )
+            .filter()
+            .category(Category::Network)
+    }
+
+    fn description(&self) -> &str {
+        "Delete the specified resource."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Performs HTTP DELETE operation."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["network", "request", "curl", "wget"]
+    }
+
+    fn run(
+        &self,
+        _plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        delete(engine, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "http delete from example.com",
+                example: "http delete https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "http delete from example.com, with username and password",
+                example: "http delete --user myuser --password mypass https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "http delete from example.com, with custom header",
+                example: "http delete --headers [my-header-key my-header-value] https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "http delete from example.com, with body",
+                example: "http delete --data 'body' https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "http delete from example.com, with JSON body",
+                example:
+                    "http delete --content-type application/json --data { field: value } https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Perform an HTTP delete with JSON content from a pipeline to example.com",
+                example: "open foo.json | http delete https://www.example.com",
+                result: None,
+            },
+        ]
+    }
+}
+
+struct Arguments {
+    url: Value,
+    headers: Option<Value>,
+    data: HttpBody,
+    content_type: Option<String>,
+    raw: bool,
+    insecure: bool,
+    user: Option<String>,
+    password: Option<String>,
+    timeout: Option<Value>,
+    full: bool,
+    allow_errors: bool,
+    redirect: Option<Spanned<String>>,
+}
+
+fn delete(
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    input: PipelineData,
+) -> Result<PipelineData, LabeledError> {
+    let (data, maybe_metadata) = call
+        .get_flag::<Value>("data")?
+        .map(|v| (HttpBody::Value(v), None))
+        .unwrap_or_else(|| match input {
+            PipelineData::Value(v, metadata) => (HttpBody::Value(v), metadata),
+            PipelineData::ByteStream(byte_stream, metadata) => {
+                (HttpBody::ByteStream(byte_stream), metadata)
+            }
+            _ => (HttpBody::None, None),
+        });
+
+    let content_type = call
+        .get_flag("content-type")?
+        .or_else(|| maybe_metadata.and_then(|m| m.content_type));
+
+    let args = Arguments {
+        url: call.req(0)?,
+        headers: call.get_flag("headers")?,
+        data,
+        content_type,
+        raw: call.has_flag("raw")?,
+        insecure: call.has_flag("insecure")?,
+        user: call.get_flag("user")?,
+        password: call.get_flag("password")?,
+        timeout: call.get_flag("max-time")?,
+        full: call.has_flag("full")?,
+        allow_errors: call.has_flag("allow-errors")?,
+        redirect: call.get_flag("redirect-mode")?,
+    };
+
+    let span = args.url.span();
+    let (requested_url, _) = http_parse_url(span, args.url)?;
+    let redirect_mode = http_parse_redirect_mode(args.redirect)?;
+
+    let client = http_client(args.insecure, redirect_mode, engine)?;
+    let mut request = client.delete(&requested_url);
+
+    request = request_set_timeout(args.timeout, request)?;
+    request = request_add_authorization_header(args.user, args.password, request);
+    request = request_add_custom_headers(args.headers, request)?;
+
+    let response = send_request(
+        request.clone(),
+        args.data,
+        args.content_type,
+        call.head,
+        engine.signals(),
+    );
+
+    let request_flags = RequestFlags {
+        raw: args.raw,
+        full: args.full,
+        allow_errors: args.allow_errors,
+    };
+
+    check_response_redirection(redirect_mode, span, &response)?;
+    request_handle_response(
+        engine,
+        span,
+        &requested_url,
+        request_flags,
+        response,
+        request,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nu_protocol::ShellError;
+
+    #[test]
+    fn test_examples() -> Result<(), ShellError> {
+        crate::test::examples(&Delete)
+    }
+}

--- a/crates/nu_plugin_http/src/commands/get.rs
+++ b/crates/nu_plugin_http/src/commands/get.rs
@@ -1,0 +1,211 @@
+use super::client::{
+    check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
+    request_add_authorization_header, request_add_custom_headers, request_handle_response,
+    request_set_timeout, send_request, HttpBody, RequestFlags,
+};
+use crate::HttpPlugin;
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, Signature, Spanned, SyntaxShape, Type, Value,
+};
+
+#[derive(Clone)]
+pub struct Get;
+
+impl PluginCommand for Get {
+    type Plugin = HttpPlugin;
+
+    fn name(&self) -> &str {
+        "http get"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("http get")
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .allow_variants_without_examples(true)
+            .required(
+                "URL",
+                SyntaxShape::String,
+                "The URL to fetch the contents from.",
+            )
+            .named(
+                "user",
+                SyntaxShape::Any,
+                "the username when authenticating",
+                Some('u'),
+            )
+            .named(
+                "password",
+                SyntaxShape::Any,
+                "the password when authenticating",
+                Some('p'),
+            )
+            .named(
+                "max-time",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
+                Some('m'),
+            )
+            .named(
+                "headers",
+                SyntaxShape::Any,
+                "custom headers you want to add ",
+                Some('H'),
+            )
+            .switch(
+                "raw",
+                "fetch contents as text rather than a table",
+                Some('r'),
+            )
+            .switch(
+                "insecure",
+                "allow insecure server connections when using SSL",
+                Some('k'),
+            )
+            .switch(
+                "full",
+                "returns the full response instead of only the body",
+                Some('f'),
+            )
+            .switch(
+                "allow-errors",
+                "do not fail if the server returns an error code",
+                Some('e'),
+            )
+            .named(
+                "redirect-mode",
+                SyntaxShape::String,
+                "What to do when encountering redirects. Default: 'follow'. Valid options: 'follow' ('f'), 'manual' ('m'), 'error' ('e').",
+                Some('R')
+            )
+            .filter()
+            .category(Category::Network)
+    }
+
+    fn description(&self) -> &str {
+        "Fetch the contents from a URL."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Performs HTTP GET operation."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec![
+            "network", "fetch", "pull", "request", "download", "curl", "wget",
+        ]
+    }
+
+    fn run(
+        &self,
+        _plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        get(engine, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Get content from example.com",
+                example: "http get https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Get content from example.com, with username and password",
+                example: "http get --user myuser --password mypass https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Get content from example.com, with custom header",
+                example: "http get --headers [my-header-key my-header-value] https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Get content from example.com, with custom headers",
+                example: "http get --headers [my-header-key-A my-header-value-A my-header-key-B my-header-value-B] https://www.example.com",
+                result: None,
+            },
+        ]
+    }
+}
+
+struct Arguments {
+    url: Value,
+    headers: Option<Value>,
+    raw: bool,
+    insecure: bool,
+    user: Option<String>,
+    password: Option<String>,
+    timeout: Option<Value>,
+    full: bool,
+    allow_errors: bool,
+    redirect: Option<Spanned<String>>,
+}
+
+fn get(
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    _input: PipelineData,
+) -> Result<PipelineData, LabeledError> {
+    let args = Arguments {
+        url: call.req(0)?,
+        headers: call.get_flag("headers")?,
+        raw: call.has_flag("raw")?,
+        insecure: call.has_flag("insecure")?,
+        user: call.get_flag("user")?,
+        password: call.get_flag("password")?,
+        timeout: call.get_flag("max-time")?,
+        full: call.has_flag("full")?,
+        allow_errors: call.has_flag("allow-errors")?,
+        redirect: call.get_flag("redirect-mode")?,
+    };
+
+    let span = args.url.span();
+    let (requested_url, _) = http_parse_url(span, args.url)?;
+    let redirect_mode = http_parse_redirect_mode(args.redirect)?;
+
+    let client = http_client(args.insecure, redirect_mode, engine)?;
+    let mut request = client.get(&requested_url);
+
+    request = request_set_timeout(args.timeout, request)?;
+    request = request_add_authorization_header(args.user, args.password, request);
+    request = request_add_custom_headers(args.headers, request)?;
+
+    let response = send_request(
+        request.clone(),
+        HttpBody::None,
+        None,
+        call.head,
+        engine.signals(),
+    );
+
+    let request_flags = RequestFlags {
+        raw: args.raw,
+        full: args.full,
+        allow_errors: args.allow_errors,
+    };
+
+    check_response_redirection(redirect_mode, span, &response)?;
+    request_handle_response(
+        engine,
+        span,
+        &requested_url,
+        request_flags,
+        response,
+        request,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nu_protocol::ShellError;
+
+    #[test]
+    fn test_examples() -> Result<(), ShellError> {
+        crate::test::examples(&Get)
+    }
+}

--- a/crates/nu_plugin_http/src/commands/head.rs
+++ b/crates/nu_plugin_http/src/commands/head.rs
@@ -1,0 +1,164 @@
+use super::client::{
+    check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
+    request_add_authorization_header, request_add_custom_headers, request_handle_response_headers,
+    request_set_timeout, send_request, HttpBody,
+};
+use crate::HttpPlugin;
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{
+    Category, Example, IntoPipelineData, LabeledError, PipelineData, Signature, Spanned,
+    SyntaxShape, Type, Value,
+};
+
+#[derive(Clone)]
+pub struct Head;
+
+impl PluginCommand for Head {
+    type Plugin = HttpPlugin;
+
+    fn name(&self) -> &str {
+        "http head"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("http head")
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .allow_variants_without_examples(true)
+            .required(
+                "URL",
+                SyntaxShape::String,
+                "The URL to fetch the contents from.",
+            )
+            .named(
+                "user",
+                SyntaxShape::Any,
+                "the username when authenticating",
+                Some('u'),
+            )
+            .named(
+                "password",
+                SyntaxShape::Any,
+                "the password when authenticating",
+                Some('p'),
+            )
+            .named(
+                "max-time",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
+                Some('m'),
+            )
+            .named(
+                "headers",
+                SyntaxShape::Any,
+                "custom headers you want to add ",
+                Some('H'),
+            )
+            .switch(
+                "insecure",
+                "allow insecure server connections when using SSL",
+                Some('k'),
+            ).named(
+                "redirect-mode",
+                SyntaxShape::String,
+                "What to do when encountering redirects. Default: 'follow'. Valid options: 'follow' ('f'), 'manual' ('m'), 'error' ('e').",
+                Some('R')
+            )
+            .filter()
+            .category(Category::Network)
+    }
+
+    fn description(&self) -> &str {
+        "Get the headers from a URL."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Performs HTTP HEAD operation."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["network", "request", "curl", "wget", "headers", "header"]
+    }
+
+    fn run(
+        &self,
+        _plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        head(engine, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Get headers from example.com",
+                example: "http head https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Get headers from example.com, with username and password",
+                example: "http head --user myuser --password mypass https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Get headers from example.com, with custom header",
+                example:
+                    "http head --headers [my-header-key my-header-value] https://www.example.com",
+                result: None,
+            },
+        ]
+    }
+}
+
+struct Arguments {
+    url: Value,
+    headers: Option<Value>,
+    insecure: bool,
+    user: Option<String>,
+    password: Option<String>,
+    timeout: Option<Value>,
+    redirect: Option<Spanned<String>>,
+}
+
+fn head(
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    _input: PipelineData,
+) -> Result<PipelineData, LabeledError> {
+    let args = Arguments {
+        url: call.req(0)?,
+        headers: call.get_flag("headers")?,
+        insecure: call.has_flag("insecure")?,
+        user: call.get_flag("user")?,
+        password: call.get_flag("password")?,
+        timeout: call.get_flag("max-time")?,
+        redirect: call.get_flag("redirect-mode")?,
+    };
+
+    let span = args.url.span();
+    let (requested_url, _) = http_parse_url(span, args.url)?;
+    let redirect_mode = http_parse_redirect_mode(args.redirect)?;
+
+    let client = http_client(args.insecure, redirect_mode, engine)?;
+    let mut request = client.head(&requested_url);
+
+    request = request_set_timeout(args.timeout, request)?;
+    request = request_add_authorization_header(args.user, args.password, request);
+    request = request_add_custom_headers(args.headers, request)?;
+
+    let response = send_request(request, HttpBody::None, None, call.head, engine.signals());
+    check_response_redirection(redirect_mode, span, &response)?;
+    request_handle_response_headers(span, response).map(|val| val.into_pipeline_data())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nu_protocol::ShellError;
+
+    #[test]
+    fn test_examples() -> Result<(), ShellError> {
+        crate::test::examples(&Head)
+    }
+}

--- a/crates/nu_plugin_http/src/commands/http.rs
+++ b/crates/nu_plugin_http/src/commands/http.rs
@@ -1,0 +1,44 @@
+use crate::HttpPlugin;
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, IntoPipelineData, LabeledError, PipelineData, Signature, Type, Value};
+
+#[derive(Clone)]
+pub struct Http;
+
+impl PluginCommand for Http {
+    type Plugin = HttpPlugin;
+
+    fn name(&self) -> &str {
+        "http"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("http")
+            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .category(Category::Network)
+    }
+
+    fn description(&self) -> &str {
+        "Various commands for working with http methods."
+    }
+
+    fn extra_description(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec![
+            "network", "fetch", "pull", "request", "download", "curl", "wget",
+        ]
+    }
+
+    fn run(
+        &self,
+        _plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        _input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        Ok(Value::string(engine.get_help()?, call.head).into_pipeline_data())
+    }
+}

--- a/crates/nu_plugin_http/src/commands/mod.rs
+++ b/crates/nu_plugin_http/src/commands/mod.rs
@@ -1,0 +1,18 @@
+pub(super) mod client;
+mod delete;
+mod get;
+mod head;
+mod http;
+mod options;
+mod patch;
+mod post;
+mod put;
+
+pub use delete::Delete as HttpDelete;
+pub use get::Get as HttpGet;
+pub use head::Head as HttpHead;
+pub use http::Http;
+pub use options::Options as HttpOptions;
+pub use patch::Patch as HttpPatch;
+pub use post::Post as HttpPost;
+pub use put::Put as HttpPut;

--- a/crates/nu_plugin_http/src/commands/options.rs
+++ b/crates/nu_plugin_http/src/commands/options.rs
@@ -1,0 +1,193 @@
+use super::client::{
+    http_client, http_parse_url, request_add_authorization_header, request_add_custom_headers,
+    request_handle_response, request_set_timeout, send_request, HttpBody, RedirectMode,
+    RequestFlags,
+};
+use crate::HttpPlugin;
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, Signature, SyntaxShape, Type, Value,
+};
+
+#[derive(Clone)]
+pub struct Options;
+
+impl PluginCommand for Options {
+    type Plugin = HttpPlugin;
+
+    fn name(&self) -> &str {
+        "http options"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("http options")
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .allow_variants_without_examples(true)
+            .required(
+                "URL",
+                SyntaxShape::String,
+                "The URL to fetch the options from.",
+            )
+            .named(
+                "user",
+                SyntaxShape::Any,
+                "the username when authenticating",
+                Some('u'),
+            )
+            .named(
+                "password",
+                SyntaxShape::Any,
+                "the password when authenticating",
+                Some('p'),
+            )
+            .named(
+                "max-time",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
+                Some('m'),
+            )
+            .named(
+                "headers",
+                SyntaxShape::Any,
+                "custom headers you want to add ",
+                Some('H'),
+            )
+            .switch(
+                "insecure",
+                "allow insecure server connections when using SSL",
+                Some('k'),
+            )
+            .switch(
+                "allow-errors",
+                "do not fail if the server returns an error code",
+                Some('e'),
+            )
+            .filter()
+            .category(Category::Network)
+    }
+
+    fn description(&self) -> &str {
+        "Requests permitted communication options for a given URL."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Performs an HTTP OPTIONS request. Most commonly used for making CORS preflight requests."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["network", "fetch", "pull", "request", "curl", "wget"]
+    }
+
+    fn run(
+        &self,
+        _plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        get(engine, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Get options from example.com",
+                example: "http options https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Get options from example.com, with username and password",
+                example: "http options --user myuser --password mypass https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Get options from example.com, with custom header",
+                example: "http options --headers [my-header-key my-header-value] https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Get options from example.com, with custom headers",
+                example: "http options --headers [my-header-key-A my-header-value-A my-header-key-B my-header-value-B] https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Simulate a browser cross-origin preflight request from www.example.com to media.example.com",
+                example: "http options https://media.example.com/api/ --headers [Origin https://www.example.com Access-Control-Request-Headers \"Content-Type, X-Custom-Header\" Access-Control-Request-Method GET]",
+                result: None,
+            },
+        ]
+    }
+}
+
+struct Arguments {
+    url: Value,
+    headers: Option<Value>,
+    insecure: bool,
+    user: Option<String>,
+    password: Option<String>,
+    timeout: Option<Value>,
+    allow_errors: bool,
+}
+
+fn get(
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    _input: PipelineData,
+) -> Result<PipelineData, LabeledError> {
+    let args = Arguments {
+        url: call.req(0)?,
+        headers: call.get_flag("headers")?,
+        insecure: call.has_flag("insecure")?,
+        user: call.get_flag("user")?,
+        password: call.get_flag("password")?,
+        timeout: call.get_flag("max-time")?,
+        allow_errors: call.has_flag("allow-errors")?,
+    };
+
+    let span = args.url.span();
+    let (requested_url, _) = http_parse_url(span, args.url)?;
+
+    let client = http_client(args.insecure, RedirectMode::Follow, engine)?;
+    let mut request = client.request("OPTIONS", &requested_url);
+
+    request = request_set_timeout(args.timeout, request)?;
+    request = request_add_authorization_header(args.user, args.password, request);
+    request = request_add_custom_headers(args.headers, request)?;
+
+    let response = send_request(
+        request.clone(),
+        HttpBody::None,
+        None,
+        call.head,
+        engine.signals(),
+    );
+
+    // http options' response always showed in header, so we set full to true.
+    // And `raw` is useless too because options method doesn't return body, here we set to true
+    // too.
+    let request_flags = RequestFlags {
+        raw: true,
+        full: true,
+        allow_errors: args.allow_errors,
+    };
+
+    request_handle_response(
+        engine,
+        span,
+        &requested_url,
+        request_flags,
+        response,
+        request,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nu_protocol::ShellError;
+
+    #[test]
+    fn test_examples() -> Result<(), ShellError> {
+        crate::test::examples(&Options)
+    }
+}

--- a/crates/nu_plugin_http/src/commands/patch.rs
+++ b/crates/nu_plugin_http/src/commands/patch.rs
@@ -1,0 +1,242 @@
+use super::client::{
+    check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
+    request_add_authorization_header, request_add_custom_headers, request_handle_response,
+    request_set_timeout, send_request, HttpBody, RequestFlags,
+};
+use crate::HttpPlugin;
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, Signature, Spanned, SyntaxShape, Type, Value,
+};
+
+#[derive(Clone)]
+pub struct Patch;
+
+impl PluginCommand for Patch {
+    type Plugin = HttpPlugin;
+
+    fn name(&self) -> &str {
+        "http patch"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("http patch")
+            .input_output_types(vec![(Type::Any, Type::Any)])
+            .allow_variants_without_examples(true)
+            .required("URL", SyntaxShape::String, "The URL to post to.")
+            .optional("data", SyntaxShape::Any, "The contents of the post body.")
+            .named(
+                "user",
+                SyntaxShape::Any,
+                "the username when authenticating",
+                Some('u'),
+            )
+            .named(
+                "password",
+                SyntaxShape::Any,
+                "the password when authenticating",
+                Some('p'),
+            )
+            .named(
+                "content-type",
+                SyntaxShape::Any,
+                "the MIME type of content to post",
+                Some('t'),
+            )
+            .named(
+                "max-time",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
+                Some('m'),
+            )
+            .named(
+                "headers",
+                SyntaxShape::Any,
+                "custom headers you want to add ",
+                Some('H'),
+            )
+            .switch(
+                "raw",
+                "return values as a string instead of a table",
+                Some('r'),
+            )
+            .switch(
+                "insecure",
+                "allow insecure server connections when using SSL",
+                Some('k'),
+            )
+            .switch(
+                "full",
+                "returns the full response instead of only the body",
+                Some('f'),
+            )
+            .switch(
+                "allow-errors",
+                "do not fail if the server returns an error code",
+                Some('e'),
+            ).named(
+                "redirect-mode",
+                SyntaxShape::String,
+                "What to do when encountering redirects. Default: 'follow'. Valid options: 'follow' ('f'), 'manual' ('m'), 'error' ('e').",
+                Some('R')
+            )
+            .filter()
+            .category(Category::Network)
+    }
+
+    fn description(&self) -> &str {
+        "Patch a body to a URL."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Performs HTTP PATCH operation."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["network", "send", "push"]
+    }
+
+    fn run(
+        &self,
+        _plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        patch(engine, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Patch content to example.com",
+                example: "http patch https://www.example.com 'body'",
+                result: None,
+            },
+            Example {
+                description: "Patch content to example.com, with username and password",
+                example:
+                    "http patch --user myuser --password mypass https://www.example.com 'body'",
+                result: None,
+            },
+            Example {
+                description: "Patch content to example.com, with custom header",
+                example:
+                    "http patch --headers [my-header-key my-header-value] https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Patch content to example.com, with JSON body",
+                example: "http patch --content-type application/json https://www.example.com { field: value }",
+                result: None,
+            },
+            Example {
+                description: "Patch JSON content from a pipeline to example.com",
+                example: "open --raw foo.json | http patch https://www.example.com",
+                result: None,
+            },
+        ]
+    }
+}
+
+struct Arguments {
+    url: Value,
+    headers: Option<Value>,
+    data: HttpBody,
+    content_type: Option<String>,
+    raw: bool,
+    insecure: bool,
+    user: Option<String>,
+    password: Option<String>,
+    timeout: Option<Value>,
+    full: bool,
+    allow_errors: bool,
+    redirect: Option<Spanned<String>>,
+}
+
+fn patch(
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    input: PipelineData,
+) -> Result<PipelineData, LabeledError> {
+    let (data, maybe_metadata) = call
+        .opt::<Value>(1)?
+        .map(|v| (HttpBody::Value(v), None))
+        .unwrap_or_else(|| match input {
+            PipelineData::Value(v, metadata) => (HttpBody::Value(v), metadata),
+            PipelineData::ByteStream(byte_stream, metadata) => {
+                (HttpBody::ByteStream(byte_stream), metadata)
+            }
+            _ => (HttpBody::None, None),
+        });
+    let content_type = call
+        .get_flag("content-type")?
+        .or_else(|| maybe_metadata.and_then(|m| m.content_type));
+
+    if let HttpBody::None = data {
+        return Err(LabeledError::new(
+            "Data must be provided either through pipeline or positional argument",
+        ));
+    }
+
+    let args = Arguments {
+        url: call.req(0)?,
+        headers: call.get_flag("headers")?,
+        data,
+        content_type,
+        raw: call.has_flag("raw")?,
+        insecure: call.has_flag("insecure")?,
+        user: call.get_flag("user")?,
+        password: call.get_flag("password")?,
+        timeout: call.get_flag("max-time")?,
+        full: call.has_flag("full")?,
+        allow_errors: call.has_flag("allow-errors")?,
+        redirect: call.get_flag("redirect-mode")?,
+    };
+
+    let span = args.url.span();
+    let (requested_url, _) = http_parse_url(span, args.url)?;
+    let redirect_mode = http_parse_redirect_mode(args.redirect)?;
+
+    let client = http_client(args.insecure, redirect_mode, engine)?;
+    let mut request = client.patch(&requested_url);
+
+    request = request_set_timeout(args.timeout, request)?;
+    request = request_add_authorization_header(args.user, args.password, request);
+    request = request_add_custom_headers(args.headers, request)?;
+
+    let response = send_request(
+        request.clone(),
+        args.data,
+        args.content_type,
+        call.head,
+        engine.signals(),
+    );
+
+    let request_flags = RequestFlags {
+        raw: args.raw,
+        full: args.full,
+        allow_errors: args.allow_errors,
+    };
+
+    check_response_redirection(redirect_mode, span, &response)?;
+    request_handle_response(
+        engine,
+        span,
+        &requested_url,
+        request_flags,
+        response,
+        request,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nu_protocol::ShellError;
+
+    #[test]
+    fn test_examples() -> Result<(), ShellError> {
+        crate::test::examples(&Patch)
+    }
+}

--- a/crates/nu_plugin_http/src/commands/post.rs
+++ b/crates/nu_plugin_http/src/commands/post.rs
@@ -1,0 +1,250 @@
+use super::client::{
+    check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
+    request_add_authorization_header, request_add_custom_headers, request_handle_response,
+    request_set_timeout, send_request, HttpBody, RequestFlags,
+};
+use crate::HttpPlugin;
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, Signature, Spanned, SyntaxShape, Type, Value,
+};
+
+#[derive(Clone)]
+pub struct Post;
+
+impl PluginCommand for Post {
+    type Plugin = HttpPlugin;
+
+    fn name(&self) -> &str {
+        "http post"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("http post")
+            .input_output_types(vec![(Type::Any, Type::Any)])
+            .allow_variants_without_examples(true)
+            .required("URL", SyntaxShape::String, "The URL to post to.")
+            .optional("data", SyntaxShape::Any, "The contents of the post body. Required unless part of a pipeline.")
+            .named(
+                "user",
+                SyntaxShape::Any,
+                "the username when authenticating",
+                Some('u'),
+            )
+            .named(
+                "password",
+                SyntaxShape::Any,
+                "the password when authenticating",
+                Some('p'),
+            )
+            .named(
+                "content-type",
+                SyntaxShape::Any,
+                "the MIME type of content to post",
+                Some('t'),
+            )
+            .named(
+                "max-time",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
+                Some('m'),
+            )
+            .named(
+                "headers",
+                SyntaxShape::Any,
+                "custom headers you want to add ",
+                Some('H'),
+            )
+            .switch(
+                "raw",
+                "return values as a string instead of a table",
+                Some('r'),
+            )
+            .switch(
+                "insecure",
+                "allow insecure server connections when using SSL",
+                Some('k'),
+            )
+            .switch(
+                "full",
+                "returns the full response instead of only the body",
+                Some('f'),
+            )
+            .switch(
+                "allow-errors",
+                "do not fail if the server returns an error code",
+                Some('e'),
+            ).named(
+                "redirect-mode",
+                SyntaxShape::String,
+                "What to do when encountering redirects. Default: 'follow'. Valid options: 'follow' ('f'), 'manual' ('m'), 'error' ('e').",
+                Some('R')
+            )
+            .filter()
+            .category(Category::Network)
+    }
+
+    fn description(&self) -> &str {
+        "Post a body to a URL."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Performs HTTP POST operation."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["network", "send", "push"]
+    }
+
+    fn run(
+        &self,
+        _plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        post(engine, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Post content to example.com",
+                example: "http post https://www.example.com 'body'",
+                result: None,
+            },
+            Example {
+                description: "Post content to example.com, with username and password",
+                example: "http post --user myuser --password mypass https://www.example.com 'body'",
+                result: None,
+            },
+            Example {
+                description: "Post content to example.com, with custom header",
+                example: "http post --headers [my-header-key my-header-value] https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Post content to example.com, with JSON body",
+                example: "http post --content-type application/json https://www.example.com { field: value }",
+                result: None,
+            },
+            Example {
+                description: "Post JSON content from a pipeline to example.com",
+                example: "open --raw foo.json | http post https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Upload a binary file to example.com",
+                example: "http post --content-type multipart/form-data https://www.example.com { file: (open -r file.mp3) }",
+                result: None,
+            },
+            Example {
+                description: "Convert a text file into binary and upload it to example.com",
+                example: "http post --content-type multipart/form-data https://www.example.com { file: (open -r file.txt | into binary) }",
+                result: None,
+            },
+        ]
+    }
+}
+
+struct Arguments {
+    url: Value,
+    headers: Option<Value>,
+    data: HttpBody,
+    content_type: Option<String>,
+    raw: bool,
+    insecure: bool,
+    user: Option<String>,
+    password: Option<String>,
+    timeout: Option<Value>,
+    full: bool,
+    allow_errors: bool,
+    redirect: Option<Spanned<String>>,
+}
+
+fn post(
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    input: PipelineData,
+) -> Result<PipelineData, LabeledError> {
+    let (data, maybe_metadata) = call
+        .opt::<Value>(1)?
+        .map(|v| (HttpBody::Value(v), None))
+        .unwrap_or_else(|| match input {
+            PipelineData::Value(v, metadata) => (HttpBody::Value(v), metadata),
+            PipelineData::ByteStream(byte_stream, metadata) => {
+                (HttpBody::ByteStream(byte_stream), metadata)
+            }
+            _ => (HttpBody::None, None),
+        });
+    let content_type = call
+        .get_flag("content-type")?
+        .or_else(|| maybe_metadata.and_then(|m| m.content_type));
+
+    if let HttpBody::None = data {
+        return Err(LabeledError::new(
+            "Data must be provided either through pipeline or positional argument",
+        ));
+    }
+
+    let args = Arguments {
+        url: call.req(0)?,
+        headers: call.get_flag("headers")?,
+        data,
+        content_type,
+        raw: call.has_flag("raw")?,
+        insecure: call.has_flag("insecure")?,
+        user: call.get_flag("user")?,
+        password: call.get_flag("password")?,
+        timeout: call.get_flag("max-time")?,
+        full: call.has_flag("full")?,
+        allow_errors: call.has_flag("allow-errors")?,
+        redirect: call.get_flag("redirect-mode")?,
+    };
+
+    let span = args.url.span();
+    let (requested_url, _) = http_parse_url(span, args.url)?;
+    let redirect_mode = http_parse_redirect_mode(args.redirect)?;
+
+    let client = http_client(args.insecure, redirect_mode, engine)?;
+    let mut request = client.post(&requested_url);
+
+    request = request_set_timeout(args.timeout, request)?;
+    request = request_add_authorization_header(args.user, args.password, request);
+    request = request_add_custom_headers(args.headers, request)?;
+
+    let response = send_request(
+        request.clone(),
+        args.data,
+        args.content_type,
+        call.head,
+        engine.signals(),
+    );
+
+    let request_flags = RequestFlags {
+        raw: args.raw,
+        full: args.full,
+        allow_errors: args.allow_errors,
+    };
+
+    check_response_redirection(redirect_mode, span, &response)?;
+    request_handle_response(
+        engine,
+        span,
+        &requested_url,
+        request_flags,
+        response,
+        request,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nu_protocol::ShellError;
+
+    #[test]
+    fn test_examples() -> Result<(), ShellError> {
+        crate::test::examples(&Post)
+    }
+}

--- a/crates/nu_plugin_http/src/commands/put.rs
+++ b/crates/nu_plugin_http/src/commands/put.rs
@@ -1,0 +1,241 @@
+use super::client::{
+    check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
+    request_add_authorization_header, request_add_custom_headers, request_handle_response,
+    request_set_timeout, send_request, HttpBody, RequestFlags,
+};
+use crate::HttpPlugin;
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, Signature, Spanned, SyntaxShape, Type, Value,
+};
+
+#[derive(Clone)]
+pub struct Put;
+
+impl PluginCommand for Put {
+    type Plugin = HttpPlugin;
+
+    fn name(&self) -> &str {
+        "http put"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("http put")
+            .input_output_types(vec![(Type::Any, Type::Any)])
+            .allow_variants_without_examples(true)
+            .required("URL", SyntaxShape::String, "The URL to post to.")
+            .optional("data", SyntaxShape::Any, "The contents of the post body. Required unless part of a pipeline.")
+            .named(
+                "user",
+                SyntaxShape::Any,
+                "the username when authenticating",
+                Some('u'),
+            )
+            .named(
+                "password",
+                SyntaxShape::Any,
+                "the password when authenticating",
+                Some('p'),
+            )
+            .named(
+                "content-type",
+                SyntaxShape::Any,
+                "the MIME type of content to post",
+                Some('t'),
+            )
+            .named(
+                "max-time",
+                SyntaxShape::Duration,
+                "max duration before timeout occurs",
+                Some('m'),
+            )
+            .named(
+                "headers",
+                SyntaxShape::Any,
+                "custom headers you want to add ",
+                Some('H'),
+            )
+            .switch(
+                "raw",
+                "return values as a string instead of a table",
+                Some('r'),
+            )
+            .switch(
+                "insecure",
+                "allow insecure server connections when using SSL",
+                Some('k'),
+            )
+            .switch(
+                "full",
+                "returns the full response instead of only the body",
+                Some('f'),
+            )
+            .switch(
+                "allow-errors",
+                "do not fail if the server returns an error code",
+                Some('e'),
+            ).named(
+                "redirect-mode",
+                SyntaxShape::String,
+                "What to do when encountering redirects. Default: 'follow'. Valid options: 'follow' ('f'), 'manual' ('m'), 'error' ('e').",
+                Some('R')
+            )
+            .filter()
+            .category(Category::Network)
+    }
+
+    fn description(&self) -> &str {
+        "Put a body to a URL."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Performs HTTP PUT operation."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["network", "send", "push"]
+    }
+
+    fn run(
+        &self,
+        _plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        put(engine, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Put content to example.com",
+                example: "http put https://www.example.com 'body'",
+                result: None,
+            },
+            Example {
+                description: "Put content to example.com, with username and password",
+                example: "http put --user myuser --password mypass https://www.example.com 'body'",
+                result: None,
+            },
+            Example {
+                description: "Put content to example.com, with custom header",
+                example: "http put --headers [my-header-key my-header-value] https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Put content to example.com, with JSON body",
+                example: "http put --content-type application/json https://www.example.com { field: value }",
+                result: None,
+            },
+            Example {
+                description: "Put JSON content from a pipeline to example.com",
+                example: "open --raw foo.json | http put https://www.example.com",
+                result: None,
+            },
+        ]
+    }
+}
+
+struct Arguments {
+    url: Value,
+    headers: Option<Value>,
+    data: HttpBody,
+    content_type: Option<String>,
+    raw: bool,
+    insecure: bool,
+    user: Option<String>,
+    password: Option<String>,
+    timeout: Option<Value>,
+    full: bool,
+    allow_errors: bool,
+    redirect: Option<Spanned<String>>,
+}
+
+fn put(
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    input: PipelineData,
+) -> Result<PipelineData, LabeledError> {
+    let (data, maybe_metadata) = call
+        .opt::<Value>(1)?
+        .map(|v| (HttpBody::Value(v), None))
+        .unwrap_or_else(|| match input {
+            PipelineData::Value(v, metadata) => (HttpBody::Value(v), metadata),
+            PipelineData::ByteStream(byte_stream, metadata) => {
+                (HttpBody::ByteStream(byte_stream), metadata)
+            }
+            _ => (HttpBody::None, None),
+        });
+
+    if let HttpBody::None = data {
+        return Err(LabeledError::new(
+            "Data must be provided either through pipeline or positional argument",
+        ));
+    }
+
+    let content_type = call
+        .get_flag("content-type")?
+        .or_else(|| maybe_metadata.and_then(|m| m.content_type));
+
+    let args = Arguments {
+        url: call.req(0)?,
+        headers: call.get_flag("headers")?,
+        data,
+        content_type,
+        raw: call.has_flag("raw")?,
+        insecure: call.has_flag("insecure")?,
+        user: call.get_flag("user")?,
+        password: call.get_flag("password")?,
+        timeout: call.get_flag("max-time")?,
+        full: call.has_flag("full")?,
+        allow_errors: call.has_flag("allow-errors")?,
+        redirect: call.get_flag("redirect-mode")?,
+    };
+
+    let span = args.url.span();
+    let (requested_url, _) = http_parse_url(span, args.url)?;
+    let redirect_mode = http_parse_redirect_mode(args.redirect)?;
+
+    let client = http_client(args.insecure, redirect_mode, engine)?;
+    let mut request = client.put(&requested_url);
+
+    request = request_set_timeout(args.timeout, request)?;
+    request = request_add_authorization_header(args.user, args.password, request);
+    request = request_add_custom_headers(args.headers, request)?;
+
+    let response = send_request(
+        request.clone(),
+        args.data,
+        args.content_type,
+        call.head,
+        engine.signals(),
+    );
+
+    let request_flags = RequestFlags {
+        raw: args.raw,
+        full: args.full,
+        allow_errors: args.allow_errors,
+    };
+
+    check_response_redirection(redirect_mode, span, &response)?;
+    request_handle_response(
+        engine,
+        span,
+        &requested_url,
+        request_flags,
+        response,
+        request,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nu_protocol::ShellError;
+
+    #[test]
+    fn test_examples() -> Result<(), ShellError> {
+        crate::test::examples(&Put)
+    }
+}

--- a/crates/nu_plugin_http/src/lib.rs
+++ b/crates/nu_plugin_http/src/lib.rs
@@ -1,0 +1,38 @@
+use commands::{Http, HttpDelete, HttpGet, HttpHead, HttpOptions, HttpPatch, HttpPost, HttpPut};
+use nu_plugin::{Plugin, PluginCommand};
+
+mod commands;
+
+#[derive(Default)]
+pub struct HttpPlugin;
+
+impl Plugin for HttpPlugin {
+    fn version(&self) -> String {
+        env!("CARGO_PKG_VERSION").into()
+    }
+
+    fn commands(&self) -> Vec<Box<dyn PluginCommand<Plugin = Self>>> {
+        vec![
+            Box::new(HttpDelete),
+            Box::new(HttpGet),
+            Box::new(HttpHead),
+            Box::new(Http),
+            Box::new(HttpOptions),
+            Box::new(HttpPatch),
+            Box::new(HttpPost),
+            Box::new(HttpPut),
+        ]
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use nu_plugin_test_support::PluginTest;
+    use nu_protocol::ShellError;
+
+    pub fn examples(command: &impl PluginCommand) -> Result<(), ShellError> {
+        let mut plugin_test = PluginTest::new(command.name(), HttpPlugin.into())?;
+        plugin_test.test_examples(&command.examples())
+    }
+}

--- a/crates/nu_plugin_http/src/main.rs
+++ b/crates/nu_plugin_http/src/main.rs
@@ -5,5 +5,5 @@ use nu_plugin_http::HttpPlugin;
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn main() {
-    serve_plugin(&HttpPlugin::default(), MsgPackSerializer {})
+    serve_plugin(&HttpPlugin, MsgPackSerializer {})
 }

--- a/crates/nu_plugin_http/src/main.rs
+++ b/crates/nu_plugin_http/src/main.rs
@@ -1,0 +1,9 @@
+use nu_plugin::{serve_plugin, MsgPackSerializer};
+use nu_plugin_http::HttpPlugin;
+
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+fn main() {
+    serve_plugin(&HttpPlugin::default(), MsgPackSerializer {})
+}


### PR DESCRIPTION
# Description

Like the titles says, this PR adds the `nu_plugin_http` crate to the workspace. The new plugin has all the same `http` commands currently available in Nushell. Request/response streaming should also still work, as the plugin is a `PluginCommand` and not a `SimplePluginCommand`.

Motivation behind this PR is mainly security but also distribution. Having a program that can interact with both the network and launch other processes seems sketchy. Not sure what a potential path to exploitation looks like, but I'd rather not have to worry about this issue. What might be more likely though is that there's some bug in the `http` commands or one of the dependencies that allows intentionally-crafted responses to cause a panic in Nushell.

Additionally, policies or rules at some organizations might disallow network capability. Rather than having to compile a custom version of Nushell, it makes sense to have the `http` commands as an optional plugin. When (not if), a bug or vulnerability is eventually found, then we only have to publish a new version of the plugin rather than doing a full patch release for Nushell as a whole.

Side note: not pleased that we have a dependency on `multipart-rs`. It has no documentation and the latest version (0.1.12) made a sem-ver breaking change although it was a patch release. This PR pins the version to `0.1.11`.

# User-Facing Changes

The current http commands will be deprecated or removed, and users will have to install the new plugin.

# After Submitting

Update the docs.