### PR TITLE
`into glob`: noop when input is glob

### DIFF
--- a/crates/nu-command/src/conversions/into/glob.rs
+++ b/crates/nu-command/src/conversions/into/glob.rs
@@ -22,6 +22,7 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("into glob")
             .input_output_types(vec![
+                (Type::Glob, Type::Glob),
                 (Type::String, Type::Glob),
                 (
                     Type::List(Box::new(Type::String)),
@@ -65,6 +66,11 @@ impl Command for SubCommand {
                 result: Some(Value::test_glob("1234")),
             },
             Example {
+                description: "convert glob to glob",
+                example: "'1234' | into glob | into glob",
+                result: Some(Value::test_glob("1234")),
+            },
+            Example {
                 description: "convert filepath to glob",
                 example: "ls Cargo.toml | get name | into glob",
                 result: None,
@@ -94,6 +100,7 @@ fn glob_helper(
 fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
     match input {
         Value::String { val, .. } => Value::glob(val.to_string(), false, span),
+        Value::Glob { .. } => input.clone(),
         x => Value::error(
             ShellError::CantConvert {
                 to_type: String::from("glob"),


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
https://github.com/nushell/nushell/pull/14845#issuecomment-2596371878

When the input to `into glob` is a glob, it will return it like other into commands.
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Before, using `into glob` with a glob as input would return an error, now it will return the input.

<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
