### PR TITLE
Do not trigger release WF on nightly tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ name: Create Release Draft
 on:
   workflow_dispatch:
   push:
-    tags: ["[0-9]+.[0-9]+.[0-9]+*"]
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+      - '!*nightly*'  # Don't trigger release for nightly tags
 
 defaults:
   run:


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Don't trigger release for nightly tags, more context could be found here: https://github.com/nushell/nightly/issues/35
