### PR TITLE
Run ENV_CONVERSIONS whenever it's modified

### DIFF
--- a/crates/nu-engine/src/compile/operator.rs
+++ b/crates/nu-engine/src/compile/operator.rs
@@ -335,43 +335,43 @@ pub(crate) fn compile_load_env(
     path: &[PathMember],
     out_reg: RegId,
 ) -> Result<(), CompileError> {
-    if path.is_empty() {
-        builder.push(
+    match path {
+        [] => builder.push(
             Instruction::LoadVariable {
                 dst: out_reg,
                 var_id: ENV_VARIABLE_ID,
             }
             .into_spanned(span),
-        )?;
-    } else {
-        let (key, optional) = match &path[0] {
-            PathMember::String { val, optional, .. } => (builder.data(val)?, *optional),
-            PathMember::Int { span, .. } => {
-                return Err(CompileError::AccessEnvByInt { span: *span })
-            }
-        };
-        let tail = &path[1..];
-
-        if optional {
-            builder.push(Instruction::LoadEnvOpt { dst: out_reg, key }.into_spanned(span))?;
-        } else {
-            builder.push(Instruction::LoadEnv { dst: out_reg, key }.into_spanned(span))?;
+        )?,
+        [PathMember::Int { span, .. }, ..] => {
+            return Err(CompileError::AccessEnvByInt { span: *span })
         }
+        [PathMember::String {
+            val: key, optional, ..
+        }, tail @ ..] => {
+            let key = builder.data(key)?;
 
-        if !tail.is_empty() {
-            let path = builder.literal(
-                Literal::CellPath(Box::new(CellPath {
-                    members: tail.to_vec(),
-                }))
-                .into_spanned(span),
-            )?;
-            builder.push(
-                Instruction::FollowCellPath {
-                    src_dst: out_reg,
-                    path,
-                }
-                .into_spanned(span),
-            )?;
+            builder.push(if *optional {
+                Instruction::LoadEnvOpt { dst: out_reg, key }.into_spanned(span)
+            } else {
+                Instruction::LoadEnv { dst: out_reg, key }.into_spanned(span)
+            })?;
+
+            if !tail.is_empty() {
+                let path = builder.literal(
+                    Literal::CellPath(Box::new(CellPath {
+                        members: tail.to_vec(),
+                    }))
+                    .into_spanned(span),
+                )?;
+                builder.push(
+                    Instruction::FollowCellPath {
+                        src_dst: out_reg,
+                        path,
+                    }
+                    .into_spanned(span),
+                )?;
+            }
         }
     }
     Ok(())

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -14,6 +14,10 @@ use nu_protocol::{
 };
 use nu_utils::IgnoreCaseExt;
 
+use crate::{
+    convert_env_vars, eval::is_automatic_env_var, eval_block_with_early_return, redirect_env,
+    ENV_CONVERSIONS,
+};
 use crate::{eval::is_automatic_env_var, eval_block_with_early_return};
 
 /// Evaluate the compiled representation of a [`Block`].
@@ -384,9 +388,15 @@ fn eval_instruction<D: DebugContext>(
 
             if !is_automatic_env_var(&key) {
                 let is_config = key == "config";
-                ctx.stack.add_env_var(key.into_owned(), value);
+                let update_conversions = key == ENV_CONVERSIONS;
+
+                ctx.stack.add_env_var(key.into_owned(), value.clone());
+
                 if is_config {
                     ctx.stack.update_config(ctx.engine_state)?;
+                }
+                if update_conversions {
+                    convert_env_vars(ctx.stack, ctx.engine_state, &value)?;
                 }
                 Ok(Continue)
             } else {

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -15,10 +15,8 @@ use nu_protocol::{
 use nu_utils::IgnoreCaseExt;
 
 use crate::{
-    convert_env_vars, eval::is_automatic_env_var, eval_block_with_early_return, redirect_env,
-    ENV_CONVERSIONS,
+    convert_env_vars, eval::is_automatic_env_var, eval_block_with_early_return, ENV_CONVERSIONS,
 };
-use crate::{eval::is_automatic_env_var, eval_block_with_early_return};
 
 /// Evaluate the compiled representation of a [`Block`].
 pub fn eval_ir_block<D: DebugContext>(

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -191,6 +191,16 @@ fn env_var_case_insensitive() {
 }
 
 #[test]
+fn env_conversion_on_assignment() {
+    let actual = nu!(r#"
+        $env.FOO = "bar:baz:quox"
+        $env.ENV_CONVERSIONS = { FOO: { from_string: {|| split row ":"} } }
+        $env.FOO | to nuon
+    "#);
+    assert_eq!(actual.out, "[bar, baz, quox]");
+}
+
+#[test]
 fn std_log_env_vars_are_not_overridden() {
     let actual = nu_with_std!(
         envs: vec![


### PR DESCRIPTION
- this PR should close #14514

# Description
Makes updates to `$env.ENV_CONVERSIONS` take effect immediately.

# User-Facing Changes
No breaking change, `$env.ENV_CONVERSIONS` can be set and its effect used in the same file.

# Tests + Formatting

- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
N/A