### PR TITLE
feat(const): implement run_const for `const`

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/const_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/const_.rs
@@ -72,6 +72,19 @@ impl Command for Const {
         }
     }
 
+    fn run_const(
+        &self,
+        _working_set: &StateWorkingSet,
+        _call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(PipelineData::empty())
+    }
+
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -433,3 +433,12 @@ fn const_takes_pipeline() {
     let actual = nu!(r#"const list = 'bar_baz_quux' | split row '_'; $list | length"#);
     assert_eq!(actual.out, "3");
 }
+
+#[test]
+fn const_const() {
+    let actual = nu!(r#"const y = (const x = "foo"; $x + $x); $y"#);
+    assert_eq!(actual.out, "foofoo");
+
+    let actual = nu!(r#"const y = (const x = "foo"; $x + $x); $x"#);
+    assert!(actual.err.contains("nu::parser::variable_not_found"));
+}


### PR DESCRIPTION
- fixes #14559

# Description
Allow using `const` keyword in const contexts. The `run_const` body is basically empty as the actual logic is already handled by the parser.

# User-Facing Changes
`const` keyword can now be used in `const` contexts.

# Tests + Formatting

I'll add some tests before marking this ready. 

- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
N/A