### PR TITLE
Bump reedline to current main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5337,8 +5337,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9834765acaa2deedf29197f2da3d309801683beb20e25775bc0249f97a7b9a74"
+source = "git+https://github.com/nushell/reedline?branch=main#3c46dc2c0c69476a625611a556e67ddb8439629c"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,7 +314,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Run all benchmarks with `cargo bench`


### PR DESCRIPTION
# Description

@fdncred mentioned that we should be dogfooding the latest Reedline changes in Nushell.  Hoping I got the steps correct.

# User-Facing Changes

New keybindings for:

* Insert Newline:  <kbd>Alt</kbd>+<kbd>Enter</kbd> and <kbd>Shift</kbd>+<kbd>Enter</kbd>
* Enter:  <kbd>Ctrl</kbd>+<kbd>J</kbd>

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

