### PR TITLE
Fix `match` blocks in `std-rfc/kv` implementation

### DIFF
--- a/crates/nu-std/std-rfc/kv/mod.nu
+++ b/crates/nu-std/std-rfc/kv/mod.nu
@@ -190,8 +190,8 @@ def db_setup [
 
   # Return the correct closure for opening on-disk vs. in-memory
   match $universal {
-    true  => {|| {|| open (universal_db_path)}}
-    false => {|| {|| stor open}}
+    true  => {{|| open (universal_db_path)}}
+    false => {{|| stor open}}
   }
 }
 


### PR DESCRIPTION
Fixes failure surfaced by merging https://github.com/nushell/nushell/pull/15032
