### PR TITLE
update banner command to respect use_ansi_colors

### DIFF
--- a/crates/nu-std/std/core/mod.nu
+++ b/crates/nu-std/std/core/mod.nu
@@ -30,7 +30,7 @@ It's been this long since (ansi green)Nushell(ansi reset)'s first commit:
 "
 }
 
-match $env.config?.use_ansi_coloring? {
+match (config use-colors) {
     false => { $banner_msg | ansi strip }
     _ => $banner_msg
 }


### PR DESCRIPTION
# Description

This PR goes along with the recent changes by @cptpiepmatz for [auto-color](https://github.com/nushell/nushell/pull/14647) and [evaluation of auto-color](https://github.com/nushell/nushell/pull/14683) which also looks at env vars along with config settings to determine when it's appropriate to show ansi coloring since it's more complicated than just reading a setting or an env var.


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
