### PR TITLE
Add missing color_config settings

### DIFF
--- a/crates/nu-utils/src/default_files/default_config.nu
+++ b/crates/nu-utils/src/default_files/default_config.nu
@@ -20,6 +20,8 @@ $env.config.color_config = {
     row_index: green_bold
     record: white
     list: white
+    closure: green_bold
+    glob:cyan_bold
     block: white
     hints: dark_gray
     search_result: { bg: red fg: white }


### PR DESCRIPTION
# Description

Fixes #14600 by adding a default value for missing keys in `default_config.nu`:

* `$env.config.color_config.glob`
* `$env.config.color_config.closure`

# User-Facing Changes

Will no longer error when accessing these keys.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A