### PR TITLE
Change `PipelineData::into_value` to use internal `Value`'s span before passed in span

### DIFF
--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -125,7 +125,13 @@ impl PipelineData {
     pub fn into_value(self, span: Span) -> Result<Value, ShellError> {
         match self {
             PipelineData::Empty => Ok(Value::nothing(span)),
-            PipelineData::Value(value, ..) => Ok(value.with_span(span)),
+            PipelineData::Value(value, ..) => {
+                if value.span() == Span::unknown() {
+                    Ok(value.with_span(span))
+                } else {
+                    Ok(value)
+                }
+            }
             PipelineData::ListStream(stream, ..) => Ok(stream.into_value()),
             PipelineData::ByteStream(stream, ..) => stream.into_value(),
         }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Changes the `Value` variant match arm of `PipelineData::into_value` to use the internal `Value`'s span instead of the span passed in by the user. This aligns more closely with the `ListStream` and `ByteStream` match arms, which already use their internal span, and allows errors to provide better diagnostics since the span information doesn't get lost when `into_value` is called. At the suggestion of @cptpiepmatz, if the `Value` has `Span::unknown` for some reason, then we replace the `Value`'s span with the passed in span. 

Before:

```nushell
{} | get foo bar
# => Error: nu::shell::column_not_found
# => 
# =>   × Cannot find column 'foo'
# =>    ╭─[entry #43:2:6]
# =>  2 │ {} | get foo bar
# =>    ·      ─┬─ ─┬─
# =>    ·       │   ╰── cannot find column 'foo'
# =>    ·       ╰── value originates here
# =>    ╰────
```

After:

```nushell
{} | get foo bar
# => Error: nu::shell::column_not_found
# => 
# =>   × Cannot find column 'foo'
# =>    ╭─[entry #2:2:1]
# =>  2 │ {} | get foo bar
# =>    · ─┬       ─┬─
# =>    ·  │        ╰── cannot find column 'foo'
# =>    ·  ╰── value originates here
# =>    ╰────
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

* Some errors may have more accurate info about where the value originates from

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A