### PR TITLE
feat(std/dirs): retain state in subshells or with exec-restarts

### DIFF
--- a/crates/nu-std/std/dirs/mod.nu
+++ b/crates/nu-std/std/dirs/mod.nu
@@ -17,8 +17,16 @@
 # This situation could arise if we started with [/a, /b, /c], then
 # we changed directories from /b to /var/tmp.
 export-env {
-    $env.DIRS_POSITION = 0
-    $env.DIRS_LIST = [($env.PWD | path expand)]
+    $env.ENV_CONVERSIONS.DIRS_LIST = {
+        from_string: {|| split row (char esep)}
+        to_string: {|| str join (char esep)}
+    }
+    $env.ENV_CONVERSIONS.DIRS_POSITION = {
+        from_string: {|| into int}
+        to_string: {|| into string}
+    }
+    $env.DIRS_POSITION = $env.DIRS_POSITION? | default (0)
+    $env.DIRS_LIST = $env.DIRS_LIST? | default [($env.PWD | path expand)]
 }
 
 # Add one or more directories to the list.

--- a/crates/nu-std/tests/test_dirs.nu
+++ b/crates/nu-std/tests/test_dirs.nu
@@ -46,7 +46,7 @@ def dirs_command [] {
     cd $c.base_path
 
     # hide existing variables to prevent the state from outside affecting the tests
-    hide-env DIRS_LIST DIRS_POSITION
+    hide-env -i DIRS_LIST DIRS_POSITION
     # must execute these uses for the UOT commands *after* the test and *not* just put them at top of test module.
     # the def --env gets messed up
     use std/dirs
@@ -97,7 +97,7 @@ def dirs_next [] {
     cd $c.base_path
     assert equal $env.PWD $c.base_path "test setup"
 
-    hide-env DIRS_LIST DIRS_POSITION
+    hide-env -i DIRS_LIST DIRS_POSITION
     use std/dirs
     cur_dir_check $c.base_path "use module test setup"
 
@@ -119,7 +119,7 @@ def dirs_cd [] {
     # must set PWD *before* doing `use` that will run the def --env block in dirs module.
     cd $c.base_path
 
-    hide-env DIRS_LIST DIRS_POSITION
+    hide-env -i DIRS_LIST DIRS_POSITION
     use std/dirs
 
     cur_dir_check $c.base_path "use module test setup"
@@ -143,7 +143,7 @@ def dirs_goto_bug10696 [] {
     let $c = $in
     cd $c.base_path
 
-    hide-env DIRS_LIST DIRS_POSITION
+    hide-env -i DIRS_LIST DIRS_POSITION
     use std/dirs
 
     dirs add $c.path_a
@@ -159,7 +159,7 @@ def dirs_goto [] {
     let $c = $in
     cd $c.base_path
 
-    hide-env DIRS_LIST DIRS_POSITION
+    hide-env -i DIRS_LIST DIRS_POSITION
     use std/dirs
 
     # check that goto can move *from* any position in the ring *to* any other position (correctly)

--- a/crates/nu-std/tests/test_dirs.nu
+++ b/crates/nu-std/tests/test_dirs.nu
@@ -45,6 +45,8 @@ def dirs_command [] {
     # must set PWD *before* doing `use` that will run the def --env block in dirs module.
     cd $c.base_path
 
+    # hide existing variables to prevent the state from outside affecting the tests
+    hide-env DIRS_LIST DIRS_POSITION
     # must execute these uses for the UOT commands *after* the test and *not* just put them at top of test module.
     # the def --env gets messed up
     use std/dirs
@@ -95,6 +97,7 @@ def dirs_next [] {
     cd $c.base_path
     assert equal $env.PWD $c.base_path "test setup"
 
+    hide-env DIRS_LIST DIRS_POSITION
     use std/dirs
     cur_dir_check $c.base_path "use module test setup"
 
@@ -116,6 +119,7 @@ def dirs_cd [] {
     # must set PWD *before* doing `use` that will run the def --env block in dirs module.
     cd $c.base_path
 
+    hide-env DIRS_LIST DIRS_POSITION
     use std/dirs
 
     cur_dir_check $c.base_path "use module test setup"
@@ -138,6 +142,8 @@ def dirs_cd [] {
 def dirs_goto_bug10696 [] {
     let $c = $in
     cd $c.base_path
+
+    hide-env DIRS_LIST DIRS_POSITION
     use std/dirs
 
     dirs add $c.path_a
@@ -152,6 +158,8 @@ def dirs_goto_bug10696 [] {
 def dirs_goto [] {
     let $c = $in
     cd $c.base_path
+
+    hide-env DIRS_LIST DIRS_POSITION
     use std/dirs
 
     # check that goto can move *from* any position in the ring *to* any other position (correctly)


### PR DESCRIPTION
# Description

# User-Facing Changes
Persist `std/dirs`'s state in subshells and also when restarting the shell with `exec $nu.current-exe`

# Tests + Formatting

- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
N/A