### PR TITLE
fix(completion): `DotNuCompletion` now completes nu scripts in const `$NU_LIB_DIRS`

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -1159,7 +1159,7 @@ fn setup_history(
 /// Setup Reedline keybindingds based on the provided config
 ///
 fn setup_keybindings(engine_state: &EngineState, line_editor: Reedline) -> Reedline {
-    return match create_keybindings(engine_state.get_config()) {
+    match create_keybindings(engine_state.get_config()) {
         Ok(keybindings) => match keybindings {
             KeybindingsMode::Emacs(keybindings) => {
                 let edit_mode = Box::new(Emacs::new(keybindings));
@@ -1177,7 +1177,7 @@ fn setup_keybindings(engine_state: &EngineState, line_editor: Reedline) -> Reedl
             report_shell_error(engine_state, &e);
             line_editor
         }
-    };
+    }
 }
 
 ///

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -132,7 +132,7 @@ fn gather_env_vars(
                     working_set.error(err);
                 }
 
-                if working_set.parse_errors.first().is_some() {
+                if !working_set.parse_errors.is_empty() {
                     report_capture_error(
                         engine_state,
                         &String::from_utf8_lossy(contents),
@@ -176,7 +176,7 @@ fn gather_env_vars(
                     working_set.error(err);
                 }
 
-                if working_set.parse_errors.first().is_some() {
+                if !working_set.parse_errors.is_empty() {
                     report_capture_error(
                         engine_state,
                         &String::from_utf8_lossy(contents),

--- a/crates/nu-lsp/src/ast.rs
+++ b/crates/nu-lsp/src/ast.rs
@@ -282,7 +282,7 @@ fn try_find_id_in_use(
     id: Option<&Id>,
 ) -> Option<(Id, Span)> {
     let call_name = working_set.get_span_contents(call.head);
-    if call_name != b"use" && call_name != b"hide" {
+    if call_name != b"use" && call_name != b"export use" && call_name != b"hide" {
         return None;
     }
     // TODO: for keyword `hide`, the decl/var is already hidden in working_set,
@@ -318,7 +318,7 @@ fn try_find_id_in_use(
     if let Some(pos) = location {
         // first argument of `use` should always be module name
         // while it is optional in `hide`
-        if span.contains(*pos) && call_name == b"use" {
+        if span.contains(*pos) && call_name != b"hide" {
             return get_matched_module_id(working_set, span, id);
         }
     }
@@ -338,7 +338,7 @@ fn try_find_id_in_use(
         })
     };
 
-    let arguments = if call_name == b"use" {
+    let arguments = if call_name != b"hide" {
         call.arguments.get(1..)?
     } else {
         call.arguments.as_slice()


### PR DESCRIPTION
# Description

For nu scripts completion with command `use`/`overlay use`/`source-env`, it now supports `nu --include-path`.

Also fixes some irrelevant clippy complaints.

# User-Facing Changes

# Tests + Formatting

# After Submitting
