### PR TITLE
expand custom values on table display

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -625,11 +625,24 @@ fn build_table_kv(
 }
 
 fn build_table_batch(
-    vals: Vec<Value>,
+    mut vals: Vec<Value>,
     view: TableView,
     opts: TableOpts<'_>,
     span: Span,
 ) -> StringResult {
+    // convert each custom value to its base value so it can be properly
+    // displayed in a table
+    for val in &mut vals {
+        let span = val.span();
+
+        if let Value::Custom { val: custom, .. } = val {
+            *val = custom
+                .to_base_value(span)
+                .or_else(|err| Result::<_, ShellError>::Ok(Value::error(err, span)))
+                .expect("error converting custom value to base value")
+        }
+    }
+
     match view {
         TableView::General => JustTable::table(&vals, opts),
         TableView::Expanded {


### PR DESCRIPTION
# Description

Presently, when custom values are displayed in a table, the entire object is stringified. e.g., a custom value that encodes a DNS message gets displayed as:

```
❯ : dns query --timeout 30sec dead10ck.dev
╭───┬─────────────────────────────────────────────────────────────────────╮
│ 0 │ {header: {id: 58404, message_type: RESPONSE, op_code: QUERY,        │
│   │ authoritative: false, truncated: false, recursion_desired: true,    │
│   │ recursion_available: true, authentic_data: true, response_code: No  │
│   │ Error, query_count: 1, answer_count: 2, name_server_count: 0,       │
│   │ additional_count: 1}, question: {name: dead10ck.dev., type: AAAA,   │
│   │ class: IN}, answer: [{name: dead10ck.dev., type: AAAA, class: IN,   │
│   │ ttl: 1hr, rdata: 2600:1f18:6af3:9f05:f526:3a1a:611:6b22, proof:     │
│   │ indeterminate}, {name: dead10ck.dev., type: RRSIG, class: IN, ttl:  │
│   │ 1hr, rdata: AAAA ECDSAP256SHA256 2 3600 1736139412 1736128612 54894 │
│   │  dead10ck.dev. HIkACE70hxznmFTJhOZSmm42KpLC6a+qHchszMyhYjqtG6eP6bzc │
│   │ +XYYjC+UKMaf56SlwBwnpF1tetmrDwyUHw==, proof: indeterminate}],       │
│   │ authority: [], additional: [], edns: {rcode_high: 0, version: 0,    │
│   │ flags: {dnssec_ok: true}, max_payload: 1.2 KiB, opts: {}}, size:    │
│   │ 177 B}                                                              │
```

With this change, expansion to a native nushell value happens earlier so that they get displayed as any other value does.

```
❯ : ./target/debug/nu -c 'dns query --timeout 30sec dead10ck.dev | table --
expand'
╭───┬────────────────────────────────────┬──────────────────────────┬─────╮
│ # │               header               │         question         │ ... │
├───┼────────────────────────────────────┼──────────────────────────┼─────┤
│ 0 │ ╭─────────────────────┬──────────╮ │ ╭───────┬──────────────╮ │ ... │
│   │ │ id                  │ 37707    │ │ │ name  │ dead10ck.dev │ │     │
│   │ │ message_type        │ RESPONSE │ │ │       │ .            │ │     │
│   │ │ op_code             │ QUERY    │ │ │ type  │ AAAA         │ │     │
│   │ │ authoritative       │ false    │ │ │ class │ IN           │ │     │
│   │ │ truncated           │ false    │ │ ╰───────┴──────────────╯ │     │
│   │ │ recursion_desired   │ true     │ │                          │     │
│   │ │ recursion_available │ true     │ │                          │     │
│   │ │ authentic_data      │ true     │ │                          │     │
│   │ │ response_code       │ No Error │ │                          │     │
│   │ │ query_count         │ 1        │ │                          │     │
│   │ │ answer_count        │ 2        │ │                          │     │
│   │ │ name_server_count   │ 0        │ │                          │     │
│   │ │ additional_count    │ 1        │ │                          │     │
│   │ ╰─────────────────────┴──────────╯ │                          │     │
```

# User-Facing Changes

Custom values are displayed as their native Nushell value.

# Tests + Formatting

Manual
