### PR TITLE
bump to rust version 1.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://www.nushell.sh"
 license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
-rust-version = "1.81.0"
+rust-version = "1.82.0"
 version = "0.101.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/nu-explore/src/commands/nu.rs
+++ b/crates/nu-explore/src/commands/nu.rs
@@ -69,12 +69,12 @@ impl ViewCommand for NuCmd {
             view.set_top_layer_orientation(Orientation::Left);
         }
 
-        Ok(NuView::Records(view))
+        Ok(NuView::Records(Box::new(view)))
     }
 }
 
 pub enum NuView {
-    Records(RecordView),
+    Records(Box<RecordView>),
     Preview(Preview),
 }
 

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -1,11 +1,8 @@
-use std::fmt;
-
+use super::ShellError;
+use crate::Span;
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
-
-use crate::Span;
-
-use super::ShellError;
+use std::fmt;
 
 /// A very generic type of error used for interfacing with external code, such as scripts and
 /// plugins.
@@ -18,7 +15,7 @@ pub struct LabeledError {
     pub msg: String,
     /// Labeled spans attached to the error, demonstrating to the user where the problem is.
     #[serde(default)]
-    pub labels: Vec<ErrorLabel>,
+    pub labels: Box<Vec<ErrorLabel>>,
     /// A unique machine- and search-friendly error code to associate to the error. (e.g.
     /// `nu::shell::missing_config_value`)
     #[serde(default)]
@@ -31,7 +28,7 @@ pub struct LabeledError {
     pub help: Option<String>,
     /// Errors that are related to or caused this error
     #[serde(default)]
-    pub inner: Vec<LabeledError>,
+    pub inner: Box<Vec<LabeledError>>,
 }
 
 impl LabeledError {
@@ -50,11 +47,11 @@ impl LabeledError {
     pub fn new(msg: impl Into<String>) -> LabeledError {
         LabeledError {
             msg: msg.into(),
-            labels: vec![],
+            labels: Box::new(vec![]),
             code: None,
             url: None,
             help: None,
-            inner: vec![],
+            inner: Box::new(vec![]),
         }
     }
 
@@ -161,7 +158,8 @@ impl LabeledError {
                     text: label.label().unwrap_or("").into(),
                     span: Span::new(label.offset(), label.offset() + label.len()),
                 })
-                .collect(),
+                .collect::<Vec<_>>()
+                .into(),
             code: diag.code().map(|s| s.to_string()),
             url: diag.url().map(|s| s.to_string()),
             help: diag.help().map(|s| s.to_string()),
@@ -170,7 +168,8 @@ impl LabeledError {
                 .into_iter()
                 .flatten()
                 .map(Self::from_diagnostic)
-                .collect(),
+                .collect::<Vec<_>>()
+                .into(),
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,4 +16,4 @@ profile = "default"
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 4 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.81.0"
+channel = "1.82.0"


### PR DESCRIPTION
# Description

The PR follows our standard of bumping the rust compiler when a new one is released.

/cc @ayax79 @sholderbach

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
