### PR TITLE
Fallback to file completer in custom/external completer

### DIFF
--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -39,7 +39,7 @@ impl<T: Completer> Completer for CustomCompletion<T> {
         span: Span,
         offset: usize,
         pos: usize,
-        completion_options: &CompletionOptions,
+        orig_options: &CompletionOptions,
     ) -> Vec<SemanticSuggestion> {
         // Line position
         let line_pos = pos - offset;
@@ -66,15 +66,14 @@ impl<T: Completer> Completer for CustomCompletion<T> {
                 parser_info: HashMap::new(),
             },
             PipelineData::empty(),
-        )
-        .and_then(|data| data.into_value(span));
+        );
 
-        let mut custom_completion_options = None;
+        let mut completion_options = orig_options.clone();
         let mut should_sort = true;
 
         // Parse result
-        let suggestions = match result {
-            Ok(value) => match value {
+        let suggestions = match result.and_then(|data| data.into_value(span)) {
+            Ok(value) => match &value {
                 Value::Record { val, .. } => {
                     let completions = val
                         .get("completions")
@@ -91,25 +90,24 @@ impl<T: Completer> Completer for CustomCompletion<T> {
                             should_sort = sort;
                         }
 
-                        custom_completion_options = Some(CompletionOptions {
-                            case_sensitive: options
-                                .get("case_sensitive")
-                                .and_then(|val| val.as_bool().ok())
-                                .unwrap_or(true),
-                            positional: options
-                                .get("positional")
-                                .and_then(|val| val.as_bool().ok())
-                                .unwrap_or(completion_options.positional),
-                            match_algorithm: match options.get("completion_algorithm") {
-                                Some(option) => option
-                                    .coerce_string()
-                                    .ok()
-                                    .and_then(|option| option.try_into().ok())
-                                    .unwrap_or(completion_options.match_algorithm),
-                                None => completion_options.match_algorithm,
-                            },
-                            sort: completion_options.sort,
-                        });
+                        if let Some(case_sensitive) = options
+                            .get("case_sensitive")
+                            .and_then(|val| val.as_bool().ok())
+                        {
+                            completion_options.case_sensitive = case_sensitive;
+                        }
+                        if let Some(positional) =
+                            options.get("positional").and_then(|val| val.as_bool().ok())
+                        {
+                            completion_options.positional = positional;
+                        }
+                        if let Some(algorithm) = options
+                            .get("completion_algorithm")
+                            .and_then(|option| option.coerce_string().ok())
+                            .and_then(|option| option.try_into().ok())
+                        {
+                            completion_options.match_algorithm = algorithm;
+                        }
                     }
 
                     completions
@@ -123,7 +121,7 @@ impl<T: Completer> Completer for CustomCompletion<T> {
                         span,
                         offset,
                         pos,
-                        completion_options,
+                        orig_options,
                     );
                 }
                 _ => {
@@ -140,8 +138,7 @@ impl<T: Completer> Completer for CustomCompletion<T> {
             }
         };
 
-        let options = custom_completion_options.unwrap_or(completion_options.clone());
-        let mut matcher = NuMatcher::new(String::from_utf8_lossy(prefix), options);
+        let mut matcher = NuMatcher::new(String::from_utf8_lossy(prefix), completion_options);
 
         if should_sort {
             for sugg in suggestions {

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -12,27 +12,29 @@ use std::collections::HashMap;
 
 use super::completion_options::NuMatcher;
 
-pub struct CustomCompletion {
+pub struct CustomCompletion<T: Completer> {
     stack: Stack,
     decl_id: DeclId,
     line: String,
+    fallback: T,
 }
 
-impl CustomCompletion {
-    pub fn new(stack: Stack, decl_id: DeclId, line: String) -> Self {
+impl<T: Completer> CustomCompletion<T> {
+    pub fn new(stack: Stack, decl_id: DeclId, line: String, fallback: T) -> Self {
         Self {
             stack,
             decl_id,
             line,
+            fallback,
         }
     }
 }
 
-impl Completer for CustomCompletion {
+impl<T: Completer> Completer for CustomCompletion<T> {
     fn fetch(
         &mut self,
         working_set: &StateWorkingSet,
-        _stack: &Stack,
+        stack: &Stack,
         prefix: &[u8],
         span: Span,
         offset: usize,
@@ -64,15 +66,15 @@ impl Completer for CustomCompletion {
                 parser_info: HashMap::new(),
             },
             PipelineData::empty(),
-        );
+        )
+        .and_then(|data| data.into_value(span));
 
-        let mut completion_options = completion_options.clone();
+        let mut custom_completion_options = None;
         let mut should_sort = true;
 
         // Parse result
-        let suggestions = result
-            .and_then(|data| data.into_value(span))
-            .map(|value| match &value {
+        let suggestions = match result {
+            Ok(value) => match value {
                 Value::Record { val, .. } => {
                     let completions = val
                         .get("completions")
@@ -89,34 +91,57 @@ impl Completer for CustomCompletion {
                             should_sort = sort;
                         }
 
-                        if let Some(case_sensitive) = options
-                            .get("case_sensitive")
-                            .and_then(|val| val.as_bool().ok())
-                        {
-                            completion_options.case_sensitive = case_sensitive;
-                        }
-                        if let Some(positional) =
-                            options.get("positional").and_then(|val| val.as_bool().ok())
-                        {
-                            completion_options.positional = positional;
-                        }
-                        if let Some(algorithm) = options
-                            .get("completion_algorithm")
-                            .and_then(|option| option.coerce_string().ok())
-                            .and_then(|option| option.try_into().ok())
-                        {
-                            completion_options.match_algorithm = algorithm;
-                        }
+                        custom_completion_options = Some(CompletionOptions {
+                            case_sensitive: options
+                                .get("case_sensitive")
+                                .and_then(|val| val.as_bool().ok())
+                                .unwrap_or(true),
+                            positional: options
+                                .get("positional")
+                                .and_then(|val| val.as_bool().ok())
+                                .unwrap_or(completion_options.positional),
+                            match_algorithm: match options.get("completion_algorithm") {
+                                Some(option) => option
+                                    .coerce_string()
+                                    .ok()
+                                    .and_then(|option| option.try_into().ok())
+                                    .unwrap_or(completion_options.match_algorithm),
+                                None => completion_options.match_algorithm,
+                            },
+                            sort: completion_options.sort,
+                        });
                     }
 
                     completions
                 }
                 Value::List { vals, .. } => map_value_completions(vals.iter(), span, offset),
-                _ => vec![],
-            })
-            .unwrap_or_default();
+                Value::Nothing { .. } => {
+                    return self.fallback.fetch(
+                        working_set,
+                        stack,
+                        prefix,
+                        span,
+                        offset,
+                        pos,
+                        completion_options,
+                    );
+                }
+                _ => {
+                    log::error!(
+                        "Custom completer returned invalid value of type {}",
+                        value.get_type().to_string()
+                    );
+                    return vec![];
+                }
+            },
+            Err(e) => {
+                log::error!("Error getting custom completions: {e}");
+                return vec![];
+            }
+        };
 
-        let mut matcher = NuMatcher::new(String::from_utf8_lossy(prefix), completion_options);
+        let options = custom_completion_options.unwrap_or(completion_options.clone());
+        let mut matcher = NuMatcher::new(String::from_utf8_lossy(prefix), options);
 
         if should_sort {
             for sugg in suggestions {

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -234,6 +234,37 @@ fn customcompletions_no_sort() {
     match_suggestions(&expected, &suggestions);
 }
 
+/// Fallback to file completions if custom completer returns null
+#[test]
+fn customcompletions_fallback() {
+    let (_, _, mut engine, mut stack) = new_engine();
+    let command = r#"
+        def comp [] { null }
+        def my-command [arg: string@comp] {}"#;
+    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let completion_str = "my-command test";
+    let suggestions = completer.complete(completion_str, completion_str.len());
+    let expected: Vec<String> = vec![folder("test_a"), file("test_a_symlink"), folder("test_b")];
+    match_suggestions(&expected, &suggestions);
+}
+
+/// Suppress completions for invalid values
+#[test]
+fn customcompletions_invalid() {
+    let (_, _, mut engine, mut stack) = new_engine();
+    let command = r#"
+        def comp [] { 123 }
+        def my-command [arg: string@comp] {}"#;
+    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+
+    let completion_str = "my-command foo";
+    let suggestions = completer.complete(completion_str, completion_str.len());
+    assert!(suggestions.is_empty());
+}
+
 #[test]
 fn dotnu_completions() {
     // Create a new engine
@@ -310,6 +341,27 @@ fn external_completer_pass_flags() {
     assert_eq!("gh", suggestions.first().unwrap().value);
     assert_eq!("api", suggestions.get(1).unwrap().value);
     assert_eq!("--", suggestions.get(2).unwrap().value);
+}
+
+/// Fallback to file completions when external completer returns null
+#[test]
+fn external_completer_fallback() {
+    let block = "{|spans| null}";
+    let input = "foo test".to_string();
+
+    let expected = vec![folder("test_a"), file("test_a_symlink"), folder("test_b")];
+    let suggestions = run_external_completion(block, &input);
+    match_suggestions(&expected, &suggestions);
+}
+
+/// Suppress completions when external completer returns invalid value
+#[test]
+fn external_completer_invalid() {
+    let block = "{|spans| 123}";
+    let input = "foo ".to_string();
+
+    let suggestions = run_external_completion(block, &input);
+    assert!(suggestions.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
# Description

Closes #14595. This modifies the behavior of both custom and external completers so that if the custom/external completer returns an invalid value, completions are suppressed and an error is logged. However, if the completer returns `null` (which this PR treats as a special value), we fall back to file completions.

Previously, custom completers and external completers had different behavior. Any time an external completer returned an invalid value (including `null`), we would fall back to file completions. Any time a custom completer returned an invalid value (including `null`), we would suppress completions.

I'm not too happy about the implementation, but it's the least intrusive way I could think of to do it. I added a `fallback` field to `CustomCompletions` that's checked after calling its `fetch()` method. If `fallback` is true, then we use file completions afterwards.

An alternative would be to make `CustomCompletions` no longer implement the `Completer` trait, and instead have its `fetch()` method return an `Option<Vec<Suggestion>>`. But that resulted in a teeny bit of code duplication.

# User-Facing Changes

For those using an external completer, if they want to fall back to file completions on invalid values, their completer will have to explicitly return `null`. Returning `"foo"` or something will no longer make Nushell use file completions instead.

For those making custom completers, they now have the option to fall back to file completions.

# Tests + Formatting

Added some tests and manually tested that if the completer returns an invalid value or the completer throws an error, that gets logged and completions are suppressed.

# After Submitting

The documentation for custom completions and external completers will have to be updated after this.