### PR TITLE
Add completions for commands with a predetermined set of accepted values.

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -1,6 +1,7 @@
 use crate::completions::{
     CommandCompletion, Completer, CompletionOptions, CustomCompletion, DirectoryCompletion,
-    DotNuCompletion, FileCompletion, FlagCompletion, OperatorCompletion, VariableCompletion,
+    DotNuCompletion, FileCompletion, FlagCompletion, OperatorCompletion, OptionsCompletion,
+    VariableCompletion,
 };
 use nu_color_config::{color_record_to_nustyle, lookup_ansi_color_style};
 use nu_engine::eval_block;
@@ -337,6 +338,17 @@ impl NuCompleter {
                                     pos,
                                 );
                             }
+                            FlatShape::Option(options) => {
+                                let mut completer = OptionsCompletion::new(options.clone());
+                                return self.process_completion(
+                                    &mut completer,
+                                    &working_set,
+                                    prefix,
+                                    new_span,
+                                    fake_offset,
+                                    pos,
+                                );
+                            }
                             FlatShape::Directory => {
                                 let mut completer = DirectoryCompletion::new();
 
@@ -550,6 +562,26 @@ pub fn map_value_completions<'a>(
         }
 
         None
+    })
+    .collect()
+}
+
+pub fn map_string_completions<'a>(
+    list: impl Iterator<Item = &'a str>,
+    span: Span,
+    offset: usize,
+) -> Vec<SemanticSuggestion> {
+    list.map(|s| SemanticSuggestion {
+        suggestion: Suggestion {
+            value: s.to_string(),
+            span: reedline::Span {
+                start: span.start - offset,
+                end: span.end - offset,
+            },
+            ..Suggestion::default()
+        },
+        // kind: Some(SuggestionKind::Type(nu_protocol::Type::String)),
+        kind: None,
     })
     .collect()
 }

--- a/crates/nu-cli/src/completions/mod.rs
+++ b/crates/nu-cli/src/completions/mod.rs
@@ -9,6 +9,7 @@ mod dotnu_completions;
 mod file_completions;
 mod flag_completions;
 mod operator_completions;
+mod options_completions;
 mod variable_completions;
 
 pub use base::{Completer, SemanticSuggestion, SuggestionKind};
@@ -21,4 +22,5 @@ pub use dotnu_completions::DotNuCompletion;
 pub use file_completions::{file_path_completion, FileCompletion};
 pub use flag_completions::FlagCompletion;
 pub use operator_completions::OperatorCompletion;
+pub use options_completions::OptionsCompletion;
 pub use variable_completions::VariableCompletion;

--- a/crates/nu-cli/src/completions/options_completions.rs
+++ b/crates/nu-cli/src/completions/options_completions.rs
@@ -1,0 +1,43 @@
+use crate::completions::{Completer, CompletionOptions, SemanticSuggestion};
+use nu_protocol::{
+    engine::{Stack, StateWorkingSet},
+    Span,
+};
+
+use super::{completer::map_string_completions, completion_options::NuMatcher};
+
+pub struct OptionsCompletion {
+    options: Vec<String>,
+}
+
+impl OptionsCompletion {
+    pub fn new(options: Vec<String>) -> Self {
+        Self { options }
+    }
+}
+
+impl Completer for OptionsCompletion {
+    fn fetch(
+        &mut self,
+        _working_set: &StateWorkingSet,
+        _stack: &Stack,
+        prefix: &[u8],
+        span: Span,
+        offset: usize,
+        _pos: usize,
+        orig_options: &CompletionOptions,
+    ) -> Vec<SemanticSuggestion> {
+        let completion_options = orig_options.clone();
+
+        // Parse result
+        let suggestions =
+            map_string_completions(self.options.iter().map(String::as_str), span, offset);
+
+        let mut matcher = NuMatcher::new(String::from_utf8_lossy(prefix), completion_options);
+
+        for sugg in suggestions {
+            matcher.add_semantic_suggestion(sugg);
+        }
+        matcher.results()
+    }
+}

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -146,6 +146,7 @@ impl Highlighter for NuHighlighter {
                 FlatShape::Pipe => add_colored_token(&shape.1, next_token),
                 FlatShape::Redirection => add_colored_token(&shape.1, next_token),
                 FlatShape::Custom(..) => add_colored_token(&shape.1, next_token),
+                FlatShape::Option(..) => add_colored_token(&shape.1, next_token),
                 FlatShape::MatchPattern => add_colored_token(&shape.1, next_token),
             }
             last_seen_span = shape.0.end;

--- a/crates/nu-color-config/src/shape_color.rs
+++ b/crates/nu-color-config/src/shape_color.rs
@@ -10,6 +10,8 @@ pub fn default_shape_color(shape: &str) -> Style {
         "shape_bool" => Style::new().fg(Color::LightCyan),
         "shape_closure" => Style::new().fg(Color::Green).bold(),
         "shape_custom" => Style::new().fg(Color::Green),
+        "shape_option" => Style::new().fg(Color::Blue),
+        "shape_options" => Style::new().fg(Color::Green),
         "shape_datetime" => Style::new().fg(Color::Cyan).bold(),
         "shape_directory" => Style::new().fg(Color::Cyan),
         "shape_external" => Style::new().fg(Color::Cyan),

--- a/crates/nu-command/src/filters/merge/deep.rs
+++ b/crates/nu-command/src/filters/merge/deep.rs
@@ -42,7 +42,20 @@ The way lists and tables are merged is controlled by the `--strategy` flag:
                 "The new value to merge with.",
             )
             .category(Category::Filters)
-            .named("strategy", SyntaxShape::String, "The list merging strategy to use. One of: table (default), overwrite, append, prepend", Some('s'))
+            .named(
+                "strategy",
+                SyntaxShape::OptionsWrapper(
+                    Box::new(SyntaxShape::String),
+                    vec![
+                        "table".into(),
+                        "overwrite".into(),
+                        "append".into(),
+                        "prepend".into(),
+                    ],
+                ),
+                "The list merging strategy to use. (default: table)",
+                Some('s'),
+            )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -51,7 +51,12 @@ impl Command for FromCsv {
             .switch("no-infer", "no field type inferencing", None)
             .named(
                 "trim",
-                SyntaxShape::String,
+                SyntaxShape::OptionsWrapper(Box::new(SyntaxShape::String), vec![
+                    "all".into(),
+                    "headers".into(),
+                    "fields".into(),
+                    "none".into(),
+                ]),
                 "drop leading and trailing whitespaces around headers names and/or field values",
                 Some('t'),
             )

--- a/crates/nu-command/src/formats/from/tsv.rs
+++ b/crates/nu-command/src/formats/from/tsv.rs
@@ -43,12 +43,15 @@ impl Command for FromTsv {
             .switch("no-infer", "no field type inferencing", None)
             .named(
                 "trim",
-                SyntaxShape::OptionsWrapper(Box::new(SyntaxShape::String), vec![
-                    "all".into(),
-                    "headers".into(),
-                    "fields".into(),
-                    "none".into(),
-                ]),
+                SyntaxShape::OptionsWrapper(
+                    Box::new(SyntaxShape::String),
+                    vec![
+                        "all".into(),
+                        "headers".into(),
+                        "fields".into(),
+                        "none".into(),
+                    ],
+                ),
                 "drop leading and trailing whitespaces around headers names and/or field values",
                 Some('t'),
             )

--- a/crates/nu-command/src/formats/from/tsv.rs
+++ b/crates/nu-command/src/formats/from/tsv.rs
@@ -43,7 +43,12 @@ impl Command for FromTsv {
             .switch("no-infer", "no field type inferencing", None)
             .named(
                 "trim",
-                SyntaxShape::String,
+                SyntaxShape::OptionsWrapper(Box::new(SyntaxShape::String), vec![
+                    "all".into(),
+                    "headers".into(),
+                    "fields".into(),
+                    "none".into(),
+                ]),
                 "drop leading and trailing whitespaces around headers names and/or field values",
                 Some('t'),
             )

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -54,7 +54,10 @@ impl Command for Table {
             // TODO: make this more precise: what turns into string and what into raw stream
             .named(
                 "theme",
-                SyntaxShape::String,
+                SyntaxShape::OptionsWrapper(
+                    Box::new(SyntaxShape::String),
+                    SUPPORTED_TABLE_MODES.iter().copied().map(String::from).collect(),
+                ),
                 "set a table mode/theme",
                 Some('t'),
             )
@@ -113,7 +116,14 @@ impl Command for Table {
         let list_themes: bool = call.has_flag(engine_state, stack, "list")?;
         // if list argument is present we just need to return a list of supported table themes
         if list_themes {
-            let val = Value::list(supported_table_modes(), Span::test_data());
+            let val = Value::list(
+                SUPPORTED_TABLE_MODES
+                    .iter()
+                    .copied()
+                    .map(Value::test_string)
+                    .collect(),
+                Span::test_data(),
+            );
             return Ok(val.into_pipeline_data());
         }
 
@@ -1133,27 +1143,25 @@ fn convert_table_to_output(
     }
 }
 
-fn supported_table_modes() -> Vec<Value> {
-    vec![
-        Value::test_string("basic"),
-        Value::test_string("compact"),
-        Value::test_string("compact_double"),
-        Value::test_string("default"),
-        Value::test_string("heavy"),
-        Value::test_string("light"),
-        Value::test_string("none"),
-        Value::test_string("reinforced"),
-        Value::test_string("rounded"),
-        Value::test_string("thin"),
-        Value::test_string("with_love"),
-        Value::test_string("psql"),
-        Value::test_string("markdown"),
-        Value::test_string("dots"),
-        Value::test_string("restructured"),
-        Value::test_string("ascii_rounded"),
-        Value::test_string("basic_compact"),
-    ]
-}
+static SUPPORTED_TABLE_MODES: &[&str] = &[
+    "basic",
+    "compact",
+    "compact_double",
+    "default",
+    "heavy",
+    "light",
+    "none",
+    "reinforced",
+    "rounded",
+    "thin",
+    "with_love",
+    "psql",
+    "markdown",
+    "dots",
+    "restructured",
+    "ascii_rounded",
+    "basic_compact",
+];
 
 fn create_table_opts<'a>(
     engine_state: &'a EngineState,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1340,7 +1340,7 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
                 span: _,
                 span_id: _,
                 ty,
-                custom_completion,
+                completion: custom_completion,
             } = &alias.clone().wrapped_call
             {
                 trace!("parsing: alias of external call");
@@ -1361,7 +1361,7 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
                     ty.clone(),
                 );
 
-                expression.custom_completion = *custom_completion;
+                expression.completion = custom_completion.clone();
                 return expression;
             } else {
                 trace!("parsing: alias of internal call");
@@ -4874,7 +4874,12 @@ pub fn parse_value(
     match shape {
         SyntaxShape::CompleterWrapper(shape, custom_completion) => {
             let mut expression = parse_value(working_set, span, shape);
-            expression.custom_completion = Some(*custom_completion);
+            expression.completion = Completion::Custom(*custom_completion);
+            expression
+        }
+        SyntaxShape::OptionsWrapper(shape, custom_completion) => {
+            let mut expression = parse_value(working_set, span, shape);
+            expression.completion = Completion::Options(custom_completion.clone());
             expression
         }
         SyntaxShape::Number => parse_number(working_set, span),

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -8,6 +8,13 @@ use std::sync::Arc;
 
 use super::ListItem;
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Completion {
+    None,
+    Custom(DeclId),
+    Options(Vec<String>),
+}
+
 /// Wrapper around [`Expr`]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Expression {
@@ -15,7 +22,7 @@ pub struct Expression {
     pub span: Span,
     pub span_id: SpanId,
     pub ty: Type,
-    pub custom_completion: Option<DeclId>,
+    pub completion: Completion,
 }
 
 impl Expression {
@@ -26,7 +33,7 @@ impl Expression {
             span,
             span_id,
             ty: Type::Any,
-            custom_completion: None,
+            completion: Completion::None,
         }
     }
 
@@ -566,7 +573,7 @@ impl Expression {
             span,
             span_id,
             ty,
-            custom_completion: None,
+            completion: Completion::None,
         }
     }
 
@@ -576,7 +583,7 @@ impl Expression {
             span,
             span_id,
             ty,
-            custom_completion: None,
+            completion: Completion::None,
         }
     }
 
@@ -586,7 +593,7 @@ impl Expression {
             span,
             span_id: SpanId::new(0),
             ty,
-            custom_completion: None,
+            completion: Completion::None,
         }
     }
 
@@ -596,7 +603,7 @@ impl Expression {
             span: self.span,
             span_id,
             ty: self.ty,
-            custom_completion: self.custom_completion,
+            completion: self.completion,
         }
     }
 

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -32,6 +32,9 @@ pub enum SyntaxShape {
     /// A [`SyntaxShape`] with custom completion logic
     CompleterWrapper(Box<SyntaxShape>, DeclId),
 
+    /// A [`SyntaxShape`] with a set of options
+    OptionsWrapper(Box<SyntaxShape>, Vec<String>),
+
     /// A datetime value, eg `2022-02-02` or `2019-10-12T07:20:50.52+00:00`
     DateTime,
 
@@ -148,6 +151,7 @@ impl SyntaxShape {
             SyntaxShape::Binary => Type::Binary,
             SyntaxShape::CellPath => Type::Any,
             SyntaxShape::CompleterWrapper(inner, _) => inner.to_type(),
+            SyntaxShape::OptionsWrapper(inner, _) => inner.to_type(),
             SyntaxShape::DateTime => Type::Date,
             SyntaxShape::Duration => Type::Duration,
             SyntaxShape::Expression => Type::Any,
@@ -249,6 +253,7 @@ impl Display for SyntaxShape {
             SyntaxShape::Boolean => write!(f, "bool"),
             SyntaxShape::Error => write!(f, "error"),
             SyntaxShape::CompleterWrapper(x, _) => write!(f, "completable<{x}>"),
+            SyntaxShape::OptionsWrapper(x, _) => write!(f, "options<{x}>"),
             SyntaxShape::OneOf(list) => {
                 let arg_vec: Vec<_> = list.iter().map(|x| x.to_string()).collect();
                 let arg_string = arg_vec.join(", ");

--- a/crates/nu-std/std/config/mod.nu
+++ b/crates/nu-std/std/config/mod.nu
@@ -31,6 +31,7 @@ export def dark-theme [] {
         shape_bool: light_cyan
         shape_closure: green_bold
         shape_custom: green
+        shape_option: blue
         shape_datetime: cyan_bold
         shape_directory: cyan
         shape_external: cyan
@@ -99,6 +100,7 @@ export def light-theme [] {
         shape_bool: light_cyan
         shape_closure: green_bold
         shape_custom: green
+        shape_option: blue
         shape_datetime: cyan_bold
         shape_directory: cyan
         shape_external: cyan

--- a/crates/nu-utils/src/default_files/default_config.nu
+++ b/crates/nu-utils/src/default_files/default_config.nu
@@ -30,6 +30,7 @@ $env.config.color_config = {
     shape_bool: light_cyan
     shape_closure: green_bold
     shape_custom: green
+    shape_option: blue
     shape_datetime: cyan_bold
     shape_directory: cyan
     shape_external: cyan

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -623,6 +623,9 @@ $env.config.color_config.shape_datetime
 # shape_custom: A custom value, usually from a plugin
 $env.config.color_config.shape_custom
 
+# shape_option: An option for a command
+$env.config.color_config.shape_option
+
 # shape_nothing: A literal `null`
 $env.config.color_config.shape_nothing
 


### PR DESCRIPTION
# Description
- Add `SyntaxShape::OptionWrapper`, similar to `SyntaxShape::CompleterWrapper`, for builtin commands to provide completions for their options.
- Similar completions can be now easily added

# User-Facing Changes
Add completions for:
- `table --theme`
- `merge deep --strategy`
- `from csv --trim`
- `from tsv --trim`

# Tests + Formatting
No additional tests added, but they really should be. Wasn't sure how to, will add them before this PR is merged.

# After Submitting
N/A