### PR TITLE
remove the deprecated index argument from filter commands' closure signature

### DIFF
--- a/crates/nu-cmd-extra/src/extra/filters/each_while.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/each_while.rs
@@ -25,7 +25,7 @@ impl Command for EachWhile {
             )])
             .required(
                 "closure",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                 "the closure to run",
             )
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -14,7 +14,7 @@ impl Command for All {
             .input_output_types(vec![(Type::List(Box::new(Type::Any)), Type::Bool)])
             .required(
                 "predicate",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                 "A closure that must evaluate to a boolean.",
             )
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -14,7 +14,7 @@ impl Command for Any {
             .input_output_types(vec![(Type::List(Box::new(Type::Any)), Type::Bool)])
             .required(
                 "predicate",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                 "A closure that must evaluate to a boolean.",
             )
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/filter.rs
+++ b/crates/nu-command/src/filters/filter.rs
@@ -30,7 +30,7 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
             ])
             .required(
                 "closure",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                 "Predicate closure.",
             )
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -38,7 +38,7 @@ impl Command for ParEach {
             )
             .required(
                 "closure",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                 "The closure to run.",
             )
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -24,11 +24,7 @@ impl Command for Reduce {
             )
             .required(
                 "closure",
-                SyntaxShape::Closure(Some(vec![
-                    SyntaxShape::Any,
-                    SyntaxShape::Any,
-                    SyntaxShape::Int,
-                ])),
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Any])),
                 "Reducing function.",
             )
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/filters/skip/skip_until.rs
+++ b/crates/nu-command/src/filters/skip/skip_until.rs
@@ -20,7 +20,7 @@ impl Command for SkipUntil {
             ])
             .required(
                 "predicate",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                 "The predicate that skipped element must not match.",
             )
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/skip/skip_while.rs
+++ b/crates/nu-command/src/filters/skip/skip_while.rs
@@ -20,7 +20,7 @@ impl Command for SkipWhile {
             ])
             .required(
                 "predicate",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                 "The predicate that skipped element must match.",
             )
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/take/take_until.rs
+++ b/crates/nu-command/src/filters/take/take_until.rs
@@ -17,7 +17,7 @@ impl Command for TakeUntil {
             )])
             .required(
                 "predicate",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                 "The predicate that element(s) must not match.",
             )
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/take/take_while.rs
+++ b/crates/nu-command/src/filters/take/take_while.rs
@@ -20,7 +20,7 @@ impl Command for TakeWhile {
             ])
             .required(
                 "predicate",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                 "The predicate that element(s) must match.",
             )
             .category(Category::Filters)


### PR DESCRIPTION
# Description

A lot of filter commands that have a closure argument (`each`, `filter`, etc), have a wrong signature for the closure, indicating an extra int argument for the closure.

I think they are a left over from before `enumerate` was added, used to access iteration index. None of the commands changed in this PR actually supply this int argument.

# User-Facing Changes
N/A

# Tests + Formatting
- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
N/A