### PR TITLE
make exec command decrement SHLVL correctly & SHLVL related test

### DIFF
--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -61,6 +61,16 @@ On Windows based systems, Nushell will wait for the command to finish and then e
         let envs = env_to_strings(engine_state, stack)?;
         command.env_clear();
         command.envs(envs);
+        // Decrement SHLVL as removing the current shell from the stack
+        // (only works in interactive mode, same as initialization)
+        if engine_state.is_interactive {
+            let shlvl = engine_state
+                .get_env_var("SHLVL")
+                .and_then(|shlvl_env| shlvl_env.coerce_str().ok()?.parse::<i64>().ok())
+                .unwrap_or(1)
+                .saturating_sub(1);
+            command.env("SHLVL", shlvl.to_string());
+        }
 
         // Configure args.
         let args = crate::eval_arguments_from_call(engine_state, stack, call)?;

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -229,3 +229,23 @@ fn std_log_env_vars_have_defaults() {
     assert!(actual.err.contains("%MSG%"));
     assert!(actual.err.contains("%Y-"));
 }
+
+#[test]
+fn env_shlvl() {
+    let actual = nu!("
+        $env.SHLVL = 5
+        nu -i -c 'print $env.SHLVL'
+    ");
+
+    assert_eq!(actual.out, "6");
+}
+
+#[test]
+fn env_shlvl_in_exec() {
+    let actual = nu!("
+        $env.SHLVL = 29
+        nu -i -c \"exec nu -i -c 'print $env.SHLVL'\"
+    ");
+
+    assert_eq!(actual.out, "30");
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Rework of #14570, fixing #14567.

`exec` will decrement `SHLVL` env value before passing it to target executable (in interactive mode).

(Same as last pr, but this time there's no wrong change to current working code)

Two `SHLVL` related tests were also added this time.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Formatted & tested (both with new test funcs and manually).

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
