### PR TITLE
Improve `sleep` example using multiple durations

### DIFF
--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -70,8 +70,8 @@ impl Command for Sleep {
                 result: Some(Value::nothing(Span::test_data())),
             },
             Example {
-                description: "Sleep for 3sec",
-                example: "sleep 1sec 1sec 1sec",
+                description: "Use multiple arguments to write a duration with multiple units, which is unsupported by duration literals",
+                example: "sleep 1min 30sec",
                 result: None,
             },
             Example {


### PR DESCRIPTION
It is to cheat our parser and not to repeat yourself.
