### PR TITLE
allow `select` to stream more

### DIFF
--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -63,7 +63,7 @@ fn complex_nested_columns() {
 fn fails_if_given_unknown_column_name() {
     let actual = nu!(pipeline(
         r#"
-            echo [
+            [
                 [first_name, last_name, rusty_at, type];
 
                 [Andrés Robalino '10/11/2013' A]
@@ -71,7 +71,6 @@ fn fails_if_given_unknown_column_name() {
                 [Yehuda Katz '10/11/2013' A]
             ]
             | select rrusty_at first_name
-            | length
         "#
     ));
 


### PR DESCRIPTION
# Description

closes https://github.com/nushell/nushell/issues/14487

This PR tries to allow the `select` to stream better by changing the for loops that collected the output into a `Vec<Value>` prior to returning it into a map that returns the data as it is processed.

One curiosity, `select` transforms the input into a `PipelineIterator`. If I remove this code, it still passes all tests. I'm not sure all this `PipelineIterator` code is even needed. I left it for someone to tell me if it's necessary.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
