### PR TITLE
Remove glob from touch signature (issue #13623)

### DIFF
--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -21,7 +21,7 @@ impl Command for Touch {
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .rest(
                 "files",
-                SyntaxShape::OneOf(vec![SyntaxShape::GlobPattern, SyntaxShape::Filepath]),
+                SyntaxShape::Filepath,
                 "The file(s) to create."
             )
             .named(


### PR DESCRIPTION
# Description
Closes #13623 by removing `glob` as a supported input in the `touch` signature.

# User-Facing Changes
`glob` no longer appears as a supported input type in the output of `help touch`
