### PR TITLE
remove `nu-check` examples with the `--all` flag

### DIFF
--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -168,16 +168,6 @@ impl Command for NuCheck {
                 example: "$'two(char nl)lines' | nu-check ",
                 result: None,
             },
-            Example {
-                description: "Heuristically parse which begins with script first, if it sees a failure, try module afterwards",
-                example: "nu-check -a script.nu",
-                result: None,
-            },
-            Example {
-                description: "Heuristically parse by showing error message",
-                example: "open foo.nu | lines | nu-check --all --debug",
-                result: None,
-            },
         ]
     }
 }


### PR DESCRIPTION
# Description

Deletes example usage of `nu-check`'s `--all` flag, which was removed in 5e937ca1afc6aee2296615f64330331952c7cd53.