### PR TITLE
Swap additional context and label in I/O errors

### DIFF
--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -112,13 +112,16 @@ impl Command for Open {
                     #[cfg(unix)]
                     let err = {
                         let mut err = err;
-                        err.additional_context = Some(match path.metadata() {
-                            Ok(md) => format!(
-                                "The permissions of {:o} does not allow access for this user",
-                                md.permissions().mode() & 0o0777
-                            ),
-                            Err(e) => e.to_string(),
-                        });
+                        err.additional_context = Some(
+                            match path.metadata() {
+                                Ok(md) => format!(
+                                    "The permissions of {:o} does not allow access for this user",
+                                    md.permissions().mode() & 0o0777
+                                ),
+                                Err(e) => e.to_string(),
+                            }
+                            .into(),
+                        );
                         err
                     };
 

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -433,7 +433,14 @@ fn open_file(path: &Path, span: Span, append: bool) -> Result<File, ShellError> 
         }
     };
 
-    file.map_err(|err_kind| ShellError::Io(IoError::new(err_kind, span, PathBuf::from(path))))
+    file.map_err(|err_kind| {
+        ShellError::Io(IoError::new_with_additional_context(
+            err_kind,
+            span,
+            PathBuf::from(path),
+            "Have some additional context here",
+        ))
+    })
 }
 
 /// Get output file and optional stderr file

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -433,14 +433,7 @@ fn open_file(path: &Path, span: Span, append: bool) -> Result<File, ShellError> 
         }
     };
 
-    file.map_err(|err_kind| {
-        ShellError::Io(IoError::new_with_additional_context(
-            err_kind,
-            span,
-            PathBuf::from(path),
-            "Have some additional context here",
-        ))
-    })
+    file.map_err(|err_kind| ShellError::Io(IoError::new(err_kind, span, PathBuf::from(path))))
 }
 
 /// Get output file and optional stderr file

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -384,10 +384,9 @@ impl Diagnostic for IoError {
     }
 
     fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
-        match &self.additional_context {
-            Some(ctx) => Some(ctx as &dyn Diagnostic),
-            None => None,
-        }
+        self.additional_context
+            .as_ref()
+            .map(|ctx| ctx as &dyn Diagnostic)
     }
 
     fn source_code(&self) -> Option<&dyn miette::SourceCode> {

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -139,12 +139,13 @@ pub enum ErrorKind {
     IsADirectory,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Diagnostic)]
+#[derive(Debug, Clone, PartialEq, Eq, Error, Diagnostic)]
+#[error("{0}")]
 pub struct AdditionalContext(String);
 
-impl Display for AdditionalContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.0.as_ref())
+impl From<String> for AdditionalContext {
+    fn from(value: String) -> Self {
+        AdditionalContext(value)
     }
 }
 
@@ -327,13 +328,6 @@ impl Display for ErrorKind {
 }
 
 impl std::error::Error for ErrorKind {}
-impl std::error::Error for AdditionalContext {}
-
-impl From<String> for AdditionalContext {
-    fn from(value: String) -> Self {
-        AdditionalContext(value)
-    }
-}
 
 impl Diagnostic for IoError {
     fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Tweaks the error style for I/O errors introduced #14927. Moves the additional context to below the text that says "I/O error", and always shows the error kind in the label.

Additional context|Before PR|After PR
:-:|:-:|:-:
yes|![image](https://github.com/user-attachments/assets/df4f2e28-fdf5-4693-b60c-255d019af25f) | ![image](https://github.com/user-attachments/assets/5915e9d0-78d4-49a6-b495-502d0c6444fa)
no| ![image](https://github.com/user-attachments/assets/e4ecaada-ec8c-4940-b08a-bbfaa45083d5) | ![image](https://github.com/user-attachments/assets/467163d8-ab39-47f0-a74f-e2effe2fe6af)



# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

N/A, as this is a follow-up to #14927 which has not been included in a release

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
N/A

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A