### PR TITLE
Only run `from_string` conversion on strings

### DIFF
--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -40,14 +40,20 @@ pub fn convert_env_values(engine_state: &mut EngineState, stack: &Stack) -> Resu
     let env_vars = engine_state.render_env_vars();
 
     for (name, val) in env_vars {
-        match get_converted_value(engine_state, stack, name, val, "from_string") {
-            ConversionResult::Ok(v) => {
-                let _ = new_scope.insert(name.to_string(), v);
+        if let Value::String { .. } = val {
+            // Only run from_string on string values
+            match get_converted_value(engine_state, stack, name, val, "from_string") {
+                ConversionResult::Ok(v) => {
+                    let _ = new_scope.insert(name.to_string(), v);
+                }
+                ConversionResult::ConversionError(e) => error = error.or(Some(e)),
+                ConversionResult::CellPathError => {
+                    let _ = new_scope.insert(name.to_string(), val.clone());
+                }
             }
-            ConversionResult::ConversionError(e) => error = error.or(Some(e)),
-            ConversionResult::CellPathError => {
-                let _ = new_scope.insert(name.to_string(), val.clone());
-            }
+        } else {
+            // Skip values that are already converted (not a string)
+            let _ = new_scope.insert(name.to_string(), val.clone());
         }
     }
 


### PR DESCRIPTION
# Description

#14249 loaded `convert_env_values()` several times to force more updates to `ENV_CONVERSION`.  This allows the user to treat variables as structured data inside `config.nu` (and others).

Unfortunately, `convert_env_values()` did not originally anticipate being called more than once, so it would attempt to re-convert values that had already been converted.  This usually leads to an error in the conversion closure.

With this PR, values are only converted with `from_string` if they are still strings; otherwise they are skipped and their existing value is used.

# User-Facing Changes

 No user-facing change when compared to 0.100, since closures written for 0.100's `ENV_CONVERSION` now work again without errors.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
- 
# After Submitting

Will remove the "workaround" from the Config doc preview.