### PR TITLE
check signals while printing values

### DIFF
--- a/crates/nu-command/tests/commands/start.rs
+++ b/crates/nu-command/tests/commands/start.rs
@@ -1,11 +1,11 @@
 use super::*;
+use nu_engine::test_help::{convert_single_value_to_cmd_args, eval_block_with_input};
+use nu_engine::{current_dir, eval_expression};
 use nu_protocol::{
     ast::Call,
     engine::{EngineState, Stack, StateWorkingSet},
     PipelineData, Span, Spanned, Type, Value,
 };
-use nu_engine::test_help::{convert_single_value_to_cmd_args, eval_block_with_input};
-use nu_engine::{current_dir, eval_expression};
 use std::path::PathBuf;
 
 /// Create a minimal test engine state and stack to run commands against.


### PR DESCRIPTION
Fixes #14960

# User-Facing Changes

- The output of non-streaming values can now be interrupted with ctrl-c:

```nushell
~> use std repeat; random chars --length 100kb | repeat 2000 | str join ' ' | collect
<data omitted>^C
Error:
  × Operation interrupted
   ╭─[entry #1:1:61]
 1 │ use std repeat; random chars --length 100kb | repeat 2000 | str join ' ' | collect
   ·                                                             ────┬───
   ·                                                                 ╰── This operation was interrupted
   ╰────
```

- When IO errors occur while printing data, nushell no longer panics:

```diff
 $ nu -c "true | print" | -

-Error:
-  x Main thread panicked.
-  |-> at crates/nu-protocol/src/errors/shell_error/io.rs:198:13
-  `-> for unknown spans with paths, use `new_internal_with_path`
+Error: nu::shell::io::broken_pipe
+
+  x I/O error
+  `->   x Broken pipe
+
+   ,-[source:1:1]
+ 1 | true | print
+   : ^^|^
+   :   `-| Writing to stdout failed
+   :     | Broken pipe
+   `----
```