### PR TITLE
History file moves to `$nu.data-dir`

### DIFF
--- a/crates/nu-cli/src/commands/history/history_.rs
+++ b/crates/nu-cli/src/commands/history/history_.rs
@@ -46,7 +46,7 @@ impl Command for History {
         };
         // todo for sqlite history this command should be an alias to `open ~/.config/nushell/history.sqlite3 | get history`
         let Some(history_path) = history.file_path() else {
-            return Err(ShellError::ConfigDirNotFound { span: Some(head) });
+            return Err(ShellError::DataDirNotFound { span: Some(head) });
         };
 
         if call.has_flag(engine_state, stack, "clear")? {

--- a/crates/nu-cli/src/commands/history/history_import.rs
+++ b/crates/nu-cli/src/commands/history/history_import.rs
@@ -74,7 +74,7 @@ Note that history item IDs are ignored when importing from file."#
             return ok;
         };
         let Some(current_history_path) = history.file_path() else {
-            return Err(ShellError::ConfigDirNotFound {
+            return Err(ShellError::DataDirNotFound {
                 span: Some(call.head),
             });
         };

--- a/crates/nu-path/src/helpers.rs
+++ b/crates/nu-path/src/helpers.rs
@@ -6,9 +6,12 @@ pub fn home_dir() -> Option<AbsolutePathBuf> {
     dirs::home_dir().and_then(|home| AbsolutePathBuf::try_from(home).ok())
 }
 
-/// Return the data directory for the current platform or XDG_DATA_HOME if specified.
-pub fn data_dir() -> Option<AbsolutePathBuf> {
-    configurable_dir_path("XDG_DATA_HOME", dirs::data_dir)
+/// Return the nushell data directory.
+pub fn nu_data_dir() -> Option<AbsolutePathBuf> {
+    configurable_dir_path("XDG_DATA_HOME", dirs::data_dir).map(|mut path| {
+        path.push("nushell");
+        path
+    })
 }
 
 /// Return the cache directory for the current platform or XDG_CACHE_HOME if specified.
@@ -18,9 +21,9 @@ pub fn cache_dir() -> Option<AbsolutePathBuf> {
 
 /// Return the nushell config directory.
 pub fn nu_config_dir() -> Option<AbsolutePathBuf> {
-    configurable_dir_path("XDG_CONFIG_HOME", dirs::config_dir).map(|mut p| {
-        p.push("nushell");
-        p
+    configurable_dir_path("XDG_CONFIG_HOME", dirs::config_dir).map(|mut path| {
+        path.push("nushell");
+        path
     })
 }
 

--- a/crates/nu-path/src/lib.rs
+++ b/crates/nu-path/src/lib.rs
@@ -11,7 +11,7 @@ mod trailing_slash;
 
 pub use components::components;
 pub use expansions::{canonicalize_with, expand_path_with, expand_to_real_path, locate_in_dirs};
-pub use helpers::{cache_dir, data_dir, home_dir, nu_config_dir};
+pub use helpers::{cache_dir, home_dir, nu_config_dir, nu_data_dir};
 pub use path::*;
 pub use tilde::expand_tilde;
 pub use trailing_slash::{has_trailing_slash, strip_trailing_slash};

--- a/crates/nu-protocol/src/errors/shell_error.rs
+++ b/crates/nu-protocol/src/errors/shell_error.rs
@@ -1434,6 +1434,21 @@ On Windows, this would be %USERPROFILE%\AppData\Roaming"#
         span: Option<Span>,
     },
 
+    /// The data directory could not be found
+    #[error("The data directory could not be found")]
+    #[diagnostic(
+        code(nu::shell::data_dir_not_found),
+        help(
+            r#"On Linux, this would be $XDG_DATA_HOME or $HOME/.local/share.
+On MacOS, this would be `$HOME/Library/Application Support`
+On Windows, this would be {{FOLDERID_RoamingAppData}}"#
+        )
+    )]
+    DataDirNotFound {
+        #[label = "Could not find state directory"]
+        span: Option<Span>,
+    },
+
     /// XDG_CONFIG_HOME was set to an invalid path
     #[error("$env.XDG_CONFIG_HOME ({xdg}) is invalid, using default config directory instead: {default}")]
     #[diagnostic(

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -153,9 +153,8 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
 
     record.push(
         "data-dir",
-        if let Some(path) = nu_path::data_dir() {
-            let mut canon_data_path = canonicalize_path(engine_state, path.as_ref());
-            canon_data_path.push("nushell");
+        if let Some(path) = nu_path::nu_data_dir() {
+            let canon_data_path = canonicalize_path(engine_state, path.as_ref());
             Value::string(canon_data_path.to_string_lossy(), span)
         } else {
             Value::error(

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,8 +137,7 @@ fn main() -> Result<()> {
         }
     }
 
-    let default_nushell_completions_path = if let Some(mut path) = nu_path::data_dir() {
-        path.push("nushell");
+    let default_nushell_completions_path = if let Some(mut path) = nu_path::nu_data_dir() {
         path.push("completions");
         path.into()
     } else {


### PR DESCRIPTION
Fixes #10100

Consensus was that the history file was not config and so should not live in the config directory by default.

Although #10100 came to agree on using `$XDG_STATE_HOME`, I ended up implementing `$XDG_DATA_HOME` simply because the `dirs` crate that Nushell uses to get default values for these paths doesn't have entries for `$XDG_STATE_HOME` on OSX and Windows. See: https://docs.rs/dirs/5.0.1/dirs/fn.state_dir.html

Also includes an automated "migration" that moves the old history file to the new path: only if the old file exists _and_ there is no file in the new path.

Notes:
  * Changes `nu_path::data_dir()` to `nu_path::nu_data_dir()` so that it returns the data dir with `/nushell` appended. This was already being done by callers of `nu_path::data_dir()` so I just refactored.

## User-Facing Changes
The old history file will automatically be moved to the new path: `$XDG_DATA_HOME/nushell/history.{txt,sqlite}`

## Tests
* `history_import.rs` tests now set `XDG_CONFIG_HOME` _and_ `XDG_DATA_HOME`, there may be other tests that will come to need both. But currently all tests pass.