### PR TITLE
fix(lsp): missing references in `use` command

### DIFF
--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -286,7 +286,8 @@ impl LanguageServer {
             let len = scripts.len();
 
             for (i, fp) in scripts.iter().enumerate() {
-                // std::thread::sleep(std::time::Duration::from_millis(500));
+                #[cfg(test)]
+                std::thread::sleep(std::time::Duration::from_millis(200));
                 // cancel the loop on cancellation message from main thread
                 if cancel_receiver.try_recv().is_ok() {
                     data_sender
@@ -605,15 +606,23 @@ mod tests {
                     }
                 ])
             );
-            assert_json_eq!(
-                changes[script.to_string().replace("foo", "bar")],
-                serde_json::json!([
-                       {
-                           "range": { "start": { "line": 5, "character": 4 }, "end": { "line": 5, "character": 11 } },
-                           "newText": "new"
-                       }
-                ])
-            );
+            let changs_bar = changes[script.to_string().replace("foo", "bar")]
+                .as_array()
+                .unwrap();
+            assert!(
+                changs_bar.contains(
+                &serde_json::json!({
+                    "range": { "start": { "line": 5, "character": 4 }, "end": { "line": 5, "character": 11 } },
+                    "newText": "new"
+                })
+            ));
+            assert!(
+                changs_bar.contains(
+                &serde_json::json!({
+                    "range": { "start": { "line": 0, "character": 20 }, "end": { "line": 0, "character": 27 } },
+                    "newText": "new"
+                })
+            ));
         } else {
             panic!()
         }

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -367,7 +367,7 @@ mod tests {
     use nu_test_support::fs::fixtures;
 
     use crate::path_to_uri;
-    use crate::tests::{initialize_language_server, open_unchecked};
+    use crate::tests::{initialize_language_server, open_unchecked, send_hover_request};
 
     fn send_reference_request(
         client_connection: &Connection,
@@ -412,6 +412,7 @@ mod tests {
         line: u32,
         character: u32,
         num: usize,
+        immediate_cancellation: bool,
     ) -> Vec<Message> {
         client_connection
             .sender
@@ -425,6 +426,11 @@ mod tests {
                 .unwrap(),
             }))
             .unwrap();
+
+        // use a hover request to interrupt
+        if immediate_cancellation {
+            send_hover_request(client_connection, uri.clone(), line, character);
+        }
 
         (0..num)
             .map(|_| {
@@ -577,8 +583,14 @@ mod tests {
         open_unchecked(&client_connection, script.clone());
 
         let message_num = 5;
-        let messages =
-            send_rename_prepare_request(&client_connection, script.clone(), 6, 11, message_num);
+        let messages = send_rename_prepare_request(
+            &client_connection,
+            script.clone(),
+            6,
+            11,
+            message_num,
+            false,
+        );
         assert_eq!(messages.len(), message_num);
         for message in messages {
             match message {
@@ -646,8 +658,14 @@ mod tests {
         open_unchecked(&client_connection, script.clone());
 
         let message_num = 5;
-        let messages =
-            send_rename_prepare_request(&client_connection, script.clone(), 3, 5, message_num);
+        let messages = send_rename_prepare_request(
+            &client_connection,
+            script.clone(),
+            3,
+            5,
+            message_num,
+            false,
+        );
         assert_eq!(messages.len(), message_num);
         for message in messages {
             match message {
@@ -682,6 +700,67 @@ mod tests {
                     }
                 }),
             )
+        } else {
+            panic!()
+        }
+    }
+
+    #[test]
+    fn rename_cancelled() {
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("workspace");
+        let (client_connection, _recv) = initialize_language_server(Some(InitializeParams {
+            workspace_folders: Some(vec![WorkspaceFolder {
+                uri: path_to_uri(&script),
+                name: "random name".to_string(),
+            }]),
+            ..Default::default()
+        }));
+        script.push("foo.nu");
+        let script = path_to_uri(&script);
+
+        open_unchecked(&client_connection, script.clone());
+
+        let message_num = 3;
+        let messages = send_rename_prepare_request(
+            &client_connection,
+            script.clone(),
+            6,
+            11,
+            message_num,
+            true,
+        );
+        assert_eq!(messages.len(), message_num);
+        if let Some(Message::Notification(cancel_notification)) = &messages.last() {
+            assert_json_eq!(
+                cancel_notification.params["value"],
+                serde_json::json!({ "kind": "end", "message": "interrupted." })
+            );
+        } else {
+            panic!("Progress not cancelled");
+        };
+        for message in messages {
+            match message {
+                Message::Notification(n) => assert_eq!(n.method, "$/progress"),
+                // the response of the preempting hover request
+                Message::Response(r) => assert_json_eq!(
+                    r.result,
+                    serde_json::json!({
+                            "contents": {
+                            "kind": "markdown",
+                            "value": "\n-----\n### Usage \n```nu\n  foo str {flags}\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n"
+                        }
+                    }),
+                ),
+                _ => panic!("unexpected message type"),
+            }
+        }
+
+        if let Message::Response(r) = send_rename_request(&client_connection, script.clone(), 6, 11)
+        {
+            // should not return any changes
+            assert_json_eq!(r.result.unwrap()["changes"], serde_json::json!({}));
         } else {
             panic!()
         }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR fixes the issue of the missing references in `use` command

<img width="832" alt="image" src="https://github.com/user-attachments/assets/f67cd4b3-2e50-4dda-b2ed-c41aee86d3e9" />

However, as described in [this discussion](https://github.com/nushell/nushell/discussions/14854), the returned reference list is still not complete due to the inconsistent IDs.

As a side effect, `hover/goto def` now also works on the `use` command arguments

<img width="752" alt="image" src="https://github.com/user-attachments/assets/e0abdc9e-097a-44c2-9084-8d7905ae1d5e" />

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Added the test for heavy requests cancellation.
Added the expected Edit for the missing ref of `use` to the existing rename test.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
