### PR TITLE
fix: make exec command decrement SHLVL correctly

### DIFF
--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -61,6 +61,16 @@ On Windows based systems, Nushell will wait for the command to finish and then e
         let envs = env_to_strings(engine_state, stack)?;
         command.env_clear();
         command.envs(envs);
+        // Decrement SHLVL as removing the current shell from the stack
+        // (only works in interactive mode, same as intialization)
+        if engine_state.is_interactive {
+            if let Some(shlvl) = engine_state.get_env_var("SHLVL") {
+                let shlvl = shlvl.as_int().unwrap_or(1) - 1;
+                command.env("SHLVL", shlvl.to_string());
+            } else {
+                command.env("SHLVL", "0");
+            }
+        }
 
         // Configure args.
         let args = crate::eval_arguments_from_call(engine_state, stack, call)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,7 +320,7 @@ fn main() -> Result<()> {
     if engine_state.is_interactive {
         let mut shlvl = engine_state
             .get_env_var("SHLVL")
-            .map(|x| x.as_str().unwrap_or("0").parse::<i64>().unwrap_or(0))
+            .map(|x| x.as_int().unwrap_or(0))
             .unwrap_or(0);
         shlvl += 1;
         engine_state.add_env_var("SHLVL".to_string(), Value::int(shlvl, Span::unknown()));


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

fixes #14567

Now NuShell's `exec` command will decrement `SHLVL` env value before passing it to target executable.

It only works in interactive session, the same as `SHLVL` initialization.

In addition, this PR also make a simple change to `SHLVL` initialization (only remove an unnecessary type conversion).

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

None.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Formatted.

With interactively tested with several shells (bash, zsh, fish) and cross-exec-ing them, it works well this time.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
