### PR TITLE
Revert "Only run `from_string` conversion on strings (#14509)"

### DIFF
--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -33,20 +33,14 @@ pub fn convert_env_values(engine_state: &mut EngineState, stack: &Stack) -> Resu
     let env_vars = engine_state.render_env_vars();
 
     for (name, val) in env_vars {
-        if let Value::String { .. } = val {
-            // Only run from_string on string values
-            match get_converted_value(engine_state, stack, name, val, "from_string") {
-                ConversionResult::Ok(v) => {
-                    let _ = new_scope.insert(name.to_string(), v);
-                }
-                ConversionResult::ConversionError(e) => error = error.or(Some(e)),
-                ConversionResult::CellPathError => {
-                    let _ = new_scope.insert(name.to_string(), val.clone());
-                }
+        match get_converted_value(engine_state, stack, name, val, "from_string") {
+            ConversionResult::Ok(v) => {
+                let _ = new_scope.insert(name.to_string(), v);
             }
-        } else {
-            // Skip values that are already converted (not a string)
-            let _ = new_scope.insert(name.to_string(), val.clone());
+            ConversionResult::ConversionError(e) => error = error.or(Some(e)),
+            ConversionResult::CellPathError => {
+                let _ = new_scope.insert(name.to_string(), val.clone());
+            }
         }
     }
 


### PR DESCRIPTION
This reverts commit fc29d826146afa9b7ac1fdb6807f25129b2d2ef8 (pr: #14509 )

currently that pr causes some strange issues when I want to run a script inside neovim, or open terminal in editors

In neovim:
```
:!black

shell failed to start: no such file or directory: nu

shell returned -1

Press ENTER or type command to continue
```

In zed editor, I can't open the terminal with following error:
```
zsh:1 command not found: nu
```
I noticed the issue might becuase we need to run from_string conversion for PATH, which is a list of string