### PR TITLE
Fix improperly escaped strings in stor update

### DIFF
--- a/crates/nu-command/src/stor/update.rs
+++ b/crates/nu-command/src/stor/update.rs
@@ -167,7 +167,6 @@ fn process(
         let mut placeholders: Vec<String> = Vec::new();
 
         for (index, (key, _)) in record.iter().enumerate() {
-            //let param_placeholder = format!("param{}", i);
             placeholders.push(format!("{} = ?{}", key, index + 1));
         }
         update_stmt.push_str(&placeholders.join(", "));

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -105,6 +105,7 @@ mod sort_by;
 mod source_env;
 mod split_column;
 mod split_row;
+mod stor;
 mod str_;
 mod table;
 mod take;

--- a/crates/nu-command/tests/commands/stor.rs
+++ b/crates/nu-command/tests/commands/stor.rs
@@ -1,0 +1,37 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn stor_insert() {
+    let actual = nu!(pipeline(
+        r#"
+            stor create --table-name test_table --columns { id: int, value: str };
+            stor insert -t test_table --data-record {
+                id: 1
+                value: "'Initial value'"
+            };
+            stor open | query db 'select value from test_table' | get 0.value
+        "#
+    ));
+
+    assert_eq!(actual.out, "'Initial value'");
+}
+
+#[test]
+fn stor_update_with_quote() {
+    let actual = nu!(pipeline(
+        r#"
+            stor create --table-name test_table --columns { id: int, value: str };
+            stor insert -t test_table --data-record {
+                id: 1
+                value: "'Initial value'"
+            };
+            stor update -t test_table --where-clause 'id = 1' --update-record {
+                id: 1
+                value: "This didn't work, but should now."
+            };
+            stor open | query db 'select value from test_table' | get 0.value
+        "#
+    ));
+
+    assert_eq!(actual.out, "This didn't work, but should now.");
+}


### PR DESCRIPTION
# Description

Fixes #14909 with the same technique used in #12820 for `stor insert`.  Single quotes (and others) now work properly in strings passed to `stor update`. Also did some minor refactoring on `stor insert` so it matches the changes in `stor update`.

# User-Facing Changes

Bug-fix.

# Tests + Formatting

Test added for this scenario.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A