### PR TITLE
Add command to get evaluated color setting

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -354,6 +354,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             ConfigFlatten,
             ConfigMeta,
             ConfigReset,
+            ConfigUseColors,
         };
 
         // Math

--- a/crates/nu-command/src/env/config/config_use_colors.rs
+++ b/crates/nu-command/src/env/config/config_use_colors.rs
@@ -1,0 +1,41 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct ConfigUseColors;
+
+impl Command for ConfigUseColors {
+    fn name(&self) -> &str {
+        "config use-colors"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .category(Category::Env)
+            .input_output_type(Type::Nothing, Type::Bool)
+    }
+
+    fn description(&self) -> &str {
+        "Get the configuration for color output."
+    }
+
+    fn extra_description(&self) -> &str {
+        r#"Use this command instead of checking `$env.config.use_ansi_coloring` to properly handle the "auto" setting, including environment variables that influence its behavior."#
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let use_ansi_coloring = engine_state
+            .get_config()
+            .use_ansi_coloring
+            .get(engine_state);
+        Ok(PipelineData::Value(
+            Value::bool(use_ansi_coloring, call.head),
+            None,
+        ))
+    }
+}

--- a/crates/nu-command/src/env/config/mod.rs
+++ b/crates/nu-command/src/env/config/mod.rs
@@ -3,9 +3,11 @@ mod config_env;
 mod config_flatten;
 mod config_nu;
 mod config_reset;
+mod config_use_colors;
 
 pub use config_::ConfigMeta;
 pub use config_env::ConfigEnv;
 pub use config_flatten::ConfigFlatten;
 pub use config_nu::ConfigNu;
 pub use config_reset::ConfigReset;
+pub use config_use_colors::ConfigUseColors;

--- a/crates/nu-command/src/env/mod.rs
+++ b/crates/nu-command/src/env/mod.rs
@@ -9,6 +9,7 @@ pub use config::ConfigFlatten;
 pub use config::ConfigMeta;
 pub use config::ConfigNu;
 pub use config::ConfigReset;
+pub use config::ConfigUseColors;
 pub use export_env::ExportEnv;
 pub use load_env::LoadEnv;
 pub use source_env::SourceEnv;


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

In #14647 I added the option `"auto"` to be a valid option for `$env.config.use_ansi_coloring`. That improves the decision making whether ansi colors should be used or not but that makes it hard for custom commands to respect that value as the config might now be a non-boolean value. To retrieve that evaluated value I added a new command called `config use-colors` that returns an evaluated boolean that may be used to decide if colors should be used or not.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Scripts that previously just checked `$env.config.use_ansi_coloring` should now use `config use-colors` for their color decision making.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

This PR essentially only runs `UseAnsiColoring::get`, and that is highly tested in the #14647, so I don't think this needs further testing.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

I'm not sure if we have any docs about that ansi coloring setup. If we have, we should update these.