### PR TITLE
refactor(parser): use var_id for most constants in `ResolvedImportPattern`

### DIFF
--- a/crates/nu-lsp/src/ast.rs
+++ b/crates/nu-lsp/src/ast.rs
@@ -296,10 +296,10 @@ fn try_find_id_in_use(
             .find_module(name)
             .and_then(|module_id| (module_id == *module_id_ref).then_some(Id::Module(module_id))),
         None => working_set
-            .find_variable(name)
-            .map(Id::Variable)
+            .find_module(name)
+            .map(Id::Module)
             .or(working_set.find_decl(name).map(Id::Declaration))
-            .or(working_set.find_module(name).map(Id::Module)),
+            .or(working_set.find_variable(name).map(Id::Variable)),
         _ => None,
     };
     let check_location = |span: &Span| location.map_or(true, |pos| span.contains(*pos));

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2468,7 +2468,11 @@ pub fn parse_use(
 
     let mut constants = vec![];
 
-    for (name, const_val) in definitions.constants {
+    for (name, const_vid) in definitions.constants {
+        constants.push((name, const_vid));
+    }
+
+    for (name, const_val) in definitions.constant_values {
         let const_var_id =
             working_set.add_variable(name.clone(), name_span, const_val.get_type(), false);
         working_set.set_variable_const_val(const_var_id, const_val);
@@ -2967,7 +2971,10 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
             )
         }
     } else {
-        (ResolvedImportPattern::new(vec![], vec![], vec![]), vec![])
+        (
+            ResolvedImportPattern::new(vec![], vec![], vec![], vec![]),
+            vec![],
+        )
     };
 
     if errors.is_empty() {


### PR DESCRIPTION
# Description

This PR replaces most of the constants in `ResolvedImportPattern` from values to VarIds, this has benefits of:
1. less duplicated variables in state
2. precise span of variable, for example when calling `goto def` on a const imported by the `use` command, this allows it to find the original definition, instead of where the `use` command is.

Note that the logic is different here for nested submodules, not all values are flattened and propagated to the outmost record variable, but I didn't find any differences in real world usage.

I noticed that it was changed from `VarId` to `Value` in #10049.
Maybe @kubouch can find some edge cases where this PR fails to work as expected.

In my view, the record constants for `ResolvedImportPattern` should even reduced to single entry, if not able to get rid of.

# User-Facing Changes

# Tests + Formatting

# After Submitting
