### PR TITLE
Replaced `IoError::new_with_additional_context` calls that still had `Span::unknown()`

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -27,11 +27,11 @@ pub fn evaluate_file(
     let cwd = engine_state.cwd_as_string(Some(stack))?;
 
     let file_path = canonicalize_with(&path, cwd).map_err(|err| {
-        IoError::new_with_additional_context(
+        IoError::new_internal_with_path(
             err.kind(),
-            Span::unknown(),
-            PathBuf::from(&path),
             "Could not access file",
+            nu_protocol::location!(),
+            PathBuf::from(&path),
         )
     })?;
 
@@ -46,21 +46,21 @@ pub fn evaluate_file(
         })?;
 
     let file = std::fs::read(&file_path).map_err(|err| {
-        IoError::new_with_additional_context(
+        IoError::new_internal_with_path(
             err.kind(),
-            Span::unknown(),
-            file_path.clone(),
             "Could not read file",
+            nu_protocol::location!(),
+            file_path.clone(),
         )
     })?;
     engine_state.file = Some(file_path.clone());
 
     let parent = file_path.parent().ok_or_else(|| {
-        IoError::new_with_additional_context(
+        IoError::new_internal_with_path(
             std::io::ErrorKind::NotFound,
-            Span::unknown(),
-            file_path.clone(),
             "The file path does not have a parent",
+            nu_protocol::location!(),
+            file_path.clone(),
         )
     })?;
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -252,11 +252,10 @@ impl Command for External {
         );
 
         let mut child = child.map_err(|err| {
-            IoError::new_with_additional_context(
+            IoError::new_internal(
                 err.kind(),
-                Span::unknown(),
-                None,
                 "Could not spawn foreground child",
+                nu_protocol::location!(),
             )
         })?;
 
@@ -443,11 +442,10 @@ fn write_pipeline_data(
         stream.write_to(writer)?;
     } else if let PipelineData::Value(Value::Binary { val, .. }, ..) = data {
         writer.write_all(&val).map_err(|err| {
-            IoError::new_with_additional_context(
+            IoError::new_internal(
                 err.kind(),
-                Span::unknown(),
-                None,
                 "Could not write pipeline data",
+                nu_protocol::location!(),
             )
         })?;
     } else {
@@ -464,11 +462,10 @@ fn write_pipeline_data(
         for value in output {
             let bytes = value.coerce_into_binary()?;
             writer.write_all(&bytes).map_err(|err| {
-                IoError::new_with_additional_context(
+                IoError::new_internal(
                     err.kind(),
-                    Span::unknown(),
-                    None,
                     "Could not write pipeline data",
+                    nu_protocol::location!(),
                 )
             })?;
         }

--- a/crates/nu-plugin-core/src/communication_mode/mod.rs
+++ b/crates/nu-plugin-core/src/communication_mode/mod.rs
@@ -3,7 +3,7 @@ use std::io::{Stdin, Stdout};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 
 use nu_protocol::shell_error::io::IoError;
-use nu_protocol::{ShellError, Span};
+use nu_protocol::ShellError;
 
 #[cfg(feature = "local-socket")]
 mod local_socket;
@@ -189,11 +189,10 @@ impl PreparedServerCommunication {
                 listener
                     .set_nonblocking(ListenerNonblockingMode::Accept)
                     .map_err(|err| {
-                        IoError::new_with_additional_context(
+                        IoError::new_internal(
                             err.kind(),
-                            Span::unknown(),
-                            None,
                             "Could not set non-blocking mode accept for listener",
+                            nu_protocol::location!(),
                         )
                     })?;
                 let mut get_socket = || {
@@ -204,11 +203,10 @@ impl PreparedServerCommunication {
                                 // Success! Ensure the stream is in nonblocking mode though, for
                                 // good measure. Had an issue without this on macOS.
                                 stream.set_nonblocking(false).map_err(|err| {
-                                    IoError::new_with_additional_context(
+                                    IoError::new_internal(
                                         err.kind(),
-                                        Span::unknown(),
-                                        None,
                                         "Could not disable non-blocking mode for listener",
+                                        nu_protocol::location!(),
                                     )
                                 })?;
                                 result = Some(stream);

--- a/crates/nu-plugin-core/src/interface/mod.rs
+++ b/crates/nu-plugin-core/src/interface/mod.rs
@@ -3,7 +3,7 @@
 use nu_plugin_protocol::{ByteStreamInfo, ListStreamInfo, PipelineDataHeader, StreamMessage};
 use nu_protocol::{
     engine::Sequence, shell_error::io::IoError, ByteStream, ListStream, PipelineData, Reader,
-    ShellError, Signals, Span,
+    ShellError, Signals,
 };
 use std::{
     io::{Read, Write},
@@ -367,11 +367,10 @@ where
                         result
                     })
                     .map_err(|err| {
-                        IoError::new_with_additional_context(
+                        IoError::new_internal(
                             err.kind(),
-                            Span::unknown(),
-                            None,
                             "Could not spawn plugin stream background writer",
+                            nu_protocol::location!(),
                         )
                     })?,
             )),

--- a/crates/nu-plugin-engine/src/persistent.rs
+++ b/crates/nu-plugin-engine/src/persistent.rs
@@ -9,7 +9,7 @@ use nu_protocol::{
     engine::{EngineState, Stack},
     shell_error::io::IoError,
     HandlerGuard, Handlers, PluginGcConfig, PluginIdentity, PluginMetadata, RegisteredPlugin,
-    ShellError, Span,
+    ShellError,
 };
 use std::{
     collections::HashMap,
@@ -186,11 +186,10 @@ impl PersistentPlugin {
 
         // Start the plugin garbage collector
         let gc = PluginGc::new(mutable.gc_config.clone(), &self).map_err(|err| {
-            IoError::new_with_additional_context(
+            IoError::new_internal(
                 err.kind(),
-                Span::unknown(),
-                None,
                 "Could not start plugin gc",
+                nu_protocol::location!(),
             )
         })?;
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -324,12 +324,7 @@ impl EngineState {
 
         let cwd = self.cwd(Some(stack))?;
         std::env::set_current_dir(cwd).map_err(|err| {
-            IoError::new_with_additional_context(
-                err.kind(),
-                Span::unknown(),
-                None,
-                "Could not set current dir",
-            )
+            IoError::new_internal(err.kind(), "Could not set current dir", crate::location!())
         })?;
 
         if let Some(config) = stack.config.take() {
@@ -521,11 +516,11 @@ impl EngineState {
                 if err.kind() == std::io::ErrorKind::NotFound {
                     Ok(PluginRegistryFile::default())
                 } else {
-                    Err(ShellError::Io(IoError::new_with_additional_context(
+                    Err(ShellError::Io(IoError::new_internal_with_path(
                         err.kind(),
-                        Span::unknown(),
-                        PathBuf::from(plugin_path),
                         "Failed to open plugin file",
+                        crate::location!(),
+                        PathBuf::from(plugin_path),
                     )))
                 }
             }
@@ -538,11 +533,11 @@ impl EngineState {
 
         // Write it to the same path
         let plugin_file = File::create(plugin_path.as_path()).map_err(|err| {
-            IoError::new_with_additional_context(
+            IoError::new_internal_with_path(
                 err.kind(),
-                Span::unknown(),
-                PathBuf::from(plugin_path),
                 "Failed to write plugin file",
+                crate::location!(),
+                PathBuf::from(plugin_path),
             )
         })?;
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
In #14968 I grepped the code for `IoError::new` calls with unknown spans, but I forgot to also grep for `IoError::new_with_additional_context`, so I missed some. Hopefullly this is the last P.S. to #14968.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

N/A

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

N/A