### PR TITLE
Make touch not accept globs

### DIFF
--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -246,7 +246,7 @@ impl Command for Touch {
             },
             Example {
                 description: r#"Update times of all JSON files in folder"#,
-                example: r#"touch ...(glob *.json)"#,
+                example: r#"touch ...(ls *.json).name"#,
                 result: None,
             },
         ]

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -21,7 +21,7 @@ impl Command for Touch {
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .rest(
                 "files",
-                SyntaxShape::OneOf(vec![SyntaxShape::GlobPattern, SyntaxShape::Filepath]),
+                SyntaxShape::Filepath,
                 "The file(s) to create."
             )
             .named(
@@ -242,6 +242,11 @@ impl Command for Touch {
             Example {
                 description: r#"Changes the last modified time of file d and e to "fixture.json"'s last modified time"#,
                 example: r#"touch -m -r fixture.json d e"#,
+                result: None,
+            },
+            Example {
+                description: r#"Update times of all JSON files in folder"#,
+                example: r#"touch ...(glob *.json)"#,
                 result: None,
             },
         ]


### PR DESCRIPTION
# Description

This changes the signature of `touch` to accept only file paths for the rest arguments, rather than both globs and file paths. This is because `touch` doesn't actually expand globs.

I also added in Kubouch's suggested example of how to use `touch` to update the timestamps of multiple files.

This is the last little piece needed to close https://github.com/nushell/nushell/issues/13623.

Note: I didn't bother using `let files = call.rest::<Spanned<PathBuf>>(...)` rather than `let files = call.rest::<Spanned<NuGlob>>(...)` because `NuGlob` lets us differentiate between `touch ~` and `touch '~'`.

# User-Facing Changes

`touch`'s signature will no longer let it (misleadingly) accept globs.

# Tests + Formatting

None.