### PR TITLE
fix: clippy warning of rust 1.8.4

### DIFF
--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -169,7 +169,7 @@ impl<'a> StyleComputer<'a> {
 
 // Because EngineState doesn't have Debug (Dec 2022),
 // this incomplete representation must be used.
-impl<'a> Debug for StyleComputer<'a> {
+impl Debug for StyleComputer<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         f.debug_struct("StyleComputer")
             .field("map", &self.map)

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -529,14 +529,14 @@ impl<'e, 's> ScopeData<'e, 's> {
 }
 
 fn extract_custom_completion_from_arg(engine_state: &EngineState, shape: &SyntaxShape) -> String {
-    return match shape {
+    match shape {
         SyntaxShape::CompleterWrapper(_, custom_completion_decl_id) => {
             let custom_completion_command = engine_state.get_decl(*custom_completion_decl_id);
             let custom_completion_command_name: &str = custom_completion_command.name();
             custom_completion_command_name.to_string()
         }
         _ => "".to_string(),
-    };
+    }
 }
 
 fn sort_rows(decls: &mut [Value]) {

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -294,7 +294,6 @@ pub fn glob_with(pattern: &str, options: MatchOptions) -> Result<Paths, PatternE
 /// This is provided primarily for testability, so multithreaded test runners can
 /// test pattern matches in different test directories at the same time without
 /// having to append the parent to the pattern under test.
-
 pub fn glob_with_parent(
     pattern: &str,
     options: MatchOptions,
@@ -790,7 +789,7 @@ impl Pattern {
     /// `Pattern` using the default match options (i.e. `MatchOptions::default()`).
     pub fn matches_path(&self, path: &Path) -> bool {
         // FIXME (#9639): This needs to handle non-utf8 paths
-        path.to_str().map_or(false, |s| self.matches(s))
+        path.to_str().is_some_and(|s| self.matches(s))
     }
 
     /// Return if the given `str` matches this `Pattern` using the specified
@@ -803,8 +802,7 @@ impl Pattern {
     /// `Pattern` using the specified match options.
     pub fn matches_path_with(&self, path: &Path, options: MatchOptions) -> bool {
         // FIXME (#9639): This needs to handle non-utf8 paths
-        path.to_str()
-            .map_or(false, |s| self.matches_with(s, options))
+        path.to_str().is_some_and(|s| self.matches_with(s, options))
     }
 
     /// Access the original glob pattern.
@@ -1069,7 +1067,7 @@ fn chars_eq(a: char, b: char, case_sensitive: bool) -> bool {
         true
     } else if !case_sensitive && a.is_ascii() && b.is_ascii() {
         // FIXME: work with non-ascii chars properly (issue #9084)
-        a.to_ascii_lowercase() == b.to_ascii_lowercase()
+        a.eq_ignore_ascii_case(&b)
     } else {
         a == b
     }

--- a/crates/nu-json/src/de.rs
+++ b/crates/nu-json/src/de.rs
@@ -505,7 +505,7 @@ where
     }
 }
 
-impl<'de, 'a, Iter> de::Deserializer<'de> for &'a mut Deserializer<Iter>
+impl<'de, Iter> de::Deserializer<'de> for &mut Deserializer<Iter>
 where
     Iter: Iterator<Item = u8>,
 {
@@ -565,7 +565,7 @@ impl<'a, Iter: Iterator<Item = u8>> SeqVisitor<'a, Iter> {
     }
 }
 
-impl<'de, 'a, Iter> de::SeqAccess<'de> for SeqVisitor<'a, Iter>
+impl<'de, Iter> de::SeqAccess<'de> for SeqVisitor<'_, Iter>
 where
     Iter: Iterator<Item = u8>,
 {
@@ -616,7 +616,7 @@ impl<'a, Iter: Iterator<Item = u8>> MapVisitor<'a, Iter> {
     }
 }
 
-impl<'de, 'a, Iter> de::MapAccess<'de> for MapVisitor<'a, Iter>
+impl<'de, Iter> de::MapAccess<'de> for MapVisitor<'_, Iter>
 where
     Iter: Iterator<Item = u8>,
 {
@@ -671,7 +671,7 @@ where
     }
 }
 
-impl<'de, 'a, Iter> de::VariantAccess<'de> for &'a mut Deserializer<Iter>
+impl<'de, Iter> de::VariantAccess<'de> for &mut Deserializer<Iter>
 where
     Iter: Iterator<Item = u8>,
 {

--- a/crates/nu-json/src/ser.rs
+++ b/crates/nu-json/src/ser.rs
@@ -310,7 +310,7 @@ where
     }
 }
 
-impl<'a, W, F> ser::SerializeSeq for Compound<'a, W, F>
+impl<W, F> ser::SerializeSeq for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -337,7 +337,7 @@ where
     }
 }
 
-impl<'a, W, F> ser::SerializeTuple for Compound<'a, W, F>
+impl<W, F> ser::SerializeTuple for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -357,7 +357,7 @@ where
     }
 }
 
-impl<'a, W, F> ser::SerializeTupleStruct for Compound<'a, W, F>
+impl<W, F> ser::SerializeTupleStruct for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -377,7 +377,7 @@ where
     }
 }
 
-impl<'a, W, F> ser::SerializeTupleVariant for Compound<'a, W, F>
+impl<W, F> ser::SerializeTupleVariant for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -401,7 +401,7 @@ where
     }
 }
 
-impl<'a, W, F> ser::SerializeMap for Compound<'a, W, F>
+impl<W, F> ser::SerializeMap for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -438,7 +438,7 @@ where
     }
 }
 
-impl<'a, W, F> ser::SerializeStruct for Compound<'a, W, F>
+impl<W, F> ser::SerializeStruct for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -458,7 +458,7 @@ where
     }
 }
 
-impl<'a, W, F> ser::SerializeStructVariant for Compound<'a, W, F>
+impl<W, F> ser::SerializeStructVariant for Compound<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -486,7 +486,7 @@ struct MapKeySerializer<'a, W: 'a, F: 'a> {
     ser: &'a mut Serializer<W, F>,
 }
 
-impl<'a, W, F> ser::Serializer for MapKeySerializer<'a, W, F>
+impl<W, F> ser::Serializer for MapKeySerializer<'_, W, F>
 where
     W: io::Write,
     F: Formatter,
@@ -694,7 +694,7 @@ struct HjsonFormatter<'a> {
     braces_same_line: bool,
 }
 
-impl<'a> Default for HjsonFormatter<'a> {
+impl Default for HjsonFormatter<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -719,7 +719,7 @@ impl<'a> HjsonFormatter<'a> {
     }
 }
 
-impl<'a> Formatter for HjsonFormatter<'a> {
+impl Formatter for HjsonFormatter<'_> {
     fn open<W>(&mut self, writer: &mut W, ch: u8) -> Result<()>
     where
         W: io::Write,

--- a/crates/nu-json/src/value.rs
+++ b/crates/nu-json/src/value.rs
@@ -432,7 +432,7 @@ struct WriterFormatter<'a, 'b: 'a> {
     inner: &'a mut fmt::Formatter<'b>,
 }
 
-impl<'a, 'b> io::Write for WriterFormatter<'a, 'b> {
+impl io::Write for WriterFormatter<'_, '_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         fn io_error<E>(_: E) -> io::Error {
             // Value does not matter because fmt::Debug and fmt::Display impls

--- a/crates/nu-path/src/tilde.rs
+++ b/crates/nu-path/src/tilde.rs
@@ -126,7 +126,7 @@ fn is_termux() -> bool {
 }
 
 fn expand_tilde_with_another_user_home(path: &Path) -> PathBuf {
-    return match path.to_str() {
+    match path.to_str() {
         Some(file_path) => {
             let mut file = file_path.to_string();
             match file_path.find(['/', '\\']) {
@@ -147,7 +147,7 @@ fn expand_tilde_with_another_user_home(path: &Path) -> PathBuf {
             }
         }
         None => path.to_path_buf(),
-    };
+    }
 }
 
 /// Expand tilde ("~") into a home directory if it is the first path component

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -354,7 +354,7 @@ impl EngineState {
     pub fn active_overlay_ids<'a, 'b>(
         &'b self,
         removed_overlays: &'a [Vec<u8>],
-    ) -> impl DoubleEndedIterator<Item = &OverlayId> + 'a
+    ) -> impl DoubleEndedIterator<Item = &'b OverlayId> + 'a
     where
         'b: 'a,
     {
@@ -368,7 +368,7 @@ impl EngineState {
     pub fn active_overlays<'a, 'b>(
         &'b self,
         removed_overlays: &'a [Vec<u8>],
-    ) -> impl DoubleEndedIterator<Item = &OverlayFrame> + 'a
+    ) -> impl DoubleEndedIterator<Item = &'b OverlayFrame> + 'a
     where
         'b: 'a,
     {
@@ -379,7 +379,7 @@ impl EngineState {
     pub fn active_overlay_names<'a, 'b>(
         &'b self,
         removed_overlays: &'a [Vec<u8>],
-    ) -> impl DoubleEndedIterator<Item = &[u8]> + 'a
+    ) -> impl DoubleEndedIterator<Item = &'b [u8]> + 'a
     where
         'b: 'a,
     {
@@ -1061,7 +1061,7 @@ impl EngineState {
     }
 }
 
-impl<'a> GetSpan for &'a EngineState {
+impl GetSpan for &EngineState {
     /// Get existing span
     fn get_span(&self, span_id: SpanId) -> Span {
         *self

--- a/crates/nu-protocol/src/engine/overlay.rs
+++ b/crates/nu-protocol/src/engine/overlay.rs
@@ -120,7 +120,7 @@ impl ScopeFrame {
     pub fn active_overlays<'a, 'b>(
         &'b self,
         removed_overlays: &'a mut Vec<Vec<u8>>,
-    ) -> impl DoubleEndedIterator<Item = &OverlayFrame> + 'a
+    ) -> impl DoubleEndedIterator<Item = &'b OverlayFrame> + 'a
     where
         'b: 'a,
     {

--- a/crates/nu-protocol/src/engine/stack_out_dest.rs
+++ b/crates/nu-protocol/src/engine/stack_out_dest.rs
@@ -153,7 +153,7 @@ impl<'a> StackIoGuard<'a> {
     }
 }
 
-impl<'a> Deref for StackIoGuard<'a> {
+impl Deref for StackIoGuard<'_> {
     type Target = Stack;
 
     fn deref(&self) -> &Self::Target {
@@ -161,7 +161,7 @@ impl<'a> Deref for StackIoGuard<'a> {
     }
 }
 
-impl<'a> DerefMut for StackIoGuard<'a> {
+impl DerefMut for StackIoGuard<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.stack
     }
@@ -202,7 +202,7 @@ impl<'a> StackCollectValueGuard<'a> {
     }
 }
 
-impl<'a> Deref for StackCollectValueGuard<'a> {
+impl Deref for StackCollectValueGuard<'_> {
     type Target = Stack;
 
     fn deref(&self) -> &Self::Target {
@@ -210,7 +210,7 @@ impl<'a> Deref for StackCollectValueGuard<'a> {
     }
 }
 
-impl<'a> DerefMut for StackCollectValueGuard<'a> {
+impl DerefMut for StackCollectValueGuard<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.stack
     }
@@ -258,7 +258,7 @@ impl<'a> StackCallArgGuard<'a> {
     }
 }
 
-impl<'a> Deref for StackCallArgGuard<'a> {
+impl Deref for StackCallArgGuard<'_> {
     type Target = Stack;
 
     fn deref(&self) -> &Self::Target {
@@ -266,7 +266,7 @@ impl<'a> Deref for StackCallArgGuard<'a> {
     }
 }
 
-impl<'a> DerefMut for StackCallArgGuard<'a> {
+impl DerefMut for StackCallArgGuard<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.stack
     }

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -399,7 +399,7 @@ impl<'a> StateWorkingSet<'a> {
         }
 
         // if no files with span were found, fall back on permanent ones
-        return self.permanent_state.get_span_contents(span);
+        self.permanent_state.get_span_contents(span)
     }
 
     pub fn enter_scope(&mut self) {
@@ -1105,13 +1105,13 @@ impl<'a> GetSpan for &'a StateWorkingSet<'a> {
     }
 }
 
-impl<'a> miette::SourceCode for &StateWorkingSet<'a> {
+impl miette::SourceCode for &StateWorkingSet<'_> {
     fn read_span<'b>(
         &'b self,
         span: &miette::SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn miette::SpanContents + 'b>, miette::MietteError> {
+    ) -> Result<Box<dyn miette::SpanContents<'b> + 'b>, miette::MietteError> {
         let debugging = std::env::var("MIETTE_DEBUG").is_ok();
         if debugging {
             let finding_span = "Finding span in StateWorkingSet";

--- a/crates/nu-protocol/src/errors/cli_error.rs
+++ b/crates/nu-protocol/src/errors/cli_error.rs
@@ -96,7 +96,7 @@ impl std::fmt::Debug for CliError<'_> {
     }
 }
 
-impl<'src> miette::Diagnostic for CliError<'src> {
+impl miette::Diagnostic for CliError<'_> {
     fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
         self.0.code()
     }

--- a/crates/nu-protocol/src/ir/display.rs
+++ b/crates/nu-protocol/src/ir/display.rs
@@ -7,7 +7,7 @@ pub struct FmtIrBlock<'a> {
     pub(super) ir_block: &'a IrBlock,
 }
 
-impl<'a> fmt::Display for FmtIrBlock<'a> {
+impl fmt::Display for FmtIrBlock<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let plural = |count| if count == 1 { "" } else { "s" };
         writeln!(
@@ -55,7 +55,7 @@ pub struct FmtInstruction<'a> {
     pub(super) data: &'a [u8],
 }
 
-impl<'a> fmt::Display for FmtInstruction<'a> {
+impl fmt::Display for FmtInstruction<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const WIDTH: usize = 22;
 
@@ -321,7 +321,7 @@ impl fmt::Display for RedirectMode {
 
 struct FmtData<'a>(&'a [u8], DataSlice);
 
-impl<'a> fmt::Display for FmtData<'a> {
+impl fmt::Display for FmtData<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Ok(s) = std::str::from_utf8(&self.0[self.1]) {
             // Write as string
@@ -338,7 +338,7 @@ struct FmtLiteral<'a> {
     data: &'a [u8],
 }
 
-impl<'a> fmt::Display for FmtLiteral<'a> {
+impl fmt::Display for FmtLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.literal {
             Literal::Bool(b) => write!(f, "bool({b:?})"),
@@ -387,7 +387,7 @@ struct FmtPattern<'a> {
     pattern: &'a Pattern,
 }
 
-impl<'a> fmt::Display for FmtPattern<'a> {
+impl fmt::Display for FmtPattern<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.pattern {
             Pattern::Record(bindings) => {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -2512,7 +2512,7 @@ impl PartialOrd for Value {
 
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
-        self.partial_cmp(other).map_or(false, Ordering::is_eq)
+        self.partial_cmp(other).is_some_and(Ordering::is_eq)
     }
 }
 

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -440,13 +440,13 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for Iter<'a> {
+impl DoubleEndedIterator for Iter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(|(col, val): &(_, _)| (col, val))
     }
 }
 
-impl<'a> ExactSizeIterator for Iter<'a> {
+impl ExactSizeIterator for Iter<'_> {
     fn len(&self) -> usize {
         self.iter.len()
     }
@@ -482,13 +482,13 @@ impl<'a> Iterator for IterMut<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for IterMut<'a> {
+impl DoubleEndedIterator for IterMut<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(|(col, val)| (&*col, val))
     }
 }
 
-impl<'a> ExactSizeIterator for IterMut<'a> {
+impl ExactSizeIterator for IterMut<'_> {
     fn len(&self) -> usize {
         self.iter.len()
     }
@@ -524,13 +524,13 @@ impl<'a> Iterator for Columns<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for Columns<'a> {
+impl DoubleEndedIterator for Columns<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(|(col, _)| col)
     }
 }
 
-impl<'a> ExactSizeIterator for Columns<'a> {
+impl ExactSizeIterator for Columns<'_> {
     fn len(&self) -> usize {
         self.iter.len()
     }
@@ -584,13 +584,13 @@ impl<'a> Iterator for Values<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for Values<'a> {
+impl DoubleEndedIterator for Values<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(|(_, val)| val)
     }
 }
 
-impl<'a> ExactSizeIterator for Values<'a> {
+impl ExactSizeIterator for Values<'_> {
     fn len(&self) -> usize {
         self.iter.len()
     }

--- a/crates/nu-utils/src/flatten_json.rs
+++ b/crates/nu-utils/src/flatten_json.rs
@@ -31,7 +31,7 @@ pub struct JsonFlattener<'a> {
     pub preserve_arrays: bool,
 }
 
-impl<'a> Default for JsonFlattener<'a> {
+impl Default for JsonFlattener<'_> {
     fn default() -> Self {
         JsonFlattener {
             separator: ".",
@@ -56,7 +56,7 @@ impl<'a> Default for JsonFlattener<'a> {
 ///
 /// let flattened_example = flattener.flatten(&example);
 /// ```
-impl<'a> JsonFlattener<'a> {
+impl JsonFlattener<'_> {
     /// Returns a flattener with the default arguments
     /// # Examples
     /// ```


### PR DESCRIPTION
# Description

I'm on rust toolchain 1.8.4, and I can see clippy warnings that can't be caught by the ci workflow, primarily related to lifetime params.

I think it doesn't hurt to fix those in advance.

# User-Facing Changes

# Tests + Formatting

# After Submitting
