### PR TITLE
auto cd should not canonicalize symbolic path

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -1579,6 +1579,13 @@ mod test_auto_cd {
         symlink(&dir, &link).unwrap();
         let input = if cfg!(windows) { r".\link" } else { "./link" };
         check(tempdir, input, link);
+
+        let dir = tempdir.join("foo").join("bar");
+        std::fs::create_dir_all(&dir).unwrap();
+        let link = tempdir.join("link2");
+        symlink(&dir, &link).unwrap();
+        let input = "..";
+        check(link, input, tempdir);
     }
 
     #[test]

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -816,8 +816,10 @@ fn parse_operation(
 ) -> Result<ReplOperation, ErrReport> {
     let tokens = lex(s.as_bytes(), 0, &[], &[], false);
     // Check if this is a single call to a directory, if so auto-cd
-    #[allow(deprecated)]
-    let cwd = nu_engine::env::current_dir_str(engine_state, stack).unwrap_or_default();
+    let cwd = engine_state
+        .cwd(Some(stack))
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
     let mut orig = s.clone();
     if orig.starts_with('`') {
         orig = trim_quotes_str(&orig).to_string()


### PR DESCRIPTION
# Description
Fixes: #13158

To fix the issue for auto-cd feature, just need to use `EngineState::cwd` instead of `nu_engine::env::current_dir_str`

# User-Facing Changes
## Before
```shell
> cd ~
> ln -s /tmp test_link; cd test_link
> ..
> $env.PWD
/
```

## After
```shell
> cd ~
> ln -s /tmp test_link; cd test_link
> ..
> $env.PWD  # it should output home directory.
```

# Tests + Formatting
Update a test under `auto_cd_symlink`
