### PR TITLE
Added S3 support for `polars save`

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/core/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/mod.rs
@@ -12,11 +12,16 @@ mod to_lazy;
 mod to_nu;
 mod to_repr;
 
-use crate::PolarsPlugin;
+use std::path::PathBuf;
+
+use crate::{cloud::build_cloud_options, PolarsPlugin};
 use nu_plugin::PluginCommand;
+use nu_protocol::{ShellError, Span, Spanned};
+use polars_io::cloud::CloudOptions;
 
 pub use self::open::OpenDataFrame;
 use fetch::LazyFetch;
+use nu_path::expand_path_with;
 pub use schema::SchemaCmd;
 pub use shape::ShapeDF;
 pub use summary::Summary;
@@ -24,7 +29,62 @@ pub use to_df::ToDataFrame;
 pub use to_lazy::ToLazyFrame;
 pub use to_nu::ToNu;
 pub use to_repr::ToRepr;
+use url::Url;
 
+pub(crate) struct Resource {
+    path: String,
+    extension: Option<String>,
+    cloud_options: Option<CloudOptions>,
+    span: Span,
+}
+
+impl std::fmt::Debug for Resource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // We can't print out the cloud options as it might have
+        // secrets in it.. So just print whether or not it was defined
+        f.debug_struct("Resource")
+            .field("path", &self.path)
+            .field("extension", &self.extension)
+            .field("has_cloud_options", &self.cloud_options.is_some())
+            .field("span", &self.span)
+            .finish()
+    }
+}
+
+impl Resource {
+    fn new(
+        plugin: &PolarsPlugin,
+        engine: &nu_plugin::EngineInterface,
+        spanned_path: &Spanned<String>,
+    ) -> Result<Self, ShellError> {
+        let mut path = spanned_path.item.clone();
+        let (path_buf, cloud_options) = if let Ok(url) = path.parse::<Url>() {
+            let cloud_options =
+                build_cloud_options(plugin, &url)?.ok_or(ShellError::GenericError {
+                    error: format!("Could not determine a supported cloud type from url: {url}"),
+                    msg: "".into(),
+                    span: None,
+                    help: None,
+                    inner: vec![],
+                })?;
+            let p: PathBuf = url.path().into();
+            (p, Some(cloud_options))
+        } else {
+            let new_path = expand_path_with(path, engine.get_current_dir()?, true);
+            path = new_path.to_string_lossy().to_string();
+            (new_path, None)
+        };
+        let extension = path_buf
+            .extension()
+            .and_then(|s| s.to_str().map(|s| s.to_string()));
+        Ok(Self {
+            path,
+            extension,
+            cloud_options,
+            span: spanned_path.span,
+        })
+    }
+}
 pub(crate) fn core_commands() -> Vec<Box<dyn PluginCommand<Plugin = PolarsPlugin>>> {
     vec![
         Box::new(columns::ColumnsDF),

--- a/crates/nu_plugin_polars/src/dataframe/command/core/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/mod.rs
@@ -3,6 +3,7 @@ mod columns;
 mod fetch;
 mod open;
 mod profile;
+mod resource;
 mod save;
 mod schema;
 mod shape;
@@ -12,16 +13,10 @@ mod to_lazy;
 mod to_nu;
 mod to_repr;
 
-use std::path::PathBuf;
-
-use crate::{cloud::build_cloud_options, PolarsPlugin};
-use nu_plugin::PluginCommand;
-use nu_protocol::{ShellError, Span, Spanned};
-use polars_io::cloud::CloudOptions;
-
 pub use self::open::OpenDataFrame;
+use crate::PolarsPlugin;
 use fetch::LazyFetch;
-use nu_path::expand_path_with;
+use nu_plugin::PluginCommand;
 pub use schema::SchemaCmd;
 pub use shape::ShapeDF;
 pub use summary::Summary;
@@ -29,62 +24,7 @@ pub use to_df::ToDataFrame;
 pub use to_lazy::ToLazyFrame;
 pub use to_nu::ToNu;
 pub use to_repr::ToRepr;
-use url::Url;
 
-pub(crate) struct Resource {
-    path: String,
-    extension: Option<String>,
-    cloud_options: Option<CloudOptions>,
-    span: Span,
-}
-
-impl std::fmt::Debug for Resource {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // We can't print out the cloud options as it might have
-        // secrets in it.. So just print whether or not it was defined
-        f.debug_struct("Resource")
-            .field("path", &self.path)
-            .field("extension", &self.extension)
-            .field("has_cloud_options", &self.cloud_options.is_some())
-            .field("span", &self.span)
-            .finish()
-    }
-}
-
-impl Resource {
-    fn new(
-        plugin: &PolarsPlugin,
-        engine: &nu_plugin::EngineInterface,
-        spanned_path: &Spanned<String>,
-    ) -> Result<Self, ShellError> {
-        let mut path = spanned_path.item.clone();
-        let (path_buf, cloud_options) = if let Ok(url) = path.parse::<Url>() {
-            let cloud_options =
-                build_cloud_options(plugin, &url)?.ok_or(ShellError::GenericError {
-                    error: format!("Could not determine a supported cloud type from url: {url}"),
-                    msg: "".into(),
-                    span: None,
-                    help: None,
-                    inner: vec![],
-                })?;
-            let p: PathBuf = url.path().into();
-            (p, Some(cloud_options))
-        } else {
-            let new_path = expand_path_with(path, engine.get_current_dir()?, true);
-            path = new_path.to_string_lossy().to_string();
-            (new_path, None)
-        };
-        let extension = path_buf
-            .extension()
-            .and_then(|s| s.to_str().map(|s| s.to_string()));
-        Ok(Self {
-            path,
-            extension,
-            cloud_options,
-            span: spanned_path.span,
-        })
-    }
-}
 pub(crate) fn core_commands() -> Vec<Box<dyn PluginCommand<Plugin = PolarsPlugin>>> {
     vec![
         Box::new(columns::ColumnsDF),

--- a/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
@@ -1,13 +1,8 @@
 use crate::{
-    cloud::build_cloud_options,
-    dataframe::values::NuSchema,
-    values::{CustomValueSupport, NuDataFrame, NuLazyFrame, PolarsFileType},
-    EngineWrapper, PolarsPlugin,
+    command::core::Resource, dataframe::values::NuSchema, values::{CustomValueSupport, NuDataFrame, NuLazyFrame, PolarsFileType}, EngineWrapper, PolarsPlugin
 };
 use log::debug;
-use nu_path::expand_path_with;
 use nu_utils::perf;
-use url::Url;
 
 use nu_plugin::PluginCommand;
 use nu_protocol::{
@@ -15,7 +10,7 @@ use nu_protocol::{
     Span, Spanned, SyntaxShape, Type, Value,
 };
 
-use std::{fmt::Debug, fs::File, io::BufReader, num::NonZeroUsize, path::PathBuf, sync::Arc};
+use std::{fs::File, io::BufReader, num::NonZeroUsize, path::PathBuf, sync::Arc};
 
 use polars::{
     lazy::frame::LazyJsonLineReader,
@@ -25,7 +20,7 @@ use polars::{
     },
 };
 
-use polars_io::{avro::AvroReader, cloud::CloudOptions, csv::read::CsvReadOptions, HiveOptions};
+use polars_io::{avro::AvroReader, csv::read::CsvReadOptions, HiveOptions};
 
 const DEFAULT_INFER_SCHEMA: usize = 100;
 
@@ -113,61 +108,6 @@ impl PluginCommand for OpenDataFrame {
         _input: nu_protocol::PipelineData,
     ) -> Result<nu_protocol::PipelineData, LabeledError> {
         command(plugin, engine, call).map_err(|e| e.into())
-    }
-}
-
-struct Resource {
-    path: String,
-    extension: Option<String>,
-    cloud_options: Option<CloudOptions>,
-    span: Span,
-}
-
-impl Debug for Resource {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // We can't print out the cloud options as it might have
-        // secrets in it.. So just print whether or not it was defined
-        f.debug_struct("Resource")
-            .field("path", &self.path)
-            .field("extension", &self.extension)
-            .field("has_cloud_options", &self.cloud_options.is_some())
-            .field("span", &self.span)
-            .finish()
-    }
-}
-
-impl Resource {
-    fn new(
-        plugin: &PolarsPlugin,
-        engine: &nu_plugin::EngineInterface,
-        spanned_path: &Spanned<String>,
-    ) -> Result<Self, ShellError> {
-        let mut path = spanned_path.item.clone();
-        let (path_buf, cloud_options) = if let Ok(url) = path.parse::<Url>() {
-            let cloud_options =
-                build_cloud_options(plugin, &url)?.ok_or(ShellError::GenericError {
-                    error: format!("Could not determine a supported cloud type from url: {url}"),
-                    msg: "".into(),
-                    span: None,
-                    help: None,
-                    inner: vec![],
-                })?;
-            let p: PathBuf = url.path().into();
-            (p, Some(cloud_options))
-        } else {
-            let new_path = expand_path_with(path, engine.get_current_dir()?, true);
-            path = new_path.to_string_lossy().to_string();
-            (new_path, None)
-        };
-        let extension = path_buf
-            .extension()
-            .and_then(|s| s.to_str().map(|s| s.to_string()));
-        Ok(Self {
-            path,
-            extension,
-            cloud_options,
-            span: spanned_path.span,
-        })
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
@@ -1,5 +1,8 @@
 use crate::{
-    command::core::Resource, dataframe::values::NuSchema, values::{CustomValueSupport, NuDataFrame, NuLazyFrame, PolarsFileType}, EngineWrapper, PolarsPlugin
+    command::core::Resource,
+    dataframe::values::NuSchema,
+    values::{CustomValueSupport, NuDataFrame, NuLazyFrame, PolarsFileType},
+    EngineWrapper, PolarsPlugin,
 };
 use log::debug;
 use nu_utils::perf;

--- a/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
@@ -185,7 +185,7 @@ fn from_parquet(
     let file_span = resource.span;
     if !is_eager {
         let args = ScanArgsParquet {
-            cloud_options: resource.cloud_options.clone(),
+            cloud_options: resource.cloud_options,
             ..Default::default()
         };
         let df: NuLazyFrame = LazyFrame::scan_parquet(file_path, args)
@@ -288,7 +288,7 @@ fn from_arrow(
             cache: true,
             rechunk: false,
             row_index: None,
-            cloud_options: resource.cloud_options.clone(),
+            cloud_options: resource.cloud_options,
             include_file_paths: None,
             hive_options: HiveOptions::default(),
         };
@@ -487,8 +487,7 @@ fn from_csv(
     let truncate_ragged_lines: bool = call.has_flag("truncate-ragged-lines")?;
 
     if !is_eager {
-        let csv_reader =
-            LazyCsvReader::new(file_path).with_cloud_options(resource.cloud_options.clone());
+        let csv_reader = LazyCsvReader::new(file_path).with_cloud_options(resource.cloud_options);
 
         let csv_reader = match delimiter {
             None => csv_reader,

--- a/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
@@ -1,5 +1,5 @@
 use crate::{
-    command::core::Resource,
+    command::core::resource::Resource,
     dataframe::values::NuSchema,
     values::{CustomValueSupport, NuDataFrame, NuLazyFrame, PolarsFileType},
     EngineWrapper, PolarsPlugin,

--- a/crates/nu_plugin_polars/src/dataframe/command/core/resource.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/resource.rs
@@ -1,0 +1,85 @@
+use std::path::{Component, Path, PathBuf};
+
+use crate::{cloud::build_cloud_options, PolarsPlugin};
+use nu_path::expand_path_with;
+use nu_protocol::{ShellError, Span, Spanned};
+use polars_io::cloud::CloudOptions;
+use url::Url;
+
+pub(crate) struct Resource {
+    pub(crate) path: String,
+    pub(crate) extension: Option<String>,
+    pub(crate) cloud_options: Option<CloudOptions>,
+    pub(crate) span: Span,
+}
+
+impl std::fmt::Debug for Resource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // We can't print out the cloud options as it might have
+        // secrets in it.. So just print whether or not it was defined
+        f.debug_struct("Resource")
+            .field("path", &self.path)
+            .field("extension", &self.extension)
+            .field("has_cloud_options", &self.cloud_options.is_some())
+            .field("span", &self.span)
+            .finish()
+    }
+}
+
+impl Resource {
+    pub(crate) fn new(
+        plugin: &PolarsPlugin,
+        engine: &nu_plugin::EngineInterface,
+        spanned_path: &Spanned<String>,
+    ) -> Result<Self, ShellError> {
+        let mut path = spanned_path.item.clone();
+
+        let (path_buf, cloud_options) = match path.parse::<Url>() {
+            Ok(url) if !is_windows_path(&path) => {
+                let cloud_options =
+                    build_cloud_options(plugin, &url)?.ok_or(ShellError::GenericError {
+                        error: format!(
+                            "Could not determine a supported cloud type from url: {url}"
+                        ),
+                        msg: "".into(),
+                        span: None,
+                        help: None,
+                        inner: vec![],
+                    })?;
+                let p: PathBuf = url.path().into();
+                (p, Some(cloud_options))
+            }
+            _ => {
+                let new_path = expand_path_with(path, engine.get_current_dir()?, true);
+                path = new_path.to_string_lossy().to_string();
+                (new_path, None)
+            }
+        };
+
+        let extension = path_buf
+            .extension()
+            .and_then(|s| s.to_str().map(|s| s.to_string()));
+        Ok(Self {
+            path,
+            extension,
+            cloud_options,
+            span: spanned_path.span,
+        })
+    }
+}
+
+// This is needed because Url parses windows paths as
+// valid URLs.
+fn is_windows_path(path: &str) -> bool {
+    // Only window spath will
+    if path.contains('\\') {
+        return true;
+    }
+
+    let path = Path::new(path);
+    match path.components().next() {
+        // This will only occur if their is a drive prefix
+        Some(Component::Prefix(_)) => true,
+        _ => false,
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/arrow.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/arrow.rs
@@ -6,7 +6,7 @@ use polars::prelude::{IpcWriter, SerWriter};
 use polars_io::ipc::IpcWriterOptions;
 
 use crate::{
-    command::core::Resource,
+    command::core::resource::Resource,
     values::{NuDataFrame, NuLazyFrame},
 };
 

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/arrow.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/arrow.rs
@@ -20,8 +20,11 @@ pub(crate) fn command_lazy(
     let file_path = resource.path;
     let file_span = resource.span;
     lazy.to_polars()
-        // todo - add cloud options
-        .sink_ipc(file_path, IpcWriterOptions::default(), None)
+        .sink_ipc(
+            file_path,
+            IpcWriterOptions::default(),
+            resource.cloud_options,
+        )
         .map_err(|e| polars_file_save_error(e, file_span))
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/arrow.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/arrow.rs
@@ -1,31 +1,33 @@
-use std::{fs::File, path::Path};
+use std::fs::File;
 
 use nu_plugin::EvaluatedCall;
-use nu_protocol::{ShellError, Span};
+use nu_protocol::ShellError;
 use polars::prelude::{IpcWriter, SerWriter};
 use polars_io::ipc::IpcWriterOptions;
 
-use crate::values::{NuDataFrame, NuLazyFrame};
+use crate::{
+    command::core::Resource,
+    values::{NuDataFrame, NuLazyFrame},
+};
 
 use super::polars_file_save_error;
 
 pub(crate) fn command_lazy(
     _call: &EvaluatedCall,
     lazy: &NuLazyFrame,
-    file_path: &Path,
-    file_span: Span,
+    resource: Resource,
 ) -> Result<(), ShellError> {
+    let file_path = resource.path;
+    let file_span = resource.span;
     lazy.to_polars()
         // todo - add cloud options
         .sink_ipc(file_path, IpcWriterOptions::default(), None)
         .map_err(|e| polars_file_save_error(e, file_span))
 }
 
-pub(crate) fn command_eager(
-    df: &NuDataFrame,
-    file_path: &Path,
-    file_span: Span,
-) -> Result<(), ShellError> {
+pub(crate) fn command_eager(df: &NuDataFrame, resource: Resource) -> Result<(), ShellError> {
+    let file_path = resource.path;
+    let file_span = resource.span;
     let mut file = File::create(file_path).map_err(|e| ShellError::GenericError {
         error: format!("Error with file name: {e}"),
         msg: "".into(),

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/avro.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/avro.rs
@@ -1,11 +1,11 @@
 use std::fs::File;
-use std::path::Path;
 
 use nu_plugin::EvaluatedCall;
-use nu_protocol::{ShellError, Span};
+use nu_protocol::ShellError;
 use polars_io::avro::{AvroCompression, AvroWriter};
 use polars_io::SerWriter;
 
+use crate::command::core::Resource;
 use crate::values::NuDataFrame;
 
 fn get_compression(call: &EvaluatedCall) -> Result<Option<AvroCompression>, ShellError> {
@@ -31,9 +31,10 @@ fn get_compression(call: &EvaluatedCall) -> Result<Option<AvroCompression>, Shel
 pub(crate) fn command_eager(
     call: &EvaluatedCall,
     df: &NuDataFrame,
-    file_path: &Path,
-    file_span: Span,
+    resource: Resource,
 ) -> Result<(), ShellError> {
+    let file_path = resource.path;
+    let file_span = resource.span;
     let compression = get_compression(call)?;
 
     let file = File::create(file_path).map_err(|e| ShellError::GenericError {

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/avro.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/avro.rs
@@ -5,7 +5,7 @@ use nu_protocol::ShellError;
 use polars_io::avro::{AvroCompression, AvroWriter};
 use polars_io::SerWriter;
 
-use crate::command::core::Resource;
+use crate::command::core::resource::Resource;
 use crate::values::NuDataFrame;
 
 fn get_compression(call: &EvaluatedCall) -> Result<Option<AvroCompression>, ShellError> {

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/csv.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/csv.rs
@@ -6,7 +6,7 @@ use polars::prelude::{CsvWriter, SerWriter};
 use polars_io::csv::write::{CsvWriterOptions, SerializeOptions};
 
 use crate::{
-    command::core::Resource,
+    command::core::resource::Resource,
     values::{NuDataFrame, NuLazyFrame},
 };
 

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/csv.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/csv.rs
@@ -1,20 +1,24 @@
-use std::{fs::File, path::Path};
+use std::fs::File;
 
 use nu_plugin::EvaluatedCall;
-use nu_protocol::{ShellError, Span, Spanned};
+use nu_protocol::{ShellError, Spanned};
 use polars::prelude::{CsvWriter, SerWriter};
 use polars_io::csv::write::{CsvWriterOptions, SerializeOptions};
 
-use crate::values::{NuDataFrame, NuLazyFrame};
+use crate::{
+    command::core::Resource,
+    values::{NuDataFrame, NuLazyFrame},
+};
 
 use super::polars_file_save_error;
 
 pub(crate) fn command_lazy(
     call: &EvaluatedCall,
     lazy: &NuLazyFrame,
-    file_path: &Path,
-    file_span: Span,
+    resource: Resource,
 ) -> Result<(), ShellError> {
+    let file_path = resource.path;
+    let file_span = resource.span;
     let delimiter: Option<Spanned<String>> = call.get_flag("csv-delimiter")?;
     let separator = delimiter
         .and_then(|d| d.item.chars().next().map(|c| c as u8))
@@ -40,9 +44,10 @@ pub(crate) fn command_lazy(
 pub(crate) fn command_eager(
     call: &EvaluatedCall,
     df: &NuDataFrame,
-    file_path: &Path,
-    file_span: Span,
+    resource: Resource,
 ) -> Result<(), ShellError> {
+    let file_path = resource.path;
+    let file_span = resource.span;
     let delimiter: Option<Spanned<String>> = call.get_flag("csv-delimiter")?;
     let no_header: bool = call.has_flag("csv-no-header")?;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/csv.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/csv.rs
@@ -36,8 +36,7 @@ pub(crate) fn command_lazy(
     };
 
     lazy.to_polars()
-        // todo - add cloud options
-        .sink_csv(file_path, options, None)
+        .sink_csv(file_path, options, resource.cloud_options)
         .map_err(|e| polars_file_save_error(e, file_span))
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
@@ -7,7 +7,7 @@ mod parquet;
 use std::path::PathBuf;
 
 use crate::{
-    command::core::Resource,
+    command::core::resource::Resource,
     values::{cant_convert_err, PolarsFileType, PolarsPluginObject, PolarsPluginType},
     PolarsPlugin,
 };

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/ndjson.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/ndjson.rs
@@ -20,8 +20,11 @@ pub(crate) fn command_lazy(
     let file_path = resource.path;
     let file_span = resource.span;
     lazy.to_polars()
-        // todo - add cloud options
-        .sink_json(file_path, JsonWriterOptions::default(), None)
+        .sink_json(
+            file_path,
+            JsonWriterOptions::default(),
+            resource.cloud_options,
+        )
         .map_err(|e| polars_file_save_error(e, file_span))
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/ndjson.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/ndjson.rs
@@ -6,7 +6,7 @@ use polars::prelude::{JsonWriter, SerWriter};
 use polars_io::json::JsonWriterOptions;
 
 use crate::{
-    command::core::Resource,
+    command::core::resource::Resource,
     values::{NuDataFrame, NuLazyFrame},
 };
 

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/ndjson.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/ndjson.rs
@@ -1,31 +1,33 @@
-use std::{fs::File, io::BufWriter, path::Path};
+use std::{fs::File, io::BufWriter};
 
 use nu_plugin::EvaluatedCall;
-use nu_protocol::{ShellError, Span};
+use nu_protocol::ShellError;
 use polars::prelude::{JsonWriter, SerWriter};
 use polars_io::json::JsonWriterOptions;
 
-use crate::values::{NuDataFrame, NuLazyFrame};
+use crate::{
+    command::core::Resource,
+    values::{NuDataFrame, NuLazyFrame},
+};
 
 use super::polars_file_save_error;
 
 pub(crate) fn command_lazy(
     _call: &EvaluatedCall,
     lazy: &NuLazyFrame,
-    file_path: &Path,
-    file_span: Span,
+    resource: Resource,
 ) -> Result<(), ShellError> {
+    let file_path = resource.path;
+    let file_span = resource.span;
     lazy.to_polars()
         // todo - add cloud options
         .sink_json(file_path, JsonWriterOptions::default(), None)
         .map_err(|e| polars_file_save_error(e, file_span))
 }
 
-pub(crate) fn command_eager(
-    df: &NuDataFrame,
-    file_path: &Path,
-    file_span: Span,
-) -> Result<(), ShellError> {
+pub(crate) fn command_eager(df: &NuDataFrame, resource: Resource) -> Result<(), ShellError> {
+    let file_path = resource.path;
+    let file_span = resource.span;
     let file = File::create(file_path).map_err(|e| ShellError::GenericError {
         error: format!("Error with file name: {e}"),
         msg: "".into(),

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/parquet.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/parquet.rs
@@ -1,31 +1,33 @@
-use std::{fs::File, path::Path};
+use std::fs::File;
 
 use nu_plugin::EvaluatedCall;
 use nu_protocol::{ShellError, Span};
 use polars::prelude::ParquetWriter;
 use polars_io::parquet::write::ParquetWriteOptions;
 
-use crate::values::{NuDataFrame, NuLazyFrame};
+use crate::{
+    command::core::Resource,
+    values::{NuDataFrame, NuLazyFrame},
+};
 
 use super::polars_file_save_error;
 
 pub(crate) fn command_lazy(
     _call: &EvaluatedCall,
     lazy: &NuLazyFrame,
-    file_path: &Path,
-    file_span: Span,
+    resource: Resource,
 ) -> Result<(), ShellError> {
+    let file_path = resource.path;
+    let file_span = resource.span;
     lazy.to_polars()
         // todo - add cloud options
         .sink_parquet(&file_path, ParquetWriteOptions::default(), None)
         .map_err(|e| polars_file_save_error(e, file_span))
 }
 
-pub(crate) fn command_eager(
-    df: &NuDataFrame,
-    file_path: &Path,
-    file_span: Span,
-) -> Result<(), ShellError> {
+pub(crate) fn command_eager(df: &NuDataFrame, resource: Resource) -> Result<(), ShellError> {
+    let file_path = resource.path;
+    let file_span = resource.span;
     let file = File::create(file_path).map_err(|e| ShellError::GenericError {
         error: "Error with file name".into(),
         msg: e.to_string(),

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/parquet.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/parquet.rs
@@ -1,7 +1,8 @@
 use std::fs::File;
 
+use log::debug;
 use nu_plugin::EvaluatedCall;
-use nu_protocol::{ShellError, Span};
+use nu_protocol::ShellError;
 use polars::prelude::ParquetWriter;
 use polars_io::parquet::write::ParquetWriteOptions;
 
@@ -19,9 +20,13 @@ pub(crate) fn command_lazy(
 ) -> Result<(), ShellError> {
     let file_path = resource.path;
     let file_span = resource.span;
+    debug!("Writing parquet file {file_path}");
     lazy.to_polars()
-        // todo - add cloud options
-        .sink_parquet(&file_path, ParquetWriteOptions::default(), None)
+        .sink_parquet(
+            &file_path,
+            ParquetWriteOptions::default(),
+            resource.cloud_options,
+        )
         .map_err(|e| polars_file_save_error(e, file_span))
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/parquet.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/parquet.rs
@@ -7,7 +7,7 @@ use polars::prelude::ParquetWriter;
 use polars_io::parquet::write::ParquetWriteOptions;
 
 use crate::{
-    command::core::Resource,
+    command::core::resource::Resource,
     values::{NuDataFrame, NuLazyFrame},
 };
 


### PR DESCRIPTION
# Description
Parquet, CSV, NDJSON, and Arrow files can be written to AWS S3 via `polars save`. This mirrors the s3 functionality provided by `polars open`.

```nushell
ls | polars into-df | polars save s3://my-bucket/test.parquet
```

# User-Facing Changes
- S3 urls are now supported by `polars save`