### PR TITLE
docs(reduce): add example demonstrating accumulator as pipeline input

### DIFF
--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -88,6 +88,15 @@ impl Command for Reduce {
                     "Concatenate a string with itself, using a range to determine the number of times.",
                 result: Some(Value::test_string("StrStrStr")),
             },
+            Example {
+                example: r#"[{a: 1} {b: 2} {c: 3}] | reduce {|it| merge $it}"#,
+                description: "Merge multiple records together, making use of the fact that the accumulated value is also supplied as pipeline input to the closure.",
+                result: Some(Value::test_record(record!(
+                    "a" => Value::test_int(1),
+                    "b" => Value::test_int(2),
+                    "c" => Value::test_int(3),
+                ))),
+            }
         ]
     }
 
@@ -135,8 +144,8 @@ mod test {
 
     #[test]
     fn test_examples() {
-        use crate::test_examples;
+        use crate::{test_examples_with_commands, Merge};
 
-        test_examples(Reduce {})
+        test_examples_with_commands(Reduce {}, &[&Merge])
     }
 }


### PR DESCRIPTION
# Description
Add an example to `reduce` that shows accumulator can also be accessed pipeline input.

# User-Facing Changes
N/A

# Tests + Formatting
- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
N/A