### PR TITLE
feat(lsp): document highlight

### DIFF
--- a/crates/nu-lsp/src/ast.rs
+++ b/crates/nu-lsp/src/ast.rs
@@ -286,43 +286,22 @@ fn try_find_id_in_use(
     if call_name != "use".as_bytes() {
         return None;
     }
-    let find_by_name = |name: &str| {
-        match id {
-            Some(Id::Variable(var_id_ref)) => {
-                if let Some(var_id) = working_set.find_variable(name.as_bytes()) {
-                    if var_id == *var_id_ref {
-                        return Some(Id::Variable(var_id));
-                    }
-                }
-            }
-            Some(Id::Declaration(decl_id_ref)) => {
-                if let Some(decl_id) = working_set.find_decl(name.as_bytes()) {
-                    if decl_id == *decl_id_ref {
-                        return Some(Id::Declaration(decl_id));
-                    }
-                }
-            }
-            Some(Id::Module(module_id_ref)) => {
-                if let Some(module_id) = working_set.find_module(name.as_bytes()) {
-                    if module_id == *module_id_ref {
-                        return Some(Id::Module(module_id));
-                    }
-                }
-            }
-            None => {
-                if let Some(var_id) = working_set.find_variable(name.as_bytes()) {
-                    return Some(Id::Variable(var_id));
-                }
-                if let Some(decl_id) = working_set.find_decl(name.as_bytes()) {
-                    return Some(Id::Declaration(decl_id));
-                }
-                if let Some(module_id) = working_set.find_module(name.as_bytes()) {
-                    return Some(Id::Module(module_id));
-                }
-            }
-            _ => (),
-        }
-        None
+    let find_by_name = |name: &[u8]| match id {
+        Some(Id::Variable(var_id_ref)) => working_set
+            .find_variable(name)
+            .and_then(|var_id| (var_id == *var_id_ref).then_some(Id::Variable(var_id))),
+        Some(Id::Declaration(decl_id_ref)) => working_set
+            .find_decl(name)
+            .and_then(|decl_id| (decl_id == *decl_id_ref).then_some(Id::Declaration(decl_id))),
+        Some(Id::Module(module_id_ref)) => working_set
+            .find_module(name)
+            .and_then(|module_id| (module_id == *module_id_ref).then_some(Id::Module(module_id))),
+        None => working_set
+            .find_variable(name)
+            .map(Id::Variable)
+            .or(working_set.find_decl(name).map(Id::Declaration))
+            .or(working_set.find_module(name).map(Id::Module)),
+        _ => None,
     };
     let check_location = |span: &Span| location.map_or(true, |pos| span.contains(*pos));
     let get_module_id = |span: Span| {
@@ -330,8 +309,7 @@ fn try_find_id_in_use(
         let name = String::from_utf8_lossy(working_set.get_span_contents(span));
         let path = PathBuf::from(name.as_ref());
         let stem = path.file_stem().and_then(|fs| fs.to_str()).unwrap_or(&name);
-        let module_id = working_set.find_module(stem.as_bytes())?;
-        let found_id = Id::Module(module_id);
+        let found_id = Id::Module(working_set.find_module(stem.as_bytes())?);
         id.map_or(true, |id_r| found_id == *id_r)
             .then_some((found_id, span))
     };
@@ -359,7 +337,7 @@ fn try_find_id_in_use(
                 .and_then(|e| {
                     let name = e.as_string()?;
                     Some((
-                        find_by_name(&name)?,
+                        find_by_name(name.as_bytes())?,
                         strip_quotes(item_expr.span, working_set),
                     ))
                 })
@@ -367,31 +345,25 @@ fn try_find_id_in_use(
     };
 
     // the imported name is always at the second argument
-    if let Argument::Positional(expr) = call.arguments.get(1)? {
-        if check_location(&expr.span) {
-            match &expr.expr {
-                Expr::String(name) => {
-                    if let Some(id) = find_by_name(name) {
-                        return Some((id, strip_quotes(expr.span, working_set)));
-                    }
-                }
-                Expr::List(items) => {
-                    if let Some(res) = search_in_list_items(items) {
-                        return Some(res);
-                    }
-                }
-                Expr::FullCellPath(fcp) => {
-                    if let Expr::List(items) = &fcp.head.expr {
-                        if let Some(res) = search_in_list_items(items) {
-                            return Some(res);
-                        }
-                    }
-                }
-                _ => (),
-            }
-        }
+    let Argument::Positional(expr) = call.arguments.get(1)? else {
+        return None;
+    };
+    if !check_location(&expr.span) {
+        return None;
     }
-    None
+    match &expr.expr {
+        Expr::String(name) => {
+            find_by_name(name.as_bytes()).map(|id| (id, strip_quotes(expr.span, working_set)))
+        }
+        Expr::List(items) => search_in_list_items(items),
+        Expr::FullCellPath(fcp) => {
+            let Expr::List(items) = &fcp.head.expr else {
+                return None;
+            };
+            search_in_list_items(items)
+        }
+        _ => None,
+    }
 }
 
 fn find_id_in_expr(
@@ -483,6 +455,7 @@ fn find_reference_by_id_in_expr(
             if let Id::Declaration(decl_id) = id {
                 if *decl_id == call.decl_id {
                     occurs.push(call.head);
+                    return Some(occurs);
                 }
             }
             if let Some((_, span_found)) = try_find_id_in_def(call, working_set, None, Some(id))

--- a/crates/nu-lsp/src/diagnostics.rs
+++ b/crates/nu-lsp/src/diagnostics.rs
@@ -10,7 +10,7 @@ impl LanguageServer {
         let mut engine_state = self.new_engine_state();
         engine_state.generate_nu_constant();
 
-        let Some((_, offset, working_set)) = self.parse_file(&mut engine_state, &uri, true) else {
+        let Some((_, span, working_set)) = self.parse_file(&mut engine_state, &uri, true) else {
             return Ok(());
         };
 
@@ -31,7 +31,7 @@ impl LanguageServer {
             let message = err.to_string();
 
             diagnostics.diagnostics.push(Diagnostic {
-                range: span_to_range(&err.span(), file, offset),
+                range: span_to_range(&err.span(), file, span.start),
                 severity: Some(DiagnosticSeverity::ERROR),
                 message,
                 ..Default::default()

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -309,7 +309,7 @@ impl LanguageServer {
         uri: &Uri,
         pos: Position,
     ) -> Result<(StateWorkingSet<'a>, Id, Span, usize)> {
-        let (block, file_span, mut working_set) = self
+        let (block, file_span, working_set) = self
             .parse_file(engine_state, uri, false)
             .ok_or_else(|| miette!("\nFailed to parse current file"))?;
 
@@ -323,8 +323,6 @@ impl LanguageServer {
         let location = file.offset_at(pos) as usize + file_span.start;
         let (id, span) = find_id(&block, &working_set, &location)
             .ok_or_else(|| miette!("\nFailed to find current name"))?;
-        // add block to working_set for later references
-        working_set.add_block(block);
         Ok((working_set, id, span, file_span.start))
     }
 
@@ -349,6 +347,8 @@ impl LanguageServer {
         }
         if self.need_parse {
             // TODO: incremental parsing
+            // add block to working_set for later references
+            working_set.add_block(block.clone());
             self.cached_state_delta = Some(working_set.delta.clone());
             self.need_parse = false;
         }

--- a/crates/nu-lsp/src/symbols.rs
+++ b/crates/nu-lsp/src/symbols.rs
@@ -203,16 +203,17 @@ impl SymbolCache {
                     continue;
                 }
                 let target_uri = path_to_uri(path);
-                let new_symbols = if let Some(doc) = docs.get_document(&target_uri) {
-                    Self::extract_all_symbols(&working_set, doc, cached_file)
-                } else {
-                    let temp_doc = FullTextDocument::new(
-                        "nu".to_string(),
-                        0,
-                        String::from_utf8((*cached_file.content).to_vec()).expect("Invalid UTF-8"),
-                    );
-                    Self::extract_all_symbols(&working_set, &temp_doc, cached_file)
-                };
+                let new_symbols = Self::extract_all_symbols(
+                    &working_set,
+                    docs.get_document(&target_uri)
+                        .unwrap_or(&FullTextDocument::new(
+                            "nu".to_string(),
+                            0,
+                            String::from_utf8((*cached_file.content).to_vec())
+                                .expect("Invalid UTF-8"),
+                        )),
+                    cached_file,
+                );
                 self.cache.insert(target_uri.clone(), new_symbols);
                 self.mark_dirty(target_uri, false);
             }

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -157,7 +157,7 @@ impl LanguageServer {
         self.occurrences = BTreeMap::new();
         let mut engine_state = self.new_engine_state();
         let path_uri = params.text_document_position.text_document.uri.to_owned();
-        let (working_set, id, span, _) = self
+        let (_, id, span, _) = self
             .parse_and_find(
                 &mut engine_state,
                 &path_uri,
@@ -165,8 +165,7 @@ impl LanguageServer {
             )
             .ok()?;
         // have to clone it again in order to move to another thread
-        let mut engine_state = self.new_engine_state();
-        engine_state.merge_delta(working_set.render()).ok()?;
+        let engine_state = self.new_engine_state();
         let current_workspace_folder = self.get_workspace_folder_by_uri(&path_uri)?;
         let token = params
             .work_done_progress_params

--- a/crates/nu-protocol/src/engine/state_delta.rs
+++ b/crates/nu-protocol/src/engine/state_delta.rs
@@ -14,6 +14,7 @@ use crate::{PluginRegistryItem, RegisteredPlugin};
 /// A delta (or change set) between the current global state and a possible future global state. Deltas
 /// can be applied to the global state to update it to contain both previous state and the state held
 /// within the delta.
+#[derive(Clone)]
 pub struct StateDelta {
     pub(super) files: Vec<CachedFile>,
     pub(super) virtual_paths: Vec<(String, VirtualPath)>,

--- a/tests/fixtures/lsp/symbols/foo.nu
+++ b/tests/fixtures/lsp/symbols/foo.nu
@@ -1,4 +1,4 @@
-use bar.nu [ var_bar def_bar ]
+use bar.nu [ def_bar ]
 
 let var_foo = 1
 def_bar


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This is a minor feature that highlights all occurrences of current variable/command in current file:

<img width="346" alt="image" src="https://github.com/user-attachments/assets/f1078e79-d02e-480e-b84a-84efb222c9a4" />

Since this kind of request happens a lot with fixed document content, to avoid unnecessary parsing, this PR caches the `StateDelta` to the server.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Can be disabled on the client side.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Implementation is directly borrowed from `references`, only one simple test case added.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
