### PR TITLE
feat(lsp): hover on external command shows manpage

### DIFF
--- a/crates/nu-lsp/src/ast.rs
+++ b/crates/nu-lsp/src/ast.rs
@@ -302,6 +302,14 @@ fn find_id_in_expr(
                     .unwrap_or_default()
             }
         }
+        Expr::ExternalCall(head, _) => {
+            if head.span.contains(*location) {
+                if let Expr::GlobPattern(cmd, _) = &head.expr {
+                    return FindMapResult::Found((Id::External(cmd.clone()), head.span));
+                }
+            }
+            FindMapResult::Continue
+        }
         Expr::FullCellPath(fcp) => {
             if fcp.head.span.contains(*location) {
                 FindMapResult::Continue

--- a/crates/nu-lsp/src/hints.rs
+++ b/crates/nu-lsp/src/hints.rs
@@ -145,7 +145,7 @@ fn extract_inlay_hints_from_expression(
 
 impl LanguageServer {
     pub(crate) fn get_inlay_hints(&mut self, params: &InlayHintParams) -> Option<Vec<InlayHint>> {
-        Some(self.inlay_hints.get(&params.text_document.uri)?.clone())
+        self.inlay_hints.get(&params.text_document.uri).cloned()
     }
 
     pub(crate) fn extract_inlay_hints(

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -594,14 +594,12 @@ impl LanguageServer {
                     .const_val
                     .clone()
                     .and_then(|v| v.coerce_into_string().ok())
-                    .map(|s| format!("\n---\n{}", s))
-                    .unwrap_or_default();
-                let contents = format!(
-                    "{} ```\n{}\n``` {}",
-                    if var.mutable { "mutable " } else { "" },
-                    var.ty,
-                    value
-                );
+                    .unwrap_or(String::from(if var.mutable {
+                        "mutable"
+                    } else {
+                        "immutable"
+                    }));
+                let contents = format!("```\n{}\n``` \n---\n{}", var.ty, value);
                 markdown_hover(contents)
             }
             Id::CellPath(var_id, cell_path) => {
@@ -929,7 +927,7 @@ mod tests {
 
         assert_json_eq!(
             result_from_message(resp),
-            serde_json::json!({ "contents": { "kind": "markdown", "value": " ```\ntable\n``` " } })
+            serde_json::json!({ "contents": { "kind": "markdown", "value": "```\ntable\n``` " } })
         );
     }
 

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -1011,12 +1011,16 @@ mod tests {
         open_unchecked(&client_connection, script.clone());
         let resp = send_hover_request(&client_connection, script.clone(), 6, 2);
 
-        assert!(result_from_message(resp)
+        let hover_text = result_from_message(resp)
             .pointer("/contents/value")
             .unwrap()
             .as_str()
             .unwrap()
-            .starts_with("SLEEP(1)"))
+            .to_string();
+        #[cfg(not(windows))]
+        assert!(hover_text.starts_with("SLEEP(1)"));
+        #[cfg(windows)]
+        assert!(hover_text.starts_with("No manpage found for sleep"));
     }
 
     #[test]

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -927,7 +927,7 @@ mod tests {
 
         assert_json_eq!(
             result_from_message(resp),
-            serde_json::json!({ "contents": { "kind": "markdown", "value": "```\ntable\n``` " } })
+            serde_json::json!({ "contents": { "kind": "markdown", "value": "```\ntable\n``` \n---\nimmutable" } })
         );
     }
 

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -647,7 +647,7 @@ impl LanguageServer {
                     Ok(output) => String::from_utf8_lossy(&output.stdout).to_string(),
                     Err(_) => format!("No command help found for {}", &cmd),
                 };
-                markdown_hover(manpage_str.to_string())
+                markdown_hover(manpage_str)
             }
         }
     }

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -43,6 +43,7 @@ pub(crate) enum Id {
     Value(Type),
     Module(ModuleId),
     CellPath(VarId, Vec<PathMember>),
+    External(String),
 }
 
 pub struct LanguageServer {
@@ -634,6 +635,14 @@ impl LanguageServer {
                 markdown_hover(description)
             }
             Id::Value(t) => markdown_hover(format!("`{}`", t)),
+            Id::External(cmd) => {
+                let output = std::process::Command::new("man").arg(&cmd).output();
+                let manpage_str = match output {
+                    Ok(output) => String::from_utf8_lossy(&output.stdout).to_string(),
+                    Err(_) => format!("No manpage found for {}", &cmd),
+                };
+                markdown_hover(manpage_str.to_string())
+            }
         }
     }
 
@@ -987,6 +996,27 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn hover_on_external_command() {
+        let (client_connection, _recv) = initialize_language_server(None);
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("hover");
+        script.push("command.nu");
+        let script = path_to_uri(&script);
+
+        open_unchecked(&client_connection, script.clone());
+        let resp = send_hover_request(&client_connection, script.clone(), 6, 2);
+
+        assert!(result_from_message(resp)
+            .pointer("/contents/value")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .starts_with("SLEEP(1)"))
     }
 
     #[test]

--- a/crates/nu-lsp/src/symbols.rs
+++ b/crates/nu-lsp/src/symbols.rs
@@ -274,9 +274,9 @@ impl LanguageServer {
         let uri = params.text_document.uri.to_owned();
         let docs = self.docs.lock().ok()?;
         self.symbol_cache.update(&uri, &engine_state, &docs);
-        Some(DocumentSymbolResponse::Flat(
-            self.symbol_cache.get_symbols_by_uri(&uri)?,
-        ))
+        self.symbol_cache
+            .get_symbols_by_uri(&uri)
+            .map(DocumentSymbolResponse::Flat)
     }
 
     pub(crate) fn workspace_symbol(

--- a/tests/fixtures/lsp/hover/command.nu
+++ b/tests/fixtures/lsp/hover/command.nu
@@ -1,6 +1,7 @@
 # Renders some greeting message
-def hello [] {}
+def hello [] { }
 
 hello
 
 [""] | str join
+^sleep


### PR DESCRIPTION
# Description

<img width="642" alt="image" src="https://github.com/user-attachments/assets/a97e4f33-df12-4240-a221-d4b97a171de0" />

Not particularly useful, but better than showing nothing I guess. #14464 

Also fixed a markdown syntax issue for mutable variable hovering

# User-Facing Changes

# Tests + Formatting

+1

# After Submitting
