### PR TITLE
Fix the document CI error for `polars profile` command

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/core/profile.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/profile.rs
@@ -30,9 +30,13 @@ impl PluginCommand for ProfileDF {
     }
 
     fn description(&self) -> &str {
-        "Profile a lazy dataframe. This will run the query and return a record containing the materialized DataFrame and a DataFrame that contains profiling information of each node that is executed.
+        "Profile a lazy dataframe."
+    }
 
-The units of the timings are microseconds."
+    fn extra_description(&self) -> &str {
+        r#"This will run the query and return a record containing the materialized DataFrame and a DataFrame that contains profiling information of each node that is executed.
+
+The units of the timings are microseconds."#
     }
 
     fn examples(&self) -> Vec<Example> {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

Fix the docs repo CI build error here: https://github.com/nushell/nushell.github.io/actions/runs/12425087184/job/34691291790#step:5:18

The doc generated by `make_docs.nu` for `polars profile` command will make the CI build fail due to the indention error of markdown front matters. I used to fix it manually before, for the long run, it's better to fix it from the source code.
