### PR TITLE
Remove duplicate implementations of `CallExt::rest`

### DIFF
--- a/crates/nu-command/src/bytes/build_.rs
+++ b/crates/nu-command/src/bytes/build_.rs
@@ -1,4 +1,4 @@
-use nu_engine::{command_prelude::*, get_eval_expression};
+use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
 pub struct BytesBuild;
@@ -49,8 +49,7 @@ impl Command for BytesBuild {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let mut output = vec![];
-        let eval_expression = get_eval_expression(engine_state);
-        for val in call.rest_iter_flattened(engine_state, stack, eval_expression, 0)? {
+        for val in call.rest::<Value>(engine_state, stack, 0)? {
             let val_span = val.span();
             match val {
                 Value::Binary { mut val, .. } => output.append(&mut val),

--- a/crates/nu-command/src/filesystem/du.rs
+++ b/crates/nu-command/src/filesystem/du.rs
@@ -1,4 +1,3 @@
-use super::util::get_rest_for_glob_pattern;
 use crate::{DirBuilder, DirInfo, FileInfo};
 #[allow(deprecated)]
 use nu_engine::{command_prelude::*, current_dir};
@@ -101,7 +100,7 @@ impl Command for Du {
         #[allow(deprecated)]
         let current_dir = current_dir(engine_state, stack)?;
 
-        let paths = get_rest_for_glob_pattern(engine_state, stack, call, 0)?;
+        let paths = call.rest::<Spanned<NuGlob>>(engine_state, stack, 0)?;
         let paths = if !call.has_positional_args(stack, 0) {
             None
         } else {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -1,4 +1,3 @@
-use super::util::get_rest_for_glob_pattern;
 use crate::{DirBuilder, DirInfo};
 use chrono::{DateTime, Local, LocalResult, TimeZone, Utc};
 use nu_engine::glob_from;
@@ -114,7 +113,7 @@ impl Command for Ls {
             call_span,
         };
 
-        let pattern_arg = get_rest_for_glob_pattern(engine_state, stack, call, 0)?;
+        let pattern_arg = call.rest::<Spanned<NuGlob>>(engine_state, stack, 0)?;
         let input_pattern_arg = if !call.has_positional_args(stack, 0) {
             None
         } else {

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -1,7 +1,6 @@
-use super::util::get_rest_for_glob_pattern;
 #[allow(deprecated)]
 use nu_engine::{command_prelude::*, current_dir, get_eval_block};
-use nu_protocol::{ast, ByteStream, DataSource, NuGlob, PipelineMetadata};
+use nu_protocol::{ast, DataSource, NuGlob, PipelineMetadata};
 use std::path::Path;
 
 #[cfg(feature = "sqlite")]
@@ -53,7 +52,7 @@ impl Command for Open {
         let call_span = call.head;
         #[allow(deprecated)]
         let cwd = current_dir(engine_state, stack)?;
-        let mut paths = get_rest_for_glob_pattern(engine_state, stack, call, 0)?;
+        let mut paths = call.rest::<Spanned<NuGlob>>(engine_state, stack, 0)?;
         let eval_block = get_eval_block(engine_state);
 
         if paths.is_empty() && !call.has_positional_args(stack, 0) {

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -1,4 +1,4 @@
-use super::util::{get_rest_for_glob_pattern, try_interaction};
+use super::util::try_interaction;
 #[allow(deprecated)]
 use nu_engine::{command_prelude::*, env::current_dir};
 use nu_glob::MatchOptions;
@@ -118,7 +118,7 @@ fn rm(
     let interactive = call.has_flag(engine_state, stack, "interactive")?;
     let interactive_once = call.has_flag(engine_state, stack, "interactive-once")? && !interactive;
 
-    let mut paths = get_rest_for_glob_pattern(engine_state, stack, call, 0)?;
+    let mut paths = call.rest::<Spanned<NuGlob>>(engine_state, stack, 0)?;
 
     if paths.is_empty() {
         return Err(ShellError::MissingParameter {

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -2,10 +2,7 @@ use filetime::FileTime;
 use nu_engine::command_prelude::*;
 use nu_path::expand_path_with;
 use nu_protocol::NuGlob;
-
 use std::{fs::OpenOptions, time::SystemTime};
-
-use super::util::get_rest_for_glob_pattern;
 
 #[derive(Clone)]
 pub struct Touch;
@@ -72,7 +69,7 @@ impl Command for Touch {
         let no_follow_symlinks: bool = call.has_flag(engine_state, stack, "no-deref")?;
         let reference: Option<Spanned<String>> = call.get_flag(engine_state, stack, "reference")?;
         let no_create: bool = call.has_flag(engine_state, stack, "no-create")?;
-        let files: Vec<Spanned<NuGlob>> = get_rest_for_glob_pattern(engine_state, stack, call, 0)?;
+        let files = call.rest::<Spanned<NuGlob>>(engine_state, stack, 0)?;
 
         let cwd = engine_state.cwd(Some(stack))?;
 

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -1,6 +1,6 @@
-use super::util::get_rest_for_glob_pattern;
 #[allow(deprecated)]
 use nu_engine::{command_prelude::*, current_dir};
+use nu_protocol::NuGlob;
 use std::path::PathBuf;
 use uu_cp::{BackupMode, CopyMode, UpdateMode};
 
@@ -156,7 +156,7 @@ impl Command for UCp {
             target_os = "macos"
         )))]
         let reflink_mode = uu_cp::ReflinkMode::Never;
-        let mut paths = get_rest_for_glob_pattern(engine_state, stack, call, 0)?;
+        let mut paths = call.rest::<Spanned<NuGlob>>(engine_state, stack, 0)?;
         if paths.is_empty() {
             return Err(ShellError::GenericError {
                 error: "Missing file operand".into(),

--- a/crates/nu-command/src/filesystem/umkdir.rs
+++ b/crates/nu-command/src/filesystem/umkdir.rs
@@ -1,11 +1,9 @@
 #[allow(deprecated)]
 use nu_engine::{command_prelude::*, current_dir};
-
+use nu_protocol::NuGlob;
 use uu_mkdir::mkdir;
 #[cfg(not(windows))]
 use uucore::mode;
-
-use super::util::get_rest_for_glob_pattern;
 
 #[derive(Clone)]
 pub struct UMkdir;
@@ -61,7 +59,8 @@ impl Command for UMkdir {
     ) -> Result<PipelineData, ShellError> {
         #[allow(deprecated)]
         let cwd = current_dir(engine_state, stack)?;
-        let mut directories = get_rest_for_glob_pattern(engine_state, stack, call, 0)?
+        let mut directories = call
+            .rest::<Spanned<NuGlob>>(engine_state, stack, 0)?
             .into_iter()
             .map(|dir| nu_path::expand_path_with(dir.item.as_ref(), &cwd, dir.item.is_expand()))
             .peekable();

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -1,4 +1,3 @@
-use super::util::get_rest_for_glob_pattern;
 #[allow(deprecated)]
 use nu_engine::{command_prelude::*, current_dir};
 use nu_path::expand_path_with;
@@ -100,7 +99,7 @@ impl Command for UMv {
 
         #[allow(deprecated)]
         let cwd = current_dir(engine_state, stack)?;
-        let mut paths = get_rest_for_glob_pattern(engine_state, stack, call, 0)?;
+        let mut paths = call.rest::<Spanned<NuGlob>>(engine_state, stack, 0)?;
         if paths.is_empty() {
             return Err(ShellError::GenericError {
                 error: "Missing file operand".into(),

--- a/crates/nu-command/src/filesystem/util.rs
+++ b/crates/nu-command/src/filesystem/util.rs
@@ -1,6 +1,4 @@
 use dialoguer::Input;
-use nu_engine::{command_prelude::*, get_eval_expression};
-use nu_protocol::{FromValue, NuGlob};
 use std::{
     error::Error,
     path::{Path, PathBuf},
@@ -88,23 +86,4 @@ pub fn is_older(src: &Path, dst: &Path) -> Option<bool> {
             .unwrap_or(u64::MAX);
         Some(src_ctime <= dst_ctime)
     }
-}
-
-/// Get rest arguments from given `call`, starts with `starting_pos`.
-///
-/// It's similar to `call.rest`, except that it always returns NuGlob.
-pub fn get_rest_for_glob_pattern(
-    engine_state: &EngineState,
-    stack: &mut Stack,
-    call: &Call,
-    starting_pos: usize,
-) -> Result<Vec<Spanned<NuGlob>>, ShellError> {
-    let eval_expression = get_eval_expression(engine_state);
-
-    call.rest_iter_flattened(engine_state, stack, eval_expression, starting_pos)?
-        .into_iter()
-        // This used to be much more complex, but I think `FromValue` should be able to handle the
-        // nuance here.
-        .map(FromValue::from_value)
-        .collect()
 }

--- a/crates/nu-command/src/filesystem/utouch.rs
+++ b/crates/nu-command/src/filesystem/utouch.rs
@@ -1,19 +1,10 @@
-use std::io::ErrorKind;
-use std::path::PathBuf;
-
 use chrono::{DateTime, FixedOffset};
 use filetime::FileTime;
-
-use nu_engine::CallExt;
+use nu_engine::command_prelude::*;
 use nu_path::expand_path_with;
-use nu_protocol::engine::{Call, Command, EngineState, Stack};
-use nu_protocol::{
-    Category, Example, NuGlob, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type,
-};
-use uu_touch::error::TouchError;
-use uu_touch::{ChangeTimes, InputFile, Options, Source};
-
-use super::util::get_rest_for_glob_pattern;
+use nu_protocol::NuGlob;
+use std::{io::ErrorKind, path::PathBuf};
+use uu_touch::{error::TouchError, ChangeTimes, InputFile, Options, Source};
 
 #[derive(Clone)]
 pub struct UTouch;
@@ -91,8 +82,7 @@ impl Command for UTouch {
         let change_atime: bool = call.has_flag(engine_state, stack, "access")?;
         let no_create: bool = call.has_flag(engine_state, stack, "no-create")?;
         let no_deref: bool = call.has_flag(engine_state, stack, "no-dereference")?;
-        let file_globs: Vec<Spanned<NuGlob>> =
-            get_rest_for_glob_pattern(engine_state, stack, call, 0)?;
+        let file_globs = call.rest::<Spanned<NuGlob>>(engine_state, stack, 0)?;
         let cwd = engine_state.cwd(Some(stack))?;
 
         if file_globs.is_empty() {

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -1,5 +1,5 @@
 use nu_cmd_base::hook::eval_hook;
-use nu_engine::{command_prelude::*, env_to_strings, get_eval_expression};
+use nu_engine::{command_prelude::*, env_to_strings};
 use nu_path::{dots::expand_ndots, expand_tilde, AbsolutePath};
 use nu_protocol::{did_you_mean, process::ChildProcess, ByteStream, NuGlob, OutDest, Signals};
 use nu_system::ForegroundChild;
@@ -295,8 +295,7 @@ pub fn eval_arguments_from_call(
     call: &Call,
 ) -> Result<Vec<Spanned<OsString>>, ShellError> {
     let cwd = engine_state.cwd(Some(stack))?;
-    let eval_expression = get_eval_expression(engine_state);
-    let call_args = call.rest_iter_flattened(engine_state, stack, eval_expression, 1)?;
+    let call_args = call.rest::<Value>(engine_state, stack, 1)?;
     let mut args: Vec<Spanned<OsString>> = Vec::with_capacity(call_args.len());
 
     for arg in call_args {

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -121,15 +121,12 @@ impl CallExt for ast::Call {
         starting_pos: usize,
     ) -> Result<Vec<T>, ShellError> {
         let stack = &mut stack.use_call_arg_out_dest();
-        let mut output = vec![];
-
-        for result in self.rest_iter_flattened(starting_pos, |expr| {
+        self.rest_iter_flattened(starting_pos, |expr| {
             eval_expression::<WithoutDebug>(engine_state, stack, expr)
-        })? {
-            output.push(FromValue::from_value(result)?);
-        }
-
-        Ok(output)
+        })?
+        .into_iter()
+        .map(FromValue::from_value)
+        .collect()
     }
 
     fn opt<T: FromValue>(


### PR DESCRIPTION
# Description

Removes unnecessary usages of `Call::rest_iter_flattened` and `get_rest_for_glob_pattern` and replaces them with `CallExt::rest`.

# User-Facing Changes

None