### PR TITLE
Enable theming the Welcome Banner

### DIFF
--- a/crates/nu-std/std/prelude/mod.nu
+++ b/crates/nu-std/std/prelude/mod.nu
@@ -4,29 +4,32 @@ use std/dt [datetime-diff, pretty-print-duration]
 export def banner [
     --short    # Only show startup time
 ] {
+let foreground = $env.config.color_config?.banner_foreground? | default "attr_normal"
+let highlight1 = $env.config.color_config?.banner_highlight1? | default "green"
+let highlight2 = $env.config.color_config?.banner_highlight2? | default "purple"
 let dt = (datetime-diff (date now) 2019-05-10T09:59:12-07:00)
 let ver = (version)
-let startup_time = $"(ansi green_bold)Startup Time: (ansi reset)($nu.startup-time)"
+let startup_time = $"(ansi $highlight1)(ansi attr_bold)Startup Time: (ansi reset)(ansi $foreground)($nu.startup-time)(ansi reset)"
 
 let banner_msg = match $short {
-    true => $"($startup_time)(char newline)"
+    true => $"($startup_time)(char eol)"
 
-    false => $"(ansi green)     __  ,(ansi reset)
-(ansi green) .--\(\)°'.' (ansi reset)Welcome to (ansi green)Nushell(ansi reset),
-(ansi green)'|, . ,'   (ansi reset)based on the (ansi green)nu(ansi reset) language,
-(ansi green) !_-\(_\\    (ansi reset)where all data is structured!
+    false => $"(ansi $highlight1)     __  ,(ansi reset)
+(ansi $highlight1) .--\(\)°'.' (ansi reset)(ansi $foreground)Welcome to (ansi $highlight1)Nushell(ansi reset)(ansi $foreground),(ansi reset)
+(ansi $highlight1)'|, . ,'   (ansi reset)(ansi $foreground)based on the (ansi $highlight1)nu(ansi reset)(ansi $foreground) language,(ansi reset)
+(ansi $highlight1) !_-\(_\\    (ansi reset)(ansi $foreground)where all data is structured!
 
-Version: (ansi green)($ver.version) \(($ver.build_target)\)
-Please join our (ansi purple)Discord(ansi reset) community at (ansi purple)https://discord.gg/NtAbbGn(ansi reset)
-Our (ansi green_bold)GitHub(ansi reset) repository is at (ansi green_bold)https://github.com/nushell/nushell(ansi reset)
-Our (ansi green)Documentation(ansi reset) is located at (ansi green)https://nushell.sh(ansi reset)
-And the (ansi green)Latest Nushell News(ansi reset) at (ansi green)https://nushell.sh/blog/(ansi reset)
-Learn how to remove this at: (ansi green)https://nushell.sh/book/configuration.html#remove-welcome-message(ansi reset)
+(ansi $foreground)Version: (ansi $highlight1)($ver.version) \(($ver.build_target)\)(ansi reset)
+(ansi $foreground)Please join our (ansi $highlight2)Discord(ansi reset)(ansi $foreground) community at (ansi $highlight2)https://discord.gg/NtAbbGn(ansi reset)
+(ansi $foreground)Our (ansi $highlight1)(ansi attr_bold)GitHub(ansi reset)(ansi $foreground) repository is at (ansi $highlight1)(ansi attr_bold)https://github.com/nushell/nushell(ansi reset)
+(ansi $foreground)Our (ansi $highlight2)Documentation(ansi reset)(ansi $foreground) is located at (ansi $highlight2)https://nushell.sh(ansi reset)
+(ansi $foreground)And the (ansi $highlight1)Latest Nushell News(ansi reset)(ansi $foreground) at (ansi $highlight1)https://nushell.sh/blog/(ansi reset)
+(ansi $foreground)Learn how to remove this at: (ansi $highlight2)https://nushell.sh/book/configuration.html#remove-welcome-message(ansi reset)
 
-It's been this long since (ansi green)Nushell(ansi reset)'s first commit:
-(pretty-print-duration $dt)
+(ansi $foreground)It's been this long since (ansi $highlight1)Nushell(ansi reset)(ansi $foreground)'s first commit:(ansi reset)
+(ansi $foreground)(pretty-print-duration $dt)
 
-($startup_time)
+($startup_time)(ansi reset)
 "
 }
 

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -785,6 +785,13 @@ $env.config.color_config.empty
 # Use { attr: n } to disable.
 $env.config.color_config.leading_trailing_space_bg = { bg: 'red' }
 
+# banner_foreground: The default text style for the Welcome Banner displayed at startup
+$env.config.color_config.banner_foreground = "attr_normal"
+
+# banner_highlight1 and banner_highlight2: Colors for highlighted text in the Welcome Banner
+$env.config.color_config.banner_highlight1 = "green"
+$env.config.color_config.banner_highlight2 = "purple"
+
 # ------------------------
 # `explore` command colors
 # ------------------------


### PR DESCRIPTION
# Description

* The banner will now use three new `$env.config.color_config` settings:
  - `banner_foreground`: The primary color of the banner text
  - `banner_highlight1`: Used for the first set of highlights, e.g., `Nushell`, `nu`, `GitHub`, et. al
  - `banner_highlight2`: Used for the second set of highlights, e.g. `Discord`, `Documentation`, et. al.

* If the settings above are not defined, `banner` continues to use the default green/purple/foreground.  However, two more lines use the purple/highlight2 in order to give more separation and consistency to the colorization.

# User-Facing Changes

## Before

![image](https://github.com/user-attachments/assets/4796c0b3-f0ee-4d74-a51b-f59f30022a86)

## After (default)

![image](https://github.com/user-attachments/assets/28f9a0db-fa3c-49bd-b40e-3fe62dec2d0a)

## After (with additional `color_config` settings defined

![image](https://github.com/user-attachments/assets/7c24b5e3-9d14-4e6e-8ad3-1fc64630818f)


# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

Update `config nu --doc`
