### PR TITLE
Use new reedline menu event for menunext with completions

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -629,7 +629,7 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
         KeyCode::Tab,
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::Menu("completion_menu".to_string()),
-            ReedlineEvent::MenuNext,
+            ReedlineEvent::MenuNextComplete,
             ReedlineEvent::Edit(vec![EditCommand::Complete]),
         ]),
     );
@@ -639,7 +639,7 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
         KeyCode::Char(' '),
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::Menu("ide_completion_menu".to_string()),
-            ReedlineEvent::MenuNext,
+            ReedlineEvent::MenuNextComplete,
             ReedlineEvent::Edit(vec![EditCommand::Complete]),
         ]),
     );
@@ -1015,6 +1015,7 @@ fn event_from_record(
         "menuleft" => ReedlineEvent::MenuLeft,
         "menuright" => ReedlineEvent::MenuRight,
         "menunext" => ReedlineEvent::MenuNext,
+        "menunextcomplete" => ReedlineEvent::MenuNextComplete,
         "menuprevious" => ReedlineEvent::MenuPrevious,
         "menupagenext" => ReedlineEvent::MenuPageNext,
         "menupageprevious" => ReedlineEvent::MenuPagePrevious,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Addresses #14152 - more context also found at (nushell/reedline#828) . Uses a new reedline Menu event, MenuNextComplete, to be added in nushell/reedline#881, in place of the current MenuNext event for selecting the next element with partial completions. 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

- MenuNext (and custom keybindings to menunext) will no longer partially complete
- Added new event, MenuNextComplete for MenuNext with partial completions.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

