### PR TITLE
Fix reject regression

### DIFF
--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -231,7 +231,6 @@ fn reject(
             let result = stream
                 .into_iter()
                 .map(move |mut value| {
-
                     let span = value.span();
 
                     for cell_path in new_columns.iter() {

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -231,7 +231,6 @@ fn reject(
             let result = stream
                 .into_iter()
                 .map(move |mut value| {
-                    eprintln!("uhh");
 
                     let span = value.span();
 

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -220,11 +220,19 @@ fn reject(
 
     new_columns.append(&mut new_rows);
 
+    let has_integer_path_member = new_columns.iter().any(|path| {
+        path.members
+            .iter()
+            .any(|member| matches!(member, PathMember::Int { .. }))
+    });
+
     match input {
-        PipelineData::ListStream(stream, ..) => {
+        PipelineData::ListStream(stream, ..) if !has_integer_path_member => {
             let result = stream
                 .into_iter()
                 .map(move |mut value| {
+                    eprintln!("uhh");
+
                     let span = value.span();
 
                     for cell_path in new_columns.iter() {

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -178,3 +178,10 @@ fn test_ignore_errors_flag_var() {
         nu!("let arg = [5 c]; [[a, b]; [1, 2], [3, 4], [5, 6]] | reject ...$arg -i | to nuon");
     assert_eq!(actual.out, "[[a, b]; [1, 2], [3, 4], [5, 6]]");
 }
+
+#[test]
+fn test_works_with_integer_path_and_stream() {
+    let actual = nu!("[[N u s h e l l]] | flatten | reject 1 | to nuon");
+
+    assert_eq!(actual.out, "[N, s, h, e, l, l]");
+}


### PR DESCRIPTION
This PR solves the regression introduced by #14622 (sorry about that). It also adds a test to cover the regression.
Closes #14929.

The main issue was that the update to reject failed to consider the case in which the cell paths are integers, in which case it should stick with the default behavior (similar to what was done to `get` in the same PR).

Off: Has nushell tried using property-based testing in the past? I think it sounds suitable for a project like this.