### PR TITLE
Deprecate `env.nu` and replace with `preconfig.nu`

### DIFF
--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -118,6 +118,7 @@ const REGEX_CACHE_SIZE: usize = 100; // must be nonzero, otherwise will panic
 pub const NU_VARIABLE_ID: VarId = VarId::new(0);
 pub const IN_VARIABLE_ID: VarId = VarId::new(1);
 pub const ENV_VARIABLE_ID: VarId = VarId::new(2);
+pub const LIB_DIRS_VARIABLE_ID: VarId = VarId::new(3);
 // NOTE: If you add more to this list, make sure to update the > checks based on the last in the list
 
 // The first span is unknown span

--- a/crates/nu-utils/src/default_files/default_env.nu
+++ b/crates/nu-utils/src/default_files/default_env.nu
@@ -1,57 +1,5 @@
 # Default Nushell Environment Config File
-# These "sensible defaults" are set before the user's `env.nu` is loaded
+#
+# This file is deprecated and has been replaced by default_preconfig.nu
 #
 # version = "0.100.1"
-
-$env.PROMPT_COMMAND = $env.PROMPT_COMMAND? | default {|| 
-    let dir = match (do -i { $env.PWD | path relative-to $nu.home-path }) {
-        null => $env.PWD
-        '' => '~'
-        $relative_pwd => ([~ $relative_pwd] | path join)
-    }
-
-    let path_color = (if (is-admin) { ansi red_bold } else { ansi green_bold })
-    let separator_color = (if (is-admin) { ansi light_red_bold } else { ansi light_green_bold })
-    let path_segment = $"($path_color)($dir)(ansi reset)"
-
-    $path_segment | str replace --all (char path_sep) $"($separator_color)(char path_sep)($path_color)"
-}
-
-$env.PROMPT_INDICATOR = $env.PROMPT_INDICATOR? | default "> "
-$env.PROMPT_INDICATOR_VI_NORMAL = $env.PROMPT_INDICATOR_VI_NORMAL? | default "> "
-$env.PROMPT_INDICATOR_VI_INSERT = $env.PROMPT_INDICATOR_VI_INSERT? | default ": "
-$env.PROMPT_MULTILINE_INDICATOR = $env.PROMPT_MULTILINE_INDICATOR? | default "::: "
-
-$env.PROMPT_COMMAND_RIGHT = $env.PROMPT_COMMAND_RIGHT? | default {|| 
-    # create a right prompt in magenta with green separators and am/pm underlined
-    let time_segment = ([
-        (ansi reset)
-        (ansi magenta)
-        (date now | format date '%x %X') # try to respect user's locale
-    ] | str join | str replace --regex --all "([/:])" $"(ansi green)${1}(ansi magenta)" |
-        str replace --regex --all "([AP]M)" $"(ansi magenta_underline)${1}")
-
-    let last_exit_code = if ($env.LAST_EXIT_CODE != 0) {([
-        (ansi rb)
-        ($env.LAST_EXIT_CODE)
-    ] | str join)
-    } else { "" }
-
-    ([$last_exit_code, (char space), $time_segment] | str join)
-}
-
-$env.ENV_CONVERSIONS = {
-    "PATH": {
-        from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
-        to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
-    }
-}
-
-$env.NU_LIB_DIRS = $env.NU_LIB_DIRS? | default [
-    ($nu.default-config-dir | path join 'scripts') # add <nushell-config-dir>/scripts
-    ($nu.data-dir | path join 'completions') # default home for nushell completions
-]
-
-$env.NU_PLUGIN_DIRS = $env.NU_PLUGIN_DIRS | default [
-    ($nu.default-config-dir | path join 'plugins') # add <nushell-config-dir>/plugins
-]

--- a/crates/nu-utils/src/default_files/default_preconfig.nu
+++ b/crates/nu-utils/src/default_files/default_preconfig.nu
@@ -1,0 +1,57 @@
+# Default Nushell Environment Config File
+# These "sensible defaults" are set before the user's `env.nu` is loaded
+#
+# version = "0.100.1"
+
+$env.PROMPT_COMMAND = $env.PROMPT_COMMAND? | default {|| 
+    let dir = match (do -i { $env.PWD | path relative-to $nu.home-path }) {
+        null => $env.PWD
+        '' => '~'
+        $relative_pwd => ([~ $relative_pwd] | path join)
+    }
+
+    let path_color = (if (is-admin) { ansi red_bold } else { ansi green_bold })
+    let separator_color = (if (is-admin) { ansi light_red_bold } else { ansi light_green_bold })
+    let path_segment = $"($path_color)($dir)(ansi reset)"
+
+    $path_segment | str replace --all (char path_sep) $"($separator_color)(char path_sep)($path_color)"
+}
+
+$env.PROMPT_INDICATOR = $env.PROMPT_INDICATOR? | default "> "
+$env.PROMPT_INDICATOR_VI_NORMAL = $env.PROMPT_INDICATOR_VI_NORMAL? | default "> "
+$env.PROMPT_INDICATOR_VI_INSERT = $env.PROMPT_INDICATOR_VI_INSERT? | default ": "
+$env.PROMPT_MULTILINE_INDICATOR = $env.PROMPT_MULTILINE_INDICATOR? | default "::: "
+
+$env.PROMPT_COMMAND_RIGHT = $env.PROMPT_COMMAND_RIGHT? | default {|| 
+    # create a right prompt in magenta with green separators and am/pm underlined
+    let time_segment = ([
+        (ansi reset)
+        (ansi magenta)
+        (date now | format date '%x %X') # try to respect user's locale
+    ] | str join | str replace --regex --all "([/:])" $"(ansi green)${1}(ansi magenta)" |
+        str replace --regex --all "([AP]M)" $"(ansi magenta_underline)${1}")
+
+    let last_exit_code = if ($env.LAST_EXIT_CODE != 0) {([
+        (ansi rb)
+        ($env.LAST_EXIT_CODE)
+    ] | str join)
+    } else { "" }
+
+    ([$last_exit_code, (char space), $time_segment] | str join)
+}
+
+$env.ENV_CONVERSIONS = {
+    "PATH": {
+        from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
+        to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
+    }
+}
+
+$env.NU_LIB_DIRS = $env.NU_LIB_DIRS? | default [
+    ($nu.default-config-dir | path join 'scripts') # add <nushell-config-dir>/scripts
+    ($nu.data-dir | path join 'completions') # default home for nushell completions
+]
+
+$env.NU_PLUGIN_DIRS = $env.NU_PLUGIN_DIRS | default [
+    ($nu.default-config-dir | path join 'plugins') # add <nushell-config-dir>/plugins
+]

--- a/crates/nu-utils/src/default_files/scaffold_preconfig.nu
+++ b/crates/nu-utils/src/default_files/scaffold_preconfig.nu
@@ -1,0 +1,3 @@
+# preconfig.nu
+#
+# This file is a placeholder. It is not currently used.

--- a/crates/nu-utils/src/lib.rs
+++ b/crates/nu-utils/src/lib.rs
@@ -10,8 +10,8 @@ pub mod utils;
 
 pub use locale::get_system_locale;
 pub use utils::{
-    enable_vt_processing, get_default_config, get_default_env, get_ls_colors, get_sample_config,
-    get_sample_env, get_scaffold_config, get_scaffold_env, stderr_write_all_and_flush,
+    enable_vt_processing, get_default_config, get_default_env, get_default_preconfig, get_ls_colors, get_sample_config,
+    get_sample_env, get_scaffold_config, get_scaffold_preconfig, stderr_write_all_and_flush,
     stdout_write_all_and_flush, terminal_size,
 };
 

--- a/crates/nu-utils/src/utils.rs
+++ b/crates/nu-utils/src/utils.rs
@@ -86,14 +86,26 @@ where
 }
 
 // See default_files/README.md for a description of these files
+
+// Deprecated
 pub fn get_default_env() -> &'static str {
     include_str!("default_files/default_env.nu")
 }
 
+pub fn get_default_preconfig() -> &'static str {
+    include_str!("default_files/default_preconfig.nu")
+}
+
+// Deprecated
 pub fn get_scaffold_env() -> &'static str {
     include_str!("default_files/scaffold_env.nu")
 }
 
+pub fn get_scaffold_preconfig() -> &'static str {
+    include_str!("default_files/scaffold_preconfig.nu")
+}
+
+// Deprecated
 pub fn get_sample_env() -> &'static str {
     include_str!("default_files/sample_env.nu")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,8 +95,8 @@ fn main() -> Result<()> {
     ctrlc_protection(&mut engine_state);
 
     // Begin: Default NU_LIB_DIRS, NU_PLUGIN_DIRS
-    // Set default NU_LIB_DIRS and NU_PLUGIN_DIRS here before the env.nu is processed. If
-    // the env.nu file exists, these values will be overwritten, if it does not exist, or
+    // Set default NU_LIB_DIRS and NU_PLUGIN_DIRS here before the preconfig.nu is processed. If
+    // the preconfig.nu file exists, these values will be overwritten, if it does not exist, or
     // there is an error reading it, these values will be used.
     let nushell_config_path: PathBuf = nu_path::nu_config_dir().map(Into::into).unwrap_or_default();
     if let Ok(xdg_config_home) = std::env::var("XDG_CONFIG_HOME") {
@@ -244,9 +244,9 @@ fn main() -> Result<()> {
     set_config_path(
         &mut engine_state,
         init_cwd.as_ref(),
-        "env.nu",
-        "env-path",
-        parsed_nu_cli_args.env_file.as_ref(),
+        "preconfig.nu",
+        "preconfig-path",
+        parsed_nu_cli_args.preconfig_file.as_ref(),
     );
     perf!("set_config_path", start_time, use_color);
 
@@ -425,7 +425,7 @@ fn main() -> Result<()> {
                 #[cfg(feature = "plugin")]
                 parsed_nu_cli_args.plugin_file,
                 parsed_nu_cli_args.config_file,
-                parsed_nu_cli_args.env_file,
+                parsed_nu_cli_args.preconfig_file,
                 false,
             );
         }

--- a/src/run.rs
+++ b/src/run.rs
@@ -54,7 +54,7 @@ pub(crate) fn run_commands(
     init_pwd_per_drive(engine_state, &mut stack);
 
     // if the --no-config-file(-n) option is NOT passed, load the plugin file,
-    // load the default env file or custom (depending on parsed_nu_cli_args.env_file),
+    // load the default preconfig file and perhaps custom (depending on parsed_nu_cli_args.preconfig_file),
     // and maybe a custom config file (depending on parsed_nu_cli_args.config_file)
     //
     // if the --no-config-file(-n) flag is passed, do not load plugin, env, or config files
@@ -65,20 +65,20 @@ pub(crate) fn run_commands(
         perf!("read plugins", start_time, use_color);
 
         let start_time = std::time::Instant::now();
-        // If we have a env file parameter *OR* we have a login shell parameter, read the env file
-        if parsed_nu_cli_args.env_file.is_some() || parsed_nu_cli_args.login_shell.is_some() {
+        // If we have a preconfig file parameter *OR* we have a login shell parameter, read the preconfig file
+        if parsed_nu_cli_args.preconfig_file.is_some() || parsed_nu_cli_args.login_shell.is_some() {
             config_files::read_config_file(
                 engine_state,
                 &mut stack,
-                parsed_nu_cli_args.env_file,
+                parsed_nu_cli_args.preconfig_file,
                 true,
                 create_scaffold,
             );
         } else {
-            config_files::read_default_env_file(engine_state, &mut stack)
+            config_files::read_default_preconfig_file(engine_state, &mut stack)
         }
 
-        perf!("read env.nu", start_time, use_color);
+        perf!("read preconfig.nu", start_time, use_color);
 
         let start_time = std::time::Instant::now();
         let create_scaffold = nu_path::nu_config_dir().map_or(false, |p| !p.exists());
@@ -145,10 +145,10 @@ pub(crate) fn run_file(
     init_pwd_per_drive(engine_state, &mut stack);
 
     // if the --no-config-file(-n) option is NOT passed, load the plugin file,
-    // load the default env file or custom (depending on parsed_nu_cli_args.env_file),
+    // load the default preconfig file and perhaps a custom (depending on parsed_nu_cli_args.preconfig_file),
     // and maybe a custom config file (depending on parsed_nu_cli_args.config_file)
     //
-    // if the --no-config-file(-n) flag is passed, do not load plugin, env, or config files
+    // if the --no-config-file(-n) flag is passed, do not load plugin, preconfig, or config files
     if parsed_nu_cli_args.no_config_file.is_none() {
         let start_time = std::time::Instant::now();
         let create_scaffold = nu_path::nu_config_dir().map_or(false, |p| !p.exists());
@@ -157,19 +157,19 @@ pub(crate) fn run_file(
         perf!("read plugins", start_time, use_color);
 
         let start_time = std::time::Instant::now();
-        // only want to load config and env if relative argument is provided.
-        if parsed_nu_cli_args.env_file.is_some() {
+        // only want to load preconfig and config if relative argument is provided.
+        if parsed_nu_cli_args.preconfig_file.is_some() {
             config_files::read_config_file(
                 engine_state,
                 &mut stack,
-                parsed_nu_cli_args.env_file,
+                parsed_nu_cli_args.preconfig_file,
                 true,
                 create_scaffold,
             );
         } else {
-            config_files::read_default_env_file(engine_state, &mut stack)
+            config_files::read_default_preconfig_file(engine_state, &mut stack)
         }
-        perf!("read env.nu", start_time, use_color);
+        perf!("read preconfig.nu", start_time, use_color);
 
         let start_time = std::time::Instant::now();
         if parsed_nu_cli_args.config_file.is_some() {
@@ -222,7 +222,7 @@ pub(crate) fn run_repl(
             #[cfg(feature = "plugin")]
             parsed_nu_cli_args.plugin_file,
             parsed_nu_cli_args.config_file,
-            parsed_nu_cli_args.env_file,
+            parsed_nu_cli_args.preconfig_file,
             parsed_nu_cli_args.login_shell.is_some(),
         );
     }


### PR DESCRIPTION
# Description

On this week's call, we decides that as part of the `env.nu` deprecation we will provide an alternative `preconfig.nu` that will be read before `config.nu`. It is optional in most cases, but will provide an "escape hatch" if someone truly needs something in place before their `config.nu`.  Currently, this includes:
  - Setting up any `ENV_CONVERSIONS` that will be used in `config.nu` (hopefully we can remove this requirement in a future PR)
  - "Meta-hacks" which write files that can subsequently be sourced or imported in `config.nu`

Our general recommendation going forward will be for all configuration, including environment, to be done in `config.nu`, but a user could continue to separate environment into `preconfig.nu` if they wish.

Also:

* We will not create a `preconfig.nu` on first start; just `config.nu`
* Temporarily, for a deprecation period, if there is no `preconfig.nu`, but `env.nu` does exists, we will read it but also provide a deprecation warning.
* We will never read both `env.nu` and `preconfig.nu` automatically.

This is currently DRAFT, with several TODO's:

* Update `config env`
* Probably *not* create an alternative `config preconfig`
* Update tests
* Update documentation (not gating for PR itself)

# User-Facing Changes

If a user is using an `env.nu`, they will see a warning at startup pointing them to use `preconfig.nu` instead. This can be a simple copy or rename.

# Tests + Formatting

TODO - I haven't even fixed `fmt` warnings at this point. I just wanted to get it up here for any discussion.

# After Submitting

TODO