### PR TITLE
fix(parser): span of keyword expression

### DIFF
--- a/crates/nu-lsp/src/ast.rs
+++ b/crates/nu-lsp/src/ast.rs
@@ -444,13 +444,6 @@ fn find_id_in_expr(
 ) -> Option<Vec<(Id, Span)>> {
     // skip the entire expression if the location is not in it
     if !expr.span.contains(*location) {
-        // TODO: the span of Keyword does not include its subsidiary expression
-        // resort to `expr_flat_map` if location found in its expr
-        if let Expr::Keyword(kw) = &expr.expr {
-            if kw.expr.span.contains(*location) {
-                return None;
-            }
-        }
         return Some(Vec::new());
     }
     let span = expr.span;

--- a/crates/nu-lsp/src/goto.rs
+++ b/crates/nu-lsp/src/goto.rs
@@ -475,6 +475,24 @@ mod tests {
             })
         );
 
+        let resp = send_goto_definition_request(&client_connection, script.clone(), 1, 25);
+        let result = if let Message::Response(response) = resp {
+            response.result
+        } else {
+            panic!()
+        };
+
+        assert_json_include!(
+            actual: result,
+            expected: serde_json::json!({
+                "uri": script.to_string().replace("use_module", "module"),
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 3 }
+                }
+            })
+        );
+
         let resp = send_goto_definition_request(&client_connection, script.clone(), 2, 30);
         let result = if let Message::Response(response) = resp {
             response.result

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -919,7 +919,7 @@ pub fn parse_multispan_value(
             Expression::new(
                 working_set,
                 Expr::Keyword(Box::new(keyword.clone())),
-                arg_span,
+                keyword.span.merge(keyword.expr.span),
                 keyword.expr.ty,
             )
         }


### PR DESCRIPTION
# Description

This PR fixes #14816 , so that expression-contains-position check won't need special treatment for keyword expressions.
e.g.

```nushell
overlay use foo as bar
                  # |_______ cursor here

if true { } else { }
                # |_______ here
```

as mentioned in #14924

# User-Facing Changes

# Tests + Formatting

# After Submitting
