### PR TITLE
Fix variable names that end in a duration suffix can't be on the right part of a range

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4950,9 +4950,9 @@ pub fn parse_value(
             } else {
                 let shapes = [
                     SyntaxShape::Binary,
+                    SyntaxShape::Range,
                     SyntaxShape::Filesize,
                     SyntaxShape::Duration,
-                    SyntaxShape::Range,
                     SyntaxShape::DateTime,
                     SyntaxShape::Int,
                     SyntaxShape::Number,

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -95,6 +95,16 @@ fn range_iteration2() -> TestResult {
 }
 
 #[test]
+fn range_ends_with_duration_suffix_variable_name() -> TestResult {
+    run_test("let runs = 10; 1..$runs | math sum", "55")
+}
+
+#[test]
+fn range_ends_with_filesize_suffix_variable_name() -> TestResult {
+    run_test("let sizekb = 10; 1..$sizekb | math sum", "55")
+}
+
+#[test]
 fn simple_value_iteration() -> TestResult {
     run_test("4 | each { |it| $it + 10 }", "14")
 }


### PR DESCRIPTION
# Description
Fixes: #14844

The issue occurs when nushell is parsing a value with `SyntaxShape::Any`, it checks `Duration` and `Filesize` first, then `Range`.  Nushell raises errors too early while parsing `Duration/Filesize`.

This pr changes the order of parsing to fix the issue.

# User-Facing Changes

The following code should be able to run after this pr
```nushell
let runs = 10;
1..$runs
```

# Tests + Formatting
Added 2 tests, one for filesize, one for duration.

# After Submitting
NaN