### PR TITLE
Propagate existing errors in insert and merge

### DIFF
--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -129,6 +129,8 @@ fn insert(
     let replacement: Value = call.req(engine_state, stack, 1)?;
 
     match input {
+        // Propagate errors in the pipeline
+        PipelineData::Value(Value::Error { error, .. }, ..) => Err(*error),
         PipelineData::Value(mut value, metadata) => {
             if let Value::Closure { val, .. } = replacement {
                 match (cell_path.members.first(), &mut value) {

--- a/crates/nu-command/src/filters/merge.rs
+++ b/crates/nu-command/src/filters/merge.rs
@@ -120,6 +120,8 @@ repeating this process with row 1, and so on."#
                 PipelineData::Value(Value::Record { val: inp, .. }, ..),
                 Value::Record { val: to_merge, .. },
             ) => Ok(Value::record(do_merge(inp, &to_merge), head).into_pipeline_data()),
+            // Propagate errors in the pipeline
+            (PipelineData::Value(Value::Error { error, .. }, ..), _) => Err(*error.clone()),
             (PipelineData::Value(val, ..), ..) => {
                 // Only point the "value originates here" arrow at the merge value
                 // if it was generated from a block. Otherwise, point at the pipeline value. -Leon 2022-10-27


### PR DESCRIPTION
# Description
Propagate existing errors in the pipeline, rather than a type error.

# User-Facing Changes
Nothing that previously worked should be affected, this should just change the errors.

# Tests + Formatting

- 🟢 `toolkit fmt`
- 🟢 `toolkit clippy`
- 🟢 `toolkit test`
- 🟢 `toolkit test stdlib`
