### PR TITLE
make plugin compatible with nightly nushell version

### DIFF
--- a/crates/nu-plugin-protocol/src/protocol_info.rs
+++ b/crates/nu-plugin-protocol/src/protocol_info.rs
@@ -1,4 +1,5 @@
 use nu_protocol::ShellError;
+use semver::Prerelease;
 use serde::{Deserialize, Serialize};
 
 /// Protocol information, sent as a `Hello` message on initialization. This determines the
@@ -41,6 +42,12 @@ impl ProtocolInfo {
         ];
 
         versions.sort();
+
+        // the versions maybe a nightly version(1.2.3-nightly.1)
+        // it's good to mark the prelease field to be empty, so plugins
+        // are able to play with a nightly version of nushell.
+        versions[1].pre = Prerelease::EMPTY;
+        versions[0].pre = Prerelease::EMPTY;
 
         // For example, if the lower version is 1.1.0, and the higher version is 1.2.3, the
         // requirement is that 1.2.3 matches ^1.1.0 (which it does)

--- a/crates/nu-plugin-protocol/src/protocol_info.rs
+++ b/crates/nu-plugin-protocol/src/protocol_info.rs
@@ -43,9 +43,9 @@ impl ProtocolInfo {
 
         versions.sort();
 
-        // the versions maybe a nightly version(1.2.3-nightly.1)
-        // it's good to mark the prelease field to be empty, so plugins
-        // are able to play with a nightly version of nushell.
+        // The version may be a nightly version (1.2.3-nightly.1).
+        // It's good to mark the prerelease field as empty, so plugins
+        // can work with a nightly version of Nushell.
         versions[1].pre = Prerelease::EMPTY;
         versions[0].pre = Prerelease::EMPTY;
 

--- a/crates/nu-plugin-protocol/src/tests.rs
+++ b/crates/nu-plugin-protocol/src/tests.rs
@@ -33,3 +33,20 @@ fn protocol_info_incompatible() -> Result<(), ShellError> {
     assert!(!ver_1_1_0.is_compatible_with(&ver_2_0_0)?);
     Ok(())
 }
+
+#[test]
+fn protocol_info_compatible_with_nightly() -> Result<(), ShellError> {
+    let ver_1_2_3 = ProtocolInfo {
+        protocol: Protocol::NuPlugin,
+        version: "1.2.3".into(),
+        features: vec![],
+    };
+    let ver_1_1_0 = ProtocolInfo {
+        protocol: Protocol::NuPlugin,
+        version: "1.1.0-nightly.1".into(),
+        features: vec![],
+    };
+    assert!(ver_1_1_0.is_compatible_with(&ver_1_2_3)?);
+    assert!(ver_1_2_3.is_compatible_with(&ver_1_1_0)?);
+    Ok(())
+}


### PR DESCRIPTION
# Description
Close: #15083

This pr will set `pre` field of version to `Prerelease::EMPTY`, as nushell does not require this level of checking currently.

# User-Facing Changes
NaN

# Tests + Formatting
Added 1 test

# After Submitting
NaN