### PR TITLE
allow `open` and `source` to work with `$null_device`

### DIFF
--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -98,6 +98,19 @@ impl Command for Open {
                 let path = path?;
                 let path = Path::new(&path);
 
+                // Now that we have the path, we can check if it's the null device.
+                // If path matches NULL_DEVICE, just return early
+                // This is to enable this type of functionality without producing an error.
+                // use std/util [null-device, null_device]
+                // open (null-device)
+                // open $null_device
+                // source (null-device) # doesn't work since it's not const
+                // source $null_device  # should work since $null_device is const
+
+                if path.to_string_lossy() == nu_utils::NULL_DEVICE {
+                    return Ok(PipelineData::Empty);
+                }
+
                 if permission_denied(path) {
                     #[cfg(unix)]
                     let error_msg = match path.metadata() {

--- a/crates/nu-command/src/misc/source.rs
+++ b/crates/nu-command/src/misc/source.rs
@@ -47,6 +47,21 @@ impl Command for Source {
         // 2. The block_id_name that corresponded to the file name at the 0th position
         let block_id: i64 = call.req_parser_info(engine_state, stack, "block_id")?;
         let block_id_name: String = call.req_parser_info(engine_state, stack, "block_id_name")?;
+
+        // Now that we have the block name, we can check if it's the null device.
+        // If block_id_name matches NULL_DEVICE, just return early
+        // This is to enable this type of functionality without producing an error.
+        // use std/util [null-device, null_device]
+        // open (null-device)
+        // open $null_device
+        // source (null-device) # doesn't work since it's not const
+        // source $null_device  # should work since $null_device is const
+        //
+        // Note: we're removing the last character from the block_id_name since it's a trailing slash or backslash
+        if block_id_name[0..block_id_name.len() - 1] == *nu_utils::NULL_DEVICE {
+            // If it's the null-device, short circuit and return the input as is
+            return Ok(input);
+        }
         let block_id = BlockId::new(block_id as usize);
         let block = engine_state.get_block(block_id).clone();
         let cwd = engine_state.cwd_as_string(Some(stack))?;

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -26,6 +26,20 @@ pub fn glob_from(
     ),
     ShellError,
 > {
+    // if pattern matches NULL_DEVICE, just return early and use it as the path
+    // This is to enable this type of functionality without producing an error.
+    // use std/util [null-device, null_device]
+    // open (null-device)
+    // open $null_device
+    // source (null-device) # doesn't work since it's not const
+    // source $null_device  # should work since $null_device is const
+    if pattern.item.as_ref() == nu_utils::NULL_DEVICE {
+        return Ok((
+            None,
+            Box::new(std::iter::once(Ok(PathBuf::from(nu_utils::NULL_DEVICE)))),
+        ));
+    }
+
     let no_glob_for_pattern = matches!(pattern.item, NuGlob::DoNotExpand(_));
     let (prefix, pattern) = if nu_glob::is_glob(pattern.item.as_ref()) {
         // Pattern contains glob, split it

--- a/crates/nu-std/tests/test_null_device.nu
+++ b/crates/nu-std/tests/test_null_device.nu
@@ -1,0 +1,18 @@
+use std *
+use std/assert
+use std/util [null-device, null_device]
+
+#[test]
+def assert_null_device_source [] {
+    assert ((source $null_device) == null)
+}
+
+#[test]
+def assert_null_device_open_var [] {
+    assert ((open $null_device) == null)
+}
+
+#[test]
+def assert_null_device_open_def [] {
+    assert ((open (null-device)) == null)
+}

--- a/crates/nu-utils/src/lib.rs
+++ b/crates/nu-utils/src/lib.rs
@@ -13,7 +13,7 @@ pub use locale::get_system_locale;
 pub use utils::{
     enable_vt_processing, get_default_config, get_default_env, get_doc_config, get_doc_env,
     get_ls_colors, get_scaffold_config, get_scaffold_env, stderr_write_all_and_flush,
-    stdout_write_all_and_flush, terminal_size,
+    stdout_write_all_and_flush, terminal_size, NULL_DEVICE,
 };
 
 pub use casing::IgnoreCaseExt;

--- a/crates/nu-utils/src/utils.rs
+++ b/crates/nu-utils/src/utils.rs
@@ -488,3 +488,10 @@ pub fn terminal_size() -> io::Result<(u16, u16)> {
     #[cfg(not(feature = "os"))]
     return Err(io::Error::from(io::ErrorKind::Unsupported));
 }
+
+// The cross platform NULL_DEVICE used in `open`, `glob_from`, and `source` commands
+pub const NULL_DEVICE: &str = if cfg!(windows) {
+    "\\\\.\\NUL"
+} else {
+    "/dev/null"
+};


### PR DESCRIPTION
# Description

This is mostly a Quality-of-Life PR which allows you to `open` and `source` the null-device in the stdlib without errors. I tested it on Windows but nowhere else. Hopefully, CI will pass. Following [the changes](https://github.com/nushell/nushell/pull/14763) to make `$null-device` a const, this PR will allow you to source `$null_device`, assuming it's in scope. This can help when you're trying to do something like this.
```nushell
use std/util null_device
let src_path = if condition {windows.nu} else {$null_device}
source $src_path
```
The key is that the else block no longer needs to be a empty file.

Closes https://github.com/nushell/nushell/issues/13872

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
