### PR TITLE
Add glob support to utouch (issue #13623)

### DIFF
--- a/crates/nu-command/src/filesystem/utouch.rs
+++ b/crates/nu-command/src/filesystem/utouch.rs
@@ -245,6 +245,11 @@ impl Command for UTouch {
                 result: None,
             },
             Example {
+                description: r#"Changes the last modified and accessed time of all files with the .json extension to today's date"#,
+                example: "utouch *.json",
+                result: None,
+            },
+            Example {
                 description: "Changes the last accessed and modified times of files a, b and c to the current time but yesterday",
                 example: r#"utouch -d "yesterday" a b c"#,
                 result: None,

--- a/crates/nu-command/src/filesystem/utouch.rs
+++ b/crates/nu-command/src/filesystem/utouch.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, FixedOffset};
 use filetime::FileTime;
 use nu_engine::command_prelude::*;
-use nu_glob::glob;
+use nu_glob::{glob, is_glob};
 use nu_path::expand_path_with;
 use nu_protocol::NuGlob;
 use std::{io::ErrorKind, path::PathBuf};
@@ -175,10 +175,7 @@ impl Command for UTouch {
                         )
                     });
 
-                    if file_name.to_string_lossy().contains("*")
-                        || file_name.to_string_lossy().contains("?")
-                        || file_name.to_string_lossy().contains("[")
-                    {
+                    if is_glob(&file_name.to_string_lossy()) {
                         return Err(ShellError::GenericError {
                             error: format!(
                                 "No matches found for glob {}",

--- a/crates/nu-command/src/filesystem/utouch.rs
+++ b/crates/nu-command/src/filesystem/utouch.rs
@@ -177,18 +177,14 @@ impl Command for UTouch {
 
                     if file_name.to_string_lossy().contains("*")
                         || file_name.to_string_lossy().contains("?")
-                        || file_name.to_string_lossy().contains("{")
                         || file_name.to_string_lossy().contains("[")
                     {
                         return Err(ShellError::GenericError {
                             error: format!(
-                                "Error while parsing file glob {}",
+                                "No matches found for glob {}",
                                 file_name.to_string_lossy()
                             ),
-                            msg: format!(
-                                "No matches found for glob pattern {}",
-                                file_name.to_string_lossy()
-                            ),
+                            msg: "No matches found for glob".into(),
                             span: Some(file_glob.span),
                             help: Some(format!(
                                 "Use quotes if you want to create a file named {}",

--- a/crates/nu-command/tests/commands/utouch.rs
+++ b/crates/nu-command/tests/commands/utouch.rs
@@ -84,6 +84,19 @@ fn creates_two_files() {
 }
 
 #[test]
+fn creates_a_file_when_glob_has_no_matches() {
+    Playground::setup("create_test_glob", |dirs, _sandbox| {
+        nu!(
+            cwd: dirs.test(),
+            "utouch *.txt"
+        );
+
+        let path = dirs.test().join("*.txt");
+        assert!(path.exists());
+    })
+}
+
+#[test]
 fn change_modified_time_of_file_to_today() {
     Playground::setup("change_time_test_9", |dirs, sandbox| {
         sandbox.with_files(&[Stub::EmptyFile("file.txt")]);
@@ -95,6 +108,36 @@ fn change_modified_time_of_file_to_today() {
         nu!(
             cwd: dirs.test(),
             "utouch -m file.txt"
+        );
+
+        let metadata = path.metadata().unwrap();
+
+        // Check only the date since the time may not match exactly
+        let today = Local::now().date_naive();
+        let mtime_day = DateTime::<Local>::from(metadata.modified().unwrap()).date_naive();
+
+        assert_eq!(today, mtime_day);
+
+        // Check that atime remains unchanged
+        assert_eq!(
+            TIME_ONE,
+            FileTime::from_system_time(metadata.accessed().unwrap())
+        );
+    })
+}
+
+#[test]
+fn change_modified_time_of_files_matching_glob_to_today() {
+    Playground::setup("change_mtime_test_glob", |dirs, sandbox| {
+        sandbox.with_files(&[Stub::EmptyFile("file.txt")]);
+        let path = dirs.test().join("file.txt");
+
+        // Set file.txt's times to the past before the test to make sure `utouch` actually changes the mtime to today
+        filetime::set_file_times(&path, TIME_ONE, TIME_ONE).unwrap();
+
+        nu!(
+            cwd: dirs.test(),
+            "utouch -m *.txt"
         );
 
         let metadata = path.metadata().unwrap();
@@ -144,6 +187,36 @@ fn change_access_time_of_file_to_today() {
 }
 
 #[test]
+fn change_access_time_of_files_matching_glob_to_today() {
+    Playground::setup("change_atime_test_glob", |dirs, sandbox| {
+        sandbox.with_files(&[Stub::EmptyFile("file.txt")]);
+        let path = dirs.test().join("file.txt");
+
+        // Set file.txt's times to the past before the test to make sure `utouch` actually changes the atime to today
+        filetime::set_file_times(&path, TIME_ONE, TIME_ONE).unwrap();
+
+        nu!(
+            cwd: dirs.test(),
+            "utouch -a *.txt"
+        );
+
+        let metadata = path.metadata().unwrap();
+
+        // Check only the date since the time may not match exactly
+        let today = Local::now().date_naive();
+        let atime_day = DateTime::<Local>::from(metadata.accessed().unwrap()).date_naive();
+
+        assert_eq!(today, atime_day);
+
+        // Check that mtime remains unchanged
+        assert_eq!(
+            TIME_ONE,
+            FileTime::from_system_time(metadata.modified().unwrap())
+        );
+    })
+}
+
+#[test]
 fn change_modified_and_access_time_of_file_to_today() {
     Playground::setup("change_time_test_27", |dirs, sandbox| {
         sandbox.with_files(&[Stub::EmptyFile("file.txt")]);
@@ -154,6 +227,31 @@ fn change_modified_and_access_time_of_file_to_today() {
         nu!(
             cwd: dirs.test(),
             "utouch -a -m file.txt"
+        );
+
+        let metadata = path.metadata().unwrap();
+
+        // Check only the date since the time may not match exactly
+        let today = Local::now().date_naive();
+        let mtime_day = DateTime::<Local>::from(metadata.modified().unwrap()).date_naive();
+        let atime_day = DateTime::<Local>::from(metadata.accessed().unwrap()).date_naive();
+
+        assert_eq!(today, mtime_day);
+        assert_eq!(today, atime_day);
+    })
+}
+
+#[test]
+fn change_modified_and_access_time_of_files_matching_glob_to_today() {
+    Playground::setup("change_mtime_atime_test_glob", |dirs, sandbox| {
+        sandbox.with_files(&[Stub::EmptyFile("file.txt")]);
+
+        let path = dirs.test().join("file.txt");
+        filetime::set_file_times(&path, TIME_ONE, TIME_ONE).unwrap();
+
+        nu!(
+            cwd: dirs.test(),
+            "utouch -a -m *.txt"
         );
 
         let metadata = path.metadata().unwrap();
@@ -198,6 +296,34 @@ fn change_file_times_if_exists_with_no_create() {
             nu!(
                 cwd: dirs.test(),
                 "utouch -c file.txt"
+            );
+
+            let metadata = path.metadata().unwrap();
+
+            // Check only the date since the time may not match exactly
+            let today = Local::now().date_naive();
+            let mtime_day = DateTime::<Local>::from(metadata.modified().unwrap()).date_naive();
+            let atime_day = DateTime::<Local>::from(metadata.accessed().unwrap()).date_naive();
+
+            assert_eq!(today, mtime_day);
+            assert_eq!(today, atime_day);
+        },
+    )
+}
+
+#[test]
+fn change_file_times_if_glob_has_matches_with_no_create() {
+    Playground::setup(
+        "change_file_times_if_glob_matches_with_no_create",
+        |dirs, sandbox| {
+            sandbox.with_files(&[Stub::EmptyFile("file.txt")]);
+            let path = dirs.test().join("file.txt");
+
+            filetime::set_file_times(&path, TIME_ONE, TIME_ONE).unwrap();
+
+            nu!(
+                cwd: dirs.test(),
+                "utouch -c *.txt"
             );
 
             let metadata = path.metadata().unwrap();

--- a/crates/nu-command/tests/commands/utouch.rs
+++ b/crates/nu-command/tests/commands/utouch.rs
@@ -87,15 +87,27 @@ fn creates_two_files() {
 // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
 #[test]
 #[cfg(not(windows))]
-fn creates_a_file_when_glob_has_no_matches() {
+fn creates_a_file_when_glob_is_quoted() {
     Playground::setup("create_test_glob", |dirs, _sandbox| {
         nu!(
             cwd: dirs.test(),
-            "utouch *.txt"
+            "utouch '*.txt'"
         );
 
         let path = dirs.test().join("*.txt");
         assert!(path.exists());
+    })
+}
+
+#[test]
+fn fails_when_glob_has_no_matches() {
+    Playground::setup("create_test_glob_no_matches", |dirs, _sandbox| {
+        let actual = nu!(
+            cwd: dirs.test(),
+            "utouch *.txt"
+        );
+
+        assert!(actual.err.contains("Error while parsing file glob *.txt"));
     })
 }
 

--- a/crates/nu-command/tests/commands/utouch.rs
+++ b/crates/nu-command/tests/commands/utouch.rs
@@ -100,7 +100,7 @@ fn creates_a_file_when_glob_is_quoted() {
 }
 
 #[test]
-fn fails_when_glob_star_has_no_matches() {
+fn fails_when_glob_has_no_matches() {
     Playground::setup("create_test_glob_no_matches", |dirs, _sandbox| {
         let actual = nu!(
             cwd: dirs.test(),
@@ -108,32 +108,6 @@ fn fails_when_glob_star_has_no_matches() {
         );
 
         assert!(actual.err.contains("No matches found for glob *.txt"));
-    })
-}
-
-#[test]
-fn fails_when_glob_question_mark_has_no_matches() {
-    Playground::setup("create_test_glob_no_matches", |dirs, _sandbox| {
-        let actual = nu!(
-            cwd: dirs.test(),
-            "utouch file?.txt"
-        );
-
-        assert!(actual.err.contains("No matches found for glob file?.txt"));
-    })
-}
-
-#[test]
-fn fails_when_glob_bracket_has_no_matches() {
-    Playground::setup("create_test_glob_no_matches", |dirs, _sandbox| {
-        let actual = nu!(
-            cwd: dirs.test(),
-            "utouch file[^0-9].txt"
-        );
-
-        assert!(actual
-            .err
-            .contains("No matches found for glob file[^0-9].txt"));
     })
 }
 

--- a/crates/nu-command/tests/commands/utouch.rs
+++ b/crates/nu-command/tests/commands/utouch.rs
@@ -83,7 +83,10 @@ fn creates_two_files() {
     })
 }
 
+// Windows forbids file names with reserved characters
+// https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
 #[test]
+#[cfg(not(windows))]
 fn creates_a_file_when_glob_has_no_matches() {
     Playground::setup("create_test_glob", |dirs, _sandbox| {
         nu!(


### PR DESCRIPTION
# Description
These changes resolve #13623 where globs are not handled by `utouch`. 

# User-Facing Changes
- Glob patterns passed to `utouch` will be resolved to all individual files that match the pattern. For example, running `utouch *.txt` in a directory that already has `file1.txt` and `file2.txt` is the same thing as running `utouch file1.txt file2.txt`. All flags such as `-a`, `-m` and `-c` will be respected.
- If a glob pattern is provided to `utouch` and doesn't match any files, a file will be created with the literal name of the glob pattern. This only applies to Linux/MacOS because Windows forbids creating file names with restricted characters (see [naming a file docs](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file))
