### PR TITLE
fix range bugs in `str substring`, `str index-of`, `slice`, `bytes at`

### DIFF
--- a/crates/nu-command/src/bytes/at.rs
+++ b/crates/nu-command/src/bytes/at.rs
@@ -141,7 +141,7 @@ fn map_value(input: &Value, args: &Arguments, head: Span) -> Value {
         Value::Binary { val, .. } => {
             let len = val.len() as u64;
             let start: u64 = range.absolute_start(len);
-            let start: usize = match start.try_into() {
+            let _start: usize = match start.try_into() {
                 Ok(start) => start,
                 Err(_) => {
                     let span = input.span();
@@ -159,10 +159,11 @@ fn map_value(input: &Value, args: &Arguments, head: Span) -> Value {
                 }
             };
 
-            let bytes: Vec<u8> = match range.absolute_end(len) {
+            let (start, end) = range.absolute_bounds(val.len());
+            let bytes: Vec<u8> = match end {
                 Bound::Unbounded => val[start..].into(),
-                Bound::Included(end) => val[start..=end as usize].into(),
-                Bound::Excluded(end) => val[start..end as usize].into(),
+                Bound::Included(end) => val[start..=end].into(),
+                Bound::Excluded(end) => val[start..end].into(),
             };
 
             Value::binary(bytes, head)

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -171,7 +171,7 @@ fn action(
             let (start_index, end_index) = if let Some(spanned_range) = range {
                 range_span = spanned_range.span;
                 let range = &spanned_range.item;
-                range.absoulute_bounds(s.len())
+                range.absolute_bounds(s.len())
             } else {
                 (0usize, s.len())
             };

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -171,13 +171,7 @@ fn action(
             let (start_index, end_index) = if let Some(spanned_range) = range {
                 range_span = spanned_range.span;
                 let range = &spanned_range.item;
-                let start = range.absolute_start(s.len() as u64) as usize;
-                let end = match range.absolute_end(s.len() as u64) {
-                    std::ops::Bound::Included(v) => (v + 1) as usize,
-                    std::ops::Bound::Excluded(v) => v as usize,
-                    std::ops::Bound::Unbounded => s.len(),
-                };
-                (start, end)
+                range.absoulute_bounds(s.len())
             } else {
                 (0usize, s.len())
             };

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -141,7 +141,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                     .grapheme_indices(true)
                     .map(|(idx, s)| (idx, s.len()))
                     .collect::<Vec<_>>();
-                let (start, end) = args.range.absoulute_bounds(indices.len());
+                let (start, end) = args.range.absolute_bounds(indices.len());
                 if start >= end {
                     String::new()
                 } else {
@@ -154,7 +154,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                     }
                 }
             } else {
-                let (start, end) = args.range.absoulute_bounds(s.len());
+                let (start, end) = args.range.absolute_bounds(s.len());
                 if end >= start {
                     String::from_utf8_lossy(&s.as_bytes()[start..end]).into_owned()
                 } else {

--- a/crates/nu-command/tests/commands/bytes/at.rs
+++ b/crates/nu-command/tests/commands/bytes/at.rs
@@ -15,7 +15,12 @@ pub fn returns_error_for_relative_range_on_infinite_stream() {
 pub fn returns_bytes_for_fixed_range_on_infinite_stream_including_end() {
     let actual = nu!("nu --testbin iecho 3 | bytes at ..10 | decode");
     assert_eq!(
-        actual.out, "33333",
+        actual.out, "333333",
+        "Expected bytes from index 0 to 10, but got different output"
+    );
+    let actual = nu!("nu --testbin iecho 3 | bytes at ..10 | decode");
+    assert_eq!(
+        actual.out, "333333",
         "Expected bytes from index 0 to 10, but got different output"
     );
 }
@@ -24,7 +29,7 @@ pub fn returns_bytes_for_fixed_range_on_infinite_stream_including_end() {
 pub fn returns_bytes_for_fixed_range_on_infinite_stream_excluding_end() {
     let actual = nu!("nu --testbin iecho 3 | bytes at ..<9 | decode");
     assert_eq!(
-        actual.out, "3333",
+        actual.out, "33333",
         "Expected bytes from index 0 to 8, but got different output"
     );
 }

--- a/crates/nu-command/tests/commands/slice.rs
+++ b/crates/nu-command/tests/commands/slice.rs
@@ -66,3 +66,17 @@ fn negative_indices() {
         assert_eq!(actual.out, "1");
     });
 }
+
+#[test]
+fn zero_to_zero_exclusive() {
+    let actual = nu!(r#"[0 1 2 3] | slice 0..<0 | to nuon"#);
+
+    assert_eq!(actual.out, "[]");
+}
+
+#[test]
+fn to_negative_one_inclusive() {
+    let actual = nu!(r#"[0 1 2 3] | slice 2..-1 | to nuon"#);
+
+    assert_eq!(actual.out, "[2, 3]");
+}

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -288,8 +288,8 @@ impl ByteStream {
 
             match range.distance() {
                 Bound::Unbounded => stream,
-                Bound::Included(distance) => stream.and_then(|s| s.take(val_span, distance)),
-                Bound::Excluded(distance) => stream.and_then(|s| s.take(val_span, distance - 1)),
+                Bound::Included(distance) => stream.and_then(|s| s.take(val_span, distance + 1)),
+                Bound::Excluded(distance) => stream.and_then(|s| s.take(val_span, distance)),
             }
         }
     }

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -96,8 +96,9 @@ mod int_range {
         pub fn distance(&self) -> Bound<u64> {
             match self.end {
                 Bound::Unbounded => Bound::Unbounded,
-                Bound::Included(end) if self.start > end => Bound::Included(0),
-                Bound::Excluded(end) if self.start > end => Bound::Excluded(0),
+                Bound::Included(end) | Bound::Excluded(end) if self.start > end => {
+                    Bound::Excluded(0)
+                }
                 Bound::Included(end) => Bound::Included((end - self.start) as u64),
                 Bound::Excluded(end) => Bound::Excluded((end - self.start) as u64),
             }

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -145,7 +145,7 @@ mod int_range {
             }
         }
 
-        pub fn absoulute_bounds(&self, len: usize) -> (usize, usize) {
+        pub fn absolute_bounds(&self, len: usize) -> (usize, usize) {
             (self.absolute_start_new(len), self.absolute_end_new(len))
         }
 

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -92,6 +92,14 @@ mod int_range {
             }
         }
 
+        // Resolves the absolute start position given the length of the input value
+        fn absolute_start_new(&self, len: usize) -> usize {
+            match self.start {
+                start if start < 0 => len.saturating_sub(start.unsigned_abs() as usize),
+                start => len.min(start as usize),
+            }
+        }
+
         /// Returns the distance between the start and end of the range
         /// The result will always be 0 or positive
         pub fn distance(&self) -> Bound<u64> {
@@ -121,6 +129,24 @@ mod int_range {
                     i => len.min(i as u64),
                 }),
             }
+        }
+
+        fn absolute_end_new(&self, len: usize) -> usize {
+            match self.end {
+                Bound::Unbounded => len,
+                Bound::Included(i) => match i {
+                    i if i < 0 => len.saturating_sub(i.unsigned_abs() as usize - 1),
+                    i => len.min(i as usize + 1),
+                },
+                Bound::Excluded(i) => match i {
+                    i if i < 0 => len.saturating_sub(i.unsigned_abs() as usize),
+                    i => len.min(i as usize),
+                },
+            }
+        }
+
+        pub fn absoulute_bounds(&self, len: usize) -> (usize, usize) {
+            (self.absolute_start_new(len), self.absolute_end_new(len))
         }
 
         pub fn step(&self) -> i64 {

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -5,9 +5,11 @@ use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, fmt::Display};
 
 mod int_range {
-    use crate::{ast::RangeInclusion, ShellError, Signals, Span, Value};
+    use crate::{ast::RangeInclusion, FromValue, ShellError, Signals, Span, Value};
     use serde::{Deserialize, Serialize};
     use std::{cmp::Ordering, fmt::Display, ops::Bound};
+
+    use super::Range;
 
     #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
     pub struct IntRange {
@@ -242,6 +244,20 @@ mod int_range {
                 Bound::Included(end) => write!(f, "{end}"),
                 Bound::Excluded(end) => write!(f, "<{end}"),
                 Bound::Unbounded => Ok(()),
+            }
+        }
+    }
+
+    impl FromValue for IntRange {
+        fn from_value(v: Value) -> Result<Self, ShellError> {
+            let span = v.span();
+            let range = Range::from_value(v)?;
+            match range {
+                Range::IntRange(v) => Ok(v),
+                Range::FloatRange(_) => Err(ShellError::TypeMismatch {
+                    err_message: "expected an int range".into(),
+                    span,
+                }),
             }
         }
     }

--- a/crates/nu-protocol/tests/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/tests/pipeline/byte_stream.rs
@@ -17,6 +17,23 @@ pub fn test_simple_positive_slice_exclusive() {
 }
 
 #[test]
+pub fn test_simple_positive_slice_exclusive_streaming() {
+    let data = b"Hello World".to_vec();
+    let stream = ByteStream::read_binary(data, Span::test_data(), Signals::empty());
+    let sliced = stream
+        .with_known_size(None)
+        .slice(
+            Span::test_data(),
+            Span::test_data(),
+            create_range(0, 5, RangeInclusion::RightExclusive),
+        )
+        .unwrap();
+    let result = sliced.into_bytes().unwrap();
+    let result = String::from_utf8(result).unwrap();
+    assert_eq!(result, "Hello");
+}
+
+#[test]
 pub fn test_negative_start_exclusive() {
     let data = b"Hello World".to_vec();
     let stream = ByteStream::read_binary(data, Span::test_data(), Signals::empty());


### PR DESCRIPTION
- fixes #14769

# Description

## Bugs

-   `str substring 0..<0`

    When passed a range containing no elements, for non-zero cases `str substring` behaves correctly:
 
    ```nushell
    ("hello world" | str substring 1..<1) == ""
    # => true
    ```

    but if the range is `0..<0`, it returns the whole string instead

    ```nushell
    "hello world" | str substring 0..<0
    # => hello world
    ```
-   `[0 1 2] | range 0..<0`
    Similar behavior to `str substring`
-   `str index-of`
    - off-by-one on end bounds
    - underflow on negative start bounds
-   `bytes at` has inconsistent behavior, works correctly when the size is known, returns one byte less when it's not known (streaming)
    This can be demonstrated by comparing the outputs of following snippets
    ```nushell
    "hello world" | into binary | bytes at ..<5 | decode
    # => hello

    "hello world" | into binary | chunks 1 | bytes collect | bytes at ..<5 | decode
    # => hell
    ```
-   `bytes at` panics on decreasing (`5..3`) ranges if the input size is known. Does not panic with streaming input.

## Changes

- implement `FromValue` for `IntRange`, as it is very common to use integer ranges as arguments
- `IntRange::absolute_start` can now point one-past-end
- `IntRange::absolute_end` converts relative `Included` bounds to absolute `Excluded` bounds
- `IntRange::absolute_bounds` is a convenience method that calls the other `absolute_*` methods and transforms reverse ranges to empty at `start` (`5..3` => `5..<5`)
- refactored `str substring` tests to allow empty exclusive range tests
- fix the `0..<0` case for `str substring` and `str index-of`
- `IntRange::distance` never returns `Included(0)`

  As a general rule `Included(n) == Excluded(n + 1)`.
  
  This makes returning `Included(0)` bug prone as users of the function will likely rely on this general rule and cause bugs.
- `ByteStream::slice` no longer has an off-by-one on inputs without a known size. This affected `bytes at`.
- `bytes at` no longer panics on reverse ranges
- `bytes at` is now consistent between streaming and non streaming inputs.

# User-Facing Changes
There should be no noticeable changes other than the bugfix.

# Tests + Formatting

- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
N/A