### PR TITLE
support raw strings in match patterns

### DIFF
--- a/crates/nu-command/tests/commands/match_.rs
+++ b/crates/nu-command/tests/commands/match_.rs
@@ -141,6 +141,15 @@ fn match_constant_7() {
 }
 
 #[test]
+fn match_constant_8() {
+    let actual =
+        nu!(r#"match "foo" { r#'foo'# => { print "success" }, _ => { print "failure" } }"#);
+    // Make sure we don't see any of these values in the output
+    // As we do not auto-print loops anymore
+    assert_eq!(actual.out, "success");
+}
+
+#[test]
 fn match_null() {
     let actual = nu!(r#"match null { null => { print "success"}, _ => { print "failure" }}"#);
     assert_eq!(actual.out, "success");

--- a/crates/nu-protocol/src/engine/pattern_match.rs
+++ b/crates/nu-protocol/src/engine/pattern_match.rs
@@ -128,7 +128,7 @@ impl Matcher for Pattern {
                             false
                         }
                     }
-                    Expr::String(x) => {
+                    Expr::String(x) | Expr::RawString(x) => {
                         if let Value::String { val, .. } = &value {
                             x == val
                         } else {


### PR DESCRIPTION
Fixes #14554

# User-Facing Changes

Raw strings are now supported in match patterns:

```diff
match "foo" { r#'foo'# => true, _ => false }
-false
+true
```