### PR TITLE
Bump `bytesize` to fix `into filesize`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "bytesize"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+checksum = "2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e"
 
 [[package]]
 name = "calamine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ bracoxide = "0.1.4"
 brotli = "7.0"
 byteorder = "1.5"
 bytes = "1"
-bytesize = "1.3"
+bytesize = "1.3.1"
 calamine = "0.26.1"
 chardetng = "0.1.17"
 chrono = { default-features = false, version = "0.4.34" }

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -128,3 +128,10 @@ fn wrong_positive_str() {
 
     assert!(actual.err.contains("can't convert string to filesize"));
 }
+
+#[test]
+fn invalid_str() {
+    let actual = nu!("'42.0 42.0 kB' | into filesize");
+
+    assert!(actual.err.contains("can't convert string to filesize"));
+}


### PR DESCRIPTION
# Description
Closes https://github.com/nushell/nushell/issues/14866

Incorporates https://github.com/bytesize-rs/bytesize/pull/59 with
bytesize version 1.3.1

# User-Facing Changes
Now rejected strings
```
"1.3 1.3 kB" | into filesize
"1 420 kB" | into filesize
```
# Tests + Formatting
Added test with invalid input that was silently ignored before
