### PR TITLE
fix multiline strings in NDNUON

### DIFF
--- a/crates/nu-std/tests/test_formats.nu
+++ b/crates/nu-std/tests/test_formats.nu
@@ -128,3 +128,17 @@ def to_ndnuon_single_object [] {
   let expect = "{a: 1}"
   assert equal $result $expect "could not convert to NDNUON"
 }
+
+#[test]
+def to_ndnuon_multiline_strings [] {
+  let result = "foo\n\\n\nbar" | to ndnuon
+  let expect = '"foo\n\\n\nbar"'
+  assert equal $result $expect "could not convert multiline string to NDNUON"
+}
+
+#[test]
+def from_ndnuon_multiline_strings [] {
+  let result = '"foo\n\\n\nbar"' | from ndnuon
+  let expect = ["foo\n\\n\nbar"]
+  assert equal $result $expect "could not convert multiline string from NDNUON"
+}

--- a/crates/nu-std/tests/test_std_formats.nu
+++ b/crates/nu-std/tests/test_std_formats.nu
@@ -128,3 +128,17 @@ def to_ndnuon_single_object [] {
   let expect = "{a: 1}"
   assert equal $result $expect "could not convert to NDNUON"
 }
+
+#[test]
+def to_ndnuon_multiline_strings [] {
+  let result = "foo\n\\n\nbar" | formats to ndnuon
+  let expect = '"foo\n\\n\nbar"'
+  assert equal $result $expect "could not convert multiline string to NDNUON"
+}
+
+#[test]
+def from_ndnuon_multiline_strings [] {
+  let result = '"foo\n\\n\nbar"' | formats from ndnuon
+  let expect = ["foo\n\\n\nbar"]
+  assert equal $result $expect "could not convert multiline string from NDNUON"
+}


### PR DESCRIPTION
- should close https://github.com/nushell/nushell/issues/14517

# Description
this will change `to ndnuon` so that newlines are encoded as a literal `\n` which `from ndnuon` is already able to handle

# User-Facing Changes
users should be able to encode multiline strings in NDNUON

# Tests + Formatting
new tests have been added:
- they don't pass on the first commit
- they do pass with the fix

# After Submitting
