### PR TITLE
Fix unstable test case: One time my windows report drive letter as lowercase

### DIFF
--- a/tests/plugins/env.rs
+++ b/tests/plugins/env.rs
@@ -45,7 +45,10 @@ fn get_current_dir() {
     #[cfg(windows)]
     {
         // cwd == r"e:\Study\Nushell", while result.out == r"E:\Study\Nushell"
-        assert_eq!(cwd.chars().next().unwrap().to_ascii_uppercase(), result.out.chars().next().unwrap().to_ascii_uppercase());
+        assert_eq!(
+            cwd.chars().next().unwrap().to_ascii_uppercase(),
+            result.out.chars().next().unwrap().to_ascii_uppercase()
+        );
         assert_eq!(cwd[1..], result.out[1..]);
     }
 }

--- a/tests/plugins/env.rs
+++ b/tests/plugins/env.rs
@@ -40,7 +40,14 @@ fn get_current_dir() {
         "cd tests; example env --cwd"
     );
     assert!(result.status.success());
+    #[cfg(not(windows))]
     assert_eq!(cwd, result.out);
+    #[cfg(windows)]
+    {
+        // cwd == r"e:\Study\Nushell", while result.out == r"E:\Study\Nushell"
+        assert_eq!(cwd.chars().next().unwrap().to_ascii_uppercase(), result.out.chars().next().unwrap().to_ascii_uppercase());
+        assert_eq!(cwd[1..], result.out[1..]);
+    }
 }
 
 #[test]


### PR DESCRIPTION
As I'm working on PWD-per-drive feature. Once the plugin test of env failed. I checked the log, found sometime Windows can give drive letter as lowercase, so the test case should be rewrite to check first letter caseinsensitive equal, and following part normal equal.

```
assert_eq! failed at tests/plugins/env.rs:43:5
left: r"e:\Study\Nushell"
right: r"E:\Study\Nushell"
```
