### PR TITLE
Remove `-a/-all` flag in du.

### DIFF
--- a/crates/nu-command/src/filesystem/du.rs
+++ b/crates/nu-command/src/filesystem/du.rs
@@ -40,11 +40,6 @@ impl Command for Du {
                 "Starting directory.",
             )
             .switch(
-                "all",
-                "Output file sizes as well as directory sizes",
-                Some('a'),
-            )
-            .switch(
                 "deref",
                 "Dereference symlinks to their targets for size",
                 Some('r'),


### PR DESCRIPTION
Just noticed that I forget to remove `-a/-all` flag in `du`'s signature in  #14407

This pr is going to remove it