### PR TITLE
Remove duplicate version line

### DIFF
--- a/crates/nu-utils/src/default_files/doc_env.nu
+++ b/crates/nu-utils/src/default_files/doc_env.nu
@@ -2,8 +2,6 @@
 #
 # version = "0.100.1"
 #
-# version = "0.100.1"
-#
 # Previously, environment variables were typically configured in `env.nu`.
 # In general, most configuration can and should be performed in `config.nu`
 # or one of the autoload directories.


### PR DESCRIPTION
# Description

Fixed:

* `version = "0.100.1"` line got duplicated during merge conflict resolution - Found while updating `bump_version.nu`.

# User-Facing Changes

N/A

# Tests + Formatting

TODO

# After Submitting

N/A