### PR TITLE
Supply `metadata.content_type` for `to html` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3542,6 +3542,7 @@ dependencies = [
  "fancy-regex",
  "heck",
  "itertools 0.13.0",
+ "mime",
  "nu-ansi-term",
  "nu-cmd-base",
  "nu-cmd-lang",

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -34,6 +34,7 @@ serde = { workspace = true }
 serde_urlencoded = { workspace = true }
 v_htmlescape = { workspace = true }
 itertools = { workspace = true }
+mime = { workspace = true }
 
 [dev-dependencies]
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.101.1" }

--- a/crates/nu-cmd-extra/src/extra/formats/to/html.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html.rs
@@ -330,7 +330,12 @@ fn to_html(
         output_string = run_regexes(&regex_hm, &output_string);
     }
 
-    Ok(Value::string(output_string, head).into_pipeline_data())
+    let metadata = PipelineMetadata {
+        data_source: nu_protocol::DataSource::None,
+        content_type: Some(mime::TEXT_HTML_UTF_8.to_string()),
+    };
+
+    Ok(Value::string(output_string, head).into_pipeline_data_with_metadata(metadata))
 }
 
 fn theme_demo(span: Span) -> PipelineData {

--- a/crates/nu-command/tests/format_conversions/html.rs
+++ b/crates/nu-command/tests/format_conversions/html.rs
@@ -15,6 +15,18 @@ fn out_html_simple() {
 }
 
 #[test]
+fn out_html_metadata() {
+    let actual = nu!(r#"
+            echo 3 | to html | metadata | get content_type
+        "#);
+
+    assert_eq!(
+        actual.out,
+        r#"text/html; charset=utf-8"#
+    );
+}
+
+#[test]
 fn out_html_partial() {
     let actual = nu!(r#"
             echo 3 | to html -p

--- a/crates/nu-command/tests/format_conversions/html.rs
+++ b/crates/nu-command/tests/format_conversions/html.rs
@@ -20,10 +20,7 @@ fn out_html_metadata() {
             echo 3 | to html | metadata | get content_type
         "#);
 
-    assert_eq!(
-        actual.out,
-        r#"text/html; charset=utf-8"#
-    );
+    assert_eq!(actual.out, r#"text/html; charset=utf-8"#);
 }
 
 #[test]


### PR DESCRIPTION
# Description

Adds pipeline metadata to the `to html` command output (hardcoded to `text/html; charset=utf-8`)

# User-Facing Changes

Pipeline metadata is now included with the `to html` command output.
