### PR TITLE
Rename `fmt` to `format number`

### DIFF
--- a/crates/nu-cmd-extra/src/extra/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/mod.rs
@@ -47,6 +47,7 @@ pub fn add_extra_command_context(mut engine_state: EngineState) -> EngineState {
         bind_command!(
             strings::format::FormatPattern,
             strings::format::FormatBits,
+            strings::format::FormatNumber,
             strings::str_::case::Str,
             strings::str_::case::StrCamelCase,
             strings::str_::case::StrKebabCase,

--- a/crates/nu-cmd-extra/src/extra/strings/format/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/mod.rs
@@ -1,6 +1,9 @@
 mod bits;
 mod command;
+mod number;
 
 pub(crate) use command::FormatPattern;
 // TODO remove `format_bits` visibility after removal of into bits
 pub(crate) use bits::{format_bits, FormatBits};
+// TODO remove `format_number` visibility after removal of into bits
+pub(crate) use number::{format_number, FormatNumber};

--- a/crates/nu-cmd-extra/src/extra/strings/format/number.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/number.rs
@@ -1,0 +1,126 @@
+use nu_cmd_base::input_handler::{operate, CellPathOnlyArgs};
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct FormatNumber;
+
+impl Command for FormatNumber {
+    fn name(&self) -> &str {
+        "format number"
+    }
+
+    fn description(&self) -> &str {
+        "Format a number."
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("format number")
+            .input_output_types(vec![(Type::Number, Type::record())])
+            .category(Category::Conversions)
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["display", "render", "format"]
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Get a record containing multiple formats for the number 42",
+            example: "42 | format number",
+            result: Some(Value::test_record(record! {
+                    "binary" =>   Value::test_string("0b101010"),
+                    "debug" =>    Value::test_string("42"),
+                    "display" =>  Value::test_string("42"),
+                    "lowerexp" => Value::test_string("4.2e1"),
+                    "lowerhex" => Value::test_string("0x2a"),
+                    "octal" =>    Value::test_string("0o52"),
+                    "upperexp" => Value::test_string("4.2E1"),
+                    "upperhex" => Value::test_string("0x2A"),
+            })),
+        }]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        format_number(engine_state, stack, call, input)
+    }
+}
+
+pub(crate) fn format_number(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+    input: PipelineData,
+) -> Result<PipelineData, ShellError> {
+    let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
+    let args = CellPathOnlyArgs::from(cell_paths);
+    operate(action, args, input, call.head, engine_state.signals())
+}
+
+fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
+    match input {
+        Value::Float { val, .. } => format_f64(*val, span),
+        Value::Int { val, .. } => format_i64(*val, span),
+        Value::Filesize { val, .. } => format_i64(val.get(), span),
+        // Propagate errors by explicitly matching them before the final case.
+        Value::Error { .. } => input.clone(),
+        other => Value::error(
+            ShellError::OnlySupportsThisInputType {
+                exp_input_type: "float, int, or filesize".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.span(),
+            },
+            span,
+        ),
+    }
+}
+
+fn format_i64(num: i64, span: Span) -> Value {
+    Value::record(
+        record! {
+            "binary" => Value::string(format!("{num:#b}"), span),
+            "debug" => Value::string(format!("{num:#?}"), span),
+            "display" => Value::string(format!("{num}"), span),
+            "lowerexp" => Value::string(format!("{num:#e}"), span),
+            "lowerhex" => Value::string(format!("{num:#x}"), span),
+            "octal" => Value::string(format!("{num:#o}"), span),
+            "upperexp" => Value::string(format!("{num:#E}"), span),
+            "upperhex" => Value::string(format!("{num:#X}"), span),
+        },
+        span,
+    )
+}
+
+fn format_f64(num: f64, span: Span) -> Value {
+    Value::record(
+        record! {
+            "binary" => Value::string(format!("{:b}", num.to_bits()), span),
+            "debug" => Value::string(format!("{num:#?}"), span),
+            "display" => Value::string(format!("{num}"), span),
+            "lowerexp" => Value::string(format!("{num:#e}"), span),
+            "lowerhex" => Value::string(format!("{:0x}", num.to_bits()), span),
+            "octal" => Value::string(format!("{:0o}", num.to_bits()), span),
+            "upperexp" => Value::string(format!("{num:#E}"), span),
+            "upperhex" => Value::string(format!("{:0X}", num.to_bits()), span),
+        },
+        span,
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(FormatNumber {})
+    }
+}


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR renames `fmt` to `format number`, to bring it in line with similar value formatting commands and make it more discoverable.


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

* The `fmt` command is now `format number`. A deprecation warning will be thrown if you use `fmt`.


# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A