### PR TITLE
fix `stor reset` when there are foreign keys

### DIFF
--- a/crates/nu-command/src/stor/reset.rs
+++ b/crates/nu-command/src/stor/reset.rs
@@ -49,9 +49,25 @@ impl Command for StorReset {
         ));
 
         if let Ok(conn) = db.open_connection() {
+            conn.execute("PRAGMA foreign_keys = OFF", [])
+                .map_err(|err| ShellError::GenericError {
+                    error: "Failed to turn off foreign_key protections for reset".into(),
+                    msg: err.to_string(),
+                    span: Some(Span::test_data()),
+                    help: None,
+                    inner: vec![],
+                })?;
             db.drop_all_tables(&conn)
                 .map_err(|err| ShellError::GenericError {
-                    error: "Failed to open SQLite connection in memory from reset".into(),
+                    error: "Failed to drop all tables in memory from reset".into(),
+                    msg: err.to_string(),
+                    span: Some(Span::test_data()),
+                    help: None,
+                    inner: vec![],
+                })?;
+            conn.execute("PRAGMA foreign_keys = ON", [])
+                .map_err(|err| ShellError::GenericError {
+                    error: "Failed to turn on foreign_key protections for reset".into(),
                     msg: err.to_string(),
                     span: Some(Span::test_data()),
                     help: None,


### PR DESCRIPTION
# Description

This PR fixes a problem with `stor reset`. That problem was that it called drop_all_tables which just iterated through the tables and dropped them one by one. This works as long as there are no foreign keys or if the tables are dropped in the "right" order. It doesn't work in most cases since you have to know what order to drop tables in. So, this PR turns off foreign key constraints, then drops all the tables, then turns the foreign key constraints back on, which seems to work well... so far. :)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
