### PR TITLE
return const values from `scope variables`

### DIFF
--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -56,11 +56,12 @@ impl<'e, 's> ScopeData<'e, 's> {
             let var_type = Value::string(var.ty.to_string(), span);
             let is_const = Value::bool(var.const_val.is_some(), span);
 
-            let var_value = if let Ok(val) = self.stack.get_var(**var_id, span) {
-                val
-            } else {
-                Value::nothing(span)
-            };
+            let var_value = self
+                .stack
+                .get_var(**var_id, span)
+                .ok()
+                .or(var.const_val.clone())
+                .unwrap_or(Value::nothing(span));
 
             let var_id_val = Value::int(var_id.get() as i64, span);
 

--- a/tests/repl/test_engine.rs
+++ b/tests/repl/test_engine.rs
@@ -90,12 +90,19 @@ fn help_works_with_missing_requirements() -> TestResult {
     run_test(r#"each --help | lines | length"#, "72")
 }
 
-#[test]
-fn scope_variable() -> TestResult {
-    run_test(
-        r#"let x = 3; scope variables | where name == "$x" | get type.0"#,
-        "int",
-    )
+#[rstest]
+#[case("let x = 3", "$x", "int", "3")]
+#[case("const x = 3", "$x", "int", "3")]
+fn scope_variable(
+    #[case] var_decl: &str,
+    #[case] exp_name: &str,
+    #[case] exp_type: &str,
+    #[case] exp_value: &str,
+) -> TestResult {
+    let get_var_info =
+        format!(r#"{var_decl}; scope variables | where name == "{exp_name}" | first"#);
+    run_test(&format!(r#"{get_var_info} | get type"#), exp_type)?;
+    run_test(&format!(r#"{get_var_info} | get value"#), exp_value)
 }
 
 #[rstest]


### PR DESCRIPTION
Fixes #14542

# User-Facing Changes

Constant values are no longer missing from `scope variables` output
when the IR evaluator is enabled:

```diff
const foo = 1
scope variables | where name == "$foo" | get value.0 | to nuon
-null
+int
```