### PR TITLE
Add search terms for hide and hide-env

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide.rs
@@ -32,6 +32,10 @@ This command is a parser keyword. For details, check:
   https://www.nushell.sh/book/thinking_in_nu.html"#
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["unset"]
+    }
+
     fn command_type(&self) -> CommandType {
         CommandType::Keyword
     }

--- a/crates/nu-cmd-lang/src/core_commands/hide_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide_env.rs
@@ -29,6 +29,10 @@ impl Command for HideEnv {
         "Hide environment variables in the current scope."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["unset", "drop"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Adds search terms for hide and hide-env.

Rel: #15013 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
N/A

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
N/A

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A
