### PR TITLE
docs(chunks): make `chunks` easier to discover for binary data

### DIFF
--- a/crates/nu-command/src/filters/chunks.rs
+++ b/crates/nu-command/src/filters/chunks.rs
@@ -25,7 +25,7 @@ impl Command for Chunks {
     }
 
     fn description(&self) -> &str {
-        "Divide a list or table into chunks of `chunk_size`."
+        "Divide a list, table or binary input into chunks of `chunk_size`."
     }
 
     fn extra_description(&self) -> &str {
@@ -33,7 +33,7 @@ impl Command for Chunks {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["batch", "group"]
+        vec!["batch", "group", "split", "bytes"]
     }
 
     fn examples(&self) -> Vec<Example> {


### PR DESCRIPTION
# Description
There has been multiple instances of users being unable to discover that `chunks` can be used with binary data.
This should make it easier for users to discover that (using `help -f`).

# User-Facing Changes
Help text of `chunks` updated as mentioned above.

# Tests + Formatting

- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting

Should we consider mentioning commands that can work with binary input (first, take, chunks, etc) in the help text for `bytes`?