### PR TITLE
better error message for "sum", "product", and "sum_of_squares"

### DIFF
--- a/crates/nu-command/src/math/reducers.rs
+++ b/crates/nu-command/src/math/reducers.rs
@@ -111,8 +111,8 @@ pub fn sum(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellError
             Value::Error { error, .. } => return Err(*error.clone()),
             other => {
                 return Err(ShellError::UnsupportedInput {
-                    msg: "Attempted to compute the sum of a value that cannot be summed"
-                        .to_string(),
+                    msg: format!("Attempted to compute the sum of a value '{}' that cannot be summed with a type of `{}`.",
+                        other.coerce_string()?, other.get_type()),
                     input: "value originates from here".into(),
                     msg_span: head,
                     input_span: other.span(),
@@ -150,8 +150,8 @@ pub fn product(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellE
             Value::Error { error, .. } => return Err(*error.clone()),
             other => {
                 return Err(ShellError::UnsupportedInput {
-                    msg: "Attempted to compute the product of a value that cannot be multiplied"
-                        .to_string(),
+                    msg: format!("Attempted to compute the product of a value '{}' that cannot be multiplied with a type of `{}`.",
+                        other.coerce_string()?, other.get_type()),
                     input: "value originates from here".into(),
                     msg_span: head,
                     input_span: other.span(),

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -90,9 +90,9 @@ fn sum_of_squares(values: &[Value], span: Span) -> Result<Value, ShellError> {
         let v = match &value {
             Value::Int { .. } | Value::Float { .. } => Ok(value),
             Value::Error { error, .. } => Err(*error.clone()),
-            _ => Err(ShellError::UnsupportedInput {
-                msg: "Attempted to compute the sum of squares of a non-int, non-float value"
-                    .to_string(),
+            other => Err(ShellError::UnsupportedInput {
+                msg: format!("Attempted to compute the sum of squares of a non-int, non-float value '{}' with a type of `{}`.",
+                        other.coerce_string()?, other.get_type()),
                 input: "value originates from here".into(),
                 msg_span: span,
                 input_span: value.span(),

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -73,9 +73,7 @@ fn sum_of_a_row_containing_a_table_is_an_error() {
         cwd: "tests/fixtures/formats/",
         "open sample-sys-output.json | math sum"
     );
-    assert!(actual
-        .err
-        .contains("Attempted to compute the sum of a value that cannot be summed"));
+    assert!(actual.err.contains("can't convert record"));
 }
 
 #[test]


### PR DESCRIPTION
# Description

This PR tries to improve a few error messages.

### Before
![image](https://github.com/user-attachments/assets/58ab3ff6-baab-4075-8746-e83cb3acab14)

### After
![image](https://github.com/user-attachments/assets/9653776a-371b-4454-b092-3cc49f1329cd)

 
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
