### PR TITLE
feat(def): add examples to custom commands

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -21,6 +21,16 @@ impl Command for Def {
             .required("block", SyntaxShape::Closure(None), "Body of the definition.")
             .switch("env", "keep the environment defined inside the command", None)
             .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
+            .named(
+                "examples",
+                SyntaxShape::Table(vec![
+                    ("example".into(), SyntaxShape::String),
+                    ("description".into(), SyntaxShape::String),
+                    ("result".into(), SyntaxShape::Any),
+                ]),
+                "add examples for the command",
+                None,
+            )
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -85,6 +85,11 @@ impl Command for Def {
                 example: r#"def only_int []: int -> int { $in }; 42 | only_int"#,
                 result: Some(Value::test_int(42)),
             },
+            Example {
+                description: "Define a command with an example",
+                example: r#"def --examples=[{description: "Double a number", example: "double 5", result: 10}] double [n: number] { $in * 2 }"#,
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-cmd-lang/src/core_commands/export_def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_def.rs
@@ -21,6 +21,16 @@ impl Command for ExportDef {
             .required("block", SyntaxShape::Block, "Body of the definition.")
             .switch("env", "keep the environment defined inside the command", None)
             .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
+            .named(
+                "examples",
+                SyntaxShape::Table(vec![
+                    ("example".into(), SyntaxShape::String),
+                    ("description".into(), SyntaxShape::String),
+                    ("result".into(), SyntaxShape::Any),
+                ]),
+                "add examples for the command",
+                None,
+            )
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/export_extern.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_extern.rs
@@ -18,6 +18,16 @@ impl Command for ExportExtern {
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .required("def_name", SyntaxShape::String, "Definition name.")
             .required("params", SyntaxShape::Signature, "Parameters.")
+            .named(
+                "examples",
+                SyntaxShape::Table(vec![
+                    ("example".into(), SyntaxShape::String),
+                    ("description".into(), SyntaxShape::String),
+                    ("result".into(), SyntaxShape::Any),
+                ]),
+                "add examples for the command",
+                None,
+            )
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/extern_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/extern_.rs
@@ -18,6 +18,16 @@ impl Command for Extern {
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .required("def_name", SyntaxShape::String, "Definition name.")
             .required("params", SyntaxShape::Signature, "Parameters.")
+            .named(
+                "examples",
+                SyntaxShape::Table(vec![
+                    ("example".into(), SyntaxShape::String),
+                    ("description".into(), SyntaxShape::String),
+                    ("result".into(), SyntaxShape::Any),
+                ]),
+                "add examples for the command",
+                None,
+            )
             .category(Category::Core)
     }
 

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -353,3 +353,38 @@ export def recursive [c: int] {
 }"#);
     assert!(actual.err.is_empty());
 }
+
+#[test]
+fn def_with_example_with_equal_sign() {
+    let actual = nu!(r#"def --examples=[] foo [] {}"#);
+    assert!(actual.status.success());
+}
+
+#[test]
+fn def_with_example_without_equal_sign() {
+    let actual = nu!(r#"def --examples [] foo [] {}"#);
+    assert!(actual.status.success());
+}
+
+#[test]
+fn def_with_full_example() {
+    Playground::setup("def_with_full_example", |dirs, _| {
+        let data = r#"
+# Command that doubles a number
+export def --examples [{
+    description: "Double a number"
+    example: "5 | double"
+    result: 10
+}] double []: [
+    number -> number
+] {
+    $in * 2
+}
+"#;
+        fs::write(dirs.root().join("example_test"), data).expect("Unable to write file");
+        let actual = nu!(cwd: dirs.root(), r#"use example_test double; help double"#);
+
+        assert!(actual.status.success());
+        assert!(actual.out.contains("Double a number"))
+    });
+}

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -3,6 +3,7 @@ use nu_protocol::{
     ast::{self, Expr, Expression},
     engine::{self, CallImpl, CommandType, UNKNOWN_SPAN_ID},
     ir::{self, DataSlice},
+    CustomExample,
 };
 
 #[derive(Clone)]
@@ -11,6 +12,7 @@ pub struct KnownExternal {
     pub signature: Box<Signature>,
     pub description: String,
     pub extra_description: String,
+    pub examples: Vec<CustomExample>,
 }
 
 impl Command for KnownExternal {
@@ -74,6 +76,13 @@ impl Command for KnownExternal {
                 command.run(engine_state, stack, &(&extern_call).into(), input)
             }
         }
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        self.examples
+            .iter()
+            .map(CustomExample::to_example)
+            .collect()
     }
 }
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -837,6 +837,7 @@ pub fn parse_extern(
                         description,
                         extra_description,
                         signature,
+                        examples: examples.unwrap_or_default(),
                     };
 
                     *declaration = Box::new(decl);

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -170,6 +170,9 @@ pub fn parse_def_predecl(working_set: &mut StateWorkingSet, spans: &[Span]) {
     // Now, pos should point at the next span after the def-like call.
     // Skip all potential flags, like --env, --wrapped, --examples or --help:
     while pos < spans.len() && working_set.get_span_contents(spans[pos]).starts_with(b"-") {
+        if working_set.get_span_contents(spans[pos]) == b"--examples" {
+            pos += 1;
+        }
         pos += 1;
     }
 
@@ -415,8 +418,17 @@ pub fn parse_def(
             // Find the first span that is not a flag
             let mut decl_name_span = None;
 
+            let mut flag = false;
             for span in rest_spans {
-                if !working_set.get_span_contents(*span).starts_with(b"-") {
+                if flag {
+                    flag = false;
+                    continue;
+                }
+                if working_set.get_span_contents(*span).starts_with(b"-") {
+                    if working_set.get_span_contents(*span) == b"--examples" {
+                        flag = true;
+                    }
+                } else {
                     decl_name_span = Some(*span);
                     break;
                 }

--- a/crates/nu-std/std/assert/mod.nu
+++ b/crates/nu-std/std/assert/mod.nu
@@ -4,36 +4,30 @@
 #
 ##################################################################################
 
+const main_examples = [
+    {
+        description: "Pass",
+        example: "assert (3 == 3)",
+    }
+    {
+        description: "Fail",
+        example: "assert (42 == 3)",
+    }
+    {
+        description: "The --error-label flag can be used if you want to create a custom assert command:",
+        example: r#'def "assert even" [number: int] {
+        assert ($number mod 2 == 0) --error-label {
+            text: $"($number) is not an even number",
+            span: (metadata $number).span,
+        }
+    }'#,
+    }
+]
+
 # Universal assert command
 #
 # If the condition is not true, it generates an error.
-#
-# # Example
-#
-# ```nushell
-# >_ assert (3 == 3)
-# >_ assert (42 == 3)
-# Error:
-#   × Assertion failed:
-#     ╭─[myscript.nu:11:1]
-#  11 │ assert (3 == 3)
-#  12 │ assert (42 == 3)
-#     ·         ───┬────
-#     ·            ╰── It is not true.
-#  13 │
-#     ╰────
-# ```
-#
-# The --error-label flag can be used if you want to create a custom assert command:
-# ```
-# def "assert even" [number: int] {
-#     assert ($number mod 2 == 0) --error-label {
-#         text: $"($number) is not an even number",
-#         span: (metadata $number).span,
-#     }
-# }
-# ```
-export def main [
+export def --examples=$main_examples main [
     condition: bool, # Condition, which should be true
     message?: string, # Optional error message
     --error-label: record<text: string, span: record<start: int, end: int>> # Label for `error make` if you want to create a custom assert
@@ -48,37 +42,30 @@ export def main [
     }
 }
 
+const not_examples = [
+    {
+        description: "Pass",
+        example: "assert (42 == 3)",
+    }
+    {
+        description: "Fail",
+        example: "assert (3 == 3)",
+    }
+    {
+        description: "The --error-label flag can be used if you want to create a custom assert command:",
+        example: r#'def "assert not even" [number: int] {
+        assert not ($number mod 2 == 0) --error-label {
+            span: (metadata $number).span,
+            text: $"($number) is an even number",
+        }
+    }'#,
+    }
+]
 
 # Negative assertion
 #
 # If the condition is not false, it generates an error.
-#
-# # Examples
-#
-# >_ assert (42 == 3)
-# >_ assert (3 == 3)
-# Error:
-#   × Assertion failed:
-#     ╭─[myscript.nu:11:1]
-#  11 │ assert (42 == 3)
-#  12 │ assert (3 == 3)
-#     ·         ───┬────
-#     ·            ╰── It is not false.
-#  13 │
-#     ╰────
-#
-#
-# The --error-label flag can be used if you want to create a custom assert command:
-# ```
-# def "assert not even" [number: int] {
-#     assert not ($number mod 2 == 0) --error-label {
-#         span: (metadata $number).span,
-#         text: $"($number) is an even number",
-#     }
-# }
-# ```
-#
-export def not [
+export def --examples=$not_examples not [
     condition: bool, # Condition, which should be false
     message?: string, # Optional error message
     --error-label: record<text: string, span: record<start: int, end: int>> # Label for `error make` if you want to create a custom assert
@@ -95,15 +82,21 @@ export def not [
     }
 }
 
+const error_examples = [
+    {
+        description: "Pass",
+        example: "assert error {|| missing_command}",
+    }
+    {
+        description: "Fail",
+        example: "assert error {|| 12}",
+    }
+]
+
 # Assert that executing the code generates an error
 #
 # For more documentation see the assert command
-#
-# # Examples
-#
-# > assert error {|| missing_command} # passes
-# > assert error {|| 12} # fails
-export def error [
+export def --examples=$error_examples error [
     code: closure,
     message?: string
 ] {
@@ -117,16 +110,25 @@ export def error [
     }
 }
 
+const equal_examples = [
+    {
+        description: "Pass"
+        example: "assert equal 1 1"
+    }
+    {
+        description: ""
+        example: "assert equal (0.1 + 0.2) 0.3"
+    }
+    {
+        description: "Fail"
+        example: "assert equal 1 2"
+    }
+]
+
 # Assert $left == $right
 #
 # For more documentation see the assert command
-#
-# # Examples
-#
-# > assert equal 1 1 # passes
-# > assert equal (0.1 + 0.2) 0.3
-# > assert equal 1 2 # fails
-export def equal [left: any, right: any, message?: string] {
+export def --examples=$equal_examples equal [left: any, right: any, message?: string] {
     main ($left == $right) $message --error-label {
         span: {
             start: (metadata $left).span.start
@@ -140,16 +142,25 @@ export def equal [left: any, right: any, message?: string] {
     }
 }
 
+const not_equal_examples = [
+    {
+        description: "Pass",
+        example: r#'assert not equal 1 2'#,
+    }
+    {
+        description: "Pass",
+        example: r#'assert not equal 1 "apple"'#,
+    }
+    {
+        description: "Fail",
+        example: r#'assert not equal 7 7'#,
+    }
+]
+
 # Assert $left != $right
 #
 # For more documentation see the assert command
-#
-# # Examples
-#
-# > assert not equal 1 2 # passes
-# > assert not equal 1 "apple" # passes
-# > assert not equal 7 7 # fails
-export def "not equal" [left: any, right: any, message?: string] {
+export def --examples=$not_equal_examples "not equal" [left: any, right: any, message?: string] {
     main ($left != $right) $message --error-label {
         span: {
             start: (metadata $left).span.start
@@ -159,16 +170,25 @@ export def "not equal" [left: any, right: any, message?: string] {
     }
 }
 
+const leq_examples = [
+    {
+        description: "Pass",
+        example: r#'assert less or equal 1 2 # passes'#,
+    }
+    {
+        description: "Pass",
+        example: r#'assert less or equal 1 1 # passes'#,
+    }
+    {
+        description: "Fail",
+        example: r#'assert less or equal 1 0 # fails'#,
+    }
+]
+
 # Assert $left <= $right
 #
 # For more documentation see the assert command
-#
-# # Examples
-#
-# > assert less or equal 1 2 # passes
-# > assert less or equal 1 1 # passes
-# > assert less or equal 1 0 # fails
-export def "less or equal" [left: any, right: any, message?: string] {
+export def --examples=$leq_examples "less or equal" [left: any, right: any, message?: string] {
     main ($left <= $right) $message --error-label {
         span: {
             start: (metadata $left).span.start
@@ -182,15 +202,21 @@ export def "less or equal" [left: any, right: any, message?: string] {
     }
 }
 
+const less_examples = [
+    {
+        description: "Pass"
+        example: r#'assert less 1 2'#,
+    }
+    {
+        description: "Fail"
+        example: r#'assert less 1 1'#
+    }
+]
+
 # Assert $left < $right
 #
 # For more documentation see the assert command
-#
-# # Examples
-#
-# > assert less 1 2 # passes
-# > assert less 1 1 # fails
-export def less [left: any, right: any, message?: string] {
+export def --examples=$less_examples less [left: any, right: any, message?: string] {
     main ($left < $right) $message --error-label {
         span: {
             start: (metadata $left).span.start
@@ -204,15 +230,21 @@ export def less [left: any, right: any, message?: string] {
     }
 }
 
+const greater_examples = [
+    {
+        description: "Pass",
+        example: r#'assert greater 2 1'#,
+    }
+    {
+        description: "Fail",
+        example: r#'assert greater 2 2'#,
+    }
+]
+
 # Assert $left > $right
 #
 # For more documentation see the assert command
-#
-# # Examples
-#
-# > assert greater 2 1 # passes
-# > assert greater 2 2 # fails
-export def greater [left: any, right: any, message?: string] {
+export def --examples=$greater_examples greater [left: any, right: any, message?: string] {
     main ($left > $right) $message --error-label {
         span: {
             start: (metadata $left).span.start
@@ -226,16 +258,26 @@ export def greater [left: any, right: any, message?: string] {
     }
 }
 
+
+const geq_examples = [
+    {
+        description: "Pass",
+        example: r#'assert greater or equal 2 1'#,
+    }
+    {
+        description: "Pass",
+        example: r#'assert greater or equal 2 2'#,
+    }
+    {
+        description: "Fail",
+        example: r#'assert greater or equal 1 2'#,
+    }
+]
+
 # Assert $left >= $right
 #
 # For more documentation see the assert command
-#
-# # Examples
-#
-# > assert greater or equal 2 1 # passes
-# > assert greater or equal 2 2 # passes
-# > assert greater or equal 1 2 # fails
-export def "greater or equal" [left: any, right: any, message?: string] {
+export def --examples=$geq_examples "greater or equal" [left: any, right: any, message?: string] {
     main ($left >= $right) $message --error-label {
         span: {
             start: (metadata $left).span.start
@@ -249,16 +291,22 @@ export def "greater or equal" [left: any, right: any, message?: string] {
     }
 }
 
+const length_examples = [
+    {
+        description: "Pass",
+        example: r#'assert length [0, 0] 2'#,
+    }
+    {
+        description: "Fail",
+        example: r#'assert length [0] 3'#,
+    }
+]
+
 alias "core length" = length
 # Assert length of $left is $right
 #
 # For more documentation see the assert command
-#
-# # Examples
-#
-# > assert length [0, 0] 2 # passes
-# > assert length [0] 3 # fails
-export def length [left: list, right: int, message?: string] {
+export def --examples=$length_examples length [left: list, right: int, message?: string] {
     main (($left | core length) == $right) $message --error-label {
         span: {
             start: (metadata $left).span.start
@@ -273,16 +321,22 @@ export def length [left: list, right: int, message?: string] {
     }
 }
 
+const str_constains_examples = [
+    {
+        description: "Pass"
+        example: r#'assert str contains "arst" "rs"'#
+    }
+    {
+        description: "Fail"
+        example: r#'assert str contains "arst" "k"'#
+    }
+]
+
 alias "core str contains" = str contains
 # Assert that ($left | str contains $right)
 #
 # For more documentation see the assert command
-#
-# # Examples
-#
-# > assert str contains "arst" "rs" # passes
-# > assert str contains "arst" "k" # fails
-export def "str contains" [left: string, right: string, message?: string] {
+export def --examples=$str_constains_examples "str contains" [left: string, right: string, message?: string] {
     main ($left | core str contains $right) $message --error-label {
         span: {
             start: (metadata $left).span.start

--- a/crates/nu-std/std/assert/mod.nu
+++ b/crates/nu-std/std/assert/mod.nu
@@ -321,7 +321,7 @@ export def --examples=$length_examples length [left: list, right: int, message?:
     }
 }
 
-const str_constains_examples = [
+const str_contains_examples = [
     {
         description: "Pass"
         example: r#'assert str contains "arst" "rs"'#
@@ -336,7 +336,7 @@ alias "core str contains" = str contains
 # Assert that ($left | str contains $right)
 #
 # For more documentation see the assert command
-export def --examples=$str_constains_examples "str contains" [left: string, right: string, message?: string] {
+export def --examples=$str_contains_examples "str contains" [left: string, right: string, message?: string] {
     main ($left | core str contains $right) $message --error-label {
         span: {
             start: (metadata $left).span.start

--- a/crates/nu-std/std/bench/mod.nu
+++ b/crates/nu-std/std/bench/mod.nu
@@ -1,45 +1,45 @@
+const main_examples = [
+    {
+        description: "measure the performance of simple addition"
+        example: r#'bench { 1 + 2 } -n 10'#
+        result: {
+            mean: (4µs + 956ns)
+            std: (4µs + 831ns)
+            times: [
+                (19µs + 402ns)
+                ( 4µs + 322ns)
+                ( 3µs + 352ns)
+                ( 2µs + 966ns)
+                ( 3µs        )
+                ( 3µs +  86ns)
+                ( 3µs +  84ns)
+                ( 3µs + 604ns)
+                ( 3µs +  98ns)
+                ( 3µs + 653ns)
+            ]
+        }
+    }
+    {
+        description: "get a pretty benchmark report"
+        example: r#'bench { 1 + 2 } --pretty'#
+        result: "3µs 125ns +/- 2µs 408ns"
+    }
+]
+
 # run a piece of `nushell` code multiple times and measure the time of execution.
 #
 # this command returns a benchmark report of the following form:
-# ```
-# record<
-#   mean: duration
-#   std: duration
-#   times: list<duration>
-# >
-# ```
 #
 # > **Note**
 # > `std bench --pretty` will return a `string`.
-#
-# # Examples
-#     measure the performance of simple addition
-#     > std bench { 1 + 2 } -n 10 | table -e
-#     ╭───────┬────────────────────╮
-#     │ mean  │ 4µs 956ns          │
-#     │ std   │ 4µs 831ns          │
-#     │       │ ╭───┬────────────╮ │
-#     │ times │ │ 0 │ 19µs 402ns │ │
-#     │       │ │ 1 │  4µs 322ns │ │
-#     │       │ │ 2 │  3µs 352ns │ │
-#     │       │ │ 3 │  2µs 966ns │ │
-#     │       │ │ 4 │        3µs │ │
-#     │       │ │ 5 │   3µs 86ns │ │
-#     │       │ │ 6 │   3µs 84ns │ │
-#     │       │ │ 7 │  3µs 604ns │ │
-#     │       │ │ 8 │   3µs 98ns │ │
-#     │       │ │ 9 │  3µs 653ns │ │
-#     │       │ ╰───┴────────────╯ │
-#     ╰───────┴────────────────────╯
-#
-#     get a pretty benchmark report
-#     > std bench { 1 + 2 } --pretty
-#     3µs 125ns +/- 2µs 408ns
-export def main [
+export def --examples=$main_examples main [
     code: closure  # the piece of `nushell` code to measure the performance of
     --rounds (-n): int = 50  # the number of benchmark rounds (hopefully the more rounds the less variance)
     --verbose (-v) # be more verbose (namely prints the progress)
     --pretty # shows the results in human-readable format: "<mean> +/- <stddev>"
+]: [
+    nothing -> record<mean: duration, std: duration, times: list<duration>>
+    nothing -> string
 ] {
     let times: list<duration> = (
         seq 1 $rounds | each {|i|

--- a/crates/nu-std/std/dt/mod.nu
+++ b/crates/nu-std/std/dt/mod.nu
@@ -88,24 +88,29 @@ def borrow-second [from: record, current: record] {
     $current
 }
 
+const datetime_diff_examples = [
+    {
+        description: ""
+        example: r#'dt datetime-diff 2023-05-07T04:08:45+12:00 2019-05-10T09:59:12-07:00'#
+        result: {
+            year: 3,
+            month: 11,
+            day: 26,
+            hour: 23,
+            minute: 9,
+            second: 33,
+            millisecond: 0,
+            microsecond: 0,
+            nanosecond: 0,
+        }
+    }
+]
+
 # Subtract later from earlier datetime and return the unit differences as a record
-# Example:
-# > dt datetime-diff 2023-05-07T04:08:45+12:00 2019-05-10T09:59:12-07:00
-# ╭─────────────┬────╮
-# │ year        │ 3  │
-# │ month       │ 11 │
-# │ day         │ 26 │
-# │ hour        │ 23 │
-# │ minute      │ 9  │
-# │ second      │ 33 │
-# │ millisecond │ 0  │
-# │ microsecond │ 0  │
-# │ nanosecond  │ 0  │
-# ╰─────────────┴────╯
-export def datetime-diff [
-        later: datetime, # a later datetime
-        earlier: datetime  # earlier (starting) datetime
-    ] {
+export def --examples=$datetime_diff_examples datetime-diff [
+    later: datetime, # a later datetime
+    earlier: datetime  # earlier (starting) datetime
+]: [nothing -> record] {
     if $earlier > $later {
         let start = (metadata $later).span.start
         let end = (metadata $earlier).span.end
@@ -161,11 +166,16 @@ export def datetime-diff [
     $result
 }
 
+const pretty_print_examples = [
+    {
+        description: "",
+        example: r#'dt pretty-print-duration (dt datetime-diff 2023-05-07T04:08:45+12:00 2019-05-10T09:59:12+12:00)'#
+        result: "3yrs 11months 27days 18hrs 9mins 33secs"
+    }
+]
+
 # Convert record from datetime-diff into humanized string
-# Example:
-# > dt pretty-print-duration (dt datetime-diff 2023-05-07T04:08:45+12:00 2019-05-10T09:59:12+12:00)
-# 3yrs 11months 27days 18hrs 9mins 33secs
-export def pretty-print-duration [dur: record] {
+export def --examples=$pretty_print_examples pretty-print-duration [dur: record]: [nothing -> string] {
     mut result = ""
     if $dur.year != 0 {
         if $dur.year > 1 {

--- a/crates/nu-std/std/iter/mod.nu
+++ b/crates/nu-std/std/iter/mod.nu
@@ -27,10 +27,8 @@ const find_examples = [
 # > The closure also has to be valid for the types it receives
 # > These will be flagged as errors later as closure annotations
 # > are implemented
-export def --examples=$find_examples find [
+export def --examples=$find_examples find [ # -> any | null  
     fn: closure # the closure used to perform the search 
-]: [
-    list<any> -> any
 ] {
     filter {|e| try {do $fn $e} } | try { first }
 }
@@ -53,10 +51,8 @@ const find_index_examples = [
 #
 # # Invariant
 # > The closure has to return a bool
-export def --examples=$find_index_examples find-index [
+export def --examples=$find_index_examples find-index [ # -> int
     fn: closure # the closure used to perform the search
-]: [
-    list<any> -> int
 ] {
     enumerate
     | find {|e| $e.item | do $fn $e.item }
@@ -73,10 +69,8 @@ const intersperse_examples = [
 
 # Returns a new list with the separator between adjacent
 # items of the original list
-export def --examples=$intersperse_examples intersperse [
+export def --examples=$intersperse_examples intersperse [ # -> list<any>
     separator: any # the separator to be used
-]: [
-    list<any> -> list<any>
 ] {
     reduce --fold [] {|e, acc|
          $acc ++ [$e, $separator]
@@ -110,8 +104,6 @@ export def --examples=$scan_examples scan [ # -> list<any>
     init: any            # initial value to seed the initial state
     fn: closure          # the closure to perform the scan
     --noinit(-n)         # remove the initial value from the result
-]: [
-    list<any> -> list<any>
 ] {
     generate {|e, acc|
         let out = $acc | do $fn $e $acc
@@ -131,10 +123,8 @@ const filter_map_examples = [
 # Returns a list of values for which the supplied closure does not
 # return `null` or an error. It is equivalent to 
 #     `$in | each $fn | filter $fn`
-export def --examples=$filter_map_examples filter-map [
+export def --examples=$filter_map_examples filter-map [ # -> list<any>
     fn: closure                # the closure to apply to the input
-]: [
-    list<any> -> list<any>
 ] {
     each {|$e|
         try {
@@ -159,8 +149,6 @@ const flat_map_examples = [
 # Maps a closure to each nested structure and flattens the result
 export def --examples=$flat_map_examples flat-map [ # -> list<any>
     fn: closure              # the closure to map to the nested structures
-]: [
-    list<any> -> list<any>
 ] {
     each {|e| do $fn $e } | flatten
 }

--- a/crates/nu-std/std/util/mod.nu
+++ b/crates/nu-std/std/util/mod.nu
@@ -1,30 +1,22 @@
+const path_add_examples = [
+    {
+        description: "adding some dummy paths to an empty PATH"
+        example: r#'with-env { PATH: [] } {
+        path add "foo"
+        path add "bar" "baz"
+        path add "fooo" --append
+        path add "returned" --ret
+    }'#
+        result: [returned bar baz foo fooo]
+    }
+    {
+        description: "adding paths based on the operating system"
+        example: r#'path add {linux: "foo", windows: "bar", darwin: "baz"}'#
+    }
+]
+
 # Add the given paths to the PATH.
-#
-# # Example
-# - adding some dummy paths to an empty PATH
-# ```nushell
-# >_ with-env { PATH: [] } {
-#     std path add "foo"
-#     std path add "bar" "baz"
-#     std path add "fooo" --append
-#
-#     assert equal $env.PATH ["bar" "baz" "foo" "fooo"]
-#
-#     print (std path add "returned" --ret)
-# }
-# ╭───┬──────────╮
-# │ 0 │ returned │
-# │ 1 │ bar      │
-# │ 2 │ baz      │
-# │ 3 │ foo      │
-# │ 4 │ fooo     │
-# ╰───┴──────────╯
-# ```
-# - adding paths based on the operating system
-# ```nushell
-# >_ std path add {linux: "foo", windows: "bar", darwin: "baz"}
-# ```
-export def --env "path add" [
+export def --env --examples=$path_add_examples "path add" [
     --ret (-r)  # return $env.PATH, useful in pipelines to avoid scoping.
     --append (-a)  # append to $env.PATH instead of prepending to.
     ...paths  # the paths to add to $env.PATH.
@@ -81,13 +73,15 @@ export def ellie [] {
     $ellie | str join "\n" | $"(ansi green)($in)(ansi reset)"
 }
 
+const repeat_example = [
+    {
+        description: "repeat a string"
+        example: r#'"foo" | std repeat 3 | str join'#
+        result: "foofoofoo"
+    }
+]
 # repeat anything a bunch of times, yielding a list of *n* times the input
-#
-# # Examples
-#     repeat a string
-#     > "foo" | std repeat 3 | str join
-#     "foofoofoo"
-export def repeat [
+export def --examples=$repeat_example repeat [
     n: int  # the number of repetitions, must be positive
 ]: any -> list<any> {
     let item = $in
@@ -117,11 +111,14 @@ export const null_device = if $nu.os-info.name == "windows" {
 	'/dev/null'
 }
 
+const null_example = [
+    {
+        description: "run a command and ignore it's stderr output"
+        example: r#'cat xxx.txt e> (null-device)'#
+    }
+]
+
 # return a null device file.
-#
-# # Examples
-#     run a command and ignore it's stderr output
-#     > cat xxx.txt e> (null-device)
-export def null-device []: nothing -> path {
+export def --examples=$null_example null-device []: nothing -> path {
     $null_device
 }


### PR DESCRIPTION
# Description

Custom/user defined commands can now be defined with a `--examples` flag, allowing the addition of examples similar to built-in commands.

```nushell
const foo_examples = [
	{
		description: "Example 1"
		example: r#'foo "world"'#,
		result: "hello world"
	}
	{
		description: "Example 2"
		example: r#'foo "everyone!"'#,
		result: "hello everyone!"
	}
	{
		description: "Example 3"
		example: r#'foo'#,
	}
]

def --examples=$foo_examples foo [name: string]: [nothing -> string] {
	$'hello ($name)'
}

foo -h
# => Usage:
# =>   > foo <name> 
# => 
# => Flags:
# =>   -h, --help: Display the help message for this command
# => 
# => Parameters:
# =>   name <string>
# => 
# => Input/output types:
# =>   ╭─#─┬──input──┬─output─╮
# =>   │ 0 │ nothing │ string │
# =>   ╰─#─┴──input──┴─output─╯
# => 
# => Examples:
# =>   Example 1
# =>   > foo "world"
# =>   hello world
# => 
# =>   Example 2
# =>   > foo "everyone!"
# =>   hello everyone!
# => 
# =>   Example 3
# =>   > foo
```

# User-Facing Changes

- `def` and `export def` now have `--examples` flag, allowing users and standard library to define commands with examples.
- In `std`, moved examples from doc-comments to actual examples.

# Tests + Formatting

- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting

- Update the documentation on the website.