### PR TITLE
Fix config reset to use scaffold config files

### DIFF
--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -1,7 +1,7 @@
 use chrono::Local;
 use nu_engine::command_prelude::*;
 
-use nu_utils::{get_default_config, get_default_env};
+use nu_utils::{get_scaffold_config, get_scaffold_env};
 use std::io::Write;
 
 #[derive(Clone)]
@@ -51,7 +51,7 @@ impl Command for ConfigReset {
         if !only_env {
             let mut nu_config = config_path.clone();
             nu_config.push("config.nu");
-            let config_file = get_default_config();
+            let config_file = get_scaffold_config();
             if !no_backup {
                 let mut backup_path = config_path.clone();
                 backup_path.push(format!(
@@ -77,7 +77,7 @@ impl Command for ConfigReset {
         if !only_nu {
             let mut env_config = config_path.clone();
             env_config.push("env.nu");
-            let config_file = get_default_env();
+            let config_file = get_scaffold_env();
             if !no_backup {
                 let mut backup_path = config_path.clone();
                 backup_path.push(format!("oldenv-{}.nu", Local::now().format("%F-%H-%M-%S"),));


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

`config reset` wasn't updated to use the scaffold config files after they were added, so running `config reset` would accidentally reset the user's config to the internal defaults. This PR updates it to use the scaffold files.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

* Fixes the `config reset` command to use the template `config.nu` and `env.nu`

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

N/A

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A