### PR TITLE
Adds platform agnostic EoL separator to `char` command

### DIFF
--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -12,6 +12,13 @@ const ENV_PATH_SEPARATOR_CHAR: char = ';';
 #[cfg(not(target_family = "windows"))]
 const ENV_PATH_SEPARATOR_CHAR: char = ':';
 
+// Character used to separate directories in a Path Environment variable on windows is ";"
+#[cfg(target_family = "windows")]
+const LINE_SEPARATOR_CHAR: char = "\r\n";
+// Character used to separate directories in a Path Environment variable on linux/mac/unix is ":"
+#[cfg(not(target_family = "windows"))]
+const LINE_SEPARATOR_CHAR: char = '\n';
+
 #[derive(Clone)]
 pub struct Char;
 
@@ -59,6 +66,10 @@ static CHAR_MAP: LazyLock<IndexMap<&'static str, String>> = LazyLock::new(|| {
         "path_sep" => std::path::MAIN_SEPARATOR.to_string(),
         "psep" => std::path::MAIN_SEPARATOR.to_string(),
         "separator" => std::path::MAIN_SEPARATOR.to_string(),
+        "eol" => LINE_SEPARATOR_CHAR.to_string(),
+        "lsep" => LINE_SEPARATOR_CHAR.to_string(),
+        "line_sep" => LINE_SEPARATOR_CHAR.to_string(),
+        "lsep" => '\n'.to_string(),
         "esep" => ENV_PATH_SEPARATOR_CHAR.to_string(),
         "env_sep" => ENV_PATH_SEPARATOR_CHAR.to_string(),
         "tilde" => '~'.to_string(),                                // ~
@@ -163,6 +174,9 @@ static NO_OUTPUT_CHARS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "crlf",
         "bel",
         "backspace",
+        "lsep",
+        "line_sep",
+        "eol",
     ]
     .into_iter()
     .collect()

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -14,7 +14,7 @@ const ENV_PATH_SEPARATOR_CHAR: char = ':';
 
 // Character used to separate directories in a Path Environment variable on windows is ";"
 #[cfg(target_family = "windows")]
-const LINE_SEPARATOR_CHAR: char = "\r\n";
+const LINE_SEPARATOR_CHAR: &str = "\r\n";
 // Character used to separate directories in a Path Environment variable on linux/mac/unix is ":"
 #[cfg(not(target_family = "windows"))]
 const LINE_SEPARATOR_CHAR: char = '\n';

--- a/crates/nu-command/tests/commands/platform/char_.rs
+++ b/crates/nu-command/tests/commands/platform/char_.rs
@@ -8,5 +8,5 @@ fn test_char_list_outputs_table() {
         "#
     ));
 
-    assert_eq!(actual.out, "107");
+    assert_eq!(actual.out, "113");
 }

--- a/crates/nu-command/tests/commands/platform/mod.rs
+++ b/crates/nu-command/tests/commands/platform/mod.rs
@@ -1,2 +1,3 @@
 mod ansi_;
+mod char_;
 mod kill;


### PR DESCRIPTION
# Description

Adds `char eol`, `char line_sep`, and `char lsep` (synonyms).  This will be the platform-specific character (`\n` on most platforms) or sequence (`\r\n` on Windows) separating lines in strings.

# User-Facing Changes

The following will work on all platforms:

```nushell
"
" == $"(char eol)"
# => true
```

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A - Already represented automatically in `char -l`
