### PR TITLE
Fix root directory traversal issue

### DIFF
--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -60,7 +60,12 @@ pub fn expand_dots(path: impl AsRef<Path>) -> PathBuf {
             Component::CurDir if last_component_is_normal(&result) => {
                 // no-op
             }
-            _ => result.push(component),
+            _ => {
+                if result.as_os_str() == "/" && component == Component::ParentDir {
+                    continue;
+                }
+                result.push(component)
+            }
         }
     }
 
@@ -215,11 +220,7 @@ mod test_expand_dots {
     #[test]
     fn backtrack_to_root() {
         let path = Path::new("/foo/bar/../../../../baz");
-        let expected = if cfg!(windows) {
-            r"\..\..\baz"
-        } else {
-            "/../../baz"
-        };
+        let expected = if cfg!(windows) { r"\baz" } else { "/baz" };
         assert_path_eq!(expand_dots(path), expected);
     }
 }

--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -61,7 +61,8 @@ pub fn expand_dots(path: impl AsRef<Path>) -> PathBuf {
                 // no-op
             }
             _ => {
-                if result.as_os_str() == "/" && component == Component::ParentDir {
+                let prev_component = result.components().last();
+                if prev_component == Some(Component::RootDir) && component == Component::ParentDir {
                     continue;
                 }
                 result.push(component)

--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -220,7 +220,7 @@ mod test_expand_dots {
     #[test]
     fn backtrack_to_root() {
         let path = Path::new("/foo/bar/../../../../baz");
-        let expected = if cfg!(windows) { r"\baz" } else { "/baz" };
+        let expected = if cfg!(windows) { r"\..\..\baz" } else { "/baz" };
         assert_path_eq!(expand_dots(path), expected);
     }
 }

--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -221,7 +221,7 @@ mod test_expand_dots {
     #[test]
     fn backtrack_to_root() {
         let path = Path::new("/foo/bar/../../../../baz");
-        let expected = if cfg!(windows) { r"\..\..\baz" } else { "/baz" };
+        let expected = if cfg!(windows) { r"\baz" } else { "/baz" };
         assert_path_eq!(expand_dots(path), expected);
     }
 }


### PR DESCRIPTION

fixes : #13729 

During dot expansion, the "parent" was added even if it was after the root (`/../../`).
Added additional check that skips appending elements to the path representation if the parent folder is the root folder.