### PR TITLE
Add comment on `nu_repl` usage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -402,6 +402,9 @@ fn main() -> Result<()> {
             "chop" => test_bins::chop(),
             "repeater" => test_bins::repeater(),
             "repeat_bytes" => test_bins::repeat_bytes(),
+            // Important: nu_repl must be called with `--testbin=nu_repl`
+            // `--testbin nu_repl` will not work due to argument count logic
+            // in test_bins.rs
             "nu_repl" => test_bins::nu_repl(),
             "input_bytes_length" => test_bins::input_bytes_length(),
             _ => std::process::exit(1),


### PR DESCRIPTION
# Description

I just spent way too long trying to get `nu --testbin nu_repl <commands>` working.  That's one argument that must be called as `nu --testbin=nu_repl <commands>` due to its implementation.  This PR simply adds a comment in `main()` noting that, hoping it will save someone else some time in the future ;-)

# User-Facing Changes

None

# Tests + Formatting

N/A

# After Submitting

N/A