### PR TITLE
"short" Welcome Banner option

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -146,15 +146,30 @@ pub fn evaluate_repl(
     // Regenerate the $nu constant to contain the startup time and any other potential updates
     engine_state.generate_nu_constant();
 
-    if load_std_lib.is_none() && engine_state.get_config().show_banner {
-        eval_source(
-            engine_state,
-            &mut unique_stack,
-            r#"banner"#.as_bytes(),
-            "show_banner",
-            PipelineData::empty(),
-            false,
-        );
+    if load_std_lib.is_none() {
+        match engine_state.get_config().show_banner {
+            Value::Bool { val: false, ..} => {}
+            Value::String { ref val, ..} if val == "short" => {
+                eval_source(
+                    engine_state,
+                    &mut unique_stack,
+                    r#"banner --short"#.as_bytes(),
+                    "show short banner",
+                    PipelineData::empty(),
+                    false,
+                );
+            }
+            _ => {
+                eval_source(
+                    engine_state,
+                    &mut unique_stack,
+                    r#"banner"#.as_bytes(),
+                    "show_banner",
+                    PipelineData::empty(),
+                    false,
+                );
+            }
+        }
     }
 
     kitty_protocol_healthcheck(engine_state);

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -148,8 +148,8 @@ pub fn evaluate_repl(
 
     if load_std_lib.is_none() {
         match engine_state.get_config().show_banner {
-            Value::Bool { val: false, ..} => {}
-            Value::String { ref val, ..} if val == "short" => {
+            Value::Bool { val: false, .. } => {}
+            Value::String { ref val, .. } if val == "short" => {
                 eval_source(
                     engine_state,
                     &mut unique_stack,

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -59,7 +59,7 @@ pub struct Config {
     pub rm: RmConfig,
     pub shell_integration: ShellIntegrationConfig,
     pub buffer_editor: Value,
-    pub show_banner: bool,
+    pub show_banner: Value,
     pub bracketed_paste: bool,
     pub render_right_prompt_on_last_line: bool,
     pub explore: HashMap<String, Value>,
@@ -82,7 +82,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            show_banner: true,
+            show_banner: Value::bool(true, Span::unknown()),
 
             table: TableConfig::default(),
             rm: RmConfig::default(),

--- a/crates/nu-std/std/core/mod.nu
+++ b/crates/nu-std/std/core/mod.nu
@@ -6,8 +6,7 @@ export def banner [
 ] {
 let dt = (datetime-diff (date now) 2019-05-10T09:59:12-07:00)
 let ver = (version)
-
-let startup_time = $"('Startup Time: ' | ansi gradient --fgstart '0x20a000' --fgend '0x20ff00')($nu.startup-time)"
+let startup_time = $"(ansi green_bold)Startup Time: (ansi reset)($nu.startup-time)"
 
 let banner_msg = match $short {
     true => $"($startup_time)(char newline)"

--- a/crates/nu-std/std/core/mod.nu
+++ b/crates/nu-std/std/core/mod.nu
@@ -1,11 +1,18 @@
 use std/dt [datetime-diff, pretty-print-duration]
 
 # Print a banner for nushell with information about the project
-export def banner [] {
+export def banner [
+    --short    # Only show startup time
+] {
 let dt = (datetime-diff (date now) 2019-05-10T09:59:12-07:00)
 let ver = (version)
 
-let banner_msg = $"(ansi green)     __  ,(ansi reset)
+let startup_time = $"('Startup Time: ' | ansi gradient --fgstart '0x20a000' --fgend '0x20ff00')($nu.startup-time)"
+
+let banner_msg = match $short {
+    true => $"($startup_time)(char newline)"
+
+    false => $"(ansi green)     __  ,(ansi reset)
 (ansi green) .--\(\)°'.' (ansi reset)Welcome to (ansi green)Nushell(ansi reset),
 (ansi green)'|, . ,'   (ansi reset)based on the (ansi green)nu(ansi reset) language,
 (ansi green) !_-\(_\\    (ansi reset)where all data is structured!
@@ -20,8 +27,9 @@ Learn how to remove this at: (ansi green)https://nushell.sh/book/configuration.h
 It's been this long since (ansi green)Nushell(ansi reset)'s first commit:
 (pretty-print-duration $dt)
 
-Startup Time: ($nu.startup-time)
+($startup_time)
 "
+}
 
 match $env.config?.use_ansi_coloring? {
     false => { $banner_msg | ansi strip }


### PR DESCRIPTION
# Description

Adds:

```nushell
$env.config.show_banner = "short"
```

This will display *only* the startup time. That was the only information from the banner that the user couldn't possibly include in their own config/banner (since it is `-1ns` during startup).  This allows one to create their own banner and yet still show the startup time.

Example (can be a file named `banner.nu` in autoloads:

```nushell
$env.config.show_banner = "short"

let ver = (version)
print $"(ansi blue_bold)Nushell Release:(ansi reset) ($ver.version) \(($ver.build_os)\)"
```

![image](https://github.com/user-attachments/assets/dd9d53a2-d89a-432e-8fa3-2d65072e08b1)


---

`true` and `false` settings continue to work as they do today.  `true` is still the default.

# User-Facing Changes

New configuration option:

```nushell
$env.config.show_banner = "short"
```

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

◼️ Update doc
◼️ Update `doc_config.nu`