### PR TITLE
Bump yanked dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6272,9 +6272,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.2.5"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b202022bb57c049555430e11fc22fea12909276a80a4c3d368da36ac1d88ed"
+checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
 dependencies = [
  "sdd",
 ]
@@ -6346,9 +6346,9 @@ dependencies = [
 
 [[package]]
 name = "sdd"
-version = "3.0.4"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95"
+checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
 
 [[package]]
 name = "security-framework"


### PR DESCRIPTION
Seen in the `cargo install --locked` step of the stdlib ci
- `scc`
- `sdd` [according to changelog potential use after free](https://github.com/wvwwvwwv/scalable-delayed-dealloc/blob/main/CHANGELOG.md)

Should only be part of the `dev-dependencies` due to `serial_test`
