### PR TITLE
Remove no-longer-needed convert_env_values calls

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -19,7 +19,7 @@ use miette::{ErrReport, IntoDiagnostic, Result};
 use nu_cmd_base::util::get_editor;
 use nu_color_config::StyleComputer;
 #[allow(deprecated)]
-use nu_engine::{convert_env_values, current_dir_str, env_to_strings};
+use nu_engine::{current_dir_str, env_to_strings};
 use nu_parser::{lex, parse, trim_quotes_str};
 use nu_protocol::{
     config::NuCursorShape,
@@ -80,13 +80,6 @@ pub fn evaluate_repl(
         engine_state.clone(),
         stack.clone(),
     );
-
-    let start_time = std::time::Instant::now();
-    // Translate environment variables from Strings to Values
-    if let Err(e) = convert_env_values(engine_state, &unique_stack) {
-        report_shell_error(engine_state, &e);
-    }
-    perf!("translate env vars", start_time, use_color);
 
     // seed env vars
     unique_stack.add_env_var(

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -362,17 +362,6 @@ fn get_converted_value(
     )
 }
 
-pub fn path_convert_from_string(
-    engine_state: &EngineState,
-    stack: &mut Stack,
-) -> Result<(), ShellError> {
-    if let Some(value) = engine_state.get_env_var_insensitive("PATH") {
-        let span = value.span();
-        stack.add_env_var("path".to_string(), Value::string("/", Span::unknown()))
-    };
-    Ok(())
-}
-
 fn ensure_path(scope: &mut HashMap<String, Value>, env_path_name: &str) -> Option<ShellError> {
     let mut error = None;
 

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -51,18 +51,6 @@ pub(crate) fn read_config_file(
             use_color
         );
     } else {
-        let start_time = std::time::Instant::now();
-        let config = engine_state.get_config();
-        let use_color = config.use_ansi_coloring.get(engine_state);
-        if let Err(e) = convert_env_values(engine_state, stack) {
-            report_shell_error(engine_state, &e);
-        }
-        perf!(
-            "translate env vars before default_config.nu",
-            start_time,
-            use_color
-        );
-
         eval_default_config(engine_state, stack, get_default_config(), is_env_config);
     };
 


### PR DESCRIPTION
# Description

Takes advantage of #14591 to remove the now-necessary calls to `convert_env_values()` that I added in #14249.  The function is now just called once to convert `PATH`.

Also removed the Windows-build-time checks for `ensure_path`, since previous case-insensitivity fixes make this unnecessary as well.

# User-Facing Changes

None - #14591 now handles conversion 'on-demand'.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A