### PR TITLE
Allow inherited environment variables

### DIFF
--- a/crates/nu-utils/src/default_files/default_env.nu
+++ b/crates/nu-utils/src/default_files/default_env.nu
@@ -3,7 +3,7 @@
 #
 # version = "0.100.1"
 
-$env.PROMPT_COMMAND = {|| 
+$env.PROMPT_COMMAND = $env.PROMPT_COMMAND? | default {|| 
     let dir = match (do -i { $env.PWD | path relative-to $nu.home-path }) {
         null => $env.PWD
         '' => '~'
@@ -17,12 +17,12 @@ $env.PROMPT_COMMAND = {||
     $path_segment | str replace --all (char path_sep) $"($separator_color)(char path_sep)($path_color)"
 }
 
-$env.PROMPT_INDICATOR = "> "
-$env.PROMPT_INDICATOR_VI_NORMAL = "> "
-$env.PROMPT_INDICATOR_VI_INSERT = ": "
-$env.PROMPT_MULTILINE_INDICATOR = "::: "
+$env.PROMPT_INDICATOR = $env.PROMPT_INDICATOR? | default "> "
+$env.PROMPT_INDICATOR_VI_NORMAL = $env.PROMPT_INDICATOR_VI_NORMAL? | default "> "
+$env.PROMPT_INDICATOR_VI_INSERT = $env.PROMPT_INDICATOR_VI_INSERT? | default ": "
+$env.PROMPT_MULTILINE_INDICATOR = $env.PROMPT_MULTILINE_INDICATOR? | default "::: "
 
-$env.PROMPT_COMMAND_RIGHT = {|| 
+$env.PROMPT_COMMAND_RIGHT = $env.PROMPT_COMMAND_RIGHT? | default {|| 
     # create a right prompt in magenta with green separators and am/pm underlined
     let time_segment = ([
         (ansi reset)
@@ -47,11 +47,11 @@ $env.ENV_CONVERSIONS = {
     }
 }
 
-$env.NU_LIB_DIRS = [
+$env.NU_LIB_DIRS = $env.NU_LIB_DIRS? | default [
     ($nu.default-config-dir | path join 'scripts') # add <nushell-config-dir>/scripts
     ($nu.data-dir | path join 'completions') # default home for nushell completions
 ]
 
-$env.NU_PLUGIN_DIRS = [
+$env.NU_PLUGIN_DIRS = $env.NU_PLUGIN_DIRS | default [
     ($nu.default-config-dir | path join 'plugins') # add <nushell-config-dir>/plugins
 ]


### PR DESCRIPTION
# Description

Due to #14249 loading `default_env.nu` before the user's `env.nu`, variables that were defined there were overriding:

* Inherited values
* Some values that were set in the Rust code, such as the `NU_LIB_PATH` when set using `--include-path`.

This change checks to see if a variable already exists, uses its value if so, and sets the default value otherwise.

Note:  `ENV_CONVERSIONS` is still "forced" to a default value regardless, as it needs to run reliably. There's probably not much reason to inherit it, but I'm open to the idea if there's a use-case.

# User-Facing Changes

* Before: Variables that were set in `default_env.nu` always overrode those that were inherited from the parent process or set internally
* After: Inherited and internal environment variables will take priority.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

Will try to find a good place to mention this behavior in the Config chapter updates