### PR TITLE
Set empty `ENV_CONVERSIONS` record by default

### DIFF
--- a/crates/nu-utils/src/default_files/default_env.nu
+++ b/crates/nu-utils/src/default_files/default_env.nu
@@ -39,10 +39,3 @@ $env.PROMPT_COMMAND_RIGHT = $env.PROMPT_COMMAND_RIGHT? | default {||
 
     ([$last_exit_code, (char space), $time_segment] | str join)
 }
-
-$env.ENV_CONVERSIONS = {
-    "PATH": {
-        from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
-        to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
-    }
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use nu_cli::gather_parent_env_vars;
 use nu_lsp::LanguageServer;
 use nu_path::canonicalize_with;
 use nu_protocol::{
-    engine::EngineState, report_shell_error, ByteStream, Config, IntoValue, PipelineData,
+    engine::EngineState, record, report_shell_error, ByteStream, Config, IntoValue, PipelineData,
     ShellError, Span, Spanned, Type, Value,
 };
 use nu_std::load_standard_library;
@@ -284,6 +284,11 @@ fn main() -> Result<()> {
         Config::default().into_value(Span::unknown()),
     );
     perf!("$env.config setup", start_time, use_color);
+
+    engine_state.add_env_var(
+        "ENV_CONVERSIONS".to_string(),
+        Value::test_record(record! {}),
+    );
 
     start_time = std::time::Instant::now();
     if let Some(include_path) = &parsed_nu_cli_args.include_path {


### PR DESCRIPTION
# Description

With Windows Path case-insensitivity in place, we no longer need an `ENV_CONVERSIONS` for `PATH`, as the `nu_engine::env::convert_env_values()` handles it automatically.

This PR:

* Removes the default `ENV_CONVERSIONS` for path from `default_env.nu`
* Sets `ENV_CONVERSIONS` to an empty record (so it can be `merge`'d) in `main()` instead

# User-Facing Changes

No behavioral changes - Users will now have an empty `ENV_CONVERSIONS` at startup by default, but the behavior should not change.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

