### PR TITLE
fix ranges over zero-length input

### DIFF
--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -389,6 +389,13 @@ fn substring_by_negative_index() {
 }
 
 #[test]
+fn substring_of_empty_string() {
+    let actual = nu!("'' | str substring ..0");
+    assert_eq!(actual.err, "");
+    assert_eq!(actual.out, "");
+}
+
+#[test]
 fn str_reverse() {
     let actual = nu!(r#"
         echo "nushell" | str reverse

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -112,8 +112,9 @@ mod int_range {
             match self.end {
                 Bound::Unbounded => Bound::Unbounded,
                 Bound::Included(i) => match i {
+                    _ if len == 0 => Bound::Excluded(0),
                     i if i < 0 => Bound::Excluded(len.saturating_sub((i + 1).unsigned_abs())),
-                    i => Bound::Included((len - 1).min(i.unsigned_abs())),
+                    i => Bound::Included((len.saturating_sub(1)).min(i.unsigned_abs())),
                 },
                 Bound::Excluded(i) => Bound::Excluded(match i {
                     i if i < 0 => len.saturating_sub(i.unsigned_abs()),


### PR DESCRIPTION
Fixes #15061

# User-Facing Changes

Fixes panics when slicing empty input with inclusive ranges:

```nushell
> random binary 0 | bytes at 0..0
Error:   x Main thread panicked.
  |-> at crates/nu-protocol/src/value/range.rs:118:42
  `-> attempt to subtract with overflow
```