### PR TITLE
feat: `let`/`mut` compound assignments

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/let_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/let_.rs
@@ -21,7 +21,7 @@ impl Command for Let {
             .required(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
-                "Equals sign followed by value.",
+                "Any assignment operator followed by a value.",
             )
             .category(Category::Core)
     }
@@ -36,7 +36,7 @@ impl Command for Let {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["set", "const"]
+        vec!["binding", "const", "lexical", "local", "my", "set", "var"]
     }
 
     fn run(
@@ -56,7 +56,7 @@ impl Command for Let {
             .expect("internal error: missing variable");
 
         let block_id = call
-            .positional_nth(1)
+            .positional_nth(2)
             .expect("checked through parser")
             .as_block()
             .expect("internal error: missing right hand side");
@@ -87,8 +87,8 @@ impl Command for Let {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Set a variable to a value",
-                example: "let x = 10",
+                description: "Set a variable to a value using an explicit type",
+                example: "let x: int = 10",
                 result: None,
             },
             Example {
@@ -97,9 +97,27 @@ impl Command for Let {
                 result: None,
             },
             Example {
-                description: "Set a variable based on the condition",
-                example: "let x = if false { -1 } else { 1 }",
-                result: None,
+                description: "Set a variable based on a condition",
+                example: "let x = 'foobar'; let x = if $x starts-with foo { 'baz' } else { '' }",
+                result: Value::test_string("baz").into(),
+            },
+            Example {
+                description:
+                    "Shorthand to shadow a variable using its previous value via compound assignment operator",
+                example: "let x = 300; let x *= 3; $x",
+                result: Value::test_int(900).into(),
+            },
+            Example {
+                description:
+                    "Shorthand to shadow a variable using its previous value via compound assignment operator",
+                example: "let x = [1]; do {|| let x ++= [2 3]; $x } | append $x.0",
+                result: Value::test_list(vec![
+                    Value::test_int(1),
+                    Value::test_int(2),
+                    Value::test_int(3),
+                    Value::test_int(1),
+                ])
+                .into(),
             },
         ]
     }

--- a/crates/nu-engine/src/compile/operator.rs
+++ b/crates/nu-engine/src/compile/operator.rs
@@ -1,5 +1,5 @@
 use nu_protocol::{
-    ast::{Assignment, Boolean, CellPath, Expr, Expression, Math, Operator, PathMember, Pattern},
+    ast::{Boolean, CellPath, Expr, Expression, Operator, PathMember, Pattern},
     engine::StateWorkingSet,
     ir::{Instruction, Literal},
     IntoSpanned, RegId, Span, Spanned, Value, ENV_VARIABLE_ID,
@@ -18,7 +18,7 @@ pub(crate) fn compile_binary_op(
     out_reg: RegId,
 ) -> Result<(), CompileError> {
     if let Operator::Assignment(assign_op) = op.item {
-        if let Some(decomposed_op) = decompose_assignment(assign_op) {
+        if let Some(decomposed_op) = assign_op.try_into_decomposed() {
             // Compiling an assignment that uses a binary op with the existing value
             compile_binary_op(
                 working_set,
@@ -143,18 +143,6 @@ pub(crate) fn compile_binary_op(
         builder.push(Instruction::Span { src_dst: out_reg }.into_spanned(span))?;
 
         Ok(())
-    }
-}
-
-/// The equivalent plain operator to use for an assignment, if any
-pub(crate) fn decompose_assignment(assignment: Assignment) -> Option<Operator> {
-    match assignment {
-        Assignment::Assign => None,
-        Assignment::PlusAssign => Some(Operator::Math(Math::Plus)),
-        Assignment::ConcatAssign => Some(Operator::Math(Math::Concat)),
-        Assignment::MinusAssign => Some(Operator::Math(Math::Minus)),
-        Assignment::MultiplyAssign => Some(Operator::Math(Math::Multiply)),
-        Assignment::DivideAssign => Some(Operator::Math(Math::Divide)),
     }
 }
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6457,6 +6457,23 @@ pub fn discover_captures_in_expr(
                     }
                 }
             }
+
+            // Pre-filter using parser_info count/len as it is quick(er) to check (as `decl` is
+            // `&dyn`).
+            if !call.parser_info.is_empty() {
+                let name = decl.name();
+                if name == "let" || name == "mut" {
+                    match call
+                        .get_parser_info("prev_var")
+                        .and_then(|expr| expr.as_var().map(|v| (v, expr.span)))
+                    {
+                        Some(cap @ (ref var_id, _span)) if !seen.contains(var_id) => {
+                            output.push(cap);
+                        }
+                        _ => (),
+                    }
+                }
+            }
         }
         Expr::CellPath(_) => {}
         Expr::DateTime(_) => {}

--- a/crates/nu-protocol/src/ast/operator.rs
+++ b/crates/nu-protocol/src/ast/operator.rs
@@ -70,6 +70,23 @@ pub enum Operator {
     Assignment(Assignment),
 }
 
+impl Assignment {
+    /// Decomposes a compound assignment operator into its corresponding non-assignment operator.
+    /// Returns `None` if this is not a compound assignment operator.
+    pub fn try_into_decomposed(self) -> Option<Operator> {
+        // NOTE: callers expect this to always returns `Some` when self is a compound assignment
+        // operator
+        match self {
+            Assignment::Assign => None,
+            Assignment::PlusAssign => Some(Operator::Math(Math::Plus)),
+            Assignment::ConcatAssign => Some(Operator::Math(Math::Concat)),
+            Assignment::MinusAssign => Some(Operator::Math(Math::Minus)),
+            Assignment::MultiplyAssign => Some(Operator::Math(Math::Multiply)),
+            Assignment::DivideAssign => Some(Operator::Math(Math::Divide)),
+        }
+    }
+}
+
 impl Operator {
     pub fn precedence(&self) -> u8 {
         match self {

--- a/crates/nu-protocol/src/errors/compile_error.rs
+++ b/crates/nu-protocol/src/errors/compile_error.rs
@@ -235,4 +235,17 @@ pub enum CompileError {
         #[label("label was used while compiling this code")]
         span: Option<Span>,
     },
+
+    /// An internal compiler error which shouldn't be possible (e.g. an invariant was violated or
+    /// not upheld). Generally signifies a Nushell bug as opposed to user error.
+    #[error("An unexpected error occurred: {msg}")]
+    #[diagnostic(
+        code(nu::compile::internal_error),
+        help("this is a compiler bug. Please report it at https://github.com/nushell/nushell/issues/new"),
+    )]
+    InternalError {
+        msg: String,
+        #[label("while compiling this code")]
+        span: Span,
+    },
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This change allows compound assignment operators to be used with `let` and `mut` variable declarations. For example, `let x += 1` is now valid and is treated as equivalent to `let x = $x + 1`. As such, a parser error is thrown if `$x` is not already defined when `let x += 1` is parsed. This shorthand is particularly useful within nested scopes and closures.

Other changes include:

Allow variables such as `$$env` and `$$$in` (i.e. a reserved/builtin variable name prefixed with two or more `$`) to be defined. The reason for this is consistency, as e.g. `$$foo` is currently both allowed and considered to be a different variable than `$foo` by the engine. Declaring a variable named `$env` etc. is still disallowed.

`let` and `mut` calls now utilize the same code for parsing, enhancing consistency and maintainability.

Change `nu-engine::compile::operator::decompose_assignment()` to a public method of `Assignment`.

Add examples and update command info of `let` and `mut`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
