### PR TITLE
Bump Ubuntu runners to 22.04 LTS for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # Pinning to Ubuntu 20.04 because building on newer Ubuntu versions causes linux-gnu
+        # Pinning to Ubuntu 22.04 because building on newer Ubuntu versions causes linux-gnu
         # builds to link against a too-new-for-many-Linux-installs glibc version. Consider
-        # revisiting this when 20.04 is closer to EOL (April 2025)
+        # revisiting this when 22.04 is closer to EOL (June 2027)
         #
         # Using macOS 13 runner because 14 is based on the M1 and has half as much RAM (7 GB,
         # instead of 14 GB) which is too little for us right now. Revisit when `dfr` commands are
         # removed and we're only building the `polars` plugin instead
-        platform: [windows-latest, macos-13, ubuntu-20.04]
+        platform: [windows-latest, macos-13, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}
 
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-20.04]
+        platform: [windows-latest, macos-latest, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}
 
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ubuntu-20.04, macos-latest, windows-latest]
+        platform: [ubuntu-22.04, macos-latest, windows-latest]
         py:
           - py
 
@@ -137,7 +137,7 @@ jobs:
         # instead of 14 GB) which is too little for us right now.
         #
         # Failure occurring with clippy for rust 1.77.2
-        platform: [windows-latest, macos-13, ubuntu-20.04]
+        platform: [windows-latest, macos-13, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
The release workflow is already on 22.04 for a while. But our tests
where still with 20.04 which is close to end of life

Closes #15052
