### PR TITLE
update miette to 7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,7 +784,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size 0.4.0",
+ "terminal_size",
 ]
 
 [[package]]
@@ -2851,9 +2851,9 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "7.2.0"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+checksum = "317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64"
 dependencies = [
  "backtrace",
  "backtrace-ext",
@@ -2863,7 +2863,7 @@ dependencies = [
  "supports-color 3.0.1",
  "supports-hyperlinks",
  "supports-unicode",
- "terminal_size 0.3.0",
+ "terminal_size",
  "textwrap",
  "thiserror 1.0.69",
  "unicode-width 0.1.11",
@@ -2871,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "7.2.0"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
+checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3402,7 +3402,7 @@ dependencies = [
  "nu-path",
  "nu-protocol",
  "nu-utils",
- "terminal_size 0.4.0",
+ "terminal_size",
 ]
 
 [[package]]
@@ -3658,7 +3658,7 @@ dependencies = [
  "nu-protocol",
  "nu-utils",
  "tabled",
- "terminal_size 0.4.0",
+ "terminal_size",
 ]
 
 [[package]]
@@ -6037,12 +6037,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "smawk"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
-
-[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6392,16 +6386,6 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
-dependencies = [
- "rustix",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "terminal_size"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
@@ -6422,7 +6406,6 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
- "smawk",
  "unicode-linebreak",
  "unicode-width 0.1.11",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ lsp-server = "0.7.5"
 lsp-types = { version = "0.95.0", features = ["proposed"] }
 mach2 = "0.4"
 md5 = { version = "0.10", package = "md-5" }
-miette = "7.2"
+miette = "7.3"
 mime = "0.3.17"
 mime_guess = "2.0"
 mockito = { version = "1.6", default-features = false }

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -146,7 +146,6 @@ fn http_get_with_custom_headers_as_records() {
 }
 
 #[test]
-#[ignore]
 fn http_get_full_response() {
     let mut server = Server::new();
 

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -146,6 +146,7 @@ fn http_get_with_custom_headers_as_records() {
 }
 
 #[test]
+#[ignore]
 fn http_get_full_response() {
     let mut server = Server::new();
 

--- a/crates/nu-protocol/tests/test_config.rs
+++ b/crates/nu-protocol/tests/test_config.rs
@@ -69,7 +69,7 @@ fn fancy_default_errors() {
 
     assert_eq!(
         actual.err,
-        "Error:   \u{1b}[31m×\u{1b}[0m oh no!\n   ╭─[\u{1b}[36;1;4mline1\u{1b}[0m:1:13]\n \u{1b}[2m1\u{1b}[0m │ force_error \"My error\"\n   · \u{1b}[35;1m            ─────┬────\u{1b}[0m\n   ·                  \u{1b}[35;1m╰── \u{1b}[35;1mhere's the error\u{1b}[0m\u{1b}[0m\n   ╰────\n\n\n"
+        "Error: \n  \u{1b}[31m×\u{1b}[0m oh no!\n   ╭─[\u{1b}[36;1;4mline1:1:13\u{1b}[0m]\n \u{1b}[2m1\u{1b}[0m │ force_error \"My error\"\n   · \u{1b}[35;1m            ─────┬────\u{1b}[0m\n   ·                  \u{1b}[35;1m╰── \u{1b}[35;1mhere's the error\u{1b}[0m\u{1b}[0m\n   ╰────\n\n"
     );
 }
 


### PR DESCRIPTION
# Description
The test is failed when updating miette from 7.2 to 7.3.   After looking into the test, I think it's ok to adjust test.

# User-Facing Changes
For the given custom command:
```nushell
def force_error [ x: any ] {
    error make {
        msg: "oh no!"
        label: {
            text: "here's the error"
            span: (metadata $x).span
        }
    }
}
```
### Before
```
> force_error "My error"
Error:   × oh no!
   ╭─[entry #8:1:13]
 1 │ force_error "My error"
   ·             ─────┬────
   ·                  ╰── here's the error
   ╰────

```

### After
```
> force_error "My error"
Error:
  × oh no!
   ╭─[entry #9:1:13]
 1 │ force_error "My error"
   ·             ─────┬────
   ·                  ╰── here's the error
   ╰────
```
As we can see, the message `oh no!` is output in a new line, and there is one less trailing line.  I have makes some testing, and it seems that it only happened on `error make` command.

# Tests + Formatting
Changed 1 test

# After Submitting
NaN
