### PR TITLE
fix(completion): expand_tilde when path contains glob chars

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -284,6 +284,8 @@ pub fn complete_item(
 pub fn escape_path(path: String, dir: bool) -> String {
     // make glob pattern have the highest priority.
     if nu_glob::is_glob(path.as_str()) {
+        let pathbuf = nu_path::expand_tilde(path);
+        let path = pathbuf.to_string_lossy();
         return if path.contains('\'') {
             // decide to use double quote, also need to escape `"` in path
             // or else users can't do anything with completed path either.


### PR DESCRIPTION
# Description

Fixes #13905 by expanding tilde directly on completion.

Before:

<img width="565" alt="image" src="https://github.com/user-attachments/assets/5410ee2c-37bf-4733-b100-7037471d96f3" />

After:

<img width="576" alt="image" src="https://github.com/user-attachments/assets/140e60d8-ae51-43f6-8cde-beaf9333aca0" />

# User-Facing Changes

# Tests + Formatting

# After Submitting
