### PR TITLE
Add config types for hooks

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -322,7 +322,7 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
 
     start_time = std::time::Instant::now();
     // Right before we start our prompt and take input from the user, fire the "pre_prompt" hook
-    if let Err(err) = hook::eval_hooks(
+    if let Err(err) = hook::eval_hook_list(
         engine_state,
         &mut stack,
         vec![],
@@ -333,7 +333,6 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
     }
     perf!("pre-prompt hook", start_time, use_color);
 
-    start_time = std::time::Instant::now();
     // Next, check all the environment variables they ask for
     // fire the "env_change" hook
     if let Err(error) = hook::eval_env_change_hook(
@@ -531,7 +530,7 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
                 repl.buffer = repl_cmd_line_text.to_string();
                 drop(repl);
 
-                if let Err(err) = hook::eval_hooks(
+                if let Err(err) = hook::eval_hook_list(
                     engine_state,
                     &mut stack,
                     vec![],

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -220,7 +220,7 @@ pub fn print_pipeline(
         let pipeline = eval_hook(
             engine_state,
             stack,
-            Some(pipeline),
+            pipeline,
             vec![],
             &hook,
             "display_output",

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -2,7 +2,8 @@ use nu_cmd_base::hook::eval_hook;
 use nu_engine::{command_prelude::*, env_to_strings};
 use nu_path::{dots::expand_ndots_safe, expand_tilde, AbsolutePath};
 use nu_protocol::{
-    did_you_mean, process::ChildProcess, ByteStream, NuGlob, OutDest, Signals, UseAnsiColoring,
+    did_you_mean, process::ChildProcess, ByteStream, IntoValue, NuGlob, OutDest, Signals,
+    UseAnsiColoring,
 };
 use nu_system::ForegroundChild;
 use nu_utils::IgnoreCaseExt;
@@ -460,11 +461,12 @@ pub fn command_not_found(
         }
         stack.add_env_var(canary.into(), Value::bool(true, Span::unknown()));
 
+        let name_val = name.into_value(span);
         let output = eval_hook(
             &mut engine_state.clone(),
             &mut stack,
-            None,
-            vec![("cmd_name".into(), Value::string(name, span))],
+            name_val.clone().into_pipeline_data(),
+            vec![("cmd_name".into(), name_val)],
             hook,
             "command_not_found",
         );

--- a/crates/nu-protocol/src/config/error.rs
+++ b/crates/nu-protocol/src/config/error.rs
@@ -2,7 +2,7 @@ use super::ConfigPath;
 use crate::{Config, ConfigError, ShellError, Span, Type, Value};
 
 #[derive(Debug)]
-pub(super) struct ConfigErrors<'a> {
+pub(crate) struct ConfigErrors<'a> {
     config: &'a Config,
     errors: Vec<ConfigError>,
 }

--- a/crates/nu-protocol/src/config/hooks.rs
+++ b/crates/nu-protocol/src/config/hooks.rs
@@ -1,15 +1,125 @@
 use super::prelude::*;
-use crate as nu_protocol;
+use crate::{self as nu_protocol, engine::Closure, IntoSpanned, Record, Spanned};
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum HookCode {
+    Code(String),
+    Closure(Closure),
+}
+
+impl IntoValue for HookCode {
+    fn into_value(self, span: Span) -> Value {
+        match self {
+            HookCode::Code(code) => code.into_value(span),
+            HookCode::Closure(closure) => closure.into_value(span),
+        }
+    }
+}
+
+#[derive(Debug, Clone, IntoValue, Serialize, Deserialize)]
+pub struct ConditionalHook {
+    pub condition: Option<Spanned<Closure>>,
+    pub code: Spanned<HookCode>,
+}
+
+impl ConditionalHook {
+    pub(crate) fn from_record<'a>(
+        record: &'a Record,
+        span: Span,
+        path: &mut ConfigPath<'a>,
+        errors: &mut ConfigErrors,
+    ) -> Option<Self> {
+        let mut condition = None;
+        let mut code = None;
+        for (col, val) in record.iter() {
+            let path = &mut path.push(col);
+            let span = val.span();
+            match col.as_str() {
+                "condition" => match val {
+                    Value::Closure { val, .. } => {
+                        condition = Some(val.as_ref().clone().into_spanned(span));
+                    }
+                    Value::Nothing { .. } => {
+                        condition = None;
+                    }
+                    val => {
+                        errors.type_mismatch(path, Type::custom("closure or nothing"), val);
+                    }
+                },
+                "code" => match val {
+                    Value::String { val, .. } => {
+                        code = Some(HookCode::Code(val.clone()).into_spanned(span));
+                    }
+                    Value::Closure { val, .. } => {
+                        code = Some(HookCode::Closure(val.as_ref().clone()).into_spanned(span));
+                    }
+                    val => {
+                        errors.type_mismatch(path, Type::custom("string or closure"), val);
+                    }
+                },
+                _ => errors.unknown_option(path, val),
+            }
+        }
+        if let Some(code) = code {
+            Some(ConditionalHook { condition, code })
+        } else {
+            errors.missing_column(path, "code", span);
+            None
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Hook {
+    Unconditional(Spanned<HookCode>),
+    Conditional(ConditionalHook),
+}
+
+impl IntoValue for Hook {
+    fn into_value(self, span: Span) -> Value {
+        match self {
+            Self::Unconditional(code) => code.into_value(span),
+            Self::Conditional(hook) => hook.into_value(span),
+        }
+    }
+}
+
+impl Hook {
+    pub(crate) fn from_value<'a>(
+        value: &'a Value,
+        path: &mut ConfigPath<'a>,
+        errors: &mut ConfigErrors,
+    ) -> Option<Self> {
+        match value {
+            Value::String { val, .. } => Some(Hook::Unconditional(
+                HookCode::Code(val.clone()).into_spanned(value.span()),
+            )),
+            Value::Closure { val, .. } => Some(Hook::Unconditional(
+                HookCode::Closure(val.as_ref().clone()).into_spanned(value.span()),
+            )),
+            Value::Record { val: record, .. } => {
+                ConditionalHook::from_record(record, value.span(), path, errors)
+                    .map(Hook::Conditional)
+            }
+            val => {
+                errors.type_mismatch(path, Type::custom("string, record, or closure"), val);
+                None
+            }
+        }
+    }
+}
+
 /// Definition of a parsed hook from the config object
-#[derive(Clone, Debug, IntoValue, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, IntoValue, Serialize, Deserialize)]
 pub struct Hooks {
-    pub pre_prompt: Vec<Value>,
-    pub pre_execution: Vec<Value>,
-    pub env_change: HashMap<String, Vec<Value>>,
-    pub display_output: Option<Value>,
-    pub command_not_found: Option<Value>,
+    pub pre_prompt: Vec<Hook>,
+    pub pre_execution: Vec<Hook>,
+    pub env_change: HashMap<String, Vec<Hook>>,
+    pub display_output: Option<Hook>,
+    pub command_not_found: Option<Hook>,
 }
 
 impl Hooks {
@@ -18,9 +128,9 @@ impl Hooks {
             pre_prompt: Vec::new(),
             pre_execution: Vec::new(),
             env_change: HashMap::new(),
-            display_output: Some(Value::string(
-                "if (term size).columns >= 100 { table -e } else { table }",
-                Span::unknown(),
+            display_output: Some(Hook::Unconditional(
+                HookCode::Code("if (term size).columns >= 100 { table -e } else { table }".into())
+                    .into_spanned(Span::unknown()),
             )),
             command_not_found: None,
         }
@@ -40,6 +150,47 @@ impl UpdateFromValue for Hooks {
         path: &mut ConfigPath<'a>,
         errors: &mut ConfigErrors,
     ) {
+        fn update_hook<'a>(
+            field: &mut Option<Hook>,
+            value: &'a Value,
+            path: &mut ConfigPath<'a>,
+            errors: &mut ConfigErrors,
+        ) {
+            match value {
+                Value::String { .. } | Value::Closure { .. } | Value::Record { .. } => {
+                    if let Some(hook) = Hook::from_value(value, path, errors) {
+                        *field = Some(hook);
+                    }
+                }
+                Value::Nothing { .. } => *field = None,
+                val => errors.type_mismatch(
+                    path,
+                    Type::custom("string, closure, record, or nothing"),
+                    val,
+                ),
+            }
+        }
+
+        fn update_hook_list<'a>(
+            field: &mut Vec<Hook>,
+            val: &'a Value,
+            path: &mut ConfigPath<'a>,
+            errors: &mut ConfigErrors,
+        ) {
+            if let Ok(hooks) = val.as_list() {
+                *field = hooks
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, val)| {
+                        let path = &mut path.push_row(i);
+                        Hook::from_value(val, path, errors)
+                    })
+                    .collect()
+            } else {
+                errors.type_mismatch(path, Type::list(Type::Any), val)
+            }
+        }
+
         let Value::Record { val: record, .. } = value else {
             errors.type_mismatch(path, Type::record(), value);
             return;
@@ -48,57 +199,36 @@ impl UpdateFromValue for Hooks {
         for (col, val) in record.iter() {
             let path = &mut path.push(col);
             match col.as_str() {
-                "pre_prompt" => {
-                    if let Ok(hooks) = val.as_list() {
-                        self.pre_prompt = hooks.into()
-                    } else {
-                        errors.type_mismatch(path, Type::list(Type::Any), val);
-                    }
-                }
-                "pre_execution" => {
-                    if let Ok(hooks) = val.as_list() {
-                        self.pre_execution = hooks.into()
-                    } else {
-                        errors.type_mismatch(path, Type::list(Type::Any), val);
-                    }
-                }
+                "pre_prompt" => update_hook_list(&mut self.pre_prompt, val, path, errors),
+                "pre_execution" => update_hook_list(&mut self.pre_execution, val, path, errors),
                 "env_change" => {
                     if let Ok(record) = val.as_record() {
                         self.env_change = record
                             .iter()
-                            .map(|(key, val)| {
-                                let old = self.env_change.remove(key).unwrap_or_default();
-                                let new = if let Ok(hooks) = val.as_list() {
-                                    hooks.into()
+                            .filter_map(|(key, val)| {
+                                let path = &mut path.push(key);
+                                if let Ok(hooks) = val.as_list() {
+                                    let hooks = hooks
+                                        .iter()
+                                        .enumerate()
+                                        .filter_map(|(i, val)| {
+                                            let path = &mut path.push_row(i);
+                                            Hook::from_value(val, path, errors)
+                                        })
+                                        .collect();
+                                    Some((key.clone(), hooks))
                                 } else {
-                                    errors.type_mismatch(
-                                        &path.push(key),
-                                        Type::list(Type::Any),
-                                        val,
-                                    );
-                                    old
-                                };
-                                (key.as_str().into(), new)
+                                    errors.type_mismatch(path, Type::list(Type::Any), val);
+                                    None
+                                }
                             })
-                            .collect();
+                            .collect()
                     } else {
-                        errors.type_mismatch(path, Type::record(), val);
+                        errors.type_mismatch(path, Type::record(), val)
                     }
                 }
-                "display_output" => {
-                    self.display_output = if val.is_nothing() {
-                        None
-                    } else {
-                        Some(val.clone())
-                    }
-                }
-                "command_not_found" => {
-                    self.command_not_found = if val.is_nothing() {
-                        None
-                    } else {
-                        Some(val.clone())
-                    }
-                }
+                "display_output" => update_hook(&mut self.display_output, val, path, errors),
+                "command_not_found" => update_hook(&mut self.command_not_found, val, path, errors),
                 _ => errors.unknown_option(path, val),
             }
         }

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -6,6 +6,9 @@ use helper::*;
 use prelude::*;
 use std::collections::HashMap;
 
+pub(crate) use error::ConfigErrors;
+pub(crate) use helper::{ConfigPath, UpdateFromValue};
+
 pub use ansi_coloring::UseAnsiColoring;
 pub use completions::{
     CompletionAlgorithm, CompletionConfig, CompletionSort, ExternalCompleterConfig,
@@ -15,7 +18,7 @@ pub use display_errors::DisplayErrors;
 pub use filesize::FilesizeConfig;
 pub use helper::extract_value;
 pub use history::{HistoryConfig, HistoryFileFormat};
-pub use hooks::Hooks;
+pub use hooks::{ConditionalHook, Hook, HookCode, Hooks};
 pub use ls::LsConfig;
 pub use output::ErrorStyle;
 pub use plugin_gc::{PluginGcConfig, PluginGcConfigs};

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -237,7 +237,7 @@ impl Stack {
     }
 
     pub fn remove_var(&mut self, var_id: VarId) {
-        for (idx, (id, _)) in self.vars.iter().enumerate() {
+        for (idx, (id, _)) in self.vars.iter().enumerate().rev() {
             if *id == var_id {
                 self.vars.remove(idx);
                 break;

--- a/crates/nu-protocol/src/errors/config_error.rs
+++ b/crates/nu-protocol/src/errors/config_error.rs
@@ -14,6 +14,7 @@ pub enum ConfigError {
         #[label = "expected {expected}, but got {actual}"]
         span: Span,
     },
+
     #[error("Invalid value for {path}")]
     #[diagnostic(code(nu::shell::invalid_value))]
     InvalidValue {
@@ -23,6 +24,7 @@ pub enum ConfigError {
         #[label = "expected {valid}, but got {actual}"]
         span: Span,
     },
+
     #[error("Unknown config option: {path}")]
     #[diagnostic(code(nu::shell::unknown_config_option))]
     UnknownOption {
@@ -30,6 +32,7 @@ pub enum ConfigError {
         #[label("remove this")]
         span: Span,
     },
+
     #[error("{path} requires a '{column}' column")]
     #[diagnostic(code(nu::shell::missing_required_column))]
     MissingRequiredColumn {
@@ -38,6 +41,7 @@ pub enum ConfigError {
         #[label("has no '{column}' column")]
         span: Span,
     },
+
     #[error("{path} is deprecated")]
     #[diagnostic(
         code(nu::shell::deprecated_config_option),
@@ -49,6 +53,7 @@ pub enum ConfigError {
         #[label("deprecated")]
         span: Span,
     },
+
     // TODO: remove this
     #[error(transparent)]
     #[diagnostic(transparent)]

--- a/crates/nu-protocol/src/value/into_value.rs
+++ b/crates/nu-protocol/src/value/into_value.rs
@@ -1,4 +1,4 @@
-use crate::{ast::CellPath, engine::Closure, Range, Record, ShellError, Span, Value};
+use crate::{ast::CellPath, engine::Closure, Range, Record, ShellError, Span, Spanned, Value};
 use chrono::{DateTime, FixedOffset};
 use std::{borrow::Borrow, collections::HashMap};
 
@@ -224,6 +224,12 @@ where
 }
 
 // Nu Types
+
+impl<T: IntoValue> IntoValue for Spanned<T> {
+    fn into_value(self, _span: Span) -> Value {
+        self.item.into_value(self.span)
+    }
+}
 
 impl IntoValue for Range {
     fn into_value(self, span: Span) -> Value {

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -1,4 +1,4 @@
-use nu_cmd_base::hook::{eval_env_change_hook, eval_hooks};
+use nu_cmd_base::hook::{eval_env_change_hook, eval_hook_list};
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_protocol::{
@@ -250,17 +250,16 @@ pub fn nu_repl() {
         }
 
         // Check for pre_prompt hook
-        let hook = engine_state.get_config().hooks.pre_prompt.clone();
-        if let Err(err) = eval_hooks(&mut engine_state, &mut stack, vec![], &hook, "pre_prompt") {
+        let hooks = engine_state.get_config().hooks.pre_prompt.clone();
+        if let Err(err) =
+            eval_hook_list(&mut engine_state, &mut stack, vec![], &hooks, "pre_prompt")
+        {
             outcome_err(&engine_state, &err);
         }
 
         // Check for env change hook
-        if let Err(err) = eval_env_change_hook(
-            &engine_state.get_config().hooks.env_change.clone(),
-            &mut engine_state,
-            &mut stack,
-        ) {
+        let hooks = engine_state.get_config().hooks.env_change.clone();
+        if let Err(err) = eval_env_change_hook(&hooks, &mut engine_state, &mut stack) {
             outcome_err(&engine_state, &err);
         }
 
@@ -272,12 +271,12 @@ pub fn nu_repl() {
             .expect("repl state mutex")
             .buffer = line.to_string();
 
-        let hook = engine_state.get_config().hooks.pre_execution.clone();
-        if let Err(err) = eval_hooks(
+        let hooks = engine_state.get_config().hooks.pre_execution.clone();
+        if let Err(err) = eval_hook_list(
             &mut engine_state,
             &mut stack,
             vec![],
-            &hook,
+            &hooks,
             "pre_execution",
         ) {
             outcome_err(&engine_state, &err);


### PR DESCRIPTION
# Description

Hooks are currently stored as `Value`s in the config. This allows invalid values to be stored which will later error at execution time. This PR adds hook types to ensure hooks are valid at the time when updating the config, rather than having to revalidate the hook values each time they are run.

# User-Facing Changes

TODO

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
