### PR TITLE
rewrite error message to not use the word `function`

### DIFF
--- a/crates/nu-protocol/src/errors/shell_error.rs
+++ b/crates/nu-protocol/src/errors/shell_error.rs
@@ -1220,10 +1220,10 @@ pub enum ShellError {
         span: Span,
     },
 
-    /// Return event, which may become an error if used outside of a function
-    #[error("Return used outside of function")]
+    /// Return event, which may become an error if used outside of a custom command or closure
+    #[error("Return used outside of custom command or closure")]
     Return {
-        #[label("used outside of function")]
+        #[label("used outside of custom command or closure")]
         span: Span,
         value: Box<Value>,
     },


### PR DESCRIPTION
# Description

After [the discussion on discord](https://discord.com/channels/601130461678272522/601130461678272524/1314600410882904125) I propose to rephrase the error message to avoid using the word `function`. 

From `Return used outside of function` to `Return used outside of custom command or closure`

![image](https://github.com/user-attachments/assets/d14331c8-e381-4b04-8709-bd6064e0791e)



# User-Facing Changes

None

# Tests + Formatting

toolkit.nu fmt is good