### PR TITLE
Update Nu to 0.101.0 for workflow and ping ubuntu-latest to 22.04 for riscv64gc build

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Bind milestone to closed issue that has a merged PR fix
       - name: Set Milestone for Issue
-        uses: hustcer/milestone-action@main
+        uses: hustcer/milestone-action@v2
         if: github.event.issue.state == 'closed'
         with:
           action: bind-issue

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -39,7 +39,7 @@ jobs:
         uses: hustcer/setup-nu@v3
         if: github.repository == 'nushell/nightly'
         with:
-          version: 0.98.0
+          version: 0.101.0
 
       # Synchronize the main branch of nightly repo with the main branch of Nushell official repo
       - name: Prepare for Nightly Release
@@ -114,7 +114,7 @@ jobs:
         - target: armv7-unknown-linux-musleabihf
           os: ubuntu-22.04
         - target: riscv64gc-unknown-linux-gnu
-          os: ubuntu-latest
+          os: ubuntu-22.04
         - target: loongarch64-unknown-linux-gnu
           os: ubuntu-22.04
 
@@ -139,7 +139,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
       with:
-        version: 0.98.0
+        version: 0.101.0
 
     - name: Release Nu Binary
       id: nu
@@ -197,7 +197,7 @@ jobs:
       - name: Setup Nushell
         uses: hustcer/setup-nu@v3
         with:
-          version: 0.98.0
+          version: 0.101.0
 
       # Keep the last a few releases
       - name: Delete Older Releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         - target: armv7-unknown-linux-musleabihf
           os: ubuntu-22.04
         - target: riscv64gc-unknown-linux-gnu
-          os: ubuntu-latest
+          os: ubuntu-22.04
         - target: loongarch64-unknown-linux-gnu
           os: ubuntu-22.04
 
@@ -89,7 +89,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
       with:
-        version: 0.98.0
+        version: 0.101.0
 
     - name: Release Nu Binary
       id: nu


### PR DESCRIPTION


<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

- [x] Update Nu to 0.101.0 for release and nightly-build workflow, test successfully in the nightly repo for a while, e.g.: https://github.com/nushell/nightly/actions/runs/12779907140
- [x] Pin `ubuntu-latest` to `ubuntu-22.04` for riscv64gc build due to [Ubuntu-latest workflows will use Ubuntu-24.04 image](https://github.com/actions/runner-images/issues/10636)
- [x] Stabilize `hustcer/milestone-action@main` to `hustcer/milestone-action@v2`


