### PR TITLE
`term query`: refactor, add `--beginning` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3350,6 +3350,7 @@ dependencies = [
  "roxmltree",
  "rstest",
  "rusqlite",
+ "scopeguard",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ roxmltree = "0.19"
 rstest = { version = "0.23", default-features = false }
 rusqlite = "0.31"
 rust-embed = "8.5.0"
+scopeguard = { version = "1.2.0" }
 serde = { version = "1.0" }
 serde_json = "1.0"
 serde_urlencoded = "0.7.1"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -79,6 +79,7 @@ regex = { workspace = true }
 roxmltree = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled", "backup", "chrono"], optional = true }
 rmp = { workspace = true }
+scopeguard = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_urlencoded = { workspace = true }

--- a/crates/nu-command/src/platform/term/term_query.rs
+++ b/crates/nu-command/src/platform/term/term_query.rs
@@ -27,7 +27,7 @@ sequence is encountered. The `terminator` is not included in the output.
 
 If `terminator` is not supplied, input will be read until Ctrl-C is pressed.
 
-If `prefix` is supplied, input's inital bytes will be validated against it.
+If `prefix` is supplied, input's initial bytes will be validated against it.
 The `prefix` is not included in the output."
     }
 

--- a/crates/nu-command/src/platform/term/term_query.rs
+++ b/crates/nu-command/src/platform/term/term_query.rs
@@ -59,17 +59,17 @@ The `beginning` is not included in the output."
         vec![
             Example {
                 description: "Get cursor position.",
-                example: r#"term query (ansi cursor_position) --terminator 'R'"#,
+                example: r#"term query (ansi cursor_position) --beginning (ansi csi) --terminator 'R'"#,
                 result: None,
             },
             Example {
                 description: "Get terminal background color.",
-                example: r#"term query $'(ansi osc)10;?(ansi st)' --terminator (ansi st)"#,
+                example: r#"term query $'(ansi osc)10;?(ansi st)' --beginning $'(ansi osc)10;' --terminator (ansi st)"#,
                 result: None,
             },
             Example {
                 description: "Read clipboard content on terminals supporting OSC-52.",
-                example: r#"term query $'(ansi osc)52;c;?(ansi st)' --terminator (ansi st)"#,
+                example: r#"term query $'(ansi osc)52;c;?(ansi st)' --beginning $'(ansi osc)52;c;' --terminator (ansi st)"#,
                 result: None,
             },
         ]

--- a/crates/nu-command/src/platform/term/term_query.rs
+++ b/crates/nu-command/src/platform/term/term_query.rs
@@ -73,6 +73,11 @@ The `prefix` is not included in the output."
                 result: None,
             },
             Example {
+                description: "Get terminal background color. (some terminals prefer `char bel` rather than `ansi st` as string terminator)",
+                example: r#"term query $'(ansi osc)10;?(char bel)' --prefix $'(ansi osc)10;' --terminator (char bel)"#,
+                result: None,
+            },
+            Example {
                 description: "Read clipboard content on terminals supporting OSC-52.",
                 example: r#"term query $'(ansi osc)52;c;?(ansi st)' --prefix $'(ansi osc)52;c;' --terminator (ansi st)"#,
                 result: None,

--- a/crates/nu-command/src/platform/term/term_query.rs
+++ b/crates/nu-command/src/platform/term/term_query.rs
@@ -134,6 +134,8 @@ If `terminator` is not supplied, input will be read until Ctrl-C is pressed."
                 buf.push(b[0]);
 
                 if buf.ends_with(&terminator) {
+                    // Remove terminator
+                    buf.drain((buf.len() - terminator.len())..);
                     break;
                 }
             }

--- a/crates/nu-command/src/platform/term/term_query.rs
+++ b/crates/nu-command/src/platform/term/term_query.rs
@@ -23,9 +23,12 @@ impl Command for TermQuery {
         "Print the given query, and read the immediate result from stdin.
 
 The standard input will be read right after `query` is printed, and consumed until the `terminator`
-sequence is encountered. The `terminator` is not removed from the output.
+sequence is encountered. The `terminator` is not included in the output.
 
-If `terminator` is not supplied, input will be read until Ctrl-C is pressed."
+If `terminator` is not supplied, input will be read until Ctrl-C is pressed.
+
+If `beginning` is supplied, input's beginning will be validated against it.
+The `beginning` is not included in the output."
     }
 
     fn signature(&self) -> Signature {


### PR DESCRIPTION
# Description

- Refactor code to be simpler.
- Make the mentioned changes.
- `scopeguard` is added as a direct dependency. Helps simplify the code. Rather than roll an ad-hoc version of it myself, I thought it would be better to use `scopeguard` as it was already an indirect dependency.

# User-Facing Changes

- Add `--beginning` flag, which is used to validate the response and provide early errors in case of unexpected inputs.
- Both `terminator` and `beginning` sequences (when provided) are not included in the command's output. Turns out they are almost always removed from the output, and because they are known beforehand they can be added back by the user.