### PR TITLE
Update config reset to use scaffold files

### DIFF
--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -1,7 +1,7 @@
 use chrono::Local;
 use nu_engine::command_prelude::*;
 
-use nu_utils::{get_default_config, get_default_env};
+use nu_utils::{get_scaffold_config, get_scaffold_env};
 use std::io::Write;
 
 #[derive(Clone)]
@@ -51,7 +51,7 @@ impl Command for ConfigReset {
         if !only_env {
             let mut nu_config = config_path.clone();
             nu_config.push("config.nu");
-            let config_file = get_default_config();
+            let config_file = get_scaffold_config();
             if !no_backup {
                 let mut backup_path = config_path.clone();
                 backup_path.push(format!(
@@ -77,7 +77,7 @@ impl Command for ConfigReset {
         if !only_nu {
             let mut env_config = config_path.clone();
             env_config.push("env.nu");
-            let config_file = get_default_env();
+            let config_file = get_scaffold_env();
             if !no_backup {
                 let mut backup_path = config_path.clone();
                 backup_path.push(format!("oldenv-{}.nu", Local::now().format("%F-%H-%M-%S"),));


### PR DESCRIPTION
# Description

After the config files changes in #14249, I forgot about `config reset`.  As a result, the command places the wrong files (internal defaults) on the filesystem.  This fixes it to use the scaffold files (those that are placed on first-load).

# User-Facing Changes

Bug fix

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A