### PR TITLE
feat(lsp): document_symbols and workspace_symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,6 +3942,7 @@ version = "0.101.1"
 dependencies = [
  "assert-json-diff",
  "crossbeam-channel",
+ "fuzzy-matcher",
  "lsp-server",
  "lsp-textdocument",
  "lsp-types",

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -22,6 +22,7 @@ miette = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }
+fuzzy-matcher = { workspace = true }
 
 [dev-dependencies]
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.101.1" }

--- a/crates/nu-lsp/src/symbols.rs
+++ b/crates/nu-lsp/src/symbols.rs
@@ -1,0 +1,533 @@
+use std::collections::{BTreeMap, HashSet};
+use std::hash::{Hash, Hasher};
+
+use crate::{path_to_uri, span_to_range, uri_to_path, Id, LanguageServer};
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+use lsp_textdocument::{FullTextDocument, TextDocuments};
+use lsp_types::{
+    DocumentSymbolParams, DocumentSymbolResponse, Location, Range, SymbolInformation, SymbolKind,
+    Uri, WorkspaceSymbolParams, WorkspaceSymbolResponse,
+};
+use nu_parser::parse;
+use nu_protocol::{
+    engine::{CachedFile, EngineState, StateWorkingSet},
+    DeclId, Span, Type, VarId,
+};
+use std::{cmp::Ordering, path::Path};
+
+#[derive(Debug, Eq, PartialEq)]
+struct Symbol {
+    name: String,
+    kind: SymbolKind,
+    uri: Uri,
+    range: Range,
+}
+
+impl Hash for Symbol {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.uri.hash(state);
+        self.range.start.hash(state);
+        self.range.end.hash(state);
+    }
+}
+
+impl PartialOrd for Symbol {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Symbol {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.kind == other.kind {
+            return self.range.start.cmp(&other.range.start);
+        }
+        match (self.kind, other.kind) {
+            (SymbolKind::FUNCTION, _) => Ordering::Less,
+            (_, SymbolKind::FUNCTION) => Ordering::Greater,
+            _ => self.range.start.cmp(&other.range.start),
+        }
+    }
+}
+
+impl Symbol {
+    fn to_symbol_information(&self) -> SymbolInformation {
+        #[allow(deprecated)]
+        SymbolInformation {
+            location: Location {
+                uri: self.uri.clone(),
+                range: self.range,
+            },
+            name: self.name.to_owned(),
+            kind: self.kind,
+            container_name: None,
+            deprecated: None,
+            tags: None,
+        }
+    }
+}
+
+/// Cache symbols for each opened file to avoid repeated parsing
+pub struct SymbolCache {
+    /// Fuzzy matcher for symbol names
+    matcher: SkimMatcherV2,
+    /// File Uri --> Symbols
+    cache: BTreeMap<Uri, Vec<SymbolInformation>>,
+    /// If marked as dirty, parse on next request
+    dirty_flags: BTreeMap<Uri, bool>,
+}
+
+impl SymbolCache {
+    pub fn new() -> Self {
+        SymbolCache {
+            matcher: SkimMatcherV2::default(),
+            cache: BTreeMap::new(),
+            dirty_flags: BTreeMap::new(),
+        }
+    }
+
+    pub fn mark_dirty(&mut self, uri: Uri, flag: bool) {
+        self.dirty_flags.insert(uri, flag);
+    }
+
+    fn get_symbol_by_id(
+        working_set: &StateWorkingSet,
+        id: Id,
+        uri: &Uri,
+        doc: &FullTextDocument,
+        doc_span: &Span,
+    ) -> Option<Symbol> {
+        match id {
+            Id::Declaration(decl_id) => {
+                let decl = working_set.get_decl(decl_id);
+                let span = working_set.get_block(decl.block_id()?).span?;
+                // multi-doc working_set, returns None if the Id is in other files
+                if !doc_span.contains(span.start) {
+                    return None;
+                }
+                Some(Symbol {
+                    name: decl.name().to_string(),
+                    kind: SymbolKind::FUNCTION,
+                    uri: uri.clone(),
+                    range: span_to_range(&span, doc, doc_span.start),
+                })
+            }
+            Id::Variable(var_id) => {
+                let var = working_set.get_variable(var_id);
+                let span = var.declaration_span;
+                if !doc_span.contains(span.start) || span.end == span.start {
+                    return None;
+                }
+                let range = span_to_range(&span, doc, doc_span.start);
+                let name = doc.get_content(Some(range));
+                // TODO: better way to filter closures with type any
+                if name.contains('\r')
+                    || name.contains('\n')
+                    || name.contains('{')
+                    || var.ty == Type::Closure
+                    || var.ty == Type::Block
+                {
+                    return None;
+                }
+                Some(Symbol {
+                    name: name.to_string(),
+                    kind: SymbolKind::VARIABLE,
+                    uri: uri.clone(),
+                    range,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    fn extract_all_symbols(
+        working_set: &StateWorkingSet,
+        uri: &Uri,
+        doc: &FullTextDocument,
+        cached_file: &CachedFile,
+    ) -> Vec<SymbolInformation> {
+        let mut all_symbols: Vec<Symbol> = (0..working_set.num_decls())
+            .filter_map(|id| {
+                Self::get_symbol_by_id(
+                    working_set,
+                    Id::Declaration(DeclId::new(id)),
+                    uri,
+                    doc,
+                    &cached_file.covered_span,
+                )
+            })
+            .chain((0..working_set.num_vars()).filter_map(|id| {
+                Self::get_symbol_by_id(
+                    working_set,
+                    Id::Variable(VarId::new(id)),
+                    uri,
+                    doc,
+                    &cached_file.covered_span,
+                )
+            }))
+            // TODO: same variable symbol can be duplicated with different VarId
+            .collect::<HashSet<Symbol>>()
+            .into_iter()
+            .collect();
+        all_symbols.sort();
+        all_symbols
+            .into_iter()
+            .map(|s| s.to_symbol_information())
+            .collect()
+    }
+
+    /// Update the symbols of given uri if marked as dirty
+    pub fn update(&mut self, uri: &Uri, engine_state: &EngineState, docs: &TextDocuments) {
+        if *self.dirty_flags.get(uri).unwrap_or(&true) {
+            let mut working_set = StateWorkingSet::new(engine_state);
+            let content = docs
+                .get_document_content(uri, None)
+                .expect("Failed to get_document_content!")
+                .as_bytes();
+            parse(
+                &mut working_set,
+                Some(
+                    uri_to_path(uri)
+                        .to_str()
+                        .expect("Failed to convert pathbuf to string"),
+                ),
+                content,
+                false,
+            );
+            for cached_file in working_set.files() {
+                let path = Path::new(&*cached_file.name);
+                if !(path.exists() && path.is_file()) {
+                    continue;
+                }
+                let target_uri = path_to_uri(path);
+                let new_symbols = if let Some(doc) = docs.get_document(&target_uri) {
+                    Self::extract_all_symbols(&working_set, &target_uri, doc, cached_file)
+                } else {
+                    let temp_doc = FullTextDocument::new(
+                        "nu".to_string(),
+                        0,
+                        String::from_utf8((*cached_file.content).to_vec()).expect("Invalid UTF-8"),
+                    );
+                    Self::extract_all_symbols(&working_set, &target_uri, &temp_doc, cached_file)
+                };
+                self.cache.insert(target_uri.clone(), new_symbols);
+                self.mark_dirty(target_uri, false);
+            }
+            self.mark_dirty(uri.clone(), false);
+        };
+    }
+
+    pub fn update_all(&mut self, engine_state: &EngineState, docs: &TextDocuments) {
+        for uri in docs.documents().keys() {
+            self.update(uri, engine_state, docs);
+        }
+    }
+
+    pub fn get_fuzzy_matched(&self, query: &str) -> Vec<SymbolInformation> {
+        self.cache
+            .values()
+            .flat_map(|s| s.clone())
+            .filter_map(|s| {
+                self.matcher.fuzzy_match(&s.name, query)?;
+                Some(s.clone())
+            })
+            .collect()
+    }
+
+    pub fn any_dirty(&self) -> bool {
+        self.dirty_flags.values().any(|f| *f)
+    }
+}
+
+impl LanguageServer {
+    pub fn document_symbol(
+        &mut self,
+        params: &DocumentSymbolParams,
+    ) -> Option<DocumentSymbolResponse> {
+        let engine_state = self.new_engine_state();
+        let uri = params.text_document.uri.to_owned();
+        self.symbol_cache.update(&uri, &engine_state, &self.docs);
+        Some(DocumentSymbolResponse::Flat(
+            self.symbol_cache.cache.get(&uri)?.clone(),
+        ))
+    }
+
+    pub fn workspace_symbol(
+        &mut self,
+        params: &WorkspaceSymbolParams,
+    ) -> Option<WorkspaceSymbolResponse> {
+        if self.symbol_cache.any_dirty() {
+            let engine_state = self.new_engine_state();
+            self.symbol_cache.update_all(&engine_state, &self.docs);
+        }
+        Some(WorkspaceSymbolResponse::Flat(
+            self.symbol_cache.get_fuzzy_matched(params.query.as_str()),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_json_diff::assert_json_eq;
+    use lsp_types::{PartialResultParams, TextDocumentIdentifier};
+    use nu_test_support::fs::fixtures;
+
+    use crate::path_to_uri;
+    use crate::tests::{initialize_language_server, open_unchecked, update};
+    use lsp_server::{Connection, Message};
+    use lsp_types::{
+        request::{DocumentSymbolRequest, Request, WorkspaceSymbolRequest},
+        DocumentSymbolParams, Uri, WorkDoneProgressParams, WorkspaceSymbolParams,
+    };
+
+    fn document_symbol_test(client_connection: &Connection, uri: Uri) -> Message {
+        client_connection
+            .sender
+            .send(Message::Request(lsp_server::Request {
+                id: 1.into(),
+                method: DocumentSymbolRequest::METHOD.to_string(),
+                params: serde_json::to_value(DocumentSymbolParams {
+                    text_document: TextDocumentIdentifier { uri },
+                    partial_result_params: PartialResultParams::default(),
+                    work_done_progress_params: WorkDoneProgressParams::default(),
+                })
+                .unwrap(),
+            }))
+            .unwrap();
+
+        client_connection
+            .receiver
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap()
+    }
+
+    fn workspace_symbol_test(client_connection: &Connection, query: String) -> Message {
+        client_connection
+            .sender
+            .send(Message::Request(lsp_server::Request {
+                id: 2.into(),
+                method: WorkspaceSymbolRequest::METHOD.to_string(),
+                params: serde_json::to_value(WorkspaceSymbolParams {
+                    query,
+                    partial_result_params: PartialResultParams::default(),
+                    work_done_progress_params: WorkDoneProgressParams::default(),
+                })
+                .unwrap(),
+            }))
+            .unwrap();
+        client_connection
+            .receiver
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap()
+    }
+
+    #[test]
+    fn document_symbol_basic() {
+        let (client_connection, _recv) = initialize_language_server();
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("symbols");
+        script.push("foo.nu");
+        let script = path_to_uri(&script);
+
+        open_unchecked(&client_connection, script.clone());
+
+        let resp = document_symbol_test(&client_connection, script.clone());
+        let result = if let Message::Response(response) = resp {
+            response.result
+        } else {
+            panic!()
+        };
+
+        assert_json_eq!(
+            result,
+            serde_json::json!([
+              {
+                "name": "def_foo",
+                "kind": 12,
+                "location": {
+                  "uri": script,
+                  "range": {
+                    "start": { "line": 5, "character": 15 },
+                    "end": { "line": 5, "character": 20 }
+                  }
+                }
+              },
+              {
+                "name": "var_foo",
+                "kind": 13,
+                "location": {
+                  "uri": script,
+                  "range": {
+                    "start": { "line": 2, "character": 4 },
+                    "end": { "line": 2, "character": 11 }
+                  }
+                }
+              }
+            ])
+        );
+    }
+
+    #[test]
+    fn document_symbol_update() {
+        let (client_connection, _recv) = initialize_language_server();
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("symbols");
+        script.push("bar.nu");
+        let script = path_to_uri(&script);
+
+        open_unchecked(&client_connection, script.clone());
+        update(
+            &client_connection,
+            script.clone(),
+            String::default(),
+            Some(lsp_types::Range {
+                start: lsp_types::Position {
+                    line: 2,
+                    character: 0,
+                },
+                end: lsp_types::Position {
+                    line: 2,
+                    character: 26,
+                },
+            }),
+        );
+
+        let resp = document_symbol_test(&client_connection, script.clone());
+        let result = if let Message::Response(response) = resp {
+            response.result
+        } else {
+            panic!()
+        };
+
+        assert_json_eq!(
+            result,
+            serde_json::json!([
+              {
+                "name": "var_bar",
+                "kind": 13,
+                "location": {
+                  "uri": script,
+                  "range": {
+                    "start": { "line": 0, "character": 13 },
+                    "end": { "line": 0, "character": 20 }
+                  }
+                }
+              }
+            ])
+        );
+    }
+
+    #[test]
+    fn workspace_symbol_current() {
+        let (client_connection, _recv) = initialize_language_server();
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("symbols");
+        script.push("foo.nu");
+        let script_foo = path_to_uri(&script);
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("symbols");
+        script.push("bar.nu");
+        let script_bar = path_to_uri(&script);
+
+        open_unchecked(&client_connection, script_foo.clone());
+        open_unchecked(&client_connection, script_bar.clone());
+
+        let resp = workspace_symbol_test(&client_connection, "br".to_string());
+        let result = if let Message::Response(response) = resp {
+            response.result
+        } else {
+            panic!()
+        };
+
+        assert_json_eq!(
+            result,
+            serde_json::json!([
+              {
+                "name": "def_bar",
+                "kind": 12,
+                "location": {
+                  "uri": script_bar,
+                  "range": {
+                    "start": { "line": 2, "character": 22 },
+                    "end": { "line": 2, "character": 27 }
+                  }
+                }
+              },
+              {
+                "name": "var_bar",
+                "kind": 13,
+                "location": {
+                  "uri": script_bar,
+                  "range": {
+                    "start": { "line": 0, "character": 13 },
+                    "end": { "line": 0, "character": 20 }
+                  }
+                }
+              }
+            ])
+        );
+    }
+
+    #[test]
+    fn workspace_symbol_other() {
+        let (client_connection, _recv) = initialize_language_server();
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("symbols");
+        script.push("foo.nu");
+        let script_foo = path_to_uri(&script);
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("symbols");
+        script.push("bar.nu");
+        let script_bar = path_to_uri(&script);
+
+        open_unchecked(&client_connection, script_foo.clone());
+        open_unchecked(&client_connection, script_bar.clone());
+
+        let resp = workspace_symbol_test(&client_connection, "foo".to_string());
+        let result = if let Message::Response(response) = resp {
+            response.result
+        } else {
+            panic!()
+        };
+
+        assert_json_eq!(
+            result,
+            serde_json::json!([
+              {
+                "name": "def_foo",
+                "kind": 12,
+                "location": {
+                  "uri": script_foo,
+                  "range": {
+                    "start": { "line": 5, "character": 15 },
+                    "end": { "line": 5, "character": 20 }
+                  }
+                }
+              },
+              {
+                "name": "var_foo",
+                "kind": 13,
+                "location": {
+                  "uri": script_foo,
+                  "range": {
+                    "start": { "line": 2, "character": 4 },
+                    "end": { "line": 2, "character": 11 }
+                  }
+                }
+              }
+            ])
+        );
+    }
+}

--- a/crates/nu-protocol/src/engine/state_delta.rs
+++ b/crates/nu-protocol/src/engine/state_delta.rs
@@ -64,6 +64,10 @@ impl StateDelta {
         self.virtual_paths.len()
     }
 
+    pub fn num_vars(&self) -> usize {
+        self.vars.len()
+    }
+
     pub fn num_decls(&self) -> usize {
         self.decls.len()
     }

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -73,6 +73,10 @@ impl<'a> StateWorkingSet<'a> {
         self.delta.num_virtual_paths() + self.permanent_state.num_virtual_paths()
     }
 
+    pub fn num_vars(&self) -> usize {
+        self.delta.num_vars() + self.permanent_state.num_vars()
+    }
+
     pub fn num_decls(&self) -> usize {
         self.delta.num_decls() + self.permanent_state.num_decls()
     }

--- a/tests/fixtures/lsp/symbols/bar.nu
+++ b/tests/fixtures/lsp/symbols/bar.nu
@@ -1,0 +1,3 @@
+export const var_bar = 2
+
+export def def_bar [] { 3 }

--- a/tests/fixtures/lsp/symbols/foo.nu
+++ b/tests/fixtures/lsp/symbols/foo.nu
@@ -1,0 +1,6 @@
+use bar.nu [ var_bar def_bar ]
+
+let var_foo = 1
+def_bar
+
+def def_foo [] { 4 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR adds symbols related features to lsp
<img width="940" alt="image" src="https://github.com/user-attachments/assets/aeaed338-133c-430a-b966-58a9bc445211" />

Notice that symbols of type variable may got filtered by client side plugins

<img width="906" alt="image" src="https://github.com/user-attachments/assets/e031b3dc-443a-486f-8a35-4415c07196d0" />


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
