### PR TITLE
fix(lsp): goto/hover on module name in some commands

### DIFF
--- a/crates/nu-lsp/src/goto.rs
+++ b/crates/nu-lsp/src/goto.rs
@@ -413,4 +413,97 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn goto_definition_of_module_in_hide() {
+        let (client_connection, _recv) = initialize_language_server(None);
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("goto");
+        script.push("use_module.nu");
+        let script = path_to_uri(&script);
+
+        open_unchecked(&client_connection, script.clone());
+
+        let resp = send_goto_definition_request(&client_connection, script.clone(), 3, 6);
+        let result = if let Message::Response(response) = resp {
+            response.result
+        } else {
+            panic!()
+        };
+
+        assert_json_eq!(
+            result,
+            serde_json::json!({
+                "uri": script.to_string().replace("use_module", "module"),
+                "range": {
+                    "start": { "line": 1, "character": 29 },
+                    "end": { "line": 1, "character": 30 }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn goto_definition_of_module_in_overlay_use() {
+        let (client_connection, _recv) = initialize_language_server(None);
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("goto");
+        script.push("use_module.nu");
+        let script = path_to_uri(&script);
+
+        open_unchecked(&client_connection, script.clone());
+
+        let resp = send_goto_definition_request(&client_connection, script.clone(), 1, 20);
+        let result = if let Message::Response(response) = resp {
+            response.result
+        } else {
+            panic!()
+        };
+
+        assert_json_eq!(
+            result,
+            serde_json::json!({
+                "uri": script.to_string().replace("use_module", "module"),
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 3, "character": 18 }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn goto_definition_of_module_in_overlay_hide() {
+        let (client_connection, _recv) = initialize_language_server(None);
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("goto");
+        script.push("use_module.nu");
+        let script = path_to_uri(&script);
+
+        open_unchecked(&client_connection, script.clone());
+
+        let resp = send_goto_definition_request(&client_connection, script.clone(), 2, 30);
+        let result = if let Message::Response(response) = resp {
+            response.result
+        } else {
+            panic!()
+        };
+
+        assert_json_eq!(
+            result,
+            serde_json::json!({
+                "uri": script.to_string().replace("use_module", "module"),
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 3, "character": 18 }
+                }
+            })
+        );
+    }
 }

--- a/crates/nu-lsp/src/goto.rs
+++ b/crates/nu-lsp/src/goto.rs
@@ -55,7 +55,7 @@ impl LanguageServer {
 mod tests {
     use crate::path_to_uri;
     use crate::tests::{initialize_language_server, open_unchecked};
-    use assert_json_diff::assert_json_eq;
+    use assert_json_diff::{assert_json_eq, assert_json_include};
     use lsp_server::{Connection, Message};
     use lsp_types::{
         request::{GotoDefinition, Request},
@@ -446,7 +446,7 @@ mod tests {
     }
 
     #[test]
-    fn goto_definition_of_module_in_overlay_use() {
+    fn goto_definition_of_module_in_overlay() {
         let (client_connection, _recv) = initialize_language_server(None);
 
         let mut script = fixtures();
@@ -464,29 +464,16 @@ mod tests {
             panic!()
         };
 
-        assert_json_eq!(
-            result,
-            serde_json::json!({
+        assert_json_include!(
+            actual: result,
+            expected: serde_json::json!({
                 "uri": script.to_string().replace("use_module", "module"),
                 "range": {
                     "start": { "line": 0, "character": 0 },
-                    "end": { "line": 3, "character": 18 }
+                    "end": { "line": 3 }
                 }
             })
         );
-    }
-
-    #[test]
-    fn goto_definition_of_module_in_overlay_hide() {
-        let (client_connection, _recv) = initialize_language_server(None);
-
-        let mut script = fixtures();
-        script.push("lsp");
-        script.push("goto");
-        script.push("use_module.nu");
-        let script = path_to_uri(&script);
-
-        open_unchecked(&client_connection, script.clone());
 
         let resp = send_goto_definition_request(&client_connection, script.clone(), 2, 30);
         let result = if let Message::Response(response) = resp {
@@ -495,13 +482,13 @@ mod tests {
             panic!()
         };
 
-        assert_json_eq!(
-            result,
-            serde_json::json!({
+        assert_json_include!(
+            actual: result,
+            expected: serde_json::json!({
                 "uri": script.to_string().replace("use_module", "module"),
                 "range": {
                     "start": { "line": 0, "character": 0 },
-                    "end": { "line": 3, "character": 18 }
+                    "end": { "line": 3 }
                 }
             })
         );

--- a/tests/fixtures/lsp/goto/use_module.nu
+++ b/tests/fixtures/lsp/goto/use_module.nu
@@ -1,1 +1,4 @@
 use module.nu "module name"
+overlay use module.nu as new_name
+overlay hide --keep-env [PWD] new_name
+hide "module name"


### PR DESCRIPTION
# Description
This PR enables basic goto def/hover features on module name in commands:
1. hide
2. overlay use
3. overlay hide

## Some pending issues

1. Somewhat related to #14816
```nushell
overlay use foo as bar
                  # |_______ cursor here
```
fails to work, since the position of the cursor is outside of the whole span of this call expression.
I'll try to fix #14816 later instead of implementing new weird workarounds.

2. references/renaming however is still buggy on overlays with `as`/`--prefix` features enabled.

# User-Facing Changes
# Tests + Formatting
3 more tests
# After Submitting
