### PR TITLE
Fix `commands::network::http::*::*_timeout` tests on non-english system

### DIFF
--- a/crates/nu-command/tests/commands/network/http/delete.rs
+++ b/crates/nu-command/tests/commands/network/http/delete.rs
@@ -145,7 +145,5 @@ fn http_delete_timeout() {
     #[cfg(not(target_os = "windows"))]
     assert!(&actual.err.contains("timed out reading response"));
     #[cfg(target_os = "windows")]
-    assert!(&actual
-        .err
-        .contains("did not properly respond after a period of time"));
+    assert!(&actual.err.contains(super::WINDOWS_ERROR_TIMEOUT_SLOW_LINK));
 }

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -339,7 +339,5 @@ fn http_get_timeout() {
     #[cfg(not(target_os = "windows"))]
     assert!(&actual.err.contains("timed out reading response"));
     #[cfg(target_os = "windows")]
-    assert!(&actual
-        .err
-        .contains("did not properly respond after a period of time"));
+    assert!(&actual.err.contains(super::WINDOWS_ERROR_TIMEOUT_SLOW_LINK));
 }

--- a/crates/nu-command/tests/commands/network/http/mod.rs
+++ b/crates/nu-command/tests/commands/network/http/mod.rs
@@ -5,3 +5,14 @@ mod options;
 mod patch;
 mod post;
 mod put;
+
+/// String representation of the Windows error code for timeouts on slow links.
+///
+/// Use this constant in tests instead of matching partial error message content,
+/// such as `"did not properly respond after a period of time"`, which can vary by language.
+/// The specific string `"(os error 10060)"` is consistent across all locales, as it represents
+/// the raw error code rather than localized text.
+///
+/// For more details, see the [Microsoft docs](https://learn.microsoft.com/en-us/troubleshoot/windows-client/networking/10060-connection-timed-out-with-proxy-server).
+#[cfg(all(test, windows))]
+const WINDOWS_ERROR_TIMEOUT_SLOW_LINK: &str = "(os error 10060)";

--- a/crates/nu-command/tests/commands/network/http/options.rs
+++ b/crates/nu-command/tests/commands/network/http/options.rs
@@ -64,7 +64,5 @@ fn http_options_timeout() {
     #[cfg(not(target_os = "windows"))]
     assert!(&actual.err.contains("timed out reading response"));
     #[cfg(target_os = "windows")]
-    assert!(&actual
-        .err
-        .contains("did not properly respond after a period of time"));
+    assert!(&actual.err.contains(super::WINDOWS_ERROR_TIMEOUT_SLOW_LINK));
 }

--- a/crates/nu-command/tests/commands/network/http/patch.rs
+++ b/crates/nu-command/tests/commands/network/http/patch.rs
@@ -189,7 +189,5 @@ fn http_patch_timeout() {
     #[cfg(not(target_os = "windows"))]
     assert!(&actual.err.contains("timed out reading response"));
     #[cfg(target_os = "windows")]
-    assert!(&actual
-        .err
-        .contains("did not properly respond after a period of time"));
+    assert!(&actual.err.contains(super::WINDOWS_ERROR_TIMEOUT_SLOW_LINK));
 }

--- a/crates/nu-command/tests/commands/network/http/post.rs
+++ b/crates/nu-command/tests/commands/network/http/post.rs
@@ -303,7 +303,5 @@ fn http_post_timeout() {
     #[cfg(not(target_os = "windows"))]
     assert!(&actual.err.contains("timed out reading response"));
     #[cfg(target_os = "windows")]
-    assert!(&actual
-        .err
-        .contains("did not properly respond after a period of time"));
+    assert!(&actual.err.contains(super::WINDOWS_ERROR_TIMEOUT_SLOW_LINK));
 }

--- a/crates/nu-command/tests/commands/network/http/put.rs
+++ b/crates/nu-command/tests/commands/network/http/put.rs
@@ -189,7 +189,5 @@ fn http_put_timeout() {
     #[cfg(not(target_os = "windows"))]
     assert!(&actual.err.contains("timed out reading response"));
     #[cfg(target_os = "windows")]
-    assert!(&actual
-        .err
-        .contains("did not properly respond after a period of time"));
+    assert!(&actual.err.contains(super::WINDOWS_ERROR_TIMEOUT_SLOW_LINK));
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
I had issues with the following tests:
- `commands::network::http::delete::http_delete_timeout`
- `commands::network::http::get::http_get_timeout`
- `commands::network::http::options::http_options_timeout`
- `commands::network::http::patch::http_patch_timeout`
- `commands::network::http::post::http_post_timeout`
- `commands::network::http::put::http_put_timeout`

I checked what the actual issue was and my problem was that the tested string `"did not properly respond after a period of time"` wasn't in the actual error. This happened because my german Windows would return a german error message which obviosly did not include that string. To fix that I replaced the string check with the os error code that is also part of the error message which should be language agnostic. (I hope.)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

None.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

\o/

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
