### PR TITLE
 fix $env.FILE_PWD and $env.CURRENT_FILE inside overlay use

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -125,16 +125,6 @@ impl Command for OverlayUse {
                     caller_stack,
                     get_dirs_var_from_call(caller_stack, call),
                 )?;
-                // module_arg_str maybe a directory, in this case
-                // find_in_dirs_env returns a directory.
-                let maybe_parent = maybe_file_path_or_dir.as_ref().and_then(|path| {
-                    if path.is_dir() {
-                        Some(path.to_path_buf())
-                    } else {
-                        path.parent().map(|p| p.to_path_buf())
-                    }
-                });
-
                 let block = engine_state.get_block(block_id);
                 let mut callee_stack = caller_stack
                     .gather_captures(engine_state, &block.captures)

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -1,4 +1,4 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
+use nu_test_support::fs::Stub::{FileWithContent, FileWithContentToBeTrimmed};
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, nu_repl_code};
 use pretty_assertions::assert_eq;
@@ -1407,4 +1407,48 @@ fn overlay_help_no_error() {
     assert!(actual.err.is_empty());
     let actual = nu!("overlay use -h");
     assert!(actual.err.is_empty());
+}
+
+#[test]
+fn test_overlay_use_with_printing_file_pwd() {
+    Playground::setup("use_with_printing_file_pwd", |dirs, nu| {
+        let file = dirs.test().join("mod.nu");
+        nu.with_files(&[FileWithContent(
+            file.as_os_str().to_str().unwrap(),
+            r#"
+                export-env {
+                    print $env.FILE_PWD
+                }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            "overlay use ."
+        );
+
+        assert_eq!(actual.out, dirs.test().to_string_lossy());
+    });
+}
+
+#[test]
+fn test_overlay_use_with_printing_current_file() {
+    Playground::setup("use_with_printing_current_file", |dirs, nu| {
+        let file = dirs.test().join("mod.nu");
+        nu.with_files(&[FileWithContent(
+            file.as_os_str().to_str().unwrap(),
+            r#"
+                export-env {
+                    print $env.CURRENT_FILE
+                }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            "overlay use ."
+        );
+
+        assert_eq!(actual.out, dirs.test().join("mod.nu").to_string_lossy());
+    });
 }

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -1412,8 +1412,8 @@ fn overlay_help_no_error() {
 #[test]
 fn test_overlay_use_with_printing_file_pwd() {
     Playground::setup("use_with_printing_file_pwd", |dirs, nu| {
-        let file = dirs.test().join("mod.nu");
-        nu.with_files(&[FileWithContent(
+        let file = dirs.test().join("foo").join("mod.nu");
+        nu.mkdir("foo").with_files(&[FileWithContent(
             file.as_os_str().to_str().unwrap(),
             r#"
                 export-env {
@@ -1424,18 +1424,18 @@ fn test_overlay_use_with_printing_file_pwd() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            "overlay use ."
+            "overlay use foo"
         );
 
-        assert_eq!(actual.out, dirs.test().to_string_lossy());
+        assert_eq!(actual.out, dirs.test().join("foo").to_string_lossy());
     });
 }
 
 #[test]
 fn test_overlay_use_with_printing_current_file() {
     Playground::setup("use_with_printing_current_file", |dirs, nu| {
-        let file = dirs.test().join("mod.nu");
-        nu.with_files(&[FileWithContent(
+        let file = dirs.test().join("foo").join("mod.nu");
+        nu.mkdir("foo").with_files(&[FileWithContent(
             file.as_os_str().to_str().unwrap(),
             r#"
                 export-env {
@@ -1446,9 +1446,12 @@ fn test_overlay_use_with_printing_current_file() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            "overlay use ."
+            "overlay use foo"
         );
 
-        assert_eq!(actual.out, dirs.test().join("mod.nu").to_string_lossy());
+        assert_eq!(
+            actual.out,
+            dirs.test().join("foo").join("mod.nu").to_string_lossy()
+        );
     });
 }


### PR DESCRIPTION
# Description
Fixes: #14540
The change is similar to #14101

User input can be a directory, in this case, we need to use the return value of find_in_dirs_env carefully, so in case, I renamed maybe_file_path to maybe_file_path_or_dir to emphasize it.

# User-Facing Changes
NaN

# Tests + Formatting
Added 2 test cases

# After Submitting
