### PR TITLE
Add label rendering to try/catch rendered errors

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -107,11 +107,7 @@ fn run_catch(
 
     if let Some(catch) = catch {
         stack.set_last_error(&error);
-        let fancy_errors = match engine_state.get_config().error_style {
-            nu_protocol::ErrorStyle::Fancy => true,
-            nu_protocol::ErrorStyle::Plain => false,
-        };
-        let error = error.into_value(span, fancy_errors);
+        let error = error.into_value(&StateWorkingSet::new(engine_state), span);
         let block = engine_state.get_block(catch.block_id);
         // Put the error value in the positional closure var
         if let Some(var) = block.signature.get_positional(0) {

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -139,23 +139,6 @@ impl LabeledError {
         self
     }
 
-    pub fn render_error_to_string(diag: impl miette::Diagnostic, fancy_errors: bool) -> String {
-        let theme = if fancy_errors {
-            miette::GraphicalTheme::unicode()
-        } else {
-            miette::GraphicalTheme::none()
-        };
-
-        let mut out = String::new();
-        miette::GraphicalReportHandler::new()
-            .with_width(80)
-            .with_theme(theme)
-            .render_report(&mut out, &diag)
-            .unwrap_or_default();
-
-        out
-    }
-
     /// Create a [`LabeledError`] from a type that implements [`miette::Diagnostic`].
     ///
     /// # Example

--- a/crates/nu-protocol/src/errors/shell_error.rs
+++ b/crates/nu-protocol/src/errors/shell_error.rs
@@ -1486,7 +1486,7 @@ impl ShellError {
             "msg" => Value::string(self.to_string(), span),
             "debug" => Value::string(format!("{self:?}"), span),
             "raw" => Value::error(self.clone(), span),
-            "rendered" => Value::string(format_shell_error(&working_set, &self), span),
+            "rendered" => Value::string(format_shell_error(working_set, &self), span),
             "json" => Value::string(serde_json::to_string(&self).expect("Could not serialize error"), span),
         };
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->



# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Before this PR, you can access rendered error values that are raised in a `try/catch` block by accessing the `rendered` element of the catch error value:
```
$ try { ls nonexist.txt } catch {|e| print "my cool error:" $e.rendered }
my cool error:
nu::shell::directory_not_found

  × Directory not found
  help: /home/rose/nonexist.txt does not exist
```

However, the rendered errors don't include the labels present in the real rendered error, which would look like this:
```
$ ls nonexist.txt
Error: nu::shell::directory_not_found

  × Directory not found
   ╭─[entry #46:1:4]
 1 │ ls nonexist.txt
   ·    ──────┬─────
   ·          ╰── directory not found
   ╰────
  help: /home/rose/nonexist.txt does not exist
```

After this PR, the rendered error includes the labels:

```
$ try { ls nonexist.txt } catch {|e| print "my cool error:" $e.rendered }
my cool error:
Error: nu::shell::directory_not_found

  × Directory not found
   ╭─[entry #4:1:10]
 1 │ try { ls nonexist.txt } catch {|e| print "my cool error:" $e.rendered }
   ·          ──────┬─────
   ·                ╰── directory not found
   ╰────
  help: /home/rose/nonexist.txt does not exist
```

This change is accomplished by using the standard error formatting code to render an error. This respects the error theme as before without any extra scaffolding, but it means that e.g., the terminal size is also respected. I think this is fine because the way the error is rendered already changed based on config, and I think that a "rendered" error should give back _exactly_ what would be shown to the user anyway.

@fdncred, let me know if you have any concerns with the way this is handled since you were the one who implemented this feature in the first place.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

The `rendered` element of the `try`/`catch` error record now includes labels in the error output. 

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`


# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A