### PR TITLE
Set `split-by` doc category to "deprecated"

### DIFF
--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -14,7 +14,7 @@ impl Command for SplitBy {
         Signature::build("split-by")
             .input_output_types(vec![(Type::record(), Type::record())])
             .optional("splitter", SyntaxShape::Any, "The splitter value to use.")
-            .category(Category::Filters)
+            .category(Category::Deprecated)
     }
 
     fn description(&self) -> &str {


### PR DESCRIPTION
# Description

#14019 deprecated the `split-by` command.  This sets its doc-category to "deprecated" so that it will display that way in the in-shell and online help

# User-Facing Changes

`split-by` will now show as a deprecated command in Help.  Will also be reported using:

```nushell
help commands | where category == deprecated
```

# Tests + Formatting



# After Submitting

N/A