### PR TITLE
Use build_target information in startup banner

### DIFF
--- a/crates/nu-std/std/prelude/mod.nu
+++ b/crates/nu-std/std/prelude/mod.nu
@@ -16,7 +16,7 @@ let banner_msg = match $short {
 (ansi green)'|, . ,'   (ansi reset)based on the (ansi green)nu(ansi reset) language,
 (ansi green) !_-\(_\\    (ansi reset)where all data is structured!
 
-Version: (ansi green)($ver.version) \(($ver.build_os)\)
+Version: (ansi green)($ver.version) \(($ver.build_target)\)
 Please join our (ansi purple)Discord(ansi reset) community at (ansi purple)https://discord.gg/NtAbbGn(ansi reset)
 Our (ansi green_bold)GitHub(ansi reset) repository is at (ansi green_bold)https://github.com/nushell/nushell(ansi reset)
 Our (ansi green)Documentation(ansi reset) is located at (ansi green)https://nushell.sh(ansi reset)


### PR DESCRIPTION
# Description
The `(version).build_os` variable inherits from `shadow_rs` `BUILD_OS`
which points to the OS on which the binary was built but does not
reflect the target if it was cross-compiled. We cross-compile several of
the targets for our binary releases. Thus the info in the banner was
misleading.

# User-Facing Changes
By changing to `build_target` the target triple is shown instead.
This is slightly more verbose but should also allow disambiguation
between the `musl` and `glibc` builds.

![grafik](https://github.com/user-attachments/assets/24dd43d7-9717-463b-809b-b81b44f9ab52)

# Tests + Formatting
(-)
