### PR TITLE
Use `proc-macro-error2` instead of `proc-macro-error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,7 +3716,7 @@ name = "nu-derive-value"
 version = "0.102.1"
 dependencies = [
  "heck",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -5452,26 +5452,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
+ "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "version_check",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ pathdiff = "0.2"
 percent-encoding = "2"
 pretty_assertions = "1.4"
 print-positions = "0.6"
-proc-macro-error = { version = "1.0", default-features = false }
+proc-macro-error2 = "2.0"
 proc-macro2 = "1.0"
 procfs = "0.17.0"
 pwd = "1.3"

--- a/crates/nu-derive-value/Cargo.toml
+++ b/crates/nu-derive-value/Cargo.toml
@@ -20,5 +20,5 @@ workspace = true
 proc-macro2 = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }
-proc-macro-error = { workspace = true }
+proc-macro-error2 = { workspace = true }
 heck = { workspace = true }

--- a/crates/nu-derive-value/src/error.rs
+++ b/crates/nu-derive-value/src/error.rs
@@ -1,7 +1,7 @@
 use std::{any, fmt::Debug, marker::PhantomData};
 
 use proc_macro2::Span;
-use proc_macro_error::{Diagnostic, Level};
+use proc_macro_error2::{Diagnostic, Level};
 
 #[derive(Debug)]
 pub enum DeriveError<M> {

--- a/crates/nu-derive-value/src/lib.rs
+++ b/crates/nu-derive-value/src/lib.rs
@@ -29,7 +29,7 @@
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
-use proc_macro_error::{proc_macro_error, Diagnostic};
+use proc_macro_error2::{proc_macro_error, Diagnostic};
 
 mod attributes;
 mod case;


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR replaces the usage of `proc-macro-error` with `proc-macro-error2`. At the time of writing `nu-derive-value` this wasn't an option, at least it wasn't clear that it is the direction to go. This shouldn't change any of the usage of `nu-derive-value` in any way but removes one security warning.

`proc-macro-error` depends on `syn 1`, that's why I initially had the default features for `proc-macro-error` disabled. `proc-macro-error2` uses `syn 2` as mostly everything. So we can use that.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Same interface, no changes.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

The tests for `nu-derive-value` do not test spans, so maybe something changed now but probably not.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

We still have `quickcheck` which depends on `syn 1` but it seems we need that for `nu-cmd-lang`. Would be great if, in the future, we can get rid of `syn 1` as that should improve build times a bit.