### PR TITLE
fix: clippy warnings with `--all-features`

### DIFF
--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -221,7 +221,7 @@ impl PartialEq for DebuggableValue<'_> {
     }
 }
 
-impl<'a> std::fmt::Debug for DebuggableValue<'a> {
+impl std::fmt::Debug for DebuggableValue<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.0 {
             Value::Bool { val, .. } => {

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -543,12 +543,12 @@ fn value_should_be_printed(
 
 fn term_contains_value(term: &Value, value: &Value, span: Span) -> bool {
     term.r#in(span, value, span)
-        .map_or(false, |value| value.is_true())
+        .is_ok_and(|value| value.is_true())
 }
 
 fn term_equals_value(term: &Value, value: &Value, span: Span) -> bool {
     term.eq(span, value, span)
-        .map_or(false, |value| value.is_true())
+        .is_ok_and(|value| value.is_true())
 }
 
 fn record_matches_term(

--- a/crates/nu-command/src/platform/ulimit.rs
+++ b/crates/nu-command/src/platform/ulimit.rs
@@ -42,7 +42,7 @@ impl<'a> ResourceInfo<'a> {
     }
 }
 
-impl<'a> Default for ResourceInfo<'a> {
+impl Default for ResourceInfo<'_> {
     fn default() -> Self {
         Self {
             name: "file-size",

--- a/crates/nu-command/src/strings/guess_width.rs
+++ b/crates/nu-command/src/strings/guess_width.rs
@@ -6,7 +6,7 @@
 /// The width seems to be a fixed length, but it doesn't always fit.
 /// GuessWidth finds the column separation position
 /// from the reference line(header) and multiple lines(body).
-
+///
 /// Briefly, the algorithm uses a histogram of spaces to find widths.
 /// blanks, lines, and pos are variables used in the algorithm. The other
 /// items names below are just for reference.
@@ -19,7 +19,7 @@
 /// spaces = "      ^        ^        ^"
 ///    pos =  6 15 24 <- the carets show these positions
 /// the items in pos map to 3's in the blanks array
-
+///
 /// Now that we have pos, we can let split() use this pos array to figure out
 /// how to split all lines by comparing each index to see if there's a space.
 /// So, it looks at position 6, 15, 24 and sees if it has a space in those

--- a/crates/nu-command/src/strings/str_/stats.rs
+++ b/crates/nu-command/src/strings/str_/stats.rs
@@ -148,7 +148,7 @@ fn counter(contents: &str, span: Span) -> Value {
     Value::record(record, span)
 }
 
-/// Take all the counts in `other_counts` and sum them into `accum`.
+// /// Take all the counts in `other_counts` and sum them into `accum`.
 // pub fn sum_counts(accum: &mut Counted, other_counts: &Counted) {
 //     for (counter, count) in other_counts {
 //         let entry = accum.entry(*counter).or_insert(0);
@@ -156,7 +156,7 @@ fn counter(contents: &str, span: Span) -> Value {
 //     }
 // }
 
-/// Sums all the `Counted` instances into a new one.
+// /// Sums all the `Counted` instances into a new one.
 // pub fn sum_all_counts<'a, I>(counts: I) -> Counted
 // where
 //     I: IntoIterator<Item = &'a Counted>,

--- a/crates/nu-plugin-engine/src/context.rs
+++ b/crates/nu-plugin-engine/src/context.rs
@@ -84,7 +84,7 @@ impl<'a> PluginExecutionCommandContext<'a> {
     }
 }
 
-impl<'a> PluginExecutionContext for PluginExecutionCommandContext<'a> {
+impl PluginExecutionContext for PluginExecutionCommandContext<'_> {
     fn span(&self) -> Span {
         self.call.head
     }

--- a/crates/nu-plugin-engine/src/util/mutable_cow.rs
+++ b/crates/nu-plugin-engine/src/util/mutable_cow.rs
@@ -5,7 +5,7 @@ pub enum MutableCow<'a, T> {
     Owned(T),
 }
 
-impl<'a, T: Clone> MutableCow<'a, T> {
+impl<T: Clone> MutableCow<'_, T> {
     pub fn owned(&self) -> MutableCow<'static, T> {
         match self {
             MutableCow::Borrowed(r) => MutableCow::Owned((*r).clone()),
@@ -14,7 +14,7 @@ impl<'a, T: Clone> MutableCow<'a, T> {
     }
 }
 
-impl<'a, T> std::ops::Deref for MutableCow<'a, T> {
+impl<T> std::ops::Deref for MutableCow<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -25,7 +25,7 @@ impl<'a, T> std::ops::Deref for MutableCow<'a, T> {
     }
 }
 
-impl<'a, T> std::ops::DerefMut for MutableCow<'a, T> {
+impl<T> std::ops::DerefMut for MutableCow<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             MutableCow::Borrowed(r) => r,

--- a/crates/nu-test-support/src/playground/play.rs
+++ b/crates/nu-test-support/src/playground/play.rs
@@ -52,7 +52,7 @@ impl Dirs {
     }
 }
 
-impl<'a> Playground<'a> {
+impl Playground<'_> {
     pub fn root(&self) -> &AbsolutePath {
         &self.dirs.root
     }


### PR DESCRIPTION
# Description

Some more `cargo clippy --all-features` warnings from rust toolchain 1.84.1 that I forgot to fix in #14984