### PR TITLE
Replaced `IoError::new` calls that still had `Span::unknown()`

### DIFF
--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -221,10 +221,10 @@ pub fn current_dir(engine_state: &EngineState, stack: &Stack) -> Result<PathBuf,
     // be an absolute path already.
     canonicalize_with(&cwd, ".").map_err(|err| {
         ShellError::Io(IoError::new_internal_with_path(
-            err.kind(), 
-            "Could not canonicalize current dir", 
+            err.kind(),
+            "Could not canonicalize current dir",
             nu_protocol::location!(),
-            PathBuf::from(cwd)
+            PathBuf::from(cwd),
         ))
     })
 }
@@ -241,10 +241,10 @@ pub fn current_dir_const(working_set: &StateWorkingSet) -> Result<PathBuf, Shell
     // be an absolute path already.
     canonicalize_with(&cwd, ".").map_err(|err| {
         ShellError::Io(IoError::new_internal_with_path(
-            err.kind(), 
-            "Could not canonicalize current dir", 
+            err.kind(),
+            "Could not canonicalize current dir",
             nu_protocol::location!(),
-            PathBuf::from(cwd)
+            PathBuf::from(cwd),
         ))
     })
 }

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -220,10 +220,11 @@ pub fn current_dir(engine_state: &EngineState, stack: &Stack) -> Result<PathBuf,
     // we still need to simplify Windows paths. "." is safe because `cwd` should
     // be an absolute path already.
     canonicalize_with(&cwd, ".").map_err(|err| {
-        ShellError::Io(IoError::new(
-            err.kind(),
-            Span::unknown(),
-            PathBuf::from(cwd),
+        ShellError::Io(IoError::new_internal_with_path(
+            err.kind(), 
+            "Could not canonicalize current dir", 
+            nu_protocol::location!(),
+            PathBuf::from(cwd)
         ))
     })
 }
@@ -239,10 +240,11 @@ pub fn current_dir_const(working_set: &StateWorkingSet) -> Result<PathBuf, Shell
     // we still need to simplify Windows paths. "." is safe because `cwd` should
     // be an absolute path already.
     canonicalize_with(&cwd, ".").map_err(|err| {
-        ShellError::Io(IoError::new(
-            err.kind(),
-            Span::unknown(),
-            PathBuf::from(cwd),
+        ShellError::Io(IoError::new_internal_with_path(
+            err.kind(), 
+            "Could not canonicalize current dir", 
+            nu_protocol::location!(),
+            PathBuf::from(cwd)
         ))
     })
 }

--- a/crates/nu-plugin-core/src/communication_mode/mod.rs
+++ b/crates/nu-plugin-core/src/communication_mode/mod.rs
@@ -219,9 +219,9 @@ impl PreparedServerCommunication {
                                     // `WouldBlock` is ok, just means it's not ready yet, but some other
                                     // kind of error should be reported
                                     return Err(ShellError::Io(IoError::new_internal(
-                                        err.kind(), 
-                                        "Accepting new data from listener failed", 
-                                        nu_protocol::location!()
+                                        err.kind(),
+                                        "Accepting new data from listener failed",
+                                        nu_protocol::location!(),
                                     )));
                                 }
                             }

--- a/crates/nu-plugin-core/src/communication_mode/mod.rs
+++ b/crates/nu-plugin-core/src/communication_mode/mod.rs
@@ -218,10 +218,10 @@ impl PreparedServerCommunication {
                                 if !is_would_block_err(&err) {
                                     // `WouldBlock` is ok, just means it's not ready yet, but some other
                                     // kind of error should be reported
-                                    return Err(ShellError::Io(IoError::new(
-                                        err.kind(),
-                                        Span::unknown(),
-                                        None,
+                                    return Err(ShellError::Io(IoError::new_internal(
+                                        err.kind(), 
+                                        "Accepting new data from listener failed", 
+                                        nu_protocol::location!()
                                     )));
                                 }
                             }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

It seems in my PR #14927 I missed a few calls to `IoError::new` that had `Span::unknown` inside them, which shouldn't be used but rather `IoError::new_internal`. I replaced these calls.

Thanks to @132ikl to finding out that I forgot some. 😄 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Pretty much none really.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
