### PR TITLE
Update `std-rfc` tests to use `@test` attributes

### DIFF
--- a/crates/nu-std/testing.nu
+++ b/crates/nu-std/testing.nu
@@ -8,12 +8,18 @@ def "nu-complete threads" [] {
     seq 1 (sys cpu | length)
 }
 
-# Here we store the map of annotations internal names and the annotation actually used during test creation
-# The reason we do that is to allow annotations to be easily renamed without modifying rest of the code
-# Functions with no annotations or with annotations not on the list are rejected during module evaluation
-# test and test-skip annotations may be used multiple times throughout the module as the function names are stored in a list
-# Other annotations should only be used once within a module file
-# If you find yourself in need of multiple before- or after- functions it's a sign your test suite probably needs redesign
+# Here we store the map of annotations' internal names along with the annotation actually
+# used during test creation. We do this to allow annotations to be easily renamed without
+# modifying rest of the code.
+# Functions with no annotations or with annotations not on the list are rejected during module evaluation.
+#
+# `test` and `test-skip` annotations may be used multiple times throughout the module as the function names
+# are stored in a list.
+#
+# Other annotations should only be used once within a module file.
+#
+# If you find yourself in need of multiple `before-*` or `after-*` functions, it's a sign your test suite
+# probably needs redesign.
 const valid_annotations = {
     "test": "test",
     "ignore": "test-skip",
@@ -23,7 +29,7 @@ const valid_annotations = {
     "after-all": "after-all"
 }
 
-# Returns a table containing the list of function names together with their annotations (comments above the declaration)
+# Returns a table containing the list of command names along with their attributes. 
 def get-annotated [
     file: path
 ]: nothing -> table<function_name: string, annotation: string> {

--- a/crates/nu-std/tests/test_std-rfc_conversions.nu
+++ b/crates/nu-std/tests/test_std-rfc_conversions.nu
@@ -1,7 +1,8 @@
-use std assert
+use std/assert
+use std/testing *
 use std-rfc/conversions *
 
-#[test]
+@test
 def range-into-list [] {
   assert equal (
     1..10 | into list
@@ -10,7 +11,7 @@ def range-into-list [] {
   )
 }
 
-#[test]
+@test
 def string-into-list [] {
   assert equal (
     "foo" | into list
@@ -19,7 +20,7 @@ def string-into-list [] {
   )
 }
 
-#[test]
+@test
 def range-stride-into-list [] {
   assert equal (
     0..2..10 | into list
@@ -28,7 +29,7 @@ def range-stride-into-list [] {
   )
 }
 
-#[test]
+@test
 def null-into-list [] {
   assert equal (
     null | into list | get 0 | describe
@@ -37,7 +38,7 @@ def null-into-list [] {
   )
 }
 
-#[test]
+@test
 def list-into-list [] {
   assert equal (
     [ foo bar baz ] | into list
@@ -47,7 +48,7 @@ def list-into-list [] {
 
 }
 
-#[test]
+@test
 def table-into-columns--roundtrip [] {
   assert equal (
     ls
@@ -61,7 +62,7 @@ const test_record_of_lists = {
   b: [ 4 5 6 ]
 }
 
-#[test]
+@test
 def record-into-columns--simple [] {
   let actual = (
     $test_record_of_lists
@@ -74,7 +75,7 @@ def record-into-columns--simple [] {
   assert equal $actual $expected
 }
 
-#[test]
+@test
 def table-into-columns--simple [] {
   let actual = (
     ls | table-into-columns | get 1 | columns | get 0
@@ -84,7 +85,7 @@ def table-into-columns--simple [] {
   assert equal $actual $expected
 }
 
-#[test]
+@test
 def name-values--simple [] {
   let actual = (
     [ 1 2 3 ] | name-values one two three
@@ -96,7 +97,7 @@ def name-values--simple [] {
   assert equal $actual $expected
 }
 
-#[test]
+@test
 def name-values--missing-keyname [] {
   let actual = (
     [ 1 2 3 ] | name-values one two

--- a/crates/nu-std/tests/test_std-rfc_kv.nu
+++ b/crates/nu-std/tests/test_std-rfc_kv.nu
@@ -1,12 +1,14 @@
-use std/assert
 const kv_module = if ("sqlite" in (version).features) { "std-rfc/kv" } else { null }
 use $kv_module *
+
+use std/assert
+use std/testing *
 
 # It's important to use random keys and to clean-up
 # after since the user running these tests may have
 # either an existing local stor or universal db.
 
-#[test]
+@test
 def simple-local-set [] {
     if ('sqlite' not-in (version).features) { return }
 
@@ -20,10 +22,11 @@ def simple-local-set [] {
     kv drop $key | ignore
 }
 
-#[test]
+@test
 def local-pipeline_set_returns_value [] {
     if ('sqlite' not-in (version).features) { return }
 
+    let key = (random uuid)
     let key = (random uuid)
     let actual = (42 | kv set $key)
     let expected = 42
@@ -36,10 +39,11 @@ def local-pipeline_set_returns_value [] {
     kv drop $key | ignore
 }
 
-#[test]
+@test
 def local-multiple_assignment [] {
     if ('sqlite' not-in (version).features) { return }
 
+    let key = (random uuid)
     let key1 = (random uuid)
     let key2 = (random uuid)
     let key3 = (random uuid)
@@ -56,10 +60,11 @@ def local-multiple_assignment [] {
     kv drop $key3
 }
 
-#[test]
+@test
 def local-transpose_to_record [] {
     if ('sqlite' not-in (version).features) { return }
 
+    let key = (random uuid)
     let key1 = (random uuid)
     let key2 = (random uuid)
     let key3 = (random uuid)
@@ -77,10 +82,11 @@ def local-transpose_to_record [] {
     kv drop $key3
 }
 
-#[test]
+@test
 def local-using_closure [] {
     if ('sqlite' not-in (version).features) { return }
 
+    let key = (random uuid)
     let name_key = (random uuid)
     let size_key = (random uuid)
 
@@ -100,10 +106,11 @@ def local-using_closure [] {
     kv drop $size_key
 }
 
-#[test]
+@test
 def local-return-entire-list [] {
     if ('sqlite' not-in (version).features) { return }
 
+    let key = (random uuid)
     let key1 = (random uuid)
     let key2 = (random uuid)
 
@@ -122,10 +129,11 @@ def local-return-entire-list [] {
     kv drop $key2
 }
 
-#[test]
+@test
 def local-return_value_only [] {
     if ('sqlite' not-in (version).features) { return }
 
+    let key = (random uuid)
     let key = (random uuid)
 
     let expected = 'VALUE'
@@ -137,9 +145,11 @@ def local-return_value_only [] {
 
 }
 
-#[test]
+@test
 def universal-simple_set [] {
     if ('sqlite' not-in (version).features) { return }
+
+    let key = (random uuid)
     $env.NU_UNIVERSAL_KV_PATH = (mktemp -t --suffix .sqlite3)
 
     let key = (random uuid)
@@ -153,9 +163,11 @@ def universal-simple_set [] {
     rm $env.NU_UNIVERSAL_KV_PATH
 }
 
-#[test]
+@test
 def universal-pipeline_set_returns_value [] {
     if ('sqlite' not-in (version).features) { return }
+
+    let key = (random uuid)
     $env.NU_UNIVERSAL_KV_PATH = (mktemp -t --suffix .sqlite3)
 
     let key = (random uuid)
@@ -171,9 +183,11 @@ def universal-pipeline_set_returns_value [] {
     rm $env.NU_UNIVERSAL_KV_PATH
 }
 
-#[test]
+@test
 def universal-multiple_assignment [] {
     if ('sqlite' not-in (version).features) { return }
+
+    let key = (random uuid)
     $env.NU_UNIVERSAL_KV_PATH = (mktemp -t --suffix .sqlite3)
 
     let key1 = (random uuid)
@@ -193,9 +207,11 @@ def universal-multiple_assignment [] {
     rm $env.NU_UNIVERSAL_KV_PATH
 }
 
-#[test]
+@test
 def universal-transpose_to_record [] {
     if ('sqlite' not-in (version).features) { return }
+
+    let key = (random uuid)
     $env.NU_UNIVERSAL_KV_PATH = (mktemp -t --suffix .sqlite3)
 
     let key1 = (random uuid)
@@ -216,9 +232,11 @@ def universal-transpose_to_record [] {
     rm $env.NU_UNIVERSAL_KV_PATH
 }
 
-#[test]
+@test
 def universal-using_closure [] {
     if ('sqlite' not-in (version).features) { return }
+
+    let key = (random uuid)
     $env.NU_UNIVERSAL_KV_PATH = (mktemp -t --suffix .sqlite3)
 
     let name_key = (random uuid)
@@ -241,9 +259,11 @@ def universal-using_closure [] {
     rm $env.NU_UNIVERSAL_KV_PATH
 }
 
-#[test]
+@test
 def universal-return-entire-list [] {
     if ('sqlite' not-in (version).features) { return }
+
+    let key = (random uuid)
     $env.NU_UNIVERSAL_KV_PATH = (mktemp -t --suffix .sqlite3)
 
     let key1 = (random uuid)
@@ -265,9 +285,11 @@ def universal-return-entire-list [] {
     rm $env.NU_UNIVERSAL_KV_PATH
 }
 
-#[test]
+@test
 def universal-return_value_only [] {
     if ('sqlite' not-in (version).features) { return }
+
+    let key = (random uuid)
     $env.NU_UNIVERSAL_KV_PATH = (mktemp -t --suffix .sqlite3)
 
     let key = (random uuid)
@@ -280,4 +302,3 @@ def universal-return_value_only [] {
     kv drop --universal $key
     rm $env.NU_UNIVERSAL_KV_PATH
 }
-

--- a/crates/nu-std/tests/test_std-rfc_path.nu
+++ b/crates/nu-std/tests/test_std-rfc_path.nu
@@ -1,7 +1,8 @@
 use std-rfc/path
 use std/assert
+use std/testing *
 
-#[test]
+@test
 def path_with_extension [] {
     let new_path = "ab.txt" | path with-extension "rs"
     assert equal $new_path "ab.rs"
@@ -10,7 +11,7 @@ def path_with_extension [] {
     assert equal $new_path "ab.rs"
 }
 
-#[test]
+@test
 def path_with_extension_for_list [] {
     let new_path = ["ab.txt", "cd.exe"] | path with-extension "rs"
     assert equal $new_path ["ab.rs", "cd.rs"]
@@ -19,7 +20,7 @@ def path_with_extension_for_list [] {
     assert equal $new_path ["ab.rs", "cd.rs"]
 }
 
-#[test]
+@test
 def path_with_stem [] {
     let new_path = $"(char psep)usr(char psep)bin" | path with-stem "share"
     assert equal $new_path $"(char psep)usr(char psep)share"
@@ -28,7 +29,7 @@ def path_with_stem [] {
     assert equal $new_path [$"(char psep)home(char psep)nushell", $"(char psep)home(char psep)bob(char psep)nushell.txt"]
 }
 
-#[test]
+@test
 def path_with_parent [] {
     let new_path = $"(char psep)etc(char psep)foobar" | path with-parent $"(char psep)usr(char psep)share(char psep)"
     assert equal $new_path $"(char psep)usr(char psep)share(char psep)foobar"

--- a/crates/nu-std/tests/test_std-rfc_str.nu
+++ b/crates/nu-std/tests/test_std-rfc_str.nu
@@ -1,7 +1,8 @@
 use std/assert
+use std/testing *
 use std-rfc/str
 
-#[test]
+@test
 def str-dedent_simple [] {
     
     # Test 1:
@@ -21,7 +22,7 @@ def str-dedent_simple [] {
     ) $"Heading(char lsep)(char lsep)    one(char lsep)    two"
 }
 
-#[test]
+@test
 def str-dedent_leave_blankline_whitespace [] {
     # Test 2:
     # Same as #1, but the blank line has leftover whitespace
@@ -39,7 +40,7 @@ def str-dedent_leave_blankline_whitespace [] {
     ) $"Heading(char lsep)                (char lsep)    one(char lsep)    two"
 }
 
-#[test]
+@test
 def str-dedent_leave_blankline_tab [] {
     # Test 3:
     # Same, but with a single tab character on the "blank" line
@@ -56,7 +57,7 @@ def str-dedent_leave_blankline_tab [] {
     ) $"Heading(char lsep)(char tab)(char lsep)    one(char lsep)    two"
 }
 
-#[test]
+@test
 def str-dedent_ends_with_newline [] {
     # Test 4:
     # Ends with line-break
@@ -74,7 +75,7 @@ def str-dedent_ends_with_newline [] {
     ) $"Heading(char lsep)(char lsep)    one(char lsep)    two(char lsep)"
 }
 
-#[test]
+@test
 def str-dedent_identity [] {
     # Test 5:
     # Identity - Returns the original string sans first and last empty lines
@@ -87,7 +88,7 @@ def str-dedent_identity [] {
     ) "  Identity  "
 }
 
-#[test]
+@test
 def str-dedent_error-no_blank_lines [] {
     # Test 6:
     # Error - Does not contain an empty first line
@@ -104,7 +105,7 @@ def str-dedent_error-no_blank_lines [] {
     }
 }
 
-#[test]
+@test
 def str-dedent_error-no_blank_first_line [] {
     # Test 7:
     # Error - Does not contain an empty last line
@@ -115,7 +116,7 @@ def str-dedent_error-no_blank_first_line [] {
     }
 }
 
-#[test]
+@test
 def str-dedent_error-missing_last_empty_line [] {
     # Test 7.1:
     # Error - Does not contain an empty last line
@@ -127,7 +128,7 @@ def str-dedent_error-missing_last_empty_line [] {
     }
 }
 
-#[test]
+@test
 def str-dedent_error-not_enough_indentation [] {
     # Test 8:
     # Error - Line 1 does not have enough indentation
@@ -140,7 +141,7 @@ def str-dedent_error-not_enough_indentation [] {
     }
 }
 
-#[test]
+@test
 def str-dedent_error-not_enough_indentation2 [] {
     # Test 8.1:
     # Error - Line 2 does not have enough indentation
@@ -153,7 +154,7 @@ def str-dedent_error-not_enough_indentation2 [] {
     }
 }
 
-#[test]
+@test
 def str-dedent_error-not_enough_indentation3 [] {
     # Test 8.2:
     # Error - Line does not have enough indentation
@@ -165,7 +166,7 @@ def str-dedent_error-not_enough_indentation3 [] {
     }
 }
 
-#[test]
+@test
 def str-dedent_first_line_whitespace_allowed [] {
     # Test 9:
     # "Hidden" whitespace on the first line is allowed
@@ -177,7 +178,7 @@ def str-dedent_first_line_whitespace_allowed [] {
     ) "  Identity  "
 }
 
-#[test]
+@test
 def str-dedent_using_tabs [] {
     # Test 10:
     # If the indentation on the last line uses tabs, then the number of tabs
@@ -192,7 +193,7 @@ def str-dedent_using_tabs [] {
     assert equal $actual $expected
 }
 
-#[test]
+@test
 def str-unindent_simple [] {
     # Test 1:
     # Should start with "Heading" in the first character position
@@ -213,7 +214,7 @@ def str-unindent_simple [] {
     assert equal $actual $expected
 }
 
-#[test]
+@test
 def str-unindent_ignore_first_and_last_whitespace [] {
     # Test 2:
     # If the first and/or last line are only whitespace
@@ -236,7 +237,7 @@ def str-unindent_ignore_first_and_last_whitespace [] {
     assert equal $actual $expected
 }
 
-#[test]
+@test
 def str-unindent_keep_extra_line [] {
   # Test 3:
   # Keep intentional blank lines at start and/or end
@@ -252,7 +253,7 @@ def str-unindent_keep_extra_line [] {
   assert equal $actual $expected
 }
 
-#[test]
+@test
 def str-unindent_works_on_single_line [] {
     # Test 4:
     # Works on a single-line string
@@ -264,7 +265,7 @@ def str-unindent_works_on_single_line [] {
     assert equal $actual $expected
 }
 
-#[test]
+@test
 def str-unindent_whitespace_only_single_line [] {
     # Test 4:
     # Works on a single-line string with whitespace-only
@@ -276,7 +277,7 @@ def str-unindent_whitespace_only_single_line [] {
     assert equal $actual $expected
 }
     
-#[test]
+@test
 def str-unindent_whitespace_works_with_tabs [] {
     # Test 4:
     # Works with tabs for indentation

--- a/crates/nu-std/tests/test_std-rfc_tables.nu
+++ b/crates/nu-std/tests/test_std-rfc_tables.nu
@@ -1,4 +1,5 @@
 use std/assert
+use std/testing *
 use std-rfc/tables *
 
 const test_table = [
@@ -29,7 +30,7 @@ const enumerated_table = [
   [   9         'a9'      'b9'      'c9'      'd9'      'e9'      'f9' ]
 ]
 
-#[test]
+@test
 def select-slice--single_int [] {
   assert equal (
     $test_table | select slices 1
@@ -38,7 +39,7 @@ def select-slice--single_int [] {
   )
 }
 
-#[test]
+@test
 def select-slice--single_slice [] {
   assert equal (
     $test_table | select slices 2..4
@@ -47,7 +48,7 @@ def select-slice--single_slice [] {
   )
 }
 
-#[test]
+@test
 def select-slice--complex [] {
   assert equal (
     # First and every following third-row + second row
@@ -57,7 +58,7 @@ def select-slice--complex [] {
   )
 }
 
-#[test]
+@test
 def select-slice--out_of_bounds [] {
   assert equal (
     $test_table | select slices 100
@@ -66,7 +67,7 @@ def select-slice--out_of_bounds [] {
   )
 }
 
-#[test]
+@test
 def reject-slice--single_index [] {
   assert equal (
     $test_table | reject slices 4
@@ -75,7 +76,7 @@ def reject-slice--single_index [] {
   )
 }
 
-#[test]
+@test
 def reject-slice--slices [] {
   assert equal (
     # Reject rows 0-3 and 5-9, leaving only 4
@@ -85,14 +86,14 @@ def reject-slice--slices [] {
   )
 }
 
-#[test]
+@test
 def reject-slice--out_of_bounds [] {
   assert error {
     $test_table | reject slices 1000
   }
 }
 
-#[test]
+@test
 def select-col--index [] {
   assert equal (
     $test_table | select column-slices 2
@@ -101,7 +102,7 @@ def select-col--index [] {
   )
 }
 
-#[test]
+@test
 def select-col--indices [] {
   assert equal (
     $test_table | select column-slices 2 4
@@ -110,7 +111,7 @@ def select-col--indices [] {
   )
 }
 
-#[test]
+@test
 def select-col--slices_and_index [] {
   assert equal (
     $test_table | select column-slices 0..2..5 1
@@ -119,7 +120,7 @@ def select-col--slices_and_index [] {
   )
 }
 
-#[test]
+@test
 def reject-col--slices_and_index [] {
   assert equal (
     $test_table | reject column-slices 0..2..5 1
@@ -128,7 +129,7 @@ def reject-col--slices_and_index [] {
   )
 }
 
-#[test]
+@test
 def reject-col--out_of_bounds [] {
   assert equal (
     $test_table | reject column-slices 1_000
@@ -217,7 +218,7 @@ const movies = [
     [ "(500) Days of Summer", comedy, Fox, 81, 8.096, 87, 60.72, 2009 ]
 ]
 
-#[test]
+@test
 def count_movies_by_Lead_Studio [] {
     let grouped = $movies | group-by Lead_Studio --to-table
     let out = $grouped | aggregate
@@ -242,7 +243,7 @@ def count_movies_by_Lead_Studio [] {
     assert equal $out $expected
 }
 
-#[test]
+@test
 def average_gross_by_Genre [] {
     let grouped = $movies | group-by Genre --to-table
     let out = $grouped | aggregate --ops {avg: {math avg}} Worldwide_Gross | select Genre Worldwide_Gross_avg
@@ -267,7 +268,7 @@ def average_gross_by_Genre [] {
     assert equal $out $expected
 }
 
-#[test]
+@test
 def aggregate_default_ops [] {
     let grouped = $movies | group-by Genre --to-table
     let out = $grouped | aggregate Worldwide_Gross
@@ -292,7 +293,7 @@ def aggregate_default_ops [] {
     assert equal $out $expected
 }
 
-#[test]
+@test
 def throw_error_on_non-table_input [] {
     # without --to-table
     let out = try {
@@ -304,7 +305,7 @@ def throw_error_on_non-table_input [] {
     assert equal $out "input must be a table"
 }
 
-#[test]
+@test
 def throw_error_on_non-existing_column [] {
     let grouped = $movies | group-by Genre --to-table
     let error = try {
@@ -316,7 +317,7 @@ def throw_error_on_non-existing_column [] {
     assert equal $error.inner.0.msg "Cannot find column '$.items.NotInTheDataSet'"
 }
 
-#[test]
+@test
 def aggregate_stats_without_grouping [] {
     let out = $movies | aggregate Year | update cells -c [Year_min Year_avg Year_max Year_sum] {math round -p 2}
     let expected = [{


### PR DESCRIPTION
# Description

After #14906, the test runner was updated to use attributes, along with the existing `std` modules.  However, since that PR was started before `std-rfc` was in main, it didn't include updates to those tests.  Once #14906 was merged, the `std-rfc` tests no longer ran in CI. This PR updates the tests accordingly.

# User-Facing Changes

None

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A