### PR TITLE
Bump lsp-textdocument from 0.4.0 to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,9 +3084,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-textdocument"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8dc223af95101fe950a871d4d567b6f98a1ecfcee5861f4b57644581aaa980d"
+checksum = "9a17dcde15cae78fb2e54166da22cd6c53f48033a0391cc392b22f2437805792"
 dependencies = [
  "lsp-types",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ lru = "0.12"
 lscolors = { version = "0.17", default-features = false }
 lsp-server = "0.7.8"
 lsp-types = { version = "0.97.0", features = ["proposed"] }
-lsp-textdocument = "0.4.0"
+lsp-textdocument = "0.4.1"
 mach2 = "0.4"
 md5 = { version = "0.10", package = "md-5" }
 miette = "7.3"


### PR DESCRIPTION
# Description

This upstream upgrade fixes a crashing bug.

# User-Facing Changes
# Tests + Formatting
# After Submitting
