### PR TITLE
External command: making a way to stop in the middle of pipeline if it runs to failed

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -261,7 +261,7 @@ impl Command for External {
             call.head,
         )?;
 
-        if engine_state.get_config().pipefail {
+        if engine_state.get_config().errexit {
             // Should wait the command running to complete.
             // Then nushell is able to check the exit status.
             //

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -257,6 +257,13 @@ impl Command for External {
             call.head,
         )?;
 
+        if matches!(stdout, OutDest::Pipe) {
+            let bytes = child.into_bytes()?;
+            return Ok(PipelineData::ByteStream(
+                ByteStream::read_binary(bytes, call.head, engine_state.signals().clone()),
+                None,
+            ));
+        }
         if matches!(stdout, OutDest::Pipe | OutDest::PipeSeparate)
             || matches!(stderr, OutDest::Pipe | OutDest::PipeSeparate)
         {

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -69,7 +69,7 @@ pub struct Config {
     pub datetime_format: DatetimeFormatConfig,
     pub error_style: ErrorStyle,
     pub display_errors: DisplayErrors,
-    pub pipefail: bool,
+    pub errexit: bool,
     pub use_kitty_protocol: bool,
     pub highlight_resolved_externals: bool,
     /// Configuration for plugins.
@@ -126,7 +126,7 @@ impl Default for Config {
             error_style: ErrorStyle::Fancy,
             display_errors: DisplayErrors::default(),
 
-            pipefail: false,
+            errexit: false,
             use_kitty_protocol: false,
             highlight_resolved_externals: false,
 
@@ -187,7 +187,7 @@ impl UpdateFromValue for Config {
                     .update(val, path, errors),
                 "bracketed_paste" => self.bracketed_paste.update(val, path, errors),
                 "use_kitty_protocol" => self.use_kitty_protocol.update(val, path, errors),
-                "pipefail" => self.pipefail.update(val, path, errors),
+                "errexit" => self.errexit.update(val, path, errors),
                 "highlight_resolved_externals" => {
                     self.highlight_resolved_externals.update(val, path, errors)
                 }

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -69,6 +69,7 @@ pub struct Config {
     pub datetime_format: DatetimeFormatConfig,
     pub error_style: ErrorStyle,
     pub display_errors: DisplayErrors,
+    pub pipefail: bool,
     pub use_kitty_protocol: bool,
     pub highlight_resolved_externals: bool,
     /// Configuration for plugins.
@@ -125,6 +126,7 @@ impl Default for Config {
             error_style: ErrorStyle::Fancy,
             display_errors: DisplayErrors::default(),
 
+            pipefail: false,
             use_kitty_protocol: false,
             highlight_resolved_externals: false,
 
@@ -185,6 +187,7 @@ impl UpdateFromValue for Config {
                     .update(val, path, errors),
                 "bracketed_paste" => self.bracketed_paste.update(val, path, errors),
                 "use_kitty_protocol" => self.use_kitty_protocol.update(val, path, errors),
+                "pipefail" => self.pipefail.update(val, path, errors),
                 "highlight_resolved_externals" => {
                     self.highlight_resolved_externals.update(val, path, errors)
                 }

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -1,7 +1,7 @@
 use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::fs::Stub::FileWithContent;
+use nu_test_support::nu;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu, nu_repl_code};
 use pretty_assertions::assert_eq;
 
 #[test]

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -655,9 +655,9 @@ fn arg_dont_run_subcommand_if_surrounded_with_quote() {
 }
 
 #[test]
-fn exit_code_pipefail() {
-    Playground::setup("pipefail", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContent("tmp_env.nu", "$env.config.pipefail = true")]);
+fn exit_code_errexit() {
+    Playground::setup("errexit", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContent("tmp_env.nu", "$env.config.errexit = true")]);
 
         let actual = nu!(
             env_config: "tmp_env.nu",

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::Stub::EmptyFile;
-use nu_test_support::nu;
+use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::playground::Playground;
+use nu_test_support::{nu, nu_repl_code};
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -651,4 +652,19 @@ fn arg_dont_run_subcommand_if_surrounded_with_quote() {
     assert_eq!(actual.out, "(echo aa)");
     let actual = nu!("nu --testbin cococo '(echo aa)'");
     assert_eq!(actual.out, "(echo aa)");
+}
+
+#[test]
+fn exit_code_pipefail() {
+    Playground::setup("pipefail", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContent("tmp_env.nu", "$env.config.pipefail = true")]);
+
+        let actual = nu!(
+            env_config: "tmp_env.nu",
+            cwd: dirs.test(),
+            "nu --testbin fail | print 'aa'",
+        );
+        assert_eq!(actual.out, "");
+        assert_eq!(actual.status.code(), Some(1));
+    })
 }


### PR DESCRIPTION
# Description
Closes:  #10633
Closes: #6617
Closes: #10624

This pr introduce a `$env.config.errexit` option ~, it's just something like `set -e` in bash shell.~

To implement the feature, nushell needs to wait the external commands run into complete in `run-external`.  And it returns `ShellError::NonZeroExitCode` if the external command runs into failed.
If the command runs to success, nushell needs to re-construct `ChildProcess` to return, so that it can be handled by the rest of the system.
All the behavior is guarded by `$env.config.errexit` option.

### Warning
Because nushell needs to check the result of external commands, if an external command never runs to complete, the whole pipeline will never complete.  For example:
```
yes | head -n 10
```
It will never run into complete unless `ctrl-c` is pressed.

In other words, the streaming feature of external commands is lost if `errexit` is set.

# User-Facing Changes
After this pr, user will be able to stop when the middle of pipeline command returns a non-zero exit code.

This behavior can be config by `$env.config.errexit` option.

```shell
$env.config.errexit= true
^false | 'aa'
```
It no longer returns 'aa'.  It will stop on `false` command.

Also, users can see `non_zero_exit_code` error if ` $env.config.display_errors.exit_code` is set to true:
```shell
$env.config.errexit = true
$env.config.display_errors.exit_code = true
^false | 'aa'
Error: nu::shell::non_zero_exit_code

  × External command had a non-zero exit code
   ╭─[entry #21:1:2]
 1 │ ^false | 'aa'
   ·  ──┬──
   ·    ╰── exited with code 1
   ╰────
```

# Tests + Formatting
Added a test to test pipefail feature

# After Submitting
I think it might be better to introduce a new command called `run-external-eagerly`, and when compiling ir, it generates call to `run-external-eagerly` if `errexit` is set.  Then nushell doesn't need to check `errexit` in `run-external`.  It might improve performance a little bit.
But for a smaller diff, maybe it's good to implement the feature first.
