### PR TITLE
Run SHLVL tests sequentially

### DIFF
--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -232,20 +232,10 @@ fn std_log_env_vars_have_defaults() {
 
 #[test]
 fn env_shlvl() {
-    let actual = nu!("
+    let actual = nu!(r#"
         $env.SHLVL = 5
-        nu -i -c 'print $env.SHLVL'
-    ");
+        nu --no-std-lib -n -e "print $env.SHLVL; exit"
+    "#);
 
     assert_eq!(actual.out, "6");
-}
-
-#[test]
-fn env_shlvl_in_exec() {
-    let actual = nu!("
-        $env.SHLVL = 29
-        nu -i -c \"exec nu -i -c 'print $env.SHLVL'\"
-    ");
-
-    assert_eq!(actual.out, "30");
 }

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -232,10 +232,17 @@ fn std_log_env_vars_have_defaults() {
 
 #[test]
 fn env_shlvl() {
-    let actual = nu!(r#"
+    let actual = nu!("
         $env.SHLVL = 5
-        nu --no-std-lib -n -e "print $env.SHLVL; exit"
-    "#);
+        nu -i -c 'print $env.SHLVL'
+    ");
 
     assert_eq!(actual.out, "6");
+
+    let actual = nu!("
+        $env.SHLVL = 29
+        nu -i -c \"exec nu -i -c 'print $env.SHLVL'\"
+    ");
+
+    assert_eq!(actual.out, "30");
 }


### PR DESCRIPTION
# Description

Tests for #14707 are causing hangs which are preventing `toolkit test` from completing on some systems.  This appears to be due to the use of `-i` to force interactive mode, which is required in order to update the `SHLVL`.  Both tests are likely attempting to acquire the terminal at the same time, and one is hanging as a result.

This is a temporary fix which runs both of these tests sequentially.  It's temporary because we need to find a solution which doesn't use `-i`, since any other future `-it` test will cause the same situation again.

# User-Facing Changes

None - Tests only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A