### PR TITLE
Change tests which may invoke externals to use non-conflicting names

### DIFF
--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -284,9 +284,9 @@ fn use_main_def_known_external() {
 #[test]
 fn use_main_not_exported() {
     let inp = &[
-        r#"module spam { def main [] { "spam" } }"#,
-        r#"use spam"#,
-        r#"spam"#,
+        r#"module my-super-cool-and-unique-module-name { def main [] { "hi" } }"#,
+        r#"use my-super-cool-and-unique-module-name"#,
+        r#"my-super-cool-and-unique-module-name"#,
     ];
 
     let actual = nu!(&inp.join("; "));

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -807,10 +807,10 @@ fn overlay_can_add_renamed_overlay() {
 #[test]
 fn overlay_hide_renamed_overlay() {
     let inp = &[
-        r#"module spam { export def foo [] { "foo" } }"#,
+        r#"module spam { export def foo-command-which-does-not-conflict [] { "foo" } }"#,
         "overlay use spam as eggs",
         "overlay hide eggs",
-        "foo",
+        "foo-command-which-does-not-conflict",
     ];
 
     let actual = nu!(&inp.join("; "));
@@ -1243,9 +1243,9 @@ fn overlay_use_main_def_known_external() {
 #[test]
 fn overlay_use_main_not_exported() {
     let inp = &[
-        r#"module foo { def main [] { "foo" } }"#,
-        "overlay use foo",
-        "foo",
+        r#"module my-super-cool-and-unique-module-name { def main [] { "hi" } }"#,
+        "overlay use my-super-cool-and-unique-module-name",
+        "my-super-cool-and-unique-module-name",
     ];
 
     let actual = nu!(&inp.join("; "));
@@ -1257,11 +1257,11 @@ fn overlay_use_main_not_exported() {
 fn alias_overlay_hide() {
     let inp = &[
         "overlay new spam",
-        "def foo [] { 'foo' }",
+        "def my-epic-command-name [] { 'foo' }",
         "overlay new eggs",
         "alias oh = overlay hide",
         "oh spam",
-        "foo",
+        "my-epic-command-name",
     ];
 
     let actual = nu!(&inp.join("; "));


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

Fixes #14515
Also tweaks the fix from #11261 _just in case_ someone has a `foo` executable


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
N/A

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
