### PR TITLE
`explore`:  add more `less` key bindings and add `Transition::None`

### DIFF
--- a/crates/nu-explore/src/commands/help.rs
+++ b/crates/nu-explore/src/commands/help.rs
@@ -33,13 +33,14 @@ Launch Explore by piping data into it: {}
 
                    Move around:  Use the cursor keys
 Drill down into records+tables:  Press <Enter> to select a cell, move around with cursor keys, press <Enter> again
-            Go back/up a level:  Press <Esc>
+            Go back/up a level:  Press <Esc> or "q"
  Transpose (flip rows+columns):  Press "t"
  Expand (show all nested data):  Press "e"
           Open this help page :  Type ":help" then <Enter>
       Open an interactive REPL:  Type ":try" then <Enter>
-                Scroll up/down:  Use the "Page Up" and "Page Down" keys
-                  Exit Explore:  Type ":q" then <Enter>, or Ctrl+D. Alternately, press <Esc> until Explore exits
+                Scroll up:  Press "Page Up", Ctrl+B, or Alt+V
+                Scroll down:  Press "Page Down", Ctrl+F, or Ctrl+V
+                  Exit Explore:  Type ":q" then <Enter>, or Ctrl+D. Alternately, press <Esc> or "q" until Explore exits
 
 {}
 Most commands support search via regular expressions.

--- a/crates/nu-explore/src/commands/help.rs
+++ b/crates/nu-explore/src/commands/help.rs
@@ -38,8 +38,8 @@ Drill down into records+tables:  Press <Enter> to select a cell, move around wit
  Expand (show all nested data):  Press "e"
           Open this help page :  Type ":help" then <Enter>
       Open an interactive REPL:  Type ":try" then <Enter>
-                Scroll up:  Press "Page Up", Ctrl+B, or Alt+V
-                Scroll down:  Press "Page Down", Ctrl+F, or Ctrl+V
+                     Scroll up:  Press "Page Up", Ctrl+B, or Alt+V
+                   Scroll down:  Press "Page Down", Ctrl+F, or Ctrl+V
                   Exit Explore:  Type ":q" then <Enter>, or Ctrl+D. Alternately, press <Esc> or "q" until Explore exits
 
 {}

--- a/crates/nu-explore/src/commands/nu.rs
+++ b/crates/nu-explore/src/commands/nu.rs
@@ -93,7 +93,7 @@ impl View for NuView {
         layout: &Layout,
         info: &mut crate::pager::ViewInfo,
         key: crossterm::event::KeyEvent,
-    ) -> Option<crate::pager::Transition> {
+    ) -> crate::pager::Transition {
         match self {
             NuView::Records(v) => v.handle_input(engine_state, stack, layout, info, key),
             NuView::Preview(v) => v.handle_input(engine_state, stack, layout, info, key),

--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -324,7 +324,7 @@ fn react_to_event_result(
                 }
             }
         }
-        Transition::None => (None, String::default())
+        Transition::None => (None, String::default()),
     }
 }
 
@@ -425,7 +425,7 @@ fn run_command(
                 Transition::Ok => Ok(CmdResult::new(false, false, String::new())),
                 Transition::Exit => Ok(CmdResult::new(true, false, String::new())),
                 Transition::Cmd { .. } => todo!("not used so far"),
-                Transition::None => panic!("Transition::None not expected from command.react()")
+                Transition::None => panic!("Transition::None not expected from command.react()"),
             }
         }
         Command::View { mut cmd, stackable } => {

--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -135,6 +135,13 @@ pub enum Transition {
 }
 
 #[derive(Debug, Clone)]
+pub enum StatusTopOrEnd {
+    Top,
+    End,
+    None,
+}
+
+#[derive(Debug, Clone)]
 pub struct PagerConfig<'a> {
     pub nu_config: &'a NuConfig,
     pub explore_config: &'a ExploreConfig,

--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -128,10 +128,10 @@ impl<'a> Pager<'a> {
 
 #[derive(Debug, Clone)]
 pub enum Transition {
-    // TODO: should we add a noop transition instead of doing Option<Transition> everywhere?
     Ok,
     Exit,
     Cmd(String),
+    None,
 }
 
 #[derive(Debug, Clone)]
@@ -219,34 +219,32 @@ fn render_ui(
             view_stack.curr_view.as_mut().map(|p| &mut p.view),
         );
 
-        if let Some(transition) = transition {
-            let (exit, cmd_name) = react_to_event_result(
-                transition,
-                engine_state,
-                &commands,
-                pager,
-                &mut view_stack,
-                stack,
-                info,
-            );
+        let (exit, cmd_name) = react_to_event_result(
+            transition,
+            engine_state,
+            &commands,
+            pager,
+            &mut view_stack,
+            stack,
+            info,
+        );
 
-            if let Some(value) = exit {
-                break Ok(value);
+        if let Some(value) = exit {
+            break Ok(value);
+        }
+
+        if !cmd_name.is_empty() {
+            if let Some(r) = info.report.as_mut() {
+                r.message = cmd_name;
+                r.level = Severity::Success;
+            } else {
+                info.report = Some(Report::success(cmd_name));
             }
 
-            if !cmd_name.is_empty() {
-                if let Some(r) = info.report.as_mut() {
-                    r.message = cmd_name;
-                    r.level = Severity::Success;
-                } else {
-                    info.report = Some(Report::success(cmd_name));
-                }
-
-                let info = info.clone();
-                term.draw(|f| {
-                    draw_info(f, pager, info);
-                })?;
-            }
+            let info = info.clone();
+            term.draw(|f| {
+                draw_info(f, pager, info);
+            })?;
         }
 
         if pager.cmd_buf.run_cmd {
@@ -326,6 +324,7 @@ fn react_to_event_result(
                 }
             }
         }
+        Transition::None => (None, String::default())
     }
 }
 
@@ -426,6 +425,7 @@ fn run_command(
                 Transition::Ok => Ok(CmdResult::new(false, false, String::new())),
                 Transition::Exit => Ok(CmdResult::new(true, false, String::new())),
                 Transition::Cmd { .. } => todo!("not used so far"),
+                Transition::None => panic!("Transition::None not expected from command.react()")
             }
         }
         Command::View { mut cmd, stackable } => {
@@ -624,17 +624,17 @@ fn handle_events<V: View>(
     search: &mut SearchBuf,
     command: &mut CommandBuf,
     mut view: Option<&mut V>,
-) -> Option<Transition> {
+) -> Transition {
     // We are only interested in Pressed events;
     // It's crucial because there are cases where terminal MIGHT produce false events;
     // 2 events 1 for release 1 for press.
     // Want to react only on 1 of them so we do.
     let mut key = match events.next_key_press() {
         Ok(Some(key)) => key,
-        Ok(None) => return None,
+        Ok(None) => return Transition::None,
         Err(e) => {
             log::error!("Failed to read key event: {e}");
-            return None;
+            return Transition::None;
         }
     };
 
@@ -654,15 +654,15 @@ fn handle_events<V: View>(
             view.as_deref_mut(),
             key,
         );
-        if result.is_some() {
+        if !matches!(result, Transition::None) {
             return result;
         }
         match events.try_next_key_press() {
             Ok(Some(next_key)) => key = next_key,
-            Ok(None) => return None,
+            Ok(None) => return Transition::None,
             Err(e) => {
                 log::error!("Failed to peek key event: {e}");
-                return None;
+                return Transition::None;
             }
         }
     }
@@ -678,29 +678,29 @@ fn handle_event<V: View>(
     command: &mut CommandBuf,
     mut view: Option<&mut V>,
     key: KeyEvent,
-) -> Option<Transition> {
+) -> Transition {
     if handle_exit_key_event(&key) {
-        return Some(Transition::Exit);
+        return Transition::Exit;
     }
 
     if handle_general_key_events1(&key, search, command, view.as_deref_mut()) {
-        return None;
+        return Transition::None;
     }
 
     if let Some(view) = &mut view {
         let t = view.handle_input(engine_state, stack, layout, info, key);
         match t {
-            Some(Transition::Exit) => return Some(Transition::Ok),
-            Some(Transition::Cmd(cmd)) => return Some(Transition::Cmd(cmd)),
-            Some(Transition::Ok) => return None,
-            None => {}
+            Transition::Exit => return Transition::Ok,
+            Transition::Cmd(cmd) => return Transition::Cmd(cmd),
+            Transition::Ok => return Transition::None,
+            Transition::None => {}
         }
     }
 
     // was not handled so we must check our default controls
     handle_general_key_events2(&key, search, command, view, info);
 
-    None
+    Transition::None
 }
 
 fn handle_exit_key_event(key: &KeyEvent) -> bool {

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -66,16 +66,16 @@ impl View for BinaryView {
         _: &Layout,
         info: &mut ViewInfo,
         key: KeyEvent,
-    ) -> Option<Transition> {
+    ) -> Transition {
         match self.handle_input_key(&key) {
-            Ok(Some((Transition::Ok, ..))) => {
+            Ok((Transition::Ok, ..)) => {
                 let report = create_report(self.cursor);
                 info.status = Some(report);
             },
             _ => {}  // currently only handle_enter() in crates/nu-explore/src/views/record/mod.rs raises an Err()
         }
 
-        None
+        Transition::None
     }
 
     fn collect_data(&self) -> Vec<NuText> {

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -2,7 +2,7 @@
 
 mod binary_widget;
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::KeyEvent;
 use nu_protocol::{
     engine::{EngineState, Stack},
     Value,
@@ -21,7 +21,7 @@ use crate::{
 
 use self::binary_widget::{BinarySettings, BinaryStyle, BinaryWidget};
 
-use super::{cursor::WindowCursor2D, Layout, View, ViewConfig};
+use super::{cursor::CursorMoveHandler, cursor::WindowCursor2D, Layout, View, ViewConfig};
 
 /// An interactive view that displays binary data in a hex dump format.
 /// Not finished; many aspects are still WIP.
@@ -67,11 +67,12 @@ impl View for BinaryView {
         info: &mut ViewInfo,
         key: KeyEvent,
     ) -> Option<Transition> {
-        let result = handle_event_view_mode(self, &key);
-
-        if matches!(&result, Some(Transition::Ok)) {
-            let report = create_report(self.cursor);
-            info.status = Some(report);
+        match self.handle_input_key(&key) {
+            Ok(Some((Transition::Ok, ..))) => {
+                let report = create_report(self.cursor);
+                info.status = Some(report);
+            },
+            _ => {}  // currently only handle_enter() in crates/nu-explore/src/views/record/mod.rs raises an Err()
         }
 
         None
@@ -93,6 +94,12 @@ impl View for BinaryView {
     }
 }
 
+impl CursorMoveHandler for BinaryView {
+    fn get_cursor(&mut self) -> &mut WindowCursor2D {
+        &mut self.cursor
+    }
+}
+
 fn create_binary_widget(v: &BinaryView) -> BinaryWidget<'_> {
     let start_line = v.cursor.window_origin().row;
     let count_elements =
@@ -104,73 +111,6 @@ fn create_binary_widget(v: &BinaryView) -> BinaryWidget<'_> {
     w.set_row_offset(index);
 
     w
-}
-
-fn handle_event_view_mode(view: &mut BinaryView, key: &KeyEvent) -> Option<Transition> {
-    match key {
-        KeyEvent {
-            code: KeyCode::Char('u'),
-            modifiers: KeyModifiers::CONTROL,
-            ..
-        }
-        | KeyEvent {
-            code: KeyCode::PageUp,
-            ..
-        } => {
-            view.cursor.prev_row_page();
-
-            return Some(Transition::Ok);
-        }
-        KeyEvent {
-            code: KeyCode::Char('d'),
-            modifiers: KeyModifiers::CONTROL,
-            ..
-        }
-        | KeyEvent {
-            code: KeyCode::PageDown,
-            ..
-        } => {
-            view.cursor.next_row_page();
-
-            return Some(Transition::Ok);
-        }
-        _ => {}
-    }
-
-    match key.code {
-        KeyCode::Esc => Some(Transition::Exit),
-        KeyCode::Up | KeyCode::Char('k') => {
-            view.cursor.prev_row_i();
-
-            Some(Transition::Ok)
-        }
-        KeyCode::Down | KeyCode::Char('j') => {
-            view.cursor.next_row_i();
-
-            Some(Transition::Ok)
-        }
-        KeyCode::Left | KeyCode::Char('h') => {
-            view.cursor.prev_column_i();
-
-            Some(Transition::Ok)
-        }
-        KeyCode::Right | KeyCode::Char('l') => {
-            view.cursor.next_column_i();
-
-            Some(Transition::Ok)
-        }
-        KeyCode::Home | KeyCode::Char('g') => {
-            view.cursor.row_move_to_start();
-
-            Some(Transition::Ok)
-        }
-        KeyCode::End | KeyCode::Char('G') => {
-            view.cursor.row_move_to_end();
-
-            Some(Transition::Ok)
-        }
-        _ => None,
-    }
 }
 
 fn settings_from_config(config: &ExploreConfig) -> Settings {

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -67,12 +67,10 @@ impl View for BinaryView {
         info: &mut ViewInfo,
         key: KeyEvent,
     ) -> Transition {
-        match self.handle_input_key(&key) {
-            Ok((Transition::Ok, ..)) => {
-                let report = create_report(self.cursor);
-                info.status = Some(report);
-            }
-            _ => {} // currently only handle_enter() in crates/nu-explore/src/views/record/mod.rs raises an Err()
+        // currently only handle_enter() in crates/nu-explore/src/views/record/mod.rs raises an Err()
+        if let Ok((Transition::Ok, ..)) = self.handle_input_key(&key) {
+            let report = create_report(self.cursor);
+            info.status = Some(report);
         }
 
         Transition::None

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -71,8 +71,8 @@ impl View for BinaryView {
             Ok((Transition::Ok, ..)) => {
                 let report = create_report(self.cursor);
                 info.status = Some(report);
-            },
-            _ => {}  // currently only handle_enter() in crates/nu-explore/src/views/record/mod.rs raises an Err()
+            }
+            _ => {} // currently only handle_enter() in crates/nu-explore/src/views/record/mod.rs raises an Err()
         }
 
         Transition::None

--- a/crates/nu-explore/src/views/cursor/mod.rs
+++ b/crates/nu-explore/src/views/cursor/mod.rs
@@ -3,7 +3,7 @@ mod window_cursor_2d;
 
 use anyhow::{bail, Result};
 pub use window_cursor::WindowCursor;
-pub use window_cursor_2d::{Position, WindowCursor2D};
+pub use window_cursor_2d::{CursorMoveHandler, Position, WindowCursor2D};
 
 /// A 1-dimensional cursor to track a position from 0 to N
 ///

--- a/crates/nu-explore/src/views/cursor/window_cursor_2d.rs
+++ b/crates/nu-explore/src/views/cursor/window_cursor_2d.rs
@@ -178,9 +178,15 @@ pub trait CursorMoveHandler {
     fn get_cursor(&mut self) -> &mut WindowCursor2D;
 
     // standard handle_EVENT handlers that can be overwritten
-    fn handle_enter(&mut self) -> Result<Transition> { Ok(Transition::None) }
-    fn handle_esc(&mut self) -> Transition { Transition::Exit }
-    fn handle_expand(&mut self) -> Transition { Transition::None }
+    fn handle_enter(&mut self) -> Result<Transition> {
+        Ok(Transition::None)
+    }
+    fn handle_esc(&mut self) -> Transition {
+        Transition::Exit
+    }
+    fn handle_expand(&mut self) -> Transition {
+        Transition::None
+    }
     fn handle_left(&mut self) {
         self.get_cursor().prev_column_i()
     }
@@ -193,7 +199,9 @@ pub trait CursorMoveHandler {
     fn handle_down(&mut self) {
         self.get_cursor().next_row_i()
     }
-    fn handle_transpose(&mut self) -> Transition { Transition::None }
+    fn handle_transpose(&mut self) -> Transition {
+        Transition::None
+    }
 
     // top-level event handler should not be overwritten
     fn handle_input_key(&mut self, key: &KeyEvent) -> Result<(Transition, StatusTopOrEnd)> {
@@ -253,19 +261,17 @@ pub trait CursorMoveHandler {
                 self.handle_down();
                 StatusTopOrEnd::End
             }
-            _ => StatusTopOrEnd::None
+            _ => StatusTopOrEnd::None,
         };
         match key_combo_status {
             StatusTopOrEnd::Top | StatusTopOrEnd::End => {
                 return Ok((Transition::Ok, key_combo_status));
             }
-            _ => {}  // not page up or page down, so don't return; continue to next match block
+            _ => {} // not page up or page down, so don't return; continue to next match block
         }
 
         match key.code {
-            KeyCode::Char('q') | KeyCode::Esc => {
-                Ok((self.handle_esc(), StatusTopOrEnd::None))
-            }
+            KeyCode::Char('q') | KeyCode::Esc => Ok((self.handle_esc(), StatusTopOrEnd::None)),
             KeyCode::Char('i') | KeyCode::Enter => Ok((self.handle_enter()?, StatusTopOrEnd::None)),
             KeyCode::Char('t') => Ok((self.handle_transpose(), StatusTopOrEnd::None)),
             KeyCode::Char('e') => Ok((self.handle_expand(), StatusTopOrEnd::None)),
@@ -293,7 +299,7 @@ pub trait CursorMoveHandler {
                 self.get_cursor().row_move_to_end();
                 Ok((Transition::Ok, StatusTopOrEnd::End))
             }
-            _ => Ok((Transition::None, StatusTopOrEnd::None))
+            _ => Ok((Transition::None, StatusTopOrEnd::None)),
         }
     }
 }

--- a/crates/nu-explore/src/views/mod.rs
+++ b/crates/nu-explore/src/views/mod.rs
@@ -89,7 +89,7 @@ pub trait View {
         layout: &Layout,
         info: &mut ViewInfo,
         key: KeyEvent,
-    ) -> Option<Transition>;
+    ) -> Transition;
 
     fn show_data(&mut self, _: usize) -> bool {
         false
@@ -116,7 +116,7 @@ impl View for Box<dyn View> {
         layout: &Layout,
         info: &mut ViewInfo,
         key: KeyEvent,
-    ) -> Option<Transition> {
+    ) -> Transition {
         self.as_mut()
             .handle_input(engine_state, stack, layout, info, key)
     }

--- a/crates/nu-explore/src/views/preview.rs
+++ b/crates/nu-explore/src/views/preview.rs
@@ -65,17 +65,17 @@ impl View for Preview {
         _: &Layout,
         info: &mut ViewInfo, // add this arg to draw too?
         key: KeyEvent,
-    ) -> Option<Transition> {
+    ) -> Transition {
         match self.handle_input_key(&key) {
-            Ok(Some((transition, status_top_or_end))) => {
+            Ok((transition, status_top_or_end)) => {
                 match status_top_or_end {
                     StatusTopOrEnd::Top => set_status_top(self, info),
                     StatusTopOrEnd::End => set_status_end(self, info),
                     _ => {}
                 }
-                Some(transition)
+                transition
             },
-            _ => None  // currently only handle_enter() in crates/nu-explore/src/views/record/mod.rs raises an Err()
+            _ => Transition::None  // currently only handle_enter() in crates/nu-explore/src/views/record/mod.rs raises an Err()
         }
     }
 

--- a/crates/nu-explore/src/views/preview.rs
+++ b/crates/nu-explore/src/views/preview.rs
@@ -1,11 +1,11 @@
 use super::{
-    colored_text_widget::ColoredTextWidget, cursor::WindowCursor2D, Layout, View, ViewConfig,
+    colored_text_widget::ColoredTextWidget, cursor::CursorMoveHandler, cursor::WindowCursor2D, Layout, View, ViewConfig,
 };
 use crate::{
     nu_common::{NuSpan, NuText},
-    pager::{report::Report, Frame, Transition, ViewInfo},
+    pager::{report::Report, Frame, StatusTopOrEnd, Transition, ViewInfo},
 };
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::KeyEvent;
 use nu_color_config::TextStyle;
 use nu_protocol::{
     engine::{EngineState, Stack},
@@ -66,57 +66,16 @@ impl View for Preview {
         info: &mut ViewInfo, // add this arg to draw too?
         key: KeyEvent,
     ) -> Option<Transition> {
-        match key.code {
-            KeyCode::Left => {
-                self.cursor
-                    .prev_column_by(max(1, self.cursor.window_width_in_columns() / 2));
-
-                Some(Transition::Ok)
-            }
-            KeyCode::Right => {
-                self.cursor
-                    .next_column_by(max(1, self.cursor.window_width_in_columns() / 2));
-
-                Some(Transition::Ok)
-            }
-            KeyCode::Up => {
-                self.cursor.prev_row_i();
-                set_status_top(self, info);
-
-                Some(Transition::Ok)
-            }
-            KeyCode::Down => {
-                self.cursor.next_row_i();
-                set_status_end(self, info);
-
-                Some(Transition::Ok)
-            }
-            KeyCode::PageUp => {
-                self.cursor.prev_row_page();
-                set_status_top(self, info);
-
-                Some(Transition::Ok)
-            }
-            KeyCode::PageDown => {
-                self.cursor.next_row_page();
-                set_status_end(self, info);
-
-                Some(Transition::Ok)
-            }
-            KeyCode::Home => {
-                self.cursor.row_move_to_start();
-                set_status_top(self, info);
-
-                Some(Transition::Ok)
-            }
-            KeyCode::End => {
-                self.cursor.row_move_to_end();
-                set_status_end(self, info);
-
-                Some(Transition::Ok)
-            }
-            KeyCode::Esc => Some(Transition::Exit),
-            _ => None,
+        match self.handle_input_key(&key) {
+            Ok(Some((transition, status_top_or_end))) => {
+                match status_top_or_end {
+                    StatusTopOrEnd::Top => set_status_top(self, info),
+                    StatusTopOrEnd::End => set_status_end(self, info),
+                    _ => {}
+                }
+                Some(transition)
+            },
+            _ => None  // currently only handle_enter() in crates/nu-explore/src/views/record/mod.rs raises an Err()
         }
     }
 
@@ -144,6 +103,20 @@ impl View for Preview {
                 Some(Value::string(text, NuSpan::unknown()))
             }
         }
+    }
+}
+
+impl CursorMoveHandler for Preview {
+    fn get_cursor(&mut self) -> &mut WindowCursor2D {
+        &mut self.cursor
+    }
+    fn handle_left(&mut self) {
+        self.cursor
+            .prev_column_by(max(1, self.cursor.window_width_in_columns() / 2));
+    }
+    fn handle_right(&mut self) {
+        self.cursor
+            .next_column_by(max(1, self.cursor.window_width_in_columns() / 2));
     }
 }
 

--- a/crates/nu-explore/src/views/preview.rs
+++ b/crates/nu-explore/src/views/preview.rs
@@ -1,5 +1,6 @@
 use super::{
-    colored_text_widget::ColoredTextWidget, cursor::CursorMoveHandler, cursor::WindowCursor2D, Layout, View, ViewConfig,
+    colored_text_widget::ColoredTextWidget, cursor::CursorMoveHandler, cursor::WindowCursor2D,
+    Layout, View, ViewConfig,
 };
 use crate::{
     nu_common::{NuSpan, NuText},
@@ -74,8 +75,8 @@ impl View for Preview {
                     _ => {}
                 }
                 transition
-            },
-            _ => Transition::None  // currently only handle_enter() in crates/nu-explore/src/views/record/mod.rs raises an Err()
+            }
+            _ => Transition::None, // currently only handle_enter() in crates/nu-explore/src/views/record/mod.rs raises an Err()
         }
     }
 

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -367,7 +367,6 @@ impl RecordLayer {
     }
 }
 
-
 impl CursorMoveHandler for RecordView {
     fn get_cursor(&mut self) -> &mut WindowCursor2D {
         &mut self.get_top_layer_mut().cursor
@@ -377,7 +376,7 @@ impl CursorMoveHandler for RecordView {
             UIMode::View => self.set_cursor_mode(),
             UIMode::Cursor => {
                 let value = self.get_current_value();
-        
+
                 // ...but it only makes sense to drill down into a few types of values
                 if !matches!(
                     value,
@@ -385,11 +384,11 @@ impl CursorMoveHandler for RecordView {
                 ) {
                     return Ok(Transition::None);
                 }
-        
+
                 let is_record = matches!(value, Value::Record { .. });
                 let next_layer = create_layer(value.clone())?;
                 push_layer(self, next_layer);
-        
+
                 if is_record {
                     self.set_top_layer_orientation(Orientation::Left);
                 } else {
@@ -409,7 +408,7 @@ impl CursorMoveHandler for RecordView {
                 } else {
                     return Transition::Exit;
                 }
-            },
+            }
             UIMode::Cursor => self.set_view_mode(),
         }
         Transition::Ok
@@ -426,8 +425,8 @@ impl CursorMoveHandler for RecordView {
                 self.transpose();
 
                 Transition::Ok
-            },
-            _ => Transition::None
+            }
+            _ => Transition::None,
         }
     }
     // for these, copy standard CursorMoveHandler for UIMode::View, but use special handling for UIMode::Cursor
@@ -442,7 +441,7 @@ impl CursorMoveHandler for RecordView {
     fn handle_right(&mut self) {
         match self.mode {
             UIMode::View => self.get_top_layer_mut().cursor.next_column_i(),
-            _ => self.get_top_layer_mut().cursor.next_column()
+            _ => self.get_top_layer_mut().cursor.next_column(),
         }
     }
     fn handle_up(&mut self) {

--- a/crates/nu-explore/src/views/try.rs
+++ b/crates/nu-explore/src/views/try.rs
@@ -149,7 +149,7 @@ impl View for TryView {
         layout: &Layout,
         info: &mut ViewInfo,
         key: KeyEvent,
-    ) -> Option<Transition> {
+    ) -> Transition {
         if self.view_mode {
             let table = self
                 .table
@@ -160,28 +160,28 @@ impl View for TryView {
 
             if was_at_the_top && matches!(key.code, KeyCode::Up | KeyCode::PageUp) {
                 self.view_mode = false;
-                return Some(Transition::Ok);
+                return Transition::Ok;
             }
 
             if matches!(key.code, KeyCode::Tab) {
                 self.view_mode = false;
-                return Some(Transition::Ok);
+                return Transition::Ok;
             }
 
             let result = table.handle_input(engine_state, stack, layout, info, key);
 
             return match result {
-                Some(Transition::Ok | Transition::Cmd { .. }) => Some(Transition::Ok),
-                Some(Transition::Exit) => {
+                Transition::Ok | Transition::Cmd { .. } => Transition::Ok,
+                Transition::Exit => {
                     self.view_mode = false;
-                    Some(Transition::Ok)
+                    Transition::Ok
                 }
-                None => None,
+                Transition::None => Transition::None,
             };
         }
 
         match &key.code {
-            KeyCode::Esc => Some(Transition::Exit),
+            KeyCode::Esc => Transition::Exit,
             KeyCode::Backspace => {
                 if !self.command.is_empty() {
                     self.command.pop();
@@ -194,7 +194,7 @@ impl View for TryView {
                     }
                 }
 
-                Some(Transition::Ok)
+                Transition::Ok
             }
             KeyCode::Char(c) => {
                 self.command.push(*c);
@@ -206,14 +206,14 @@ impl View for TryView {
                     }
                 }
 
-                Some(Transition::Ok)
+                Transition::Ok
             }
             KeyCode::Down | KeyCode::Tab => {
                 if self.table.is_some() {
                     self.view_mode = true;
                 }
 
-                Some(Transition::Ok)
+                Transition::Ok
             }
             KeyCode::Enter => {
                 match self.try_run(engine_state, stack) {
@@ -221,9 +221,9 @@ impl View for TryView {
                     Err(err) => info.report = Some(Report::error(format!("Error: {err}"))),
                 }
 
-                Some(Transition::Ok)
+                Transition::Ok
             }
-            _ => None,
+            _ => Transition::None,
         }
     }
 


### PR DESCRIPTION
# Description
The `explore` command is `less`-like, but it's missing the `Emacs` keybindings for up/down and PageUp/PageDown as well as the "q" to quit out. When I looked into adding those additional keybindings, I noticed there was a lot of duplicated code in the various views, so I refactored the code into a new `trait CursorMoveHandler`. I also noticed that there was an existing `TODO: should we add a noop transition instead of doing Option<Transition> everywhere?` comment in the code. I went ahead and implemented a new `Transition::None`, and that made the new `trait CursorMoveHandler` code MUCH cleaner, in addition to making some of the old code a little cleaner as well.

# User-Facing Changes
Users that are used to the keybindings for `less` should feel much more comfortable using `explore`.

# Tests + Formatting
Unfortunately, there aren't any existing tests for the `explore` command, so I didn't know where I should add new tests to cover my code changes.