### PR TITLE
Make `timeit` take only closures as an argument

### DIFF
--- a/crates/nu-command/tests/commands/debug/timeit.rs
+++ b/crates/nu-command/tests/commands/debug/timeit.rs
@@ -2,7 +2,7 @@ use nu_test_support::nu;
 
 #[test]
 fn timeit_show_stdout() {
-    let actual = nu!("let t = timeit nu --testbin cococo abcdefg");
+    let actual = nu!("let t = timeit { nu --testbin cococo abcdefg }");
     assert_eq!(actual.out, "abcdefg");
 }
 

--- a/crates/nu-engine/src/closure_eval.rs
+++ b/crates/nu-engine/src/closure_eval.rs
@@ -88,6 +88,29 @@ impl ClosureEval {
         }
     }
 
+    pub fn new_preserve_out_dest(
+        engine_state: &EngineState,
+        stack: &Stack,
+        closure: Closure,
+    ) -> Self {
+        let engine_state = engine_state.clone();
+        let stack = stack.captures_to_stack_preserve_out_dest(closure.captures);
+        let block = engine_state.get_block(closure.block_id).clone();
+        let env_vars = stack.env_vars.clone();
+        let env_hidden = stack.env_hidden.clone();
+        let eval = get_eval_block_with_early_return(&engine_state);
+
+        Self {
+            engine_state,
+            stack,
+            block,
+            arg_index: 0,
+            env_vars,
+            env_hidden,
+            eval,
+        }
+    }
+
     /// Sets whether to enable debugging when evaluating the closure.
     ///
     /// By default, this is controlled by the [`EngineState`] used to create this [`ClosureEval`].
@@ -183,6 +206,22 @@ impl<'a> ClosureEvalOnce<'a> {
         Self {
             engine_state,
             stack: stack.captures_to_stack(closure.captures),
+            block,
+            arg_index: 0,
+            eval,
+        }
+    }
+
+    pub fn new_preserve_out_dest(
+        engine_state: &'a EngineState,
+        stack: &Stack,
+        closure: Closure,
+    ) -> Self {
+        let block = engine_state.get_block(closure.block_id);
+        let eval = get_eval_block_with_early_return(engine_state);
+        Self {
+            engine_state,
+            stack: stack.captures_to_stack_preserve_out_dest(closure.captures),
             block,
             arg_index: 0,
             eval,


### PR DESCRIPTION
# Description

Fixes #14401 where expressions passed to `timeit` will execute twice. This PR removes the expression support for `timeit`, as this behavior is almost exclusive to `timeit` and can hinder migration to the IR evaluator in the future. Additionally, `timeit` used to be able to take a `block` as an argument. Blocks should probably only be allowed for parser keywords, so this PR changes `timeit` to instead only take closures as an argument. This also fixes an issue where environment updates inside the `timeit` block would affect the parent scope and all commands later in the pipeline.

```nu
> timeit { $env.FOO = 'bar' }; print $env.FOO
bar
```

# User-Facing Changes

`timeit` now only takes a closure as the first argument.

# After Submitting

Update examples in the book/docs if necessary.