### PR TITLE
Add flag to `debug profile` to output duration field as Value::Duration

### DIFF
--- a/crates/nu-command/src/debug/profile.rs
+++ b/crates/nu-command/src/debug/profile.rs
@@ -59,7 +59,7 @@ The output can be heavily customized. By default, the following columns are incl
                 be shown with the --expand-source flag.
 - pc          : The index of the instruction within the block.
 - instruction : The pretty printed instruction being evaluated.
-- duration_ms : How long it took to run the instruction in milliseconds.
+- duration    : How long it took to run the instruction.
 - (optional) span        : Span associated with the instruction. Can be viewed via the `view span`
                            command. Enabled with the --spans flag.
 - (optional) output      : The output value of the instruction. Enabled with the --values flag.


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR adds a flag to `debug profile` to output the duration field as Value::Duration. Without the flag, the behavior is same as before: a column named `duration_ms` which is `Value::Float`. With the flag, there is instead a column named just `duration` which is `Value::Duration`. Additionally, this PR changes the time tracking to use nanoseconds instead of float seconds, so it can be output as either milliseconds or `Duration` (which uses nanoseconds internally). I don't think overflow is a concern here, because the maximum amount of time a `Duration` can store is over 292 years, and if a Nushell instruction takes longer than that to run then I think we might have bigger issues.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

* Adds a flag `--duration-values` to `debug profile` which  the `duration_ms` field in `debug profile` to a `duration` field which uses proper `duration` values.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A