### PR TITLE
Use `ref-cast` crate to remove some `unsafe`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3994,6 +3994,7 @@ dependencies = [
  "dirs",
  "omnipath",
  "pwd",
+ "ref-cast",
 ]
 
 [[package]]

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -13,6 +13,7 @@ bench = false
 
 [dependencies]
 dirs = { workspace = true }
+ref-cast = "1.0.23"
 
 [target.'cfg(windows)'.dependencies]
 omnipath = { workspace = true }

--- a/crates/nu-path/src/form.rs
+++ b/crates/nu-path/src/form.rs
@@ -14,7 +14,7 @@ mod private {
 }
 
 /// A marker trait for the different kinds of path forms.
-/// Each form has its own invariants that are guaranteed be upheld.
+/// Each form has its own invariants that are guaranteed to be upheld.
 /// The list of path forms are:
 /// - [`Any`]: a path with no invariants. It may be a relative or an absolute path.
 /// - [`Relative`]: a strictly relative path.


### PR DESCRIPTION
# Description

In a few places, `nu-path` uses `unsafe` to do reference casts. This PR adds the [`ref-cast`](https://crates.io/crates/ref-cast) crate to do reference casts in a "safe" manner.