### PR TITLE
stop the prompt from removing the last newline

### DIFF
--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -87,14 +87,6 @@ fn get_prompt_string(
                     x.insert_str(0, "\x1b[0m")
                 };
 
-                // Just remove the very last newline.
-                if x.ends_with('\n') {
-                    x.pop();
-                }
-
-                if x.ends_with('\r') {
-                    x.pop();
-                }
                 x
             });
             // Let's keep this for debugging purposes with nu --log-level warn


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
I tried to setup a multiline prompt like this.
<img width="175" alt="スクリーンショット 2024-12-15 17 45 06" src="https://github.com/user-attachments/assets/8d00a203-b341-45ce-8427-b4d5a9d3d7c3" />

But when I set PROMT_COMMAND like this, 

```nu
$env.PROMPT_COMMAND = {|| $"(ansi reset)(ansi magenta)(date now | format date "%Y-%m-%dT%H:%M:%S%z")\n(pwd)\n" } 
```

The result is like this, due to dropping `\n` and `\r` on `prompt_update.rs`.
<img width="185" alt="スクリーンショット 2024-12-15 17 54 21" src="https://github.com/user-attachments/assets/5ead998e-6f87-479f-b2de-e267f0cc3acd" />

Currently, adding two newlines can detour the drop.
I think this drop newline makes little sense, so I removed it on this PR.
If you don't like it, feel free to close it.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Trailing newline of PROMPT_COMMAND is not dropped anymore.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

This is a subtle change just on prompt string, so I think particular test is not so necessary.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
As far as I read https://www.nushell.sh/book/coloring_and_theming.html#prompt-configuration-and-coloring , the behavior seems undocumented. 
