### PR TITLE
Remove `--no-default-features` for `std-lib-and-python-virtualenv` CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
 
       - name: Install Nushell
-        run: cargo install --path . --locked --no-default-features --force
+        run: cargo install --path . --locked --force
 
       - name: Standard library tests
         run: nu -c 'use crates/nu-std/testing.nu; testing run-tests --path crates/nu-std'


### PR DESCRIPTION
# Description

Current CI tests `std-lib-and-python-virtualenv` using Nushell installed with:

```
cargo install --path . --locked --no-default-features --force
```

However, this disables certain features that may be utilized in `std` or (now) `std-rfc`; namely `stor` and `into sqlite`.

This PR simply removes the `--no-default-features` flag, which *should* allow #15042 CI to complete successfully.

Historically, I believe that this was set up to mirror [`pypa/virtualenv` CI](https://github.com/pypa/virtualenv/pulls?q=is%3Apr+is%3Amerged+nushell).  However, with all Nushell binary builds now including these features, it seems to me that a more accurate CI will test with default features.  Let me know if my understanding is off here, and we can look for alternatives.

# User-Facing Changes

None

# Tests + Formatting

CI Update

# After Submitting

N/A
