### PR TITLE
`cp`: disable unsupported reflink mode in freebsd builds

### DIFF
--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -142,19 +142,9 @@ impl Command for UCp {
         } else {
             uu_cp::OverwriteMode::Clobber(uu_cp::ClobberMode::Standard)
         };
-        #[cfg(any(
-            target_os = "linux",
-            target_os = "freebsd",
-            target_os = "android",
-            target_os = "macos"
-        ))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
         let reflink_mode = uu_cp::ReflinkMode::Auto;
-        #[cfg(not(any(
-            target_os = "linux",
-            target_os = "freebsd",
-            target_os = "android",
-            target_os = "macos"
-        )))]
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
         let reflink_mode = uu_cp::ReflinkMode::Never;
         let mut paths = call.rest::<Spanned<NuGlob>>(engine_state, stack, 0)?;
         if paths.is_empty() {

--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -894,11 +894,17 @@ fn test_cp_debug_default() {
         {
             panic!("{}", format!("Failure: stdout was \n{}", actual.out));
         }
-        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+        #[cfg(target_os = "linux")]
         if !actual
             .out
             .contains("copy offload: yes, reflink: unsupported, sparse detection: no")
         {
+            panic!("{}", format!("Failure: stdout was \n{}", actual.out));
+        }
+        #[cfg(target_os = "freebsd")]
+        if !actual.out.contains(
+            "copy offload: unsupported, reflink: unsupported, sparse detection: unsupported",
+        ) {
             panic!("{}", format!("Failure: stdout was \n{}", actual.out));
         }
 


### PR DESCRIPTION
Fixes #12627

# User-Facing Changes

Under FreeBSD, `cp` no longer errors with "--reflink is only supported on
linux and macOS".

# Tests

The `commands::ucp` tests now pass on a FreeBSD 14.2 machine with ZFS.