### PR TITLE
Immediately return error if detected as pipeline input or positional argument

### DIFF
--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1250,15 +1250,15 @@ fn gather_arguments(
 
 /// Type check helper. Produces `CantConvert` error if `val` is not compatible with `ty`.
 fn check_type(val: &Value, ty: &Type) -> Result<(), ShellError> {
-    if val.is_subtype_of(ty) {
-        Ok(())
-    } else {
-        Err(ShellError::CantConvert {
+    match val {
+        Value::Error { error, .. } => Err(*error.clone()),
+        _ if val.is_subtype_of(ty) => Ok(()),
+        _ => Err(ShellError::CantConvert {
             to_type: ty.to_string(),
             from_type: val.get_type().to_string(),
             span: val.span(),
             help: None,
-        })
+        }),
     }
 }
 

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1283,12 +1283,12 @@ fn check_input_types(
         _ => (),
     }
 
-    // Errors and custom values bypass input type checking
-    if matches!(
-        input,
-        PipelineData::Value(Value::Error { .. } | Value::Custom { .. }, ..)
-    ) {
-        return Ok(());
+    match input {
+        // early return error directly if detected
+        PipelineData::Value(Value::Error { error, .. }, ..) => return Err(*error.clone()),
+        // bypass run-time typechecking for custom types
+        PipelineData::Value(Value::Custom { .. }, ..) => return Ok(()),
+        _ => (),
     }
 
     // Check if the input type is compatible with *any* of the command's possible input types


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR returns error values while checking pipeline input types and positional argument types. This should help return non-nested errors earlier and prevent confusing errors.

The positional argument change is directly related to an example given on Discord. Before this PR, this is the error shown:

```
Error: nu::shell::cant_convert

  × Can't convert to record.
    ╭─[/home/rose/tmp/script.nu:23:5]
 22 │         let entry = $in
 23 │ ╭─▶     {
 24 │ │         name: $entry,
 25 │ │         details: {
 26 │ │           context: $context
 27 │ │         }
 28 │ ├─▶     }
    · ╰──── can't convert error to record
 29 │       }
    ╰────
```

After this PR, this is the error shown:

```
Error: nu::shell::eval_block_with_input

  × Eval block failed with pipeline input
    ╭─[/home/rose/tmp/script.nu:23:5]
 22 │         let entry = $in
 23 │ ╭─▶     {
 24 │ │         name: $entry,
 25 │ │         details: {
 26 │ │           context: $context
 27 │ │         }
 28 │ ├─▶     }
    · ╰──── source value
 29 │       }
    ╰────

Error: nu::shell::type_mismatch

  × Type mismatch.
   ╭─[/home/rose/tmp/much.nu:3:38]
 2 │   $in | each { |elem|
 3 │     print $elem.details.context.yaml.0
   ·                                      ┬
   ·                                      ╰── Can't access record values with a row index. Try specifying a column name instead
 4 │   } | each { |elem|
   ╰────
```

I'm not certain if the pipeline input error check actually can ever be triggered, but it seems to be a good defensive error handling strategy regardless. My addition of the `Value::Error` case in the first place would suggest it can be, but after looking at it more closely the error that caused me to add the case in the first place was actually unrelated to input typechecking.

Additionally, this PR does not affect the handling of nested errors, so something like:

```nushell
try { ... } catch {|e| $e | reject raw | to nuon }
```

works the same before and after this PR.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Errors values detected as arguments to commands or as pipeline input to commands are immediately thrown, rather than passed to the command. 

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A