### PR TITLE
Add input support to `generate`

### DIFF
--- a/crates/nu-command/src/generators/generate.rs
+++ b/crates/nu-command/src/generators/generate.rs
@@ -36,11 +36,14 @@ impl Command for Generate {
 containing two optional keys: 'out' and 'next'. Each invocation, the 'out'
 value, if present, is added to the stream. If a 'next' key is present, it is
 used as the next argument to the closure, otherwise generation stops.
-"#
+
+Additionally, if an input stream is provided, on each invocation an element of
+the input stream is provided as pipeline input to the closure. In this case
+generation also stops when the input stream stops."#
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["unfold", "stream", "yield", "expand"]
+        vec!["unfold", "stream", "yield", "expand", "state", "scan"]
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -72,6 +75,17 @@ used as the next argument to the closure, otherwise generation stops.
                 description:
                     "Generate a continuous stream of Fibonacci numbers, using default parameters",
                 result: None,
+            },
+            Example {
+                example: "1..5 | generate {|sum=0| let sum = $in + $sum; {out: $sum, next: $sum} }",
+                description: "Generate a running sum of the inputs",
+                result: Some(Value::test_list(vec![
+                    Value::test_int(1),
+                    Value::test_int(3),
+                    Value::test_int(6),
+                    Value::test_int(10),
+                    Value::test_int(15),
+                ])),
             },
         ]
     }

--- a/crates/nu-command/tests/commands/generate.rs
+++ b/crates/nu-command/tests/commands/generate.rs
@@ -151,7 +151,7 @@ fn generate_raise_error_on_no_default_parameter_closure_and_init_val() {
 
 #[test]
 fn generate_allows_pipeline_input() {
-    let actual = nu!(r#"[1 2 3] | generate {|x=null| {out: $in, next: null}} | to nuon"#);
+    let actual = nu!(r#"[1 2 3] | generate {|e, x=null| {out: $e, next: null}} | to nuon"#);
     assert_eq!(actual.out, "[1, 2, 3]");
 }
 
@@ -161,7 +161,7 @@ fn generate_with_input_is_streaming() {
         r#"
         1..10
         | each {|x| print -en $x; $x}
-        | generate {|sum=0| let sum = $in + $sum; {out: $sum, next: $sum}}
+        | generate {|e, sum=0| let sum = $e + $sum; {out: $sum, next: $sum}}
         | first 5
         | to nuon
         "#

--- a/crates/nu-command/tests/commands/generate.rs
+++ b/crates/nu-command/tests/commands/generate.rs
@@ -148,3 +148,23 @@ fn generate_raise_error_on_no_default_parameter_closure_and_init_val() {
     ));
     assert!(actual.err.contains("The initial value is missing"));
 }
+
+#[test]
+fn generate_allows_pipeline_input() {
+    let actual = nu!(r#"[1 2 3] | generate {|x=null| {out: $in, next: null}} | to nuon"#);
+    assert_eq!(actual.out, "[1, 2, 3]");
+}
+
+#[test]
+fn generate_with_input_is_streaming() {
+    let actual = nu!(pipeline(r#"
+    1..10
+    | each {|x| print -en $x; $x}
+    | generate {|sum=0| let sum = $in + $sum; {out: $sum, next: $sum}}
+    | first 5
+    | to nuon
+    "#));
+
+    assert_eq!(actual.out, "[1, 3, 6, 10, 15]");
+    assert_eq!(actual.err, "12345");
+}

--- a/crates/nu-command/tests/commands/generate.rs
+++ b/crates/nu-command/tests/commands/generate.rs
@@ -157,13 +157,15 @@ fn generate_allows_pipeline_input() {
 
 #[test]
 fn generate_with_input_is_streaming() {
-    let actual = nu!(pipeline(r#"
-    1..10
-    | each {|x| print -en $x; $x}
-    | generate {|sum=0| let sum = $in + $sum; {out: $sum, next: $sum}}
-    | first 5
-    | to nuon
-    "#));
+    let actual = nu!(pipeline(
+        r#"
+        1..10
+        | each {|x| print -en $x; $x}
+        | generate {|sum=0| let sum = $in + $sum; {out: $sum, next: $sum}}
+        | first 5
+        | to nuon
+        "#
+    ));
 
     assert_eq!(actual.out, "[1, 3, 6, 10, 15]");
     assert_eq!(actual.err, "12345");

--- a/crates/nu-std/std/iter/mod.nu
+++ b/crates/nu-std/std/iter/mod.nu
@@ -108,9 +108,8 @@ export def scan [ # -> list<any>
     fn: closure          # the closure to perform the scan
     --noinit(-n)         # remove the initial value from the result
 ] {
-    generate {|acc|
-        let IN = $in
-        let out = $acc | do $fn $IN $acc
+    generate {|e, acc|
+        let out = $acc | do $fn $e $acc
         {next: $out, out: $out}
     } $init
     | if not $noinit { prepend $init } else { }

--- a/crates/nu-std/std/iter/mod.nu
+++ b/crates/nu-std/std/iter/mod.nu
@@ -107,16 +107,13 @@ export def scan [ # -> list<any>
     init: any            # initial value to seed the initial state
     fn: closure          # the closure to perform the scan
     --noinit(-n)         # remove the initial value from the result
-] {                      
-    reduce --fold [$init] {|e, acc|
-        let acc_last = $acc | last
-        $acc ++ [($acc_last | do $fn $e $acc_last)]
-    }
-    | if $noinit {
-        $in | skip
-    } else {
-        $in
-    }
+] {
+    generate {|acc|
+        let IN = $in
+        let out = $acc | do $fn $IN $acc
+        {next: $out, out: $out}
+    } $init
+    | if not $noinit { prepend $init } else { }
 }
 
 # Returns a list of values for which the supplied closure does not


### PR DESCRIPTION
- closes #8523 

# Description

This PR adds pipeline input support to `generate`.
- Without input, `generate` keeps its current behavior.
- With input, each invocation of the closure is provided an item from the input stream as pipeline input (`$in`). If/when the input stream runs out, `generate` also stops.

Before this PR, there is no filter command that is both stateful _and_ streaming.

This PR also refactors `std/iter scan` to use `generate`, making it streaming and more performant over larger inputs.

# User-Facing Changes
- `generate` now supports pipeline input, passing each element to the closure as `$in` until it runs out
- `std/iter scan` is now streaming

# Tests + Formatting
Added tests to validate the new feature.

- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
N/A