### PR TITLE
Use single atom for fuzzy matching (fix #14904)

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1038,8 +1038,8 @@ fn subcommand_completions() {
     match_suggestions(
         &vec![
             "food bar".to_string(),
-            "foo-test-command aagap bcr".to_string(),
             "foo-test-command bar".to_string(),
+            "foo-test-command aagap bcr".to_string(),
         ],
         &suggestions,
     );


### PR DESCRIPTION
# Description

Closes #14904. The bug there was introduced by #14846, which replaced skim with Nucleo. It turns out that Nucleo's `Pattern::new` function doesn't treat the needle as a single atom - it splits on spaces and makes each word its own atom. This PR fixes the problem by creating a single `Atom` for the whole needle rather than creating a `Pattern`.

Because of the bug, when you typed `lines <TAB>` (with a space at the end), the suggestion `lines` was also matched. This suggestion was shorter than the original typed needle, which would cause an out-of-bounds error.

This also meant that if you typed `foo bar<TAB>`, `foo aaaaa bar` would be shown before `foo bar aaa`. At the time, I didn't realize that it was more intuitive to have `foo bar aaa` be put first.

# User-Facing Changes

Typing something like `lines <TAB>` should no longer cause a panic.

# Tests + Formatting

- Added a test to ensure spaces are respected when fuzzy matching
- Updated a test with the changed sort order for subcommand suggestions

# After Submitting

No need to update docs.