### PR TITLE
gh-6388: add new built-in command `title`

### DIFF
--- a/crates/nu-cli/src/commands/default_context.rs
+++ b/crates/nu-cli/src/commands/default_context.rs
@@ -23,6 +23,7 @@ pub fn add_cli_context(mut engine_state: EngineState) -> EngineState {
             KeybindingsDefault,
             KeybindingsList,
             KeybindingsListen,
+            Title,
         };
 
         working_set.render()

--- a/crates/nu-cli/src/commands/mod.rs
+++ b/crates/nu-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ mod keybindings;
 mod keybindings_default;
 mod keybindings_list;
 mod keybindings_listen;
+mod title;
 
 pub use commandline::{Commandline, CommandlineEdit, CommandlineGetCursor, CommandlineSetCursor};
 pub use history::{History, HistoryImport, HistorySession};
@@ -12,5 +13,6 @@ pub use keybindings::Keybindings;
 pub use keybindings_default::KeybindingsDefault;
 pub use keybindings_list::KeybindingsList;
 pub use keybindings_listen::KeybindingsListen;
+pub use title::Title;
 
 pub use default_context::add_cli_context;

--- a/crates/nu-cli/src/commands/title.rs
+++ b/crates/nu-cli/src/commands/title.rs
@@ -1,0 +1,52 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct Title;
+
+impl Command for Title {
+    fn name(&self) -> &str {
+        "title"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .optional(
+                "title_override",
+                SyntaxShape::String,
+                "Terminal window title to use instead of current path.",
+            )
+            .category(Category::Shells)
+    }
+
+    fn description(&self) -> &str {
+        "Use the given value to override the default terminal window title."
+    }
+
+    fn extra_description(&self) -> &str {
+        "This sets or unsets the NU_REPL_TITLE_OVERRIDE environment variable to override the osc2 default title."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["terminal", "window", "title"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let title_override: Option<String> = call.opt(engine_state, stack, 0)?;
+        if let Some(value) = title_override {
+            stack.add_env_var(
+                "NU_REPL_TITLE_OVERRIDE".to_string(),
+                Value::string(value, Span::unknown()),
+            );
+        } else {
+            stack.remove_env_var(engine_state, "NU_REPL_TITLE_OVERRIDE");
+        }
+        Ok(PipelineData::empty())
+    }
+}

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -122,7 +122,7 @@ pub fn convert_env_values(
 
 /// Translate one environment variable from Value to String
 ///
-/// Returns Ok(None) if the env var is not
+/// Returns Ok(None) if the env var is not coercible to a string
 pub fn env_to_string(
     env_name: &str,
     value: &Value,


### PR DESCRIPTION
this PR should close #6388 (and should be a better resolution for #10703)

# Description
Add a new built-in command called `title`.

NOTE: I copy and pasted code from various places in the `nushell` code base, so I hope I am following the preferred coding standards (of course, running `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` also helped clean things up).

# User-Facing Changes
Users can now set their own desired terminal window title and have `$env.config.shell_integration.osc2 = true` without having their desired title be removed. Users can also set a `NU_REPL_TITLE_OVERRIDE` environment variable before running `nu` to preemptively set their desired terminal window title.

# After Submitting
After people approve of my approach (or suggest a different approach for the `title` command), I'll create a PR in https://github.com/nushell/nushell.github.io
