### PR TITLE
Add `buffer_editor` example with arguments in `config nu --doc`

### DIFF
--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -97,6 +97,8 @@ $env.config.edit_mode = "emacs"
 # Tip: Set to "editor" to use the default editor on Unix platforms using
 #      the Alternatives system or equivalent
 $env.config.buffer_editor = "editor"
+# To set arguments for the editor, a list can be used:
+$env.config.buffer_editor = ["emacsclient", "-s", "light", "-t"]
 
 # cursor_shape_* (string)
 # -----------------------


### PR DESCRIPTION
# Description

Counterpart to https://github.com/nushell/nushell.github.io/pull/1810 - Adds an example to the `config nu --doc` for using a `buffer_editor` with arguments.

Closes https://github.com/nushell/nushell.github.io/issues/1660 and resolves the main issue in #14893, but we'll leave it open based on [this suggestion](https://github.com/nushell/nushell/issues/14893#issuecomment-2607670442)

# User-Facing Changes

Doc/help only

# Tests + Formatting

N/A

# After Submitting

N/A