### PR TITLE
Shorten --max-time in tests and use a more stable error check

### DIFF
--- a/crates/nu-command/tests/commands/network/http/delete.rs
+++ b/crates/nu-command/tests/commands/network/http/delete.rs
@@ -141,5 +141,11 @@ fn http_delete_timeout() {
     ));
 
     assert!(&actual.err.contains("nu::shell::network_failure"));
+
+    #[cfg(not(target_os = "windows"))]
     assert!(&actual.err.contains("timed out reading response"));
+    #[cfg(target_os = "windows")]
+    assert!(&actual
+        .err
+        .contains("did not properly respond after a period of time"));
 }

--- a/crates/nu-command/tests/commands/network/http/delete.rs
+++ b/crates/nu-command/tests/commands/network/http/delete.rs
@@ -131,14 +131,15 @@ fn http_delete_timeout() {
     let _mock = server
         .mock("DELETE", "/")
         .with_chunked_body(|w| {
-            thread::sleep(Duration::from_secs(1));
+            thread::sleep(Duration::from_secs(10));
             w.write_all(b"Delayed response!")
         })
         .create();
 
     let actual = nu!(pipeline(
-        format!("http delete --max-time 500ms {url}", url = server.url()).as_str()
+        format!("http delete --max-time 100ms {url}", url = server.url()).as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::io_error"));
+    assert!(&actual.err.contains("nu::shell::network_failure"));
+    assert!(&actual.err.contains("timed out reading response"));
 }

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -325,14 +325,16 @@ fn http_get_timeout() {
     let _mock = server
         .mock("GET", "/")
         .with_chunked_body(|w| {
-            thread::sleep(Duration::from_secs(1));
+            thread::sleep(Duration::from_secs(10));
             w.write_all(b"Delayed response!")
         })
         .create();
 
     let actual = nu!(pipeline(
-        format!("http get --max-time 500ms {url}", url = server.url()).as_str()
+        format!("http get --max-time 100ms {url}", url = server.url()).as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::io_error"));
+    assert!(&actual.err.contains("nu::shell::network_failure"));
+
+    assert!(&actual.err.contains("timed out reading response"));
 }

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -336,5 +336,10 @@ fn http_get_timeout() {
 
     assert!(&actual.err.contains("nu::shell::network_failure"));
 
+    #[cfg(not(target_os = "windows"))]
     assert!(&actual.err.contains("timed out reading response"));
+    #[cfg(target_os = "windows")]
+    assert!(&actual
+        .err
+        .contains("did not properly respond after a period of time"));
 }

--- a/crates/nu-command/tests/commands/network/http/options.rs
+++ b/crates/nu-command/tests/commands/network/http/options.rs
@@ -61,5 +61,10 @@ fn http_options_timeout() {
 
     assert!(&actual.err.contains("nu::shell::network_failure"));
 
+    #[cfg(not(target_os = "windows"))]
     assert!(&actual.err.contains("timed out reading response"));
+    #[cfg(target_os = "windows")]
+    assert!(&actual
+        .err
+        .contains("did not properly respond after a period of time"));
 }

--- a/crates/nu-command/tests/commands/network/http/options.rs
+++ b/crates/nu-command/tests/commands/network/http/options.rs
@@ -50,14 +50,16 @@ fn http_options_timeout() {
     let _mock = server
         .mock("OPTIONS", "/")
         .with_chunked_body(|w| {
-            thread::sleep(Duration::from_secs(1));
+            thread::sleep(Duration::from_secs(10));
             w.write_all(b"Delayed response!")
         })
         .create();
 
     let actual = nu!(pipeline(
-        format!("http options --max-time 500ms {url}", url = server.url()).as_str()
+        format!("http options --max-time 100ms {url}", url = server.url()).as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::io_error"));
+    assert!(&actual.err.contains("nu::shell::network_failure"));
+
+    assert!(&actual.err.contains("timed out reading response"));
 }

--- a/crates/nu-command/tests/commands/network/http/patch.rs
+++ b/crates/nu-command/tests/commands/network/http/patch.rs
@@ -171,18 +171,20 @@ fn http_patch_timeout() {
     let _mock = server
         .mock("PATCH", "/")
         .with_chunked_body(|w| {
-            thread::sleep(Duration::from_secs(1));
+            thread::sleep(Duration::from_secs(10));
             w.write_all(b"Delayed response!")
         })
         .create();
 
     let actual = nu!(pipeline(
         format!(
-            "http patch --max-time 500ms {url} patchbody",
+            "http patch --max-time 100ms {url} patchbody",
             url = server.url()
         )
         .as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::io_error"));
+    assert!(&actual.err.contains("nu::shell::network_failure"));
+
+    assert!(&actual.err.contains("timed out reading response"));
 }

--- a/crates/nu-command/tests/commands/network/http/patch.rs
+++ b/crates/nu-command/tests/commands/network/http/patch.rs
@@ -186,5 +186,10 @@ fn http_patch_timeout() {
 
     assert!(&actual.err.contains("nu::shell::network_failure"));
 
+    #[cfg(not(target_os = "windows"))]
     assert!(&actual.err.contains("timed out reading response"));
+    #[cfg(target_os = "windows")]
+    assert!(&actual
+        .err
+        .contains("did not properly respond after a period of time"));
 }

--- a/crates/nu-command/tests/commands/network/http/post.rs
+++ b/crates/nu-command/tests/commands/network/http/post.rs
@@ -285,18 +285,20 @@ fn http_post_timeout() {
     let _mock = server
         .mock("POST", "/")
         .with_chunked_body(|w| {
-            thread::sleep(Duration::from_secs(1));
+            thread::sleep(Duration::from_secs(10));
             w.write_all(b"Delayed response!")
         })
         .create();
 
     let actual = nu!(pipeline(
         format!(
-            "http post --max-time 500ms {url} postbody",
+            "http post --max-time 100ms {url} postbody",
             url = server.url()
         )
         .as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::io_error"));
+    assert!(&actual.err.contains("nu::shell::network_failure"));
+
+    assert!(&actual.err.contains("timed out reading response"));
 }

--- a/crates/nu-command/tests/commands/network/http/post.rs
+++ b/crates/nu-command/tests/commands/network/http/post.rs
@@ -300,5 +300,10 @@ fn http_post_timeout() {
 
     assert!(&actual.err.contains("nu::shell::network_failure"));
 
+    #[cfg(not(target_os = "windows"))]
     assert!(&actual.err.contains("timed out reading response"));
+    #[cfg(target_os = "windows")]
+    assert!(&actual
+        .err
+        .contains("did not properly respond after a period of time"));
 }

--- a/crates/nu-command/tests/commands/network/http/put.rs
+++ b/crates/nu-command/tests/commands/network/http/put.rs
@@ -171,18 +171,20 @@ fn http_put_timeout() {
     let _mock = server
         .mock("PUT", "/")
         .with_chunked_body(|w| {
-            thread::sleep(Duration::from_secs(1));
+            thread::sleep(Duration::from_secs(10));
             w.write_all(b"Delayed response!")
         })
         .create();
 
     let actual = nu!(pipeline(
         format!(
-            "http put --max-time 500ms {url} putbody",
+            "http put --max-time 100ms {url} putbody",
             url = server.url()
         )
         .as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::io_error"));
+    assert!(&actual.err.contains("nu::shell::network_failure"));
+
+    assert!(&actual.err.contains("timed out reading response"));
 }

--- a/crates/nu-command/tests/commands/network/http/put.rs
+++ b/crates/nu-command/tests/commands/network/http/put.rs
@@ -186,5 +186,10 @@ fn http_put_timeout() {
 
     assert!(&actual.err.contains("nu::shell::network_failure"));
 
+    #[cfg(not(target_os = "windows"))]
     assert!(&actual.err.contains("timed out reading response"));
+    #[cfg(target_os = "windows")]
+    assert!(&actual
+        .err
+        .contains("did not properly respond after a period of time"));
 }

--- a/crates/nu-protocol/src/errors/shell_error.rs
+++ b/crates/nu-protocol/src/errors/shell_error.rs
@@ -1544,8 +1544,8 @@ impl From<io::Error> for ShellError {
 impl From<Spanned<io::Error>> for ShellError {
     fn from(error: Spanned<io::Error>) -> Self {
         let Spanned { item: error, span } = error;
-        if error.kind() == io::ErrorKind::Other {
-            match error.into_inner() {
+        match error.kind() {
+            io::ErrorKind::Other => match error.into_inner() {
                 Some(err) => match err.downcast() {
                     Ok(err) => *err,
                     Err(err) => Self::IOErrorSpanned {
@@ -1557,12 +1557,15 @@ impl From<Spanned<io::Error>> for ShellError {
                     msg: "unknown error".into(),
                     span,
                 },
-            }
-        } else {
-            Self::IOErrorSpanned {
+            },
+            io::ErrorKind::TimedOut => Self::NetworkFailure {
                 msg: error.to_string(),
                 span,
-            }
+            },
+            _ => Self::IOErrorSpanned {
+                msg: error.to_string(),
+                span,
+            },
         }
     }
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.


you can also mention related issues, PRs or discussions!
-->

- fixes flakey tests from solving #14241

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

@sholderbach: This is a preliminary fix for the flaky tests and also shortened the `--max-time` in the tests.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
