### PR TITLE
Refactor I/O Errors

### DIFF
--- a/crates/nu-cli/src/commands/history/history_.rs
+++ b/crates/nu-cli/src/commands/history/history_.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::HistoryFileFormat;
+use nu_protocol::{shell_error::io::IoError, HistoryFileFormat};
 use reedline::{
     FileBackedHistory, History as ReedlineHistory, HistoryItem, SearchDirection, SearchQuery,
     SqliteBackedHistory,
@@ -93,10 +93,11 @@ impl Command for History {
                         )
                     })
                 })
-                .ok_or(ShellError::FileNotFound {
-                    file: history_path.display().to_string(),
-                    span: head,
-                })?
+                .ok_or(IoError::new(
+                    std::io::ErrorKind::NotFound,
+                    head,
+                    history_path,
+                ))?
                 .into_pipeline_data(head, signals)),
             HistoryFileFormat::Sqlite => Ok(history_reader
                 .and_then(|h| {
@@ -109,10 +110,11 @@ impl Command for History {
                         .enumerate()
                         .map(move |(idx, entry)| create_history_record(idx, entry, long, head))
                 })
-                .ok_or(ShellError::FileNotFound {
-                    file: history_path.display().to_string(),
-                    span: head,
-                })?
+                .ok_or(IoError::new(
+                    std::io::ErrorKind::NotFound,
+                    head,
+                    history_path,
+                ))?
                 .into_pipeline_data(head, signals)),
         }
     }

--- a/crates/nu-cli/src/commands/history/history_import.rs
+++ b/crates/nu-cli/src/commands/history/history_import.rs
@@ -1,7 +1,10 @@
 use std::path::{Path, PathBuf};
 
 use nu_engine::command_prelude::*;
-use nu_protocol::HistoryFileFormat;
+use nu_protocol::{
+    shell_error::{self, io::IoError},
+    HistoryFileFormat,
+};
 
 use reedline::{
     FileBackedHistory, History, HistoryItem, ReedlineError, SearchQuery, SqliteBackedHistory,
@@ -69,17 +72,16 @@ Note that history item IDs are ignored when importing from file."#
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let span = call.head;
         let ok = Ok(Value::nothing(call.head).into_pipeline_data());
 
         let Some(history) = engine_state.history_config() else {
             return ok;
         };
         let Some(current_history_path) = history.file_path() else {
-            return Err(ShellError::ConfigDirNotFound {
-                span: Some(call.head),
-            });
+            return Err(ShellError::ConfigDirNotFound { span: span.into() });
         };
-        if let Some(bak_path) = backup(&current_history_path)? {
+        if let Some(bak_path) = backup(&current_history_path, span)? {
             println!("Backed history to {}", bak_path.display());
         }
         match input {
@@ -216,7 +218,7 @@ fn item_from_record(mut rec: Record, span: Span) -> Result<HistoryItem, ShellErr
         hostname: get(rec, fields::HOSTNAME, |v| Ok(v.as_str()?.to_owned()))?,
         cwd: get(rec, fields::CWD, |v| Ok(v.as_str()?.to_owned()))?,
         exit_status: get(rec, fields::EXIT_STATUS, |v| v.as_int())?,
-        duration: get(rec, fields::DURATION, duration_from_value)?,
+        duration: get(rec, fields::DURATION, |v| duration_from_value(v, span))?,
         more_info: None,
         // TODO: Currently reedline doesn't let you create session IDs.
         session_id: None,
@@ -232,19 +234,21 @@ fn item_from_record(mut rec: Record, span: Span) -> Result<HistoryItem, ShellErr
     Ok(item)
 }
 
-fn duration_from_value(v: Value) -> Result<std::time::Duration, ShellError> {
+fn duration_from_value(v: Value, span: Span) -> Result<std::time::Duration, ShellError> {
     chrono::Duration::nanoseconds(v.as_duration()?)
         .to_std()
-        .map_err(|_| ShellError::IOError {
-            msg: "negative duration not supported".to_string(),
-        })
+        .map_err(|_| ShellError::NeedsPositiveValue { span })
 }
 
-fn find_backup_path(path: &Path) -> Result<PathBuf, ShellError> {
+fn find_backup_path(path: &Path, span: Span) -> Result<PathBuf, ShellError> {
     let Ok(mut bak_path) = path.to_path_buf().into_os_string().into_string() else {
         // This isn't fundamentally problem, but trying to work with OsString is a nightmare.
-        return Err(ShellError::IOError {
-            msg: "History path mush be representable as UTF-8".to_string(),
+        return Err(ShellError::GenericError {
+            error: "History path not UTF-8".to_string(),
+            msg: "History path must be representable as UTF-8".to_string(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
         });
     };
     bak_path.push_str(".bak");
@@ -260,23 +264,31 @@ fn find_backup_path(path: &Path) -> Result<PathBuf, ShellError> {
             return Ok(PathBuf::from(bak_path));
         }
     }
-    Err(ShellError::IOError {
-        msg: "Too many existing backup files".to_string(),
+    Err(ShellError::GenericError {
+        error: "Too many backup files".to_string(),
+        msg: "Found too many existing backup files".to_string(),
+        span: Some(span),
+        help: None,
+        inner: vec![],
     })
 }
 
-fn backup(path: &Path) -> Result<Option<PathBuf>, ShellError> {
+fn backup(path: &Path, span: Span) -> Result<Option<PathBuf>, ShellError> {
     match path.metadata() {
         Ok(md) if md.is_file() => (),
         Ok(_) => {
-            return Err(ShellError::IOError {
-                msg: "history path exists but is not a file".to_string(),
-            })
+            return Err(IoError::new_with_additional_context(
+                shell_error::io::ErrorKind::NotAFile,
+                span,
+                PathBuf::from(path),
+                "history path exists but is not a file",
+            )
+            .into())
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => return Err(e.into()),
     }
-    let bak_path = find_backup_path(path)?;
+    let bak_path = find_backup_path(path, span)?;
     std::fs::copy(path, &bak_path)?;
     Ok(Some(bak_path))
 }
@@ -388,7 +400,7 @@ mod tests {
         for name in existing {
             std::fs::File::create_new(dir.path().join(name)).unwrap();
         }
-        let got = find_backup_path(&dir.path().join("history.dat")).unwrap();
+        let got = find_backup_path(&dir.path().join("history.dat"), Span::test_data()).unwrap();
         assert_eq!(got, dir.path().join(want))
     }
 
@@ -400,7 +412,7 @@ mod tests {
         write!(&mut history, "123").unwrap();
         let want_bak_path = dir.path().join("history.dat.bak");
         assert_eq!(
-            backup(&dir.path().join("history.dat")),
+            backup(&dir.path().join("history.dat"), Span::test_data()),
             Ok(Some(want_bak_path.clone()))
         );
         let got_data = String::from_utf8(std::fs::read(want_bak_path).unwrap()).unwrap();
@@ -410,7 +422,7 @@ mod tests {
     #[test]
     fn test_backup_no_file() {
         let dir = tempfile::tempdir().unwrap();
-        let bak_path = backup(&dir.path().join("history.dat")).unwrap();
+        let bak_path = backup(&dir.path().join("history.dat"), Span::test_data()).unwrap();
         assert!(bak_path.is_none());
     }
 }

--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -2,6 +2,7 @@ use crossterm::{
     event::Event, event::KeyCode, event::KeyEvent, execute, terminal, QueueableCommand,
 };
 use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::io::IoError;
 use std::io::{stdout, Write};
 
 #[derive(Clone)]
@@ -39,7 +40,13 @@ impl Command for KeybindingsListen {
         match print_events(engine_state) {
             Ok(v) => Ok(v.into_pipeline_data()),
             Err(e) => {
-                terminal::disable_raw_mode()?;
+                terminal::disable_raw_mode().map_err(|err| {
+                    IoError::new_internal(
+                        err.kind(),
+                        "Could not disable raw mode",
+                        nu_protocol::location!(),
+                    )
+                })?;
                 Err(ShellError::GenericError {
                     error: "Error with input".into(),
                     msg: "".into(),
@@ -63,8 +70,20 @@ impl Command for KeybindingsListen {
 pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
     let config = engine_state.get_config();
 
-    stdout().flush()?;
-    terminal::enable_raw_mode()?;
+    stdout().flush().map_err(|err| {
+        IoError::new_internal(
+            err.kind(),
+            "Could not flush stdout",
+            nu_protocol::location!(),
+        )
+    })?;
+    terminal::enable_raw_mode().map_err(|err| {
+        IoError::new_internal(
+            err.kind(),
+            "Could not enable raw mode",
+            nu_protocol::location!(),
+        )
+    })?;
 
     if config.use_kitty_protocol {
         if let Ok(false) = crossterm::terminal::supports_keyboard_enhancement() {
@@ -94,7 +113,9 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
     let mut stdout = std::io::BufWriter::new(std::io::stderr());
 
     loop {
-        let event = crossterm::event::read()?;
+        let event = crossterm::event::read().map_err(|err| {
+            IoError::new_internal(err.kind(), "Could not read event", nu_protocol::location!())
+        })?;
         if event == Event::Key(KeyCode::Esc.into()) {
             break;
         }
@@ -113,9 +134,25 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
 
             _ => "".to_string(),
         };
-        stdout.queue(crossterm::style::Print(o))?;
-        stdout.queue(crossterm::style::Print("\r\n"))?;
-        stdout.flush()?;
+        stdout.queue(crossterm::style::Print(o)).map_err(|err| {
+            IoError::new_internal(
+                err.kind(),
+                "Could not print output record",
+                nu_protocol::location!(),
+            )
+        })?;
+        stdout
+            .queue(crossterm::style::Print("\r\n"))
+            .map_err(|err| {
+                IoError::new_internal(
+                    err.kind(),
+                    "Could not print linebreak",
+                    nu_protocol::location!(),
+                )
+            })?;
+        stdout.flush().map_err(|err| {
+            IoError::new_internal(err.kind(), "Could not flush", nu_protocol::location!())
+        })?;
     }
 
     if config.use_kitty_protocol {
@@ -125,7 +162,13 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
         );
     }
 
-    terminal::disable_raw_mode()?;
+    terminal::disable_raw_mode().map_err(|err| {
+        IoError::new_internal(
+            err.kind(),
+            "Could not disable raw mode",
+            nu_protocol::location!(),
+        )
+    })?;
 
     Ok(Value::nothing(Span::unknown()))
 }

--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -18,7 +18,7 @@ const OLD_PLUGIN_FILE: &str = "plugin.nu";
 
 #[cfg(feature = "plugin")]
 pub fn read_plugin_file(engine_state: &mut EngineState, plugin_file: Option<Spanned<String>>) {
-    use nu_protocol::ShellError;
+    use nu_protocol::{shell_error::io::IoError, ShellError};
     use std::path::Path;
 
     let span = plugin_file.as_ref().map(|s| s.span);
@@ -78,16 +78,12 @@ pub fn read_plugin_file(engine_state: &mut EngineState, plugin_file: Option<Span
                 } else {
                     report_shell_error(
                         engine_state,
-                        &ShellError::GenericError {
-                            error: format!(
-                                "Error while opening plugin registry file: {}",
-                                plugin_path.display()
-                            ),
-                            msg: "plugin path defined here".into(),
-                            span,
-                            help: None,
-                            inner: vec![err.into()],
-                        },
+                        &ShellError::Io(IoError::new_internal_with_path(
+                            err.kind(),
+                            "Could not open plugin registry file",
+                            nu_protocol::location!(),
+                            plugin_path,
+                        )),
                     );
                     return;
                 }
@@ -234,8 +230,8 @@ pub fn eval_config_contents(
 #[cfg(feature = "plugin")]
 pub fn migrate_old_plugin_file(engine_state: &EngineState) -> bool {
     use nu_protocol::{
-        PluginExample, PluginIdentity, PluginRegistryItem, PluginRegistryItemData, PluginSignature,
-        ShellError,
+        shell_error::io::IoError, PluginExample, PluginIdentity, PluginRegistryItem,
+        PluginRegistryItemData, PluginSignature, ShellError,
     };
     use std::collections::BTreeMap;
 
@@ -324,7 +320,15 @@ pub fn migrate_old_plugin_file(engine_state: &EngineState) -> bool {
     // Write the new file
     let new_plugin_file_path = config_dir.join(PLUGIN_FILE);
     if let Err(err) = std::fs::File::create(&new_plugin_file_path)
-        .map_err(|e| e.into())
+        .map_err(|err| {
+            IoError::new_internal_with_path(
+                err.kind(),
+                "Could not create new plugin file",
+                nu_protocol::location!(),
+                new_plugin_file_path.clone(),
+            )
+        })
+        .map_err(ShellError::from)
         .and_then(|file| contents.write_to(file, None))
     {
         report_shell_error(

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -847,10 +847,12 @@ fn do_auto_cd(
         if !path.exists() {
             report_shell_error(
                 engine_state,
-                &ShellError::DirectoryNotFound {
-                    dir: path.to_string_lossy().to_string(),
+                &ShellError::Io(IoError::new_with_additional_context(
+                    std::io::ErrorKind::NotFound,
                     span,
-                },
+                    PathBuf::from(&path),
+                    "Cannot change directory",
+                )),
             );
         }
         path.to_string_lossy().to_string()

--- a/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
@@ -3,7 +3,7 @@ use std::io::{self, Read, Write};
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
 
-use nu_protocol::Signals;
+use nu_protocol::{shell_error::io::IoError, Signals};
 use num_traits::ToPrimitive;
 
 struct Arguments {
@@ -142,7 +142,7 @@ fn byte_stream_to_bits(stream: ByteStream, head: Span) -> ByteStream {
             ByteStreamType::String,
             move |buffer| {
                 let mut byte = [0];
-                if reader.read(&mut byte[..]).err_span(head)? > 0 {
+                if reader.read(&mut byte[..]).map_err(|err| IoError::new(err.kind(), head, None))? > 0 {
                     // Format the byte as bits
                     if is_first {
                         is_first = false;

--- a/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
@@ -142,7 +142,11 @@ fn byte_stream_to_bits(stream: ByteStream, head: Span) -> ByteStream {
             ByteStreamType::String,
             move |buffer| {
                 let mut byte = [0];
-                if reader.read(&mut byte[..]).map_err(|err| IoError::new(err.kind(), head, None))? > 0 {
+                if reader
+                    .read(&mut byte[..])
+                    .map_err(|err| IoError::new(err.kind(), head, None))?
+                    > 0
+                {
                     // Format the byte as bits
                     if is_first {
                         is_first = false;

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -164,7 +164,9 @@ impl Command for Do {
                             None => String::new(),
                             Some(mut stderr) => {
                                 let mut buf = String::new();
-                                stderr.read_to_string(&mut buf).map_err(|err| IoError::new(err.kind(), span, None))?;
+                                stderr
+                                    .read_to_string(&mut buf)
+                                    .map_err(|err| IoError::new(err.kind(), span, None))?;
                                 buf
                             }
                         };

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -154,7 +154,7 @@ impl Command for Do {
                                         })?;
                                         Ok::<_, ShellError>(buf)
                                     })
-                                    .err_span(head)
+                                    .map_err(|err| IoError::new(err.kind(), head, None))
                             })
                             .transpose()?;
 
@@ -164,7 +164,7 @@ impl Command for Do {
                             None => String::new(),
                             Some(mut stderr) => {
                                 let mut buf = String::new();
-                                stderr.read_to_string(&mut buf).err_span(span)?;
+                                stderr.read_to_string(&mut buf).map_err(|err| IoError::new(err.kind(), span, None))?;
                                 buf
                             }
                         };

--- a/crates/nu-cmd-plugin/src/commands/plugin/add.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/add.rs
@@ -1,8 +1,8 @@
 use crate::util::{get_plugin_dirs, modify_plugin_file};
 use nu_engine::command_prelude::*;
 use nu_plugin_engine::{GetPlugin, PersistentPlugin};
-use nu_protocol::{PluginGcConfig, PluginIdentity, PluginRegistryItem, RegisteredPlugin};
-use std::sync::Arc;
+use nu_protocol::{shell_error::io::IoError, PluginGcConfig, PluginIdentity, PluginRegistryItem, RegisteredPlugin};
+use std::{path::PathBuf, sync::Arc};
 
 #[derive(Clone)]
 pub struct PluginAdd;
@@ -86,11 +86,11 @@ apparent the next time `nu` is next launched with that plugin registry file.
         let filename_expanded = nu_path::locate_in_dirs(&filename.item, &cwd, || {
             get_plugin_dirs(engine_state, stack)
         })
-        .err_span(filename.span)?;
+        .map_err(|err| IoError::new(err.kind(), filename.span, PathBuf::from(filename.item)))?;
 
         let shell_expanded = shell
             .as_ref()
-            .map(|s| nu_path::canonicalize_with(&s.item, &cwd).err_span(s.span))
+            .map(|s| nu_path::canonicalize_with(&s.item, &cwd).map_err(|err| IoError::new(err.kind(), s.span, None)))
             .transpose()?;
 
         // Parse the plugin filename so it can be used to spawn the plugin

--- a/crates/nu-cmd-plugin/src/commands/plugin/add.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/add.rs
@@ -1,7 +1,9 @@
 use crate::util::{get_plugin_dirs, modify_plugin_file};
 use nu_engine::command_prelude::*;
 use nu_plugin_engine::{GetPlugin, PersistentPlugin};
-use nu_protocol::{shell_error::io::IoError, PluginGcConfig, PluginIdentity, PluginRegistryItem, RegisteredPlugin};
+use nu_protocol::{
+    shell_error::io::IoError, PluginGcConfig, PluginIdentity, PluginRegistryItem, RegisteredPlugin,
+};
 use std::{path::PathBuf, sync::Arc};
 
 #[derive(Clone)]
@@ -90,7 +92,10 @@ apparent the next time `nu` is next launched with that plugin registry file.
 
         let shell_expanded = shell
             .as_ref()
-            .map(|s| nu_path::canonicalize_with(&s.item, &cwd).map_err(|err| IoError::new(err.kind(), s.span, None)))
+            .map(|s| {
+                nu_path::canonicalize_with(&s.item, &cwd)
+                    .map_err(|err| IoError::new(err.kind(), s.span, None))
+            })
             .transpose()?;
 
         // Parse the plugin filename so it can be used to spawn the plugin

--- a/crates/nu-cmd-plugin/src/util.rs
+++ b/crates/nu-cmd-plugin/src/util.rs
@@ -45,8 +45,8 @@ pub(crate) fn read_plugin_file(
     // Try to read the plugin file if it exists
     if fs::metadata(&plugin_registry_file_path).is_ok_and(|m| m.len() > 0) {
         PluginRegistryFile::read_from(
-
-            File::open(&plugin_registry_file_path).map_err(|err| IoError::new(err.kind(), file_span, plugin_registry_file_path))?,
+            File::open(&plugin_registry_file_path)
+                .map_err(|err| IoError::new(err.kind(), file_span, plugin_registry_file_path))?,
             Some(file_span),
         )
     } else if let Some(path) = custom_path {
@@ -74,7 +74,9 @@ pub(crate) fn modify_plugin_file(
     // Try to read the plugin file if it exists
     let mut contents = if fs::metadata(&plugin_registry_file_path).is_ok_and(|m| m.len() > 0) {
         PluginRegistryFile::read_from(
-            File::open(&plugin_registry_file_path).map_err(|err| IoError::new(err.kind(), file_span, plugin_registry_file_path.clone()))?,
+            File::open(&plugin_registry_file_path).map_err(|err| {
+                IoError::new(err.kind(), file_span, plugin_registry_file_path.clone())
+            })?,
             Some(file_span),
         )?
     } else {
@@ -86,7 +88,8 @@ pub(crate) fn modify_plugin_file(
 
     // Save the modified file on success
     contents.write_to(
-        File::create(&plugin_registry_file_path).map_err(|err| IoError::new(err.kind(), file_span, plugin_registry_file_path))?,
+        File::create(&plugin_registry_file_path)
+            .map_err(|err| IoError::new(err.kind(), file_span, plugin_registry_file_path))?,
         Some(span),
     )?;
 

--- a/crates/nu-cmd-plugin/src/util.rs
+++ b/crates/nu-cmd-plugin/src/util.rs
@@ -50,10 +50,11 @@ pub(crate) fn read_plugin_file(
             Some(file_span),
         )
     } else if let Some(path) = custom_path {
-        Err(ShellError::FileNotFound {
-            file: path.item.clone(),
-            span: path.span,
-        })
+        Err(ShellError::Io(IoError::new(
+            std::io::ErrorKind::NotFound,
+            path.span,
+            PathBuf::from(&path.item),
+        )))
     } else {
         Ok(PluginRegistryFile::default())
     }

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::io::IoError;
 use std::{
     collections::VecDeque,
     io::{self, BufRead},
@@ -76,7 +77,7 @@ impl Command for BytesEndsWith {
                     Ok(&[]) => break,
                     Ok(buf) => buf,
                     Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
-                    Err(e) => return Err(e.into_spanned(span).into()),
+                    Err(e) => return Err(IoError::new(e.kind(), span, None).into()),
                 };
                 let len = buf.len();
                 if len >= cap {

--- a/crates/nu-command/src/bytes/starts_with.rs
+++ b/crates/nu-command/src/bytes/starts_with.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::io::IoError;
 use std::io::Read;
 
 struct Arguments {
@@ -71,7 +72,7 @@ impl Command for BytesStartsWith {
             reader
                 .take(pattern.len() as u64)
                 .read_to_end(&mut start)
-                .err_span(span)?;
+                .map_err(|err| IoError::new(err.kind(), span, None))?;
 
             Ok(Value::bool(start == pattern, head).into_pipeline_data())
         } else {

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
-use nu_protocol::{into_code, Config};
+use nu_protocol::{shell_error::into_code, Config};
 use nu_utils::get_system_locale;
 use num_format::ToFormattedString;
 

--- a/crates/nu-command/src/env/source_env.rs
+++ b/crates/nu-command/src/env/source_env.rs
@@ -2,7 +2,7 @@ use nu_engine::{
     command_prelude::*, find_in_dirs_env, get_dirs_var_from_call, get_eval_block_with_early_return,
     redirect_env,
 };
-use nu_protocol::{engine::CommandType, BlockId};
+use nu_protocol::{engine::CommandType, shell_error::io::IoError, BlockId};
 use std::path::PathBuf;
 
 /// Source a file for environment variables.
@@ -65,10 +65,11 @@ impl Command for SourceEnv {
         )? {
             PathBuf::from(&path)
         } else {
-            return Err(ShellError::FileNotFound {
-                file: source_filename.item,
-                span: source_filename.span,
-            });
+            return Err(ShellError::Io(IoError::new(
+                std::io::ErrorKind::NotFound,
+                source_filename.span,
+                PathBuf::from(source_filename.item),
+            )));
         };
 
         if let Some(parent) = file_path.parent() {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -254,10 +254,12 @@ fn ls_for_one_pattern(
         if let Some(path) = pattern_arg {
             // it makes no sense to list an empty string.
             if path.item.as_ref().is_empty() {
-                return Err(ShellError::FileNotFoundCustom {
-                    msg: "empty string('') directory or file does not exist".to_string(),
-                    span: path.span,
-                });
+                return Err(ShellError::Io(IoError::new_with_additional_context(
+                    std::io::ErrorKind::NotFound,
+                    path.span,
+                    PathBuf::from(path.item.to_string()),
+                    "empty string('') directory or file does not exist",
+                )));
             }
             match path.item {
                 NuGlob::DoNotExpand(p) => Some(Spanned {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -907,14 +907,12 @@ mod windows_helper {
                 &mut find_data,
             ) {
                 Ok(_) => Ok(find_data),
-                Err(e) => Err(ShellError::ReadingFile {
-                    msg: format!(
-                        "Could not read metadata for '{}':\n  '{}'",
-                        filename.to_string_lossy(),
-                        e
-                    ),
+                Err(e) => Err(ShellError::Io(IoError::new_with_additional_context(
+                    std::io::ErrorKind::Other,
                     span,
-                }),
+                    PathBuf::from(filename),
+                    format!("Could not read metadata: {e}"),
+                ))),
             }
         }
     }

--- a/crates/nu-command/src/filesystem/mktemp.rs
+++ b/crates/nu-command/src/filesystem/mktemp.rs
@@ -109,10 +109,7 @@ impl Command for Mktemp {
             Ok(res) => {
                 res.into_os_string()
                     .into_string()
-                    .map_err(|e| ShellError::IOErrorSpanned {
-                        msg: e.to_string_lossy().to_string(),
-                        span,
-                    })?
+                    .map_err(|_| ShellError::NonUtf8 { span })?
             }
             Err(e) => {
                 return Err(ShellError::GenericError {

--- a/crates/nu-command/src/filesystem/mktemp.rs
+++ b/crates/nu-command/src/filesystem/mktemp.rs
@@ -106,11 +106,10 @@ impl Command for Mktemp {
         };
 
         let res = match uu_mktemp::mktemp(&options) {
-            Ok(res) => {
-                res.into_os_string()
-                    .into_string()
-                    .map_err(|_| ShellError::NonUtf8 { span })?
-            }
+            Ok(res) => res
+                .into_os_string()
+                .into_string()
+                .map_err(|_| ShellError::NonUtf8 { span })?,
             Err(e) => {
                 return Err(ShellError::GenericError {
                     error: format!("{}", e),

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -93,8 +93,6 @@ impl Command for Open {
                 .map_err(|err| match err {
                     ShellError::Io(mut err) => {
                         err.span = arg_span;
-                        // The additional context from `nu_engine::glob_from` doesn't help here
-                        err.additional_context = None;
                         err.into()
                     }
                     _ => err,

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -141,7 +141,7 @@ impl Command for Open {
                     }
 
                     if path.is_dir() {
-                        // At least under this windows this check ensures that we don't get a
+                        // At least under windows this check ensures that we don't get a
                         // permission denied error on directories
                         return Err(ShellError::Io(IoError::new(
                             shell_error::io::ErrorKind::IsADirectory,

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -91,10 +91,12 @@ impl Command for Open {
 
             for path in nu_engine::glob_from(&path, &cwd, call_span, None)
                 .map_err(|err| match err {
-                    ShellError::Io(err) => ShellError::Io(IoError {
-                        span: arg_span,
-                        ..err
-                    }),
+                    ShellError::Io(mut err) => {
+                        err.span = arg_span;
+                        // The additional context fromm `nu_engine::glob_from` doesn't help here
+                        err.additional_context = None;
+                        err.into()
+                    }
                     _ => err,
                 })?
                 .1

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -93,7 +93,7 @@ impl Command for Open {
                 .map_err(|err| match err {
                     ShellError::Io(mut err) => {
                         err.span = arg_span;
-                        // The additional context fromm `nu_engine::glob_from` doesn't help here
+                        // The additional context from `nu_engine::glob_from` doesn't help here
                         err.additional_context = None;
                         err.into()
                     }

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -425,8 +425,7 @@ fn rm(
                 };
 
                 if let Err(e) = result {
-                    let msg = format!("Could not delete {:}: {e:}", f.to_string_lossy());
-                    Err(ShellError::RemoveNotPossible { msg, span })
+                    Err(ShellError::Io(IoError::new(e.kind(), span, f)))
                 } else if verbose {
                     let msg = if interactive && !confirmed {
                         "not deleted"

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -433,13 +433,11 @@ fn open_file(path: &Path, span: Span, append: bool) -> Result<File, ShellError> 
         }
     };
 
-    file.map_err(|e| ShellError::GenericError {
-        error: format!("Problem with [{}], Permission denied", path.display()),
-        msg: e.to_string(),
-        span: Some(span),
-        help: None,
-        inner: vec![],
-    })
+    file.map_err(|err| ShellError::Io(IoError::new(
+        err.kind(), 
+        span, 
+        PathBuf::from(path)
+    )))
 }
 
 /// Get output file and optional stderr file

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -433,11 +433,7 @@ fn open_file(path: &Path, span: Span, append: bool) -> Result<File, ShellError> 
         }
     };
 
-    file.map_err(|err| ShellError::Io(IoError::new(
-        err.kind(), 
-        span, 
-        PathBuf::from(path)
-    )))
+    file.map_err(|err| ShellError::Io(IoError::new(err.kind(), span, PathBuf::from(path))))
 }
 
 /// Get output file and optional stderr file

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -1,6 +1,6 @@
 #[allow(deprecated)]
 use nu_engine::{command_prelude::*, current_dir};
-use nu_protocol::NuGlob;
+use nu_protocol::{shell_error::io::IoError, NuGlob};
 use std::path::PathBuf;
 use uu_cp::{BackupMode, CopyMode, UpdateMode};
 
@@ -197,10 +197,11 @@ impl Command for UCp {
                     .map(|f| f.1)?
                     .collect();
             if exp_files.is_empty() {
-                return Err(ShellError::FileNotFound {
-                    file: p.item.to_string(),
-                    span: p.span,
-                });
+                return Err(ShellError::Io(IoError::new(
+                    std::io::ErrorKind::NotFound,
+                    p.span,
+                    PathBuf::from(p.item.to_string()),
+                )));
             };
             let mut app_vals: Vec<PathBuf> = Vec::new();
             for v in exp_files {

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -1,7 +1,7 @@
 #[allow(deprecated)]
 use nu_engine::{command_prelude::*, current_dir};
 use nu_path::expand_path_with;
-use nu_protocol::NuGlob;
+use nu_protocol::{shell_error::io::IoError, NuGlob};
 use std::{ffi::OsString, path::PathBuf};
 use uu_mv::{BackupMode, UpdateMode};
 
@@ -138,10 +138,11 @@ impl Command for UMv {
                     .map(|f| f.1)?
                     .collect();
             if exp_files.is_empty() {
-                return Err(ShellError::FileNotFound {
-                    file: p.item.to_string(),
-                    span: p.span,
-                });
+                return Err(ShellError::Io(IoError::new(
+                    std::io::ErrorKind::NotFound,
+                    p.span,
+                    PathBuf::from(p.item.to_string()),
+                )));
             };
             let mut app_vals: Vec<PathBuf> = Vec::new();
             for v in exp_files {

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -151,14 +151,22 @@ impl Command for Watch {
         let mut debouncer = match new_debouncer(debounce_duration, None, tx) {
             Ok(d) => d,
             Err(e) => {
-                return Err(ShellError::IOError {
-                    msg: format!("Failed to create watcher: {e}"),
-                })
+                return Err(ShellError::GenericError {
+                    error: "Failed to create watcher".to_string(),
+                    msg: e.to_string(),
+                    span: Some(call.head),
+                    help: None,
+                    inner: vec![],
+                });
             }
         };
         if let Err(e) = debouncer.watcher().watch(&path, recursive_mode) {
-            return Err(ShellError::IOError {
-                msg: format!("Failed to create watcher: {e}"),
+            return Err(ShellError::GenericError {
+                error: "Failed to create watcher".to_string(),
+                msg: e.to_string(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
             });
         }
         // need to cache to make sure that rename event works.
@@ -249,13 +257,21 @@ impl Command for Watch {
                     }
                 }
                 Ok(Err(_)) => {
-                    return Err(ShellError::IOError {
+                    return Err(ShellError::GenericError {
+                        error: "Receiving events failed".to_string(),
                         msg: "Unexpected errors when receiving events".into(),
-                    })
+                        span: None,
+                        help: None,
+                        inner: vec![],
+                    });
                 }
                 Err(RecvTimeoutError::Disconnected) => {
-                    return Err(ShellError::IOError {
+                    return Err(ShellError::GenericError {
+                        error: "Disconnected".to_string(),
                         msg: "Unexpected disconnect from file watcher".into(),
+                        span: None,
+                        help: None,
+                        inner: vec![],
                     });
                 }
                 Err(RecvTimeoutError::Timeout) => {}

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -9,6 +9,7 @@ use nu_engine::{command_prelude::*, ClosureEval};
 use nu_protocol::{
     engine::{Closure, StateWorkingSet},
     format_shell_error,
+    shell_error::io::IoError,
 };
 use std::{
     path::PathBuf,
@@ -83,11 +84,12 @@ impl Command for Watch {
 
         let path = match nu_path::canonicalize_with(path_no_whitespace, cwd) {
             Ok(p) => p,
-            Err(_) => {
-                return Err(ShellError::DirectoryNotFound {
-                    dir: path_no_whitespace.to_string(),
-                    span: path_arg.span,
-                })
+            Err(err) => {
+                return Err(ShellError::Io(IoError::new(
+                    err.kind(),
+                    path_arg.span,
+                    PathBuf::from(path_no_whitespace),
+                )))
             }
         };
 

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -42,7 +42,12 @@ pub fn empty(
                 let span = stream.span();
                 match stream.reader() {
                     Some(reader) => {
-                        let is_empty = reader.bytes().next().transpose().map_err(|err| IoError::new(err.kind(), span, None))?.is_none();
+                        let is_empty = reader
+                            .bytes()
+                            .next()
+                            .transpose()
+                            .map_err(|err| IoError::new(err.kind(), span, None))?
+                            .is_none();
                         if negate {
                             Ok(Value::bool(!is_empty, head).into_pipeline_data())
                         } else {

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::io::IoError;
 use std::io::Read;
 
 pub fn empty(
@@ -41,7 +42,7 @@ pub fn empty(
                 let span = stream.span();
                 match stream.reader() {
                     Some(reader) => {
-                        let is_empty = reader.bytes().next().transpose().err_span(span)?.is_none();
+                        let is_empty = reader.bytes().next().transpose().map_err(|err| IoError::new(err.kind(), span, None))?.is_none();
                         if negate {
                             Ok(Value::bool(!is_empty, head).into_pipeline_data())
                         } else {

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::Signals;
+use nu_protocol::{shell_error::io::IoError, Signals};
 use std::io::Read;
 
 #[derive(Clone)]
@@ -180,7 +180,7 @@ fn first_helper(
                     if return_single_element {
                         // Take a single byte
                         let mut byte = [0u8];
-                        if reader.read(&mut byte).err_span(span)? > 0 {
+                        if reader.read(&mut byte).map_err(|err| IoError::new(err.kind(), span, None))? > 0 {
                             Ok(Value::int(byte[0] as i64, head).into_pipeline_data())
                         } else {
                             Err(ShellError::AccessEmptyContent { span: head })

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -180,7 +180,11 @@ fn first_helper(
                     if return_single_element {
                         // Take a single byte
                         let mut byte = [0u8];
-                        if reader.read(&mut byte).map_err(|err| IoError::new(err.kind(), span, None))? > 0 {
+                        if reader
+                            .read(&mut byte)
+                            .map_err(|err| IoError::new(err.kind(), span, None))?
+                            > 0
+                        {
                             Ok(Value::int(byte[0] as i64, head).into_pipeline_data())
                         } else {
                             Err(ShellError::AccessEmptyContent { span: head })

--- a/crates/nu-command/src/filters/interleave.rs
+++ b/crates/nu-command/src/filters/interleave.rs
@@ -1,5 +1,5 @@
 use nu_engine::{command_prelude::*, ClosureEvalOnce};
-use nu_protocol::engine::Closure;
+use nu_protocol::{engine::Closure, shell_error::io::IoError};
 use std::{sync::mpsc, thread};
 
 #[derive(Clone)]
@@ -137,10 +137,7 @@ interleave
                             }
                         })
                         .map(|_| ())
-                        .map_err(|err| ShellError::IOErrorSpanned {
-                            msg: err.to_string(),
-                            span: head,
-                        })
+                        .map_err(|err| IoError::new(err.kind(), head, None).into())
                 })
             })?;
 

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::io::IoError;
 use std::{collections::VecDeque, io::Read};
 
 #[derive(Clone)]
@@ -165,7 +166,7 @@ impl Command for Last {
                         let mut buf = VecDeque::with_capacity(rows + TAKE as usize);
                         loop {
                             let taken = std::io::copy(&mut (&mut reader).take(TAKE), &mut buf)
-                                .err_span(span)?;
+                                .map_err(|err| IoError::new(err.kind(), span, None))?;
                             if buf.len() > rows {
                                 buf.drain(..(buf.len() - rows));
                             }

--- a/crates/nu-command/src/filters/tee.rs
+++ b/crates/nu-command/src/filters/tee.rs
@@ -533,10 +533,10 @@ fn tee_forwards_errors_back_immediately() {
     let slow_input = (0..100).inspect(|_| std::thread::sleep(Duration::from_millis(1)));
     let iter = tee(slow_input, |_| {
         Err(ShellError::Io(IoError::new_with_additional_context(
-            std::io::ErrorKind::Other, 
-            Span::test_data(), 
-            None, 
-            "test"
+            std::io::ErrorKind::Other,
+            Span::test_data(),
+            None,
+            "test",
         )))
     })
     .expect("io error");
@@ -565,10 +565,10 @@ fn tee_waits_for_the_other_thread() {
         std::thread::sleep(Duration::from_millis(10));
         waited_clone.store(true, Ordering::Relaxed);
         Err(ShellError::Io(IoError::new_with_additional_context(
-            std::io::ErrorKind::Other, 
-            Span::test_data(), 
-            None, 
-            "test"
+            std::io::ErrorKind::Other,
+            Span::test_data(),
+            None,
+            "test",
         )))
     })
     .expect("io error");

--- a/crates/nu-command/src/filters/tee.rs
+++ b/crates/nu-command/src/filters/tee.rs
@@ -2,7 +2,8 @@ use nu_engine::{command_prelude::*, get_eval_block_with_early_return};
 #[cfg(feature = "os")]
 use nu_protocol::process::ChildPipe;
 use nu_protocol::{
-    byte_stream::copy_with_signals, engine::Closure, report_shell_error, shell_error::io::IoError, ByteStream, ByteStreamSource, OutDest, PipelineMetadata, Signals
+    byte_stream::copy_with_signals, engine::Closure, report_shell_error, shell_error::io::IoError,
+    ByteStream, ByteStreamSource, OutDest, PipelineMetadata, Signals,
 };
 use std::{
     io::{self, Read, Write},
@@ -439,7 +440,9 @@ fn spawn_tee(
             );
             eval_block(PipelineData::ByteStream(stream, info.metadata))
         })
-        .map_err(|err| IoError::new_with_additional_context(err.kind(), info.span, None, "Could not spawn tee"))?;
+        .map_err(|err| {
+            IoError::new_with_additional_context(err.kind(), info.span, None, "Could not spawn tee")
+        })?;
 
     Ok(TeeThread { sender, thread })
 }
@@ -478,7 +481,15 @@ fn copy_on_thread(
             copy_with_signals(src, dest, span, &signals)?;
             Ok(())
         })
-        .map_err(|err| IoError::new_with_additional_context(err.kind(), span, None, "Could not spawn stderr copier").into())
+        .map_err(|err| {
+            IoError::new_with_additional_context(
+                err.kind(),
+                span,
+                None,
+                "Could not spawn stderr copier",
+            )
+            .into()
+        })
 }
 
 #[cfg(feature = "os")]

--- a/crates/nu-command/src/filters/tee.rs
+++ b/crates/nu-command/src/filters/tee.rs
@@ -2,8 +2,7 @@ use nu_engine::{command_prelude::*, get_eval_block_with_early_return};
 #[cfg(feature = "os")]
 use nu_protocol::process::ChildPipe;
 use nu_protocol::{
-    byte_stream::copy_with_signals, engine::Closure, report_shell_error, ByteStream,
-    ByteStreamSource, OutDest, PipelineMetadata, Signals,
+    byte_stream::copy_with_signals, engine::Closure, report_shell_error, shell_error::io::IoError, ByteStream, ByteStreamSource, OutDest, PipelineMetadata, Signals
 };
 use std::{
     io::{self, Read, Write},
@@ -82,6 +81,7 @@ use it in your pipeline."#
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
+        let from_io_error = IoError::factory(head, None);
         let use_stderr = call.has_flag(engine_state, stack, "stderr")?;
 
         let closure: Spanned<Closure> = call.req(engine_state, stack, 0)?;
@@ -263,7 +263,7 @@ use it in your pipeline."#
                     let input = rx.into_pipeline_data_with_metadata(span, signals, metadata_clone);
                     eval_block(input)
                 })
-                .err_span(call.head)?
+                .map_err(&from_io_error)?
                 .map(move |result| result.unwrap_or_else(|err| Value::error(err, closure_span)))
                 .into_pipeline_data_with_metadata(
                     span,
@@ -278,7 +278,7 @@ use it in your pipeline."#
                 tee_once(engine_state_arc, move || {
                     eval_block(value_clone.into_pipeline_data_with_metadata(metadata_clone))
                 })
-                .err_span(call.head)?;
+                .map_err(&from_io_error)?;
                 Ok(value.into_pipeline_data_with_metadata(metadata))
             }
         }
@@ -439,7 +439,7 @@ fn spawn_tee(
             );
             eval_block(PipelineData::ByteStream(stream, info.metadata))
         })
-        .err_span(info.span)?;
+        .map_err(|err| IoError::new_with_additional_context(err.kind(), info.span, None, "Could not spawn tee"))?;
 
     Ok(TeeThread { sender, thread })
 }
@@ -478,7 +478,7 @@ fn copy_on_thread(
             copy_with_signals(src, dest, span, &signals)?;
             Ok(())
         })
-        .map_err(|e| e.into_spanned(span).into())
+        .map_err(|err| IoError::new_with_additional_context(err.kind(), span, None, "Could not spawn stderr copier").into())
 }
 
 #[cfg(feature = "os")]

--- a/crates/nu-command/src/filters/tee.rs
+++ b/crates/nu-command/src/filters/tee.rs
@@ -532,7 +532,12 @@ fn tee_forwards_errors_back_immediately() {
     use std::time::Duration;
     let slow_input = (0..100).inspect(|_| std::thread::sleep(Duration::from_millis(1)));
     let iter = tee(slow_input, |_| {
-        Err(ShellError::IOError { msg: "test".into() })
+        Err(ShellError::Io(IoError::new_with_additional_context(
+            std::io::ErrorKind::Other, 
+            Span::test_data(), 
+            None, 
+            "test"
+        )))
     })
     .expect("io error");
     for result in iter {
@@ -559,7 +564,12 @@ fn tee_waits_for_the_other_thread() {
     let iter = tee(0..100, move |_| {
         std::thread::sleep(Duration::from_millis(10));
         waited_clone.store(true, Ordering::Relaxed);
-        Err(ShellError::IOError { msg: "test".into() })
+        Err(ShellError::Io(IoError::new_with_additional_context(
+            std::io::ErrorKind::Other, 
+            Span::test_data(), 
+            None, 
+            "test"
+        )))
     })
     .expect("io error");
     let last = iter.last();

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -1,7 +1,7 @@
 use std::io::{BufRead, Cursor};
 
 use nu_engine::command_prelude::*;
-use nu_protocol::{ListStream, Signals};
+use nu_protocol::{shell_error::io::IoError, ListStream, Signals};
 
 #[derive(Clone)]
 pub struct FromJson;
@@ -134,7 +134,7 @@ fn read_json_lines(
         .lines()
         .filter(|line| line.as_ref().is_ok_and(|line| !line.trim().is_empty()) || line.is_err())
         .map(move |line| {
-            let line = line.err_span(span)?;
+            let line = line.map_err(|err| IoError::new(err.kind(), span, None))?;
             if strict {
                 convert_string_to_value_strict(&line, span)
             } else {

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -1,7 +1,8 @@
 use csv::WriterBuilder;
 use nu_cmd_base::formats::to::delimited::merge_descriptors;
 use nu_protocol::{
-    shell_error::io::IoError, ByteStream, ByteStreamType, Config, PipelineData, ShellError, Signals, Span, Spanned, Value
+    shell_error::io::IoError, ByteStream, ByteStreamType, Config, PipelineData, ShellError,
+    Signals, Span, Spanned, Value,
 };
 use std::{iter, sync::Arc};
 

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -1,16 +1,13 @@
 use csv::WriterBuilder;
 use nu_cmd_base::formats::to::delimited::merge_descriptors;
 use nu_protocol::{
-    ByteStream, ByteStreamType, Config, PipelineData, ShellError, Signals, Span, Spanned, Value,
+    shell_error::io::IoError, ByteStream, ByteStreamType, Config, PipelineData, ShellError, Signals, Span, Spanned, Value
 };
 use std::{iter, sync::Arc};
 
 fn make_csv_error(error: csv::Error, format_name: &str, head: Span) -> ShellError {
     if let csv::ErrorKind::Io(error) = error.kind() {
-        ShellError::IOErrorSpanned {
-            msg: error.to_string(),
-            span: head,
-        }
+        IoError::new(error.kind(), head, None).into()
     } else {
         ShellError::GenericError {
             error: format!("Failed to generate {format_name} data"),

--- a/crates/nu-command/src/formats/to/msgpack.rs
+++ b/crates/nu-command/src/formats/to/msgpack.rs
@@ -5,7 +5,7 @@ use std::io;
 
 use byteorder::{BigEndian, WriteBytesExt};
 use nu_engine::command_prelude::*;
-use nu_protocol::{ast::PathMember, Signals, Spanned};
+use nu_protocol::{ast::PathMember, shell_error::io::IoError, Signals, Spanned};
 use rmp::encode as mp;
 
 /// Max recursion depth
@@ -138,7 +138,7 @@ impl From<WriteError> for ShellError {
                 help: None,
                 inner: vec![],
             },
-            WriteError::Io(err, span) => err.into_spanned(span).into(),
+            WriteError::Io(err, span) => ShellError::Io(IoError::new(err.kind(), span, None)),
             WriteError::Shell(err) => *err,
         }
     }

--- a/crates/nu-command/src/formats/to/msgpackz.rs
+++ b/crates/nu-command/src/formats/to/msgpackz.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 
 use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::io::IoError;
 
 use super::msgpack::write_value;
 
@@ -80,7 +81,7 @@ impl Command for ToMsgpackz {
         );
 
         write_value(&mut out, &value, 0)?;
-        out.flush().err_span(call.head)?;
+        out.flush().map_err(|err| IoError::new(err.kind(), call.head, None))?;
         drop(out);
 
         Ok(Value::binary(out_buf, call.head).into_pipeline_data())

--- a/crates/nu-command/src/formats/to/msgpackz.rs
+++ b/crates/nu-command/src/formats/to/msgpackz.rs
@@ -81,7 +81,8 @@ impl Command for ToMsgpackz {
         );
 
         write_value(&mut out, &value, 0)?;
-        out.flush().map_err(|err| IoError::new(err.kind(), call.head, None))?;
+        out.flush()
+            .map_err(|err| IoError::new(err.kind(), call.head, None))?;
         drop(out);
 
         Ok(Value::binary(out_buf, call.head).into_pipeline_data())

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -1,6 +1,6 @@
 use chrono_humanize::HumanTime;
 use nu_engine::command_prelude::*;
-use nu_protocol::{format_duration, ByteStream, Config, PipelineMetadata};
+use nu_protocol::{format_duration, shell_error::io::IoError, ByteStream, Config, PipelineMetadata};
 use std::io::Write;
 
 const LINE_ENDING: &str = if cfg!(target_os = "windows") {
@@ -72,6 +72,7 @@ impl Command for ToText {
             }
             PipelineData::ListStream(stream, meta) => {
                 let span = stream.span();
+                let from_io_error = IoError::factory(head, None);
                 let stream = if no_newline {
                     let mut first = true;
                     let mut iter = stream.into_inner();
@@ -87,7 +88,7 @@ impl Command for ToText {
                             if first {
                                 first = false;
                             } else {
-                                write!(buf, "{LINE_ENDING}").err_span(head)?;
+                                write!(buf, "{LINE_ENDING}").map_err(&from_io_error)?;
                             }
                             // TODO: write directly into `buf` instead of creating an intermediate
                             // string.
@@ -98,7 +99,7 @@ impl Command for ToText {
                                 &config,
                                 serialize_types,
                             );
-                            write!(buf, "{str}").err_span(head)?;
+                            write!(buf, "{str}").map_err(&from_io_error)?;
                             Ok(true)
                         },
                     )

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -1,6 +1,8 @@
 use chrono_humanize::HumanTime;
 use nu_engine::command_prelude::*;
-use nu_protocol::{format_duration, shell_error::io::IoError, ByteStream, Config, PipelineMetadata};
+use nu_protocol::{
+    format_duration, shell_error::io::IoError, ByteStream, Config, PipelineMetadata,
+};
 use std::io::Write;
 
 const LINE_ENDING: &str = if cfg!(target_os = "windows") {

--- a/crates/nu-command/src/misc/source.rs
+++ b/crates/nu-command/src/misc/source.rs
@@ -56,7 +56,7 @@ impl Command for Source {
         let pb = std::path::PathBuf::from(block_id_name);
         let parent = pb.parent().unwrap_or(std::path::Path::new(""));
         let file_path = canonicalize_with(pb.as_path(), cwd)
-            .map_err(|err| IoError::new(err.kind(), Span::unknown(), pb.clone()))?;
+            .map_err(|err| IoError::new(err.kind(), call.head, pb.clone()))?;
 
         // Note: We intentionally left out PROCESS_PATH since it's supposed to
         // to work like argv[0] in C, which is the name of the program being executed.

--- a/crates/nu-command/src/misc/source.rs
+++ b/crates/nu-command/src/misc/source.rs
@@ -1,6 +1,6 @@
 use nu_engine::{command_prelude::*, get_eval_block_with_early_return};
 use nu_path::canonicalize_with;
-use nu_protocol::{engine::CommandType, BlockId};
+use nu_protocol::{engine::CommandType, shell_error::io::IoError, BlockId};
 
 /// Source a file for environment variables.
 #[derive(Clone)]
@@ -55,11 +55,8 @@ impl Command for Source {
         let cwd = engine_state.cwd_as_string(Some(stack))?;
         let pb = std::path::PathBuf::from(block_id_name);
         let parent = pb.parent().unwrap_or(std::path::Path::new(""));
-        let file_path =
-            canonicalize_with(pb.as_path(), cwd).map_err(|err| ShellError::FileNotFoundCustom {
-                msg: format!("Could not access file '{}': {err}", pb.as_path().display()),
-                span: Span::unknown(),
-            })?;
+        let file_path = canonicalize_with(pb.as_path(), cwd)
+            .map_err(|err| IoError::new(err.kind(), Span::unknown(), pb.clone()))?;
 
         // Note: We intentionally left out PROCESS_PATH since it's supposed to
         // to work like argv[0] in C, which is the name of the program being executed.

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -464,6 +464,14 @@ fn send_cancellable_request(
             let ret = request_fn();
             let _ = tx.send(ret); // may fail if the user has cancelled the operation
         })
+        .map_err(|err| {
+            IoError::new_with_additional_context(
+                err.kind(),
+                span,
+                None,
+                "Could not spawn HTTP requester",
+            )
+        })
         .map_err(ShellError::from)?;
 
     // ...and poll the channel for responses
@@ -518,6 +526,14 @@ fn send_cancellable_request_bytes(
 
             // may fail if the user has cancelled the operation
             let _ = tx.send(ret);
+        })
+        .map_err(|err| {
+            IoError::new_with_additional_context(
+                err.kind(),
+                span,
+                None,
+                "Could not spawn HTTP requester",
+            )
         })
         .map_err(ShellError::from)?;
 

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -184,6 +184,7 @@ pub fn request_add_authorization_header(
     request
 }
 
+#[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum ShellErrorOrRequestError {
     ShellError(ShellError),

--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -153,12 +153,7 @@ fn exists(path: &Path, span: Span, args: &Arguments) -> Value {
     Value::bool(
         match exists {
             Ok(exists) => exists,
-            Err(err) => {
-                return Value::error(
-                    IoError::new(err.kind(), span, path).into(),
-                    span,
-                )
-            }
+            Err(err) => return Value::error(IoError::new(err.kind(), span, path).into(), span),
         },
         span,
     )

--- a/crates/nu-command/src/path/type.rs
+++ b/crates/nu-command/src/path/type.rs
@@ -1,7 +1,7 @@
 use super::PathSubcommandArguments;
 use nu_engine::command_prelude::*;
 use nu_path::AbsolutePathBuf;
-use nu_protocol::engine::StateWorkingSet;
+use nu_protocol::{engine::StateWorkingSet, shell_error::io::IoError};
 use std::{io, path::Path};
 
 struct Arguments {
@@ -108,7 +108,7 @@ fn path_type(path: &Path, span: Span, args: &Arguments) -> Value {
     match path.symlink_metadata() {
         Ok(metadata) => Value::string(get_file_type(&metadata), span),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Value::nothing(span),
-        Err(err) => Value::error(err.into_spanned(span).into(), span),
+        Err(err) => Value::error(IoError::new(err.kind(), span, None).into(), span),
     }
 }
 

--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -4,6 +4,7 @@ use crossterm::{
     QueueableCommand,
 };
 use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::io::IoError;
 
 use std::io::Write;
 
@@ -41,19 +42,27 @@ impl Command for Clear {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let from_io_error = IoError::factory(call.head, None);
         match call.has_flag(engine_state, stack, "keep-scrollback")? {
             true => {
                 std::io::stdout()
-                    .queue(MoveTo(0, 0))?
-                    .queue(ClearCommand(ClearType::All))?
-                    .flush()?;
+                    .queue(MoveTo(0, 0))
+                    .map_err(&from_io_error)?
+                    .queue(ClearCommand(ClearType::All))
+                    .map_err(&from_io_error)?
+                    .flush()
+                    .map_err(&from_io_error)?;
             }
             _ => {
                 std::io::stdout()
-                    .queue(MoveTo(0, 0))?
-                    .queue(ClearCommand(ClearType::All))?
-                    .queue(ClearCommand(ClearType::Purge))?
-                    .flush()?;
+                    .queue(MoveTo(0, 0))
+                    .map_err(&from_io_error)?
+                    .queue(ClearCommand(ClearType::All))
+                    .map_err(&from_io_error)?
+                    .queue(ClearCommand(ClearType::Purge))
+                    .map_err(&from_io_error)?
+                    .flush()
+                    .map_err(&from_io_error)?;
             }
         };
 

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -70,6 +70,8 @@ impl Command for Input {
             span: call.head,
         });
 
+        let from_io_error = IoError::factory(call.head, None);
+
         if numchar.item < 1 {
             return Err(ShellError::UnsupportedInput {
                 msg: "Number of characters to read has to be positive".to_string(),
@@ -90,11 +92,11 @@ impl Command for Input {
 
         let mut buf = String::new();
 
-        crossterm::terminal::enable_raw_mode()?;
+        crossterm::terminal::enable_raw_mode().map_err(&from_io_error)?;
         // clear terminal events
-        while crossterm::event::poll(Duration::from_secs(0))? {
+        while crossterm::event::poll(Duration::from_secs(0)).map_err(&from_io_error)? {
             // If there's an event, read it to remove it from the queue
-            let _ = crossterm::event::read()?;
+            let _ = crossterm::event::read().map_err(&from_io_error)?;
         }
 
         loop {
@@ -111,7 +113,8 @@ impl Command for Input {
                                     || k.modifiers == KeyModifiers::CONTROL
                                 {
                                     if k.modifiers == KeyModifiers::CONTROL && c == 'c' {
-                                        crossterm::terminal::disable_raw_mode()?;
+                                        crossterm::terminal::disable_raw_mode()
+                                            .map_err(&from_io_error)?;
                                         return Err(IoError::new(
                                             std::io::ErrorKind::Interrupted,
                                             call.head,
@@ -142,8 +145,8 @@ impl Command for Input {
                 },
                 Ok(_) => continue,
                 Err(event_error) => {
-                    crossterm::terminal::disable_raw_mode()?;
-                    return Err(event_error.into());
+                    crossterm::terminal::disable_raw_mode().map_err(&from_io_error)?;
+                    return Err(from_io_error(event_error).into());
                 }
             }
             if !suppress_output {
@@ -152,16 +155,18 @@ impl Command for Input {
                     std::io::stdout(),
                     terminal::Clear(ClearType::CurrentLine),
                     cursor::MoveToColumn(0),
-                )?;
+                )
+                .map_err(|err| IoError::new(err.kind(), call.head, None))?;
                 if let Some(prompt) = &prompt {
-                    execute!(std::io::stdout(), Print(prompt.to_string()))?;
+                    execute!(std::io::stdout(), Print(prompt.to_string()))
+                        .map_err(&from_io_error)?;
                 }
-                execute!(std::io::stdout(), Print(buf.to_string()))?;
+                execute!(std::io::stdout(), Print(buf.to_string())).map_err(&from_io_error)?;
             }
         }
-        crossterm::terminal::disable_raw_mode()?;
+        crossterm::terminal::disable_raw_mode().map_err(&from_io_error)?;
         if !suppress_output {
-            std::io::stdout().write_all(b"\n")?;
+            std::io::stdout().write_all(b"\n").map_err(&from_io_error)?;
         }
         match default_val {
             Some(val) if buf.is_empty() => Ok(Value::string(val, call.head).into_pipeline_data()),

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -7,6 +7,7 @@ use crossterm::{
 };
 use itertools::Itertools;
 use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::io::IoError;
 
 use std::{io::Write, time::Duration};
 
@@ -111,9 +112,12 @@ impl Command for Input {
                                 {
                                     if k.modifiers == KeyModifiers::CONTROL && c == 'c' {
                                         crossterm::terminal::disable_raw_mode()?;
-                                        return Err(ShellError::IOError {
-                                            msg: "SIGINT".to_string(),
-                                        });
+                                        return Err(IoError::new(
+                                            std::io::ErrorKind::Interrupted,
+                                            call.head,
+                                            None,
+                                        )
+                                        .into());
                                     }
                                     continue;
                                 }

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -5,6 +5,7 @@ use crossterm::event::{
 use crossterm::{execute, terminal};
 use nu_engine::command_prelude::*;
 
+use nu_protocol::shell_error::io::IoError;
 use num_traits::AsPrimitive;
 use std::io::stdout;
 
@@ -83,7 +84,7 @@ There are 4 `key_type` variants:
         let add_raw = call.has_flag(engine_state, stack, "raw")?;
         let config = engine_state.get_config();
 
-        terminal::enable_raw_mode()?;
+        terminal::enable_raw_mode().map_err(|err| IoError::new(err.kind(), head, None))?;
 
         if config.use_kitty_protocol {
             if let Ok(false) = crossterm::terminal::supports_keyboard_enhancement() {
@@ -111,7 +112,7 @@ There are 4 `key_type` variants:
             );
         }
 
-        let console_state = event_type_filter.enable_events()?;
+        let console_state = event_type_filter.enable_events(head)?;
         loop {
             let event = crossterm::event::read().map_err(|_| ShellError::GenericError {
                 error: "Error with user input".into(),
@@ -122,7 +123,7 @@ There are 4 `key_type` variants:
             })?;
             let event = parse_event(head, &event, &event_type_filter, add_raw);
             if let Some(event) = event {
-                terminal::disable_raw_mode()?;
+                terminal::disable_raw_mode().map_err(|err| IoError::new(err.kind(), head, None))?;
                 if config.use_kitty_protocol {
                     let _ = execute!(
                         std::io::stdout(),
@@ -226,17 +227,20 @@ impl EventTypeFilter {
     /// Enable capturing of all events allowed by this filter.
     /// Call [`DeferredConsoleRestore::restore`] when done capturing events to restore
     /// console state
-    fn enable_events(&self) -> Result<DeferredConsoleRestore, ShellError> {
+    fn enable_events(&self, span: Span) -> Result<DeferredConsoleRestore, ShellError> {
         if self.listen_mouse {
-            crossterm::execute!(stdout(), EnableMouseCapture)?;
+            crossterm::execute!(stdout(), EnableMouseCapture)
+                .map_err(|err| IoError::new(err.kind(), span, None))?;
         }
 
         if self.listen_paste {
-            crossterm::execute!(stdout(), EnableBracketedPaste)?;
+            crossterm::execute!(stdout(), EnableBracketedPaste)
+                .map_err(|err| IoError::new(err.kind(), span, None))?;
         }
 
         if self.listen_focus {
-            crossterm::execute!(stdout(), crossterm::event::EnableFocusChange)?;
+            crossterm::execute!(stdout(), crossterm::event::EnableFocusChange)
+                .map_err(|err| IoError::new(err.kind(), span, None))?;
         }
 
         Ok(DeferredConsoleRestore {

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -1,5 +1,6 @@
 use dialoguer::{console::Term, FuzzySelect, MultiSelect, Select};
 use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::io::IoError;
 
 use std::fmt::{Display, Formatter};
 
@@ -141,8 +142,13 @@ impl Command for InputList {
                 .items(&options)
                 .report(false)
                 .interact_on_opt(&Term::stderr())
-                .map_err(|err| ShellError::IOError {
-                    msg: format!("{}: {}", INTERACT_ERROR, err),
+                .map_err(|dialoguer::Error::IO(err)| {
+                    IoError::new_with_additional_context(
+                        err.kind(),
+                        call.head,
+                        None,
+                        INTERACT_ERROR,
+                    )
                 })?,
             )
         } else if fuzzy {
@@ -158,8 +164,13 @@ impl Command for InputList {
                 .default(0)
                 .report(false)
                 .interact_on_opt(&Term::stderr())
-                .map_err(|err| ShellError::IOError {
-                    msg: format!("{}: {}", INTERACT_ERROR, err),
+                .map_err(|dialoguer::Error::IO(err)| {
+                    IoError::new_with_additional_context(
+                        err.kind(),
+                        call.head,
+                        None,
+                        INTERACT_ERROR,
+                    )
                 })?,
             )
         } else {
@@ -174,8 +185,13 @@ impl Command for InputList {
                 .default(0)
                 .report(false)
                 .interact_on_opt(&Term::stderr())
-                .map_err(|err| ShellError::IOError {
-                    msg: format!("{}: {}", INTERACT_ERROR, err),
+                .map_err(|dialoguer::Error::IO(err)| {
+                    IoError::new_with_additional_context(
+                        err.kind(),
+                        call.head,
+                        None,
+                        INTERACT_ERROR,
+                    )
                 })?,
             )
         };

--- a/crates/nu-command/src/platform/term/term_query.rs
+++ b/crates/nu-command/src/platform/term/term_query.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::io::IoError;
 
 const CTRL_C: u8 = 3;
 
@@ -98,15 +99,19 @@ The `prefix` is not included in the output."
         let prefix = prefix.unwrap_or_default();
         let terminator: Option<Vec<u8>> = call.get_flag(engine_state, stack, "terminator")?;
 
-        crossterm::terminal::enable_raw_mode()?;
+        crossterm::terminal::enable_raw_mode()
+            .map_err(|err| IoError::new(err.kind(), call.head, None))?;
         scopeguard::defer! {
             let _ = crossterm::terminal::disable_raw_mode();
         }
 
         // clear terminal events
-        while crossterm::event::poll(Duration::from_secs(0))? {
+        while crossterm::event::poll(Duration::from_secs(0))
+            .map_err(|err| IoError::new(err.kind(), call.head, None))?
+        {
             // If there's an event, read it to remove it from the queue
-            let _ = crossterm::event::read()?;
+            let _ = crossterm::event::read()
+                .map_err(|err| IoError::new(err.kind(), call.head, None))?;
         }
 
         let mut b = [0u8; 1];
@@ -115,13 +120,19 @@ The `prefix` is not included in the output."
 
         {
             let mut stdout = std::io::stdout().lock();
-            stdout.write_all(&query)?;
-            stdout.flush()?;
+            stdout
+                .write_all(&query)
+                .map_err(|err| IoError::new(err.kind(), call.head, None))?;
+            stdout
+                .flush()
+                .map_err(|err| IoError::new(err.kind(), call.head, None))?;
         }
 
         // Validate and skip prefix
         for bc in prefix {
-            stdin.read_exact(&mut b)?;
+            stdin
+                .read_exact(&mut b)
+                .map_err(|err| IoError::new(err.kind(), call.head, None))?;
             if b[0] != bc {
                 return Err(ShellError::GenericError {
                     error: "Input did not begin with expected sequence".into(),
@@ -138,7 +149,9 @@ The `prefix` is not included in the output."
 
         if let Some(terminator) = terminator {
             loop {
-                stdin.read_exact(&mut b)?;
+                stdin
+                    .read_exact(&mut b)
+                    .map_err(|err| IoError::new(err.kind(), call.head, None))?;
 
                 if b[0] == CTRL_C {
                     return Err(ShellError::InterruptedByUser {
@@ -158,7 +171,9 @@ The `prefix` is not included in the output."
             }
         } else {
             loop {
-                stdin.read_exact(&mut b)?;
+                stdin
+                    .read_exact(&mut b)
+                    .map_err(|err| IoError::new(err.kind(), call.head, None))?;
 
                 if b[0] == CTRL_C {
                     break;

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -92,17 +92,15 @@ impl Command for NuCheck {
                         stack,
                         get_dirs_var_from_call(stack, call),
                     ) {
-                        Ok(path) => {
-                            if let Some(path) = path {
-                                path
-                            } else {
-                                return Err(ShellError::FileNotFound {
-                                    file: path_str.item,
-                                    span: path_span,
-                                });
-                            }
+                        Ok(Some(path)) => path,
+                        Ok(None) => {
+                            return Err(ShellError::Io(IoError::new(
+                                std::io::ErrorKind::NotFound,
+                                path_span,
+                                PathBuf::from(path_str.item),
+                            )))
                         }
-                        Err(error) => return Err(error),
+                        Err(err) => return Err(err),
                     };
 
                     let result = if as_module || path.is_dir() {

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -1,6 +1,9 @@
 use nu_engine::{command_prelude::*, find_in_dirs_env, get_dirs_var_from_call};
 use nu_parser::{parse, parse_module_block, parse_module_file_or_dir, unescape_unquote_string};
-use nu_protocol::{engine::{FileStack, StateWorkingSet}, shell_error::io::IoError};
+use nu_protocol::{
+    engine::{FileStack, StateWorkingSet},
+    shell_error::io::IoError,
+};
 use std::path::{Path, PathBuf};
 
 #[derive(Clone)]
@@ -260,7 +263,11 @@ fn parse_file_script(
 
     match std::fs::read(path) {
         Ok(contents) => parse_script(working_set, Some(&filename), &contents, is_debug, call_head),
-        Err(err) => Err(ShellError::Io(IoError::new(err.kind(), path_span, PathBuf::from(path))))
+        Err(err) => Err(ShellError::Io(IoError::new(
+            err.kind(),
+            path_span,
+            PathBuf::from(path),
+        ))),
     }
 }
 

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -1,5 +1,6 @@
 use nu_engine::command_prelude::*;
 
+use nu_protocol::shell_error::io::IoError;
 use windows::{core::PCWSTR, Win32::System::Environment::ExpandEnvironmentStringsW};
 use winreg::{enums::*, types::FromRegValue, RegKey};
 
@@ -90,7 +91,9 @@ fn registry_query(
     let registry_value: Option<Spanned<String>> = call.opt(engine_state, stack, 1)?;
 
     let reg_hive = get_reg_hive(engine_state, stack, call)?;
-    let reg_key = reg_hive.open_subkey(registry_key.item)?;
+    let reg_key = reg_hive
+        .open_subkey(registry_key.item)
+        .map_err(|err| IoError::new(err.kind(), *registry_key_span, None))?;
 
     if registry_value.is_none() {
         let mut reg_values = vec![];

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -270,7 +270,7 @@ impl Command for External {
                 .spawn(move || {
                     let _ = write_pipeline_data(engine_state, stack, data, stdin);
                 })
-                .err_span(call.head)?;
+                .map_err(|err| IoError::new_with_additional_context(err.kind(), call.head, None, "Could not spawn external stdin worker"))?;
         }
 
         // Wrap the output into a `PipelineData::ByteStream`.

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -270,7 +270,14 @@ impl Command for External {
                 .spawn(move || {
                     let _ = write_pipeline_data(engine_state, stack, data, stdin);
                 })
-                .map_err(|err| IoError::new_with_additional_context(err.kind(), call.head, None, "Could not spawn external stdin worker"))?;
+                .map_err(|err| {
+                    IoError::new_with_additional_context(
+                        err.kind(),
+                        call.head,
+                        None,
+                        "Could not spawn external stdin worker",
+                    )
+                })?;
         }
 
         // Wrap the output into a `PipelineData::ByteStream`.

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -13,7 +13,7 @@ use nu_engine::{command_prelude::*, env_to_string};
 use nu_path::form::Absolute;
 use nu_pretty_hex::HexConfig;
 use nu_protocol::{
-    ByteStream, Config, DataSource, ListStream, PipelineMetadata, Signals, TableMode, ValueIterator,
+    shell_error::io::IoError, ByteStream, Config, DataSource, ListStream, PipelineMetadata, Signals, TableMode, ValueIterator
 };
 use nu_table::{
     common::configure_table, CollapsedTable, ExpandedTable, JustTable, NuRecordsValue, NuTable,
@@ -518,7 +518,7 @@ fn pretty_hex_stream(stream: ByteStream, span: Span) -> ByteStream {
                 (&mut reader)
                     .take(cfg.width as u64)
                     .read_to_end(&mut read_buf)
-                    .err_span(span)?;
+                    .map_err(|err| IoError::new(err.kind(), span, None))?;
 
                 if !read_buf.is_empty() {
                     nu_pretty_hex::hex_write(&mut write_buf, &read_buf, cfg, Some(true))

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -13,7 +13,8 @@ use nu_engine::{command_prelude::*, env_to_string};
 use nu_path::form::Absolute;
 use nu_pretty_hex::HexConfig;
 use nu_protocol::{
-    shell_error::io::IoError, ByteStream, Config, DataSource, ListStream, PipelineMetadata, Signals, TableMode, ValueIterator
+    shell_error::io::IoError, ByteStream, Config, DataSource, ListStream, PipelineMetadata,
+    Signals, TableMode, ValueIterator,
 };
 use nu_table::{
     common::configure_table, CollapsedTable, ExpandedTable, JustTable, NuRecordsValue, NuTable,

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -282,7 +282,7 @@ fn cd_permission_denied_folder() {
                 cd banned
             "
         );
-        assert!(actual.err.contains("Cannot change directory to"));
+        assert!(actual.err.contains("nu::shell::io::permission_denied"));
         nu!(
             cwd: dirs.test(),
             "

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -188,7 +188,7 @@ fn filesystem_not_a_directory() {
             actual.err
         );
         assert!(
-            actual.err.contains("is not a directory"),
+            actual.err.contains("nu::shell::io::not_a_directory"),
             "actual={:?}",
             actual.err
         );
@@ -210,7 +210,7 @@ fn filesystem_directory_not_found() {
             actual.err
         );
         assert!(
-            actual.err.contains("directory not found"),
+            actual.err.contains("nu::shell::io::not_found"),
             "actual={:?}",
             actual.err
         );

--- a/crates/nu-command/tests/commands/du.rs
+++ b/crates/nu-command/tests/commands/du.rs
@@ -93,7 +93,7 @@ fn du_with_multiple_path() {
 
     // report errors if one path not exists
     let actual = nu!(cwd: "tests/fixtures", "du cp asdf | get path | path basename");
-    assert!(actual.err.contains("directory not found"));
+    assert!(actual.err.contains("nu::shell::io::not_found"));
     assert!(!actual.status.success());
 
     // du with spreading empty list should returns nothing.

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -610,7 +610,7 @@ fn can_list_system_folder() {
 fn list_a_directory_not_exists() {
     Playground::setup("ls_test_directory_not_exists", |dirs, _sandbox| {
         let actual = nu!(cwd: dirs.test(), "ls a_directory_not_exists");
-        assert!(actual.err.contains("directory not found"));
+        assert!(actual.err.contains("nu::shell::io::not_found"));
     })
 }
 
@@ -735,7 +735,7 @@ fn list_with_tilde() {
         assert!(actual.out.contains("f2.txt"));
         assert!(actual.out.contains("~tilde"));
         let actual = nu!(cwd: dirs.test(), "ls ~tilde");
-        assert!(actual.err.contains("does not exist"));
+        assert!(actual.err.contains("nu::shell::io::not_found"));
 
         // pass variable
         let actual = nu!(cwd: dirs.test(), "let f = '~tilde'; ls $f");
@@ -762,7 +762,7 @@ fn list_with_multiple_path() {
 
         // report errors if one path not exists
         let actual = nu!(cwd: dirs.test(), "ls asdf f1.txt");
-        assert!(actual.err.contains("directory not found"));
+        assert!(actual.err.contains("nu::shell::io::not_found"));
         assert!(!actual.status.success());
 
         // ls with spreading empty list should returns nothing.

--- a/crates/nu-command/tests/commands/move_/umv.rs
+++ b/crates/nu-command/tests/commands/move_/umv.rs
@@ -202,7 +202,7 @@ fn errors_if_source_doesnt_exist() {
             cwd: dirs.test(),
             "mv non-existing-file test_folder/"
         );
-        assert!(actual.err.contains("Directory not found"));
+        assert!(actual.err.contains("nu::shell::io::not_found"));
     })
 }
 

--- a/crates/nu-command/tests/commands/network/http/delete.rs
+++ b/crates/nu-command/tests/commands/network/http/delete.rs
@@ -140,10 +140,6 @@ fn http_delete_timeout() {
         format!("http delete --max-time 100ms {url}", url = server.url()).as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::network_failure"));
-
-    #[cfg(not(target_os = "windows"))]
-    assert!(&actual.err.contains("timed out reading response"));
-    #[cfg(target_os = "windows")]
-    assert!(&actual.err.contains(super::WINDOWS_ERROR_TIMEOUT_SLOW_LINK));
+    assert!(&actual.err.contains("nu::shell::io::timed_out"));
+    assert!(&actual.err.contains("Timed out"));
 }

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -334,10 +334,6 @@ fn http_get_timeout() {
         format!("http get --max-time 100ms {url}", url = server.url()).as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::network_failure"));
-
-    #[cfg(not(target_os = "windows"))]
-    assert!(&actual.err.contains("timed out reading response"));
-    #[cfg(target_os = "windows")]
-    assert!(&actual.err.contains(super::WINDOWS_ERROR_TIMEOUT_SLOW_LINK));
+    assert!(&actual.err.contains("nu::shell::io::timed_out"));
+    assert!(&actual.err.contains("Timed out"));
 }

--- a/crates/nu-command/tests/commands/network/http/mod.rs
+++ b/crates/nu-command/tests/commands/network/http/mod.rs
@@ -5,14 +5,3 @@ mod options;
 mod patch;
 mod post;
 mod put;
-
-/// String representation of the Windows error code for timeouts on slow links.
-///
-/// Use this constant in tests instead of matching partial error message content,
-/// such as `"did not properly respond after a period of time"`, which can vary by language.
-/// The specific string `"(os error 10060)"` is consistent across all locales, as it represents
-/// the raw error code rather than localized text.
-///
-/// For more details, see the [Microsoft docs](https://learn.microsoft.com/en-us/troubleshoot/windows-client/networking/10060-connection-timed-out-with-proxy-server).
-#[cfg(all(test, windows))]
-const WINDOWS_ERROR_TIMEOUT_SLOW_LINK: &str = "(os error 10060)";

--- a/crates/nu-command/tests/commands/network/http/options.rs
+++ b/crates/nu-command/tests/commands/network/http/options.rs
@@ -59,10 +59,6 @@ fn http_options_timeout() {
         format!("http options --max-time 100ms {url}", url = server.url()).as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::network_failure"));
-
-    #[cfg(not(target_os = "windows"))]
-    assert!(&actual.err.contains("timed out reading response"));
-    #[cfg(target_os = "windows")]
-    assert!(&actual.err.contains(super::WINDOWS_ERROR_TIMEOUT_SLOW_LINK));
+    assert!(&actual.err.contains("nu::shell::io::timed_out"));
+    assert!(&actual.err.contains("Timed out"));
 }

--- a/crates/nu-command/tests/commands/network/http/patch.rs
+++ b/crates/nu-command/tests/commands/network/http/patch.rs
@@ -184,10 +184,6 @@ fn http_patch_timeout() {
         .as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::network_failure"));
-
-    #[cfg(not(target_os = "windows"))]
-    assert!(&actual.err.contains("timed out reading response"));
-    #[cfg(target_os = "windows")]
-    assert!(&actual.err.contains(super::WINDOWS_ERROR_TIMEOUT_SLOW_LINK));
+    assert!(&actual.err.contains("nu::shell::io::timed_out"));
+    assert!(&actual.err.contains("Timed out"));
 }

--- a/crates/nu-command/tests/commands/network/http/post.rs
+++ b/crates/nu-command/tests/commands/network/http/post.rs
@@ -298,10 +298,6 @@ fn http_post_timeout() {
         .as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::network_failure"));
-
-    #[cfg(not(target_os = "windows"))]
-    assert!(&actual.err.contains("timed out reading response"));
-    #[cfg(target_os = "windows")]
-    assert!(&actual.err.contains(super::WINDOWS_ERROR_TIMEOUT_SLOW_LINK));
+    assert!(&actual.err.contains("nu::shell::io::timed_out"));
+    assert!(&actual.err.contains("Timed out"));
 }

--- a/crates/nu-command/tests/commands/network/http/put.rs
+++ b/crates/nu-command/tests/commands/network/http/put.rs
@@ -184,10 +184,6 @@ fn http_put_timeout() {
         .as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::network_failure"));
-
-    #[cfg(not(target_os = "windows"))]
-    assert!(&actual.err.contains("timed out reading response"));
-    #[cfg(target_os = "windows")]
-    assert!(&actual.err.contains(super::WINDOWS_ERROR_TIMEOUT_SLOW_LINK));
+    assert!(&actual.err.contains("nu::shell::io::timed_out"));
+    assert!(&actual.err.contains("Timed out"));
 }

--- a/crates/nu-command/tests/commands/nu_check.rs
+++ b/crates/nu-command/tests/commands/nu_check.rs
@@ -172,7 +172,7 @@ fn file_not_exist() {
             "
         ));
 
-        assert!(actual.err.contains("file not found"));
+        assert!(actual.err.contains("nu::shell::io::not_found"));
     })
 }
 

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
@@ -248,14 +250,13 @@ fn errors_if_file_not_found() {
     //
     // This seems to be not directly affected by localization compared to the OS
     // provided error message
-    let expected = "File not found";
 
-    assert!(
-        actual.err.contains(expected),
-        "Error:\n{}\ndoes not contain{}",
-        actual.err,
-        expected
-    );
+    assert!(actual.err.contains("nu::shell::io::not_found"));
+    assert!(actual.err.contains(
+        &PathBuf::from_iter(["tests", "fixtures", "formats", "i_dont_exist.txt"])
+            .display()
+            .to_string()
+    ));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/path/self_.rs
+++ b/crates/nu-command/tests/commands/path/self_.rs
@@ -60,5 +60,5 @@ fn self_path_runtime() {
 fn self_path_repl() {
     let actual = nu!("const foo = path self; $foo");
     assert!(!actual.status.success());
-    assert!(actual.err.contains("nu::shell::file_not_found"));
+    assert!(actual.err.contains("nu::shell::io::not_found"));
 }

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -454,14 +454,8 @@ fn rm_prints_filenames_on_error() {
 
         assert!(files_exist_at(&file_names, test_dir));
         for file_name in file_names {
-            let path = test_dir.join(file_name);
-            let substr = format!("Could not delete {}", path.to_string_lossy());
-            assert!(
-                actual.err.contains(&substr),
-                "Matching: {}\n=== Command stderr:\n{}\n=== End stderr",
-                substr,
-                actual.err
-            );
+            assert!(actual.err.contains("nu::shell::io::permission_denied"));
+            assert!(actual.err.contains(file_name));
         }
     });
 }

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -532,5 +532,5 @@ fn force_save_to_dir() {
         "aaa" | save -f ..
         "#);
 
-    assert!(actual.err.contains("Is a directory"));
+    assert!(actual.err.contains("nu::shell::io::is_a_directory"));
 }

--- a/crates/nu-engine/src/command_prelude.rs
+++ b/crates/nu-engine/src/command_prelude.rs
@@ -5,4 +5,5 @@ pub use nu_protocol::{
     record, ByteStream, ByteStreamType, Category, ErrSpan, Example, IntoInterruptiblePipelineData,
     IntoPipelineData, IntoSpanned, IntoValue, PipelineData, Record, ShellError, Signature, Span,
     Spanned, SyntaxShape, Type, Value,
+    shell_error::io::IoError
 };

--- a/crates/nu-engine/src/command_prelude.rs
+++ b/crates/nu-engine/src/command_prelude.rs
@@ -2,8 +2,9 @@ pub use crate::CallExt;
 pub use nu_protocol::{
     ast::CellPath,
     engine::{Call, Command, EngineState, Stack, StateWorkingSet},
-    record, ByteStream, ByteStreamType, Category, ErrSpan, Example, IntoInterruptiblePipelineData,
+    record,
+    shell_error::io::IoError,
+    ByteStream, ByteStreamType, Category, ErrSpan, Example, IntoInterruptiblePipelineData,
     IntoPipelineData, IntoSpanned, IntoValue, PipelineData, Record, ShellError, Signature, Span,
     Spanned, SyntaxShape, Type, Value,
-    shell_error::io::IoError
 };

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -3,6 +3,7 @@ use nu_path::canonicalize_with;
 use nu_protocol::{
     ast::Expr,
     engine::{Call, EngineState, Stack, StateWorkingSet},
+    shell_error::io::IoError,
     ShellError, Span, Type, Value, VarId,
 };
 use std::{
@@ -218,9 +219,12 @@ pub fn current_dir(engine_state: &EngineState, stack: &Stack) -> Result<PathBuf,
     // We're using `canonicalize_with` instead of `fs::canonicalize()` because
     // we still need to simplify Windows paths. "." is safe because `cwd` should
     // be an absolute path already.
-    canonicalize_with(&cwd, ".").map_err(|_| ShellError::DirectoryNotFound {
-        dir: cwd.to_string_lossy().to_string(),
-        span: Span::unknown(),
+    canonicalize_with(&cwd, ".").map_err(|err| {
+        ShellError::Io(IoError::new(
+            err.kind(),
+            Span::unknown(),
+            PathBuf::from(cwd),
+        ))
     })
 }
 
@@ -234,9 +238,12 @@ pub fn current_dir_const(working_set: &StateWorkingSet) -> Result<PathBuf, Shell
     // We're using `canonicalize_with` instead of `fs::canonicalize()` because
     // we still need to simplify Windows paths. "." is safe because `cwd` should
     // be an absolute path already.
-    canonicalize_with(&cwd, ".").map_err(|_| ShellError::DirectoryNotFound {
-        dir: cwd.to_string_lossy().to_string(),
-        span: Span::unknown(),
+    canonicalize_with(&cwd, ".").map_err(|err| {
+        ShellError::Io(IoError::new(
+            err.kind(),
+            Span::unknown(),
+            PathBuf::from(cwd),
+        ))
     })
 }
 

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -2,9 +2,16 @@ use std::{borrow::Cow, fs::File, sync::Arc};
 
 use nu_path::{expand_path_with, AbsolutePathBuf};
 use nu_protocol::{
-    ast::{Bits, Block, Boolean, CellPath, Comparison, Math, Operator}, debugger::DebugContext, engine::{
+    ast::{Bits, Block, Boolean, CellPath, Comparison, Math, Operator},
+    debugger::DebugContext,
+    engine::{
         Argument, Closure, EngineState, ErrorHandler, Matcher, Redirection, Stack, StateWorkingSet,
-    }, ir::{Call, DataSlice, Instruction, IrAstRef, IrBlock, Literal, RedirectMode}, shell_error::io::IoError, DataSource, DeclId, ErrSpan, Flag, IntoPipelineData, IntoSpanned, ListStream, OutDest, PipelineData, PipelineMetadata, PositionalArg, Range, Record, RegId, ShellError, Signals, Signature, Span, Spanned, Type, Value, VarId, ENV_VARIABLE_ID
+    },
+    ir::{Call, DataSlice, Instruction, IrAstRef, IrBlock, Literal, RedirectMode},
+    shell_error::io::IoError,
+    DataSource, DeclId, ErrSpan, Flag, IntoPipelineData, IntoSpanned, ListStream, OutDest,
+    PipelineData, PipelineMetadata, PositionalArg, Range, Record, RegId, ShellError, Signals,
+    Signature, Span, Spanned, Type, Value, VarId, ENV_VARIABLE_ID,
 };
 use nu_utils::IgnoreCaseExt;
 

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -2,15 +2,9 @@ use std::{borrow::Cow, fs::File, sync::Arc};
 
 use nu_path::{expand_path_with, AbsolutePathBuf};
 use nu_protocol::{
-    ast::{Bits, Block, Boolean, CellPath, Comparison, Math, Operator},
-    debugger::DebugContext,
-    engine::{
+    ast::{Bits, Block, Boolean, CellPath, Comparison, Math, Operator}, debugger::DebugContext, engine::{
         Argument, Closure, EngineState, ErrorHandler, Matcher, Redirection, Stack, StateWorkingSet,
-    },
-    ir::{Call, DataSlice, Instruction, IrAstRef, IrBlock, Literal, RedirectMode},
-    DataSource, DeclId, ErrSpan, Flag, IntoPipelineData, IntoSpanned, ListStream, OutDest,
-    PipelineData, PipelineMetadata, PositionalArg, Range, Record, RegId, ShellError, Signals,
-    Signature, Span, Spanned, Type, Value, VarId, ENV_VARIABLE_ID,
+    }, ir::{Call, DataSlice, Instruction, IrAstRef, IrBlock, Literal, RedirectMode}, shell_error::io::IoError, DataSource, DeclId, ErrSpan, Flag, IntoPipelineData, IntoSpanned, ListStream, OutDest, PipelineData, PipelineMetadata, PositionalArg, Range, Record, RegId, ShellError, Signals, Signature, Span, Spanned, Type, Value, VarId, ENV_VARIABLE_ID
 };
 use nu_utils::IgnoreCaseExt;
 
@@ -1489,8 +1483,8 @@ fn open_file(ctx: &EvalContext<'_>, path: &Value, append: bool) -> Result<Arc<Fi
     }
     let file = options
         .create(true)
-        .open(path_expanded)
-        .err_span(path.span())?;
+        .open(&path_expanded)
+        .map_err(|err| IoError::new(err.kind(), path.span(), path_expanded))?;
     Ok(Arc::new(file))
 }
 

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -9,7 +9,7 @@ use nu_protocol::{
     },
     ir::{Call, DataSlice, Instruction, IrAstRef, IrBlock, Literal, RedirectMode},
     shell_error::io::IoError,
-    DataSource, DeclId, ErrSpan, Flag, IntoPipelineData, IntoSpanned, ListStream, OutDest,
+    DataSource, DeclId, Flag, IntoPipelineData, IntoSpanned, ListStream, OutDest,
     PipelineData, PipelineMetadata, PositionalArg, Range, Record, RegId, ShellError, Signals,
     Signature, Span, Spanned, Type, Value, VarId, ENV_VARIABLE_ID,
 };

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -9,9 +9,9 @@ use nu_protocol::{
     },
     ir::{Call, DataSlice, Instruction, IrAstRef, IrBlock, Literal, RedirectMode},
     shell_error::io::IoError,
-    DataSource, DeclId, Flag, IntoPipelineData, IntoSpanned, ListStream, OutDest,
-    PipelineData, PipelineMetadata, PositionalArg, Range, Record, RegId, ShellError, Signals,
-    Signature, Span, Spanned, Type, Value, VarId, ENV_VARIABLE_ID,
+    DataSource, DeclId, Flag, IntoPipelineData, IntoSpanned, ListStream, OutDest, PipelineData,
+    PipelineMetadata, PositionalArg, Range, Record, RegId, ShellError, Signals, Signature, Span,
+    Spanned, Type, Value, VarId, ENV_VARIABLE_ID,
 };
 use nu_utils::IgnoreCaseExt;
 

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -27,6 +27,7 @@ pub fn glob_from(
     ShellError,
 > {
     let no_glob_for_pattern = matches!(pattern.item, NuGlob::DoNotExpand(_));
+    let pattern_span = pattern.span;
     let (prefix, pattern) = if nu_glob::is_glob(pattern.item.as_ref()) {
         // Pattern contains glob, split it
         let mut p = PathBuf::new();
@@ -79,13 +80,7 @@ pub fn glob_from(
                 }
                 Ok(p) => p,
                 Err(err) => {
-                    return Err(IoError::new_internal_with_path(
-                        err.kind(),
-                        "Could not canonicalize path",
-                        nu_protocol::location!(),
-                        path,
-                    )
-                    .into())
+                    return Err(IoError::new(err.kind(), pattern_span, path).into());
                 }
             };
             (path.parent().map(|parent| parent.to_path_buf()), path)

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -78,7 +78,15 @@ pub fn glob_from(
                     PathBuf::from(nu_glob::Pattern::escape(&p.to_string_lossy()))
                 }
                 Ok(p) => p,
-                Err(err) => return Err(IoError::new(err.kind(), Span::unknown(), path).into()),
+                Err(err) => {
+                    return Err(IoError::new_internal_with_path(
+                        err.kind(),
+                        "Could not canonicalize path",
+                        nu_protocol::location!(),
+                        path,
+                    )
+                    .into())
+                }
             };
             (path.parent().map(|parent| parent.to_path_buf()), path)
         }

--- a/crates/nu-explore/src/nu_common/command.rs
+++ b/crates/nu-explore/src/nu_common/command.rs
@@ -14,16 +14,24 @@ pub fn run_command_with_value(
     stack: &mut Stack,
 ) -> Result<PipelineData, ShellError> {
     if is_ignored_command(command) {
-        return Err(ShellError::IOError {
-            msg: String::from("the command is ignored"),
+        return Err(ShellError::GenericError {
+            error: "Command ignored".to_string(),
+            msg: "the command is ignored".to_string(),
+            span: None,
+            help: None,
+            inner: vec![],
         });
     }
 
     let pipeline = PipelineData::Value(input.clone(), None);
     let pipeline = run_nu_command(engine_state, stack, command, pipeline)?;
     if let PipelineData::Value(Value::Error { error, .. }, ..) = pipeline {
-        Err(ShellError::IOError {
+        Err(ShellError::GenericError {
+            error: "Error from pipeline".to_string(),
             msg: error.to_string(),
+            span: None,
+            help: None,
+            inner: vec![*error],
         })
     } else {
         Ok(pipeline)
@@ -69,8 +77,12 @@ fn eval_source2(
         );
 
         if let Some(err) = working_set.parse_errors.first() {
-            return Err(ShellError::IOError {
+            return Err(ShellError::GenericError {
+                error: "Parse error".to_string(),
                 msg: err.to_string(),
+                span: None,
+                help: None,
+                inner: vec![],
             });
         }
 
@@ -79,8 +91,12 @@ fn eval_source2(
 
     // We need to merge different info other wise things like PIPEs etc will not work.
     if let Err(err) = engine_state.merge_delta(delta) {
-        return Err(ShellError::IOError {
+        return Err(ShellError::GenericError {
+            error: "Merge error".to_string(),
             msg: err.to_string(),
+            span: None,
+            help: None,
+            inner: vec![err],
         });
     }
 

--- a/crates/nu-plugin-core/src/communication_mode/mod.rs
+++ b/crates/nu-plugin-core/src/communication_mode/mod.rs
@@ -85,7 +85,16 @@ impl CommunicationMode {
 
                 let listener = interpret_local_socket_name(name)
                     .and_then(|name| ListenerOptions::new().name(name).create_sync())
-                    .map_err(|err| IoError::new(err.kind(), Span::unknown(), None))?;
+                    .map_err(|err| {
+                        IoError::new_internal(
+                            err.kind(),
+                            format!(
+                                "Could not interpret local socket name {:?}",
+                                name.to_string_lossy()
+                            ),
+                            nu_protocol::location!(),
+                        )
+                    })?;
                 Ok(PreparedServerCommunication::LocalSocket { listener })
             }
         }
@@ -107,7 +116,14 @@ impl CommunicationMode {
                     interpret_local_socket_name(name)
                         .and_then(|name| ls::Stream::connect(name))
                         .map_err(|err| {
-                            ShellError::Io(IoError::new(err.kind(), Span::unknown(), None))
+                            ShellError::Io(IoError::new_internal(
+                                err.kind(),
+                                format!(
+                                    "Could not interpret local socket name {:?}",
+                                    name.to_string_lossy()
+                                ),
+                                nu_protocol::location!(),
+                            ))
                         })
                 };
                 // Reverse order from the server: read in, write out

--- a/crates/nu-plugin-core/src/interface/mod.rs
+++ b/crates/nu-plugin-core/src/interface/mod.rs
@@ -340,7 +340,7 @@ where
                 writer.write_all(std::iter::from_fn(move || match reader.read(buf) {
                     Ok(0) => None,
                     Ok(len) => Some(Ok(buf[..len].to_vec())),
-                    Err(err) => Some(Err(ShellError::from(err.into_spanned(span)))),
+                    Err(err) => Some(Err(ShellError::from(IoError::new(err.kind(), span, None)))),
                 }))?;
                 Ok(())
             }

--- a/crates/nu-plugin-core/src/interface/mod.rs
+++ b/crates/nu-plugin-core/src/interface/mod.rs
@@ -2,7 +2,7 @@
 
 use nu_plugin_protocol::{ByteStreamInfo, ListStreamInfo, PipelineDataHeader, StreamMessage};
 use nu_protocol::{
-    engine::Sequence, shell_error::io::IoError, ByteStream, IntoSpanned, ListStream, PipelineData,
+    engine::Sequence, shell_error::io::IoError, ByteStream, ListStream, PipelineData,
     Reader, ShellError, Signals, Span,
 };
 use std::{

--- a/crates/nu-plugin-core/src/interface/mod.rs
+++ b/crates/nu-plugin-core/src/interface/mod.rs
@@ -357,6 +357,14 @@ where
                             log::warn!("Error while writing pipeline in background: {err}");
                         }
                         result
+                    })
+                    .map_err(|err| {
+                        IoError::new_with_additional_context(
+                            err.kind(),
+                            Span::unknown(),
+                            None,
+                            "Could not spawn plugin stream background writer",
+                        )
                     })?,
             )),
         }

--- a/crates/nu-plugin-core/src/interface/mod.rs
+++ b/crates/nu-plugin-core/src/interface/mod.rs
@@ -80,10 +80,13 @@ where
     }
 
     fn flush(&self) -> Result<(), ShellError> {
-        self.0
-            .lock()
-            .flush()
-            .map_err(|err| ShellError::Io(IoError::new(err.kind(), Span::unknown(), None)))
+        self.0.lock().flush().map_err(|err| {
+            ShellError::Io(IoError::new_internal(
+                err.kind(),
+                "PluginWrite could not flush",
+                nu_protocol::location!(),
+            ))
+        })
     }
 
     fn is_stdout(&self) -> bool {
@@ -107,8 +110,13 @@ where
         let mut lock = self.0.lock().map_err(|_| ShellError::NushellFailed {
             msg: "writer mutex poisoned".into(),
         })?;
-        lock.flush()
-            .map_err(|err| ShellError::Io(IoError::new(err.kind(), Span::unknown(), None)))
+        lock.flush().map_err(|err| {
+            ShellError::Io(IoError::new_internal(
+                err.kind(),
+                "PluginWrite could not flush",
+                nu_protocol::location!(),
+            ))
+        })
     }
 }
 

--- a/crates/nu-plugin-core/src/interface/mod.rs
+++ b/crates/nu-plugin-core/src/interface/mod.rs
@@ -2,8 +2,8 @@
 
 use nu_plugin_protocol::{ByteStreamInfo, ListStreamInfo, PipelineDataHeader, StreamMessage};
 use nu_protocol::{
-    engine::Sequence, shell_error::io::IoError, ByteStream, ListStream, PipelineData,
-    Reader, ShellError, Signals, Span,
+    engine::Sequence, shell_error::io::IoError, ByteStream, ListStream, PipelineData, Reader,
+    ShellError, Signals, Span,
 };
 use std::{
     io::{Read, Write},

--- a/crates/nu-plugin-core/src/interface/tests.rs
+++ b/crates/nu-plugin-core/src/interface/tests.rs
@@ -8,8 +8,7 @@ use nu_plugin_protocol::{
     StreamMessage,
 };
 use nu_protocol::{
-    engine::Sequence, ByteStream, ByteStreamSource, ByteStreamType, DataSource, ListStream,
-    PipelineData, PipelineMetadata, ShellError, Signals, Span, Value,
+    engine::Sequence, shell_error::io::IoError, ByteStream, ByteStreamSource, ByteStreamType, DataSource, ListStream, PipelineData, PipelineMetadata, ShellError, Signals, Span, Value
 };
 use std::{path::Path, sync::Arc};
 
@@ -245,7 +244,7 @@ fn read_pipeline_data_byte_stream() -> Result<(), ShellError> {
             match stream.into_source() {
                 ByteStreamSource::Read(mut read) => {
                     let mut buf = Vec::new();
-                    read.read_to_end(&mut buf)?;
+                    read.read_to_end(&mut buf).map_err(|err| IoError::new(err.kind(), test_span, None))?;
                     let iter = buf.chunks_exact(out_pattern.len());
                     assert_eq!(iter.len(), iterations);
                     for chunk in iter {

--- a/crates/nu-plugin-core/src/interface/tests.rs
+++ b/crates/nu-plugin-core/src/interface/tests.rs
@@ -8,7 +8,8 @@ use nu_plugin_protocol::{
     StreamMessage,
 };
 use nu_protocol::{
-    engine::Sequence, shell_error::io::IoError, ByteStream, ByteStreamSource, ByteStreamType, DataSource, ListStream, PipelineData, PipelineMetadata, ShellError, Signals, Span, Value
+    engine::Sequence, shell_error::io::IoError, ByteStream, ByteStreamSource, ByteStreamType,
+    DataSource, ListStream, PipelineData, PipelineMetadata, ShellError, Signals, Span, Value,
 };
 use std::{path::Path, sync::Arc};
 
@@ -244,7 +245,8 @@ fn read_pipeline_data_byte_stream() -> Result<(), ShellError> {
             match stream.into_source() {
                 ByteStreamSource::Read(mut read) => {
                     let mut buf = Vec::new();
-                    read.read_to_end(&mut buf).map_err(|err| IoError::new(err.kind(), test_span, None))?;
+                    read.read_to_end(&mut buf)
+                        .map_err(|err| IoError::new(err.kind(), test_span, None))?;
                     let iter = buf.chunks_exact(out_pattern.len());
                     assert_eq!(iter.len(), iterations);
                     for chunk in iter {

--- a/crates/nu-plugin-core/src/serializers/json.rs
+++ b/crates/nu-plugin-core/src/serializers/json.rs
@@ -94,9 +94,9 @@ fn json_decode_err<T>(err: serde_json::Error) -> Result<Option<T>, ShellError> {
         Ok(None)
     } else if err.is_io() {
         Err(ShellError::Io(IoError::new_internal(
-            err.io_error_kind().expect("is io"), 
-            "Could not decode with json", 
-            nu_protocol::location!()
+            err.io_error_kind().expect("is io"),
+            "Could not decode with json",
+            nu_protocol::location!(),
         )))
     } else {
         Err(ShellError::PluginFailedToDecode {

--- a/crates/nu-plugin-core/src/serializers/json.rs
+++ b/crates/nu-plugin-core/src/serializers/json.rs
@@ -1,5 +1,5 @@
 use nu_plugin_protocol::{PluginInput, PluginOutput};
-use nu_protocol::{location, shell_error::io::IoError, ShellError, Span};
+use nu_protocol::{location, shell_error::io::IoError, ShellError};
 use serde::Deserialize;
 
 use crate::{Encoder, PluginEncoder};

--- a/crates/nu-plugin-core/src/serializers/json.rs
+++ b/crates/nu-plugin-core/src/serializers/json.rs
@@ -53,9 +53,13 @@ impl Encoder<PluginOutput> for JsonSerializer {
         writer: &mut impl std::io::Write,
     ) -> Result<(), ShellError> {
         serde_json::to_writer(&mut *writer, plugin_output).map_err(json_encode_err)?;
-        writer
-            .write_all(b"\n")
-            .map_err(|err| ShellError::Io(IoError::new(err.kind(), Span::unknown(), None)))
+        writer.write_all(b"\n").map_err(|err| {
+            ShellError::Io(IoError::new_internal(
+                err.kind(),
+                "JsonSerializer could not encode linebreak",
+                nu_protocol::location!(),
+            ))
+        })
     }
 
     fn decode(

--- a/crates/nu-plugin-core/src/serializers/json.rs
+++ b/crates/nu-plugin-core/src/serializers/json.rs
@@ -76,10 +76,10 @@ impl Encoder<PluginOutput> for JsonSerializer {
 /// Handle a `serde_json` encode error.
 fn json_encode_err(err: serde_json::Error) -> ShellError {
     if err.is_io() {
-        ShellError::Io(IoError::new(
+        ShellError::Io(IoError::new_internal(
             err.io_error_kind().expect("is io"),
-            Span::unknown(),
-            None,
+            "Could not encode with json",
+            nu_protocol::location!(),
         ))
     } else {
         ShellError::PluginFailedToEncode {
@@ -93,10 +93,10 @@ fn json_decode_err<T>(err: serde_json::Error) -> Result<Option<T>, ShellError> {
     if err.is_eof() {
         Ok(None)
     } else if err.is_io() {
-        Err(ShellError::Io(IoError::new(
-            err.io_error_kind().expect("is io"),
-            Span::unknown(),
-            None,
+        Err(ShellError::Io(IoError::new_internal(
+            err.io_error_kind().expect("is io"), 
+            "Could not decode with json", 
+            nu_protocol::location!()
         )))
     } else {
         Err(ShellError::PluginFailedToDecode {

--- a/crates/nu-plugin-core/src/serializers/msgpack.rs
+++ b/crates/nu-plugin-core/src/serializers/msgpack.rs
@@ -92,9 +92,9 @@ fn rmp_decode_err<T>(err: rmp_serde::decode::Error) -> Result<Option<T>, ShellEr
                 // I/O error
                 Err(ShellError::Io(IoError::new_internal(
                     // TODO: get a better kind here
-                    std::io::ErrorKind::Other, 
-                    "Could not decode with rmp", 
-                    nu_protocol::location!()
+                    std::io::ErrorKind::Other,
+                    "Could not decode with rmp",
+                    nu_protocol::location!(),
                 )))
             }
         }

--- a/crates/nu-plugin-core/src/serializers/msgpack.rs
+++ b/crates/nu-plugin-core/src/serializers/msgpack.rs
@@ -64,11 +64,11 @@ fn rmp_encode_err(err: rmp_serde::encode::Error) -> ShellError {
     match err {
         rmp_serde::encode::Error::InvalidValueWrite(_) => {
             // I/O error
-            ShellError::Io(IoError::new_with_additional_context(
+            ShellError::Io(IoError::new_internal(
+                // TODO: get a better kind here
                 std::io::ErrorKind::Other,
-                Span::unknown(),
-                None,
-                err,
+                "Could not encode with rmp",
+                nu_protocol::location!(),
             ))
         }
         _ => {
@@ -90,10 +90,11 @@ fn rmp_decode_err<T>(err: rmp_serde::decode::Error) -> Result<Option<T>, ShellEr
                 Ok(None)
             } else {
                 // I/O error
-                Err(ShellError::Io(IoError::new(
-                    err.kind(),
-                    Span::unknown(),
-                    None,
+                Err(ShellError::Io(IoError::new_internal(
+                    // TODO: get a better kind here
+                    std::io::ErrorKind::Other, 
+                    "Could not decode with rmp", 
+                    nu_protocol::location!()
                 )))
             }
         }

--- a/crates/nu-plugin-core/src/serializers/msgpack.rs
+++ b/crates/nu-plugin-core/src/serializers/msgpack.rs
@@ -1,7 +1,7 @@
 use std::io::ErrorKind;
 
 use nu_plugin_protocol::{PluginInput, PluginOutput};
-use nu_protocol::{shell_error::io::IoError, ShellError, Span};
+use nu_protocol::{shell_error::io::IoError, ShellError};
 use serde::Deserialize;
 
 use crate::{Encoder, PluginEncoder};

--- a/crates/nu-plugin-core/src/serializers/tests.rs
+++ b/crates/nu-plugin-core/src/serializers/tests.rs
@@ -378,9 +378,11 @@ macro_rules! generate_tests {
                 .with_url("https://example.org/test/error")
                 .with_help("some help")
                 .with_label("msg", Span::new(2, 30))
-                .with_inner(ShellError::IOError {
-                    msg: "io error".into(),
-                });
+                .with_inner(ShellError::Io(IoError::new(
+                    std::io::ErrorKind::NotFound,
+                    Span::test_data(),
+                    None,
+                )));
 
             let response = PluginCallResponse::Error(error.clone());
             let output = PluginOutput::CallResponse(6, response);

--- a/crates/nu-plugin-core/src/serializers/tests.rs
+++ b/crates/nu-plugin-core/src/serializers/tests.rs
@@ -36,18 +36,18 @@ macro_rules! generate_tests {
             let mut buffered = std::io::BufReader::new(ErrorProducer);
             match Encoder::<PluginInput>::decode(&encoder, &mut buffered) {
                 Ok(_) => panic!("decode: i/o error was not passed through"),
-                Err(ShellError::IOError { .. }) => (), // okay
+                Err(ShellError::Io(_)) => (), // okay
                 Err(other) => panic!(
                     "decode: got other error, should have been a \
-                    ShellError::IOError: {other:?}"
+                    ShellError::Io: {other:?}"
                 ),
             }
             match Encoder::<PluginOutput>::decode(&encoder, &mut buffered) {
                 Ok(_) => panic!("decode: i/o error was not passed through"),
-                Err(ShellError::IOError { .. }) => (), // okay
+                Err(ShellError::Io(_)) => (), // okay
                 Err(other) => panic!(
                     "decode: got other error, should have been a \
-                    ShellError::IOError: {other:?}"
+                    ShellError::Io: {other:?}"
                 ),
             }
         }

--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -381,8 +381,13 @@ impl PluginInterfaceManager {
                 // don't block
                 this.state.writer.write(&PluginInput::EngineCallResponse(
                     engine_call_id,
-                    EngineCallResponse::Error(ShellError::IOError {
-                        msg: "Can't make engine call because the original caller hung up".into(),
+                    EngineCallResponse::Error(ShellError::GenericError {
+                        error: "Caller hung up".to_string(),
+                        msg: "Can't make engine call because the original caller hung up"
+                            .to_string(),
+                        span: None,
+                        help: None,
+                        inner: vec![],
                     }),
                 ))?;
                 this.state.writer.flush()

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -6,6 +6,7 @@ use crate::{
     plugin_custom_value_with_source::WithSource, test_util::*, PluginCustomValueWithSource,
     PluginSource,
 };
+use nu_engine::command_prelude::IoError;
 use nu_plugin_core::{interface_test_util::TestCase, Interface, InterfaceManager};
 use nu_plugin_protocol::{
     test_util::{expected_test_custom_value, test_plugin_custom_value},
@@ -86,9 +87,12 @@ fn manager_consume_all_exits_after_streams_and_interfaces_are_dropped() -> Resul
 }
 
 fn test_io_error() -> ShellError {
-    ShellError::IOError {
-        msg: "test io error".into(),
-    }
+    ShellError::Io(IoError::new_with_additional_context(
+        std::io::ErrorKind::Other, 
+        Span::test_data(), 
+        None, 
+        "test io error"
+    ))
 }
 
 fn check_test_io_error(error: &ShellError) {

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -88,10 +88,10 @@ fn manager_consume_all_exits_after_streams_and_interfaces_are_dropped() -> Resul
 
 fn test_io_error() -> ShellError {
     ShellError::Io(IoError::new_with_additional_context(
-        std::io::ErrorKind::Other, 
-        Span::test_data(), 
-        None, 
-        "test io error"
+        std::io::ErrorKind::Other,
+        Span::test_data(),
+        None,
+        "test io error",
     ))
 }
 

--- a/crates/nu-plugin-engine/src/persistent.rs
+++ b/crates/nu-plugin-engine/src/persistent.rs
@@ -7,8 +7,9 @@ use super::{PluginInterface, PluginSource};
 use nu_plugin_core::CommunicationMode;
 use nu_protocol::{
     engine::{EngineState, Stack},
+    shell_error::io::IoError,
     HandlerGuard, Handlers, PluginGcConfig, PluginIdentity, PluginMetadata, RegisteredPlugin,
-    ShellError,
+    ShellError, Span,
 };
 use std::{
     collections::HashMap,
@@ -184,7 +185,14 @@ impl PersistentPlugin {
         })?;
 
         // Start the plugin garbage collector
-        let gc = PluginGc::new(mutable.gc_config.clone(), &self)?;
+        let gc = PluginGc::new(mutable.gc_config.clone(), &self).map_err(|err| {
+            IoError::new_with_additional_context(
+                err.kind(),
+                Span::unknown(),
+                None,
+                "Could not start plugin gc",
+            )
+        })?;
 
         let pid = child.id();
         let interface = make_plugin_interface(

--- a/crates/nu-plugin-test-support/src/spawn_fake_plugin.rs
+++ b/crates/nu-plugin-test-support/src/spawn_fake_plugin.rs
@@ -21,8 +21,12 @@ impl<T: Clone + Send> PluginWrite<T> for FakePluginWrite<T> {
     fn write(&self, data: &T) -> Result<(), ShellError> {
         self.0
             .send(data.clone())
-            .map_err(|err| ShellError::IOError {
-                msg: err.to_string(),
+            .map_err(|e| ShellError::GenericError {
+                error: "Error sending data".to_string(),
+                msg: e.to_string(),
+                span: None,
+                help: None,
+                inner: vec![],
             })
     }
 

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -1047,7 +1047,7 @@ impl ForegroundGuard {
                 use nix::unistd::{setpgid, Pid};
                 // This should always succeed, frankly, but handle the error just in case
                 setpgid(Pid::from_raw(0), Pid::from_raw(0)).map_err(|err| {
-                    shell_error::io::IoError::new_internal(
+                    nu_protocol::shell_error::io::IoError::new_internal(
                         std::io::Error::from(err).kind(),
                         "Could not set pgid",
                         nu_protocol::location!(),

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -12,6 +12,7 @@ use nu_plugin_protocol::{
 };
 use nu_protocol::{
     engine::{Closure, Sequence},
+    shell_error::io::IoError,
     Config, DeclId, Handler, HandlerGuard, Handlers, LabeledError, PipelineData, PluginMetadata,
     PluginSignature, ShellError, SignalAction, Signals, Span, Spanned, Value,
 };
@@ -1046,8 +1047,12 @@ impl ForegroundGuard {
             {
                 use nix::unistd::{setpgid, Pid};
                 // This should always succeed, frankly, but handle the error just in case
-                setpgid(Pid::from_raw(0), Pid::from_raw(0)).map_err(|err| ShellError::IOError {
-                    msg: err.to_string(),
+                setpgid(Pid::from_raw(0), Pid::from_raw(0)).map_err(|err| {
+                    IoError::new_internal(
+                        std::io::Error::from(err).kind(),
+                        "Could not set pgid",
+                        nu_protocol::location!(),
+                    )
                 })?;
             }
             interface.leave_foreground()?;

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -12,7 +12,6 @@ use nu_plugin_protocol::{
 };
 use nu_protocol::{
     engine::{Closure, Sequence},
-    shell_error::io::IoError,
     Config, DeclId, Handler, HandlerGuard, Handlers, LabeledError, PipelineData, PluginMetadata,
     PluginSignature, ShellError, SignalAction, Signals, Span, Spanned, Value,
 };
@@ -1048,7 +1047,7 @@ impl ForegroundGuard {
                 use nix::unistd::{setpgid, Pid};
                 // This should always succeed, frankly, but handle the error just in case
                 setpgid(Pid::from_raw(0), Pid::from_raw(0)).map_err(|err| {
-                    IoError::new_internal(
+                    shell_error::io::IoError::new_internal(
                         std::io::Error::from(err).kind(),
                         "Could not set pgid",
                         nu_protocol::location!(),

--- a/crates/nu-plugin/src/plugin/interface/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/tests.rs
@@ -93,7 +93,7 @@ fn test_io_error() -> ShellError {
         std::io::ErrorKind::Other,
         Span::test_data(),
         None,
-        "test io error"
+        "test io error",
     ))
 }
 

--- a/crates/nu-plugin/src/plugin/interface/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/tests.rs
@@ -1,6 +1,7 @@
 use crate::test_util::TestCaseExt;
 
 use super::{EngineInterfaceManager, ReceivedPluginCall};
+use nu_engine::command_prelude::IoError;
 use nu_plugin_core::{interface_test_util::TestCase, Interface, InterfaceManager};
 use nu_plugin_protocol::{
     test_util::{expected_test_custom_value, test_plugin_custom_value, TestCustomValue},
@@ -88,9 +89,12 @@ fn manager_consume_all_exits_after_streams_and_interfaces_are_dropped() -> Resul
 }
 
 fn test_io_error() -> ShellError {
-    ShellError::IOError {
-        msg: "test io error".into(),
-    }
+    ShellError::Io(IoError::new_with_additional_context(
+        std::io::ErrorKind::Other,
+        Span::test_data(),
+        None,
+        "test io error"
+    ))
 }
 
 fn check_test_io_error(error: &ShellError) {

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -387,7 +387,7 @@ pub enum ServePluginError {
 impl From<ShellError> for ServePluginError {
     fn from(error: ShellError) -> Self {
         match error {
-            ShellError::IOError { .. } => ServePluginError::IOError(error),
+            ShellError::Io(_) => ServePluginError::IOError(error),
             ShellError::PluginFailedToLoad { .. } => ServePluginError::Incompatible(error),
             _ => ServePluginError::UnreportedError(error),
         }

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -143,14 +143,16 @@ impl LabeledError {
     /// [`ShellError`] implements `miette::Diagnostic`:
     ///
     /// ```rust
-    /// # use nu_protocol::{ShellError, LabeledError, shell_error::io::IoError};
-    /// let err = labeledError::from_diagnostic(&Shell)
-    /// let error = LabeledError::from_diagnostic(&ShellError::Io(IoError::new_with_additional_context(
-    ///     std::io::ErrorKind::Other,
-    ///     Span::test_data(),
-    ///     None,
-    ///     "some error"
-    /// ));
+    /// # use nu_protocol::{ShellError, LabeledError, shell_error::io::IoError, Span};
+    /// #
+    /// let error = LabeledError::from_diagnostic(
+    ///     &ShellError::Io(IoError::new_with_additional_context(
+    ///         std::io::ErrorKind::Other,
+    ///         Span::test_data(),
+    ///         None,
+    ///         "some error"
+    ///     ))
+    /// );
     /// assert!(error.to_string().contains("I/O error"));
     /// ```
     pub fn from_diagnostic(diag: &(impl miette::Diagnostic + ?Sized)) -> LabeledError {

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -143,8 +143,14 @@ impl LabeledError {
     /// [`ShellError`] implements `miette::Diagnostic`:
     ///
     /// ```rust
-    /// # use nu_protocol::{ShellError, LabeledError};
-    /// let error = LabeledError::from_diagnostic(&ShellError::IOError { msg: "error".into() });
+    /// # use nu_protocol::{ShellError, LabeledError, shell_error::io::IoError};
+    /// let err = labeledError::from_diagnostic(&Shell)
+    /// let error = LabeledError::from_diagnostic(&ShellError::Io(IoError::new_with_additional_context(
+    ///     std::io::ErrorKind::Other,
+    ///     Span::test_data(),
+    ///     None,
+    ///     "some error"
+    /// ));
     /// assert!(error.to_string().contains("I/O error"));
     /// ```
     pub fn from_diagnostic(diag: &(impl miette::Diagnostic + ?Sized)) -> LabeledError {

--- a/crates/nu-protocol/src/errors/mod.rs
+++ b/crates/nu-protocol/src/errors/mod.rs
@@ -4,7 +4,7 @@ mod config_error;
 mod labeled_error;
 mod parse_error;
 mod parse_warning;
-mod shell_error;
+pub mod shell_error;
 
 pub use cli_error::{
     format_shell_error, report_parse_error, report_parse_warning, report_shell_error,
@@ -15,4 +15,4 @@ pub use config_error::ConfigError;
 pub use labeled_error::{ErrorLabel, LabeledError};
 pub use parse_error::{DidYouMean, ParseError};
 pub use parse_warning::ParseWarning;
-pub use shell_error::*;
+pub use shell_error::ShellError;

--- a/crates/nu-protocol/src/errors/shell_error/bridge.rs
+++ b/crates/nu-protocol/src/errors/shell_error/bridge.rs
@@ -1,0 +1,47 @@
+use super::ShellError;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// A bridge for transferring a [`ShellError`] between Nushell or similar processes.
+///
+/// This newtype encapsulates a [`ShellError`] to facilitate its transfer between Nushell processes
+/// or processes with similar behavior.
+/// By defining this type, we eliminate ambiguity about what is being transferred and avoid the
+/// need to implement [`From<io::Error>`](From) and [`Into<io::Error>`](Into) directly on
+/// `ShellError`.
+#[derive(Debug, Clone, PartialEq, Error, Serialize, Deserialize)]
+#[error("{0}")]
+pub struct ShellErrorBridge(pub ShellError);
+
+impl TryFrom<std::io::Error> for ShellErrorBridge {
+    type Error = std::io::Error;
+
+    fn try_from(value: std::io::Error) -> Result<Self, Self::Error> {
+        let kind = value.kind();
+        value
+            .downcast()
+            .inspect(|_| debug_assert_eq!(kind, std::io::ErrorKind::Other))
+    }
+}
+
+impl From<ShellErrorBridge> for std::io::Error {
+    fn from(value: ShellErrorBridge) -> Self {
+        std::io::Error::other(value)
+    }
+}
+
+#[test]
+fn test_bridge_io_error_roundtrip() {
+    let shell_error = ShellError::GenericError {
+        error: "some error".into(),
+        msg: "some message".into(),
+        span: None,
+        help: None,
+        inner: vec![],
+    };
+
+    let bridge = ShellErrorBridge(shell_error);
+    let io_error = std::io::Error::from(bridge.clone());
+    let bridge_again = ShellErrorBridge::try_from(io_error).unwrap();
+    assert_eq!(bridge.0, bridge_again.0);
+}

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -369,7 +369,11 @@ impl Diagnostic for IoError {
             (true, Some(location)) => SourceSpan::new(0.into(), location.len()),
         };
 
-        let label = LabeledSpan::new_with_span(self.additional_context.clone(), span);
+        let label = match self.additional_context.as_ref() {
+            Some(ctx) => format!("{ctx}\n{}", self.kind),
+            None => self.kind.to_string(),
+        };
+        let label = LabeledSpan::new_with_span(Some(label), span);
         Some(Box::new(std::iter::once(label)))
     }
 

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -45,6 +45,9 @@ pub enum ErrorKind {
     NotADirectory,
     #[error("not a file")]
     NotAFile,
+    // TODO: in Rust 1.83 this can be std::io::ErrorKind::IsADirectory
+    #[error("is a directory")]
+    IsADirectory,
 }
 
 impl IoError {
@@ -101,6 +104,7 @@ impl Diagnostic for IoError {
             },
             ErrorKind::NotADirectory => code.push_str("not_a_directory"),
             ErrorKind::NotAFile => code.push_str("not_a_file"),
+            ErrorKind::IsADirectory => code.push_str("is_a_directory"),
         }
 
         Some(Box::new(code))

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -344,7 +344,7 @@ impl Diagnostic for IoError {
                 std::io::ErrorKind::UnexpectedEof => code.push_str("unexpected_eof"),
                 std::io::ErrorKind::OutOfMemory => code.push_str("out_of_memory"),
                 std::io::ErrorKind::Other => code.push_str("other"),
-                _ => code.push_str("unknown"),
+                _ => code.push_str(&code.to_string().to_lowercase().replace(" ", "_")),
             },
             ErrorKind::NotADirectory => code.push_str("not_a_directory"),
             ErrorKind::NotAFile => code.push_str("not_a_file"),

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -88,6 +88,8 @@ impl IoError {
     /// - `new_internal_with_path` if a path is available.
     pub fn new(kind: impl Into<ErrorKind>, span: Span, path: impl Into<Option<PathBuf>>) -> Self {
         let path = path.into();
+
+        #[cfg(not(test))]
         if span == Span::unknown() {
             debug_assert!(
                 path.is_some(),
@@ -127,6 +129,8 @@ impl IoError {
         additional_context: impl ToString,
     ) -> Self {
         let path = path.into();
+        
+        #[cfg(not(test))]
         if span == Span::unknown() {
             debug_assert!(
                 path.is_some(),

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -128,7 +128,7 @@ impl IoError {
         additional_context: impl ToString,
     ) -> Self {
         let path = path.into();
-        
+
         if span == Span::unknown() {
             debug_assert!(
                 path.is_some(),
@@ -201,7 +201,7 @@ impl IoError {
     /// ```rust
     /// use std::path::PathBuf;
     /// use nu_protocol::shell_error::io::IoError;
-    /// 
+    ///
     /// let error = IoError::new_internal_with_path(
     ///     std::io::ErrorKind::NotFound,
     ///     "Could not find special file",

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -10,6 +10,7 @@ use crate::Span;
 use super::{location::Location, ShellError};
 
 #[derive(Debug, Clone, Error, PartialEq)]
+#[non_exhaustive]
 #[error("I/O error")]
 pub struct IoError {
     /// The type of the underlying I/O error.
@@ -48,19 +49,6 @@ pub struct IoError {
     /// This value is only used if `span` is [`Span::unknown()`] as most of the time we want to
     /// refer to user code than the Rust code.
     pub location: Option<String>,
-
-    /// An intentionally unused private field to prevent direct construction.
-    ///
-    /// This field ensures that the struct can only be created through the accompanying constructors,
-    /// motivating construction of this type with proper fields.
-    ///
-    /// Public fields can still be modified if required but this requires more work and is therefore
-    /// probably not done.
-    ///
-    /// This field is marked with `#[doc(hidden)]` to hide it from the public API.
-    /// It is purely a zero-sized marker field and has no runtime cost.
-    #[doc(hidden)]
-    _force_constructor: (),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Diagnostic)]
@@ -103,10 +91,9 @@ impl IoError {
         Self {
             kind: kind.into(),
             span,
-            path: path.into(),
+            path,
             additional_context: None,
             location: None,
-            _force_constructor: (),
         }
     }
 
@@ -143,10 +130,9 @@ impl IoError {
         Self {
             kind: kind.into(),
             span,
-            path: path,
+            path,
             additional_context: Some(additional_context.to_string()),
             location: None,
-            _force_constructor: (),
         }
     }
 
@@ -187,7 +173,6 @@ impl IoError {
             path: None,
             additional_context: Some(additional_context.to_string()),
             location: Some(location.to_string()),
-            _force_constructor: (),
         }
     }
 
@@ -221,7 +206,6 @@ impl IoError {
             path: path.into(),
             additional_context: Some(additional_context.to_string()),
             location: Some(location.to_string()),
-            _force_constructor: (),
         }
     }
 

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -344,7 +344,7 @@ impl Diagnostic for IoError {
                 std::io::ErrorKind::UnexpectedEof => code.push_str("unexpected_eof"),
                 std::io::ErrorKind::OutOfMemory => code.push_str("out_of_memory"),
                 std::io::ErrorKind::Other => code.push_str("other"),
-                _ => code.push_str(&code.to_string().to_lowercase().replace(" ", "_")),
+                kind => code.push_str(&kind.to_string().to_lowercase().replace(" ", "_")),
             },
             ErrorKind::NotADirectory => code.push_str("not_a_directory"),
             ErrorKind::NotAFile => code.push_str("not_a_file"),

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -35,9 +35,13 @@ use super::{location::Location, ShellError};
 /// # use nu_protocol::Span;
 /// use std::path::PathBuf;
 ///
-/// # let span = Span::new(10, 20);
+/// # let span = Span::test_data();
 /// let path = PathBuf::from("/some/missing/file");
-/// let error = IoError::new(ErrorKind::NotFound, span, Some(path));
+/// let error = IoError::new(
+///     std::io::ErrorKind::NotFound, 
+///     span, 
+///     path
+/// );
 /// println!("Error: {:?}", error);
 /// ```
 ///
@@ -46,7 +50,7 @@ use super::{location::Location, ShellError};
 /// # use nu_protocol::shell_error::io::{IoError, ErrorKind};
 //  #
 /// let error = IoError::new_internal(
-///     ErrorKind::UnexpectedEof,
+///     std::io::ErrorKind::UnexpectedEof,
 ///     "Failed to read data from buffer",
 ///     nu_protocol::location!()
 /// );
@@ -56,14 +60,19 @@ use super::{location::Location, ShellError};
 /// ## Using the Factory Method
 /// ```rust
 /// # use nu_protocol::shell_error::io::{IoError, ErrorKind};
-/// # use nu_protocol::Span;
+/// # use nu_protocol::{Span, ShellError};
 /// use std::path::PathBuf;
 ///
+/// # fn should_return_err() -> Result<(), ShellError> {
 /// # let span = Span::new(50, 60);
 /// let path = PathBuf::from("/some/file");
-/// let from_io_error = IoError::factory(span, Some(&path));
+/// let from_io_error = IoError::factory(span, Some(path.as_path()));
 ///
 /// let content = std::fs::read_to_string(&path).map_err(from_io_error)?;
+/// # Ok(())
+/// # }
+/// #
+/// # assert!(should_return_err().is_err());
 /// ```
 ///
 /// # ShellErrorBridge

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -89,7 +89,6 @@ impl IoError {
     pub fn new(kind: impl Into<ErrorKind>, span: Span, path: impl Into<Option<PathBuf>>) -> Self {
         let path = path.into();
 
-        #[cfg(not(test))]
         if span == Span::unknown() {
             debug_assert!(
                 path.is_some(),
@@ -130,7 +129,6 @@ impl IoError {
     ) -> Self {
         let path = path.into();
         
-        #[cfg(not(test))]
         if span == Span::unknown() {
             debug_assert!(
                 path.is_some(),

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -168,12 +168,12 @@ impl IoError {
     ///
     /// # Examples
     /// ```rust
-    /// use nu_protocol::location;
+    /// use nu_protocol::shell_error::io::IoError;
     ///
     /// let error = IoError::new_internal(
-    ///     ErrorKind::UnexpectedEof,
+    ///     std::io::ErrorKind::UnexpectedEof,
     ///     "Failed to read from buffer",
-    ///     location!(),
+    ///     nu_protocol::location!(),
     /// );
     /// ```
     pub fn new_internal(
@@ -199,13 +199,14 @@ impl IoError {
     ///
     /// # Examples
     /// ```rust
-    /// use nu_protocol::location;
-    ///
+    /// use std::path::PathBuf;
+    /// use nu_protocol::shell_error::io::IoError;
+    /// 
     /// let error = IoError::new_internal_with_path(
-    ///     ErrorKind::PermissionDenied,
-    ///     Some("/root/private-file".into()),
-    ///     "Access denied while attempting to read the file",
-    ///     location!(),
+    ///     std::io::ErrorKind::NotFound,
+    ///     "Could not find special file",
+    ///     nu_protocol::location!(),
+    ///     PathBuf::from("/some/file"),
     /// );
     /// ```
     pub fn new_internal_with_path(

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -1,0 +1,86 @@
+use miette::Diagnostic;
+use std::path::PathBuf;
+use thiserror::Error;
+
+use crate::Span;
+
+use super::ShellError;
+
+#[derive(Debug, Clone, Error, PartialEq)]
+#[error("I/O error")]
+pub struct IoError {
+    /// The type of the underlying I/O error.
+    ///
+    /// [`std::io::ErrorKind`] provides detailed context about the type of I/O error that occurred
+    /// and is part of [`std::io::Error`].
+    /// If a kind cannot be represented by it, consider adding a new variant to [`ErrorKind`].
+    ///
+    /// Only in very rare cases should [`std::io::ErrorKind::Other`] be used.
+    pub kind: ErrorKind,
+
+    /// The source location of the error.
+    pub span: Span,
+
+    /// The path related to the I/O error, if applicable.
+    ///
+    /// Many I/O errors involve a file or directory path, but operating system error messages
+    /// often don't include the specific path.
+    /// Setting this to [`Some`] allows users to see which path caused the error.
+    pub path: Option<PathBuf>,
+
+    /// Additional details to provide more context about the error.
+    ///
+    /// Only set this field if it adds meaningful context.
+    /// If [`ErrorKind`] already contains all the necessary information, leave this as [`None`].
+    pub additional_context: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ErrorKind {
+    Std(std::io::ErrorKind),
+    // TODO: in Rust 1.83 this can be std::io::ErrorKind::NotADirectory
+    NotADirectory,
+}
+
+impl IoError {
+    pub fn new(kind: impl Into<ErrorKind>, span: Span, path: impl Into<Option<PathBuf>>) -> Self {
+        Self {
+            kind: kind.into(),
+            span,
+            path: path.into(),
+            additional_context: None,
+        }
+    }
+
+    pub fn new_with_additional_context(
+        kind: impl Into<ErrorKind>,
+        span: Span,
+        path: impl Into<Option<PathBuf>>,
+        additional_context: impl ToString,
+    ) -> Self {
+        Self {
+            kind: kind.into(),
+            span,
+            path: path.into(),
+            additional_context: Some(additional_context.to_string()),
+        }
+    }
+}
+
+impl Diagnostic for IoError {
+    fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        todo!()
+    }
+}
+
+impl From<IoError> for ShellError {
+    fn from(value: IoError) -> Self {
+        ShellError::Io(value)
+    }
+}
+
+impl From<std::io::ErrorKind> for ErrorKind {
+    fn from(value: std::io::ErrorKind) -> Self {
+        ErrorKind::Std(value)
+    }
+}

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -50,8 +50,8 @@ pub struct IoError {
     ///
     /// This field ensures that the struct can only be created through the accompanying constructors,
     /// motivating construction of this type with proper fields.
-    /// 
-    /// Public fields can still be modified if required but this requires more work and is therefore 
+    ///
+    /// Public fields can still be modified if required but this requires more work and is therefore
     /// probably not done.
     ///
     /// This field is marked with `#[doc(hidden)]` to hide it from the public API.
@@ -86,10 +86,16 @@ impl IoError {
     pub fn new(kind: impl Into<ErrorKind>, span: Span, path: impl Into<Option<PathBuf>>) -> Self {
         let path = path.into();
         if span == Span::unknown() {
-            debug_assert!(path.is_some(), "for unknown spans with paths, use `new_internal_with_path`");
-            debug_assert!(path.is_none(), "for unknown spans without paths, use `new_internal`");
+            debug_assert!(
+                path.is_some(),
+                "for unknown spans with paths, use `new_internal_with_path`"
+            );
+            debug_assert!(
+                path.is_none(),
+                "for unknown spans without paths, use `new_internal`"
+            );
         }
-        
+
         Self {
             kind: kind.into(),
             span,
@@ -106,7 +112,7 @@ impl IoError {
     /// explain the error, and additional context can provide meaningful details.
     /// Avoid redundant context (e.g., "Permission denied" for an error kind of
     /// [`ErrorKind::PermissionDenied`](std::io::ErrorKind::PermissionDenied)).
-    /// 
+    ///
     /// # Constraints
     /// If `span` is unknown, use:
     /// - `new_internal` if no path is available.
@@ -119,8 +125,14 @@ impl IoError {
     ) -> Self {
         let path = path.into();
         if span == Span::unknown() {
-            debug_assert!(path.is_some(), "for unknown spans with paths, use `new_internal_with_path`");
-            debug_assert!(path.is_none(), "for unknown spans without paths, use `new_internal`");
+            debug_assert!(
+                path.is_some(),
+                "for unknown spans with paths, use `new_internal_with_path`"
+            );
+            debug_assert!(
+                path.is_none(),
+                "for unknown spans without paths, use `new_internal`"
+            );
         }
 
         Self {
@@ -129,7 +141,7 @@ impl IoError {
             path: path,
             additional_context: Some(additional_context.to_string()),
             location: None,
-            _force_constructor: ()
+            _force_constructor: (),
         }
     }
 
@@ -170,20 +182,20 @@ impl IoError {
             path: None,
             additional_context: Some(additional_context.to_string()),
             location: Some(location.to_string()),
-            _force_constructor: ()
+            _force_constructor: (),
         }
     }
 
     /// Creates a new `IoError` for internal I/O errors with a specific path.
     ///
-    /// This constructor is similar to [`new_internal`] but also includes a file or directory 
-    /// path relevant to the error. Use this function in rare cases where an internal error 
+    /// This constructor is similar to [`new_internal`] but also includes a file or directory
+    /// path relevant to the error. Use this function in rare cases where an internal error
     /// involves a specific path, and the combination of path and additional context is helpful.
-    /// 
+    ///
     /// # Examples
     /// ```rust
     /// use nu_protocol::location;
-    /// 
+    ///
     /// let error = IoError::new_internal_with_path(
     ///     ErrorKind::PermissionDenied,
     ///     Some("/root/private-file".into()),
@@ -215,7 +227,7 @@ impl Display for ErrorKind {
                 let msg = error_kind.to_string();
                 let (first, rest) = msg.split_at(1);
                 write!(f, "{}{}", first.to_uppercase(), rest)
-            },
+            }
             ErrorKind::NotADirectory => write!(f, "Not a directory"),
             ErrorKind::NotAFile => write!(f, "Not a file"),
             ErrorKind::IsADirectory => write!(f, "Is a directory"),

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -38,8 +38,8 @@ use super::{location::Location, ShellError};
 /// # let span = Span::test_data();
 /// let path = PathBuf::from("/some/missing/file");
 /// let error = IoError::new(
-///     std::io::ErrorKind::NotFound, 
-///     span, 
+///     std::io::ErrorKind::NotFound,
+///     span,
 ///     path
 /// );
 /// println!("Error: {:?}", error);

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -1,10 +1,10 @@
-use miette::{Diagnostic, LabeledSpan};
-use std::path::PathBuf;
+use miette::{Diagnostic, LabeledSpan, SourceSpan};
+use std::{fmt::Display, path::PathBuf};
 use thiserror::Error;
 
 use crate::Span;
 
-use super::ShellError;
+use super::{location::Location, ShellError};
 
 #[derive(Debug, Clone, Error, PartialEq)]
 #[error("I/O error")]
@@ -33,55 +33,197 @@ pub struct IoError {
     ///
     /// Only set this field if it adds meaningful context.
     /// If [`ErrorKind`] already contains all the necessary information, leave this as [`None`].
-    pub additional_context: Option<AdditionalContext>,
+    pub additional_context: Option<String>,
+
+    /// The precise location in the Rust code where the error originated.
+    ///
+    /// This field is particularly useful for debugging errors that stem from the Rust
+    /// implementation rather than user-provided Nushell code.
+    /// The original [`Location`] is converted to a string to more easily report the error
+    /// attributing the location.
+    ///
+    /// This value is only used if `span` is [`Span::unknown()`] as most of the time we want to
+    /// refer to user code than the Rust code.
+    pub location: Option<String>,
+
+    /// An intentionally unused private field to prevent direct construction.
+    ///
+    /// This field ensures that the struct can only be created through the accompanying constructors,
+    /// motivating construction of this type with proper fields.
+    /// 
+    /// Public fields can still be modified if required but this requires more work and is therefore 
+    /// probably not done.
+    ///
+    /// This field is marked with `#[doc(hidden)]` to hide it from the public API.
+    /// It is purely a zero-sized marker field and has no runtime cost.
+    #[doc(hidden)]
+    _force_constructor: (),
 }
 
-/// Provides additional context for an [`IoError`].
-///
-/// This newtype exists solely to implement [`Error`] and [`Diagnostic`], enhancing the layout of
-/// error reports for I/O errors.
-#[derive(Debug, Clone, Error, Diagnostic, PartialEq, Eq)]
-#[error("{0}")]
-pub struct AdditionalContext(pub String);
-
-#[derive(Debug, Clone, Copy, PartialEq, Error)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Diagnostic)]
 pub enum ErrorKind {
-    #[error("{0}")]
     Std(std::io::ErrorKind),
     // TODO: in Rust 1.83 this can be std::io::ErrorKind::NotADirectory
-    #[error("not a directory")]
     NotADirectory,
-    #[error("not a file")]
     NotAFile,
     // TODO: in Rust 1.83 this can be std::io::ErrorKind::IsADirectory
-    #[error("is a directory")]
     IsADirectory,
 }
 
 impl IoError {
+    /// Creates a new [`IoError`] with the given kind, span, and optional path.
+    ///
+    /// This constructor should be used in all cases where the combination of the error kind, span,
+    /// and path provides enough information to describe the error clearly.
+    /// For example, errors like "File not found" or "Permission denied" are typically
+    /// self-explanatory when paired with the file path and the location in user-provided
+    /// Nushell code (`span`).
+    ///
+    /// # Constraints
+    /// If `span` is unknown, use:
+    /// - `new_internal` if no path is available.
+    /// - `new_internal_with_path` if a path is available.
     pub fn new(kind: impl Into<ErrorKind>, span: Span, path: impl Into<Option<PathBuf>>) -> Self {
+        let path = path.into();
+        if span == Span::unknown() {
+            debug_assert!(path.is_some(), "for unknown spans with paths, use `new_internal_with_path`");
+            debug_assert!(path.is_none(), "for unknown spans without paths, use `new_internal`");
+        }
+        
         Self {
             kind: kind.into(),
             span,
             path: path.into(),
             additional_context: None,
+            location: None,
+            _force_constructor: (),
         }
     }
 
+    /// Creates a new [`IoError`] with additional context.
+    ///
+    /// Use this constructor when the error kind, span, and path are not sufficient to fully
+    /// explain the error, and additional context can provide meaningful details.
+    /// Avoid redundant context (e.g., "Permission denied" for an error kind of
+    /// [`ErrorKind::PermissionDenied`](std::io::ErrorKind::PermissionDenied)).
+    /// 
+    /// # Constraints
+    /// If `span` is unknown, use:
+    /// - `new_internal` if no path is available.
+    /// - `new_internal_with_path` if a path is available.
     pub fn new_with_additional_context(
         kind: impl Into<ErrorKind>,
         span: Span,
         path: impl Into<Option<PathBuf>>,
         additional_context: impl ToString,
     ) -> Self {
+        let path = path.into();
+        if span == Span::unknown() {
+            debug_assert!(path.is_some(), "for unknown spans with paths, use `new_internal_with_path`");
+            debug_assert!(path.is_none(), "for unknown spans without paths, use `new_internal`");
+        }
+
         Self {
             kind: kind.into(),
             span,
+            path: path,
+            additional_context: Some(additional_context.to_string()),
+            location: None,
+            _force_constructor: ()
+        }
+    }
+
+    /// Creates a new [`IoError`] for internal I/O errors without a user-provided span or path.
+    ///
+    /// This constructor is intended for internal errors in the Rust implementation that still need
+    /// to be reported to the end user.
+    /// Since these errors are not tied to user-provided Nushell code, they generally have no
+    /// meaningful span or path.
+    ///
+    /// Instead, these errors provide:
+    /// - `additional_context`:
+    ///   Details about what went wrong internally.
+    /// - `location`:
+    ///   The location in the Rust code where the error occurred, allowing us to trace and debug
+    ///   the issue.
+    ///   Use the [`nu_protocol::location!`](crate::location) macro to generate the location
+    ///   information.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use nu_protocol::location;
+    ///
+    /// let error = IoError::new_internal(
+    ///     ErrorKind::UnexpectedEof,
+    ///     "Failed to read from buffer",
+    ///     location!(),
+    /// );
+    /// ```
+    pub fn new_internal(
+        kind: impl Into<ErrorKind>,
+        additional_context: impl ToString,
+        location: Location,
+    ) -> Self {
+        Self {
+            kind: kind.into(),
+            span: Span::unknown(),
+            path: None,
+            additional_context: Some(additional_context.to_string()),
+            location: Some(location.to_string()),
+            _force_constructor: ()
+        }
+    }
+
+    /// Creates a new `IoError` for internal I/O errors with a specific path.
+    ///
+    /// This constructor is similar to [`new_internal`] but also includes a file or directory 
+    /// path relevant to the error. Use this function in rare cases where an internal error 
+    /// involves a specific path, and the combination of path and additional context is helpful.
+    /// 
+    /// # Examples
+    /// ```rust
+    /// use nu_protocol::location;
+    /// 
+    /// let error = IoError::new_internal_with_path(
+    ///     ErrorKind::PermissionDenied,
+    ///     Some("/root/private-file".into()),
+    ///     "Access denied while attempting to read the file",
+    ///     location!(),
+    /// );
+    /// ```
+    pub fn new_internal_with_path(
+        kind: impl Into<ErrorKind>,
+        additional_context: impl ToString,
+        location: Location,
+        path: PathBuf,
+    ) -> Self {
+        Self {
+            kind: kind.into(),
+            span: Span::unknown(),
             path: path.into(),
-            additional_context: Some(AdditionalContext(additional_context.to_string())),
+            additional_context: Some(additional_context.to_string()),
+            location: Some(location.to_string()),
+            _force_constructor: (),
         }
     }
 }
+
+impl Display for ErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ErrorKind::Std(error_kind) => {
+                let msg = error_kind.to_string();
+                let (first, rest) = msg.split_at(1);
+                write!(f, "{}{}", first.to_uppercase(), rest)
+            },
+            ErrorKind::NotADirectory => write!(f, "Not a directory"),
+            ErrorKind::NotAFile => write!(f, "Not a file"),
+            ErrorKind::IsADirectory => write!(f, "Is a directory"),
+        }
+    }
+}
+
+impl std::error::Error for ErrorKind {}
 
 impl Diagnostic for IoError {
     fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
@@ -126,14 +268,27 @@ impl Diagnostic for IoError {
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-        let label = LabeledSpan::new_with_span(self.kind.to_string().into(), self.span);
+        let span_is_unknown = self.span == Span::unknown();
+        let span = match (span_is_unknown, self.location.as_ref()) {
+            (true, None) => return None,
+            (false, _) => SourceSpan::from(self.span),
+            (true, Some(location)) => SourceSpan::new(0.into(), location.len()),
+        };
+
+        let label = LabeledSpan::new_with_span(self.additional_context.clone(), span);
         Some(Box::new(std::iter::once(label)))
     }
 
     fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
-        self.additional_context
-            .as_ref()
-            .map(|diagnostic| diagnostic as &dyn Diagnostic)
+        Some(&self.kind as &dyn Diagnostic)
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        let span_is_unknown = self.span == Span::unknown();
+        match (span_is_unknown, self.location.as_ref()) {
+            (true, None) | (false, _) => None,
+            (true, Some(location)) => Some(location as &dyn miette::SourceCode),
+        }
     }
 }
 

--- a/crates/nu-protocol/src/errors/shell_error/location.rs
+++ b/crates/nu-protocol/src/errors/shell_error/location.rs
@@ -1,0 +1,56 @@
+use thiserror::Error;
+
+/// Represents a specific location in the Rust code.
+///
+/// This data structure is used to provide detailed information about where in the Rust code
+/// an error occurred.
+/// While most errors in [`ShellError`](super::ShellError) are related to user-provided Nushell
+/// code, some originate from the underlying Rust implementation.
+/// With this type, we can pinpoint the exact location of such errors, improving debugging
+/// and error reporting.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("{file}:{line}:{column}")]
+pub struct Location {
+    file: &'static str,
+    line: u32,
+    column: u32,
+}
+
+impl Location {
+    /// Internal constructor for [`Location`].
+    ///
+    /// This function is not intended to be called directly.
+    /// Instead, use the [`location!`] macro to create instances.
+    #[doc(hidden)]
+    #[deprecated(
+        note = "This function is not meant to be called directly. Use `nu_protocol::location` instead."
+    )]
+    pub fn new(file: &'static str, line: u32, column: u32) -> Self {
+        Location { file, line, column }
+    }
+}
+
+/// Macro to create a new [`Location`] for the exact position in your code.
+///
+/// This macro captures the current file, line, and column during compilation,
+/// providing an easy way to associate errors with specific locations in the Rust code.
+///
+/// # Note
+/// This macro relies on the [`file!`], [`line!`], and [`column!`] macros to fetch the
+/// compilation context.
+#[macro_export]
+macro_rules! location {
+    () => {{
+        #[allow(deprecated)]
+        $crate::shell_error::location::Location::new(file!(), line!(), column!())
+    }};
+}
+
+#[test]
+fn test_location_macro() {
+    let location = crate::location!();
+    let line = line!() - 1; // Adjust for the macro call being on the previous line.
+    let file = file!();
+    assert_eq!(location.line, line);
+    assert_eq!(location.file, file);
+}

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1679,3 +1679,26 @@ fn shell_error_serialize_roundtrip() {
         deserialized.help().map(|c| c.to_string())
     );
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    impl From<std::io::Error> for ShellError {
+        fn from(_: std::io::Error) -> ShellError {
+            unimplemented!("This implementation is defined in the test module to ensure no other implementation exists.")
+        }
+    }
+
+    impl From<Spanned<std::io::Error>> for ShellError {
+        fn from(_: Spanned<std::io::Error>) -> Self {
+            unimplemented!("This implementation is defined in the test module to ensure no other implementation exists.")
+        }
+    }
+
+    impl From<ShellError> for std::io::Error {
+        fn from(_: ShellError) -> Self {
+            unimplemented!("This implementation is defined in the test module to ensure no other implementation exists.")
+        }
+    }
+}

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1064,6 +1064,7 @@ pub enum ShellError {
     /// Removal can fail for a number of reasons, such as permissions problems. Refer to the specific error message for more details.
     #[error("Remove not possible")]
     #[diagnostic(code(nu::shell::remove_not_possible))]
+    #[deprecated]
     RemoveNotPossible {
         msg: String,
         #[label("{msg}")]

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1561,12 +1561,12 @@ impl ShellError {
 // }
 
 // FIXME: this impl is originally absolutely cursed, we need to do something about it
-impl From<Spanned<std::io::Error>> for ShellError {
-    fn from(error: Spanned<std::io::Error>) -> Self {
-        let Spanned { item: error, span } = error;
-        IoError::new(error.kind(), span, None).into()
-    }
-}
+// impl From<Spanned<std::io::Error>> for ShellError {
+//     fn from(error: Spanned<std::io::Error>) -> Self {
+//         let Spanned { item: error, span } = error;
+//         IoError::new(error.kind(), span, None).into()
+//     }
+// }
 
 // impl From<ShellError> for std::io::Error {
 //     fn from(error: ShellError) -> Self {

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use std::num::NonZeroI32;
 use thiserror::Error;
 
+pub mod bridge;
 pub mod io;
+pub mod location;
 
 /// The fundamental error type for the evaluation engine. These cases represent different kinds of errors
 /// the evaluator might face, along with helpful spans to label. An error renderer will take this error value
@@ -1551,12 +1553,12 @@ impl ShellError {
     }
 }
 
-impl From<std::io::Error> for ShellError {
-    // TODO: deprecate this
-    fn from(error: std::io::Error) -> ShellError {
-        Self::Io(IoError::new(error.kind(), Span::unknown(), None))
-    }
-}
+// impl From<std::io::Error> for ShellError {
+//     // TODO: deprecate this
+//     fn from(error: std::io::Error) -> ShellError {
+//         Self::Io(IoError::new(error.kind(), Span::unknown(), None))
+//     }
+// }
 
 // FIXME: this impl is originally absolutely cursed, we need to do something about it
 impl From<Spanned<std::io::Error>> for ShellError {
@@ -1566,14 +1568,14 @@ impl From<Spanned<std::io::Error>> for ShellError {
     }
 }
 
-impl From<ShellError> for std::io::Error {
-    fn from(error: ShellError) -> Self {
-        match error {
-            ShellError::Io(error) => error.into(),
-            _ => Self::new(std::io::ErrorKind::Other, error),
-        }
-    }
-}
+// impl From<ShellError> for std::io::Error {
+//     fn from(error: ShellError) -> Self {
+//         match error {
+//             ShellError::Io(error) => error.into(),
+//             _ => Self::new(std::io::ErrorKind::Other, error),
+//         }
+//     }
+// }
 
 impl From<Box<dyn std::error::Error>> for ShellError {
     fn from(error: Box<dyn std::error::Error>) -> ShellError {

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1022,6 +1022,7 @@ pub enum ShellError {
     /// This is a fairly generic error. Refer to the specific error message for further details.
     #[error("Create not possible")]
     #[diagnostic(code(nu::shell::create_not_possible))]
+    #[deprecated]
     CreateNotPossible {
         msg: String,
         #[label("{msg}")]
@@ -1035,6 +1036,7 @@ pub enum ShellError {
     /// This can be for various reasons, such as your platform or permission flags. Refer to the specific error message for more details.
     #[error("Not possible to change the access time")]
     #[diagnostic(code(nu::shell::change_access_time_not_possible))]
+    #[deprecated]
     ChangeAccessTimeNotPossible {
         msg: String,
         #[label("{msg}")]
@@ -1048,6 +1050,7 @@ pub enum ShellError {
     /// This can be for various reasons, such as your platform or permission flags. Refer to the specific error message for more details.
     #[error("Not possible to change the modified time")]
     #[diagnostic(code(nu::shell::change_modified_time_not_possible))]
+    #[deprecated]
     ChangeModifiedTimeNotPossible {
         msg: String,
         #[label("{msg}")]

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -962,6 +962,7 @@ pub enum ShellError {
     /// This is a generic error. Refer to the specific error message for further details.
     #[error("I/O error")]
     #[diagnostic(code(nu::shell::io_error))]
+    #[deprecated]
     IOErrorSpanned {
         msg: String,
         #[label("{msg}")]

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1558,6 +1558,7 @@ impl From<std::io::Error> for ShellError {
     }
 }
 
+// FIXME: this impl is originally absolutely cursed, we need to do something about it
 impl From<Spanned<std::io::Error>> for ShellError {
     fn from(error: Spanned<std::io::Error>) -> Self {
         let Spanned { item: error, span } = error;

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1078,6 +1078,7 @@ pub enum ShellError {
     /// The error will show the result from a file operation
     #[error("Error trying to read file")]
     #[diagnostic(code(nu::shell::error_reading_file))]
+    #[deprecated]
     ReadingFile {
         msg: String,
         #[label("{msg}")]

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -2,7 +2,6 @@ use crate::{
     ast::Operator, engine::StateWorkingSet, format_shell_error, record, ConfigError, LabeledError,
     ParseError, Span, Spanned, Type, Value,
 };
-use io::IoError;
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroI32;

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -812,34 +812,6 @@ pub enum ShellError {
         span: Span,
     },
 
-    /// Failed to find a file during a nushell operation.
-    ///
-    /// ## Resolution
-    ///
-    /// Does the file in the error message exist? Is it readable and accessible? Is the casing right?
-    #[error("File not found")]
-    #[diagnostic(code(nu::shell::file_not_found), help("{file} does not exist"))]
-    #[deprecated]
-    FileNotFound {
-        file: String,
-        #[label("file not found")]
-        span: Span,
-    },
-
-    /// Failed to find a file during a nushell operation.
-    ///
-    /// ## Resolution
-    ///
-    /// Does the file in the error message exist? Is it readable and accessible? Is the casing right?
-    #[error("File not found")]
-    #[diagnostic(code(nu::shell::file_not_found))]
-    #[deprecated]
-    FileNotFoundCustom {
-        msg: String,
-        #[label("{msg}")]
-        span: Span,
-    },
-
     /// The registered plugin data for a plugin is invalid.
     ///
     /// ## Resolution
@@ -930,163 +902,14 @@ pub enum ShellError {
         span: Span,
     },
 
+    /// An I/O operation failed.
+    ///
+    /// ## Resolution
+    ///
+    /// This is the main I/O error, for further details check the error kind and additional context.
     #[error(transparent)]
     #[diagnostic(transparent)]
     Io(io::IoError),
-
-    /// I/O operation interrupted.
-    ///
-    /// ## Resolution
-    ///
-    /// This is a generic error. Refer to the specific error message for further details.
-    #[error("I/O interrupted")]
-    #[diagnostic(code(nu::shell::io_interrupted))]
-    #[deprecated]
-    IOInterrupted {
-        msg: String,
-        #[label("{msg}")]
-        span: Span,
-    },
-
-    /// An I/O operation failed.
-    ///
-    /// ## Resolution
-    ///
-    /// This is a generic error. Refer to the specific error message for further details.
-    #[error("I/O error")]
-    #[diagnostic(code(nu::shell::io_error), help("{msg}"))]
-    #[deprecated]
-    IOError { msg: String },
-
-    /// An I/O operation failed.
-    ///
-    /// ## Resolution
-    ///
-    /// This is a generic error. Refer to the specific error message for further details.
-    #[error("I/O error")]
-    #[diagnostic(code(nu::shell::io_error))]
-    #[deprecated]
-    IOErrorSpanned {
-        msg: String,
-        #[label("{msg}")]
-        span: Span,
-    },
-
-    /// Tried to `cd` to a path that isn't a directory.
-    ///
-    /// ## Resolution
-    ///
-    /// Make sure the path is a directory. It currently exists, but is of some other type, like a file.
-    #[error("Cannot change to directory")]
-    #[diagnostic(code(nu::shell::cannot_cd_to_directory))]
-    #[deprecated]
-    NotADirectory {
-        #[label("is not a directory")]
-        span: Span,
-    },
-
-    /// Attempted to perform an operation on a directory that doesn't exist.
-    ///
-    /// ## Resolution
-    ///
-    /// Make sure the directory in the error message actually exists before trying again.
-    #[error("Directory not found")]
-    #[diagnostic(code(nu::shell::directory_not_found), help("{dir} does not exist"))]
-    #[deprecated]
-    DirectoryNotFound {
-        dir: String,
-        #[label("directory not found")]
-        span: Span,
-    },
-
-    /// The requested move operation cannot be completed. This is typically because both paths exist,
-    /// but are of different types. For example, you might be trying to overwrite an existing file with
-    /// a directory.
-    ///
-    /// ## Resolution
-    ///
-    /// Make sure the destination path does not exist before moving a directory.
-    #[error("Move not possible")]
-    #[diagnostic(code(nu::shell::move_not_possible))]
-    #[deprecated]
-    MoveNotPossible {
-        source_message: String,
-        #[label("{source_message}")]
-        source_span: Span,
-        destination_message: String,
-        #[label("{destination_message}")]
-        destination_span: Span,
-    },
-
-    /// Failed to create either a file or directory.
-    ///
-    /// ## Resolution
-    ///
-    /// This is a fairly generic error. Refer to the specific error message for further details.
-    #[error("Create not possible")]
-    #[diagnostic(code(nu::shell::create_not_possible))]
-    #[deprecated]
-    CreateNotPossible {
-        msg: String,
-        #[label("{msg}")]
-        span: Span,
-    },
-
-    /// Changing the access time ("atime") of this file is not possible.
-    ///
-    /// ## Resolution
-    ///
-    /// This can be for various reasons, such as your platform or permission flags. Refer to the specific error message for more details.
-    #[error("Not possible to change the access time")]
-    #[diagnostic(code(nu::shell::change_access_time_not_possible))]
-    #[deprecated]
-    ChangeAccessTimeNotPossible {
-        msg: String,
-        #[label("{msg}")]
-        span: Span,
-    },
-
-    /// Changing the modification time ("mtime") of this file is not possible.
-    ///
-    /// ## Resolution
-    ///
-    /// This can be for various reasons, such as your platform or permission flags. Refer to the specific error message for more details.
-    #[error("Not possible to change the modified time")]
-    #[diagnostic(code(nu::shell::change_modified_time_not_possible))]
-    #[deprecated]
-    ChangeModifiedTimeNotPossible {
-        msg: String,
-        #[label("{msg}")]
-        span: Span,
-    },
-
-    /// Unable to remove this item.
-    ///
-    /// ## Resolution
-    ///
-    /// Removal can fail for a number of reasons, such as permissions problems. Refer to the specific error message for more details.
-    #[error("Remove not possible")]
-    #[diagnostic(code(nu::shell::remove_not_possible))]
-    #[deprecated]
-    RemoveNotPossible {
-        msg: String,
-        #[label("{msg}")]
-        span: Span,
-    },
-
-    /// Error while trying to read a file
-    ///
-    /// ## Resolution
-    ///
-    /// The error will show the result from a file operation
-    #[error("Error trying to read file")]
-    #[diagnostic(code(nu::shell::error_reading_file))]
-    #[deprecated]
-    ReadingFile {
-        msg: String,
-        #[label("{msg}")]
-        span: Span,
-    },
 
     /// A name was not found. Did you mean a different name?
     ///
@@ -1551,30 +1374,6 @@ impl ShellError {
         )
     }
 }
-
-// impl From<std::io::Error> for ShellError {
-//     // TODO: deprecate this
-//     fn from(error: std::io::Error) -> ShellError {
-//         Self::Io(IoError::new(error.kind(), Span::unknown(), None))
-//     }
-// }
-
-// FIXME: this impl is originally absolutely cursed, we need to do something about it
-// impl From<Spanned<std::io::Error>> for ShellError {
-//     fn from(error: Spanned<std::io::Error>) -> Self {
-//         let Spanned { item: error, span } = error;
-//         IoError::new(error.kind(), span, None).into()
-//     }
-// }
-
-// impl From<ShellError> for std::io::Error {
-//     fn from(error: ShellError) -> Self {
-//         match error {
-//             ShellError::Io(error) => error.into(),
-//             _ => Self::new(std::io::ErrorKind::Other, error),
-//         }
-//     }
-// }
 
 impl From<Box<dyn std::error::Error>> for ShellError {
     fn from(error: Box<dyn std::error::Error>) -> ShellError {

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -818,6 +818,7 @@ pub enum ShellError {
     /// Does the file in the error message exist? Is it readable and accessible? Is the casing right?
     #[error("File not found")]
     #[diagnostic(code(nu::shell::file_not_found), help("{file} does not exist"))]
+    #[deprecated]
     FileNotFound {
         file: String,
         #[label("file not found")]

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -832,6 +832,7 @@ pub enum ShellError {
     /// Does the file in the error message exist? Is it readable and accessible? Is the casing right?
     #[error("File not found")]
     #[diagnostic(code(nu::shell::file_not_found))]
+    #[deprecated]
     FileNotFoundCustom {
         msg: String,
         #[label("{msg}")]

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -989,6 +989,7 @@ pub enum ShellError {
     /// Make sure the directory in the error message actually exists before trying again.
     #[error("Directory not found")]
     #[diagnostic(code(nu::shell::directory_not_found), help("{dir} does not exist"))]
+    #[deprecated]
     DirectoryNotFound {
         dir: String,
         #[label("directory not found")]

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -143,8 +143,12 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
             Value::string(canon_home_path.to_string_lossy(), span)
         } else {
             Value::error(
-                ShellError::IOError {
+                ShellError::GenericError {
+                    error: "setting $nu.home-path failed".into(),
                     msg: "Could not get home path".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
                 },
                 span,
             )
@@ -159,8 +163,12 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
             Value::string(canon_data_path.to_string_lossy(), span)
         } else {
             Value::error(
-                ShellError::IOError {
+                ShellError::GenericError {
+                    error: "setting $nu.data-dir failed".into(),
                     msg: "Could not get data path".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
                 },
                 span,
             )
@@ -175,8 +183,12 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
             Value::string(canon_cache_path.to_string_lossy(), span)
         } else {
             Value::error(
-                ShellError::IOError {
+                ShellError::GenericError {
+                    error: "setting $nu.cache-dir failed".into(),
                     msg: "Could not get cache path".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
                 },
                 span,
             )
@@ -248,8 +260,12 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
             Value::string(current_exe.to_string_lossy(), span)
         } else {
             Value::error(
-                ShellError::IOError {
-                    msg: "Could not get current executable path".to_string(),
+                ShellError::GenericError {
+                    error: "setting $nu.current-exe failed".into(),
+                    msg: "Could not get current executable path".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
                 },
                 span,
             )

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -1287,7 +1287,10 @@ fn generic_copy(
             Ok(0) => break,
             Ok(n) => n,
             Err(e) if e.kind() == ErrorKind::Interrupted => continue,
-            Err(e) => return Err(from_io_error(e).into()),
+            Err(e) => match ShellErrorBridge::try_from(e) {
+                Ok(ShellErrorBridge(e)) => return Err(e),
+                Err(e) => return Err(from_io_error(e).into())
+            }
         };
         len += n;
         writer.write_all(&buf[..n]).map_err(&from_io_error)?;

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -2,7 +2,8 @@
 #[cfg(feature = "os")]
 use crate::process::{ChildPipe, ChildProcess};
 use crate::{
-    shell_error::{bridge::ShellErrorBridge, io::IoError}, IntRange, PipelineData, ShellError, Signals, Span, Type, Value,
+    shell_error::{bridge::ShellErrorBridge, io::IoError},
+    IntRange, PipelineData, ShellError, Signals, Span, Type, Value,
 };
 use serde::{Deserialize, Serialize};
 use std::ops::Bound;

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -1030,9 +1030,15 @@ impl Iterator for SplitRead {
         if self.signals.interrupted() {
             return None;
         }
-        self.internal
-            .next()
-            .map(|r| r.map_err(|e| ShellError::Io(IoError::new(e.kind(), Span::unknown(), None))))
+        self.internal.next().map(|r| {
+            r.map_err(|err| {
+                ShellError::Io(IoError::new_internal(
+                    err.kind(),
+                    "Could not get next value for SplitRead",
+                    crate::location!(),
+                ))
+            })
+        })
     }
 }
 

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -2,8 +2,7 @@
 #[cfg(feature = "os")]
 use crate::process::{ChildPipe, ChildProcess};
 use crate::{
-    shell_error::{bridge::ShellErrorBridge, io::IoError},
-    ErrSpan, IntRange, IntoSpanned, PipelineData, ShellError, Signals, Span, Type, Value,
+    shell_error::{bridge::ShellErrorBridge, io::IoError}, IntRange, PipelineData, ShellError, Signals, Span, Type, Value,
 };
 use serde::{Deserialize, Serialize};
 use std::ops::Bound;

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -228,7 +228,8 @@ impl ByteStream {
         let known_size = self.known_size.map(|len| len.saturating_sub(n));
         if let Some(mut reader) = self.reader() {
             // Copy the number of skipped bytes into the sink before proceeding
-            io::copy(&mut (&mut reader).take(n), &mut io::sink()).map_err(|err| IoError::new(err.kind(), span, None))?;
+            io::copy(&mut (&mut reader).take(n), &mut io::sink())
+                .map_err(|err| IoError::new(err.kind(), span, None))?;
             Ok(
                 ByteStream::read(reader, span, Signals::empty(), ByteStreamType::Binary)
                     .with_known_size(known_size),
@@ -1074,7 +1075,6 @@ impl Chunks {
     }
 
     fn next_string(&mut self) -> Result<Option<String>, (Vec<u8>, ShellError)> {
-
         let from_io_error = IoError::factory(self.span, None);
 
         // Get some data from the reader
@@ -1157,7 +1157,11 @@ impl Iterator for Chunks {
                         Ok(buf) => buf,
                         Err(err) => {
                             self.error = true;
-                            return Some(Err(ShellError::Io(IoError::new(err.kind(), self.span, None))));
+                            return Some(Err(ShellError::Io(IoError::new(
+                                err.kind(),
+                                self.span,
+                                None,
+                            ))));
                         }
                     };
                     if !buf.is_empty() {

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -1,4 +1,7 @@
 //! Module managing the streaming of raw bytes between pipeline elements
+//! 
+//! This module also handles conversions the [`ShellError`] <-> [`io::Error`](std::io::Error),
+//! so remember the usage of [`ShellErrorBridge`] where applicable.
 #[cfg(feature = "os")]
 use crate::process::{ChildPipe, ChildProcess};
 use crate::{

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -1,5 +1,5 @@
 //! Module managing the streaming of raw bytes between pipeline elements
-//! 
+//!
 //! This module also handles conversions the [`ShellError`] <-> [`io::Error`](std::io::Error),
 //! so remember the usage of [`ShellErrorBridge`] where applicable.
 #[cfg(feature = "os")]
@@ -1078,11 +1078,9 @@ impl Chunks {
     }
 
     fn next_string(&mut self) -> Result<Option<String>, (Vec<u8>, ShellError)> {
-        let from_io_error = |err: std::io::Error| {
-            match ShellErrorBridge::try_from(err) {
-                Ok(err) => err.0,
-                Err(err) => IoError::new(err.kind(), self.span, None).into(),
-            }
+        let from_io_error = |err: std::io::Error| match ShellErrorBridge::try_from(err) {
+            Ok(err) => err.0,
+            Err(err) => IoError::new(err.kind(), self.span, None).into(),
         };
 
         // Get some data from the reader
@@ -1249,7 +1247,7 @@ pub fn copy_with_signals(
                 let _ = writer.flush();
                 match ShellErrorBridge::try_from(err) {
                     Ok(ShellErrorBridge(shell_error)) => Err(shell_error),
-                    Err(err) => Err(from_io_error(err).into())
+                    Err(err) => Err(from_io_error(err).into()),
                 }
             }
         }
@@ -1289,8 +1287,8 @@ fn generic_copy(
             Err(e) if e.kind() == ErrorKind::Interrupted => continue,
             Err(e) => match ShellErrorBridge::try_from(e) {
                 Ok(ShellErrorBridge(e)) => return Err(e),
-                Err(e) => return Err(from_io_error(e).into())
-            }
+                Err(e) => return Err(from_io_error(e).into()),
+            },
         };
         len += n;
         writer.write_all(&buf[..n]).map_err(&from_io_error)?;

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -1087,7 +1087,7 @@ impl Chunks {
         let buf = self
             .reader
             .fill_buf()
-            .map_err(&from_io_error)
+            .map_err(from_io_error)
             .map_err(|err| (vec![], err))?;
 
         // If empty, this is EOF

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -1239,7 +1239,10 @@ pub fn copy_with_signals(
             }
             Err(err) => {
                 let _ = writer.flush();
-                Err(from_io_error(err).into())
+                match ShellErrorBridge::try_from(err) {
+                    Ok(ShellErrorBridge(shell_error)) => Err(shell_error),
+                    Err(err) => Err(from_io_error(err).into())
+                }
             }
         }
     } else {

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -220,22 +220,47 @@ impl PipelineData {
             PipelineData::Empty => Ok(()),
             PipelineData::Value(value, ..) => {
                 let bytes = value_to_bytes(value)?;
-                dest.write_all(&bytes)
-                    .map_err(|err| IoError::new(err.kind(), Span::unknown(), None))?;
-                dest.flush()
-                    .map_err(|err| IoError::new(err.kind(), Span::unknown(), None))?;
+                dest.write_all(&bytes).map_err(|err| {
+                    IoError::new_internal(
+                        err.kind(),
+                        "Could not write PipelineData to dest",
+                        crate::location!(),
+                    )
+                })?;
+                dest.flush().map_err(|err| {
+                    IoError::new_internal(
+                        err.kind(),
+                        "Could not flush PipelineData to dest",
+                        crate::location!(),
+                    )
+                })?;
                 Ok(())
             }
             PipelineData::ListStream(stream, ..) => {
                 for value in stream {
                     let bytes = value_to_bytes(value)?;
-                    dest.write_all(&bytes)
-                        .map_err(|err| IoError::new(err.kind(), Span::unknown(), None))?;
-                    dest.write_all(b"\n")
-                        .map_err(|err| IoError::new(err.kind(), Span::unknown(), None))?;
+                    dest.write_all(&bytes).map_err(|err| {
+                        IoError::new_internal(
+                            err.kind(),
+                            "Could not write PipelineData to dest",
+                            crate::location!(),
+                        )
+                    })?;
+                    dest.write_all(b"\n").map_err(|err| {
+                        IoError::new_internal(
+                            err.kind(),
+                            "Could not write linebreak after PipelineData to dest",
+                            crate::location!(),
+                        )
+                    })?;
                 }
-                dest.flush()
-                    .map_err(|err| IoError::new(err.kind(), Span::unknown(), None))?;
+                dest.flush().map_err(|err| {
+                    IoError::new_internal(
+                        err.kind(),
+                        "Could not flush PipelineData to dest",
+                        crate::location!(),
+                    )
+                })?;
                 Ok(())
             }
             PipelineData::ByteStream(stream, ..) => stream.write_to(dest),

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -1,6 +1,7 @@
 use crate::{
     ast::{Call, PathMember},
     engine::{EngineState, Stack},
+    shell_error::io::IoError,
     ByteStream, ByteStreamType, Config, ListStream, OutDest, PipelineMetadata, Range, ShellError,
     Signals, Span, Type, Value,
 };
@@ -219,17 +220,22 @@ impl PipelineData {
             PipelineData::Empty => Ok(()),
             PipelineData::Value(value, ..) => {
                 let bytes = value_to_bytes(value)?;
-                dest.write_all(&bytes)?;
-                dest.flush()?;
+                dest.write_all(&bytes)
+                    .map_err(|err| IoError::new(err.kind(), Span::unknown(), None))?;
+                dest.flush()
+                    .map_err(|err| IoError::new(err.kind(), Span::unknown(), None))?;
                 Ok(())
             }
             PipelineData::ListStream(stream, ..) => {
                 for value in stream {
                     let bytes = value_to_bytes(value)?;
-                    dest.write_all(&bytes)?;
-                    dest.write_all(b"\n")?;
+                    dest.write_all(&bytes)
+                        .map_err(|err| IoError::new(err.kind(), Span::unknown(), None))?;
+                    dest.write_all(b"\n")
+                        .map_err(|err| IoError::new(err.kind(), Span::unknown(), None))?;
                 }
-                dest.flush()?;
+                dest.flush()
+                    .map_err(|err| IoError::new(err.kind(), Span::unknown(), None))?;
                 Ok(())
             }
             PipelineData::ByteStream(stream, ..) => stream.write_to(dest),
@@ -633,9 +639,23 @@ impl PipelineData {
     ) -> Result<(), ShellError> {
         if let PipelineData::Value(Value::Binary { val: bytes, .. }, _) = self {
             if to_stderr {
-                stderr_write_all_and_flush(bytes)?;
+                stderr_write_all_and_flush(bytes).map_err(|err| {
+                    IoError::new_with_additional_context(
+                        err.kind(),
+                        Span::unknown(),
+                        None,
+                        "Writing to stderr failed",
+                    )
+                })?
             } else {
-                stdout_write_all_and_flush(bytes)?;
+                stdout_write_all_and_flush(bytes).map_err(|err| {
+                    IoError::new_with_additional_context(
+                        err.kind(),
+                        Span::unknown(),
+                        None,
+                        "Writing to stdout failed",
+                    )
+                })?
             }
             Ok(())
         } else {
@@ -666,9 +686,23 @@ impl PipelineData {
                 }
 
                 if to_stderr {
-                    stderr_write_all_and_flush(out)?
+                    stderr_write_all_and_flush(out).map_err(|err| {
+                        IoError::new_with_additional_context(
+                            err.kind(),
+                            Span::unknown(),
+                            None,
+                            "Writing to stderr failed",
+                        )
+                    })?
                 } else {
-                    stdout_write_all_and_flush(out)?
+                    stdout_write_all_and_flush(out).map_err(|err| {
+                        IoError::new_with_additional_context(
+                            err.kind(),
+                            Span::unknown(),
+                            None,
+                            "Writing to stdout failed",
+                        )
+                    })?
                 }
             }
 

--- a/crates/nu-protocol/src/process/child.rs
+++ b/crates/nu-protocol/src/process/child.rs
@@ -1,4 +1,6 @@
-use crate::{byte_stream::convert_file, shell_error::io::IoError, ErrSpan, IntoSpanned, ShellError, Span};
+use crate::{
+    byte_stream::convert_file, shell_error::io::IoError, ErrSpan, IntoSpanned, ShellError, Span,
+};
 use nu_system::{ExitStatus, ForegroundChild};
 use os_pipe::PipeReader;
 use std::{
@@ -74,13 +76,18 @@ impl ExitStatusFuture {
                         Ok(status)
                     }
                     Ok(Ok(status)) => Ok(status),
-                    Ok(Err(err)) => Err(ShellError::Io(IoError::new_with_additional_context(err.kind(), span, None, "failed to get exit code"))),
-                    Err(err @ RecvError) => Err(ShellError::GenericError { 
-                        error: err.to_string(), 
-                        msg: "failed to get exit code".into(), 
-                        span: span.into(), 
-                        help: None, 
-                        inner: vec![] 
+                    Ok(Err(err)) => Err(ShellError::Io(IoError::new_with_additional_context(
+                        err.kind(),
+                        span,
+                        None,
+                        "failed to get exit code",
+                    ))),
+                    Err(err @ RecvError) => Err(ShellError::GenericError {
+                        error: err.to_string(),
+                        msg: "failed to get exit code".into(),
+                        span: span.into(),
+                        help: None,
+                        inner: vec![],
                     }),
                 };
 
@@ -98,19 +105,19 @@ impl ExitStatusFuture {
             ExitStatusFuture::Running(receiver) => {
                 let code = match receiver.try_recv() {
                     Ok(Ok(status)) => Ok(Some(status)),
-                    Ok(Err(err)) => Err(ShellError::GenericError { 
-                        error: err.to_string(), 
-                        msg: "failed to get exit code".to_string(), 
-                        span: span.into(), 
-                        help: None, 
-                        inner: vec![] 
+                    Ok(Err(err)) => Err(ShellError::GenericError {
+                        error: err.to_string(),
+                        msg: "failed to get exit code".to_string(),
+                        span: span.into(),
+                        help: None,
+                        inner: vec![],
                     }),
-                    Err(TryRecvError::Disconnected) => Err(ShellError::GenericError { 
-                        error: "receiver disconnected".to_string(), 
-                        msg: "failed to get exit code".into(), 
-                        span: span.into(), 
-                        help: None, 
-                        inner: vec![] 
+                    Err(TryRecvError::Disconnected) => Err(ShellError::GenericError {
+                        error: "receiver disconnected".to_string(),
+                        msg: "failed to get exit code".into(),
+                        span: span.into(),
+                        help: None,
+                        inner: vec![],
                     }),
                     Err(TryRecvError::Empty) => Ok(None),
                 };
@@ -220,12 +227,12 @@ impl ChildProcess {
     pub fn into_bytes(mut self) -> Result<Vec<u8>, ShellError> {
         if self.stderr.is_some() {
             debug_assert!(false, "stderr should not exist");
-            return Err(ShellError::GenericError { 
-                error: "internal error".into(), 
-                msg: "stderr should not exist".into(), 
-                span: self.span.into(), 
-                help: None, 
-                inner: vec![] 
+            return Err(ShellError::GenericError {
+                error: "internal error".into(),
+                msg: "stderr should not exist".into(),
+                span: self.span.into(),
+                help: None,
+                inner: vec![],
             });
         }
 

--- a/crates/nu-protocol/src/process/child.rs
+++ b/crates/nu-protocol/src/process/child.rs
@@ -1,7 +1,4 @@
-use crate::{
-    byte_stream::convert_file,
-    shell_error::io::IoError, ShellError, Span,
-};
+use crate::{byte_stream::convert_file, shell_error::io::IoError, ShellError, Span};
 use nu_system::{ExitStatus, ForegroundChild};
 use os_pipe::PipeReader;
 use std::{

--- a/crates/nu-protocol/src/process/child.rs
+++ b/crates/nu-protocol/src/process/child.rs
@@ -1,5 +1,7 @@
 use crate::{
-    byte_stream::convert_file, shell_error::{bridge::ShellErrorBridge, io::IoError}, ErrSpan, IntoSpanned, ShellError, Span,
+    byte_stream::convert_file,
+    shell_error::{bridge::ShellErrorBridge, io::IoError},
+    ErrSpan, IntoSpanned, ShellError, Span,
 };
 use nu_system::{ExitStatus, ForegroundChild};
 use os_pipe::PipeReader;
@@ -193,7 +195,14 @@ impl ChildProcess {
         thread::Builder::new()
             .name("exit status waiter".into())
             .spawn(move || exit_status_sender.send(child.wait()))
-            .map_err(|err| IoError::new_with_additional_context(err.kind(), span, None, "Could now spawn exit status waiter"))?;
+            .map_err(|err| {
+                IoError::new_with_additional_context(
+                    err.kind(),
+                    span,
+                    None,
+                    "Could now spawn exit status waiter",
+                )
+            })?;
 
         Ok(Self::from_raw(stdout, stderr, Some(exit_status), span))
     }

--- a/crates/nu-protocol/src/process/child.rs
+++ b/crates/nu-protocol/src/process/child.rs
@@ -1,4 +1,4 @@
-use crate::{byte_stream::convert_file, ErrSpan, IntoSpanned, ShellError, Span};
+use crate::{byte_stream::convert_file, shell_error::io::IoError, ErrSpan, IntoSpanned, ShellError, Span};
 use nu_system::{ExitStatus, ForegroundChild};
 use os_pipe::PipeReader;
 use std::{
@@ -74,13 +74,13 @@ impl ExitStatusFuture {
                         Ok(status)
                     }
                     Ok(Ok(status)) => Ok(status),
-                    Ok(Err(err)) => Err(ShellError::IOErrorSpanned {
-                        msg: format!("failed to get exit code: {err:?}"),
-                        span,
-                    }),
-                    Err(RecvError) => Err(ShellError::IOErrorSpanned {
-                        msg: "failed to get exit code".into(),
-                        span,
+                    Ok(Err(err)) => Err(ShellError::Io(IoError::new_with_additional_context(err.kind(), span, None, "failed to get exit code"))),
+                    Err(err @ RecvError) => Err(ShellError::GenericError { 
+                        error: err.to_string(), 
+                        msg: "failed to get exit code".into(), 
+                        span: span.into(), 
+                        help: None, 
+                        inner: vec![] 
                     }),
                 };
 
@@ -98,13 +98,19 @@ impl ExitStatusFuture {
             ExitStatusFuture::Running(receiver) => {
                 let code = match receiver.try_recv() {
                     Ok(Ok(status)) => Ok(Some(status)),
-                    Ok(Err(err)) => Err(ShellError::IOErrorSpanned {
-                        msg: format!("failed to get exit code: {err:?}"),
-                        span,
+                    Ok(Err(err)) => Err(ShellError::GenericError { 
+                        error: err.to_string(), 
+                        msg: "failed to get exit code".to_string(), 
+                        span: span.into(), 
+                        help: None, 
+                        inner: vec![] 
                     }),
-                    Err(TryRecvError::Disconnected) => Err(ShellError::IOErrorSpanned {
-                        msg: "failed to get exit code".into(),
-                        span,
+                    Err(TryRecvError::Disconnected) => Err(ShellError::GenericError { 
+                        error: "receiver disconnected".to_string(), 
+                        msg: "failed to get exit code".into(), 
+                        span: span.into(), 
+                        help: None, 
+                        inner: vec![] 
                     }),
                     Err(TryRecvError::Empty) => Ok(None),
                 };
@@ -214,9 +220,12 @@ impl ChildProcess {
     pub fn into_bytes(mut self) -> Result<Vec<u8>, ShellError> {
         if self.stderr.is_some() {
             debug_assert!(false, "stderr should not exist");
-            return Err(ShellError::IOErrorSpanned {
-                msg: "internal error".into(),
-                span: self.span,
+            return Err(ShellError::GenericError { 
+                error: "internal error".into(), 
+                msg: "stderr should not exist".into(), 
+                span: self.span.into(), 
+                help: None, 
+                inner: vec![] 
             });
         }
 

--- a/crates/nu-protocol/src/process/child.rs
+++ b/crates/nu-protocol/src/process/child.rs
@@ -1,7 +1,6 @@
 use crate::{
     byte_stream::convert_file,
-    shell_error::{bridge::ShellErrorBridge, io::IoError},
-    ErrSpan, IntoSpanned, ShellError, Span,
+    shell_error::io::IoError, ShellError, Span,
 };
 use nu_system::{ExitStatus, ForegroundChild};
 use os_pipe::PipeReader;

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -219,28 +219,17 @@ impl From<Span> for SourceSpan {
     }
 }
 
-/// An extension trait for `Result`, which adds a span to the error type.
+/// An extension trait for [`Result`], which adds a span to the error type.
+/// 
+/// This trait might be removed later, since the old [`Spanned<std::io::Error>`] to [`ShellError`]
+/// conversion was replaced by [`IoError`](io_error::IoError).
 pub trait ErrSpan {
     type Result;
 
-    /// Add the given span to the error type `E`, turning it into a `Spanned<E>`.
-    ///
-    /// Some auto-conversion methods to `ShellError` from other error types are available on spanned
-    /// errors, to give users better information about where an error came from. For example, it is
-    /// preferred when working with `std::io::Error`:
-    ///
-    /// ```no_run
-    /// use nu_protocol::{ErrSpan, ShellError, Span};
-    /// use std::io::Read;
-    ///
-    /// fn read_from(mut reader: impl Read, span: Span) -> Result<Vec<u8>, ShellError> {
-    ///     let mut vec = vec![];
-    ///     reader.read_to_end(&mut vec).err_span(span)?;
-    ///     Ok(vec)
-    /// }
-    /// ```
+    /// Adds the given span to the error type, turning it into a [`Spanned<E>`].
     fn err_span(self, span: Span) -> Self::Result;
 }
+
 
 impl<T, E> ErrSpan for Result<T, E> {
     type Result = Result<T, Spanned<E>>;

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -124,7 +124,7 @@ impl Span {
     pub const fn test_data() -> Self {
         Self {
             start: usize::MAX / 2,
-            end: 0,
+            end: usize::MAX / 2,
         }
     }
 

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -116,13 +116,16 @@ impl Span {
     }
 
     /// Span for testing purposes.
-    /// 
+    ///
     /// The provided span does not point into any known source but is unequal to [`Span::unknown()`].
-    /// 
+    ///
     /// Note: Only use this for test data, *not* live data, as it will point into unknown source
     /// when used in errors
     pub const fn test_data() -> Self {
-        Self { start: usize::MAX / 2, end: 0 }
+        Self {
+            start: usize::MAX / 2,
+            end: 0,
+        }
     }
 
     pub fn offset(&self, offset: usize) -> Self {
@@ -220,7 +223,7 @@ impl From<Span> for SourceSpan {
 }
 
 /// An extension trait for [`Result`], which adds a span to the error type.
-/// 
+///
 /// This trait might be removed later, since the old [`Spanned<std::io::Error>`] to [`ShellError`]
 /// conversion was replaced by [`IoError`](io_error::IoError).
 pub trait ErrSpan {
@@ -229,7 +232,6 @@ pub trait ErrSpan {
     /// Adds the given span to the error type, turning it into a [`Spanned<E>`].
     fn err_span(self, span: Span) -> Self::Result;
 }
-
 
 impl<T, E> ErrSpan for Result<T, E> {
     type Result = Result<T, Spanned<E>>;

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -115,10 +115,11 @@ impl Span {
         Self { start: 0, end: 0 }
     }
 
-    /// Note: Only use this for test data, *not* live data, as it will point into unknown source
-    /// when used in errors.
+    /// Span for testing purposes.
+    /// 
+    /// The provided span does not point into any known source but is unequal to [`Span::unknown()`].
     pub const fn test_data() -> Self {
-        Self::unknown()
+        Self { start: usize::MAX, end: 0 }
     }
 
     pub fn offset(&self, offset: usize) -> Self {

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -118,8 +118,11 @@ impl Span {
     /// Span for testing purposes.
     /// 
     /// The provided span does not point into any known source but is unequal to [`Span::unknown()`].
+    /// 
+    /// Note: Only use this for test data, *not* live data, as it will point into unknown source
+    /// when used in errors
     pub const fn test_data() -> Self {
-        Self { start: usize::MAX, end: 0 }
+        Self { start: usize::MAX / 2, end: 0 }
     }
 
     pub fn offset(&self, offset: usize) -> Self {

--- a/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
@@ -11,8 +11,8 @@ use url::Url;
 
 use nu_plugin::PluginCommand;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Type, Value,
+    shell_error::io::IoError, Category, Example, LabeledError, PipelineData, ShellError, Signature,
+    Span, Spanned, SyntaxShape, Type, Value,
 };
 
 use std::{fmt::Debug, fs::File, io::BufReader, num::NonZeroUsize, path::PathBuf, sync::Arc};
@@ -221,10 +221,12 @@ fn command(
                 blamed,
             )),
         },
-        None => Err(ShellError::FileNotFoundCustom {
-            msg: "File without extension".into(),
-            span: spanned_file.span,
-        }),
+        None => Err(ShellError::Io(IoError::new_with_additional_context(
+            std::io::ErrorKind::NotFound,
+            spanned_file.span,
+            PathBuf::from(spanned_file.item),
+            "File without extension",
+        ))),
     }
     .map(|value| PipelineData::Value(value, None))
 }

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
@@ -14,8 +14,8 @@ use crate::{
 use nu_path::expand_path_with;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Type,
+    shell_error::io::IoError, Category, Example, LabeledError, PipelineData, ShellError, Signature,
+    Span, Spanned, SyntaxShape, Type,
 };
 use polars::error::PolarsError;
 
@@ -204,10 +204,12 @@ fn command(
                 blamed,
             )),
         },
-        None => Err(ShellError::FileNotFoundCustom {
-            msg: "File without extension".into(),
-            span: spanned_file.span,
-        }),
+        None => Err(ShellError::Io(IoError::new_with_additional_context(
+            std::io::ErrorKind::NotFound,
+            spanned_file.span,
+            spanned_file.item,
+            "File without extension",
+        ))),
     }?;
 
     Ok(PipelineData::empty())

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,10 @@ use nu_engine::convert_env_values;
 use nu_lsp::LanguageServer;
 use nu_path::canonicalize_with;
 use nu_protocol::{
-    engine::{EngineState, Stack}, record, report_shell_error, shell_error::io::IoError, ByteStream, Config, IntoValue, PipelineData, ShellError, Span, Spanned, Type, Value
+    engine::{EngineState, Stack},
+    record, report_shell_error,
+    shell_error::io::IoError,
+    ByteStream, Config, IntoValue, PipelineData, ShellError, Span, Spanned, Type, Value,
 };
 use nu_std::load_standard_library;
 use nu_utils::perf;
@@ -426,7 +429,13 @@ fn main() -> Result<()> {
         for plugin_filename in plugins {
             // Make sure the plugin filenames are canonicalized
             let filename = canonicalize_with(&plugin_filename.item, &init_cwd)
-                .map_err(|err| IoError::new(err.kind(), plugin_filename.span, PathBuf::from(&plugin_filename.item)))
+                .map_err(|err| {
+                    IoError::new(
+                        err.kind(),
+                        plugin_filename.span,
+                        PathBuf::from(&plugin_filename.item),
+                    )
+                })
                 .map_err(ShellError::from)?;
 
             let identity = PluginIdentity::new(&filename, None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,9 +26,8 @@ use nu_lsp::LanguageServer;
 use nu_path::canonicalize_with;
 use nu_protocol::{
     engine::{EngineState, Stack},
-    record, report_shell_error,
-    shell_error::io::IoError,
-    ByteStream, Config, IntoValue, PipelineData, ShellError, Span, Spanned, Type, Value,
+    record, report_shell_error, ByteStream, Config, IntoValue, PipelineData, ShellError, Span,
+    Spanned, Type, Value,
 };
 use nu_std::load_standard_library;
 use nu_utils::perf;
@@ -430,7 +429,7 @@ fn main() -> Result<()> {
             // Make sure the plugin filenames are canonicalized
             let filename = canonicalize_with(&plugin_filename.item, &init_cwd)
                 .map_err(|err| {
-                    IoError::new(
+                    nu_protocol::shell_error::io::IoError::new(
                         err.kind(),
                         plugin_filename.span,
                         PathBuf::from(&plugin_filename.item),

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,7 @@ use nu_engine::convert_env_values;
 use nu_lsp::LanguageServer;
 use nu_path::canonicalize_with;
 use nu_protocol::{
-    engine::{EngineState, Stack},
-    record, report_shell_error, ByteStream, Config, IntoValue, PipelineData, ShellError, Span,
-    Spanned, Type, Value,
+    engine::{EngineState, Stack}, record, report_shell_error, shell_error::io::IoError, ByteStream, Config, IntoValue, PipelineData, ShellError, Span, Spanned, Type, Value
 };
 use nu_std::load_standard_library;
 use nu_utils::perf;
@@ -428,7 +426,7 @@ fn main() -> Result<()> {
         for plugin_filename in plugins {
             // Make sure the plugin filenames are canonicalized
             let filename = canonicalize_with(&plugin_filename.item, &init_cwd)
-                .err_span(plugin_filename.span)
+                .map_err(|err| IoError::new(err.kind(), plugin_filename.span, PathBuf::from(&plugin_filename.item)))
                 .map_err(ShellError::from)?;
 
             let identity = PluginIdentity::new(&filename, None)


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

As mentioned in #10698, we have too many `ShellError` variants, with some even overlapping in meaning. This PR simplifies and improves I/O error handling by restructuring `ShellError` related to I/O issues. Previously, `ShellError::IOError` only contained a message string, making it convenient but overly generic. It was widely used without providing spans (#4323).

This PR introduces a new `ShellError::Io` variant that consolidates multiple I/O-related errors (except for `ShellError::NetworkFailure`, which remains distinct for now). The new `ShellError::Io` variant replaces the following:

- `FileNotFound`
- `FileNotFoundCustom`
- `IOInterrupted`
- `IOError`
- `IOErrorSpanned`
- `NotADirectory`
- `DirectoryNotFound`
- `MoveNotPossible`
- `CreateNotPossible`
- `ChangeAccessTimeNotPossible`
- `ChangeModifiedTimeNotPossible`
- `RemoveNotPossible`
- `ReadingFile`

## The `IoError`
`IoError` includes the following fields:

1. **`kind`**: Extends `std::io::ErrorKind` to specify the type of I/O error without needing new `ShellError` variants. This aligns with the approach used in `std::io::Error`. This adds a second dimension to error reporting by combining the `kind` field with `ShellError` variants, making it easier to describe errors in more detail. As proposed by @kubouch in [#design-discussion on Discord](https://discord.com/channels/601130461678272522/615329862395101194/1323699197165178930), this helps reduce the number of `ShellError` variants. In the error report, the `kind` field is displayed as the "source" of the error, e.g., "I/O error," followed by the specific kind of I/O error. 
2. **`span`**: A non-optional field to encourage providing spans for better error reporting (#4323).
3. **`path`**: Optional `PathBuf` to give context about the file or directory involved in the error (#7695). If provided, it’s shown as a help entry in error reports.
4. **`additional_context`**: Allows adding custom messages when the span, kind, and path are insufficient. This is rendered in the error report at the labeled span.
5. **`location`**: Sometimes, I/O errors occur in the engine itself and are not caused directly by user input. In such cases, if we don’t have a span and must set it to `Span::unknown()`, we need another way to reference the error. For this, the `location` field uses the new `Location` struct, which records the Rust file and line number where the error occurred. This ensures that we at least know the Rust code location that failed, helping with debugging. To make this work, a new `location!` macro was added, which retrieves `file!`, `line!`, and `column!` values accurately. If `Location::new` is used directly, it issues a warning to remind developers to use the macro instead, ensuring consistent and correct usage.

### Constructor Behavior
`IoError` provides five constructor methods:
- `new` and `new_with_additional_context`: Used for errors caused by user input and require a valid (non-unknown) span to ensure precise error reporting.
- `new_internal` and `new_internal_with_path`: Used for internal errors where a span is not available. These methods require additional context and the `Location` struct to pinpoint the source of the error in the engine code.
- `factory`: Returns a closure that maps an `std::io::Error` to an `IoError`. This is useful for handling multiple I/O errors that share the same span and path, streamlining error handling in such cases.

## New Report Look
This is simulation how the I/O errors look like (the `open crates` is simulated to show how internal errors are referenced now):
![Screenshot 2025-01-25 190426](https://github.com/user-attachments/assets/a41b6aa6-a440-497d-bbcc-3ac0121c9226)

## `Span::test_data()`
To enable better testing, `Span::test_data()` now returns a value distinct from `Span::unknown()`. Both `Span::test_data()` and `Span::unknown()` refer to invalid source code, but having a separate value for test data helps identify issues during testing while keeping spans unique.

## Cursed Sneaky Error Transfers
I removed the conversions between `std::io::Error` and `ShellError` as they often removed important information and were used too broadly to handle I/O errors. This also removed the problematic implementation found here:
https://github.com/nushell/nushell/blob/7ea489551315a5ab68fd1e9e5a7ed5a0b3ef494a/crates/nu-protocol/src/errors/shell_error.rs#L1534-L1583

which hid some downcasting from I/O errors and made it hard to trace where `ShellError` was converted into `std::io::Error`. To address this, I introduced a new struct called `ShellErrorBridge`, which explicitly defines this transfer behavior. With `ShellErrorBridge`, we can now easily grep the codebase to locate and manage such conversions.

## Miscellaneous
- Removed the OS error added in #14640, as it’s no longer needed.
- Improved error messages in `glob_from` (#14679).
- Trying to open a directory with `open` caused a permissions denied error (it's just what the OS provides). I added a `is_dir` check to provide a better error in that case.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

- Error outputs now include more detailed information and are formatted differently, including updated error codes.
- The structure of `ShellError` has changed, requiring plugin authors and embedders to update their implementations.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

I updated tests to account for the new I/O error structure and formatting changes.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

This PR closes #7695 and closes #14892 and partially addresses #4323 and #10698.