### PR TITLE
Switch from serde_yaml to serde_yml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2686,6 +2686,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,7 +3406,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "serde_yaml",
+ "serde_yml",
  "sha2",
  "sysinfo 0.32.1",
  "tabled",
@@ -6234,16 +6244,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yml"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
  "indexmap",
  "itoa",
+ "libyml",
+ "memchr",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "version_check",
 ]
 
 [[package]]
@@ -7250,12 +7262,6 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ scopeguard = { version = "1.2.0" }
 serde = { version = "1.0" }
 serde_json = "1.0"
 serde_urlencoded = "0.7.1"
-serde_yaml = "0.9"
+serde_yml = "0.0.12"
 sha2 = "0.10"
 strip-ansi-escapes = "0.2.0"
 syn = "2.0"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -84,7 +84,7 @@ scopeguard = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_urlencoded = { workspace = true }
-serde_yaml = { workspace = true }
+serde_yml = { workspace = true }
 sha2 = { workspace = true }
 sysinfo = { workspace = true }
 tabled = { workspace = true, features = ["ansi"], default-features = false }

--- a/crates/nu-command/src/formats/from/yaml.rs
+++ b/crates/nu-command/src/formats/from/yaml.rs
@@ -72,7 +72,7 @@ impl Command for FromYml {
 }
 
 fn convert_yaml_value_to_nu_value(
-    v: &serde_yaml::Value,
+    v: &serde_yml::Value,
     span: Span,
     val_span: Span,
 ) -> Result<Value, ShellError> {
@@ -83,22 +83,22 @@ fn convert_yaml_value_to_nu_value(
         input_span: val_span,
     };
     Ok(match v {
-        serde_yaml::Value::Bool(b) => Value::bool(*b, span),
-        serde_yaml::Value::Number(n) if n.is_i64() => {
+        serde_yml::Value::Bool(b) => Value::bool(*b, span),
+        serde_yml::Value::Number(n) if n.is_i64() => {
             Value::int(n.as_i64().ok_or(err_not_compatible_number)?, span)
         }
-        serde_yaml::Value::Number(n) if n.is_f64() => {
+        serde_yml::Value::Number(n) if n.is_f64() => {
             Value::float(n.as_f64().ok_or(err_not_compatible_number)?, span)
         }
-        serde_yaml::Value::String(s) => Value::string(s.to_string(), span),
-        serde_yaml::Value::Sequence(a) => {
+        serde_yml::Value::String(s) => Value::string(s.to_string(), span),
+        serde_yml::Value::Sequence(a) => {
             let result: Result<Vec<Value>, ShellError> = a
                 .iter()
                 .map(|x| convert_yaml_value_to_nu_value(x, span, val_span))
                 .collect();
             Value::list(result?, span)
         }
-        serde_yaml::Value::Mapping(t) => {
+        serde_yml::Value::Mapping(t) => {
             // Using an IndexMap ensures consistent ordering
             let mut collected = IndexMap::new();
 
@@ -111,19 +111,19 @@ fn convert_yaml_value_to_nu_value(
                     input_span: val_span,
                 };
                 match (k, v) {
-                    (serde_yaml::Value::Number(k), _) => {
+                    (serde_yml::Value::Number(k), _) => {
                         collected.insert(
                             k.to_string(),
                             convert_yaml_value_to_nu_value(v, span, val_span)?,
                         );
                     }
-                    (serde_yaml::Value::Bool(k), _) => {
+                    (serde_yml::Value::Bool(k), _) => {
                         collected.insert(
                             k.to_string(),
                             convert_yaml_value_to_nu_value(v, span, val_span)?,
                         );
                     }
-                    (serde_yaml::Value::String(k), _) => {
+                    (serde_yml::Value::String(k), _) => {
                         collected.insert(
                             k.clone(),
                             convert_yaml_value_to_nu_value(v, span, val_span)?,
@@ -132,16 +132,16 @@ fn convert_yaml_value_to_nu_value(
                     // Hard-code fix for cases where "v" is a string without quotations with double curly braces
                     // e.g. k = value
                     // value: {{ something }}
-                    // Strangely, serde_yaml returns
+                    // Strangely, serde_yml returns
                     // "value" -> Mapping(Mapping { map: {Mapping(Mapping { map: {String("something"): Null} }): Null} })
-                    (serde_yaml::Value::Mapping(m), serde_yaml::Value::Null) => {
+                    (serde_yml::Value::Mapping(m), serde_yml::Value::Null) => {
                         return m
                             .iter()
                             .take(1)
                             .collect_vec()
                             .first()
                             .and_then(|e| match e {
-                                (serde_yaml::Value::String(s), serde_yaml::Value::Null) => {
+                                (serde_yml::Value::String(s), serde_yml::Value::Null) => {
                                     Some(Value::string("{{ ".to_owned() + s.as_str() + " }}", span))
                                 }
                                 _ => None,
@@ -156,22 +156,22 @@ fn convert_yaml_value_to_nu_value(
 
             Value::record(collected.into_iter().collect(), span)
         }
-        serde_yaml::Value::Tagged(t) => {
+        serde_yml::Value::Tagged(t) => {
             let tag = &t.tag;
             let value = match &t.value {
-                serde_yaml::Value::String(s) => {
+                serde_yml::Value::String(s) => {
                     let val = format!("{} {}", tag, s).trim().to_string();
                     Value::string(val, span)
                 }
-                serde_yaml::Value::Number(n) => {
+                serde_yml::Value::Number(n) => {
                     let val = format!("{} {}", tag, n).trim().to_string();
                     Value::string(val, span)
                 }
-                serde_yaml::Value::Bool(b) => {
+                serde_yml::Value::Bool(b) => {
                     let val = format!("{} {}", tag, b).trim().to_string();
                     Value::string(val, span)
                 }
-                serde_yaml::Value::Null => {
+                serde_yml::Value::Null => {
                     let val = format!("{}", tag).trim().to_string();
                     Value::string(val, span)
                 }
@@ -180,7 +180,7 @@ fn convert_yaml_value_to_nu_value(
 
             value
         }
-        serde_yaml::Value::Null => Value::nothing(span),
+        serde_yml::Value::Null => Value::nothing(span),
         x => unimplemented!("Unsupported YAML case: {:?}", x),
     })
 }
@@ -188,9 +188,9 @@ fn convert_yaml_value_to_nu_value(
 pub fn from_yaml_string_to_value(s: &str, span: Span, val_span: Span) -> Result<Value, ShellError> {
     let mut documents = vec![];
 
-    for document in serde_yaml::Deserializer::from_str(s) {
-        let v: serde_yaml::Value =
-            serde_yaml::Value::deserialize(document).map_err(|x| ShellError::UnsupportedInput {
+    for document in serde_yml::Deserializer::from_str(s) {
+        let v: serde_yml::Value =
+            serde_yml::Value::deserialize(document).map_err(|x| ShellError::UnsupportedInput {
                 msg: format!("Could not load YAML: {x}"),
                 input: "value originates from here".into(),
                 msg_span: span,
@@ -393,8 +393,8 @@ mod test {
         ];
 
         for test_case in test_cases {
-            let doc = serde_yaml::Deserializer::from_str(test_case.input);
-            let v: serde_yaml::Value = serde_yaml::Value::deserialize(doc.last().unwrap()).unwrap();
+            let doc = serde_yml::Deserializer::from_str(test_case.input);
+            let v: serde_yml::Value = serde_yml::Value::deserialize(doc.last().unwrap()).unwrap();
             let result = convert_yaml_value_to_nu_value(&v, Span::test_data(), Span::test_data());
             assert!(result.is_ok());
             assert!(result.ok().unwrap() == test_case.expected.ok().unwrap());

--- a/crates/nu-command/tests/format_conversions/yaml.rs
+++ b/crates/nu-command/tests/format_conversions/yaml.rs
@@ -48,3 +48,18 @@ fn convert_dict_to_yaml_with_integer_floats_key() {
     assert!(actual.out.contains("2.11"));
     assert!(actual.err.is_empty());
 }
+
+#[test]
+fn convert_bool_to_yaml_in_yaml_spec_1_2() {
+    let actual = nu!(pipeline(
+        r#"
+            [y n no On OFF True true false] | to yaml
+        "#
+    ));
+
+    assert_eq!(
+        actual.out,
+        "- 'y'- 'n'- 'no'- 'On'- 'OFF'- 'True'- true- false"
+    );
+    assert!(actual.err.is_empty());
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR fixes #14339.

Since [serde_yaml](https://docs.rs/serde_yaml/latest/serde_yaml/) is already deprecated, replaced it with [serde_yml](https://doc.serdeyml.com/serde_yml/).

After this change, the `to yaml` boolean parsing issue in #14339 is also fixed.
Now the command
```
['y' 'Y' 'yes' 'Yes' 'YES' 'n' 'N' 'no' 'No' 'No' 'on' 'On' 'ON' 'off' 'Off' 'OFF'] | to yaml
```
will return
```
- 'y'
- 'Y'
- 'yes'
- 'Yes'
- 'YES'
- 'n'
- 'N'
- 'no'
- 'No'
- 'No'
- 'on'
- 'On'
- 'ON'
- 'off'
- 'Off'
- 'OFF'
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

I'm not sure if the yaml spec change is a user-facing change.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used`
- [x] `cargo test --workspace`
- [x] `cargo run -- -c "use toolkit.nu; toolkit test stdlib"`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
