### PR TITLE
Make length only operate on supported input types

### DIFF
--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -19,6 +19,7 @@ impl Command for Length {
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Any)), Type::Int),
                 (Type::Binary, Type::Int),
+                (Type::Nothing, Type::Int),
             ])
             .category(Category::Filters)
     }
@@ -61,23 +62,19 @@ impl Command for Length {
 fn length_row(call: &Call, input: PipelineData) -> Result<PipelineData, ShellError> {
     let span = input.span().unwrap_or(call.head);
     match input {
-        PipelineData::Value(Value::Nothing { .. }, ..) => {
+        PipelineData::Empty | PipelineData::Value(Value::Nothing { .. }, ..) => {
             Ok(Value::int(0, call.head).into_pipeline_data())
-        }
-        // I added this here because input_output_type() wasn't catching a record
-        // being sent in as input from echo. e.g. "echo {a:1 b:2} | length"
-        PipelineData::Value(Value::Record { .. }, ..) => {
-            Err(ShellError::OnlySupportsThisInputType {
-                exp_input_type: "list, and table".into(),
-                wrong_type: "record".into(),
-                dst_span: call.head,
-                src_span: span,
-            })
         }
         PipelineData::Value(Value::Binary { val, .. }, ..) => {
             Ok(Value::int(val.len() as i64, call.head).into_pipeline_data())
         }
-        PipelineData::ByteStream(stream, _) if stream.type_().is_binary_coercible() => {
+        PipelineData::Value(Value::List { vals, .. }, ..) => {
+            Ok(Value::int(vals.len() as i64, call.head).into_pipeline_data())
+        }
+        PipelineData::ListStream(stream, ..) => {
+            Ok(Value::int(stream.into_iter().count() as i64, call.head).into_pipeline_data())
+        }
+        PipelineData::ByteStream(stream, ..) if stream.type_().is_binary_coercible() => {
             Ok(Value::int(
                 match stream.reader() {
                     Some(r) => r.bytes().count() as i64,
@@ -87,17 +84,12 @@ fn length_row(call: &Call, input: PipelineData) -> Result<PipelineData, ShellErr
             )
             .into_pipeline_data())
         }
-        _ => {
-            let mut count: i64 = 0;
-            // Check for and propagate errors
-            for value in input.into_iter() {
-                if let Value::Error { error, .. } = value {
-                    return Err(*error);
-                }
-                count += 1
-            }
-            Ok(Value::int(count, call.head).into_pipeline_data())
-        }
+        _ => Err(ShellError::OnlySupportsThisInputType {
+            exp_input_type: "list, table, and binary".into(),
+            wrong_type: input.get_type().to_string(),
+            dst_span: call.head,
+            src_span: span,
+        }),
     }
 }
 

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -55,6 +55,11 @@ impl Command for Length {
                 example: "0x[01 02] | length",
                 result: Some(Value::test_int(2)),
             },
+            Example {
+                description: "Count the length a null value",
+                example: "null | length",
+                result: Some(Value::test_int(0)),
+            },
         ]
     }
 }
@@ -85,7 +90,7 @@ fn length_row(call: &Call, input: PipelineData) -> Result<PipelineData, ShellErr
             .into_pipeline_data())
         }
         _ => Err(ShellError::OnlySupportsThisInputType {
-            exp_input_type: "list, table, and binary".into(),
+            exp_input_type: "list, table, binary, and nothing".into(),
             wrong_type: input.get_type().to_string(),
             dst_span: call.head,
             src_span: span,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Before this PR, `length` did not check its input type at run-time, so it would attempt to calculate a length for any input with indeterminate type (e.g., `echo` which has an `any` output type). This PR makes `length` only work on the types specifically supported in its input/output types (list/table, binary, and nothing), making the behavior the same at parse-time and at run-time.

Fixes #14462

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Length will error if passed an unsupported type:

Before (only caught at parse-time):
```nushell
"hello" | length
Error: nu::parser::input_type_mismatch

  × Command does not support string input.
   ╭─[entry #2:1:11]
 1 │ "hello" | length
   ·           ───┬──
   ·              ╰── command doesn't support string input
   ╰────

echo "hello" | length
# => 1
```

After (caught at parse-time and run-time):
```nushell
"hello" | length
Error: nu::parser::input_type_mismatch

  × Command does not support string input.
   ╭─[entry #22:1:11]
 1 │ "hello" | length
   ·           ───┬──
   ·              ╰── command doesn't support string input
   ╰────

echo "hello" | length
Error: nu::shell::only_supports_this_input_type

  × Input type not supported.
   ╭─[entry #23:1:6]
 1 │ echo "hello" | length
   ·      ───┬───   ───┬──
   ·         │         ╰── only list, table, binary, and nothing input data is supported
   ·         ╰── input type: string
   ╰────
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`


# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
