### PR TITLE
fix error propagation in `export-env`

### DIFF
--- a/crates/nu-command/src/env/export_env.rs
+++ b/crates/nu-command/src/env/export_env.rs
@@ -57,8 +57,10 @@ impl Command for ExportEnv {
 
         let eval_block = get_eval_block(engine_state);
 
-        let _ = eval_block(engine_state, &mut callee_stack, block, input);
+        // Run the block (discard the result)
+        let _ = eval_block(engine_state, &mut callee_stack, block, input)?;
 
+        // Merge the block's environment to the current stack
         redirect_env(engine_state, caller_stack, &callee_stack);
 
         Ok(PipelineData::empty())

--- a/tests/repl/test_modules.rs
+++ b/tests/repl/test_modules.rs
@@ -187,3 +187,19 @@ fn test_lexical_binding() -> TestResult {
         "3",
     )
 }
+
+#[test]
+fn propagate_errors_in_export_env_on_use() -> TestResult {
+    fail_test(
+        r#"module foo { export-env { error make -u { msg: "error in export-env"} } }; use foo"#,
+        "error in export-env",
+    )
+}
+
+#[test]
+fn propagate_errors_in_export_env_when_run() -> TestResult {
+    fail_test(
+        r#"export-env { error make -u { msg: "error in export-env" } }"#,
+        "error in export-env",
+    )
+}


### PR DESCRIPTION
- fixes #14801

# Description

- Fixed the issue
- Added some comments mirroring the ones used in `export-env` handling in `use`
- Added two tests to prevent regressions

# User-Facing Changes

# Tests + Formatting

- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
