### PR TITLE
Use serde-yaml-ng instead of serde-yml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2978,16 +2978,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "libz-rs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3689,7 +3679,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "serde_yml",
+ "serde_yaml_ng",
  "sha2",
  "sysinfo 0.32.1",
  "tabled",
@@ -6486,18 +6476,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -7504,6 +7492,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ scopeguard = { version = "1.2.0" }
 serde = { version = "1.0" }
 serde_json = "1.0"
 serde_urlencoded = "0.7.1"
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10"
 sha2 = "0.10"
 strip-ansi-escapes = "0.2.0"
 syn = "2.0"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -84,7 +84,7 @@ scopeguard = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_urlencoded = { workspace = true }
-serde_yml = { workspace = true }
+serde_yaml_ng = { workspace = true }
 sha2 = { workspace = true }
 sysinfo = { workspace = true }
 tabled = { workspace = true, features = ["ansi"], default-features = false }

--- a/crates/nu-command/src/formats/from/yaml.rs
+++ b/crates/nu-command/src/formats/from/yaml.rs
@@ -72,7 +72,7 @@ impl Command for FromYml {
 }
 
 fn convert_yaml_value_to_nu_value(
-    v: &serde_yml::Value,
+    v: &serde_yaml_ng::Value,
     span: Span,
     val_span: Span,
 ) -> Result<Value, ShellError> {
@@ -83,22 +83,22 @@ fn convert_yaml_value_to_nu_value(
         input_span: val_span,
     };
     Ok(match v {
-        serde_yml::Value::Bool(b) => Value::bool(*b, span),
-        serde_yml::Value::Number(n) if n.is_i64() => {
+        serde_yaml_ng::Value::Bool(b) => Value::bool(*b, span),
+        serde_yaml_ng::Value::Number(n) if n.is_i64() => {
             Value::int(n.as_i64().ok_or(err_not_compatible_number)?, span)
         }
-        serde_yml::Value::Number(n) if n.is_f64() => {
+        serde_yaml_ng::Value::Number(n) if n.is_f64() => {
             Value::float(n.as_f64().ok_or(err_not_compatible_number)?, span)
         }
-        serde_yml::Value::String(s) => Value::string(s.to_string(), span),
-        serde_yml::Value::Sequence(a) => {
+        serde_yaml_ng::Value::String(s) => Value::string(s.to_string(), span),
+        serde_yaml_ng::Value::Sequence(a) => {
             let result: Result<Vec<Value>, ShellError> = a
                 .iter()
                 .map(|x| convert_yaml_value_to_nu_value(x, span, val_span))
                 .collect();
             Value::list(result?, span)
         }
-        serde_yml::Value::Mapping(t) => {
+        serde_yaml_ng::Value::Mapping(t) => {
             // Using an IndexMap ensures consistent ordering
             let mut collected = IndexMap::new();
 
@@ -111,19 +111,19 @@ fn convert_yaml_value_to_nu_value(
                     input_span: val_span,
                 };
                 match (k, v) {
-                    (serde_yml::Value::Number(k), _) => {
+                    (serde_yaml_ng::Value::Number(k), _) => {
                         collected.insert(
                             k.to_string(),
                             convert_yaml_value_to_nu_value(v, span, val_span)?,
                         );
                     }
-                    (serde_yml::Value::Bool(k), _) => {
+                    (serde_yaml_ng::Value::Bool(k), _) => {
                         collected.insert(
                             k.to_string(),
                             convert_yaml_value_to_nu_value(v, span, val_span)?,
                         );
                     }
-                    (serde_yml::Value::String(k), _) => {
+                    (serde_yaml_ng::Value::String(k), _) => {
                         collected.insert(
                             k.clone(),
                             convert_yaml_value_to_nu_value(v, span, val_span)?,
@@ -132,16 +132,16 @@ fn convert_yaml_value_to_nu_value(
                     // Hard-code fix for cases where "v" is a string without quotations with double curly braces
                     // e.g. k = value
                     // value: {{ something }}
-                    // Strangely, serde_yml returns
+                    // Strangely, serde_yaml_ng returns
                     // "value" -> Mapping(Mapping { map: {Mapping(Mapping { map: {String("something"): Null} }): Null} })
-                    (serde_yml::Value::Mapping(m), serde_yml::Value::Null) => {
+                    (serde_yaml_ng::Value::Mapping(m), serde_yaml_ng::Value::Null) => {
                         return m
                             .iter()
                             .take(1)
                             .collect_vec()
                             .first()
                             .and_then(|e| match e {
-                                (serde_yml::Value::String(s), serde_yml::Value::Null) => {
+                                (serde_yaml_ng::Value::String(s), serde_yaml_ng::Value::Null) => {
                                     Some(Value::string("{{ ".to_owned() + s.as_str() + " }}", span))
                                 }
                                 _ => None,
@@ -156,22 +156,22 @@ fn convert_yaml_value_to_nu_value(
 
             Value::record(collected.into_iter().collect(), span)
         }
-        serde_yml::Value::Tagged(t) => {
+        serde_yaml_ng::Value::Tagged(t) => {
             let tag = &t.tag;
             let value = match &t.value {
-                serde_yml::Value::String(s) => {
+                serde_yaml_ng::Value::String(s) => {
                     let val = format!("{} {}", tag, s).trim().to_string();
                     Value::string(val, span)
                 }
-                serde_yml::Value::Number(n) => {
+                serde_yaml_ng::Value::Number(n) => {
                     let val = format!("{} {}", tag, n).trim().to_string();
                     Value::string(val, span)
                 }
-                serde_yml::Value::Bool(b) => {
+                serde_yaml_ng::Value::Bool(b) => {
                     let val = format!("{} {}", tag, b).trim().to_string();
                     Value::string(val, span)
                 }
-                serde_yml::Value::Null => {
+                serde_yaml_ng::Value::Null => {
                     let val = format!("{}", tag).trim().to_string();
                     Value::string(val, span)
                 }
@@ -180,7 +180,7 @@ fn convert_yaml_value_to_nu_value(
 
             value
         }
-        serde_yml::Value::Null => Value::nothing(span),
+        serde_yaml_ng::Value::Null => Value::nothing(span),
         x => unimplemented!("Unsupported YAML case: {:?}", x),
     })
 }
@@ -188,14 +188,15 @@ fn convert_yaml_value_to_nu_value(
 pub fn from_yaml_string_to_value(s: &str, span: Span, val_span: Span) -> Result<Value, ShellError> {
     let mut documents = vec![];
 
-    for document in serde_yml::Deserializer::from_str(s) {
-        let v: serde_yml::Value =
-            serde_yml::Value::deserialize(document).map_err(|x| ShellError::UnsupportedInput {
+    for document in serde_yaml_ng::Deserializer::from_str(s) {
+        let v: serde_yaml_ng::Value = serde_yaml_ng::Value::deserialize(document).map_err(|x| {
+            ShellError::UnsupportedInput {
                 msg: format!("Could not load YAML: {x}"),
                 input: "value originates from here".into(),
                 msg_span: span,
                 input_span: val_span,
-            })?;
+            }
+        })?;
         documents.push(convert_yaml_value_to_nu_value(&v, span, val_span)?);
     }
 
@@ -393,8 +394,9 @@ mod test {
         ];
 
         for test_case in test_cases {
-            let doc = serde_yml::Deserializer::from_str(test_case.input);
-            let v: serde_yml::Value = serde_yml::Value::deserialize(doc.last().unwrap()).unwrap();
+            let doc = serde_yaml_ng::Deserializer::from_str(test_case.input);
+            let v: serde_yaml_ng::Value =
+                serde_yaml_ng::Value::deserialize(doc.last().unwrap()).unwrap();
             let result = convert_yaml_value_to_nu_value(&v, Span::test_data(), Span::test_data());
             assert!(result.is_ok());
             assert!(result.ok().unwrap() == test_case.expected.ok().unwrap());

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -51,27 +51,29 @@ pub fn value_to_yaml_value(
     engine_state: &EngineState,
     v: &Value,
     serialize_types: bool,
-) -> Result<serde_yml::Value, ShellError> {
+) -> Result<serde_yaml_ng::Value, ShellError> {
     Ok(match &v {
-        Value::Bool { val, .. } => serde_yml::Value::Bool(*val),
-        Value::Int { val, .. } => serde_yml::Value::Number(serde_yml::Number::from(*val)),
-        Value::Filesize { val, .. } => serde_yml::Value::Number(serde_yml::Number::from(val.get())),
-        Value::Duration { val, .. } => serde_yml::Value::String(val.to_string()),
-        Value::Date { val, .. } => serde_yml::Value::String(val.to_string()),
-        Value::Range { .. } => serde_yml::Value::Null,
-        Value::Float { val, .. } => serde_yml::Value::Number(serde_yml::Number::from(*val)),
+        Value::Bool { val, .. } => serde_yaml_ng::Value::Bool(*val),
+        Value::Int { val, .. } => serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(*val)),
+        Value::Filesize { val, .. } => {
+            serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(val.get()))
+        }
+        Value::Duration { val, .. } => serde_yaml_ng::Value::String(val.to_string()),
+        Value::Date { val, .. } => serde_yaml_ng::Value::String(val.to_string()),
+        Value::Range { .. } => serde_yaml_ng::Value::Null,
+        Value::Float { val, .. } => serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(*val)),
         Value::String { val, .. } | Value::Glob { val, .. } => {
-            serde_yml::Value::String(val.clone())
+            serde_yaml_ng::Value::String(val.clone())
         }
         Value::Record { val, .. } => {
-            let mut m = serde_yml::Mapping::new();
+            let mut m = serde_yaml_ng::Mapping::new();
             for (k, v) in &**val {
                 m.insert(
-                    serde_yml::Value::String(k.clone()),
+                    serde_yaml_ng::Value::String(k.clone()),
                     value_to_yaml_value(engine_state, v, serialize_types)?,
                 );
             }
-            serde_yml::Value::Mapping(m)
+            serde_yaml_ng::Value::Mapping(m)
         }
         Value::List { vals, .. } => {
             let mut out = vec![];
@@ -80,7 +82,7 @@ pub fn value_to_yaml_value(
                 out.push(value_to_yaml_value(engine_state, value, serialize_types)?);
             }
 
-            serde_yml::Value::Sequence(out)
+            serde_yaml_ng::Value::Sequence(out)
         }
         Value::Closure { val, .. } => {
             if serialize_types {
@@ -88,36 +90,36 @@ pub fn value_to_yaml_value(
                 if let Some(span) = block.span {
                     let contents_bytes = engine_state.get_span_contents(span);
                     let contents_string = String::from_utf8_lossy(contents_bytes);
-                    serde_yml::Value::String(contents_string.to_string())
+                    serde_yaml_ng::Value::String(contents_string.to_string())
                 } else {
-                    serde_yml::Value::String(format!(
+                    serde_yaml_ng::Value::String(format!(
                         "unable to retrieve block contents for yaml block_id {}",
                         val.block_id.get()
                     ))
                 }
             } else {
-                serde_yml::Value::Null
+                serde_yaml_ng::Value::Null
             }
         }
-        Value::Nothing { .. } => serde_yml::Value::Null,
+        Value::Nothing { .. } => serde_yaml_ng::Value::Null,
         Value::Error { error, .. } => return Err(*error.clone()),
-        Value::Binary { val, .. } => serde_yml::Value::Sequence(
+        Value::Binary { val, .. } => serde_yaml_ng::Value::Sequence(
             val.iter()
-                .map(|x| serde_yml::Value::Number(serde_yml::Number::from(*x)))
+                .map(|x| serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(*x)))
                 .collect(),
         ),
-        Value::CellPath { val, .. } => serde_yml::Value::Sequence(
+        Value::CellPath { val, .. } => serde_yaml_ng::Value::Sequence(
             val.members
                 .iter()
                 .map(|x| match &x {
-                    PathMember::String { val, .. } => Ok(serde_yml::Value::String(val.clone())),
-                    PathMember::Int { val, .. } => {
-                        Ok(serde_yml::Value::Number(serde_yml::Number::from(*val)))
-                    }
+                    PathMember::String { val, .. } => Ok(serde_yaml_ng::Value::String(val.clone())),
+                    PathMember::Int { val, .. } => Ok(serde_yaml_ng::Value::Number(
+                        serde_yaml_ng::Number::from(*val),
+                    )),
                 })
-                .collect::<Result<Vec<serde_yml::Value>, ShellError>>()?,
+                .collect::<Result<Vec<serde_yaml_ng::Value>, ShellError>>()?,
         ),
-        Value::Custom { .. } => serde_yml::Value::Null,
+        Value::Custom { .. } => serde_yaml_ng::Value::Null,
     })
 }
 
@@ -135,11 +137,9 @@ fn to_yaml(
     let value = input.into_value(head)?;
 
     let yaml_value = value_to_yaml_value(engine_state, &value, serialize_types)?;
-    match serde_yml::to_string(&yaml_value) {
-        Ok(serde_yml_string) => {
-            Ok(Value::string(serde_yml_string, head)
-                .into_pipeline_data_with_metadata(Some(metadata)))
-        }
+    match serde_yaml_ng::to_string(&yaml_value) {
+        Ok(serde_yaml_ng_string) => Ok(Value::string(serde_yaml_ng_string, head)
+            .into_pipeline_data_with_metadata(Some(metadata))),
         _ => Ok(Value::error(
             ShellError::CantConvert {
                 to_type: "YAML".into(),


### PR DESCRIPTION
# Description
As we discussed in this week's team meeting, we want to replace `serde-yml` with `serde-yaml-ng` due to the former being a carelessly, clearly AI-modified fork of the original `serde-yaml`.

While this PR does that, it reopens #14630, as `serde-yaml-ng` does not have that fix. We should look for an open bug there or create a new one.
