### PR TITLE
Fix failing test when using man version 2.13.0

### DIFF
--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -1025,7 +1025,7 @@ mod tests {
             .to_string();
 
         #[cfg(not(windows))]
-        assert!(hover_text.starts_with("SLEEP(1)"));
+        assert!(hover_text.contains("SLEEP"));
         #[cfg(windows)]
         assert!(hover_text.starts_with("NAME\r\n    Start-Sleep"));
     }


### PR DESCRIPTION
# Description

The test added in #15115 fails on systems using later versions of `man` (2.13.0 triggers the issue, at least). This updates the test to ignore formatting characters. There may still be an issue with the actual implementation of #15115 on systems with that `man` version, but I haven't been able to test that yet.

Thanks to @fdncred and @blindFS for the debugging assistance.

# User-Facing Changes

None - test only.

# Tests + Formatting

One test updated:

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A