### PR TITLE
#14123 Overwriting default date format to make it more consistent.

### DIFF
--- a/crates/nu-command/src/date/utils.rs
+++ b/crates/nu-command/src/date/utils.rs
@@ -1,17 +1,27 @@
 use chrono::{DateTime, FixedOffset, Local, LocalResult, TimeZone};
 use nu_protocol::{record, ShellError, Span, Value};
+use std::collections::HashMap;
 
 pub(crate) fn parse_date_from_string(
     input: &str,
     span: Span,
 ) -> Result<DateTime<FixedOffset>, Value> {
-    match dtparse::parse(input) {
-        Ok((native_dt, fixed_offset)) => {
-            let offset = match fixed_offset {
+    match dtparse::Parser::default().parse(
+        input,
+        Some(true),
+        Some(true),
+        false,
+        false,
+        None,
+        false,
+        &HashMap::new(),
+    ) {
+        Ok(result) => {
+            let offset = match result.1 {
                 Some(offset) => offset,
                 None => *(Local::now().offset()),
             };
-            match offset.from_local_datetime(&native_dt) {
+            match offset.from_local_datetime(&result.0) {
                 LocalResult::Single(d) => Ok(d),
                 LocalResult::Ambiguous(d, _) => Ok(d),
                 LocalResult::None => Err(Value::error(


### PR DESCRIPTION
This is just a draft. 

Just to get the talk started on a solution. 

So we are using: https://docs.rs/dtparse/latest/dtparse/ 

The parse method lets us configure the following relevant fields:
1. dayfirst
2. yearfirst

# Testing

## `dayfirst` set to true and `yearfirst` to true
```
~/Projects/nushell> '12-13-01' | into datetime                 
Thu, 13 Dec 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell> '13-01-2001' | into datetime            
Sat, 13 Jan 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell> '12-01-2001' | into datetime           
Fri, 12 Jan 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell> '2001-12-01' | into datetime         
Fri, 12 Jan 2001 00:00:00 +0100 (23 years ago)            
~/Projects/nushell>  '2001-13-01' | into datetime            
Sat, 13 Jan 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell> '32-13-01' | into datetime         
Tue, 13 Jan 2032 00:00:00 +0100 (in 7 years)
~/Projects/nushell> '12-12-01' | into datetime      
Thu, 12 Jan 2012 00:00:00 +0100 (12 years ago)
```  

1. '12-13-01' is not year first?! So `dayfirst` overrules `yearfirst` i guess. 
1. Year is magical between '32-13-01'  and  '12-13-01' 
1. Day/month is magical between '12-12-01'   and  '12-13-01' 

## `dayfirst` set to false and `yearfirst` to true
```
~/Projects/nushell> '12-13-01' | into datetime                  
Thu, 13 Dec 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell>  '13-01-2001' | into datetime           
Sat, 13 Jan 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell> '12-01-2001' | into datetime       
Sat, 1 Dec 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell>  '2001-12-01' | into datetime          
Sat, 1 Dec 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell>  '2001-13-01' | into datetime     
Error: nu::shell::datetime_parse_error

  × Unable to parse datetime: [2001-13-01].
   ╭─[entry #5:1:2]
 1 │  '2001-13-01' | into datetime     
   ·  ──────┬─────
   ·        ╰── datetime parsing failed
   ╰────
  help: Examples of supported inputs:
         * "5 pm"
         * "2020/12/4"
         * "2020.12.04 22:10 +2"
         * "2020-04-12 22:10:57 +02:00"
         * "2020-04-12T22:10:57.213231+02:00"
         * "Tue, 1 Jul 2003 10:52:37 +0200"
~/Projects/nushell> '32-13-01' | into datetime        
Error: nu::shell::datetime_parse_error

  × Unable to parse datetime: [32-13-01].
   ╭─[entry #1:1:1]
 1 │ '32-13-01' | into datetime  
   · ─────┬────
   ·      ╰── datetime parsing failed
   ╰────
  help: Examples of supported inputs:
         * "5 pm"
         * "2020/12/4"
         * "2020.12.04 22:10 +2"
         * "2020-04-12 22:10:57 +02:00"
         * "2020-04-12T22:10:57.213231+02:00"
         * "Tue, 1 Jul 2003 10:52:37 +0200"
~/Projects/nushell> '12-12-01' | into datetime                                                                                                                                                                                                                                                                                                                                                           12/09/2024 07:34:18 PM
Sat, 1 Dec 2012 00:00:00 +0100 (12 years ago)
```  

1. '2001-13-01' and  '32-13-01' fails
1. Year is magical between '32-13-01'  and  '12-13-01' 
2. Day/month is magical '13-01-2001' and  '12-01-2001'

## `dayfirst` set to false and `yearfirst` to false (as it is today)
```
~/Projects/nushell> '12-13-01' | into datetime           
Thu, 13 Dec 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell> '13-01-2001' | into datetime             
Sat, 13 Jan 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell> '12-01-2001' | into datetime      
Sat, 1 Dec 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell> '2001-12-01' | into datetime           
Sat, 1 Dec 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell>  '2001-13-01' | into datetime      
Error: nu::shell::datetime_parse_error

  × Unable to parse datetime: [2001-13-01].
   ╭─[entry #7:1:2]
 1 │  '2001-13-01' | into datetime        
   ·  ──────┬─────
   ·        ╰── datetime parsing failed
   ╰────
  help: Examples of supported inputs:
         * "5 pm"
         * "2020/12/4"
         * "2020.12.04 22:10 +2"
         * "2020-04-12 22:10:57 +02:00"
         * "2020-04-12T22:10:57.213231+02:00"
         * "Tue, 1 Jul 2003 10:52:37 +0200"
~/Projects/nushell> '32-13-01' | into datetime            
Tue, 13 Jan 2032 00:00:00 +0100 (in 7 years)
~/Projects/nushell> '12-12-01' | into datetime    
Wed, 12 Dec 2001 00:00:00 +0100 (23 years ago)

```  

1. '2001-13-01'  fails
1. Year is magical between '32-13-01'  and  '12-13-01' 
2. Day/month is magical '13-01-2001' and  '12-01-2001'

## `dayfirst` set to true and `yearfirst` to false 
```
~/Projects/nushell> '12-13-01' | into datetime        
Thu, 13 Dec 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell> '13-01-2001' | into datetime          
Sat, 13 Jan 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell> '12-01-2001' | into datetime             
Fri, 12 Jan 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell>  '2001-12-01' | into datetime         
Fri, 12 Jan 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell> '2001-13-01' | into datetime              
Sat, 13 Jan 2001 00:00:00 +0100 (23 years ago)
~/Projects/nushell> '32-13-01' | into datetime  
Tue, 13 Jan 2032 00:00:00 +0100 (in 7 years)
~/Projects/nushell> '12-12-01' | into datetime      
Wed, 12 Dec 2001 00:00:00 +0100 (23 years ago)
```  

1. Year is magical between '32-13-01'  and  '12-13-01' 

## The above data as a table

|dayfirst|yearfirst|12-13-01'| '13-01-2001' | '12-01-2001' |2001-12-01' |2001-13-01'|32-13-01'|12-12-01'|
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
|TRUE|TRUE|Thu, 13 Dec 2001 00:00:00 +0100 (23 years ago)|"Sat, 13 Jan 2001 00:00:00 +0100 (23 years ago)|"Fri, 12 Jan 2001 00:00:00 +0100 (23 years ago)|"Fri, 12 Jan 2001 00:00:00 +0100 (23 years ago) |"Sat, 13 Jan 2001 00:00:00 +0100 (23 years ago)|"Tue, 13 Jan 2032 00:00:00 +0100 (in 7 years)"| "Thu, 12 Jan 2012 00:00:00 +0100 (12 years ago)" |
|FALSE|TRUE|Thu, 13 Dec 2001 00:00:00 +0100 (23 years ago)|"Sat, 13 Jan 2001 00:00:00 +0100 (23 years ago)|"Sat, 1 Dec 2001 00:00:00 +0100 (23 years ago)|"Sat, 1 Dec 2001 00:00:00 +0100 (23 years ago)|ERROR|ERROR| "Sat, 1 Dec 2012 00:00:00 +0100 (12 years ago)" |
|FALSE|FALSE|Thu, 13 Dec 2001 00:00:00 +0100 (23 years ago)|"Sat, 13 Jan 2001 00:00:00 +0100 (23 years ago)|"Sat, 1 Dec 2001 00:00:00 +0100 (23 years ago)|"Sat, 1 Dec 2001 00:00:00 +0100 (23 years ago)|ERROR| "Tue, 13 Jan 2032 00:00:00 +0100 (in 7 years)"| "Wed, 12 Dec 2001 00:00:00 +0100 (23 years ago)" |
|TRUE|FALSE|Thu, 13 Dec 2001 00:00:00 +0100 (23 years ago)|"Sat, 13 Jan 2001 00:00:00 +0100 (23 years ago|"Fri, 12 Jan 2001 00:00:00 +0100 (23 years ago)|"Fri, 12 Jan 2001 00:00:00 +0100 (23 years ago)|"Sat, 13 Jan 2001 00:00:00 +0100 (23 years ago)|"Tue, 13 Jan 2032 00:00:00 +0100 (in 7 years)"| "Wed, 12 Dec 2001 00:00:00 +0100 (23 years ago)" |



# Suggestions: 

"`dayfirst` set to true and `yearfirst` to false" Has the fewest comments. So maybe we go with that? 

# Is it a good crate? 

So the chosen crate seems popular enough: https://crates.io/crates/dtparse ? (I have very little experience in evaluating crates)

There are plenty of tests: https://github.com/bspeice/dtparse/blob/081cd7bea06d2f3284631b648a5693404e158c4f/src/tests/pycompat_parser.rs the naming makes it a bit tricky to see if our cases are covered. 

It seems quite a fine crate if we want to try to parse any string into some date, time or datetime. Maybe we just have to accept that it cannot be perfect? 

With the suggestion above it could be fine. 

# Alternatives for the user

## Using `--format` 

This seems broken too:
```
~/Projects/nushell> '01-12-01' | into datetime --format %y-%m-%d                                                                                                                                                                                                                                                                                                                                         12/09/2024 06:44:40 PM
Error: nu::shell::cant_convert

  × Can't convert to could not parse as datetime using format '%y-%m-%d'.
   ╭─[entry #1:1:14]
 1 │ '01-12-01' | into datetime --format %y-%m-%d
   ·              ──────┬──────
   ·                    ╰── can't convert input is not enough for unique date and time to could not parse as datetime using format '%y-%m-%d'
   ╰────
  help: you can use `into datetime` without a format string to enable flexible parsing
``` 

```
~/Projects/nushell> '2001-12-01' | into datetime --format %F                                                                                                                                                                                                                                                                                                                                             12/09/2024 06:47:23 PM
Error: nu::shell::cant_convert

  × Can't convert to could not parse as datetime using format '%F'.
   ╭─[entry #4:1:16]
 1 │ '2001-12-01' | into datetime --format %F
   ·                ──────┬──────
   ·                      ╰── can't convert input is not enough for unique date and time to could not parse as datetime using format '%F'
   ╰────
  help: you can use `into datetime` without a format string to enable flexible parsing
``` 

Will create a separate bug for this. 

## Other alternative? 

I do not know. Any suggestions? 

















<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
