### PR TITLE
Add help pipe-and-redirect command. 

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -144,6 +144,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             HelpCommands,
             HelpModules,
             HelpOperators,
+            HelpPipeAndRedirect,
             HelpEscapes,
         };
 

--- a/crates/nu-command/src/help/help_pipe_and_redirect.rs
+++ b/crates/nu-command/src/help/help_pipe_and_redirect.rs
@@ -1,0 +1,119 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct HelpPipeAndRedirect;
+
+impl Command for HelpPipeAndRedirect {
+    fn name(&self) -> &str {
+        "help pipe-and-redirect"
+    }
+
+    fn description(&self) -> &str {
+        "Show help on nushell pipes and redirects."
+    }
+
+    fn extra_description(&self) -> &str {
+        r#"This command contains basic usage of pipe and redirect symbol, for more detail, check:
+https://www.nushell.sh/lang-guide/chapters/pipelines.html"#
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("help pipe-and-redirect")
+            .category(Category::Core)
+            .input_output_types(vec![(Type::Nothing, Type::table())])
+            .allow_variants_without_examples(true)
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        let examples = vec![
+            HelpExamples::new(
+                "|",
+                "pipe",
+                "pipeline stdout of a command to another command",
+                "^cmd1 | ^cmd2",
+            ),
+            HelpExamples::new(
+                "e>|",
+                "stderr pipe",
+                "pipeline stderr of a command to another command",
+                "^cmd1 e>| ^cmd2",
+            ),
+            HelpExamples::new(
+                "o+e>|",
+                "stdout and stderr pipe",
+                "pipeline stdout and stderr of a command to another command",
+                "^cmd1 o+e>| ^cmd2",
+            ),
+            HelpExamples::new(
+                "o>",
+                "redirection",
+                "redirect stdout of a command to a file",
+                "^cmd1 o> file.txt",
+            ),
+            HelpExamples::new(
+                "e>",
+                "stderr redirection",
+                "redirect stderr of a command to a file",
+                "^cmd1 e> file.txt",
+            ),
+            HelpExamples::new(
+                "o+e>",
+                "stdout and stderr redirection",
+                "redirect stdout and stderr of a command to a file",
+                "^cmd1 o+e> file.txt",
+            ),
+        ];
+        let examples: Vec<Value> = examples
+            .into_iter()
+            .map(|x| x.to_val_record(head))
+            .collect();
+        Ok(Value::list(examples, head).into_pipeline_data())
+    }
+}
+
+struct HelpExamples {
+    symbol: String,
+    name: String,
+    description: String,
+    example: String,
+}
+
+impl HelpExamples {
+    fn new(symbol: &str, name: &str, description: &str, example: &str) -> Self {
+        Self {
+            symbol: symbol.to_string(),
+            name: name.to_string(),
+            description: description.to_string(),
+            example: example.to_string(),
+        }
+    }
+
+    fn to_val_record(self, span: Span) -> Value {
+        Value::record(
+            record! {
+                "symbol" => Value::string(self.symbol, span),
+                "name" => Value::string(self.name, span),
+                "description" => Value::string(self.description, span),
+                "example" => Value::string(self.example, span),
+            },
+            span,
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_examples() {
+        use super::HelpPipeAndRedirect;
+        use crate::test_examples;
+        test_examples(HelpPipeAndRedirect {})
+    }
+}

--- a/crates/nu-command/src/help/help_pipe_and_redirect.rs
+++ b/crates/nu-command/src/help/help_pipe_and_redirect.rs
@@ -54,20 +54,44 @@ https://www.nushell.sh/lang-guide/chapters/pipelines.html"#
             HelpExamples::new(
                 "o>",
                 "redirection",
-                "redirect stdout of a command to a file",
+                "redirect stdout of a command, overwriting a file",
                 "^cmd1 o> file.txt",
             ),
             HelpExamples::new(
                 "e>",
                 "stderr redirection",
-                "redirect stderr of a command to a file",
+                "redirect stderr of a command, overwriting a file",
                 "^cmd1 e> file.txt",
             ),
             HelpExamples::new(
                 "o+e>",
                 "stdout and stderr redirection",
-                "redirect stdout and stderr of a command to a file",
+                "redirect stdout and stderr of a command, overwriting a file",
                 "^cmd1 o+e> file.txt",
+            ),
+            HelpExamples::new(
+                "o>>",
+                "redirection append",
+                "redirect stdout of a command, appending to a file",
+                "^cmd1 o> file.txt",
+            ),
+            HelpExamples::new(
+                "e>>",
+                "stderr redirection append",
+                "redirect stderr of a command, appending to a file",
+                "^cmd1 e> file.txt",
+            ),
+            HelpExamples::new(
+                "o+e>>",
+                "stdout and stderr redirection append",
+                "redirect stdout and stderr of a command, appending to a file",
+                "^cmd1 o+e> file.txt",
+            ),
+            HelpExamples::new(
+                "o>|",
+                "stdout pipe",
+                "UNSUPPORTED, Redirecting stdout to a pipe is the same as normal piping",
+                "",
             ),
         ];
         let examples: Vec<Value> = examples

--- a/crates/nu-command/src/help/help_pipe_and_redirect.rs
+++ b/crates/nu-command/src/help/help_pipe_and_redirect.rs
@@ -72,7 +72,7 @@ https://www.nushell.sh/lang-guide/chapters/pipelines.html"#
         ];
         let examples: Vec<Value> = examples
             .into_iter()
-            .map(|x| x.to_val_record(head))
+            .map(|x| x.into_val_record(head))
             .collect();
         Ok(Value::list(examples, head).into_pipeline_data())
     }
@@ -95,7 +95,7 @@ impl HelpExamples {
         }
     }
 
-    fn to_val_record(self, span: Span) -> Value {
+    fn into_val_record(self, span: Span) -> Value {
         Value::record(
             record! {
                 "symbol" => Value::string(self.symbol, span),

--- a/crates/nu-command/src/help/help_pipe_and_redirect.rs
+++ b/crates/nu-command/src/help/help_pipe_and_redirect.rs
@@ -89,7 +89,7 @@ https://www.nushell.sh/lang-guide/chapters/pipelines.html"#
             ),
             HelpExamples::new(
                 "o>|",
-                "stdout pipe",
+                "",
                 "UNSUPPORTED, Redirecting stdout to a pipe is the same as normal piping",
                 "",
             ),

--- a/crates/nu-command/src/help/mod.rs
+++ b/crates/nu-command/src/help/mod.rs
@@ -5,6 +5,7 @@ mod help_escapes;
 mod help_externs;
 mod help_modules;
 mod help_operators;
+mod help_pipe_and_redirect;
 
 pub use help_::Help;
 pub use help_aliases::HelpAliases;
@@ -13,6 +14,7 @@ pub use help_escapes::HelpEscapes;
 pub use help_externs::HelpExterns;
 pub use help_modules::HelpModules;
 pub use help_operators::HelpOperators;
+pub use help_pipe_and_redirect::HelpPipeAndRedirect;
 
 pub(crate) use help_::{highlight_search_in_table, highlight_search_string};
 pub(crate) use help_aliases::help_aliases;


### PR DESCRIPTION
# Description
This pr is going to add a new command named `help pipe-and-redirect`.

So user can detect such feature easier.

# User-Facing Changes
Here is the output of this command:
```
╭───┬────────┬──────────────────────────────────────┬──────────────────────────────────────────────────────────────┬─────────────────────╮
│ # │ symbol │                 name                 │                         description                          │       example       │
├───┼────────┼──────────────────────────────────────┼──────────────────────────────────────────────────────────────┼─────────────────────┤
│ 0 │ |      │ pipe                                 │ pipeline stdout of a command to another command              │ ^cmd1 | ^cmd2       │
│ 1 │ e>|    │ stderr pipe                          │ pipeline stderr of a command to another command              │ ^cmd1 e>| ^cmd2     │
│ 2 │ o+e>|  │ stdout and stderr pipe               │ pipeline stdout and stderr of a command to another command   │ ^cmd1 o+e>| ^cmd2   │
│ 3 │ o>     │ redirection                          │ redirect stdout of a command, overwriting a file             │ ^cmd1 o> file.txt   │
│ 4 │ e>     │ stderr redirection                   │ redirect stderr of a command, overwriting a file             │ ^cmd1 e> file.txt   │
│ 5 │ o+e>   │ stdout and stderr redirection        │ redirect stdout and stderr of a command, overwriting a file  │ ^cmd1 o+e> file.txt │
│ 6 │ o>>    │ redirection append                   │ redirect stdout of a command, appending to a file            │ ^cmd1 o> file.txt   │
│ 7 │ e>>    │ stderr redirection append            │ redirect stderr of a command, appending to a file            │ ^cmd1 e> file.txt   │
│ 8 │ o+e>>  │ stdout and stderr redirection append │ redirect stdout and stderr of a command, appending to a file │ ^cmd1 o+e> file.txt │
│ 9 │ o>|    │                                      │ Unsupported, it's the same to `|`, use it instead            │                     │
├───┼────────┼──────────────────────────────────────┼──────────────────────────────────────────────────────────────┼─────────────────────┤
│ # │ symbol │                 name                 │                         description                          │       example       │
╰───┴────────┴──────────────────────────────────────┴──────────────────────────────────────────────────────────────┴─────────────────────╯
```

# Tests + Formatting


# After Submitting
Should update more examples in [nushell doc](https://www.nushell.sh/lang-guide/chapters/pipelines.html) to fill more examples
