### PR TITLE
Fix `char lsep` assignment

### DIFF
--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -69,7 +69,6 @@ static CHAR_MAP: LazyLock<IndexMap<&'static str, String>> = LazyLock::new(|| {
         "eol" => LINE_SEPARATOR_CHAR.to_string(),
         "lsep" => LINE_SEPARATOR_CHAR.to_string(),
         "line_sep" => LINE_SEPARATOR_CHAR.to_string(),
-        "lsep" => '\n'.to_string(),
         "esep" => ENV_PATH_SEPARATOR_CHAR.to_string(),
         "env_sep" => ENV_PATH_SEPARATOR_CHAR.to_string(),
         "tilde" => '~'.to_string(),                                // ~

--- a/crates/nu-command/tests/commands/platform/char_.rs
+++ b/crates/nu-command/tests/commands/platform/char_.rs
@@ -10,3 +10,13 @@ fn test_char_list_outputs_table() {
 
     assert_eq!(actual.out, "113");
 }
+
+#[test]
+fn test_char_eol() {
+    let actual = nu!(r#"
+        let expected = if ($nu.os-info.name == 'windows') { "\r\n" } else { "\n" }
+        ((char lsep) == $expected) and ((char line_sep) == $expected) and ((char eol) == $expected)
+    "#);
+
+    assert_eq!(actual.out, "true");
+}


### PR DESCRIPTION
# Description

Fix issue with #15059 where there was still a hardcoded `\n` taking effect on Windows.

# User-Facing Changes

Fix

# Tests + Formatting

Test added

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A