### PR TITLE
Bump titlecase dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2549,12 +2549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "joinery"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
-
-[[package]]
 name = "js-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6992,12 +6986,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "titlecase"
-version = "2.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38397a8cdb017cfeb48bf6c154d6de975ac69ffeed35980fde199d2ee0842042"
+checksum = "e0e20e744fbec1913fa168f3ffbef64324bbcb152c6cda8394baa79fa5ec9142"
 dependencies = [
- "joinery",
- "lazy_static",
  "regex",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ sysinfo = "0.32"
 tabled = { version = "0.16.0", default-features = false }
 tempfile = "3.14"
 terminal_size = "0.4"
-titlecase = "2.0"
+titlecase = "3.0"
 toml = "0.8"
 trash = "5.2"
 umask = "2.1"


### PR DESCRIPTION
# Description

v3 drops the dependency on joinery, as well as on lazy_static. The MSRV is bumped to 1.70.0 but that is still way below what nushell requires.

# User-Facing Changes

N/A

# Tests + Formatting

All tests pass (including nu-command which is the direct user)

# After Submitting

N/A