### PR TITLE
use 0-indexing in `explore`

### DIFF
--- a/crates/nu-explore/src/views/record/table_widget.rs
+++ b/crates/nu-explore/src/views/record/table_widget.rs
@@ -502,7 +502,7 @@ impl<'a> IndexColumn<'a> {
 impl Widget for IndexColumn<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         for row in 0..area.height {
-            let i = 1 + row as usize + self.start;
+            let i = row as usize + self.start;
             let text = i.to_string();
             let style = nu_style_to_tui(self.style_computer.compute(
                 "row_index",


### PR DESCRIPTION
# Description
The index in `explore --index` starting with 1 is inconsistent with rest of nushell. Also it tripped me up a few times when I wanted to select a row with `:nu get n`

# User-Facing Changes
Index in `explore --index` now starts with 0.

# Tests + Formatting

- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
N/A