### PR TITLE
Make the `--no-newline` test use `--no-config-file` as well

### DIFF
--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -274,7 +274,7 @@ fn run_in_noninteractive_mode() {
 #[test]
 fn run_with_no_newline() {
     let child_output = std::process::Command::new(nu_test_support::fs::executable_path())
-        .args(["--no-newline", "-c", "\"hello world\""])
+        .args(["-n", "--no-newline", "-c", "\"hello world\""])
         .output()
         .expect("failed to run nu");
 


### PR DESCRIPTION
Just a quick change: the test I made for `--no-newline` was missing `--no-config-file`, so it could false-negative if you have problems with your config.
