### PR TITLE
fix(lsp): missing references in `use` command

### DIFF
--- a/crates/nu-lsp/src/ast.rs
+++ b/crates/nu-lsp/src/ast.rs
@@ -198,10 +198,7 @@ fn try_find_id_in_def(
     };
     let mut span = None;
     for arg in call.arguments.iter() {
-        if location
-            .map(|pos| arg.span().contains(*pos))
-            .unwrap_or(true)
-        {
+        if location.map_or(true, |pos| arg.span().contains(*pos)) {
             // String means this argument is the name
             if let Argument::Positional(expr) = arg {
                 if let Expr::String(_) = &expr.expr {
@@ -220,8 +217,7 @@ fn try_find_id_in_def(
     let name = working_set.get_span_contents(span);
     let decl_id = Id::Declaration(working_set.find_decl(name)?);
     id_ref
-        .map(|id_r| decl_id == *id_r)
-        .unwrap_or(true)
+        .map_or(true, |id_r| decl_id == *id_r)
         .then_some((decl_id, span))
 }
 
@@ -245,7 +241,7 @@ fn try_find_id_in_mod(
     if call_name != "module".as_bytes() && call_name != "export module".as_bytes() {
         return None;
     };
-    let check_location = |span: &Span| location.map(|pos| span.contains(*pos)).unwrap_or(true);
+    let check_location = |span: &Span| location.map_or(true, |pos| span.contains(*pos));
 
     call.arguments.first().and_then(|arg| {
         if !check_location(&arg.span()) {
@@ -258,8 +254,7 @@ fn try_find_id_in_mod(
                     let found_id = Id::Module(module_id);
                     let found_span = strip_quotes(arg.span(), working_set);
                     id_ref
-                        .map(|id_r| found_id == *id_r)
-                        .unwrap_or(true)
+                        .map_or(true, |id_r| found_id == *id_r)
                         .then_some((found_id, found_span))
                 } else {
                     None
@@ -327,7 +322,7 @@ fn try_find_id_in_use(
         }
         None
     };
-    let check_location = |span: &Span| location.map(|pos| span.contains(*pos)).unwrap_or(true);
+    let check_location = |span: &Span| location.map_or(true, |pos| span.contains(*pos));
     let get_module_id = |span: Span| {
         let span = strip_quotes(span, working_set);
         let name = String::from_utf8_lossy(working_set.get_span_contents(span));
@@ -335,8 +330,7 @@ fn try_find_id_in_use(
         let stem = path.file_stem().and_then(|fs| fs.to_str()).unwrap_or(&name);
         let module_id = working_set.find_module(stem.as_bytes())?;
         let found_id = Id::Module(module_id);
-        id.map(|id_r| found_id == *id_r)
-            .unwrap_or(true)
+        id.map_or(true, |id_r| found_id == *id_r)
             .then_some((found_id, span))
     };
 

--- a/crates/nu-lsp/src/ast.rs
+++ b/crates/nu-lsp/src/ast.rs
@@ -254,16 +254,13 @@ fn try_find_id_in_mod(
         }
         match arg {
             Argument::Positional(expr) => {
-                if let Expr::String(name) = &expr.expr {
-                    let module_id = working_set.find_module(name.as_bytes())?;
-                    let found_id = Id::Module(module_id);
-                    let found_span = strip_quotes(arg.span(), working_set);
-                    id_ref
-                        .map_or(true, |id_r| found_id == *id_r)
-                        .then_some((found_id, found_span))
-                } else {
-                    None
-                }
+                let name = expr.as_string()?;
+                let module_id = working_set.find_module(name.as_bytes())?;
+                let found_id = Id::Module(module_id);
+                let found_span = strip_quotes(arg.span(), working_set);
+                id_ref
+                    .map_or(true, |id_r| found_id == *id_r)
+                    .then_some((found_id, found_span))
             }
             _ => None,
         }
@@ -358,16 +355,13 @@ fn try_find_id_in_use(
         items.iter().find_map(|item| {
             let item_expr = item.expr();
             check_location(&item_expr.span)
-                .then_some(&item_expr.expr)
+                .then_some(item_expr)
                 .and_then(|e| {
-                    if let Expr::String(name) = e {
-                        Some((
-                            find_by_name(name)?,
-                            strip_quotes(item_expr.span, working_set),
-                        ))
-                    } else {
-                        None
-                    }
+                    let name = e.as_string()?;
+                    Some((
+                        find_by_name(&name)?,
+                        strip_quotes(item_expr.span, working_set),
+                    ))
                 })
         })
     };

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -574,7 +574,7 @@ impl LanguageServer {
                     description.push_str(
                         String::from_utf8_lossy(working_set.get_span_contents(*cmt_span)).as_ref(),
                     );
-                    description.push_str("\n-----\n");
+                    description.push_str("\n");
                 }
                 markdown_hover(description)
             }
@@ -929,7 +929,7 @@ mod tests {
 
         assert_json_eq!(
             result,
-            serde_json::json!({ "contents": { "kind": "markdown", "value": "# module doc\n-----\n" } })
+            serde_json::json!({ "contents": { "kind": "markdown", "value": "# module doc\n" } })
         );
     }
 

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -927,9 +927,14 @@ mod tests {
             panic!()
         };
 
-        assert_json_eq!(
-            result,
-            serde_json::json!({ "contents": { "kind": "markdown", "value": "# module doc\n" } })
+        assert_eq!(
+            result
+                .unwrap()
+                .pointer("/contents/value")
+                .unwrap()
+                .to_string()
+                .replace('\r', ""),
+            "\"# module doc\\n\""
         );
     }
 

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -574,7 +574,7 @@ impl LanguageServer {
                     description.push_str(
                         String::from_utf8_lossy(working_set.get_span_contents(*cmt_span)).as_ref(),
                     );
-                    description.push_str("\n");
+                    description.push('\n');
                 }
                 markdown_hover(description)
             }

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -409,16 +409,23 @@ impl LanguageServer {
             )
             .ok()?;
 
+        let markdown_hover = |content: String| {
+            Some(Hover {
+                contents: HoverContents::Markup(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: content,
+                }),
+                // TODO
+                range: None,
+            })
+        };
+
         match id {
             Id::Variable(var_id) => {
                 let var = working_set.get_variable(var_id);
-                let contents = format!("{}{}", if var.mutable { "mutable " } else { "" }, var.ty);
-
-                Some(Hover {
-                    contents: HoverContents::Scalar(lsp_types::MarkedString::String(contents)),
-                    // TODO
-                    range: None,
-                })
+                let contents =
+                    format!("{} `{}`", if var.mutable { "mutable " } else { "" }, var.ty);
+                markdown_hover(contents)
             }
             Id::Declaration(decl_id) => {
                 let decl = working_set.get_decl(decl_id);
@@ -559,24 +566,19 @@ impl LanguageServer {
                         ));
                     }
                 }
-
-                Some(Hover {
-                    contents: HoverContents::Markup(MarkupContent {
-                        kind: MarkupKind::Markdown,
-                        value: description,
-                    }),
-                    // TODO
-                    range: None,
-                })
+                markdown_hover(description)
             }
-            Id::Value(t) => {
-                Some(Hover {
-                    contents: HoverContents::Scalar(lsp_types::MarkedString::String(t.to_string())),
-                    // TODO
-                    range: None,
-                })
+            Id::Module(module_id) => {
+                let mut description = String::new();
+                for cmt_span in working_set.get_module_comments(module_id)? {
+                    description.push_str(
+                        String::from_utf8_lossy(working_set.get_span_contents(*cmt_span)).as_ref(),
+                    );
+                    description.push_str("\n-----\n");
+                }
+                markdown_hover(description)
             }
-            _ => None,
+            Id::Value(t) => markdown_hover(format!("`{}`", t)),
         }
     }
 
@@ -842,9 +844,7 @@ mod tests {
 
         assert_json_eq!(
             result,
-            serde_json::json!({
-                "contents": "table"
-            })
+            serde_json::json!({ "contents": { "kind": "markdown", "value": " `table`" } })
         );
     }
 
@@ -905,6 +905,31 @@ mod tests {
                     "value": "Concatenate multiple strings into a single string, with an optional separator between each.\n-----\n### Usage \n```nu\n  str join {flags} <separator?>\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n\n### Parameters\n\n  `separator: string` - Optional separator to use when creating string.\n\n\n### Input/output types\n\n```nu\n list<any> | string\n string | string\n\n```\n### Example(s)\n  Create a string from input\n```nu\n  ['nu', 'shell'] | str join\n```\n  Create a string from input with a separator\n```nu\n  ['nu', 'shell'] | str join '-'\n```\n"
                 }
             })
+        );
+    }
+
+    #[test]
+    fn hover_on_module() {
+        let (client_connection, _recv) = initialize_language_server(None);
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("goto");
+        script.push("module.nu");
+        let script = path_to_uri(&script);
+
+        open_unchecked(&client_connection, script.clone());
+
+        let resp = send_hover_request(&client_connection, script.clone(), 3, 12);
+        let result = if let Message::Response(response) = resp {
+            response.result
+        } else {
+            panic!()
+        };
+
+        assert_json_eq!(
+            result,
+            serde_json::json!({ "contents": { "kind": "markdown", "value": "# module doc\n-----\n" } })
         );
     }
 

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -933,7 +933,7 @@ mod tests {
                 .pointer("/contents/value")
                 .unwrap()
                 .to_string()
-                .replace('\r', ""),
+                .replace("\\r", ""),
             "\"# module doc\\n\""
         );
     }

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -286,7 +286,8 @@ impl LanguageServer {
             let len = scripts.len();
 
             for (i, fp) in scripts.iter().enumerate() {
-                // std::thread::sleep(std::time::Duration::from_millis(500));
+                #[cfg(test)]
+                std::thread::sleep(std::time::Duration::from_millis(200));
                 // cancel the loop on cancellation message from main thread
                 if cancel_receiver.try_recv().is_ok() {
                     data_sender
@@ -605,15 +606,23 @@ mod tests {
                     }
                 ])
             );
-            assert_json_eq!(
-                changes[script.to_string().replace("foo", "bar")],
-                serde_json::json!([
-                       {
-                           "range": { "start": { "line": 5, "character": 4 }, "end": { "line": 5, "character": 11 } },
-                           "newText": "new"
-                       }
-                ])
-            );
+            let changs_bar = changes[script.to_string().replace("foo", "bar")]
+                .as_array()
+                .unwrap();
+            assert!(
+                changs_bar.contains(
+                &serde_json::json!({
+                    "range": { "start": { "line": 5, "character": 4 }, "end": { "line": 5, "character": 11 } },
+                    "newText": "new"
+                })
+            ));
+            assert!(
+                changs_bar.contains(
+                &serde_json::json!({
+                    "range": { "start": { "line": 0, "character": 20 }, "end": { "line": 0, "character": 27 } },
+                    "newText": "new"
+                })
+            ));
         } else {
             panic!()
         }

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -367,7 +367,7 @@ mod tests {
     use nu_test_support::fs::fixtures;
 
     use crate::path_to_uri;
-    use crate::tests::{initialize_language_server, open_unchecked};
+    use crate::tests::{initialize_language_server, open_unchecked, send_hover_request};
 
     fn send_reference_request(
         client_connection: &Connection,
@@ -412,6 +412,7 @@ mod tests {
         line: u32,
         character: u32,
         num: usize,
+        immediate_cancellation: bool,
     ) -> Vec<Message> {
         client_connection
             .sender
@@ -425,6 +426,11 @@ mod tests {
                 .unwrap(),
             }))
             .unwrap();
+
+        // use a hover request to interrupt
+        if immediate_cancellation {
+            send_hover_request(client_connection, uri.clone(), line, character);
+        }
 
         (0..num)
             .map(|_| {
@@ -577,8 +583,14 @@ mod tests {
         open_unchecked(&client_connection, script.clone());
 
         let message_num = 5;
-        let messages =
-            send_rename_prepare_request(&client_connection, script.clone(), 6, 11, message_num);
+        let messages = send_rename_prepare_request(
+            &client_connection,
+            script.clone(),
+            6,
+            11,
+            message_num,
+            false,
+        );
         assert_eq!(messages.len(), message_num);
         for message in messages {
             match message {
@@ -646,8 +658,14 @@ mod tests {
         open_unchecked(&client_connection, script.clone());
 
         let message_num = 5;
-        let messages =
-            send_rename_prepare_request(&client_connection, script.clone(), 3, 5, message_num);
+        let messages = send_rename_prepare_request(
+            &client_connection,
+            script.clone(),
+            3,
+            5,
+            message_num,
+            false,
+        );
         assert_eq!(messages.len(), message_num);
         for message in messages {
             match message {
@@ -682,6 +700,67 @@ mod tests {
                     }
                 }),
             )
+        } else {
+            panic!()
+        }
+    }
+
+    #[test]
+    fn rename_cancelled() {
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("workspace");
+        let (client_connection, _recv) = initialize_language_server(Some(InitializeParams {
+            workspace_folders: Some(vec![WorkspaceFolder {
+                uri: path_to_uri(&script),
+                name: "random name".to_string(),
+            }]),
+            ..Default::default()
+        }));
+        script.push("foo.nu");
+        let script = path_to_uri(&script);
+
+        open_unchecked(&client_connection, script.clone());
+
+        let message_num = 3;
+        let messages = send_rename_prepare_request(
+            &client_connection,
+            script.clone(),
+            6,
+            11,
+            message_num,
+            true,
+        );
+        assert_eq!(messages.len(), message_num);
+        if let Some(Message::Notification(cancel_notification)) = &messages.last() {
+            assert_json_eq!(
+                cancel_notification.params["value"],
+                serde_json::json!({ "kind": "end", "message": "interrupted." })
+            );
+        } else {
+            panic!("Progress not cancelled");
+        };
+        for message in messages {
+            match message {
+                Message::Notification(n) => assert_eq!(n.method, "$/progress"),
+                // the response of the preempting hover request
+                Message::Response(r) => assert_json_eq!(
+                    r.result,
+                    serde_json::json!({
+                            "contents": {
+                            "kind": "markdown",
+                            "value": "\n-----\n### Usage \n```nu\n  foo str {flags}\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n"
+                        }
+                    }),
+                ),
+                _ => panic!("unexpected message type"),
+            }
+        }
+
+        if let Message::Response(r) = send_rename_request(&client_connection, script.clone(), 6, 11)
+        {
+            // should not return any changes
+            assert_json_eq!(r.result.unwrap()["changes"], serde_json::json!({}));
         } else {
             panic!()
         }

--- a/tests/fixtures/lsp/goto/module.nu
+++ b/tests/fixtures/lsp/goto/module.nu
@@ -1,0 +1,4 @@
+# module doc
+export module "module name" { }
+
+use "module name"

--- a/tests/fixtures/lsp/goto/use_module.nu
+++ b/tests/fixtures/lsp/goto/use_module.nu
@@ -1,0 +1,1 @@
+use module.nu "module name"


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR fixes the issue of the missing references in `use` command

<img width="832" alt="image" src="https://github.com/user-attachments/assets/f67cd4b3-2e50-4dda-b2ed-c41aee86d3e9" />

However, as described in [this discussion](https://github.com/nushell/nushell/discussions/14854), the returned reference list is still not complete due to the inconsistent IDs.

As a side effect, `hover/goto def` now also works on the `use` command arguments

<img width="752" alt="image" src="https://github.com/user-attachments/assets/e0abdc9e-097a-44c2-9084-8d7905ae1d5e" />

Actions including `goto def/hover/references/rename` now work with module (maybe some edge cases of `overlay` are not covered)

<img width="571" alt="image" src="https://github.com/user-attachments/assets/b4edb9b7-1540-4c52-bf8b-145bc6a1ad4a" />

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->


# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Added
1. the test for heavy requests cancellation.
2. expected Edit for the missing ref of `use` to the existing rename test.
3. `goto/hover` on module name


# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
