### PR TITLE
Bump Rust version to `1.82.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://www.nushell.sh"
 license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
-rust-version = "1.81.0"
+rust-version = "1.82.0"
 version = "0.101.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,4 +16,4 @@ profile = "default"
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 4 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.81.0"
+channel = "1.82.0"


### PR DESCRIPTION
When we will release 0.102.0 the stable Rust version will be 1.84.0 so
we uphold our rough rule of being two releases behind.

Should unblock #14714
