### PR TITLE
Fix error messages encountered while performing actions on a file or directory not found

### DIFF
--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -87,8 +87,8 @@ impl Command for Open {
 
             for path in nu_engine::glob_from(&path, &cwd, call_span, None)
                 .map_err(|err| match err {
-                    ShellError::DirectoryNotFound { span, .. } => ShellError::FileNotFound {
-                        file: path.item.to_string(),
+                    ShellError::NotFound { span, .. } => ShellError::DirectoryOrFileNotFound {
+                        target: path.item.to_string(),
                         span,
                     },
                     // that particular error in `nu_engine::glob_from` doesn't have a span attached

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -299,9 +299,9 @@ fn rm(
                 }
             }
             Err(e) => {
-                // glob_from may canonicalize path and return `DirectoryNotFound`
+                // glob_from may canonicalize path and return `DirectoryOrFileNotFound`
                 // nushell should suppress the error if `--force` is used.
-                if !(force && matches!(e, ShellError::DirectoryNotFound { .. })) {
+                if !(force && matches!(e, ShellError::DirectoryOrFileNotFound { .. })) {
                     return Err(e);
                 }
             }

--- a/crates/nu-command/tests/commands/du.rs
+++ b/crates/nu-command/tests/commands/du.rs
@@ -93,7 +93,7 @@ fn du_with_multiple_path() {
 
     // report errors if one path not exists
     let actual = nu!(cwd: "tests/fixtures", "du cp asdf | get path | path basename");
-    assert!(actual.err.contains("directory not found"));
+    assert!(actual.err.contains("directory or file not found"));
     assert!(!actual.status.success());
 
     // du with spreading empty list should returns nothing.

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -610,7 +610,7 @@ fn can_list_system_folder() {
 fn list_a_directory_not_exists() {
     Playground::setup("ls_test_directory_not_exists", |dirs, _sandbox| {
         let actual = nu!(cwd: dirs.test(), "ls a_directory_not_exists");
-        assert!(actual.err.contains("directory not found"));
+        assert!(actual.err.contains("directory or file not found"));
     })
 }
 
@@ -762,7 +762,7 @@ fn list_with_multiple_path() {
 
         // report errors if one path not exists
         let actual = nu!(cwd: dirs.test(), "ls asdf f1.txt");
-        assert!(actual.err.contains("directory not found"));
+        assert!(actual.err.contains("directory or file not found"));
         assert!(!actual.status.success());
 
         // ls with spreading empty list should returns nothing.

--- a/crates/nu-command/tests/commands/move_/umv.rs
+++ b/crates/nu-command/tests/commands/move_/umv.rs
@@ -202,7 +202,7 @@ fn errors_if_source_doesnt_exist() {
             cwd: dirs.test(),
             "mv non-existing-file test_folder/"
         );
-        assert!(actual.err.contains("Directory not found"));
+        assert!(actual.err.contains("directory or file not found"));
     })
 }
 

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -248,7 +248,7 @@ fn errors_if_file_not_found() {
     //
     // This seems to be not directly affected by localization compared to the OS
     // provided error message
-    let expected = "File not found";
+    let expected = "file not found";
 
     assert!(
         actual.err.contains(expected),

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -88,12 +88,16 @@ pub fn glob_from(
                             help: None,
                             inner: vec![],
                         }),
-                        // Previously, all these errors were treated as "directory not found."
-                        // Now, permission denied errors are handled separately.
-                        // TODO: Refine handling of I/O errors for more precise responses.
-                        _ => Err(ShellError::DirectoryNotFound {
-                            dir: path.to_string_lossy().to_string(),
+                        ErrorKind::NotFound => Err(ShellError::DirectoryOrFileNotFound {
+                            target: path.to_string_lossy().to_string(),
                             span: pattern.span,
+                        }),
+                        _ => Err(ShellError::GenericError {
+                            error: "Error accessing path".into(),
+                            msg: err.to_string(),
+                            span: None,
+                            help: None,
+                            inner: vec![],
                         }),
                     };
                 }

--- a/crates/nu-protocol/src/errors/shell_error.rs
+++ b/crates/nu-protocol/src/errors/shell_error.rs
@@ -984,6 +984,22 @@ pub enum ShellError {
         span: Span,
     },
 
+    /// Attempted to perform an operation on a directory or a file that doesn't exist.
+    ///
+    /// ## Resolution
+    ///
+    /// Make sure the directory or the file in the error message actually exists before trying again.
+    #[error("Directory or file not found")]
+    #[diagnostic(
+        code(nu::shell::directory_or_file_not_found),
+        help("{target} does not exist")
+    )]
+    DirectoryOrFileNotFound {
+        target: String,
+        #[label("directory or file not found")]
+        span: Span,
+    },
+
     /// The requested move operation cannot be completed. This is typically because both paths exist,
     /// but are of different types. For example, you might be trying to overwrite an existing file with
     /// a directory.


### PR DESCRIPTION
# Description
This PR fixes https://github.com/nushell/nushell/issues/14892.

This PR addresses an issue where performing a glob action on a file would incorrectly return an error stating `directory not found`. The error message has been updated to explicitly include files when they are not found.

# User-Facing Changes
Improved glob error messages to clearly indicate when a file or directory is not found.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
