### PR TITLE
make `echo` const

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/echo.rs
+++ b/crates/nu-cmd-lang/src/core_commands/echo.rs
@@ -43,6 +43,25 @@ little reason to use this over just writing the values as-is."#
         Ok(value.into_pipeline_data())
     }
 
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let mut args = call.rest_const(working_set, 0)?;
+        let value = match args.len() {
+            0 => Value::string("", call.head),
+            1 => args.pop().expect("one element"),
+            _ => Value::list(args, call.head),
+        };
+        Ok(value.into_pipeline_data())
+    }
+
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {

--- a/crates/nu-cmd-lang/src/core_commands/echo.rs
+++ b/crates/nu-cmd-lang/src/core_commands/echo.rs
@@ -34,13 +34,8 @@ little reason to use this over just writing the values as-is."#
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let mut args = call.rest(engine_state, stack, 0)?;
-        let value = match args.len() {
-            0 => Value::string("", call.head),
-            1 => args.pop().expect("one element"),
-            _ => Value::list(args, call.head),
-        };
-        Ok(value.into_pipeline_data())
+        let args = call.rest(engine_state, stack, 0)?;
+        echo_impl(args, call.head)
     }
 
     fn run_const(
@@ -49,13 +44,8 @@ little reason to use this over just writing the values as-is."#
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let mut args = call.rest_const(working_set, 0)?;
-        let value = match args.len() {
-            0 => Value::string("", call.head),
-            1 => args.pop().expect("one element"),
-            _ => Value::list(args, call.head),
-        };
-        Ok(value.into_pipeline_data())
+        let args = call.rest_const(working_set, 0)?;
+        echo_impl(args, call.head)
     }
 
     fn is_const(&self) -> bool {
@@ -80,6 +70,15 @@ little reason to use this over just writing the values as-is."#
             },
         ]
     }
+}
+
+fn echo_impl(mut args: Vec<Value>, head: Span) -> Result<PipelineData, ShellError> {
+    let value = match args.len() {
+        0 => Value::string("", head),
+        1 => args.pop().expect("one element"),
+        _ => Value::list(args, head),
+    };
+    Ok(value.into_pipeline_data())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/tests/commands/echo.rs
+++ b/crates/nu-command/tests/commands/echo.rs
@@ -34,3 +34,9 @@ fn echo_range_handles_exclusive_down() {
 
     assert_eq!(actual.out, "[3,2]");
 }
+
+#[test]
+fn echo_is_const() {
+    let actual = nu!(r#"const val = echo 1..3; $val | to json --raw"#);
+    assert_eq!(actual.out, "[1,2,3]");
+}


### PR DESCRIPTION
# Description

Make `echo` const.
- It's a very simple command, there is no reason for it to not be const.
- It's return type `any` is utilized in tests to type erase values, this might be useful for testing const evaluation too. 
- The upcoming custom command attribute feature can make use of it as a stopgap replacement for `const def` commands.

# User-Facing Changes

`echo` can be used in const contexts.

# Tests + Formatting

# After Submitting
N/A