### PR TITLE
fix(help operators): include `has` and `not-has` operators

### DIFF
--- a/crates/nu-command/src/help/help_operators.rs
+++ b/crates/nu-command/src/help/help_operators.rs
@@ -45,6 +45,8 @@ impl Command for HelpOperators {
             Operator::Comparison(Comparison::NotRegexMatch),
             Operator::Comparison(Comparison::In),
             Operator::Comparison(Comparison::NotIn),
+            Operator::Comparison(Comparison::Has),
+            Operator::Comparison(Comparison::NotHas),
             Operator::Comparison(Comparison::StartsWith),
             Operator::Comparison(Comparison::EndsWith),
             Operator::Math(Math::Plus),


### PR DESCRIPTION
# Description

Realized the recently `has`/`not-has` operators were not shown with `help operators`.

https://github.com/nushell/nushell/blob/45f9d03025eff995642be1b7b17ad75e4cdc3f3a/crates/nu-command/src/help/help_operators.rs#L117-L118

# User-Facing Changes

# Tests + Formatting

# After Submitting
