### PR TITLE
Fix (Windows, all-caps) `PATH` in `convert_env_values()`

### DIFF
--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -398,6 +398,16 @@ fn ensure_path(scope: &mut HashMap<String, Value>, env_path_name: &str) -> Optio
                 });
             }
         }
+    } else {
+        error = error.or_else(|| {
+            Some(ShellError::GenericError {
+                error: format!("{env_path_name} not found"),
+                msg: format!("{env_path_name} was not found"),
+                span: None,
+                help: None,
+                inner: vec![],
+            })
+        });
     }
 
     error


### PR DESCRIPTION
# Description

Fixes part of the issue with `convert_env_values()` on Windows.  The following code attempts to convert both `Path` and `PATH` (as a fallback) to a list, but fails because it relies on the `ensure_path()` to give an error if the `Path` variable doesn't exists.

https://github.com/nushell/nushell/blob/4d3283e23555610bd5443e1e57afdd5f748d25dc/crates/nu-engine/src/env.rs#L14-L19

https://github.com/nushell/nushell/blob/4d3283e23555610bd5443e1e57afdd5f748d25dc/crates/nu-engine/src/env.rs#L59-L69

Unfortunately, the `ensure_path()` code just falls through *without* returning an error if `Path` isn't found, so the `PATH` handling is unreachable.  This PR adds the error condition when `Path` isn't found.

# User-Facing Changes

* Before:  If Nushell inherited a `PATH` (instead of a `Path`), it would *not* be converted to a list (even though it was supposed to).
* After: A `PATH` (all caps) on Windows will behave (halfway) properly by becoming a Nushell list.

Note that the `to_string()` handling is still broken and requires an `ENV_CONVERSIONS` variable in order to workaround it.

This function should probably be converted to just handle the same "case-preserving" behavior from #12701.  Consider that a TODO, but in the meantime at least we continue to have a workaround using `ENV_CONVERSIONS`.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A
