### PR TITLE
`into cell-path`: noop when input is cell-path

### DIFF
--- a/crates/nu-command/src/conversions/into/cell_path.rs
+++ b/crates/nu-command/src/conversions/into/cell_path.rs
@@ -104,7 +104,7 @@ fn into_cell_path(call: &Call, input: PipelineData) -> Result<PipelineData, Shel
     let head = call.head;
 
     match input {
-        PipelineData::Value(value, _) => Ok(value_to_cell_path(&value, head)?.into_pipeline_data()),
+        PipelineData::Value(value, _) => Ok(value_to_cell_path(value, head)?.into_pipeline_data()),
         PipelineData::ListStream(stream, ..) => {
             let list: Vec<_> = stream.into_iter().collect();
             Ok(list_to_cell_path(&list, head)?.into_pipeline_data())
@@ -178,11 +178,11 @@ fn record_to_path_member(
     Ok(member)
 }
 
-fn value_to_cell_path(value: &Value, span: Span) -> Result<Value, ShellError> {
+fn value_to_cell_path(value: Value, span: Span) -> Result<Value, ShellError> {
     match value {
-        Value::CellPath { .. } => Ok(value.clone()),
-        Value::Int { val, .. } => Ok(int_to_cell_path(*val, span)),
-        Value::List { vals, .. } => list_to_cell_path(vals, span),
+        Value::CellPath { .. } => Ok(value),
+        Value::Int { val, .. } => Ok(int_to_cell_path(val, span)),
+        Value::List { vals, .. } => list_to_cell_path(&vals, span),
         other => Err(ShellError::OnlySupportsThisInputType {
             exp_input_type: "int, list".into(),
             wrong_type: other.get_type().to_string(),

--- a/crates/nu-command/src/conversions/into/cell_path.rs
+++ b/crates/nu-command/src/conversions/into/cell_path.rs
@@ -12,6 +12,7 @@ impl Command for IntoCellPath {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("into cell-path")
             .input_output_types(vec![
+                (Type::CellPath, Type::CellPath),
                 (Type::Int, Type::CellPath),
                 (Type::List(Box::new(Type::Any)), Type::CellPath),
                 (
@@ -52,6 +53,13 @@ impl Command for IntoCellPath {
             Example {
                 description: "Convert integer into cell path",
                 example: "5 | into cell-path",
+                result: Some(Value::test_cell_path(CellPath {
+                    members: vec![PathMember::test_int(5, false)],
+                })),
+            },
+            Example {
+                description: "Convert cell path into cell path",
+                example: "5 | into cell-path | into cell-path",
                 result: Some(Value::test_cell_path(CellPath {
                     members: vec![PathMember::test_int(5, false)],
                 })),
@@ -172,6 +180,7 @@ fn record_to_path_member(
 
 fn value_to_cell_path(value: &Value, span: Span) -> Result<Value, ShellError> {
     match value {
+        Value::CellPath { .. } => Ok(value.clone()),
         Value::Int { val, .. } => Ok(int_to_cell_path(*val, span)),
         Value::List { vals, .. } => list_to_cell_path(vals, span),
         other => Err(ShellError::OnlySupportsThisInputType {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
https://github.com/nushell/nushell/pull/14845#issuecomment-2596371878

When the input to `into cell-path` is a cell-path, it will return it like other into commands.
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Before, using `into cell-path` with a cell-path as input would return an error, now it will return the input.

<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
