### PR TITLE
Trigger tests for patch release branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'patch-release-*'
 
 name: continuous-integration
 


### PR DESCRIPTION
Make sure that when creating a cherry-picked or otherwise diverging
patch release branch the final product still gets checked via CI before
a release is cut.

To trigger this patch release branches MUST follow the pattern:
`patch-release-*` (e.g. `patch-release-0.102.1`)
