### PR TITLE
Let `table` only check for `use_ansi_coloring` config value

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -2,7 +2,7 @@
 //        overall reduce the redundant calls to StyleComputer etc.
 //        the goal is to configure it once...
 
-use std::{collections::VecDeque, io::IsTerminal, io::Read, path::PathBuf, str::FromStr};
+use std::{collections::VecDeque, io::Read, path::PathBuf, str::FromStr};
 
 use lscolors::{LsColors, Style};
 use url::Url;
@@ -310,7 +310,7 @@ fn get_cli_args(call: &Call<'_>, state: &EngineState, stack: &mut Stack) -> Shel
         get_theme_flag(call, state, stack)?.unwrap_or_else(|| stack.get_config(state).table.mode);
     let index = get_index_flag(call, state, stack)?;
 
-    let use_ansi_coloring = state.get_config().use_ansi_coloring.get(state);
+    let use_ansi_coloring = stack.get_config(state).use_ansi_coloring.get(state);
 
     Ok(CLIArgs {
         theme,
@@ -1067,8 +1067,9 @@ fn render_path_name(
 }
 
 fn maybe_strip_color(output: String, use_ansi_coloring: bool) -> String {
-    // the terminal is for when people do ls from vim, there should be no coloring there
-    if !use_ansi_coloring || !std::io::stdout().is_terminal() {
+    // only use `use_ansi_coloring` here, it already includes `std::io::stdout().is_terminal()`
+    // when set to "auto"
+    if !use_ansi_coloring {
         // Draw the table without ansi colors
         nu_utils::strip_ansi_string_likely(output)
     } else {

--- a/crates/nu-command/tests/commands/table.rs
+++ b/crates/nu-command/tests/commands/table.rs
@@ -3100,3 +3100,22 @@ fn table_footer_inheritance_list_rows() {
          ╰───┴──────┴───────────────────────╯"
     );
 }
+
+/// Test checking whether automatic table rendering correctly uses ansi coloring.
+#[test]
+fn table_colors() {
+    let actual = nu!(concat!(
+        "$env.config.use_ansi_coloring = true;",
+        "{a: 1, b: 2}",
+    ));
+    assert_eq!(
+        actual.out,
+        "\u{1b}[37m╭───┬───╮\u{1b}[0m\u{1b}[37m│\u{1b}[0m \u{1b}[1;32ma\u{1b}[0m \u{1b}[37m│\u{1b}[0m \u{1b}[37m1\u{1b}[0m \u{1b}[37m│\u{1b}[0m\u{1b}[37m│\u{1b}[0m \u{1b}[1;32mb\u{1b}[0m \u{1b}[37m│\u{1b}[0m \u{1b}[37m2\u{1b}[0m \u{1b}[37m│\u{1b}[0m\u{1b}[37m╰───┴───╯\u{1b}[0m" 
+    );
+
+    let actual = nu!(concat!(
+        "$env.config.use_ansi_coloring = false;",
+        "{a: 1, b: 2}",
+    ));
+    assert_eq!(actual.out, "╭───┬───╮│ a │ 1 ││ b │ 2 │╰───┴───╯");
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR removes the `std::io::stdout().is_terminal()` check in `table` again. To ensure that in the future this doesn't happen again, I added a comment and a test.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Resets the behavior of `table` to #14647 again, after #14415 included it again.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Added a new test to check for these color outputs.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
