### PR TITLE
Add version info to startup banner

### DIFF
--- a/crates/nu-std/std/core/mod.nu
+++ b/crates/nu-std/std/core/mod.nu
@@ -6,7 +6,7 @@ let dt = (datetime-diff (date now) 2019-05-10T09:59:12-07:00)
 let ver = (version)
 
 let banner_msg = $"(ansi green)     __  ,(ansi reset)
-(ansi green) .--\(\)°'.' (ansi reset)Welcome to (ansi green)Nushell(ansi reset)
+(ansi green) .--\(\)°'.' (ansi reset)Welcome to (ansi green)Nushell(ansi reset),
 (ansi green)'|, . ,'   (ansi reset)based on the (ansi green)nu(ansi reset) language,
 (ansi green) !_-\(_\\    (ansi reset)where all data is structured!
 

--- a/crates/nu-std/std/core/mod.nu
+++ b/crates/nu-std/std/core/mod.nu
@@ -3,11 +3,12 @@ use std/dt [datetime-diff, pretty-print-duration]
 # Print a banner for nushell with information about the project
 export def banner [] {
 let dt = (datetime-diff (date now) 2019-05-10T09:59:12-07:00)
+let ver = (version)
 
 let banner_msg = $"(ansi green)     __  ,(ansi reset)
-(ansi green) .--\(\)°'.' (ansi reset)Welcome to (ansi green)Nushell(ansi reset),
-(ansi green)'|, . ,'   (ansi reset)where all data is structured!
-(ansi green) !_-\(_\\    (ansi reset)v((version).version) ((version).build_os) 
+(ansi green) .--\(\)°'.' (ansi reset)Welcome to (ansi green)Nushell(ansi reset) - the shell (ansi green)and(ansi reset)
+(ansi green)'|, . ,'   (ansi reset)language where all data is structured!
+(ansi green) !_-\(_\\    (ansi reset)v($ver.version) \(($ver.build_os)\)
 
 Please join our (ansi purple)Discord(ansi reset) community at (ansi purple)https://discord.gg/NtAbbGn(ansi reset)
 Our (ansi green_bold)GitHub(ansi reset) repository is at (ansi green_bold)https://github.com/nushell/nushell(ansi reset)

--- a/crates/nu-std/std/core/mod.nu
+++ b/crates/nu-std/std/core/mod.nu
@@ -6,10 +6,11 @@ let dt = (datetime-diff (date now) 2019-05-10T09:59:12-07:00)
 let ver = (version)
 
 let banner_msg = $"(ansi green)     __  ,(ansi reset)
-(ansi green) .--\(\)°'.' (ansi reset)Welcome to (ansi green)Nushell(ansi reset) - the shell (ansi green)and(ansi reset)
-(ansi green)'|, . ,'   (ansi reset)language where all data is structured!
-(ansi green) !_-\(_\\    (ansi reset)v($ver.version) \(($ver.build_os)\)
+(ansi green) .--\(\)°'.' (ansi reset)Welcome to (ansi green)Nushell(ansi reset)
+(ansi green)'|, . ,'   (ansi reset)based on the (ansi green)nu(ansi reset) language,
+(ansi green) !_-\(_\\    (ansi reset)where all data is structured!
 
+Version: (ansi green)($ver.version) \(($ver.build_os)\)
 Please join our (ansi purple)Discord(ansi reset) community at (ansi purple)https://discord.gg/NtAbbGn(ansi reset)
 Our (ansi green_bold)GitHub(ansi reset) repository is at (ansi green_bold)https://github.com/nushell/nushell(ansi reset)
 Our (ansi green)Documentation(ansi reset) is located at (ansi green)https://nushell.sh(ansi reset)

--- a/crates/nu-std/std/core/mod.nu
+++ b/crates/nu-std/std/core/mod.nu
@@ -6,8 +6,8 @@ let dt = (datetime-diff (date now) 2019-05-10T09:59:12-07:00)
 
 let banner_msg = $"(ansi green)     __  ,(ansi reset)
 (ansi green) .--\(\)°'.' (ansi reset)Welcome to (ansi green)Nushell(ansi reset),
-(ansi green)'|, . ,'   (ansi reset)based on the (ansi green)nu(ansi reset) language,
-(ansi green) !_-\(_\\    (ansi reset)where all data is structured!
+(ansi green)'|, . ,'   (ansi reset)where all data is structured!
+(ansi green) !_-\(_\\    (ansi reset)v((version).version) ((version).build_os) 
 
 Please join our (ansi purple)Discord(ansi reset) community at (ansi purple)https://discord.gg/NtAbbGn(ansi reset)
 Our (ansi green_bold)GitHub(ansi reset) repository is at (ansi green_bold)https://github.com/nushell/nushell(ansi reset)

--- a/crates/nu-std/tests/test_core.nu
+++ b/crates/nu-std/tests/test_core.nu
@@ -3,5 +3,5 @@ use std/assert
 #[test]
 def banner [] {
     use std/core
-    assert ((core banner | lines | length) == 15)
+    assert ((core banner | lines | length) == 16)
 }


### PR DESCRIPTION
# Description

Adds version info to the Startup Banner

# User-Facing Changes

## Before

![image](https://github.com/user-attachments/assets/de2a415f-1608-4d87-ab28-f3238cf532c3)

## After

![image](https://github.com/user-attachments/assets/db3f8419-0680-4a0b-9f09-8d9a273c4726)

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
- 
# After Submitting

N/A