### PR TITLE
fix extern commands' extra description

### DIFF
--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -7,15 +7,12 @@ use nu_protocol::{
 
 #[derive(Clone)]
 pub struct KnownExternal {
-    pub name: String,
     pub signature: Box<Signature>,
-    pub description: String,
-    pub extra_description: String,
 }
 
 impl Command for KnownExternal {
     fn name(&self) -> &str {
-        &self.name
+        &self.signature.name
     }
 
     fn signature(&self) -> Signature {
@@ -23,7 +20,19 @@ impl Command for KnownExternal {
     }
 
     fn description(&self) -> &str {
-        &self.description
+        &self.signature.description
+    }
+
+    fn extra_description(&self) -> &str {
+        &self.signature.extra_description
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        self.signature
+            .search_terms
+            .iter()
+            .map(String::as_str)
+            .collect()
     }
 
     fn command_type(&self) -> CommandType {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -785,12 +785,7 @@ pub fn parse_extern(
                         );
                     }
 
-                    let decl = KnownExternal {
-                        name: external_name,
-                        description,
-                        extra_description,
-                        signature,
-                    };
+                    let decl = KnownExternal { signature };
 
                     *declaration = Box::new(decl);
                 }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -758,9 +758,9 @@ pub fn parse_extern(
                     name.clone()
                 };
 
-                signature.name.clone_from(&external_name);
-                signature.description.clone_from(&description);
-                signature.extra_description.clone_from(&extra_description);
+                signature.name = external_name;
+                signature.description = description;
+                signature.extra_description = extra_description;
                 signature.allows_unknown_args = true;
 
                 if let Some(block_id) = body.and_then(|x| x.as_block()) {


### PR DESCRIPTION
# Description

- Remove redundant fields from KnownExternal
- Command::extra_description and Command::search_terms using the signature field

# User-Facing Changes

`extern` commands extra description is now shown in help text.

# Tests + Formatting

# After Submitting
