### PR TITLE
lsp and --ide-check fix for `path self` related diagnostics

### DIFF
--- a/crates/nu-lsp/src/diagnostics.rs
+++ b/crates/nu-lsp/src/diagnostics.rs
@@ -7,7 +7,7 @@ use miette::{IntoDiagnostic, Result};
 use nu_parser::parse;
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
-    Value,
+    Span, Value,
 };
 
 impl LanguageServer {
@@ -28,6 +28,7 @@ impl LanguageServer {
 
         let contents = rope_of_file.bytes().collect::<Vec<u8>>();
         let offset = working_set.next_span_start();
+        working_set.files.push(file_path.into(), Span::unknown())?;
         parse(
             &mut working_set,
             Some(&file_path.to_string_lossy()),

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -274,6 +274,9 @@ impl LanguageServer {
 
         // TODO: think about passing down the rope into the working_set
         let contents = file.bytes().collect::<Vec<u8>>();
+        let _ = working_set
+            .files
+            .push(file_path.as_ref().into(), Span::unknown());
         let block = parse(working_set, Some(&file_path), &contents, false);
         let flattened = flatten_block(working_set, &block);
 

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -24,6 +24,7 @@ fn find_id(
 ) -> Option<(Id, usize, Span)> {
     let file_id = working_set.add_file(file_path.to_string(), file);
     let offset = working_set.get_span_for_file(file_id).start;
+    let _ = working_set.files.push(file_path.into(), Span::unknown());
     let block = parse(working_set, Some(file_path), file, false);
     let flattened = flatten_block(working_set, &block);
 
@@ -88,6 +89,7 @@ pub fn check(engine_state: &mut EngineState, file_path: &str, max_errors: &Value
 
     if let Ok(contents) = file {
         let offset = working_set.next_span_start();
+        let _ = working_set.files.push(file_path.into(), Span::unknown());
         let block = parse(&mut working_set, Some(file_path), &contents, false);
 
         for (idx, err) in working_set.parse_errors.iter().enumerate() {
@@ -631,6 +633,7 @@ pub fn ast(engine_state: &mut EngineState, file_path: &str) {
 
     if let Ok(contents) = file {
         let offset = working_set.next_span_start();
+        let _ = working_set.files.push(file_path.into(), Span::unknown());
         let parsed_block = parse(&mut working_set, Some(file_path), &contents, false);
 
         let flat = flatten_block(&working_set, &parsed_block);


### PR DESCRIPTION
# Description

fixes [this](https://github.com/nushell/nushell/pull/14303#issuecomment-2525100480) where lsp and ide integration would produce the following error

---

```sh
nu --ide-check 100 "/path/to/env.nu"
```
with
```nu
const const_env = path self
```
would lead to
```
Error: nu::shell::file_not_found

  × File not found
   ╭─[/path/to/env.nu:1:19]
 1 │ const const_env = path self
   ·                   ────┬────
   ·                       ╰── Couldn't find current file
   ╰────
```

# Tests + Formatting
- :green_circle: `cargo fmt --all`
- :green_circle: `cargo clippy --workspace`