### PR TITLE
add dateparser crate to allow more parsing more datetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,6 +1234,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
+name = "dateparser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ef451feee09ae5ecd8a02e738bd9adee9266b8fa9b44e22d3ce968d8694238"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,18 +1402,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
-]
-
-[[package]]
-name = "dtparse"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb403c0926d35af2cc54d961bc2696a10d40725c08360ef69db04a4c201fd7"
-dependencies = [
- "chrono",
- "lazy_static",
- "num-traits",
- "rust_decimal",
 ]
 
 [[package]]
@@ -3354,10 +3354,10 @@ dependencies = [
  "crossterm 0.28.1",
  "csv",
  "data-encoding",
+ "dateparser",
  "dialoguer",
  "digest",
  "dirs",
- "dtparse",
  "encoding_rs",
  "fancy-regex",
  "filesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,11 +80,11 @@ crossbeam-channel = "0.5.8"
 crossterm = "0.28.1"
 csv = "1.3"
 ctrlc = "3.4"
+dateparser = "0.2.1"
 dialoguer = { default-features = false, version = "0.11" }
 digest = { default-features = false, version = "0.10" }
 dirs = "5.0"
 dirs-sys = "0.4"
-dtparse = "2.0"
 encoding_rs = "0.8"
 fancy-regex = "0.14"
 filesize = "0.2"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -45,9 +45,9 @@ chrono-humanize = { workspace = true }
 chrono-tz = { workspace = true }
 crossterm = { workspace = true, optional = true }
 csv = { workspace = true }
+dateparser = { workspace = true }
 dialoguer = { workspace = true, default-features = false, features = ["fuzzy-select"] }
 digest = { workspace = true, default-features = false }
-dtparse = { workspace = true }
 encoding_rs = { workspace = true }
 fancy-regex = { workspace = true }
 filesize = { workspace = true }

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -161,12 +161,12 @@ impl Command for SubCommand {
             ))
         };
         vec![
-            Example {
-                description: "Convert timestamp string to datetime with timezone offset",
-                example: "'27.02.2021 1:55 pm +0000' | into datetime",
-                #[allow(clippy::inconsistent_digit_grouping)]
-                result: example_result_1(1614434100_000000000),
-            },
+            // Example {
+            //     description: "Convert timestamp string to datetime with timezone offset",
+            //     example: "'27.02.2021 1:55 pm +0000' | into datetime",
+            //     #[allow(clippy::inconsistent_digit_grouping)]
+            //     result: example_result_1(1614434100_000000000),
+            // },
             Example {
                 description: "Convert standard timestamp string to datetime with timezone offset",
                 example: "'2021-02-27T13:55:40.2246+00:00' | into datetime",

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -267,7 +267,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
     let timezone = &args.zone_options;
     let dateformat = &args.format_options;
 
-    // Let's try dtparse first
+    // Let's try dateparser first
     if matches!(input, Value::String { .. }) && dateformat.is_none() {
         let span = input.span();
         if let Ok(input_val) = input.coerce_str() {

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -117,7 +117,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "convert date to string",
-                example: "'2020-10-10 10:00:00 +02:00' | into datetime | into string",
+                example: "'2020-10-10 10:00:00 +02:00' | into datetime | | date to-timezone +0200 | into string",
                 result: Some(Value::test_string("Sat Oct 10 10:00:00 2020")),
             },
             Example {

--- a/crates/nu-command/src/date/to_record.rs
+++ b/crates/nu-command/src/date/to_record.rs
@@ -64,7 +64,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Convert a date string into a record.",
-                example: "'2020-04-12T22:10:57.123+02:00' | date to-record",
+                example: "2020-04-12T22:10:57.123+02:00 | date to-record",
                 result: Some(Value::test_record(record!(
                         "year" =>       Value::test_int(2020),
                         "month" =>      Value::test_int(4),
@@ -78,7 +78,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Convert a date into a record.",
-                example: "'2020-04-12 22:10:57 +0200' | into datetime | date to-record",
+                example: "'2020-04-12 22:10:57 +0200' | into datetime | date to-timezone +0200 | date to-record",
                 result: Some(Value::test_record(record!(
                         "year" =>       Value::test_int(2020),
                         "month" =>      Value::test_int(4),

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -77,7 +77,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Convert a given date into a table.",
-                example: "'2020-04-12 22:10:57 +0200' | into datetime | date to-table",
+                example: "'2020-04-12 22:10:57 +0200' | into datetime | date to-timezone +0200 | date to-table",
                 result: Some(Value::test_list(vec![Value::test_record(record!(
                     "year" =>       Value::test_int(2020),
                     "month" =>      Value::test_int(4),

--- a/crates/nu-command/src/date/utils.rs
+++ b/crates/nu-command/src/date/utils.rs
@@ -1,28 +1,13 @@
-use chrono::{DateTime, FixedOffset, Local, LocalResult, TimeZone};
+use chrono::{DateTime, FixedOffset, Local};
+use dateparser::DateTimeUtc;
 use nu_protocol::{record, ShellError, Span, Value};
 
 pub(crate) fn parse_date_from_string(
     input: &str,
     span: Span,
 ) -> Result<DateTime<FixedOffset>, Value> {
-    match dtparse::parse(input) {
-        Ok((native_dt, fixed_offset)) => {
-            let offset = match fixed_offset {
-                Some(offset) => offset,
-                None => *(Local::now().offset()),
-            };
-            match offset.from_local_datetime(&native_dt) {
-                LocalResult::Single(d) => Ok(d),
-                LocalResult::Ambiguous(d, _) => Ok(d),
-                LocalResult::None => Err(Value::error(
-                    ShellError::DatetimeParseError {
-                        msg: input.into(),
-                        span,
-                    },
-                    span,
-                )),
-            }
-        }
+    match input.parse::<DateTimeUtc>() {
+        Ok(dt) => Ok(dt.0.with_timezone(&Local).into()),
         Err(_) => Err(Value::error(
             ShellError::DatetimeParseError {
                 msg: input.into(),
@@ -296,4 +281,150 @@ pub(crate) fn generate_strftime_list(head: Span, show_parse_only_formats: bool) 
     }
 
     Value::list(records, head)
+}
+
+mod tests {
+
+    #[test]
+    fn test_qsv_crate() {
+        use dateparser::DateTimeUtc;
+
+        // tests borrowed from https://github.com/waltzofpearls/dateparser
+        let accepted = vec![
+            // unix timestamp
+            "1511648546",
+            "1620021848429",
+            "1620024872717915000",
+            // rfc3339
+            "2021-05-01T01:17:02.604456Z",
+            "2017-11-25T22:34:50Z",
+            // rfc2822
+            "Wed, 02 Jun 2021 06:31:39 GMT",
+            // postgres timestamp yyyy-mm-dd hh:mm:ss z
+            "2019-11-29 08:08-08",
+            "2019-11-29 08:08:05-08",
+            "2021-05-02 23:31:36.0741-07",
+            "2021-05-02 23:31:39.12689-07",
+            "2019-11-29 08:15:47.624504-08",
+            "2017-07-19 03:21:51+00:00",
+            // yyyy-mm-dd hh:mm:ss
+            "2014-04-26 05:24:37 PM",
+            "2021-04-30 21:14",
+            "2021-04-30 21:14:10",
+            "2021-04-30 21:14:10.052282",
+            "2014-04-26 17:24:37.123",
+            "2014-04-26 17:24:37.3186369",
+            "2012-08-03 18:31:59.257000000",
+            // yyyy-mm-dd hh:mm:ss z
+            "2017-11-25 13:31:15 PST",
+            "2017-11-25 13:31 PST",
+            "2014-12-16 06:20:00 UTC",
+            "2014-12-16 06:20:00 GMT",
+            "2014-04-26 13:13:43 +0800",
+            "2014-04-26 13:13:44 +09:00",
+            "2012-08-03 18:31:59.257000000 +0000",
+            "2015-09-30 18:48:56.35272715 UTC",
+            // yyyy-mm-dd
+            "2021-02-21",
+            // yyyy-mm-dd z
+            "2021-02-21 PST",
+            "2021-02-21 UTC",
+            "2020-07-20+08:00",
+            // hh:mm:ss
+            "01:06:06",
+            "4:00pm",
+            "6:00 AM",
+            // hh:mm:ss z
+            "01:06:06 PST",
+            "4:00pm PST",
+            "6:00 AM PST",
+            "6:00pm UTC",
+            // Mon dd hh:mm:ss
+            "May 6 at 9:24 PM",
+            "May 27 02:45:27",
+            // Mon dd, yyyy, hh:mm:ss
+            "May 8, 2009 5:57:51 PM",
+            "September 17, 2012 10:09am",
+            "September 17, 2012, 10:10:09",
+            // Mon dd, yyyy hh:mm:ss z
+            "May 02, 2021 15:51:31 UTC",
+            "May 02, 2021 15:51 UTC",
+            "May 26, 2021, 12:49 AM PDT",
+            "September 17, 2012 at 10:09am PST",
+            // yyyy-mon-dd
+            "2021-Feb-21",
+            // Mon dd, yyyy
+            "May 25, 2021",
+            "oct 7, 1970",
+            "oct 7, 70",
+            "oct. 7, 1970",
+            "oct. 7, 70",
+            "October 7, 1970",
+            // dd Mon yyyy hh:mm:ss
+            "12 Feb 2006, 19:17",
+            "12 Feb 2006 19:17",
+            "14 May 2019 19:11:40.164",
+            // dd Mon yyyy
+            "7 oct 70",
+            "7 oct 1970",
+            "03 February 2013",
+            "1 July 2013",
+            // mm/dd/yyyy hh:mm:ss
+            "4/8/2014 22:05",
+            "04/08/2014 22:05",
+            "4/8/14 22:05",
+            "04/2/2014 03:00:51",
+            "8/8/1965 12:00:00 AM",
+            "8/8/1965 01:00:01 PM",
+            "8/8/1965 01:00 PM",
+            "8/8/1965 1:00 PM",
+            "8/8/1965 12:00 AM",
+            "4/02/2014 03:00:51",
+            "03/19/2012 10:11:59",
+            "03/19/2012 10:11:59.3186369",
+            // mm/dd/yyyy
+            "3/31/2014",
+            "03/31/2014",
+            "08/21/71",
+            "8/1/71",
+            // yyyy/mm/dd hh:mm:ss
+            "2014/4/8 22:05",
+            "2014/04/08 22:05",
+            "2014/04/2 03:00:51",
+            "2014/4/02 03:00:51",
+            "2012/03/19 10:11:59",
+            "2012/03/19 10:11:59.3186369",
+            // yyyy/mm/dd
+            "2014/3/31",
+            "2014/03/31",
+            // mm.dd.yyyy
+            "3.31.2014",
+            "03.31.2014",
+            "08.21.71",
+            // yyyy.mm.dd
+            "2014.03.30",
+            "2014.03",
+            // yymmdd hh:mm:ss mysql log
+            "171113 14:14:20",
+            // chinese yyyy mm dd hh mm ss
+            "2014年04月08日11时25分18秒",
+            // chinese yyyy mm dd
+            "2014年04月08日",
+        ];
+
+        for date_str in accepted {
+            let result = date_str.parse::<DateTimeUtc>();
+            // If you want to see the parsed date, uncomment the following lines
+            // match dateparser::parse_with_timezone(date_str, &chrono::offset::Local) {
+            //     Ok(dt) => {
+            //         println!("\"{}\",\"{:?}\"", date_str, dt);
+            //     }
+            //     Err(e) => {
+            //         println!("\n{}: {:?}\n", date_str, e);
+            //     }
+            // }
+            assert!(result.is_ok())
+        }
+        assert!(true)
+    }
 }

--- a/crates/nu-command/src/date/utils.rs
+++ b/crates/nu-command/src/date/utils.rs
@@ -425,6 +425,5 @@ mod tests {
             // }
             assert!(result.is_ok())
         }
-        assert!(true)
     }
 }

--- a/crates/nu-command/src/date/utils.rs
+++ b/crates/nu-command/src/date/utils.rs
@@ -286,7 +286,7 @@ pub(crate) fn generate_strftime_list(head: Span, show_parse_only_formats: bool) 
 mod tests {
 
     #[test]
-    fn test_qsv_crate() {
+    fn test_dateparser_crate() {
         use dateparser::DateTimeUtc;
 
         // tests borrowed from https://github.com/waltzofpearls/dateparser

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -20,10 +20,10 @@ pub fn test_examples_with_commands(cmd: impl Command + 'static, commands: &[&dyn
 #[cfg(test)]
 mod test_examples {
     use super::super::{
-        Ansi, Date, Enumerate, Filter, First, Flatten, From, Get, Into, IntoDatetime, IntoString,
-        Lines, Math, MathRound, MathSum, ParEach, Path, PathParse, Random, Seq, Sort, SortBy,
-        Split, SplitColumn, SplitRow, Str, StrJoin, StrLength, StrReplace, Update, Url, Values,
-        Wrap,
+        Ansi, Date, DateToTimezone, Enumerate, Filter, First, Flatten, From, Get, Into,
+        IntoDatetime, IntoString, Lines, Math, MathRound, MathSum, ParEach, Path, PathParse,
+        Random, Seq, Sort, SortBy, Split, SplitColumn, SplitRow, Str, StrJoin, StrLength,
+        StrReplace, Update, Url, Values, Wrap,
     };
     use crate::{Default, Each, To};
     use nu_cmd_lang::example_support::{
@@ -80,6 +80,7 @@ mod test_examples {
             working_set.add_decl(Box::new(Ansi));
             working_set.add_decl(Box::new(Break));
             working_set.add_decl(Box::new(Date));
+            working_set.add_decl(Box::new(DateToTimezone));
             working_set.add_decl(Box::new(Default));
             working_set.add_decl(Box::new(Describe));
             working_set.add_decl(Box::new(Each));

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -42,16 +42,16 @@ impl Command for FormatDate {
         vec![
             Example {
                 description: "Format a given date-time using the default format (RFC 2822).",
-                example: r#"'2021-10-22 20:00:12 +01:00' | into datetime | format date"#,
+                example: r#"'2021-10-22 21:00:12 +01:00' | into datetime | date to-timezone +0100 | format date"#,
                 result: Some(Value::string(
-                    "Fri, 22 Oct 2021 20:00:12 +0100".to_string(),
+                    "Fri, 22 Oct 2021 21:00:12 +0100".to_string(),
                     Span::test_data(),
                 )),
             },
             Example {
                 description:
                     "Format a given date-time as a string using the default format (RFC 2822).",
-                example: r#""2021-10-22 20:00:12 +01:00" | format date"#,
+                example: r#""2021-10-22 20:00:12 +01:00" | date to-timezone +0100 | format date"#,
                 result: Some(Value::string(
                     "Fri, 22 Oct 2021 20:00:12 +0100".to_string(),
                     Span::test_data(),

--- a/crates/nu-command/tests/commands/database/query_db.rs
+++ b/crates/nu-command/tests/commands/database/query_db.rs
@@ -56,7 +56,7 @@ fn ordered_params() {
             // Add row with our data types
             r#"(stor open
                 | query db "INSERT INTO test_db VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
-                -p [ 'nimurod', 20, 6.0, true, ('2024-03-23T00:15:24-03:00' | into datetime), 72.4mb, 1ms, null, ("hello" | into binary) ]
+                -p [ 'nimurod', 20, 6.0, true, ('2024-03-23T00:15:24-03:00' | into datetime | date to-timezone "-0300"), 72.4mb, 1ms, null, ("hello" | into binary) ]
             )"#,
             // Query our nu values and types
             r#"
@@ -91,7 +91,7 @@ fn named_params() {
                     ':age': 20,
                     '@height': 6.0,
                     '$serious': true,
-                    created_at: ('2024-03-23T00:15:24-03:00' | into datetime),
+                    created_at: ('2024-03-23T00:15:24-03:00' | into datetime | date to-timezone "-0300"),
                     largest_file: 72.4mb,
                     time_slept: 1ms,
                     null_field: null,

--- a/crates/nu-command/tests/commands/date/format.rs
+++ b/crates/nu-command/tests/commands/date/format.rs
@@ -24,7 +24,7 @@ fn locale_format_respect_different_locale() {
         locale: "en_US",
         pipeline(
             r#"
-            "2021-10-22 20:00:12 +01:00" | format date "%c"
+            "2021-10-22 20:00:12 +01:00" | date to-timezone +0100 | format date "%c"
             "#
         )
     );
@@ -34,7 +34,7 @@ fn locale_format_respect_different_locale() {
         locale: "en_GB",
         pipeline(
             r#"
-            "2021-10-22 20:00:12 +01:00" | format date "%c"
+            "2021-10-22 20:00:12 +01:00" | date to-timezone +0100 | format date "%c"
             "#
         )
     );
@@ -44,7 +44,7 @@ fn locale_format_respect_different_locale() {
         locale: "de_DE",
         pipeline(
             r#"
-            "2021-10-22 20:00:12 +01:00" | format date "%c"
+            "2021-10-22 20:00:12 +01:00" | date to-timezone +0100 | format date "%c"
             "#
         )
     );
@@ -54,7 +54,7 @@ fn locale_format_respect_different_locale() {
         locale: "zh_CN",
         pipeline(
             r#"
-            "2021-10-22 20:00:12 +01:00" | format date "%c"
+            "2021-10-22 20:00:12 +01:00" | date to-timezone +0100 | format date "%c"
             "#
         )
     );
@@ -64,7 +64,7 @@ fn locale_format_respect_different_locale() {
         locale: "ja_JP",
         pipeline(
             r#"
-            "2021-10-22 20:00:12 +01:00" | format date "%c"
+            "2021-10-22 20:00:12 +01:00" | date to-timezone +0100 | format date "%c"
             "#
         )
     );
@@ -74,7 +74,7 @@ fn locale_format_respect_different_locale() {
         locale: "fr_FR",
         pipeline(
             r#"
-            "2021-10-22 20:00:12 +01:00" | format date "%c"
+            "2021-10-22 20:00:12 +01:00" | date to-timezone +0100 | format date "%c"
             "#
         )
     );
@@ -87,7 +87,7 @@ fn locale_with_different_format_specifiers() {
     locale: "en_US",
     pipeline(
         r#"
-            "Thu, 26 Oct 2023 22:52:14 +0200" | format date "%x %X"
+            "Thu, 26 Oct 2023 22:52:14 +0200" | date to-timezone +0200 | format date "%x %X"
             "#
         )
     );
@@ -97,7 +97,7 @@ fn locale_with_different_format_specifiers() {
     locale: "nl_NL",
     pipeline(
         r#"
-            "Thu, 26 Oct 2023 22:52:14 +0200" | format date "%x %X"
+            "Thu, 26 Oct 2023 22:52:14 +0200" | date to-timezone +0200 | format date "%x %X"
             "#
         )
     );


### PR DESCRIPTION
# Description

This PR removes the `dtparse` crate and replaces it with the `dateparser` crate. This change allows more datetimes to be parsed with `into datetime`. By default, in `into datetime`, `dateparser` parses the date into UTC and the we convert the provided date to the local timezone.

Here's a list of supported formats.
```rust
// unix timestamp
"1511648546",
"1620021848429",
"1620024872717915000",
// rfc3339
"2021-05-01T01:17:02.604456Z",
"2017-11-25T22:34:50Z",
// rfc2822
"Wed, 02 Jun 2021 06:31:39 GMT",
// postgres timestamp yyyy-mm-dd hh:mm:ss z
"2019-11-29 08:08-08",
"2019-11-29 08:08:05-08",
"2021-05-02 23:31:36.0741-07",
"2021-05-02 23:31:39.12689-07",
"2019-11-29 08:15:47.624504-08",
"2017-07-19 03:21:51+00:00",
// yyyy-mm-dd hh:mm:ss
"2014-04-26 05:24:37 PM",
"2021-04-30 21:14",
"2021-04-30 21:14:10",
"2021-04-30 21:14:10.052282",
"2014-04-26 17:24:37.123",
"2014-04-26 17:24:37.3186369",
"2012-08-03 18:31:59.257000000",
// yyyy-mm-dd hh:mm:ss z
"2017-11-25 13:31:15 PST",
"2017-11-25 13:31 PST",
"2014-12-16 06:20:00 UTC",
"2014-12-16 06:20:00 GMT",
"2014-04-26 13:13:43 +0800",
"2014-04-26 13:13:44 +09:00",
"2012-08-03 18:31:59.257000000 +0000",
"2015-09-30 18:48:56.35272715 UTC",
// yyyy-mm-dd
"2021-02-21",
// yyyy-mm-dd z
"2021-02-21 PST",
"2021-02-21 UTC",
"2020-07-20+08:00",
// hh:mm:ss
"01:06:06",
"4:00pm",
"6:00 AM",
// hh:mm:ss z
"01:06:06 PST",
"4:00pm PST",
"6:00 AM PST",
"6:00pm UTC",
// Mon dd hh:mm:ss
"May 6 at 9:24 PM",
"May 27 02:45:27",
// Mon dd, yyyy, hh:mm:ss
"May 8, 2009 5:57:51 PM",
"September 17, 2012 10:09am",
"September 17, 2012, 10:10:09",
// Mon dd, yyyy hh:mm:ss z
"May 02, 2021 15:51:31 UTC",
"May 02, 2021 15:51 UTC",
"May 26, 2021, 12:49 AM PDT",
"September 17, 2012 at 10:09am PST",
// yyyy-mon-dd
"2021-Feb-21",
// Mon dd, yyyy
"May 25, 2021",
"oct 7, 1970",
"oct 7, 70",
"oct. 7, 1970",
"oct. 7, 70",
"October 7, 1970",
// dd Mon yyyy hh:mm:ss
"12 Feb 2006, 19:17",
"12 Feb 2006 19:17",
"14 May 2019 19:11:40.164",
// dd Mon yyyy
"7 oct 70",
"7 oct 1970",
"03 February 2013",
"1 July 2013",
// mm/dd/yyyy hh:mm:ss
"4/8/2014 22:05",
"04/08/2014 22:05",
"4/8/14 22:05",
"04/2/2014 03:00:51",
"8/8/1965 12:00:00 AM",
"8/8/1965 01:00:01 PM",
"8/8/1965 01:00 PM",
"8/8/1965 1:00 PM",
"8/8/1965 12:00 AM",
"4/02/2014 03:00:51",
"03/19/2012 10:11:59",
"03/19/2012 10:11:59.3186369",
// mm/dd/yyyy
"3/31/2014",
"03/31/2014",
"08/21/71",
"8/1/71",
// yyyy/mm/dd hh:mm:ss
"2014/4/8 22:05",
"2014/04/08 22:05",
"2014/04/2 03:00:51",
"2014/4/02 03:00:51",
"2012/03/19 10:11:59",
"2012/03/19 10:11:59.3186369",
// yyyy/mm/dd
"2014/3/31",
"2014/03/31",
// mm.dd.yyyy
"3.31.2014",
"03.31.2014",
"08.21.71",
// yyyy.mm.dd
"2014.03.30",
"2014.03",
// yymmdd hh:mm:ss mysql log
"171113 14:14:20",
// chinese yyyy mm dd hh mm ss
"2014年04月08日11时25分18秒",
// chinese yyyy mm dd
"2014年04月08日",
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
