### PR TITLE
update unicode-width to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3363,7 +3363,7 @@ dependencies = [
  "trash",
  "umask",
  "unicode-segmentation",
- "unicode-width 0.1.11",
+ "unicode-width 0.2.0",
  "ureq",
  "url",
  "uu_cp",
@@ -3426,7 +3426,7 @@ dependencies = [
  "nu-utils",
  "ratatui",
  "strip-ansi-escapes",
- "unicode-width 0.1.11",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3666,7 +3666,7 @@ name = "nu-term-grid"
 version = "0.100.1"
 dependencies = [
  "nu-utils",
- "unicode-width 0.1.11",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ toml = "0.8"
 trash = "5.2"
 umask = "2.1"
 unicode-segmentation = "1.12"
-unicode-width = "0.1"
+unicode-width = "0.2"
 ureq = { version = "2.10", default-features = false }
 url = "2.2"
 uu_cp = "0.0.28"

--- a/crates/nu-command/src/strings/str_/stats.rs
+++ b/crates/nu-command/src/strings/str_/stats.rs
@@ -307,7 +307,7 @@ fn test_one_newline() {
     correct_counts.insert(Counter::GraphemeClusters, 1);
     correct_counts.insert(Counter::Bytes, 1);
     correct_counts.insert(Counter::CodePoints, 1);
-    correct_counts.insert(Counter::UnicodeWidth, 0);
+    correct_counts.insert(Counter::UnicodeWidth, 1);
 
     assert_eq!(correct_counts, counts);
 }
@@ -347,7 +347,7 @@ fn test_count_counts_lines() {
 
     // one more than grapheme clusters because of \r\n
     correct_counts.insert(Counter::CodePoints, 24);
-    correct_counts.insert(Counter::UnicodeWidth, 17);
+    correct_counts.insert(Counter::UnicodeWidth, 23);
 
     assert_eq!(correct_counts, counts);
 }


### PR DESCRIPTION
# Description
When looking into #14395, I found that `unicode-width` from 0.1 to 0.2 contains a breaking change, the mainly change is it treats newlines as width 1.  So relative tests(str stats) are broken.
But I think it's ok to adjust the test.

# User-Facing Changes
The output of `str stats` might change if there are `\n` in the input.
### Before
```nushell
> "a\nb" | str stats | get unicode-width
2
```
### After
```nushell
> "a\nb" | str stats | get unicode-width
3
```
# Tests + Formatting
Adjusted 2 tests.

# After Submitting
NaN