### PR TITLE
feat(lsp): use lsp-textdocument to handle utf16 position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,6 +1965,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3195,16 +3204,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "lsp-types"
-version = "0.95.1"
+name = "lsp-textdocument"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
+checksum = "d8dc223af95101fe950a871d4d567b6f98a1ecfcee5861f4b57644581aaa980d"
+dependencies = [
+ "lsp-types",
+ "serde_json",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -3924,6 +3943,7 @@ dependencies = [
  "assert-json-diff",
  "crossbeam-channel",
  "lsp-server",
+ "lsp-textdocument",
  "lsp-types",
  "miette",
  "nu-cli",
@@ -3933,7 +3953,6 @@ dependencies = [
  "nu-protocol",
  "nu-test-support",
  "reedline",
- "ropey",
  "serde",
  "serde_json",
 ]
@@ -6248,16 +6267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ropey"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
-dependencies = [
- "smallvec",
- "str_indices",
-]
-
-[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7014,12 +7023,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "str_indices"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
 
 [[package]]
 name = "streaming-decompression"
@@ -7800,7 +7803,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3955,6 +3955,7 @@ dependencies = [
  "reedline",
  "serde",
  "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,8 @@ log = "0.4"
 lru = "0.12"
 lscolors = { version = "0.17", default-features = false }
 lsp-server = "0.7.5"
-lsp-types = { version = "0.95.0", features = ["proposed"] }
+lsp-types = { version = "0.97.0", features = ["proposed"] }
+lsp-textdocument = "0.4.0"
 mach2 = "0.4"
 md5 = { version = "0.10", package = "md-5" }
 miette = "7.3"
@@ -139,10 +140,8 @@ rand_chacha = "0.3.1"
 ratatui = "0.26"
 rayon = "1.10"
 reedline = "0.38.0"
-regex = "1.9.5"
 rmp = "0.8"
 rmp-serde = "1.3"
-ropey = "1.6.1"
 roxmltree = "0.20"
 rstest = { version = "0.23", default-features = false }
 rusqlite = "0.31"

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -21,6 +21,7 @@ lsp-textdocument = { workspace = true }
 miette = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.101.1" }

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -15,10 +15,10 @@ nu-protocol = { path = "../nu-protocol", version = "0.101.1" }
 reedline = { workspace = true }
 
 crossbeam-channel = { workspace = true }
-lsp-types = { workspace = true }
 lsp-server = { workspace = true }
+lsp-types = { workspace = true }
+lsp-textdocument = { workspace = true }
 miette = { workspace = true }
-ropey = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/nu-lsp/src/diagnostics.rs
+++ b/crates/nu-lsp/src/diagnostics.rs
@@ -14,7 +14,7 @@ impl LanguageServer {
         engine_state.generate_nu_constant();
 
         let Some((_, offset, working_set, file)) =
-            self.update_engine_state(&mut engine_state, uri.clone())
+            self.update_engine_state(&mut engine_state, &uri)
         else {
             return Ok(());
         };

--- a/crates/nu-lsp/src/diagnostics.rs
+++ b/crates/nu-lsp/src/diagnostics.rs
@@ -50,7 +50,8 @@ mod tests {
     use assert_json_diff::assert_json_eq;
     use nu_test_support::fs::fixtures;
 
-    use crate::tests::{initialize_language_server, open_unchecked, pathbuf_to_uri, update};
+    use crate::path_to_uri;
+    use crate::tests::{initialize_language_server, open_unchecked, update};
 
     #[test]
     fn publish_diagnostics_variable_does_not_exists() {
@@ -60,7 +61,7 @@ mod tests {
         script.push("lsp");
         script.push("diagnostics");
         script.push("var.nu");
-        let script = pathbuf_to_uri(&script);
+        let script = path_to_uri(&script);
 
         let notification = open_unchecked(&client_connection, script.clone());
 
@@ -91,7 +92,7 @@ mod tests {
         script.push("lsp");
         script.push("diagnostics");
         script.push("var.nu");
-        let script = pathbuf_to_uri(&script);
+        let script = path_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
         let notification = update(

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -588,14 +588,13 @@ mod tests {
     use assert_json_diff::{assert_json_eq, assert_json_include};
     use lsp_types::{
         notification::{
-            DidChangeTextDocument, DidOpenTextDocument, DidSaveTextDocument, Exit, Initialized,
-            Notification,
+            DidChangeTextDocument, DidOpenTextDocument, Exit, Initialized, Notification,
         },
         request::{Completion, GotoDefinition, HoverRequest, Initialize, Request, Shutdown},
         CompletionParams, DidChangeTextDocumentParams, DidOpenTextDocumentParams,
-        DidSaveTextDocumentParams, GotoDefinitionParams, InitializeParams, InitializedParams,
-        PartialResultParams, Position, TextDocumentContentChangeEvent, TextDocumentIdentifier,
-        TextDocumentItem, TextDocumentPositionParams, WorkDoneProgressParams,
+        GotoDefinitionParams, InitializeParams, InitializedParams, PartialResultParams, Position,
+        TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem,
+        TextDocumentPositionParams, WorkDoneProgressParams,
     };
     use nu_test_support::fs::{fixtures, root};
     use std::sync::mpsc::Receiver;

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -1,27 +1,22 @@
 #![doc = include_str!("../README.md")]
 use lsp_server::{Connection, IoThreads, Message, Response, ResponseError};
+use lsp_textdocument::{FullTextDocument, TextDocuments};
 use lsp_types::{
     request::{Completion, GotoDefinition, HoverRequest, Request},
     CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse, CompletionTextEdit,
     GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverContents, HoverParams, Location,
-    MarkupContent, MarkupKind, OneOf, Position, PositionEncodingKind, Range, ServerCapabilities,
-    TextDocumentSyncKind, TextEdit, Url,
+    MarkupContent, MarkupKind, OneOf, Range, ServerCapabilities, TextDocumentSyncKind, TextEdit,
+    Uri,
 };
 use miette::{IntoDiagnostic, Result};
 use nu_cli::{NuCompleter, SuggestionKind};
 use nu_parser::{flatten_block, parse, FlatShape};
 use nu_protocol::{
-    engine::{CachedFile, EngineState, Stack, StateWorkingSet},
+    ast::Block,
+    engine::{EngineState, Stack, StateWorkingSet},
     DeclId, Span, Value, VarId,
 };
-use ropey::Rope;
-use serde_json::json;
-use std::{
-    collections::BTreeMap,
-    path::{Path, PathBuf},
-    sync::Arc,
-    time::Duration,
-};
+use std::{path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 
 mod diagnostics;
 mod notification;
@@ -36,40 +31,30 @@ enum Id {
 pub struct LanguageServer {
     connection: Connection,
     io_threads: Option<IoThreads>,
-    ropes: BTreeMap<PathBuf, Rope>,
-    position_encoding: PositionEncodingKind,
+    docs: TextDocuments,
+    engine_state: EngineState,
 }
 
 impl LanguageServer {
-    pub fn initialize_stdio_connection() -> Result<Self> {
+    pub fn initialize_stdio_connection(engine_state: EngineState) -> Result<Self> {
         let (connection, io_threads) = Connection::stdio();
-        Self::initialize_connection(connection, Some(io_threads))
+        Self::initialize_connection(connection, Some(io_threads), engine_state)
     }
 
     fn initialize_connection(
         connection: Connection,
         io_threads: Option<IoThreads>,
+        engine_state: EngineState,
     ) -> Result<Self> {
         Ok(Self {
             connection,
             io_threads,
-            ropes: BTreeMap::new(),
-            position_encoding: PositionEncodingKind::UTF16,
+            docs: TextDocuments::new(),
+            engine_state,
         })
     }
 
-    fn get_offset_encoding(&self, initialization_params: serde_json::Value) -> String {
-        initialization_params
-            .pointer("/capabilities/offsetEncoding/0")
-            .unwrap_or(
-                initialization_params
-                    .pointer("/capabilities/offset_encoding/0")
-                    .unwrap_or(&json!("utf-16")),
-            )
-            .to_string()
-    }
-
-    pub fn serve_requests(mut self, engine_state: EngineState) -> Result<()> {
+    pub fn serve_requests(mut self) -> Result<()> {
         let server_capabilities = serde_json::to_value(ServerCapabilities {
             text_document_sync: Some(lsp_types::TextDocumentSyncCapability::Kind(
                 TextDocumentSyncKind::INCREMENTAL,
@@ -77,20 +62,20 @@ impl LanguageServer {
             definition_provider: Some(OneOf::Left(true)),
             hover_provider: Some(lsp_types::HoverProviderCapability::Simple(true)),
             completion_provider: Some(lsp_types::CompletionOptions::default()),
+            // document_symbol_provider: Some(lsp_types::OneOf::Left(true)),
+            // workspace_symbol_provider: Some(lsp_types::OneOf::Left(true)),
             ..Default::default()
         })
         .expect("Must be serializable");
 
-        let initialization_params = self
+        let _ = self
             .connection
             .initialize_while(server_capabilities, || {
-                !engine_state.signals().interrupted()
+                !self.engine_state.signals().interrupted()
             })
             .into_diagnostic()?;
-        self.position_encoding =
-            PositionEncodingKind::from(self.get_offset_encoding(initialization_params));
 
-        while !engine_state.signals().interrupted() {
+        while !self.engine_state.signals().interrupted() {
             let msg = match self
                 .connection
                 .receiver
@@ -113,23 +98,16 @@ impl LanguageServer {
                         return Ok(());
                     }
 
-                    let mut engine_state = engine_state.clone();
                     let resp = match request.method.as_str() {
-                        GotoDefinition::METHOD => Self::handle_lsp_request(
-                            &mut engine_state,
-                            request,
-                            |engine_state, params| self.goto_definition(engine_state, params),
-                        ),
-                        HoverRequest::METHOD => Self::handle_lsp_request(
-                            &mut engine_state,
-                            request,
-                            |engine_state, params| self.hover(engine_state, params),
-                        ),
-                        Completion::METHOD => Self::handle_lsp_request(
-                            &mut engine_state,
-                            request,
-                            |engine_state, params| self.complete(engine_state, params),
-                        ),
+                        GotoDefinition::METHOD => {
+                            Self::handle_lsp_request(request, |params| self.goto_definition(params))
+                        }
+                        HoverRequest::METHOD => {
+                            Self::handle_lsp_request(request, |params| self.hover(params))
+                        }
+                        Completion::METHOD => {
+                            Self::handle_lsp_request(request, |params| self.complete(params))
+                        }
                         _ => {
                             continue;
                         }
@@ -143,8 +121,7 @@ impl LanguageServer {
                 Message::Response(_) => {}
                 Message::Notification(notification) => {
                     if let Some(updated_file) = self.handle_lsp_notification(notification) {
-                        let mut engine_state = engine_state.clone();
-                        self.publish_diagnostics_for_file(updated_file, &mut engine_state)?;
+                        self.publish_diagnostics_for_file(updated_file)?;
                     }
                 }
             }
@@ -157,21 +134,39 @@ impl LanguageServer {
         Ok(())
     }
 
-    fn handle_lsp_request<P, H, R>(
-        engine_state: &mut EngineState,
-        req: lsp_server::Request,
-        mut param_handler: H,
-    ) -> Response
+    pub fn update_engine_state<'a>(
+        &mut self,
+        engine_state: &'a mut EngineState,
+        uri: Uri,
+    ) -> Option<(Arc<Block>, usize, StateWorkingSet<'a>, &FullTextDocument)> {
+        let mut working_set = StateWorkingSet::new(engine_state);
+        let file = self.docs.get_document(&uri)?;
+        let file_path = uri.path().as_str();
+        let contents = file.get_content(None).as_bytes();
+        let _ = working_set
+            .files
+            .push(PathBuf::from(file_path), Span::unknown());
+        let block = parse(&mut working_set, Some(file_path), contents, false);
+        let offset = working_set
+            .get_span_for_filename(file_path)
+            .unwrap_or_else(|| panic!("Failed at get_span_for_filename {}", file_path))
+            .start;
+        // TODO: merge delta back to engine_state?
+        // self.engine_state.merge_delta(working_set.render());
+        Some((block, offset, working_set, file))
+    }
+
+    fn handle_lsp_request<P, H, R>(req: lsp_server::Request, mut param_handler: H) -> Response
     where
         P: serde::de::DeserializeOwned,
-        H: FnMut(&mut EngineState, &P) -> Option<R>,
+        H: FnMut(&P) -> Option<R>,
         R: serde::ser::Serialize,
     {
         match serde_json::from_value::<P>(req.params) {
             Ok(params) => Response {
                 id: req.id,
                 result: Some(
-                    param_handler(engine_state, &params)
+                    param_handler(&params)
                         .and_then(|response| serde_json::to_value(response).ok())
                         .unwrap_or(serde_json::Value::Null),
                 ),
@@ -190,97 +185,17 @@ impl LanguageServer {
         }
     }
 
-    fn span_to_range(
-        span: &Span,
-        rope_of_file: &Rope,
-        offset: usize,
-        position_encoding: &PositionEncodingKind,
-    ) -> Range {
-        let start = Self::lsp_byte_offset_to_utf_cu_position(
-            span.start.saturating_sub(offset),
-            rope_of_file,
-            position_encoding,
-        );
-        let end = Self::lsp_byte_offset_to_utf_cu_position(
-            span.end.saturating_sub(offset),
-            rope_of_file,
-            position_encoding,
-        );
+    fn span_to_range(span: &Span, file: &FullTextDocument, offset: usize) -> Range {
+        let start = file.position_at(span.start.saturating_sub(offset) as u32);
+        let end = file.position_at(span.end.saturating_sub(offset) as u32);
         Range { start, end }
     }
 
-    fn lsp_byte_offset_to_utf_cu_position(
-        offset: usize,
-        rope_of_file: &Rope,
-        position_encoding: &PositionEncodingKind,
-    ) -> Position {
-        let line = rope_of_file.try_byte_to_line(offset).unwrap_or(0);
-        match position_encoding.as_str() {
-            "\"utf-8\"" => {
-                let character = offset - rope_of_file.line_to_byte(line);
-                Position {
-                    line: line as u32,
-                    character: character as u32,
-                }
-            }
-            _ => {
-                let character = rope_of_file.char_to_utf16_cu(rope_of_file.byte_to_char(offset))
-                    - rope_of_file.char_to_utf16_cu(rope_of_file.line_to_char(line));
-                Position {
-                    line: line as u32,
-                    character: character as u32,
-                }
-            }
-        }
-    }
-
-    fn utf16_cu_position_to_char(rope_of_file: &Rope, position: &Position) -> usize {
-        let line_utf_idx =
-            rope_of_file.char_to_utf16_cu(rope_of_file.line_to_char(position.line as usize));
-        rope_of_file.utf16_cu_to_char(line_utf_idx + position.character as usize)
-    }
-
-    pub fn lsp_position_to_location(
-        position: &Position,
-        rope_of_file: &Rope,
-        position_encoding: &PositionEncodingKind,
-    ) -> usize {
-        match position_encoding.as_str() {
-            "\"utf-8\"" => rope_of_file.byte_to_char(
-                rope_of_file.line_to_byte(position.line as usize) + position.character as usize,
-            ),
-            _ => Self::utf16_cu_position_to_char(rope_of_file, position),
-        }
-    }
-
-    fn lsp_position_to_byte_offset(&self, position: &Position, rope_of_file: &Rope) -> usize {
-        match self.position_encoding.as_str() {
-            "\"utf-8\"" => {
-                rope_of_file.line_to_byte(position.line as usize) + position.character as usize
-            }
-            _ => rope_of_file
-                .try_char_to_byte(Self::utf16_cu_position_to_char(rope_of_file, position))
-                .expect("Character index out of range!"),
-        }
-    }
-
     fn find_id(
-        working_set: &mut StateWorkingSet,
-        path: &Path,
-        file: &Rope,
+        flattened: Vec<(Span, FlatShape)>,
         location: usize,
+        offset: usize,
     ) -> Option<(Id, usize, Span)> {
-        let file_path = path.to_string_lossy();
-
-        // TODO: think about passing down the rope into the working_set
-        let contents = file.bytes().collect::<Vec<u8>>();
-        let _ = working_set
-            .files
-            .push(file_path.as_ref().into(), Span::unknown());
-        let block = parse(working_set, Some(&file_path), &contents, false);
-        let flattened = flatten_block(working_set, &block);
-
-        let offset = working_set.get_span_for_filename(&file_path)?.start;
         let location = location + offset;
 
         for (span, shape) in flattened {
@@ -299,55 +214,54 @@ impl LanguageServer {
         None
     }
 
-    fn rope<'a, 'b: 'a>(&'b self, file_url: &Url) -> Option<(&'a Rope, &'a PathBuf)> {
-        let file_path = file_url.to_file_path().ok()?;
-
-        self.ropes
-            .get_key_value(&file_path)
-            .map(|(path, rope)| (rope, path))
-    }
-
-    fn read_in_file<'a>(
+    fn get_goto_response(
         &self,
-        engine_state: &'a mut EngineState,
-        file_url: &Url,
-    ) -> Option<(&Rope, &PathBuf, StateWorkingSet<'a>)> {
-        let (file, path) = self.rope(file_url)?;
-
-        engine_state.file = Some(path.to_owned());
-
-        let working_set = StateWorkingSet::new(engine_state);
-
-        Some((file, path, working_set))
-    }
-
-    fn rope_file_from_cached_file(&mut self, cached_file: &CachedFile) -> Result<(Url, &Rope), ()> {
-        let uri = Url::from_file_path(&*cached_file.name)?;
-        let rope_of_file = self.ropes.entry(uri.to_file_path()?).or_insert_with(|| {
-            let raw_string = String::from_utf8_lossy(&cached_file.content);
-            Rope::from_str(&raw_string)
-        });
-        Ok((uri, rope_of_file))
-    }
-
-    fn goto_definition(
-        &mut self,
-        engine_state: &mut EngineState,
-        params: &GotoDefinitionParams,
+        working_set: &StateWorkingSet,
+        span: &Span,
     ) -> Option<GotoDefinitionResponse> {
+        for cached_file in working_set.files() {
+            if cached_file.covered_span.contains(span.start) {
+                let target_uri = Uri::from_str(format!("file://{}", &cached_file.name).as_str())
+                    .expect("Failed to convert CachedFile name to Uri.");
+                if let Some(doc) = self.docs.get_document(&target_uri) {
+                    return Some(GotoDefinitionResponse::Scalar(Location {
+                        uri: target_uri,
+                        range: Self::span_to_range(span, doc, cached_file.covered_span.start),
+                    }));
+                } else {
+                    // in case where the document is not opened yet, typically included by ``
+                    let temp_doc = FullTextDocument::new(
+                        "Unk".to_string(),
+                        0,
+                        String::from_utf8((*cached_file.content).to_vec()).expect("Invalid UTF-8"),
+                    );
+                    return Some(GotoDefinitionResponse::Scalar(Location {
+                        uri: target_uri,
+                        range: Self::span_to_range(span, &temp_doc, cached_file.covered_span.start),
+                    }));
+                }
+            }
+        }
+        None
+    }
+
+    fn goto_definition(&mut self, params: &GotoDefinitionParams) -> Option<GotoDefinitionResponse> {
+        let mut engine_state = self.engine_state.clone();
         let cwd = std::env::current_dir().expect("Could not get current working directory.");
         engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
 
-        let (file, path, mut working_set) = self.read_in_file(
-            engine_state,
-            &params.text_document_position_params.text_document.uri,
-        )?;
-
+        let path_uri = params
+            .text_document_position_params
+            .text_document
+            .uri
+            .to_owned();
+        let (block, file_offset, working_set, file) =
+            self.update_engine_state(&mut engine_state, path_uri.clone())?;
+        let flattened = flatten_block(&working_set, &block);
         let (id, _, _) = Self::find_id(
-            &mut working_set,
-            path,
-            file,
-            self.lsp_position_to_byte_offset(&params.text_document_position_params.position, file),
+            flattened,
+            file.offset_at(params.text_document_position_params.position) as usize,
+            file_offset,
         )?;
 
         match id {
@@ -355,22 +269,7 @@ impl LanguageServer {
                 if let Some(block_id) = working_set.get_decl(decl_id).block_id() {
                     let block = working_set.get_block(block_id);
                     if let Some(span) = &block.span {
-                        for cached_file in working_set.files() {
-                            if cached_file.covered_span.contains(span.start) {
-                                let position_encoding = self.position_encoding.clone();
-                                let (uri, rope_of_file) =
-                                    self.rope_file_from_cached_file(cached_file).ok()?;
-                                return Some(GotoDefinitionResponse::Scalar(Location {
-                                    uri,
-                                    range: Self::span_to_range(
-                                        span,
-                                        rope_of_file,
-                                        cached_file.covered_span.start,
-                                        &position_encoding,
-                                    ),
-                                }));
-                            }
-                        }
+                        return self.get_goto_response(&working_set, span);
                     }
                 }
             }
@@ -381,18 +280,7 @@ impl LanguageServer {
                         .covered_span
                         .contains(var.declaration_span.start)
                     {
-                        let position_encoding = self.position_encoding.clone();
-                        let (uri, rope_of_file) =
-                            self.rope_file_from_cached_file(cached_file).ok()?;
-                        return Some(GotoDefinitionResponse::Scalar(Location {
-                            uri,
-                            range: Self::span_to_range(
-                                &var.declaration_span,
-                                rope_of_file,
-                                cached_file.covered_span.start,
-                                &position_encoding,
-                            ),
-                        }));
+                        return self.get_goto_response(&working_set, &var.declaration_span);
                     }
                 }
             }
@@ -401,20 +289,23 @@ impl LanguageServer {
         None
     }
 
-    fn hover(&mut self, engine_state: &mut EngineState, params: &HoverParams) -> Option<Hover> {
+    fn hover(&mut self, params: &HoverParams) -> Option<Hover> {
+        let mut engine_state = self.engine_state.clone();
         let cwd = std::env::current_dir().expect("Could not get current working directory.");
         engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
 
-        let (file, path, mut working_set) = self.read_in_file(
-            engine_state,
-            &params.text_document_position_params.text_document.uri,
-        )?;
-
+        let path_uri = params
+            .text_document_position_params
+            .text_document
+            .uri
+            .to_owned();
+        let (block, file_offset, working_set, file) =
+            self.update_engine_state(&mut engine_state, path_uri.clone())?;
+        let flattened = flatten_block(&working_set, &block);
         let (id, _, _) = Self::find_id(
-            &mut working_set,
-            path,
-            file,
-            self.lsp_position_to_byte_offset(&params.text_document_position_params.position, file),
+            flattened,
+            file.offset_at(params.text_document_position_params.position) as usize,
+            file_offset,
         )?;
 
         match id {
@@ -615,26 +506,15 @@ impl LanguageServer {
         }
     }
 
-    fn complete(
-        &mut self,
-        engine_state: &mut EngineState,
-        params: &CompletionParams,
-    ) -> Option<CompletionResponse> {
-        let cwd = std::env::current_dir().expect("Could not get current working directory.");
-        engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
-
-        let (rope_of_file, _, _) = self.read_in_file(
-            engine_state,
-            &params.text_document_position.text_document.uri,
-        )?;
+    fn complete(&mut self, params: &CompletionParams) -> Option<CompletionResponse> {
+        let path_uri = params.text_document_position.text_document.uri.to_owned();
+        let file = self.docs.get_document(&path_uri)?;
 
         let mut completer =
-            NuCompleter::new(Arc::new(engine_state.clone()), Arc::new(Stack::new()));
+            NuCompleter::new(Arc::new(self.engine_state.clone()), Arc::new(Stack::new()));
 
-        let location =
-            self.lsp_position_to_byte_offset(&params.text_document_position.position, rope_of_file);
-        let results =
-            completer.fetch_completions_at(&rope_of_file.to_string()[..location], location);
+        let location = file.offset_at(params.text_document_position.position) as usize;
+        let results = completer.fetch_completions_at(&file.get_content(None)[..location], location);
         if results.is_empty() {
             None
         } else {
@@ -687,30 +567,37 @@ mod tests {
     use assert_json_diff::{assert_json_eq, assert_json_include};
     use lsp_types::{
         notification::{
-            DidChangeTextDocument, DidOpenTextDocument, Exit, Initialized, Notification,
+            DidChangeTextDocument, DidOpenTextDocument, DidSaveTextDocument, Exit, Initialized,
+            Notification,
         },
         request::{Completion, GotoDefinition, HoverRequest, Initialize, Request, Shutdown},
         CompletionParams, DidChangeTextDocumentParams, DidOpenTextDocumentParams,
-        GotoDefinitionParams, InitializeParams, InitializedParams, PartialResultParams,
-        TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem,
-        TextDocumentPositionParams, Url, WorkDoneProgressParams,
+        DidSaveTextDocumentParams, GotoDefinitionParams, InitializeParams, InitializedParams,
+        PartialResultParams, Position, TextDocumentContentChangeEvent, TextDocumentIdentifier,
+        TextDocumentItem, TextDocumentPositionParams, WorkDoneProgressParams,
     };
-    use nu_test_support::fs::{fixtures, root};
+    use nu_test_support::{
+        fs::{fixtures, root},
+        nu_path::AbsolutePathBuf,
+    };
+    use std::path::Path;
     use std::sync::mpsc::Receiver;
 
-    pub fn initialize_language_server(
-        client_offset_encoding: Option<Vec<String>>,
-    ) -> (Connection, Receiver<Result<()>>) {
+    pub fn pathbuf_to_uri(path: &AbsolutePathBuf) -> Uri {
+        Uri::from_str(format!("file://{}", path.to_str().unwrap()).as_str())
+            .expect("Failed to convert path to Uri.")
+    }
+
+    pub fn initialize_language_server() -> (Connection, Receiver<Result<()>>) {
         use std::sync::mpsc;
         let (client_connection, server_connection) = Connection::memory();
-        let lsp_server = LanguageServer::initialize_connection(server_connection, None).unwrap();
+        let engine_state = nu_cmd_lang::create_default_context();
+        let engine_state = nu_command::add_shell_command_context(engine_state);
+        let lsp_server =
+            LanguageServer::initialize_connection(server_connection, None, engine_state).unwrap();
 
         let (send, recv) = mpsc::channel();
-        std::thread::spawn(move || {
-            let engine_state = nu_cmd_lang::create_default_context();
-            let engine_state = nu_command::add_shell_command_context(engine_state);
-            send.send(lsp_server.serve_requests(engine_state))
-        });
+        std::thread::spawn(move || send.send(lsp_server.serve_requests()));
 
         client_connection
             .sender
@@ -719,7 +606,6 @@ mod tests {
                 method: Initialize::METHOD.to_string(),
                 params: serde_json::to_value(InitializeParams {
                     capabilities: lsp_types::ClientCapabilities {
-                        offset_encoding: client_offset_encoding,
                         ..Default::default()
                     },
                     ..Default::default()
@@ -745,7 +631,7 @@ mod tests {
 
     #[test]
     fn shutdown_on_request() {
-        let (client_connection, recv) = initialize_language_server(None);
+        let (client_connection, recv) = initialize_language_server();
 
         client_connection
             .sender
@@ -771,7 +657,7 @@ mod tests {
 
     #[test]
     fn goto_definition_for_none_existing_file() {
-        let (client_connection, _recv) = initialize_language_server(None);
+        let (client_connection, _recv) = initialize_language_server();
 
         let mut none_existent_path = root();
         none_existent_path.push("none-existent.nu");
@@ -784,7 +670,7 @@ mod tests {
                 params: serde_json::to_value(GotoDefinitionParams {
                     text_document_position_params: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: Url::from_file_path(none_existent_path).unwrap(),
+                            uri: Uri::from_str(none_existent_path.to_str().unwrap()).unwrap(),
                         },
                         position: Position {
                             line: 0,
@@ -811,16 +697,16 @@ mod tests {
         assert_json_eq!(result, serde_json::json!(null));
     }
 
-    pub fn open_unchecked(client_connection: &Connection, uri: Url) -> lsp_server::Notification {
+    pub fn open_unchecked(client_connection: &Connection, uri: Uri) -> lsp_server::Notification {
         open(client_connection, uri).unwrap()
     }
 
     pub fn open(
         client_connection: &Connection,
-        uri: Url,
+        uri: Uri,
     ) -> Result<lsp_server::Notification, String> {
         let text =
-            std::fs::read_to_string(uri.to_file_path().unwrap()).map_err(|e| e.to_string())?;
+            std::fs::read_to_string(Path::new(uri.path().as_str())).map_err(|e| e.to_string())?;
 
         client_connection
             .sender
@@ -852,7 +738,7 @@ mod tests {
 
     pub fn update(
         client_connection: &Connection,
-        uri: Url,
+        uri: Uri,
         text: String,
         range: Option<Range>,
     ) -> lsp_server::Notification {
@@ -863,7 +749,7 @@ mod tests {
                     method: DidChangeTextDocument::METHOD.to_string(),
                     params: serde_json::to_value(DidChangeTextDocumentParams {
                         text_document: lsp_types::VersionedTextDocumentIdentifier {
-                            uri,
+                            uri: uri.clone(),
                             version: 2,
                         },
                         content_changes: vec![TextDocumentContentChangeEvent {
@@ -871,6 +757,19 @@ mod tests {
                             range_length: None,
                             text,
                         }],
+                    })
+                    .unwrap(),
+                },
+            ))
+            .unwrap();
+        client_connection
+            .sender
+            .send(lsp_server::Message::Notification(
+                lsp_server::Notification {
+                    method: DidSaveTextDocument::METHOD.to_string(),
+                    params: serde_json::to_value(DidSaveTextDocumentParams {
+                        text_document: lsp_types::TextDocumentIdentifier { uri },
+                        text: None,
                     })
                     .unwrap(),
                 },
@@ -891,7 +790,7 @@ mod tests {
 
     fn goto_definition(
         client_connection: &Connection,
-        uri: Url,
+        uri: Uri,
         line: u32,
         character: u32,
     ) -> Message {
@@ -920,13 +819,13 @@ mod tests {
 
     #[test]
     fn goto_definition_of_variable() {
-        let (client_connection, _recv) = initialize_language_server(None);
+        let (client_connection, _recv) = initialize_language_server();
 
         let mut script = fixtures();
         script.push("lsp");
         script.push("goto");
         script.push("var.nu");
-        let script = Url::from_file_path(script).unwrap();
+        let script = pathbuf_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
@@ -940,24 +839,24 @@ mod tests {
         assert_json_eq!(
             result,
             serde_json::json!({
-               "uri": script,
-               "range": {
-                  "start": { "line": 0, "character": 4 },
-                  "end": { "line": 0, "character": 12 }
-               }
+                "uri": script,
+                "range": {
+                "start": { "line": 0, "character": 4 },
+                "end": { "line": 0, "character": 12 }
+            }
             })
         );
     }
 
     #[test]
     fn goto_definition_of_command() {
-        let (client_connection, _recv) = initialize_language_server(None);
+        let (client_connection, _recv) = initialize_language_server();
 
         let mut script = fixtures();
         script.push("lsp");
         script.push("goto");
         script.push("command.nu");
-        let script = Url::from_file_path(script).unwrap();
+        let script = pathbuf_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
@@ -971,29 +870,28 @@ mod tests {
         assert_json_eq!(
             result,
             serde_json::json!({
-               "uri": script,
-               "range": {
-                  "start": { "line": 0, "character": 17 },
-                  "end": { "line": 2, "character": 1 }
-               }
+                "uri": script,
+                "range": {
+                "start": { "line": 0, "character": 17 },
+                "end": { "line": 2, "character": 1 }
+            }
             })
         );
     }
 
     #[test]
-    fn goto_definition_of_command_utf8() {
-        let (client_connection, _recv) =
-            initialize_language_server(Some(vec!["utf-8".to_string(), "utf-16".to_string()]));
+    fn goto_definition_of_command_unicode() {
+        let (client_connection, _recv) = initialize_language_server();
 
         let mut script = fixtures();
         script.push("lsp");
         script.push("goto");
         script.push("command_unicode.nu");
-        let script = Url::from_file_path(script).unwrap();
+        let script = pathbuf_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
-        let resp = goto_definition(&client_connection, script.clone(), 4, 1);
+        let resp = goto_definition(&client_connection, script.clone(), 4, 2);
         let result = if let Message::Response(response) = resp {
             response.result
         } else {
@@ -1003,55 +901,24 @@ mod tests {
         assert_json_eq!(
             result,
             serde_json::json!({
-               "uri": script,
-               "range": {
-                  "start": { "line": 0, "character": 28 },
-                  "end": { "line": 2, "character": 1 }
-               }
-            })
-        );
-    }
-
-    #[test]
-    fn goto_definition_of_command_utf16() {
-        let (client_connection, _recv) = initialize_language_server(None);
-
-        let mut script = fixtures();
-        script.push("lsp");
-        script.push("goto");
-        script.push("command_unicode.nu");
-        let script = Url::from_file_path(script).unwrap();
-
-        open_unchecked(&client_connection, script.clone());
-
-        let resp = goto_definition(&client_connection, script.clone(), 4, 1);
-        let result = if let Message::Response(response) = resp {
-            response.result
-        } else {
-            panic!()
-        };
-
-        assert_json_eq!(
-            result,
-            serde_json::json!({
-               "uri": script,
-               "range": {
-                  "start": { "line": 0, "character": 19 },
-                  "end": { "line": 2, "character": 1 }
-               }
+                "uri": script,
+                "range": {
+                "start": { "line": 0, "character": 19 },
+                "end": { "line": 2, "character": 1 }
+            }
             })
         );
     }
 
     #[test]
     fn goto_definition_of_command_parameter() {
-        let (client_connection, _recv) = initialize_language_server(None);
+        let (client_connection, _recv) = initialize_language_server();
 
         let mut script = fixtures();
         script.push("lsp");
         script.push("goto");
         script.push("command.nu");
-        let script = Url::from_file_path(script).unwrap();
+        let script = pathbuf_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
@@ -1065,16 +932,16 @@ mod tests {
         assert_json_eq!(
             result,
             serde_json::json!({
-               "uri": script,
-               "range": {
-                  "start": { "line": 0, "character": 11 },
-                  "end": { "line": 0, "character": 15 }
-               }
+                "uri": script,
+                "range": {
+                "start": { "line": 0, "character": 11 },
+                "end": { "line": 0, "character": 15 }
+            }
             })
         );
     }
 
-    pub fn hover(client_connection: &Connection, uri: Url, line: u32, character: u32) -> Message {
+    pub fn hover(client_connection: &Connection, uri: Uri, line: u32, character: u32) -> Message {
         client_connection
             .sender
             .send(Message::Request(lsp_server::Request {
@@ -1099,13 +966,13 @@ mod tests {
 
     #[test]
     fn hover_on_variable() {
-        let (client_connection, _recv) = initialize_language_server(None);
+        let (client_connection, _recv) = initialize_language_server();
 
         let mut script = fixtures();
         script.push("lsp");
         script.push("hover");
         script.push("var.nu");
-        let script = Url::from_file_path(script).unwrap();
+        let script = pathbuf_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
@@ -1126,13 +993,13 @@ mod tests {
 
     #[test]
     fn hover_on_custom_command() {
-        let (client_connection, _recv) = initialize_language_server(None);
+        let (client_connection, _recv) = initialize_language_server();
 
         let mut script = fixtures();
         script.push("lsp");
         script.push("hover");
         script.push("command.nu");
-        let script = Url::from_file_path(script).unwrap();
+        let script = pathbuf_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
@@ -1146,7 +1013,7 @@ mod tests {
         assert_json_eq!(
             result,
             serde_json::json!({
-                "contents": {
+                    "contents": {
                     "kind": "markdown",
                     "value": "Renders some greeting message\n### Usage \n```nu\n  hello {flags}\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n"
                 }
@@ -1156,13 +1023,13 @@ mod tests {
 
     #[test]
     fn hover_on_str_join() {
-        let (client_connection, _recv) = initialize_language_server(None);
+        let (client_connection, _recv) = initialize_language_server();
 
         let mut script = fixtures();
         script.push("lsp");
         script.push("hover");
         script.push("command.nu");
-        let script = Url::from_file_path(script).unwrap();
+        let script = pathbuf_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
@@ -1176,7 +1043,7 @@ mod tests {
         assert_json_eq!(
             result,
             serde_json::json!({
-                "contents": {
+                    "contents": {
                     "kind": "markdown",
                     "value": "Concatenate multiple strings into a single string, with an optional separator between each.\n### Usage \n```nu\n  str join {flags} <separator?>\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n\n### Parameters\n\n  `separator: string` - Optional separator to use when creating string.\n\n\n### Input/output types\n\n```nu\n list<any> | string\n string | string\n\n```\n### Example(s)\n  Create a string from input\n```nu\n  ['nu', 'shell'] | str join\n```\n  Create a string from input with a separator\n```nu\n  ['nu', 'shell'] | str join '-'\n```\n"
                 }
@@ -1184,7 +1051,7 @@ mod tests {
         );
     }
 
-    fn complete(client_connection: &Connection, uri: Url, line: u32, character: u32) -> Message {
+    fn complete(client_connection: &Connection, uri: Uri, line: u32, character: u32) -> Message {
         client_connection
             .sender
             .send(Message::Request(lsp_server::Request {
@@ -1211,13 +1078,13 @@ mod tests {
 
     #[test]
     fn complete_on_variable() {
-        let (client_connection, _recv) = initialize_language_server(None);
+        let (client_connection, _recv) = initialize_language_server();
 
         let mut script = fixtures();
         script.push("lsp");
         script.push("completion");
         script.push("var.nu");
-        let script = Url::from_file_path(script).unwrap();
+        let script = pathbuf_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
@@ -1231,30 +1098,30 @@ mod tests {
         assert_json_eq!(
             result,
             serde_json::json!([
-               {
-                  "label": "$greeting",
-                  "textEdit": {
-                     "newText": "$greeting",
-                     "range": {
-                        "start": { "character": 5, "line": 2 },
-                        "end": { "character": 9, "line": 2 }
-                     }
-                  },
-                  "kind": 6
-               }
+                {
+                    "label": "$greeting",
+                    "textEdit": {
+                    "newText": "$greeting",
+                    "range": {
+                    "start": { "character": 5, "line": 2 },
+                "end": { "character": 9, "line": 2 }
+            }
+            },
+                "kind": 6
+            }
             ])
         );
     }
 
     #[test]
     fn complete_command_with_space() {
-        let (client_connection, _recv) = initialize_language_server(None);
+        let (client_connection, _recv) = initialize_language_server();
 
         let mut script = fixtures();
         script.push("lsp");
         script.push("completion");
         script.push("command.nu");
-        let script = Url::from_file_path(script).unwrap();
+        let script = pathbuf_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
@@ -1268,71 +1135,31 @@ mod tests {
         assert_json_eq!(
             result,
             serde_json::json!([
-               {
-                  "label": "config nu",
-                  "detail": "Edit nu configurations.",
-                  "textEdit": {
-                     "range": {
-                        "start": { "line": 0, "character": 0 },
-                        "end": { "line": 0, "character": 8 },
-                     },
-                     "newText": "config nu"
-                  },
-                  "kind": 3
-               }
+                {
+                    "label": "config nu",
+                    "detail": "Edit nu configurations.",
+                    "textEdit": {
+                    "range": {
+                    "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 8 },
+            },
+                "newText": "config nu"
+            },
+                "kind": 3
+            }
             ])
         );
     }
 
     #[test]
-    fn complete_command_with_utf8_line() {
-        let (client_connection, _recv) =
-            initialize_language_server(Some(vec!["utf-8".to_string()]));
+    fn complete_command_with_line() {
+        let (client_connection, _recv) = initialize_language_server();
 
         let mut script = fixtures();
         script.push("lsp");
         script.push("completion");
         script.push("utf_pipeline.nu");
-        let script = Url::from_file_path(script).unwrap();
-
-        open_unchecked(&client_connection, script.clone());
-
-        let resp = complete(&client_connection, script, 0, 14);
-        let result = if let Message::Response(response) = resp {
-            response.result
-        } else {
-            panic!()
-        };
-
-        assert_json_eq!(
-            result,
-            serde_json::json!([
-               {
-                  "label": "str trim",
-                  "detail": "Trim whitespace or specific character.",
-                  "textEdit": {
-                     "range": {
-                        "start": { "line": 0, "character": 9 },
-                        "end": { "line": 0, "character": 14 },
-                     },
-                     "newText": "str trim"
-                  },
-                  "kind": 3
-               }
-            ])
-        );
-    }
-
-    #[test]
-    fn complete_command_with_utf16_line() {
-        let (client_connection, _recv) =
-            initialize_language_server(Some(vec!["utf-16".to_string()]));
-
-        let mut script = fixtures();
-        script.push("lsp");
-        script.push("completion");
-        script.push("utf_pipeline.nu");
-        let script = Url::from_file_path(script).unwrap();
+        let script = pathbuf_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
@@ -1346,31 +1173,31 @@ mod tests {
         assert_json_eq!(
             result,
             serde_json::json!([
-               {
-                  "label": "str trim",
-                  "detail": "Trim whitespace or specific character.",
-                  "textEdit": {
-                     "range": {
-                        "start": { "line": 0, "character": 8 },
-                        "end": { "line": 0, "character": 13 },
-                     },
-                     "newText": "str trim"
-                  },
-                  "kind": 3
-               }
+                {
+                    "label": "str trim",
+                    "detail": "Trim whitespace or specific character.",
+                    "textEdit": {
+                    "range": {
+                    "start": { "line": 0, "character": 8 },
+                "end": { "line": 0, "character": 13 },
+            },
+                "newText": "str trim"
+            },
+                "kind": 3
+            }
             ])
         );
     }
 
     #[test]
     fn complete_keyword() {
-        let (client_connection, _recv) = initialize_language_server(None);
+        let (client_connection, _recv) = initialize_language_server();
 
         let mut script = fixtures();
         script.push("lsp");
         script.push("completion");
         script.push("keyword.nu");
-        let script = Url::from_file_path(script).unwrap();
+        let script = pathbuf_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
@@ -1387,14 +1214,14 @@ mod tests {
                 {
                     "label": "overlay",
                     "textEdit": {
-                        "newText": "overlay",
-                        "range": {
-                            "start": { "character": 0, "line": 0 },
-                            "end": { "character": 2, "line": 0 }
-                        }
-                    },
-                    "kind": 14
-                },
+                    "newText": "overlay",
+                    "range": {
+                    "start": { "character": 0, "line": 0 },
+                "end": { "character": 2, "line": 0 }
+            }
+            },
+                "kind": 14
+            },
             ])
         );
     }

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -592,7 +592,6 @@ mod tests {
         TextDocumentItem, TextDocumentPositionParams, WorkDoneProgressParams,
     };
     use nu_test_support::fs::{fixtures, root};
-    use std::path::Path;
     use std::sync::mpsc::Receiver;
 
     pub fn initialize_language_server() -> (Connection, Receiver<Result<()>>) {
@@ -712,8 +711,13 @@ mod tests {
         client_connection: &Connection,
         uri: Uri,
     ) -> Result<lsp_server::Notification, String> {
-        let text =
-            std::fs::read_to_string(Path::new(uri.path().as_str())).map_err(|e| e.to_string())?;
+        let text = std::fs::read_to_string(
+            Url::from_str(uri.as_str())
+                .expect("Failed to convert Uri to Url")
+                .to_file_path()
+                .expect("Failed to convert Url to path"),
+        )
+        .map_err(|e| e.to_string())?;
 
         client_connection
             .sender

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -239,7 +239,11 @@ impl LanguageServer {
     fn get_location_by_span(&self, working_set: &StateWorkingSet, span: &Span) -> Option<Location> {
         for cached_file in working_set.files() {
             if cached_file.covered_span.contains(span.start) {
-                let target_uri = path_to_uri(&*cached_file.name);
+                let path = Path::new(&*cached_file.name);
+                if !(path.exists() && path.is_file()) {
+                    return None;
+                }
+                let target_uri = path_to_uri(path);
                 if let Some(doc) = self.docs.get_document(&target_uri) {
                     return Some(Location {
                         uri: target_uri,

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -682,7 +682,7 @@ mod tests {
                 params: serde_json::to_value(GotoDefinitionParams {
                     text_document_position_params: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: Uri::from_str(none_existent_path.to_str().unwrap()).unwrap(),
+                            uri: path_to_uri(&none_existent_path),
                         },
                         position: Position {
                             line: 0,

--- a/crates/nu-lsp/src/notification.rs
+++ b/crates/nu-lsp/src/notification.rs
@@ -1,6 +1,6 @@
 use lsp_types::{
-    notification::{DidOpenTextDocument, DidSaveTextDocument, Notification},
-    DidOpenTextDocumentParams, DidSaveTextDocumentParams, Uri,
+    notification::{DidChangeTextDocument, DidOpenTextDocument, DidSaveTextDocument, Notification},
+    DidChangeTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, Uri,
 };
 
 use crate::LanguageServer;
@@ -21,6 +21,12 @@ impl LanguageServer {
             }
             DidSaveTextDocument::METHOD => {
                 let params: DidSaveTextDocumentParams =
+                    serde_json::from_value(notification.params.clone())
+                        .expect("Expect receive DidOpenTextDocumentParams");
+                Some(params.text_document.uri)
+            }
+            DidChangeTextDocument::METHOD => {
+                let params: DidChangeTextDocumentParams =
                     serde_json::from_value(notification.params.clone())
                         .expect("Expect receive DidOpenTextDocumentParams");
                 Some(params.text_document.uri)

--- a/crates/nu-lsp/src/notification.rs
+++ b/crates/nu-lsp/src/notification.rs
@@ -22,13 +22,13 @@ impl LanguageServer {
             DidSaveTextDocument::METHOD => {
                 let params: DidSaveTextDocumentParams =
                     serde_json::from_value(notification.params.clone())
-                        .expect("Expect receive DidOpenTextDocumentParams");
+                        .expect("Expect receive DidSaveTextDocumentParams");
                 Some(params.text_document.uri)
             }
             DidChangeTextDocument::METHOD => {
                 let params: DidChangeTextDocumentParams =
                     serde_json::from_value(notification.params.clone())
-                        .expect("Expect receive DidOpenTextDocumentParams");
+                        .expect("Expect receive DidChangeTextDocumentParams");
                 Some(params.text_document.uri)
             }
             _ => None,

--- a/crates/nu-lsp/src/notification.rs
+++ b/crates/nu-lsp/src/notification.rs
@@ -37,9 +37,8 @@ mod tests {
     use lsp_types::Range;
     use nu_test_support::fs::fixtures;
 
-    use crate::tests::{
-        hover, initialize_language_server, open, open_unchecked, pathbuf_to_uri, update,
-    };
+    use crate::path_to_uri;
+    use crate::tests::{hover, initialize_language_server, open, open_unchecked, update};
 
     #[test]
     fn hover_correct_documentation_on_let() {
@@ -49,7 +48,7 @@ mod tests {
         script.push("lsp");
         script.push("hover");
         script.push("var.nu");
-        let script = pathbuf_to_uri(&script);
+        let script = path_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
@@ -79,7 +78,7 @@ mod tests {
         script.push("lsp");
         script.push("hover");
         script.push("command.nu");
-        let script = pathbuf_to_uri(&script);
+        let script = path_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
         update(
@@ -120,7 +119,7 @@ hello"#,
         script.push("lsp");
         script.push("hover");
         script.push("command.nu");
-        let script = pathbuf_to_uri(&script);
+        let script = path_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
         update(
@@ -165,7 +164,7 @@ hello"#,
         script.push("lsp");
         script.push("notifications");
         script.push("issue_11522.nu");
-        let script = pathbuf_to_uri(&script);
+        let script = path_to_uri(&script);
 
         let result = open(&client_connection, script);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -460,7 +460,7 @@ fn main() -> Result<()> {
             );
         }
 
-        LanguageServer::initialize_stdio_connection()?.serve_requests(engine_state)?
+        LanguageServer::initialize_stdio_connection(engine_state)?.serve_requests()?
     } else if let Some(commands) = parsed_nu_cli_args.commands.clone() {
         run_commands(
             &mut engine_state,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR replaces `ropey` with `lsp-textdocument` for easier utf16 position handling.
As a side effect, if fixes the following crashing bug:

1. create a `foo.nu` file with errors in it
2. in `bar.nu`, add code `use foo.nu *`

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

* <s>Diagnostics are now triggered only with document open/save, that's my personal preference. Changing back to previous behavior is easy if you guys have other concerns.</s>
* UTF-8 position encoding is not supported by lsp-textdocument, but that's not an issue, since the previous utf-8 ropey implementation is buggy when used in real scenarios in a text editor.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

No new tests added, removed some utf-8 related ones.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
