### PR TITLE
fix polars save example typo

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
@@ -93,12 +93,12 @@ impl PluginCommand for SaveDF {
             },
             Example {
                 description: "Saves dataframe to CSV file",
-                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr save test.csv",
+                example: "[[a b]; [1 2] [3 4]] | polars into-df | polars save test.csv",
                 result: None,
             },
             Example {
                 description: "Saves dataframe to CSV file using other delimiter",
-                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr save test.csv --delimiter '|'",
+                example: "[[a b]; [1 2] [3 4]] | polars into-df | polars save test.csv --csv-delimiter '|'",
                 result: None,
             },
         ]


### PR DESCRIPTION
# Description
 fix polars save example dfr -> polars 

I'm wondering why the commands `polars open` and `polars save` don't have the same flags?