### PR TITLE
Fix `table` command when targeting WASM

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -136,7 +136,12 @@ impl Command for Table {
             let _ = nu_utils::enable_vt_processing();
         }
 
-        handle_table_command(input, cfg, #[cfg(feature = "os")] cwd)
+        handle_table_command(
+            input,
+            cfg,
+            #[cfg(feature = "os")]
+            cwd,
+        )
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -368,8 +373,7 @@ impl<'a> CmdInput<'a> {
 fn handle_table_command(
     mut input: CmdInput<'_>,
     cfg: TableConfig,
-    #[cfg(feature = "os")]
-    cwd: nu_path::PathBuf<Absolute>,
+    #[cfg(feature = "os")] cwd: nu_path::PathBuf<Absolute>,
 ) -> Result<PipelineData, ShellError> {
     let span = input.data.span().unwrap_or(input.call.head);
     match input.data {
@@ -392,11 +396,25 @@ fn handle_table_command(
             let stream = ListStream::new(vals.into_iter(), span, signals);
             input.data = PipelineData::Empty;
 
-            handle_row_stream(input, cfg, stream, metadata, #[cfg(feature = "os")] cwd)
+            handle_row_stream(
+                input,
+                cfg,
+                stream,
+                metadata,
+                #[cfg(feature = "os")]
+                cwd,
+            )
         }
         PipelineData::ListStream(stream, metadata) => {
             input.data = PipelineData::Empty;
-            handle_row_stream(input, cfg, stream, metadata, #[cfg(feature = "os")] cwd)
+            handle_row_stream(
+                input,
+                cfg,
+                stream,
+                metadata,
+                #[cfg(feature = "os")]
+                cwd,
+            )
         }
         PipelineData::Value(Value::Record { val, .. }, ..) => {
             input.data = PipelineData::Empty;
@@ -416,7 +434,14 @@ fn handle_table_command(
             let stream =
                 ListStream::new(val.into_range_iter(span, Signals::empty()), span, signals);
             input.data = PipelineData::Empty;
-            handle_row_stream(input, cfg, stream, metadata, #[cfg(feature = "os")] cwd)
+            handle_row_stream(
+                input,
+                cfg,
+                stream,
+                metadata,
+                #[cfg(feature = "os")]
+                cwd,
+            )
         }
         x => Ok(x),
     }
@@ -608,8 +633,7 @@ fn handle_row_stream(
     cfg: TableConfig,
     stream: ListStream,
     metadata: Option<PipelineMetadata>,
-    #[cfg(feature = "os")]
-    cwd: nu_path::PathBuf<Absolute>,
+    #[cfg(feature = "os")] cwd: nu_path::PathBuf<Absolute>,
 ) -> Result<PipelineData, ShellError> {
     let stream = match metadata.as_ref() {
         // First, `ls` sources:
@@ -639,9 +663,14 @@ fn handle_row_stream(
                     if let Some(value) = record.to_mut().get_mut("name") {
                         let span = value.span();
                         if let Value::String { val, .. } = value {
-                            if let Some(val) =
-                                render_path_name(val, &config, &ls_colors, #[cfg(feature = "os")] cwd.clone(), span)
-                            {
+                            if let Some(val) = render_path_name(
+                                val,
+                                &config,
+                                &ls_colors,
+                                #[cfg(feature = "os")]
+                                cwd.clone(),
+                                span,
+                            ) {
                                 *value = val;
                             }
                         }
@@ -1034,8 +1063,7 @@ fn render_path_name(
     path: &str,
     config: &Config,
     ls_colors: &LsColors,
-    #[cfg(feature = "os")]
-    cwd: nu_path::PathBuf<Absolute>,
+    #[cfg(feature = "os")] cwd: nu_path::PathBuf<Absolute>,
     span: Span,
 ) -> Option<Value> {
     if !config.ls.use_ls_colors {
@@ -1046,7 +1074,7 @@ fn render_path_name(
     let fullpath = cwd.join(path);
     #[cfg(not(feature = "os"))]
     let fullpath = path;
-    
+
     let stripped_path = nu_utils::strip_ansi_unlikely(path);
     let metadata = std::fs::symlink_metadata(fullpath);
     let has_metadata = metadata.is_ok();


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
In this PR I made the `cwd` parameter in the functions from the `table` command not used when targeting `not(feature = "os)`. As without an OS and therefore without filesystem we don't have any real concept of a current working directory. This allows using the `table` command in the WASM context.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
None.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
My tests timed out on the http stuff but I cannot think why this would trigger a test failure. Let's see what the CI finds out.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
