### PR TITLE
Fuzz more realistically with keyword const eval

### DIFF
--- a/crates/nu-parser/fuzz/Cargo.toml
+++ b/crates/nu-parser/fuzz/Cargo.toml
@@ -10,6 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 nu-protocol = { path = "../../nu-protocol" }
+nu-cmd-lang = { path = "../../nu-cmd-lang" }
 
 
 [dependencies.nu-parser]
@@ -25,5 +26,11 @@ debug = 1
 [[bin]]
 name = "parse"
 path = "fuzz_targets/parse.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "parse_with_keywords"
+path = "fuzz_targets/parse_with_keywords.rs"
 test = false
 doc = false

--- a/crates/nu-parser/fuzz/README.md
+++ b/crates/nu-parser/fuzz/README.md
@@ -4,6 +4,10 @@
 
 # Quick start guide
 - Install cargo-fuzz by `cargo install cargo-fuzz`
-- Run `gather_seeds.nu` for preparing the initial seeds corpus
-- Make output directory `mkdir out`
-- Run the fuzzer with `cargo fuzz run parse out seeds`
+- Run `gather_seeds.nu` for preparing the initial seeds corpus. This pulls `.nu` files in the nushell repository as checked out and uses them as a starting of point. You can add additional files to increase diversity.
+- Make an output directory `mkdir out`
+- Run the fuzzer with `cargo fuzz run parse out seeds` where `parse` is the name of the target
+
+# Targets
+- `parse` just pulls in `nu-parser` and reaches the lexing and parsing logic. No command gets executed.
+- `parse_with_keywords` also loads `nu-cmd-lang` providing the command implementations for the core keywords. This permits the fuzzer to reach more code paths as some parts depend on the availability of those declarations. This may also execute the const eval code paths of the keyword commands. As of now this command set should not have negative side effects upon const eval. The overall code is not executed by this target.

--- a/crates/nu-parser/fuzz/fuzz_targets/parse_with_keywords.rs
+++ b/crates/nu-parser/fuzz/fuzz_targets/parse_with_keywords.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use nu_cmd_lang::create_default_context;
+use nu_parser::*;
+use nu_protocol::engine::StateWorkingSet;
+
+fuzz_target!(|data: &[u8]| {
+    let engine_state = create_default_context();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let _block = parse(&mut working_set, None, &data, true);
+});


### PR DESCRIPTION
# Description
The parsing logic for several of our keywords is conditional on the particular commands for those keywords being in scope:

https://github.com/nushell/nushell/blob/942030199dc570dab0be6e59b053cf60598e6bcd/crates/nu-parser/src/parse_keywords.rs#L272-L279

Thus the following involved parsing logic was not fuzzed by the existing `parse` fuzz target so far.

This adds an additional fuzz target `parse_with_keywords` that loads the commands from `nu-cmd-lang`. Those are primarily the keyword implementations, thus the relevant code paths in the parser that depend on those `DeclId`s and the potential const eval of `if` etc. get unlocked.

The existing `parse` target is preserved if you have concerns about the fuzzing breaking containment in some form due to those commands.

# Tests + Formatting
Found https://github.com/nushell/nushell/issues/14972 with this target
