### PR TITLE
Improve example for epoch -> datetime

### DIFF
--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -205,15 +205,14 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Convert standard (seconds) unix timestamp to a UTC datetime",
-                example: "1614434140 * 1_000_000_000 | into datetime",
+                example: "1614434140 | into datetime -f '%s'",
                 #[allow(clippy::inconsistent_digit_grouping)]
                 result: example_result_1(1614434140_000000000),
             },
             Example {
-                description: "Leave it as it is when the input is already a datetime",
-                example: "1614434140 * 1_000_000_000 | into datetime | into datetime",
-                #[allow(clippy::inconsistent_digit_grouping)]
-                result: example_result_1(1614434140_000000000),
+                description: "Using a datetime as input simply returns the value",
+                example: "date now | into datetime",
+                result: None,
             },
             Example {
                 description: "Convert list of timestamps to datetimes",

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -211,8 +211,9 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Using a datetime as input simply returns the value",
-                example: "date now | into datetime",
-                result: None,
+                example: "2021-02-27T13:55:40 | into datetime",
+                #[allow(clippy::inconsistent_digit_grouping)]
+                result: example_result_1(1614434140_000000000),
             },
             Example {
                 description: "Convert list of timestamps to datetimes",


### PR DESCRIPTION
# Description

Mentioned in Discord today - A while back `into datetime` was updated to allow ints to be passed directly into the `-f '%s'`, but the examples still used an older, outdated `* 1_000_000_000` for conversion.

Also replaced the other new "noop" example since it used the same form.  

# User-Facing Changes

Doc-only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
- 
# After Submitting

N/A