### PR TITLE
Add shape_garbage

### DIFF
--- a/crates/nu-utils/src/default_files/default_config.nu
+++ b/crates/nu-utils/src/default_files/default_config.nu
@@ -60,4 +60,9 @@ $env.config.color_config = {
     shape_variable: purple
     shape_vardecl: purple
     shape_raw_string: light_purple
+    shape_garbage: {
+        fg: white
+        bg: red
+        attr: b
+    }
 }


### PR DESCRIPTION
# Description

Adds `$env.config.color_config.shape_garbage` to the default config so that it is populated out of the box.

Thanks to @PerchunPak for finding that it was missing.

# User-Facing Changes

I think this is useful on two levels, but it will be a change for a lot of users:

1. Accessing it won't generate an error out-of-the-box
2. Garbage errors are highlighted in reverse-red in real-time in the REPL.  This means that, for example, typing just a `$` will start out as an error - Once a valid variable (e.g., `$env`) is completed, then the highlight will change to the parsed shape.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A