### PR TITLE
Fix missing `installed_plugins` field in `version` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,13 +251,18 @@ tempfile = { workspace = true }
 
 [features]
 plugin = [
-  "nu-plugin-engine",
+  # crates
   "nu-cmd-plugin",
+  "nu-plugin-engine",
+
+  # features
   "nu-cli/plugin",
-  "nu-parser/plugin",
+  "nu-cmd-lang/plugin",
   "nu-command/plugin",
-  "nu-protocol/plugin",
   "nu-engine/plugin",
+  "nu-engine/plugin",
+  "nu-parser/plugin",
+  "nu-protocol/plugin",
 ]
 
 default = [


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
In #14418 I added the `plugin` feature to the crate `nu-cmd-lang`. I forgot to include that feature in the `nushell/plugin` feature. This caused the `version` command to not have the `installed_plugins` field. With this PR I fixed that.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

None 😇

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

Running `version` shows `installed_plugins` again.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

That should be it.
