### PR TITLE
Add --raw to find command

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -53,9 +53,9 @@ impl Command for Find {
                 Some('c'),
             )
             .switch(
-                "raw",
-                "raw mode: find without marking with ascii code",
-                Some('w')
+                "no-highlight",
+                "no-highlight mode: find without marking with ascii code",
+                Some('n')
             )
             .switch("invert", "invert the match", Some('v'))
             .rest("rest", SyntaxShape::Any, "Terms to search.")
@@ -166,7 +166,7 @@ impl Command for Find {
             },
             Example {
                 description: "Remove ANSI sequenses from result",
-                example:"[[foo bar]; [abc 123] [def 456]] | find --raw 123",
+                example:"[[foo bar]; [abc 123] [def 456]] | find --no-highlight 123",
                 result: Some(Value::list(
                     vec![Value::test_record(record! {
                         "foo" => Value::test_string("abc"),
@@ -362,7 +362,7 @@ fn find_with_rest_and_highlight(
     let span = call.head;
     let config = stack.get_config(engine_state);
     let filter_config = config.clone();
-    let raw = call.has_flag(engine_state, stack, "raw")?;
+    let no_highlight = call.has_flag(engine_state, stack, "no-highlight")?;
     let invert = call.has_flag(engine_state, stack, "invert")?;
     let terms = call.rest::<Value>(engine_state, stack, 0)?;
     let lower_terms = terms
@@ -390,7 +390,7 @@ fn find_with_rest_and_highlight(
             .map(
                 move |mut x| {
                     let span = x.span();
-                    if raw { return x };
+                    if no_highlight { return x };
                     match &mut x {
                         Value::Record { val, .. } => highlight_terms_in_record_with_search_columns(
                             &cols_to_search_in_map,
@@ -431,7 +431,7 @@ fn find_with_rest_and_highlight(
             let stream = stream.modify(|iter| {
                 iter.map(move |mut x| {
                     let span = x.span();
-                    if raw { return x };
+                    if no_highlight { return x };
                     match &mut x {
                         Value::Record { val, .. } => highlight_terms_in_record_with_search_columns(
                             &cols_to_search_in_map,
@@ -473,7 +473,7 @@ fn find_with_rest_and_highlight(
                     let lower_val = line.to_lowercase();
                     for term in &terms {
                         if lower_val.contains(term) {
-                            if raw { 
+                            if no_highlight { 
                                 output.push(Value::string(&line, span))
                             } else {
                                 output.push(Value::string(

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -170,7 +170,7 @@ impl Command for Find {
                 result: Some(Value::list(
                     vec![Value::test_record(record! {
                         "foo" => Value::test_string("abc"),
-                        "bar" => Value::test_string("bar")
+                        "bar" => Value::test_int(123)
                     }
                     )],
                     Span::test_data(),
@@ -431,6 +431,7 @@ fn find_with_rest_and_highlight(
             let stream = stream.modify(|iter| {
                 iter.map(move |mut x| {
                     let span = x.span();
+                    if raw { return x };
                     match &mut x {
                         Value::Record { val, .. } => highlight_terms_in_record_with_search_columns(
                             &cols_to_search_in_map,
@@ -472,15 +473,19 @@ fn find_with_rest_and_highlight(
                     let lower_val = line.to_lowercase();
                     for term in &terms {
                         if lower_val.contains(term) {
-                            output.push(Value::string(
-                                highlight_search_string(
-                                    &line,
-                                    term,
-                                    &string_style,
-                                    &highlight_style,
-                                )?,
-                                span,
-                            ))
+                            if raw { 
+                                output.push(Value::string(&line, span))
+                            } else {
+                                output.push(Value::string(
+                                    highlight_search_string(
+                                        &line,
+                                        term,
+                                        &string_style,
+                                        &highlight_style,
+                                    )?,
+                                    span,
+                                ))
+                            }
                         }
                     }
                 }

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -55,7 +55,7 @@ impl Command for Find {
             .switch(
                 "no-highlight",
                 "no-highlight mode: find without marking with ascii code",
-                Some('n')
+                Some('n'),
             )
             .switch("invert", "invert the match", Some('v'))
             .rest("rest", SyntaxShape::Any, "Terms to search.")
@@ -165,7 +165,7 @@ impl Command for Find {
                 )),
             },
             Example {
-                description: "Remove ANSI sequenses from result",
+                description: "Remove ANSI sequences from result",
                 example:"[[foo bar]; [abc 123] [def 456]] | find --no-highlight 123",
                 result: Some(Value::list(
                     vec![Value::test_record(record! {
@@ -390,7 +390,9 @@ fn find_with_rest_and_highlight(
             .map(
                 move |mut x| {
                     let span = x.span();
-                    if no_highlight { return x };
+                    if no_highlight {
+                        return x;
+                    };
                     match &mut x {
                         Value::Record { val, .. } => highlight_terms_in_record_with_search_columns(
                             &cols_to_search_in_map,
@@ -431,7 +433,9 @@ fn find_with_rest_and_highlight(
             let stream = stream.modify(|iter| {
                 iter.map(move |mut x| {
                     let span = x.span();
-                    if no_highlight { return x };
+                    if no_highlight {
+                        return x;
+                    };
                     match &mut x {
                         Value::Record { val, .. } => highlight_terms_in_record_with_search_columns(
                             &cols_to_search_in_map,
@@ -473,7 +477,7 @@ fn find_with_rest_and_highlight(
                     let lower_val = line.to_lowercase();
                     for term in &terms {
                         if lower_val.contains(term) {
-                            if no_highlight { 
+                            if no_highlight {
                                 output.push(Value::string(&line, span))
                             } else {
                                 output.push(Value::string(

--- a/crates/nu-command/tests/commands/find.rs
+++ b/crates/nu-command/tests/commands/find.rs
@@ -3,62 +3,91 @@ use nu_test_support::nu;
 #[test]
 fn find_with_list_search_with_string() {
     let actual = nu!("[moe larry curly] | find moe | get 0");
+    let actual_raw = nu!("[moe larry curly] | find --raw moe | get 0");
 
     assert_eq!(
         actual.out,
         "\u{1b}[37m\u{1b}[0m\u{1b}[41;37mmoe\u{1b}[0m\u{1b}[37m\u{1b}[0m"
+    );
+    assert_eq!(
+        actual_raw.out,
+        "moe"
     );
 }
 
 #[test]
 fn find_with_list_search_with_char() {
     let actual = nu!("[moe larry curly] | find l | to json -r");
+    let actual_raw = nu!("[moe larry curly] | find --raw l | to json -r");
 
     assert_eq!(actual.out, "[\"\\u001b[37m\\u001b[0m\\u001b[41;37ml\\u001b[0m\\u001b[37marry\\u001b[0m\",\"\\u001b[37mcur\\u001b[0m\\u001b[41;37ml\\u001b[0m\\u001b[37my\\u001b[0m\"]");
+    assert_eq!(actual_raw.out, "[\"larry\",\"curly\"]");
 }
 
 #[test]
 fn find_with_bytestream_search_with_char() {
     let actual =
         nu!("\"ABC\" | save foo.txt; let res = open foo.txt | find abc; rm foo.txt; $res | get 0");
+    let actual_raw =
+        nu!("\"ABC\" | save foo.txt; let res = open foo.txt | find --raw abc; rm foo.txt; $res | get 0");
+
     assert_eq!(
         actual.out,
         "\u{1b}[37m\u{1b}[0m\u{1b}[41;37mABC\u{1b}[0m\u{1b}[37m\u{1b}[0m"
-    )
+    );
+    assert_eq!(
+        actual_raw.out,
+        "ABC"
+    );
 }
 
 #[test]
 fn find_with_list_search_with_number() {
     let actual = nu!("[1 2 3 4 5] | find 3 | get 0");
+    let actual_raw = nu!("[1 2 3 4 5] | find --raw 3 | get 0");
 
     assert_eq!(actual.out, "3");
+    assert_eq!(actual_raw.out, "3");
 }
 
 #[test]
 fn find_with_string_search_with_string() {
     let actual = nu!("echo Cargo.toml | find toml");
+    let actual_raw = nu!("echo Cargo.toml | find --raw toml");
 
     assert_eq!(
         actual.out,
         "\u{1b}[37mCargo.\u{1b}[0m\u{1b}[41;37mtoml\u{1b}[0m\u{1b}[37m\u{1b}[0m"
+    );
+    assert_eq!(
+        actual_raw.out,
+        "Cargo.toml"
     );
 }
 
 #[test]
 fn find_with_string_search_with_string_not_found() {
     let actual = nu!("[moe larry curly] | find shemp | is-empty");
+    let actual_raw = nu!("[moe larry curly] | find --raw shemp | is-empty");
 
     assert_eq!(actual.out, "true");
+    assert_eq!(actual_raw.out, "true");
 }
 
 #[test]
 fn find_with_filepath_search_with_string() {
     let actual =
         nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find arep | to json -r"#);
+    let actual_raw =
+        nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find --raw arep | to json -r"#);
 
     assert_eq!(
         actual.out,
         "[\"\\u001b[37m\\u001b[0m\\u001b[41;37marep\\u001b[0m\\u001b[37mas.clu\\u001b[0m\"]"
+    );
+    assert_eq!(
+        actual_raw.out,
+        "[\"arepas.clu\"]"
     );
 }
 
@@ -66,15 +95,20 @@ fn find_with_filepath_search_with_string() {
 fn find_with_filepath_search_with_multiple_patterns() {
     let actual =
         nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find arep ami | to json -r"#);
+    let actual_raw =
+        nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find --raw arep ami | to json -r"#);
 
     assert_eq!(actual.out, "[\"\\u001b[37m\\u001b[0m\\u001b[41;37mami\\u001b[0m\\u001b[37mgos.txt\\u001b[0m\",\"\\u001b[37m\\u001b[0m\\u001b[41;37marep\\u001b[0m\\u001b[37mas.clu\\u001b[0m\"]");
+    assert_eq!(actual_raw.out, "[\"amigos.txt\",\"arepas.clu\"]");
 }
 
 #[test]
 fn find_takes_into_account_linebreaks_in_string() {
     let actual = nu!(r#""atest\nanothertest\nnohit\n" | find a | length"#);
+    let actual_raw = nu!(r#""atest\nanothertest\nnohit\n" | find --raw a | length"#);
 
     assert_eq!(actual.out, "2");
+    assert_eq!(actual_raw.out, "2");
 }
 
 #[test]
@@ -82,8 +116,12 @@ fn find_with_regex_in_table_keeps_row_if_one_column_matches() {
     let actual = nu!(
         "[[name nickname]; [Maurice moe] [Laurence larry]] | find --regex ce | get name | to json -r"
     );
+    let actual_raw = nu!(
+        "[[name nickname]; [Maurice moe] [Laurence larry]] | find --raw --regex ce | get name | to json -r"
+    );
 
     assert_eq!(actual.out, r#"["Maurice","Laurence"]"#);
+    assert_eq!(actual_raw.out, r#"["Maurice","Laurence"]"#);
 }
 
 #[test]
@@ -91,8 +129,12 @@ fn inverted_find_with_regex_in_table_keeps_row_if_none_of_the_columns_matches() 
     let actual = nu!(
         "[[name nickname]; [Maurice moe] [Laurence larry]] | find --regex moe --invert | get name | to json -r"
     );
+    let actual_raw = nu!(
+        "[[name nickname]; [Maurice moe] [Laurence larry]] | find --raw --regex moe --invert | get name | to json -r"
+    );
 
     assert_eq!(actual.out, r#"["Laurence"]"#);
+    assert_eq!(actual_raw.out, r#"["Laurence"]"#);
 }
 
 #[test]
@@ -100,9 +142,14 @@ fn find_in_table_only_keep_rows_with_matches_on_selected_columns() {
     let actual = nu!(
         "[[name nickname]; [Maurice moe] [Laurence larry]] | find r --columns [nickname] | get name | to json -r"
     );
+    let actual_raw = nu!(
+        "[[name nickname]; [Maurice moe] [Laurence larry]] | find r --raw --columns [nickname] | get name | to json -r"
+    );
 
     assert!(actual.out.contains("Laurence"));
     assert!(!actual.out.contains("Maurice"));
+    assert!(actual_raw.out.contains("Laurence"));
+    assert!(!actual_raw.out.contains("Maurice"));
 }
 
 #[test]
@@ -110,23 +157,34 @@ fn inverted_find_in_table_keeps_row_if_none_of_the_selected_columns_matches() {
     let actual = nu!(
         "[[name nickname]; [Maurice moe] [Laurence larry]] | find r --columns [nickname] --invert | get name | to json -r"
     );
+    let actual_raw = nu!(
+        "[[name nickname]; [Maurice moe] [Laurence larry]] | find r --raw --columns [nickname] --invert | get name | to json -r"
+    );
 
     assert_eq!(actual.out, r#"["Maurice"]"#);
+    assert_eq!(actual_raw.out, r#"["Maurice"]"#);
 }
 
 #[test]
 fn find_in_table_keeps_row_with_single_matched_and_keeps_other_columns() {
     let actual = nu!("[[name nickname Age]; [Maurice moe 23] [Laurence larry 67] [William will 18]] | find Maurice");
+    let actual_raw = nu!("[[name nickname Age]; [Maurice moe 23] [Laurence larry 67] [William will 18]] | find --raw Maurice");
 
     println!("{:?}", actual.out);
     assert!(actual.out.contains("moe"));
     assert!(actual.out.contains("Maurice"));
     assert!(actual.out.contains("23"));
+
+    println!("{:?}", actual_raw.out);
+    assert!(actual_raw.out.contains("moe"));
+    assert!(actual_raw.out.contains("Maurice"));
+    assert!(actual_raw.out.contains("23"));
 }
 
 #[test]
 fn find_in_table_keeps_row_with_multiple_matched_and_keeps_other_columns() {
     let actual = nu!("[[name nickname Age]; [Maurice moe 23] [Laurence larry 67] [William will 18] [William bill 60]] | find moe William");
+    let actual_raw = nu!("[[name nickname Age]; [Maurice moe 23] [Laurence larry 67] [William will 18] [William bill 60]] | find --raw moe William");
 
     println!("{:?}", actual.out);
     assert!(actual.out.contains("moe"));
@@ -137,64 +195,104 @@ fn find_in_table_keeps_row_with_multiple_matched_and_keeps_other_columns() {
     assert!(actual.out.contains("18"));
     assert!(actual.out.contains("bill"));
     assert!(actual.out.contains("60"));
+
+    println!("{:?}", actual_raw.out);
+    assert!(actual_raw.out.contains("moe"));
+    assert!(actual_raw.out.contains("Maurice"));
+    assert!(actual_raw.out.contains("23"));
+    assert!(actual_raw.out.contains("William"));
+    assert!(actual_raw.out.contains("will"));
+    assert!(actual_raw.out.contains("18"));
+    assert!(actual_raw.out.contains("bill"));
+    assert!(actual_raw.out.contains("60"));
 }
 
 #[test]
 fn find_with_string_search_with_special_char_1() {
     let actual = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find '?' | to json -r");
+    let actual_raw = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find --raw '?' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m?\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
+    );
+    assert_eq!(
+        actual_raw.out,
+        "[{\"d\":\"a?b\"}]"
     );
 }
 
 #[test]
 fn find_with_string_search_with_special_char_2() {
     let actual = nu!("[[d]; [a?b] [a*b] [a{1}b]] | find '*' | to json -r");
+    let actual_raw = nu!("[[d]; [a?b] [a*b] [a{1}b]] | find --raw '*' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m*\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
+    );
+    assert_eq!(
+        actual_raw.out,
+        "[{\"d\":\"a*b\"}]"
     );
 }
 
 #[test]
 fn find_with_string_search_with_special_char_3() {
     let actual = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find '{1}' | to json -r");
+    let actual_raw = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find --raw '{1}' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m{1}\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
+    );
+    assert_eq!(
+        actual_raw.out,
+        "[{\"d\":\"a{1}b\"}]"
     );
 }
 
 #[test]
 fn find_with_string_search_with_special_char_4() {
     let actual = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find '[' | to json -r");
+    let actual_raw = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --raw '[' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m[\\u001b[0m\\u001b[37m]b\\u001b[0m\"}]"
+    );
+    assert_eq!(
+        actual_raw.out,
+        "[{\"d\":\"a[]b\"}]"
     );
 }
 
 #[test]
 fn find_with_string_search_with_special_char_5() {
     let actual = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find ']' | to json -r");
+    let actual_raw = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --raw ']' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma[\\u001b[0m\\u001b[41;37m]\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
+    );
+    assert_eq!(
+        actual_raw.out,
+        "[{\"d\":\"a[]b\"}]"
     );
 }
 
 #[test]
 fn find_with_string_search_with_special_char_6() {
     let actual = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find '[]' | to json -r");
+    let actual_raw = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --raw '[]' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m[]\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
+    );
+    assert_eq!(
+        actual_raw.out,
+        "[{\"d\":\"a[]b\"}]"
     );
 }

--- a/crates/nu-command/tests/commands/find.rs
+++ b/crates/nu-command/tests/commands/find.rs
@@ -3,14 +3,14 @@ use nu_test_support::nu;
 #[test]
 fn find_with_list_search_with_string() {
     let actual = nu!("[moe larry curly] | find moe | get 0");
-    let actual_raw = nu!("[moe larry curly] | find --raw moe | get 0");
+    let actual_no_highlight = nu!("[moe larry curly] | find --no-highlight moe | get 0");
 
     assert_eq!(
         actual.out,
         "\u{1b}[37m\u{1b}[0m\u{1b}[41;37mmoe\u{1b}[0m\u{1b}[37m\u{1b}[0m"
     );
     assert_eq!(
-        actual_raw.out,
+        actual_no_highlight.out,
         "moe"
     );
 }
@@ -18,25 +18,25 @@ fn find_with_list_search_with_string() {
 #[test]
 fn find_with_list_search_with_char() {
     let actual = nu!("[moe larry curly] | find l | to json -r");
-    let actual_raw = nu!("[moe larry curly] | find --raw l | to json -r");
+    let actual_no_highlight = nu!("[moe larry curly] | find --no-highlight l | to json -r");
 
     assert_eq!(actual.out, "[\"\\u001b[37m\\u001b[0m\\u001b[41;37ml\\u001b[0m\\u001b[37marry\\u001b[0m\",\"\\u001b[37mcur\\u001b[0m\\u001b[41;37ml\\u001b[0m\\u001b[37my\\u001b[0m\"]");
-    assert_eq!(actual_raw.out, "[\"larry\",\"curly\"]");
+    assert_eq!(actual_no_highlight.out, "[\"larry\",\"curly\"]");
 }
 
 #[test]
 fn find_with_bytestream_search_with_char() {
     let actual =
         nu!("\"ABC\" | save foo.txt; let res = open foo.txt | find abc; rm foo.txt; $res | get 0");
-    let actual_raw =
-        nu!("\"ABC\" | save foo.txt; let res = open foo.txt | find --raw abc; rm foo.txt; $res | get 0");
+    let actual_no_highlight =
+        nu!("\"ABC\" | save foo.txt; let res = open foo.txt | find --no-highlight abc; rm foo.txt; $res | get 0");
 
     assert_eq!(
         actual.out,
         "\u{1b}[37m\u{1b}[0m\u{1b}[41;37mABC\u{1b}[0m\u{1b}[37m\u{1b}[0m"
     );
     assert_eq!(
-        actual_raw.out,
+        actual_no_highlight.out,
         "ABC"
     );
 }
@@ -44,23 +44,23 @@ fn find_with_bytestream_search_with_char() {
 #[test]
 fn find_with_list_search_with_number() {
     let actual = nu!("[1 2 3 4 5] | find 3 | get 0");
-    let actual_raw = nu!("[1 2 3 4 5] | find --raw 3 | get 0");
+    let actual_no_highlight = nu!("[1 2 3 4 5] | find --no-highlight 3 | get 0");
 
     assert_eq!(actual.out, "3");
-    assert_eq!(actual_raw.out, "3");
+    assert_eq!(actual_no_highlight.out, "3");
 }
 
 #[test]
 fn find_with_string_search_with_string() {
     let actual = nu!("echo Cargo.toml | find toml");
-    let actual_raw = nu!("echo Cargo.toml | find --raw toml");
+    let actual_no_highlight = nu!("echo Cargo.toml | find --no-highlight toml");
 
     assert_eq!(
         actual.out,
         "\u{1b}[37mCargo.\u{1b}[0m\u{1b}[41;37mtoml\u{1b}[0m\u{1b}[37m\u{1b}[0m"
     );
     assert_eq!(
-        actual_raw.out,
+        actual_no_highlight.out,
         "Cargo.toml"
     );
 }
@@ -68,25 +68,25 @@ fn find_with_string_search_with_string() {
 #[test]
 fn find_with_string_search_with_string_not_found() {
     let actual = nu!("[moe larry curly] | find shemp | is-empty");
-    let actual_raw = nu!("[moe larry curly] | find --raw shemp | is-empty");
+    let actual_no_highlight = nu!("[moe larry curly] | find --no-highlight shemp | is-empty");
 
     assert_eq!(actual.out, "true");
-    assert_eq!(actual_raw.out, "true");
+    assert_eq!(actual_no_highlight.out, "true");
 }
 
 #[test]
 fn find_with_filepath_search_with_string() {
     let actual =
         nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find arep | to json -r"#);
-    let actual_raw =
-        nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find --raw arep | to json -r"#);
+    let actual_no_highlight =
+        nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find --no-highlight arep | to json -r"#);
 
     assert_eq!(
         actual.out,
         "[\"\\u001b[37m\\u001b[0m\\u001b[41;37marep\\u001b[0m\\u001b[37mas.clu\\u001b[0m\"]"
     );
     assert_eq!(
-        actual_raw.out,
+        actual_no_highlight.out,
         "[\"arepas.clu\"]"
     );
 }
@@ -95,20 +95,20 @@ fn find_with_filepath_search_with_string() {
 fn find_with_filepath_search_with_multiple_patterns() {
     let actual =
         nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find arep ami | to json -r"#);
-    let actual_raw =
-        nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find --raw arep ami | to json -r"#);
+    let actual_no_highlight =
+        nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find --no-highlight arep ami | to json -r"#);
 
     assert_eq!(actual.out, "[\"\\u001b[37m\\u001b[0m\\u001b[41;37mami\\u001b[0m\\u001b[37mgos.txt\\u001b[0m\",\"\\u001b[37m\\u001b[0m\\u001b[41;37marep\\u001b[0m\\u001b[37mas.clu\\u001b[0m\"]");
-    assert_eq!(actual_raw.out, "[\"amigos.txt\",\"arepas.clu\"]");
+    assert_eq!(actual_no_highlight.out, "[\"amigos.txt\",\"arepas.clu\"]");
 }
 
 #[test]
 fn find_takes_into_account_linebreaks_in_string() {
     let actual = nu!(r#""atest\nanothertest\nnohit\n" | find a | length"#);
-    let actual_raw = nu!(r#""atest\nanothertest\nnohit\n" | find --raw a | length"#);
+    let actual_no_highlight = nu!(r#""atest\nanothertest\nnohit\n" | find --no-highlight a | length"#);
 
     assert_eq!(actual.out, "2");
-    assert_eq!(actual_raw.out, "2");
+    assert_eq!(actual_no_highlight.out, "2");
 }
 
 #[test]
@@ -116,12 +116,12 @@ fn find_with_regex_in_table_keeps_row_if_one_column_matches() {
     let actual = nu!(
         "[[name nickname]; [Maurice moe] [Laurence larry]] | find --regex ce | get name | to json -r"
     );
-    let actual_raw = nu!(
-        "[[name nickname]; [Maurice moe] [Laurence larry]] | find --raw --regex ce | get name | to json -r"
+    let actual_no_highlight = nu!(
+        "[[name nickname]; [Maurice moe] [Laurence larry]] | find --no-highlight --regex ce | get name | to json -r"
     );
 
     assert_eq!(actual.out, r#"["Maurice","Laurence"]"#);
-    assert_eq!(actual_raw.out, r#"["Maurice","Laurence"]"#);
+    assert_eq!(actual_no_highlight.out, r#"["Maurice","Laurence"]"#);
 }
 
 #[test]
@@ -129,12 +129,12 @@ fn inverted_find_with_regex_in_table_keeps_row_if_none_of_the_columns_matches() 
     let actual = nu!(
         "[[name nickname]; [Maurice moe] [Laurence larry]] | find --regex moe --invert | get name | to json -r"
     );
-    let actual_raw = nu!(
-        "[[name nickname]; [Maurice moe] [Laurence larry]] | find --raw --regex moe --invert | get name | to json -r"
+    let actual_no_highlight = nu!(
+        "[[name nickname]; [Maurice moe] [Laurence larry]] | find --no-highlight --regex moe --invert | get name | to json -r"
     );
 
     assert_eq!(actual.out, r#"["Laurence"]"#);
-    assert_eq!(actual_raw.out, r#"["Laurence"]"#);
+    assert_eq!(actual_no_highlight.out, r#"["Laurence"]"#);
 }
 
 #[test]
@@ -142,14 +142,14 @@ fn find_in_table_only_keep_rows_with_matches_on_selected_columns() {
     let actual = nu!(
         "[[name nickname]; [Maurice moe] [Laurence larry]] | find r --columns [nickname] | get name | to json -r"
     );
-    let actual_raw = nu!(
-        "[[name nickname]; [Maurice moe] [Laurence larry]] | find r --raw --columns [nickname] | get name | to json -r"
+    let actual_no_highlight = nu!(
+        "[[name nickname]; [Maurice moe] [Laurence larry]] | find r --no-highlight --columns [nickname] | get name | to json -r"
     );
 
     assert!(actual.out.contains("Laurence"));
     assert!(!actual.out.contains("Maurice"));
-    assert!(actual_raw.out.contains("Laurence"));
-    assert!(!actual_raw.out.contains("Maurice"));
+    assert!(actual_no_highlight.out.contains("Laurence"));
+    assert!(!actual_no_highlight.out.contains("Maurice"));
 }
 
 #[test]
@@ -157,34 +157,34 @@ fn inverted_find_in_table_keeps_row_if_none_of_the_selected_columns_matches() {
     let actual = nu!(
         "[[name nickname]; [Maurice moe] [Laurence larry]] | find r --columns [nickname] --invert | get name | to json -r"
     );
-    let actual_raw = nu!(
-        "[[name nickname]; [Maurice moe] [Laurence larry]] | find r --raw --columns [nickname] --invert | get name | to json -r"
+    let actual_no_highlight = nu!(
+        "[[name nickname]; [Maurice moe] [Laurence larry]] | find r --no-highlight --columns [nickname] --invert | get name | to json -r"
     );
 
     assert_eq!(actual.out, r#"["Maurice"]"#);
-    assert_eq!(actual_raw.out, r#"["Maurice"]"#);
+    assert_eq!(actual_no_highlight.out, r#"["Maurice"]"#);
 }
 
 #[test]
 fn find_in_table_keeps_row_with_single_matched_and_keeps_other_columns() {
     let actual = nu!("[[name nickname Age]; [Maurice moe 23] [Laurence larry 67] [William will 18]] | find Maurice");
-    let actual_raw = nu!("[[name nickname Age]; [Maurice moe 23] [Laurence larry 67] [William will 18]] | find --raw Maurice");
+    let actual_no_highlight = nu!("[[name nickname Age]; [Maurice moe 23] [Laurence larry 67] [William will 18]] | find --no-highlight Maurice");
 
     println!("{:?}", actual.out);
     assert!(actual.out.contains("moe"));
     assert!(actual.out.contains("Maurice"));
     assert!(actual.out.contains("23"));
 
-    println!("{:?}", actual_raw.out);
-    assert!(actual_raw.out.contains("moe"));
-    assert!(actual_raw.out.contains("Maurice"));
-    assert!(actual_raw.out.contains("23"));
+    println!("{:?}", actual_no_highlight.out);
+    assert!(actual_no_highlight.out.contains("moe"));
+    assert!(actual_no_highlight.out.contains("Maurice"));
+    assert!(actual_no_highlight.out.contains("23"));
 }
 
 #[test]
 fn find_in_table_keeps_row_with_multiple_matched_and_keeps_other_columns() {
     let actual = nu!("[[name nickname Age]; [Maurice moe 23] [Laurence larry 67] [William will 18] [William bill 60]] | find moe William");
-    let actual_raw = nu!("[[name nickname Age]; [Maurice moe 23] [Laurence larry 67] [William will 18] [William bill 60]] | find --raw moe William");
+    let actual_no_highlight = nu!("[[name nickname Age]; [Maurice moe 23] [Laurence larry 67] [William will 18] [William bill 60]] | find --no-highlight moe William");
 
     println!("{:?}", actual.out);
     assert!(actual.out.contains("moe"));
@@ -196,28 +196,28 @@ fn find_in_table_keeps_row_with_multiple_matched_and_keeps_other_columns() {
     assert!(actual.out.contains("bill"));
     assert!(actual.out.contains("60"));
 
-    println!("{:?}", actual_raw.out);
-    assert!(actual_raw.out.contains("moe"));
-    assert!(actual_raw.out.contains("Maurice"));
-    assert!(actual_raw.out.contains("23"));
-    assert!(actual_raw.out.contains("William"));
-    assert!(actual_raw.out.contains("will"));
-    assert!(actual_raw.out.contains("18"));
-    assert!(actual_raw.out.contains("bill"));
-    assert!(actual_raw.out.contains("60"));
+    println!("{:?}", actual_no_highlight.out);
+    assert!(actual_no_highlight.out.contains("moe"));
+    assert!(actual_no_highlight.out.contains("Maurice"));
+    assert!(actual_no_highlight.out.contains("23"));
+    assert!(actual_no_highlight.out.contains("William"));
+    assert!(actual_no_highlight.out.contains("will"));
+    assert!(actual_no_highlight.out.contains("18"));
+    assert!(actual_no_highlight.out.contains("bill"));
+    assert!(actual_no_highlight.out.contains("60"));
 }
 
 #[test]
 fn find_with_string_search_with_special_char_1() {
     let actual = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find '?' | to json -r");
-    let actual_raw = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find --raw '?' | to json -r");
+    let actual_no_highlight = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find --no-highlight '?' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m?\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
     );
     assert_eq!(
-        actual_raw.out,
+        actual_no_highlight.out,
         "[{\"d\":\"a?b\"}]"
     );
 }
@@ -225,14 +225,14 @@ fn find_with_string_search_with_special_char_1() {
 #[test]
 fn find_with_string_search_with_special_char_2() {
     let actual = nu!("[[d]; [a?b] [a*b] [a{1}b]] | find '*' | to json -r");
-    let actual_raw = nu!("[[d]; [a?b] [a*b] [a{1}b]] | find --raw '*' | to json -r");
+    let actual_no_highlight = nu!("[[d]; [a?b] [a*b] [a{1}b]] | find --no-highlight '*' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m*\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
     );
     assert_eq!(
-        actual_raw.out,
+        actual_no_highlight.out,
         "[{\"d\":\"a*b\"}]"
     );
 }
@@ -240,14 +240,14 @@ fn find_with_string_search_with_special_char_2() {
 #[test]
 fn find_with_string_search_with_special_char_3() {
     let actual = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find '{1}' | to json -r");
-    let actual_raw = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find --raw '{1}' | to json -r");
+    let actual_no_highlight = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find --no-highlight '{1}' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m{1}\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
     );
     assert_eq!(
-        actual_raw.out,
+        actual_no_highlight.out,
         "[{\"d\":\"a{1}b\"}]"
     );
 }
@@ -255,14 +255,14 @@ fn find_with_string_search_with_special_char_3() {
 #[test]
 fn find_with_string_search_with_special_char_4() {
     let actual = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find '[' | to json -r");
-    let actual_raw = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --raw '[' | to json -r");
+    let actual_no_highlight = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --no-highlight '[' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m[\\u001b[0m\\u001b[37m]b\\u001b[0m\"}]"
     );
     assert_eq!(
-        actual_raw.out,
+        actual_no_highlight.out,
         "[{\"d\":\"a[]b\"}]"
     );
 }
@@ -270,14 +270,14 @@ fn find_with_string_search_with_special_char_4() {
 #[test]
 fn find_with_string_search_with_special_char_5() {
     let actual = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find ']' | to json -r");
-    let actual_raw = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --raw ']' | to json -r");
+    let actual_no_highlight = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --no-highlight ']' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma[\\u001b[0m\\u001b[41;37m]\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
     );
     assert_eq!(
-        actual_raw.out,
+        actual_no_highlight.out,
         "[{\"d\":\"a[]b\"}]"
     );
 }
@@ -285,14 +285,14 @@ fn find_with_string_search_with_special_char_5() {
 #[test]
 fn find_with_string_search_with_special_char_6() {
     let actual = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find '[]' | to json -r");
-    let actual_raw = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --raw '[]' | to json -r");
+    let actual_no_highlight = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --no-highlight '[]' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m[]\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
     );
     assert_eq!(
-        actual_raw.out,
+        actual_no_highlight.out,
         "[{\"d\":\"a[]b\"}]"
     );
 }

--- a/crates/nu-command/tests/commands/find.rs
+++ b/crates/nu-command/tests/commands/find.rs
@@ -9,10 +9,7 @@ fn find_with_list_search_with_string() {
         actual.out,
         "\u{1b}[37m\u{1b}[0m\u{1b}[41;37mmoe\u{1b}[0m\u{1b}[37m\u{1b}[0m"
     );
-    assert_eq!(
-        actual_no_highlight.out,
-        "moe"
-    );
+    assert_eq!(actual_no_highlight.out, "moe");
 }
 
 #[test]
@@ -35,10 +32,7 @@ fn find_with_bytestream_search_with_char() {
         actual.out,
         "\u{1b}[37m\u{1b}[0m\u{1b}[41;37mABC\u{1b}[0m\u{1b}[37m\u{1b}[0m"
     );
-    assert_eq!(
-        actual_no_highlight.out,
-        "ABC"
-    );
+    assert_eq!(actual_no_highlight.out, "ABC");
 }
 
 #[test]
@@ -59,10 +53,7 @@ fn find_with_string_search_with_string() {
         actual.out,
         "\u{1b}[37mCargo.\u{1b}[0m\u{1b}[41;37mtoml\u{1b}[0m\u{1b}[37m\u{1b}[0m"
     );
-    assert_eq!(
-        actual_no_highlight.out,
-        "Cargo.toml"
-    );
+    assert_eq!(actual_no_highlight.out, "Cargo.toml");
 }
 
 #[test]
@@ -78,25 +69,24 @@ fn find_with_string_search_with_string_not_found() {
 fn find_with_filepath_search_with_string() {
     let actual =
         nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find arep | to json -r"#);
-    let actual_no_highlight =
-        nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find --no-highlight arep | to json -r"#);
+    let actual_no_highlight = nu!(
+        r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find --no-highlight arep | to json -r"#
+    );
 
     assert_eq!(
         actual.out,
         "[\"\\u001b[37m\\u001b[0m\\u001b[41;37marep\\u001b[0m\\u001b[37mas.clu\\u001b[0m\"]"
     );
-    assert_eq!(
-        actual_no_highlight.out,
-        "[\"arepas.clu\"]"
-    );
+    assert_eq!(actual_no_highlight.out, "[\"arepas.clu\"]");
 }
 
 #[test]
 fn find_with_filepath_search_with_multiple_patterns() {
     let actual =
         nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find arep ami | to json -r"#);
-    let actual_no_highlight =
-        nu!(r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find --no-highlight arep ami | to json -r"#);
+    let actual_no_highlight = nu!(
+        r#"["amigos.txt","arepas.clu","los.txt","tres.txt"] | find --no-highlight arep ami | to json -r"#
+    );
 
     assert_eq!(actual.out, "[\"\\u001b[37m\\u001b[0m\\u001b[41;37mami\\u001b[0m\\u001b[37mgos.txt\\u001b[0m\",\"\\u001b[37m\\u001b[0m\\u001b[41;37marep\\u001b[0m\\u001b[37mas.clu\\u001b[0m\"]");
     assert_eq!(actual_no_highlight.out, "[\"amigos.txt\",\"arepas.clu\"]");
@@ -105,7 +95,8 @@ fn find_with_filepath_search_with_multiple_patterns() {
 #[test]
 fn find_takes_into_account_linebreaks_in_string() {
     let actual = nu!(r#""atest\nanothertest\nnohit\n" | find a | length"#);
-    let actual_no_highlight = nu!(r#""atest\nanothertest\nnohit\n" | find --no-highlight a | length"#);
+    let actual_no_highlight =
+        nu!(r#""atest\nanothertest\nnohit\n" | find --no-highlight a | length"#);
 
     assert_eq!(actual.out, "2");
     assert_eq!(actual_no_highlight.out, "2");
@@ -210,89 +201,77 @@ fn find_in_table_keeps_row_with_multiple_matched_and_keeps_other_columns() {
 #[test]
 fn find_with_string_search_with_special_char_1() {
     let actual = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find '?' | to json -r");
-    let actual_no_highlight = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find --no-highlight '?' | to json -r");
+    let actual_no_highlight =
+        nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find --no-highlight '?' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m?\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
     );
-    assert_eq!(
-        actual_no_highlight.out,
-        "[{\"d\":\"a?b\"}]"
-    );
+    assert_eq!(actual_no_highlight.out, "[{\"d\":\"a?b\"}]");
 }
 
 #[test]
 fn find_with_string_search_with_special_char_2() {
     let actual = nu!("[[d]; [a?b] [a*b] [a{1}b]] | find '*' | to json -r");
-    let actual_no_highlight = nu!("[[d]; [a?b] [a*b] [a{1}b]] | find --no-highlight '*' | to json -r");
+    let actual_no_highlight =
+        nu!("[[d]; [a?b] [a*b] [a{1}b]] | find --no-highlight '*' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m*\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
     );
-    assert_eq!(
-        actual_no_highlight.out,
-        "[{\"d\":\"a*b\"}]"
-    );
+    assert_eq!(actual_no_highlight.out, "[{\"d\":\"a*b\"}]");
 }
 
 #[test]
 fn find_with_string_search_with_special_char_3() {
     let actual = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find '{1}' | to json -r");
-    let actual_no_highlight = nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find --no-highlight '{1}' | to json -r");
+    let actual_no_highlight =
+        nu!("[[d]; [a?b] [a*b] [a{1}b] ] | find --no-highlight '{1}' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m{1}\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
     );
-    assert_eq!(
-        actual_no_highlight.out,
-        "[{\"d\":\"a{1}b\"}]"
-    );
+    assert_eq!(actual_no_highlight.out, "[{\"d\":\"a{1}b\"}]");
 }
 
 #[test]
 fn find_with_string_search_with_special_char_4() {
     let actual = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find '[' | to json -r");
-    let actual_no_highlight = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --no-highlight '[' | to json -r");
+    let actual_no_highlight =
+        nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --no-highlight '[' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m[\\u001b[0m\\u001b[37m]b\\u001b[0m\"}]"
     );
-    assert_eq!(
-        actual_no_highlight.out,
-        "[{\"d\":\"a[]b\"}]"
-    );
+    assert_eq!(actual_no_highlight.out, "[{\"d\":\"a[]b\"}]");
 }
 
 #[test]
 fn find_with_string_search_with_special_char_5() {
     let actual = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find ']' | to json -r");
-    let actual_no_highlight = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --no-highlight ']' | to json -r");
+    let actual_no_highlight =
+        nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --no-highlight ']' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma[\\u001b[0m\\u001b[41;37m]\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
     );
-    assert_eq!(
-        actual_no_highlight.out,
-        "[{\"d\":\"a[]b\"}]"
-    );
+    assert_eq!(actual_no_highlight.out, "[{\"d\":\"a[]b\"}]");
 }
 
 #[test]
 fn find_with_string_search_with_special_char_6() {
     let actual = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find '[]' | to json -r");
-    let actual_no_highlight = nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --no-highlight '[]' | to json -r");
+    let actual_no_highlight =
+        nu!("[{d: a?b} {d: a*b} {d: a{1}b} {d: a[]b}] | find --no-highlight '[]' | to json -r");
 
     assert_eq!(
         actual.out,
         "[{\"d\":\"\\u001b[37ma\\u001b[0m\\u001b[41;37m[]\\u001b[0m\\u001b[37mb\\u001b[0m\"}]"
     );
-    assert_eq!(
-        actual_no_highlight.out,
-        "[{\"d\":\"a[]b\"}]"
-    );
+    assert_eq!(actual_no_highlight.out, "[{\"d\":\"a[]b\"}]");
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
When using `find`, we insert ansi code.

This is great for visual but it make comparison a tedious task.

For exemple

```nu
> ([{a: 1 b: 1}] | find 1 | get 0 | get a) == 1
# false
```
The documentation recommand using the `ansi strip` command but you then lose your typing converting it to a string.
```nu
> [{a: 1 b: 1}] | find 1 | get 0 | get a | ansi strip | describe
# string
```
And this makes me very sad 😢 .

The idea here is to have a simple option to keep the usage of `find` without the ansi marking.
```nu
> ([{a: 1 b: 1}] | find --raw 1 | get 0 | get a) == 1
# true
```

Tbh I think we could also do a fix on the parser to really escape the ansi makers but this sounded like way more work so I would like your opinion on this before working on it.

Also note that this is my first time writting rust and trying to contribute to nushell so if you see any weird shenanigans be sure to tell me !
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
A new flag for find
# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
For testing I updated all the previous `find` test to also run them with this new flag just to be sure that we didn't lose any other functionalities
# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
