### PR TITLE
Remove inheritance for PROMPT variables created in `default_env.nu`

### DIFF
--- a/crates/nu-utils/src/default_files/default_env.nu
+++ b/crates/nu-utils/src/default_files/default_env.nu
@@ -3,7 +3,7 @@
 #
 # version = "0.102.1"
 
-$env.PROMPT_COMMAND = $env.PROMPT_COMMAND? | default {||
+$env.PROMPT_COMMAND = {||
     let dir = match (do -i { $env.PWD | path relative-to $nu.home-path }) {
         null => $env.PWD
         '' => '~'
@@ -17,7 +17,7 @@ $env.PROMPT_COMMAND = $env.PROMPT_COMMAND? | default {||
     $path_segment | str replace --all (char path_sep) $"($separator_color)(char path_sep)($path_color)"
 }
 
-$env.PROMPT_COMMAND_RIGHT = $env.PROMPT_COMMAND_RIGHT? | default {||
+$env.PROMPT_COMMAND_RIGHT = {||
     # create a right prompt in magenta with green separators and am/pm underlined
     let time_segment = ([
         (ansi reset)


### PR DESCRIPTION
# Description

As far as I can tell, there's no useful situation in which allowing inheritance of `$env.PROMPT_COMMAND` or `$env.PROMPT_COMMAND_RIGHT` is a good idea. I added that in #14467, but it causes the issue mentioned in #15116. If the `PROMPT_COMMAND` is a closure (as it typically should be), then it doesn't even get inherited anyway, since Nushell can't export closures.  Any time the `PROMPT_COMMAND` is inherited, it must be a string or other basic value, and that means it probably came from the POSIX setup and will fail as in #15116.

This PR always sets a fresh `PROMPT_COMMAND` and `PROMPT_COMMAND_RIGHT` during startup in `default_env.nu`.  This is a more "sensible default", and can then be overridden with user config later in the startup.

# User-Facing Changes

Should be bug-fix-only.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A