### PR TITLE
allow `view source` to take `int` as a parameter

### DIFF
--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -33,6 +33,22 @@ impl Command for ViewSource {
         let arg_span = arg.span();
 
         let source = match arg {
+            Value::Int { val, .. } => {
+                let block = engine_state.get_block(nu_protocol::BlockId::new(val as usize));
+                if let Some(span) = block.span {
+                    let contents = engine_state.get_span_contents(span);
+                    Ok(Value::string(String::from_utf8_lossy(contents), call.head)
+                        .into_pipeline_data())
+                } else {
+                    Err(ShellError::GenericError {
+                        error: "Cannot view int value".to_string(),
+                        msg: "the block does not have a viewable span".to_string(),
+                        span: Some(arg_span),
+                        help: None,
+                        inner: vec![],
+                    })
+                }
+            }
             Value::String { val, .. } => {
                 if let Some(decl_id) = engine_state.find_decl(val.as_bytes(), &[]) {
                     // arg is a command
@@ -130,7 +146,7 @@ impl Command for ViewSource {
                             Ok(Value::string(final_contents, call.head).into_pipeline_data())
                         } else {
                             Err(ShellError::GenericError {
-                                error: "Cannot view value".to_string(),
+                                error: "Cannot view string value".to_string(),
                                 msg: "the command does not have a viewable block span".to_string(),
                                 span: Some(arg_span),
                                 help: None,
@@ -139,7 +155,7 @@ impl Command for ViewSource {
                         }
                     } else {
                         Err(ShellError::GenericError {
-                            error: "Cannot view value".to_string(),
+                            error: "Cannot view string decl value".to_string(),
                             msg: "the command does not have a viewable block".to_string(),
                             span: Some(arg_span),
                             help: None,
@@ -155,7 +171,7 @@ impl Command for ViewSource {
                             .into_pipeline_data())
                     } else {
                         Err(ShellError::GenericError {
-                            error: "Cannot view value".to_string(),
+                            error: "Cannot view string module value".to_string(),
                             msg: "the module does not have a viewable block".to_string(),
                             span: Some(arg_span),
                             help: None,
@@ -164,7 +180,7 @@ impl Command for ViewSource {
                     }
                 } else {
                     Err(ShellError::GenericError {
-                        error: "Cannot view value".to_string(),
+                        error: "Cannot view string value".to_string(),
                         msg: "this name does not correspond to a viewable value".to_string(),
                         span: Some(arg_span),
                         help: None,


### PR DESCRIPTION
# Description

This PR allows the `view source` command to view source based on an int value. I wrote this specifically to be able to see closures where the text is hidden. For example:
![image](https://github.com/user-attachments/assets/d8fe2692-0951-4366-9cb9-55f20044b68a)

And then you can use those `<Closure #>` with the `view source` command like this.
![image](https://github.com/user-attachments/assets/f428c8ad-56a9-4e72-880e-e32fb9155531)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
