### PR TITLE
Always populate config record during startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ use nu_cli::gather_parent_env_vars;
 use nu_lsp::LanguageServer;
 use nu_path::canonicalize_with;
 use nu_protocol::{
-    engine::EngineState, report_shell_error, ByteStream, PipelineData, ShellError, Span, Spanned,
-    Value,
+    engine::EngineState, report_shell_error, ByteStream, Config, IntoValue, PipelineData,
+    ShellError, Span, Spanned, Value,
 };
 use nu_std::load_standard_library;
 use nu_utils::perf;
@@ -256,6 +256,13 @@ fn main() -> Result<()> {
         terminal::acquire(engine_state.is_interactive);
         perf!("acquire_terminal", start_time, use_color);
     }
+
+    start_time = std::time::Instant::now();
+    engine_state.add_env_var(
+        "config".into(),
+        Config::default().into_value(Span::unknown()),
+    );
+    perf!("$env.config setup", start_time, use_color);
 
     start_time = std::time::Instant::now();
     if let Some(include_path) = &parsed_nu_cli_args.include_path {

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -298,3 +298,68 @@ fn test_xdg_config_symlink() {
         );
     });
 }
+
+#[test]
+fn no_config_does_not_load_env_files() {
+    let nu = nu_test_support::fs::executable_path().display().to_string();
+    let cmd = format!(
+        r#"
+            {nu} -n -c "view files | where filename =~ 'env\\.nu$' | length"
+        "#
+    );
+    let actual = nu!(cmd);
+
+    assert_eq!(actual.out, "0");
+}
+
+#[test]
+fn no_config_does_not_load_config_files() {
+    let nu = nu_test_support::fs::executable_path().display().to_string();
+    let cmd = format!(
+        r#"
+            {nu} -n -c "view files | where filename =~ 'config\\.nu$' | length"
+        "#
+    );
+    let actual = nu!(cmd);
+
+    assert_eq!(actual.out, "0");
+}
+
+#[test]
+fn commandstring_does_not_load_config_files() {
+    let nu = nu_test_support::fs::executable_path().display().to_string();
+    let cmd = format!(
+        r#"
+            {nu} -c "view files | where filename =~ 'config\\.nu$' | length"
+        "#
+    );
+    let actual = nu!(cmd);
+
+    assert_eq!(actual.out, "0");
+}
+
+#[test]
+fn commandstring_does_not_load_user_env() {
+    let nu = nu_test_support::fs::executable_path().display().to_string();
+    let cmd = format!(
+        r#"
+            {nu} -c "view files | where filename =~ '[^_]env\\.nu$' | length"
+        "#
+    );
+    let actual = nu!(cmd);
+
+    assert_eq!(actual.out, "0");
+}
+
+#[test]
+fn commandstring_loads_default_env() {
+    let nu = nu_test_support::fs::executable_path().display().to_string();
+    let cmd = format!(
+        r#"
+            {nu} -c "view files | where filename =~ 'default_env\\.nu$' | length"
+        "#
+    );
+    let actual = nu!(cmd);
+
+    assert_eq!(actual.out, "1");
+}

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -363,3 +363,16 @@ fn commandstring_loads_default_env() {
 
     assert_eq!(actual.out, "1");
 }
+
+#[test]
+fn commandstring_populates_config_record() {
+    let nu = nu_test_support::fs::executable_path().display().to_string();
+    let cmd = format!(
+        r#"
+            {nu} --no-std-lib -n -c "$env.config.show_banner"
+        "#
+    );
+    let actual = nu!(cmd);
+
+    assert_eq!(actual.out, "true");
+}


### PR DESCRIPTION
# Description

As a bit of a follow-on to #13802 and #14249, this (pretty much a "one-line" change) really does *always* populate the `$env.config` record with the `nu-protocol::config` defaults during startup.  This means that an `$env.config` record is value (with defaults) even during:

* `nu -n` to suppress loading of config files
* `nu -c <commandstring>`
* `nu <script>`

# User-Facing Changes

There should be no case in which there isn't a valid `$env.config`.

* Before:

  ```nushell
  nu -c "$env.config"
  # -> Error
  ```

* After:

  ```nushell
  nu -c "$env.config"
  # -> Default $env.config record
  ```

Startup time impact is negligible (17.072µs from `perf!` on my system) - Seems well worth it.

# Tests + Formatting

Added tests for several `-n -c` cases.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

Config chapter update still in progress.
