### PR TITLE
Add `help pipe-and-redirect` command.

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -145,6 +145,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             HelpCommands,
             HelpModules,
             HelpOperators,
+            HelpPipeAndRedirect,
             HelpEscapes,
         };
 

--- a/crates/nu-command/src/help/help_pipe_and_redirect.rs
+++ b/crates/nu-command/src/help/help_pipe_and_redirect.rs
@@ -1,0 +1,119 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct HelpPipeAndRedirect;
+
+impl Command for HelpPipeAndRedirect {
+    fn name(&self) -> &str {
+        "help pipe-and-redirect"
+    }
+
+    fn description(&self) -> &str {
+        "Show help on nushell pipes and redirects."
+    }
+
+    fn extra_description(&self) -> &str {
+        r#"This command contains basic usage of pipe and redirect symbol, for more detail, check:
+https://www.nushell.sh/lang-guide/chapters/pipelines.html"#
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("help pipe-and-redirect")
+            .category(Category::Core)
+            .input_output_types(vec![(Type::Nothing, Type::table())])
+            .allow_variants_without_examples(true)
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        let examples = vec![
+            HelpExamples::new(
+                "|",
+                "pipe",
+                "pipeline stdout of a command to another command",
+                "^cmd1 | ^cmd2",
+            ),
+            HelpExamples::new(
+                "e>|",
+                "stderr pipe",
+                "pipeline stderr of a command to another command",
+                "^cmd1 e>| ^cmd2",
+            ),
+            HelpExamples::new(
+                "o+e>|",
+                "stdout and stderr pipe",
+                "pipeline stdout and stderr of a command to another command",
+                "^cmd1 o+e>| ^cmd2",
+            ),
+            HelpExamples::new(
+                "o>",
+                "redirection",
+                "redirect stdout of a command to a file",
+                "^cmd1 o> file.txt",
+            ),
+            HelpExamples::new(
+                "e>",
+                "stderr redirection",
+                "redirect stderr of a command to a file",
+                "^cmd1 e> file.txt",
+            ),
+            HelpExamples::new(
+                "o+e>",
+                "stdout and stderr redirection",
+                "redirect stdout and stderr of a command to a file",
+                "^cmd1 o+e> file.txt",
+            ),
+        ];
+        let examples: Vec<Value> = examples
+            .into_iter()
+            .map(|x| x.to_val_record(head))
+            .collect();
+        Ok(Value::list(examples, head).into_pipeline_data())
+    }
+}
+
+struct HelpExamples {
+    symbol: String,
+    name: String,
+    description: String,
+    example: String,
+}
+
+impl HelpExamples {
+    fn new(symbol: &str, name: &str, description: &str, example: &str) -> Self {
+        Self {
+            symbol: symbol.to_string(),
+            name: name.to_string(),
+            description: description.to_string(),
+            example: example.to_string(),
+        }
+    }
+
+    fn to_val_record(self, span: Span) -> Value {
+        Value::record(
+            record! {
+                "symbol" => Value::string(self.symbol, span),
+                "name" => Value::string(self.name, span),
+                "description" => Value::string(self.description, span),
+                "example" => Value::string(self.example, span),
+            },
+            span,
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_examples() {
+        use super::HelpPipeAndRedirect;
+        use crate::test_examples;
+        test_examples(HelpPipeAndRedirect {})
+    }
+}

--- a/crates/nu-command/src/help/mod.rs
+++ b/crates/nu-command/src/help/mod.rs
@@ -5,6 +5,7 @@ mod help_escapes;
 mod help_externs;
 mod help_modules;
 mod help_operators;
+mod help_pipe_and_redirect;
 
 pub use help_::Help;
 pub use help_aliases::HelpAliases;
@@ -13,6 +14,7 @@ pub use help_escapes::HelpEscapes;
 pub use help_externs::HelpExterns;
 pub use help_modules::HelpModules;
 pub use help_operators::HelpOperators;
+pub use help_pipe_and_redirect::HelpPipeAndRedirect;
 
 pub(crate) use help_::{highlight_search_in_table, highlight_search_string};
 pub(crate) use help_aliases::help_aliases;

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -261,7 +261,7 @@ impl Command for External {
             call.head,
         )?;
 
-        if engine_state.get_config().pipefail {
+        if engine_state.get_config().errexit {
             // Should wait the command running to complete.
             // Then nushell is able to check the exit status.
             //

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -257,6 +257,13 @@ impl Command for External {
             call.head,
         )?;
 
+        if matches!(stdout, OutDest::Pipe) {
+            let bytes = child.into_bytes()?;
+            return Ok(PipelineData::ByteStream(
+                ByteStream::read_binary(bytes, call.head, engine_state.signals().clone()),
+                None,
+            ));
+        }
         if matches!(stdout, OutDest::Pipe | OutDest::PipeSeparate)
             || matches!(stderr, OutDest::Pipe | OutDest::PipeSeparate)
         {

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -69,7 +69,7 @@ pub struct Config {
     pub datetime_format: DatetimeFormatConfig,
     pub error_style: ErrorStyle,
     pub display_errors: DisplayErrors,
-    pub pipefail: bool,
+    pub errexit: bool,
     pub use_kitty_protocol: bool,
     pub highlight_resolved_externals: bool,
     /// Configuration for plugins.
@@ -126,7 +126,7 @@ impl Default for Config {
             error_style: ErrorStyle::Fancy,
             display_errors: DisplayErrors::default(),
 
-            pipefail: false,
+            errexit: false,
             use_kitty_protocol: false,
             highlight_resolved_externals: false,
 
@@ -187,7 +187,7 @@ impl UpdateFromValue for Config {
                     .update(val, path, errors),
                 "bracketed_paste" => self.bracketed_paste.update(val, path, errors),
                 "use_kitty_protocol" => self.use_kitty_protocol.update(val, path, errors),
-                "pipefail" => self.pipefail.update(val, path, errors),
+                "errexit" => self.errexit.update(val, path, errors),
                 "highlight_resolved_externals" => {
                     self.highlight_resolved_externals.update(val, path, errors)
                 }

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -69,6 +69,7 @@ pub struct Config {
     pub datetime_format: DatetimeFormatConfig,
     pub error_style: ErrorStyle,
     pub display_errors: DisplayErrors,
+    pub pipefail: bool,
     pub use_kitty_protocol: bool,
     pub highlight_resolved_externals: bool,
     /// Configuration for plugins.
@@ -125,6 +126,7 @@ impl Default for Config {
             error_style: ErrorStyle::Fancy,
             display_errors: DisplayErrors::default(),
 
+            pipefail: false,
             use_kitty_protocol: false,
             highlight_resolved_externals: false,
 
@@ -185,6 +187,7 @@ impl UpdateFromValue for Config {
                     .update(val, path, errors),
                 "bracketed_paste" => self.bracketed_paste.update(val, path, errors),
                 "use_kitty_protocol" => self.use_kitty_protocol.update(val, path, errors),
+                "pipefail" => self.pipefail.update(val, path, errors),
                 "highlight_resolved_externals" => {
                     self.highlight_resolved_externals.update(val, path, errors)
                 }

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -1,7 +1,7 @@
 use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::fs::Stub::FileWithContent;
+use nu_test_support::nu;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu, nu_repl_code};
 use pretty_assertions::assert_eq;
 
 #[test]

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -655,9 +655,9 @@ fn arg_dont_run_subcommand_if_surrounded_with_quote() {
 }
 
 #[test]
-fn exit_code_pipefail() {
-    Playground::setup("pipefail", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContent("tmp_env.nu", "$env.config.pipefail = true")]);
+fn exit_code_errexit() {
+    Playground::setup("errexit", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContent("tmp_env.nu", "$env.config.errexit = true")]);
 
         let actual = nu!(
             env_config: "tmp_env.nu",

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::Stub::EmptyFile;
-use nu_test_support::nu;
+use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::playground::Playground;
+use nu_test_support::{nu, nu_repl_code};
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -651,4 +652,19 @@ fn arg_dont_run_subcommand_if_surrounded_with_quote() {
     assert_eq!(actual.out, "(echo aa)");
     let actual = nu!("nu --testbin cococo '(echo aa)'");
     assert_eq!(actual.out, "(echo aa)");
+}
+
+#[test]
+fn exit_code_pipefail() {
+    Playground::setup("pipefail", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContent("tmp_env.nu", "$env.config.pipefail = true")]);
+
+        let actual = nu!(
+            env_config: "tmp_env.nu",
+            cwd: dirs.test(),
+            "nu --testbin fail | print 'aa'",
+        );
+        assert_eq!(actual.out, "");
+        assert_eq!(actual.status.code(), Some(1));
+    })
 }


### PR DESCRIPTION
# Description
This pr is going to add a new command named `help pipe-and-redirect`.

So user can detect such feature easier.

# User-Facing Changes
Here is the output of this command:
```
╭───┬────────┬───────────────────────────────┬────────────────────────────────────────────────────────────┬─────────────────────╮
│ # │ symbol │             name              │                        description                         │       example       │
├───┼────────┼───────────────────────────────┼────────────────────────────────────────────────────────────┼─────────────────────┤
│ 0 │ |      │ pipe                          │ pipeline stdout of a command to another command            │ ^cmd1 | ^cmd2       │
│ 1 │ e>|    │ stderr pipe                   │ pipeline stderr of a command to another command            │ ^cmd1 e>| ^cmd2     │
│ 2 │ o+e>|  │ stdout and stderr pipe        │ pipeline stdout and stderr of a command to another command │ ^cmd1 o+e>| ^cmd2   │
│ 3 │ o>     │ redirection                   │ redirect stdout of a command to a file                     │ ^cmd1 o> file.txt   │
│ 4 │ e>     │ stderr redirection            │ redirect stderr of a command to a file                     │ ^cmd1 e> file.txt   │
│ 5 │ o+e>   │ stdout and stderr redirection │ redirect stdout and stderr of a command to a file          │ ^cmd1 o+e> file.txt │
├───┼────────┼───────────────────────────────┼────────────────────────────────────────────────────────────┼─────────────────────┤
│ # │ symbol │             name              │                        description                         │       example       │
╰───┴────────┴───────────────────────────────┴────────────────────────────────────────────────────────────┴─────────────────────╯
```

# Tests + Formatting


# After Submitting
Should update more examples in [nushell doc](https://www.nushell.sh/lang-guide/chapters/pipelines.html) to fill more examples
