### PR TITLE
Remove unused `FlatShape`s `And`/`Or`

### DIFF
--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -144,8 +144,6 @@ impl Highlighter for NuHighlighter {
                 }
                 FlatShape::Flag => add_colored_token(&shape.1, next_token),
                 FlatShape::Pipe => add_colored_token(&shape.1, next_token),
-                FlatShape::And => add_colored_token(&shape.1, next_token),
-                FlatShape::Or => add_colored_token(&shape.1, next_token),
                 FlatShape::Redirection => add_colored_token(&shape.1, next_token),
                 FlatShape::Custom(..) => add_colored_token(&shape.1, next_token),
                 FlatShape::MatchPattern => add_colored_token(&shape.1, next_token),

--- a/crates/nu-color-config/src/shape_color.rs
+++ b/crates/nu-color-config/src/shape_color.rs
@@ -5,7 +5,6 @@ use nu_protocol::{Config, Value};
 // The default colors for shapes, used when there is no config for them.
 pub fn default_shape_color(shape: &str) -> Style {
     match shape {
-        "shape_and" => Style::new().fg(Color::Purple).bold(),
         "shape_binary" => Style::new().fg(Color::Purple).bold(),
         "shape_block" => Style::new().fg(Color::Blue).bold(),
         "shape_bool" => Style::new().fg(Color::LightCyan),
@@ -30,7 +29,6 @@ pub fn default_shape_color(shape: &str) -> Style {
         "shape_match_pattern" => Style::new().fg(Color::Green),
         "shape_nothing" => Style::new().fg(Color::LightCyan),
         "shape_operator" => Style::new().fg(Color::Yellow),
-        "shape_or" => Style::new().fg(Color::Purple).bold(),
         "shape_pipe" => Style::new().fg(Color::Purple).bold(),
         "shape_range" => Style::new().fg(Color::Yellow).bold(),
         "shape_raw_string" => Style::new().fg(Color::LightMagenta).bold(),

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -576,7 +576,6 @@ impl LanguageServer {
             }
             Id::Value(shape) => {
                 let hover = String::from(match shape {
-                    FlatShape::And => "and",
                     FlatShape::Binary => "binary",
                     FlatShape::Block => "block",
                     FlatShape::Bool => "bool",

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -11,7 +11,6 @@ use std::fmt::{Display, Formatter, Result};
 
 #[derive(Debug, Eq, PartialEq, Ord, Clone, PartialOrd)]
 pub enum FlatShape {
-    And,
     Binary,
     Block,
     Bool,
@@ -36,7 +35,6 @@ pub enum FlatShape {
     MatchPattern,
     Nothing,
     Operator,
-    Or,
     Pipe,
     Range,
     RawString,
@@ -53,7 +51,6 @@ pub enum FlatShape {
 impl FlatShape {
     pub fn as_str(&self) -> &str {
         match self {
-            FlatShape::And => "shape_and",
             FlatShape::Binary => "shape_binary",
             FlatShape::Block => "shape_block",
             FlatShape::Bool => "shape_bool",
@@ -78,7 +75,6 @@ impl FlatShape {
             FlatShape::MatchPattern => "shape_match_pattern",
             FlatShape::Nothing => "shape_nothing",
             FlatShape::Operator => "shape_operator",
-            FlatShape::Or => "shape_or",
             FlatShape::Pipe => "shape_pipe",
             FlatShape::Range => "shape_range",
             FlatShape::RawString => "shape_raw_string",

--- a/crates/nu-std/std/config/mod.nu
+++ b/crates/nu-std/std/config/mod.nu
@@ -26,7 +26,6 @@ export def dark-theme [] {
         block: white
         hints: dark_gray
         search_result: { bg: red fg: white }
-        shape_and: purple_bold
         shape_binary: purple_bold
         shape_block: blue_bold
         shape_bool: light_cyan
@@ -53,7 +52,6 @@ export def dark-theme [] {
         shape_matching_brackets: { attr: u }
         shape_nothing: light_cyan
         shape_operator: yellow
-        shape_or: purple_bold
         shape_pipe: purple_bold
         shape_range: yellow_bold
         shape_record: cyan_bold
@@ -96,7 +94,6 @@ export def light-theme [] {
         block: dark_gray
         hints: dark_gray
         search_result: { fg: white bg: red }
-        shape_and: purple_bold
         shape_binary: purple_bold
         shape_block: blue_bold
         shape_bool: light_cyan
@@ -123,7 +120,6 @@ export def light-theme [] {
         shape_matching_brackets: { attr: u }
         shape_nothing: light_cyan
         shape_operator: yellow
-        shape_or: purple_bold
         shape_pipe: purple_bold
         shape_range: yellow_bold
         shape_record: cyan_bold

--- a/crates/nu-utils/src/default_files/default_config.nu
+++ b/crates/nu-utils/src/default_files/default_config.nu
@@ -23,7 +23,6 @@ $env.config.color_config = {
     block: white
     hints: dark_gray
     search_result: { bg: red fg: white }
-    shape_and: purple_bold
     shape_binary: purple_bold
     shape_block: blue_bold
     shape_bool: light_cyan
@@ -48,7 +47,6 @@ $env.config.color_config = {
     shape_matching_brackets: { attr: u }
     shape_nothing: light_cyan
     shape_operator: yellow
-    shape_or: purple_bold
     shape_pipe: purple_bold
     shape_range: yellow_bold
     shape_record: cyan_bold

--- a/crates/nu-utils/src/default_files/sample_config.nu
+++ b/crates/nu-utils/src/default_files/sample_config.nu
@@ -632,11 +632,6 @@ $env.config.color_config.shape_glob_interpolation
 # an expression is not (yet) properly closed.
 $env.config.color_config.shape_garbage
 
-# shape_or and shape_and: The and and or operators.
-# Note: Not currently implemented.
-$env.config.color_config.shape_or
-$env.config.color_config.shape_and
-
 # shape_variable: The *use* of a variable. E.g., `$env` or `$a`.
 $env.config.color_config.shape_variable
 


### PR DESCRIPTION
# Description
This removes the need for the `shape_and` and `shape_or` entries in the
themes. We did not color those underlying FlatShapes or operators
differently.

Closes #14372
# User-Facing Changes
Our theme handling currently doesn't reject invalid entries so should
not cause an error. The non-functional nature was already documented.

