### PR TITLE
finish removing terminal_size dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3889,7 +3889,6 @@ dependencies = [
  "nu-path",
  "nu-protocol",
  "nu-utils",
- "terminal_size",
 ]
 
 [[package]]
@@ -4150,7 +4149,6 @@ dependencies = [
  "nu-protocol",
  "nu-utils",
  "tabled",
- "terminal_size",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,6 @@ syn = "2.0"
 sysinfo = "0.32"
 tabled = { version = "0.17.0", default-features = false }
 tempfile = "3.15"
-terminal_size = "0.4"
 titlecase = "3.0"
 toml = "0.8"
 trash = "5.2"

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -19,7 +19,6 @@ nu-path = { path = "../nu-path", version = "0.101.1" }
 nu-glob = { path = "../nu-glob", version = "0.101.1" }
 nu-utils = { path = "../nu-utils", version = "0.101.1", default-features = false }
 log = { workspace = true }
-terminal_size = { workspace = true }
 
 [features]
 default = ["os"]

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -7,8 +7,8 @@ use nu_protocol::{
     record, Category, Config, Example, IntoPipelineData, PipelineData, PositionalArg, Signature,
     Span, SpanId, Spanned, SyntaxShape, Type, Value,
 };
+use nu_utils::terminal_size;
 use std::{collections::HashMap, fmt::Write};
-use terminal_size::{Height, Width};
 
 /// ANSI style reset
 const RESET: &str = "\x1b[0m";
@@ -194,7 +194,7 @@ fn get_documentation(
     }
 
     fn get_term_width() -> usize {
-        if let Some((Width(w), Height(_))) = terminal_size::terminal_size() {
+        if let Ok((w, _h)) = terminal_size() {
             w as usize
         } else {
             80

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -21,7 +21,6 @@ nu-color-config = { path = "../nu-color-config", version = "0.101.1" }
 nu-ansi-term = { workspace = true }
 fancy-regex = { workspace = true }
 tabled = { workspace = true, features = ["ansi"], default-features = false }
-terminal_size = { workspace = true }
 
 [dev-dependencies]
 # nu-test-support = { path="../nu-test-support", version = "0.101.1"  }

--- a/crates/nu-table/src/common.rs
+++ b/crates/nu-table/src/common.rs
@@ -1,9 +1,7 @@
+use crate::{clean_charset, colorize_space_str, string_wrap, TableOutput, TableTheme};
 use nu_color_config::{Alignment, StyleComputer, TextStyle};
 use nu_protocol::{Config, FooterMode, ShellError, Span, TableMode, TrimStrategy, Value};
-
-use terminal_size::{terminal_size, Height, Width};
-
-use crate::{clean_charset, colorize_space_str, string_wrap, TableOutput, TableTheme};
+use nu_utils::terminal_size;
 
 pub type NuText = (String, TextStyle);
 pub type TableResult = Result<Option<TableOutput>, ShellError>;
@@ -211,10 +209,9 @@ fn need_footer(config: &Config, count_records: u64) -> bool {
         // Calculate the screen height and row count, if screen height is larger than row count, don't show footer
         FooterMode::Auto => {
             let (_width, height) = match terminal_size() {
-                Some((w, h)) => (Width(w.0).0 as u64, Height(h.0).0 as u64),
-                None => (Width(0).0 as u64, Height(0).0 as u64),
+                Ok((w, h)) => (w as u64, h as u64),
+                _ => (0, 0),
             };
-
             height <= count_records
         }
     }


### PR DESCRIPTION
# Description

This PR is a follow on to https://github.com/nushell/nushell/pull/14423 and finishes removing the `terminal_size` crate in favor of `crossterm`'s `size()`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
