### PR TITLE
Add content type metadata to `config nu` commands

### DIFF
--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::PipelineMetadata;
 
 #[derive(Clone)]
 pub struct ConfigNu;
@@ -70,13 +71,21 @@ impl Command for ConfigNu {
         // `--default` flag handling
         if default_flag {
             let head = call.head;
-            return Ok(Value::string(nu_utils::get_default_config(), head).into_pipeline_data());
+            return Ok(Value::string(nu_utils::get_default_config(), head)
+                .into_pipeline_data_with_metadata(
+                    PipelineMetadata::default()
+                        .with_content_type("application/x-nuscript".to_string().into()),
+                ));
         }
 
         // `--doc` flag handling
         if doc_flag {
             let head = call.head;
-            return Ok(Value::string(nu_utils::get_doc_config(), head).into_pipeline_data());
+            return Ok(Value::string(nu_utils::get_doc_config(), head)
+                .into_pipeline_data_with_metadata(
+                    PipelineMetadata::default()
+                        .with_content_type("application/x-nuscript".to_string().into()),
+                ));
         }
 
         super::config_::start_editor("config-path", engine_state, stack, call)


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
In v0.101.0 we got `config nu --default` and `config nu --doc` which return a default config. That default config is valid `.nu`, so it should have the metadata for it. We defined our MIME types [here in the docs](https://www.nushell.sh/lang-guide/chapters/mime_types.html), so I added that.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Tools that read the metadata can now also detect that these two commands are nushell scripts.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
