### PR TITLE
Use `$nu.data-dir` as last directory for vendor autoloads on all platforms

### DIFF
--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -321,23 +321,8 @@ pub fn get_vendor_autoload_dirs(_engine_state: &EngineState) -> Vec<PathBuf> {
         append_fn(PathBuf::from(path));
     }
 
-    #[cfg(target_os = "macos")]
-    std::env::var("XDG_DATA_HOME")
-        .ok()
-        .map(PathBuf::from)
-        .or_else(|| {
-            dirs::home_dir().map(|mut home| {
-                home.push(".local");
-                home.push("share");
-                home
-            })
-        })
-        .map(into_autoload_path_fn)
-        .into_iter()
-        .for_each(&mut append_fn);
-
-    if let Some(data_dir) = dirs::data_dir() {
-        append_fn(into_autoload_path_fn(data_dir));
+    if let Some(data_dir) = nu_path::data_dir() {
+        append_fn(PathBuf::from(data_dir).join("vendor").join("autoload"));
     }
 
     if let Some(path) = std::env::var_os("NU_VENDOR_AUTOLOAD_DIR") {

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -265,8 +265,7 @@ pub fn get_vendor_autoload_dirs(_engine_state: &EngineState) -> Vec<PathBuf> {
     // <dir>/nushell/vendor/autoload for every dir in XDG_DATA_DIRS in reverse order on platforms other than windows. If XDG_DATA_DIRS is not set, it falls back to <PREFIX>/share if PREFIX ends in local, or <PREFIX>/local/share:<PREFIX>/share otherwise. If PREFIX is not set, fall back to /usr/local/share:/usr/share.
     // %ProgramData%\nushell\vendor\autoload on windows
     // NU_VENDOR_AUTOLOAD_DIR from compile time, if env var is set at compile time
-    // if on macOS, additionally check XDG_DATA_HOME, which `dirs` is only doing on Linux
-    // <data_dir>/nushell/vendor/autoload of the current user according to the `dirs` crate
+    // <$nu.data_dir>/vendor/autoload
     // NU_VENDOR_AUTOLOAD_DIR at runtime, if env var is set
 
     let into_autoload_path_fn = |mut path: PathBuf| {


### PR DESCRIPTION
# Description

Should fix #14872.

## Before

The vendor autoload code in #13382 has the same issue that I just fixed in user-autoloads via #14877. Specifically, it uses `dirs::data_dir()` (from the `dirs` crate), leading to a different behavior when `XDG_DATA_HOME` is set on each platform.

* On Linux, the `dirs` crate automatically uses `XDG_DATA_HOME` for `dirs::data_dir()`, so everything worked as expected.
* On macOS, `dirs` doesn't use the XDG spec, but the vendor autoload code from #13382 specifically added `XDG_DATA_HOME`.  However, even if `XDG_DATA_HOME` was set, vendor autoloads would still use the `dirs` version *as well*.
* On Windows, `XDG_DATA_HOME` was ignored completely by vendor autoloads, even though `$nu.data-dirs` was respecting it.

## After

This PR uses `nu::data_dirs()` on all platforms.  `nu::data_dirs()` respects `XDG_DATA_HOME` (if set) on all platforms.

# User-Facing Changes

Might be a breaking change if someone was depending on the old behavior, but the doc already specified the behavior in this PR.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

Documentation already reflects the behavior in this PR.