### PR TITLE
add `attr category` `@category` to custom command attributes

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1317,7 +1317,7 @@ fn attribute_completions() {
     let suggestions = completer.complete("@", 1);
 
     // Only checking for the builtins and not the std attributes
-    let expected: Vec<String> = vec!["example".into(), "search-terms".into()];
+    let expected: Vec<String> = vec!["category".into(), "example".into(), "search-terms".into()];
 
     // Match results
     match_suggestions(&expected, &suggestions);

--- a/crates/nu-cmd-lang/src/core_commands/attr/category.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/category.rs
@@ -1,0 +1,61 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct AttrCategory;
+
+impl Command for AttrCategory {
+    fn name(&self) -> &str {
+        "attr category"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("attr category")
+            .input_output_type(Type::Nothing, Type::list(Type::String))
+            .allow_variants_without_examples(true)
+            .required(
+                "category",
+                SyntaxShape::String,
+                "Category of the custom command.",
+            )
+            .category(Category::Core)
+    }
+
+    fn description(&self) -> &str {
+        "Attribute for adding a category to custom commands."
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let arg: String = call.req(engine_state, stack, 0)?;
+        Ok(Value::string(arg, call.head).into_pipeline_data())
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let arg: String = call.req_const(working_set, 0)?;
+        Ok(Value::string(arg, call.head).into_pipeline_data())
+    }
+
+    fn is_const(&self) -> bool {
+        true
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Add a category to a custom command",
+            example: r###"# Double numbers
+    @category math
+    def double []: [number -> number] { $in * 2 }"###,
+            result: None,
+        }]
+    }
+}

--- a/crates/nu-cmd-lang/src/core_commands/attr/mod.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/mod.rs
@@ -1,5 +1,7 @@
+mod category;
 mod example;
 mod search_terms;
 
+pub use category::AttrCategory;
 pub use example::AttrExample;
 pub use search_terms::AttrSearchTerms;

--- a/crates/nu-cmd-lang/src/default_context.rs
+++ b/crates/nu-cmd-lang/src/default_context.rs
@@ -16,6 +16,7 @@ pub fn create_default_context() -> EngineState {
         // Core
         bind_command! {
             Alias,
+            AttrCategory,
             AttrExample,
             AttrSearchTerms,
             Break,

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -1027,7 +1027,7 @@ mod tests {
         #[cfg(not(windows))]
         assert!(hover_text.contains("SLEEP"));
         #[cfg(windows)]
-        assert!(hover_text.starts_with("NAME\r\n    Start-Sleep"));
+        assert!(hover_text.contains("Start-Sleep"));
     }
 
     #[test]

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -113,6 +113,42 @@ impl std::fmt::Display for Category {
     }
 }
 
+pub fn category_from_string(category: &str) -> Category {
+    match category {
+        "bits" => Category::Bits,
+        "bytes" => Category::Bytes,
+        "chart" => Category::Chart,
+        "conversions" => Category::Conversions,
+        "core" => Category::Core,
+        "database" => Category::Database,
+        "date" => Category::Date,
+        "debug" => Category::Debug,
+        "default" => Category::Default,
+        "deprecated" => Category::Deprecated,
+        "removed" => Category::Removed,
+        "env" => Category::Env,
+        "experimental" => Category::Experimental,
+        "filesystem" => Category::FileSystem,
+        "filter" => Category::Filters,
+        "formats" => Category::Formats,
+        "generators" => Category::Generators,
+        "hash" => Category::Hash,
+        "history" => Category::History,
+        "math" => Category::Math,
+        "misc" => Category::Misc,
+        "network" => Category::Network,
+        "path" => Category::Path,
+        "platform" => Category::Platform,
+        "plugin" => Category::Plugin,
+        "random" => Category::Random,
+        "shells" => Category::Shells,
+        "strings" => Category::Strings,
+        "system" => Category::System,
+        "viewers" => Category::Viewers,
+        _ => Category::Custom(category.to_string()),
+    }
+}
+
 /// Signature information of a [`Command`]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Signature {

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -119,7 +119,8 @@ pub fn category_from_string(category: &str) -> Category {
         "bytes" => Category::Bytes,
         "chart" => Category::Chart,
         "conversions" => Category::Conversions,
-        "core" => Category::Core,
+        // Let's protect our own "core" commands by preventing scripts from having this category.
+        "core" => Category::Custom("custom_core".to_string()),
         "database" => Category::Database,
         "date" => Category::Date,
         "debug" => Category::Debug,


### PR DESCRIPTION
# Description

This PR adds the `@category` attribute to nushell for use with custom commands.

### Example Code
```nushell
# Some example with category
@category "math"
@search-terms "addition"
@example "add two numbers together" {
    blah 5 6
} --result 11
def blah [
  a: int # First number to add
  b: int # Second number to add
  ] {
    $a + $b
}
```
#### Source & Help
```nushell
❯ source blah.nu
❯ help blah
Some example with category

Search terms: addition

Usage:
  > blah <a> <b>

Flags:
  -h, --help: Display the help message for this command

Parameters:
  a <int>: First number to add
  b <int>: Second number to add

Input/output types:
  ╭─#─┬─input─┬─output─╮
  │ 0 │ any   │ any    │
  ╰───┴───────┴────────╯

Examples:
  add two numbers together
  > blah 5 6
  11
```
#### Show the category
```nushell
❯ help commands | where name == blah
╭─#─┬─name─┬─category─┬─command_type─┬────────description─────────┬─────params─────┬──input_output──┬─search_terms─┬─is_const─╮
│ 0 │ blah │ math     │ custom       │ Some example with category │ [table 3 rows] │ [list 0 items] │ addition     │ false    │
╰───┴──────┴──────────┴──────────────┴────────────────────────────┴────────────────┴────────────────┴──────────────┴──────────╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

/cc @Bahex 