### PR TITLE
Fix retrieval of config directory for user autoloads

### DIFF
--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -350,12 +350,6 @@ pub fn get_vendor_autoload_dirs(_engine_state: &EngineState) -> Vec<PathBuf> {
 pub fn get_user_autoload_dirs(_engine_state: &EngineState) -> Vec<PathBuf> {
     // User autoload directories - Currently just `autoload` in the default
     // configuration directory
-    let into_autoload_path_fn = |mut path: PathBuf| {
-        path.push("nushell");
-        path.push("autoload");
-        path
-    };
-
     let mut dirs = Vec::new();
 
     let mut append_fn = |path: PathBuf| {
@@ -364,8 +358,8 @@ pub fn get_user_autoload_dirs(_engine_state: &EngineState) -> Vec<PathBuf> {
         }
     };
 
-    if let Some(config_dir) = dirs::config_dir() {
-        append_fn(into_autoload_path_fn(config_dir));
+    if let Some(config_dir) = nu_path::nu_config_dir() {
+        append_fn(config_dir.join("autoload").into());
     }
 
     dirs


### PR DESCRIPTION
# Description

Fixes an issue with #14669 - I mistakenly used `dirs::config_dir()` when it should be `nu_path::config_dir()`.  This allows `XDG_CONFIG_DIR` to specify the location properly.

# User-Facing Changes

Fix: If `XDG_CONFIG_DIR` is set, it will be used for the `autoload` location.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A