### PR TITLE
Revert `/` vi binding due to priority bug

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -707,11 +707,6 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
         EditBindings::Vi => {
             add_menu_keybindings(&mut insert_keybindings);
             add_menu_keybindings(&mut normal_keybindings);
-            normal_keybindings.add_binding(
-                KeyModifiers::NONE,
-                KeyCode::Char('/'),
-                ReedlineEvent::Menu("history_menu".to_string()),
-            );
         }
     }
     for keybinding in parsed_keybindings {


### PR DESCRIPTION
Manually added bindings take priority to the vi-mode state machine in
reedline thus this addition blocked the use of `f/`/`t/` etc.

Partial revert of #14908

Addresses #15096 with a temporary fix. The full solution of that should
resolve it on the reedline side so you can have both the search option
and the availability of `/` in normal mode bindings
