### PR TITLE
add streaming to `get` and `reject`

### DIFF
--- a/crates/nu-command/tests/commands/split_by.rs
+++ b/crates/nu-command/tests/commands/split_by.rs
@@ -56,8 +56,11 @@ fn errors_if_non_record_input() {
             "
         ));
 
-        assert!(only_supports
-            .err
-            .contains("only Record input data is supported"));
+        assert!(
+            only_supports
+                .err
+                .contains("only Record input data is supported")
+                || only_supports.err.contains("expected: record")
+        );
     })
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

Closes #14487.

# Description

`get` and `reject` now stream properly:

Before:
![image](https://github.com/user-attachments/assets/57ecb705-1f98-49a4-a47e-27bba1c6c732)

Now:
![image](https://github.com/user-attachments/assets/dc5c7fba-e1ef-46d2-bd78-fd777b9e9dad)

# User-Facing Changes

# Tests + Formatting

# After Submitting
