### PR TITLE
Add example for PROMPT_COMMAND_RIGHT

### DIFF
--- a/crates/nu-utils/src/default_files/sample_env.nu
+++ b/crates/nu-utils/src/default_files/sample_env.nu
@@ -24,6 +24,11 @@ $env.PROMPT_COMMAND = "Nushell"
 # Simple example - Dynamic closure displaying the path:
 $env.PROMPT_COMMAND = {|| pwd}
 
+# PROMPT_COMMAND_RIGHT
+# --------------------
+# Defines a prompt which will appear right-aligned in the terminal
+$env.PROMPT_COMMAND_RIGHT = {|| date now | format date "%d-%a %r" }
+
 # PROMPT_INDICATOR*
 # -----------------
 # The prompt indicators are environmental variables that represent


### PR DESCRIPTION
# Description

I just completely left out `$env.PROMPT_COMMAND_RIGHT` in the `sample_env.nu`.  This adds it in.

# User-Facing Changes

`config env --sample` will now include doc for `PROMPT_COMMAND_RIGHT`.

# Tests + Formatting

Doc-only

# After Submitting

n/a