### PR TITLE
Remove `pub` on some command internals

### DIFF
--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -1,7 +1,7 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
 
-pub struct Arguments {
+struct Arguments {
     cell_paths: Option<Vec<CellPath>>,
     compact: bool,
 }
@@ -142,7 +142,7 @@ fn into_binary(
     }
 }
 
-pub fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
+fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
     let value = match input {
         Value::Binary { .. } => input.clone(),
         Value::Int { val, .. } => Value::binary(val.to_ne_bytes().to_vec(), span),

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -116,7 +116,7 @@ impl Command for SubCommand {
     }
 }
 
-pub fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
+fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
     let value_span = input.span();
     match input {
         Value::Filesize { .. } => input.clone(),

--- a/crates/nu-command/src/platform/ansi/strip.rs
+++ b/crates/nu-command/src/platform/ansi/strip.rs
@@ -4,7 +4,7 @@ use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
 use nu_protocol::Config;
 
-pub struct Arguments {
+struct Arguments {
     cell_paths: Option<Vec<CellPath>>,
     config: Arc<Config>,
 }


### PR DESCRIPTION
Stumbled over unnecessary `pub` `fn action` and `struct Arguments` when
reworking `into bits` in #14634

Stuff like this should be local until proven otherwise and then named
approrpiately.
