### PR TITLE
Don't expand ndots if prefixed with `./`

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -1,6 +1,6 @@
 use nu_cmd_base::hook::eval_hook;
 use nu_engine::{command_prelude::*, env_to_strings};
-use nu_path::{dots::expand_ndots, expand_tilde, AbsolutePath};
+use nu_path::{dots::expand_ndots_safe, expand_tilde, AbsolutePath};
 use nu_protocol::{
     did_you_mean, process::ChildProcess, ByteStream, NuGlob, OutDest, Signals, UseAnsiColoring,
 };
@@ -636,21 +636,6 @@ fn escape_cmd_argument(arg: &Spanned<OsString>) -> Result<Cow<'_, OsStr>, ShellE
     } else {
         // FIXME?: what if `arg.is_empty()`?
         Ok(Cow::Borrowed(arg))
-    }
-}
-
-/// Expand ndots, but only if it looks like it probably contains them, because there is some lossy
-/// path normalization that happens.
-fn expand_ndots_safe(path: impl AsRef<Path>) -> PathBuf {
-    let string = path.as_ref().to_string_lossy();
-
-    // Use ndots if it contains at least `...`, since that's the minimum trigger point, and don't
-    // use it if it contains ://, because that looks like a URL scheme and the path normalization
-    // will mess with that.
-    if string.contains("...") && !string.contains("://") {
-        expand_ndots(path)
-    } else {
-        path.as_ref().to_owned()
     }
 }
 

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -248,6 +248,16 @@ fn external_command_ndots_args() {
 }
 
 #[test]
+fn external_command_ndots_leading_dot_slash() {
+    // Don't expand ndots with a leading `./`
+    let actual = nu!(r#"
+        nu --testbin cococo ./... ./....
+    "#);
+
+    assert_eq!(actual.out, "./... ./....");
+}
+
+#[test]
 fn external_command_url_args() {
     // If ndots is not handled correctly, we can lose the double forward slashes that are needed
     // here

--- a/crates/nu-path/src/tilde.rs
+++ b/crates/nu-path/src/tilde.rs
@@ -152,7 +152,6 @@ fn expand_tilde_with_another_user_home(path: &Path) -> PathBuf {
 
 /// Expand tilde ("~") into a home directory if it is the first path component
 pub fn expand_tilde(path: impl AsRef<Path>) -> PathBuf {
-    // TODO: Extend this to work with "~user" style of home paths
     expand_tilde_with_home(path, dirs::home_dir())
 }
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
Prevents ndots from being expanded if they are prefixed with `./`, as the agreed resolution to #13303. Only applies to externals, mirroring the fix from #13218.

I did [attempt](https://github.com/132ikl/nushell/tree/internal-ndots-attempt) to apply the fix for internal commands as well, but it seems like the path is expanded too aggressively and I haven't investigated it further yet. `./...` gets normalized into `<pwd>/./...`, which gets normalized into `<pwd>/...` before being handed to `expand_ndots`, and at that point it just looks like a normal n-dots so we can't tell we shouldn't expand.

(Fixes #13303)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

* N-dots are no longer expanded to external command calls when prefixed with `./`.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->



Added tests to prevent regression.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

N/A