### PR TITLE
Fix usages of `fmt` to `format number`

### DIFF
--- a/crates/nu-std/std/input/mod.nu
+++ b/crates/nu-std/std/input/mod.nu
@@ -4,7 +4,7 @@ def format-event [ ] {
   # Replace numeric value of raw_code with hex string
   let record = match $record {
     {raw_code: $code} => {
-      $record | update raw_code {|| $in | fmt | get upperhex}
+      $record | update raw_code {|| $in | format number | get upperhex}
     }
     _ => $record
   }
@@ -12,7 +12,7 @@ def format-event [ ] {
   # Replace numeric value of raw_modifiers with binary string
   let record = match $record {
     {raw_modifiers: $flags} => {
-      $record | update raw_modifiers {|| $in | fmt | get binary}
+      $record | update raw_modifiers {|| $in | format number | get binary}
     }
     _ => $record
   }


### PR DESCRIPTION
Those slipped through the cracks with https://github.com/nushell/nushell/pull/14875

Avoids deprecation warning and failure after https://github.com/nushell/nushell/pull/15040
