### PR TITLE
Remove unsued types

### DIFF
--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -360,7 +360,6 @@ fn nu_value_to_sqlite_type(val: &Value) -> Result<&'static str, ShellError> {
         | Type::List(_)
         | Type::Range
         | Type::Record(_)
-        | Type::Signature
         | Type::Glob
         | Type::Table(_) => Err(ShellError::OnlySupportsThisInputType {
             exp_input_type: "sql".into(),

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -353,7 +353,6 @@ fn nu_value_to_sqlite_type(val: &Value) -> Result<&'static str, ShellError> {
 
         // intentionally enumerated so that any future types get handled
         Type::Any
-        | Type::Block
         | Type::CellPath
         | Type::Closure
         | Type::Custom(_)

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2259,7 +2259,7 @@ pub fn parse_module(
     module_comments.extend(inner_comments);
     let module_id = working_set.add_module(&module_name, module, module_comments);
 
-    let block_expr = Expression::new(working_set, Expr::Block(block_id), block_span, Type::Block);
+    let block_expr = Expression::new(working_set, Expr::Block(block_id), block_span, Type::Any);
 
     let module_decl_id = working_set
         .find_decl(b"module")

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3498,7 +3498,7 @@ pub fn parse_signature(working_set: &mut StateWorkingSet, span: Span) -> Express
 
     let sig = parse_signature_helper(working_set, Span::new(start, end));
 
-    Expression::new(working_set, Expr::Signature(sig), span, Type::Signature)
+    Expression::new(working_set, Expr::Signature(sig), span, Type::Any)
 }
 
 pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> Box<Signature> {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4471,7 +4471,7 @@ pub fn parse_block_expression(working_set: &mut StateWorkingSet, span: Span) -> 
 
     let block_id = working_set.add_block(Arc::new(output));
 
-    Expression::new(working_set, Expr::Block(block_id), span, Type::Block)
+    Expression::new(working_set, Expr::Block(block_id), span, Type::Any)
 }
 
 pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Span) -> Expression {

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -55,7 +55,6 @@ pub fn type_compatible(lhs: &Type, rhs: &Type) -> bool {
         (Type::Int, Type::Number) => true,
         (Type::Number, Type::Float) => true,
         (Type::Float, Type::Number) => true,
-        (Type::Closure, Type::Block) => true,
         (Type::Any, _) => true,
         (_, Type::Any) => true,
         (Type::Record(lhs), Type::Record(rhs)) | (Type::Table(lhs), Type::Table(rhs)) => {

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -176,7 +176,7 @@ impl SyntaxShape {
             SyntaxShape::Record(entries) => Type::Record(mk_ty(entries)),
             SyntaxShape::RowCondition => Type::Bool,
             SyntaxShape::Boolean => Type::Bool,
-            SyntaxShape::Signature => Type::Signature,
+            SyntaxShape::Signature => Type::Any,
             SyntaxShape::String => Type::String,
             SyntaxShape::Table(columns) => Type::Table(mk_ty(columns)),
             SyntaxShape::VarWithOptType => Type::Any,

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -143,7 +143,7 @@ impl SyntaxShape {
 
         match self {
             SyntaxShape::Any => Type::Any,
-            SyntaxShape::Block => Type::Block,
+            SyntaxShape::Block => Type::Any,
             SyntaxShape::Closure(_) => Type::Closure,
             SyntaxShape::Binary => Type::Binary,
             SyntaxShape::CellPath => Type::Any,

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -1,17 +1,14 @@
+use crate::SyntaxShape;
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 #[cfg(test)]
 use strum_macros::EnumIter;
-
-use std::fmt::Display;
-
-use crate::SyntaxShape;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[cfg_attr(test, derive(EnumIter))]
 pub enum Type {
     Any,
     Binary,
-    Block,
     Bool,
     CellPath,
     Closure,
@@ -113,7 +110,6 @@ impl Type {
             Type::Range => SyntaxShape::Range,
             Type::Bool => SyntaxShape::Boolean,
             Type::String => SyntaxShape::String,
-            Type::Block => SyntaxShape::Block, // FIXME needs more accuracy
             Type::Closure => SyntaxShape::Closure(None), // FIXME needs more accuracy
             Type::CellPath => SyntaxShape::CellPath,
             Type::Duration => SyntaxShape::Duration,
@@ -137,7 +133,6 @@ impl Type {
     /// tables and records (get `list` instead of `list<any>`
     pub fn get_non_specified_string(&self) -> String {
         match self {
-            Type::Block => String::from("block"),
             Type::Closure => String::from("closure"),
             Type::Bool => String::from("bool"),
             Type::CellPath => String::from("cell-path"),
@@ -166,7 +161,6 @@ impl Type {
 impl Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Type::Block => write!(f, "block"),
             Type::Closure => write!(f, "closure"),
             Type::Bool => write!(f, "bool"),
             Type::CellPath => write!(f, "cell-path"),

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -25,7 +25,6 @@ pub enum Type {
     Number,
     Range,
     Record(Box<[(String, Type)]>),
-    Signature,
     String,
     Glob,
     Table(Box<[(String, Type)]>),
@@ -124,7 +123,6 @@ impl Type {
             Type::Error => SyntaxShape::Any,
             Type::Binary => SyntaxShape::Binary,
             Type::Custom(_) => SyntaxShape::Any,
-            Type::Signature => SyntaxShape::Signature,
             Type::Glob => SyntaxShape::GlobPattern,
         }
     }
@@ -152,7 +150,6 @@ impl Type {
             Type::Error => String::from("error"),
             Type::Binary => String::from("binary"),
             Type::Custom(_) => String::from("custom"),
-            Type::Signature => String::from("signature"),
             Type::Glob => String::from("glob"),
         }
     }
@@ -208,7 +205,6 @@ impl Display for Type {
             Type::Error => write!(f, "error"),
             Type::Binary => write!(f, "binary"),
             Type::Custom(custom) => write!(f, "{custom}"),
-            Type::Signature => write!(f, "signature"),
             Type::Glob => write!(f, "glob"),
         }
     }


### PR DESCRIPTION
# Description

`Type::Block` and `Type::Signature` do not correspond to any `Value` cases and should be able to be removed.