### PR TITLE
check signals in `nu-glob` and `ls`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3762,6 +3762,7 @@ name = "nu-glob"
 version = "0.102.1"
 dependencies = [
  "doc-comment",
+ "nu-protocol",
 ]
 
 [[package]]

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -95,16 +95,17 @@ impl Command for Open {
             let arg_span = path.span;
             // let path_no_whitespace = &path.item.trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
 
-            for path in nu_engine::glob_from(&path, &cwd, call_span, None)
-                .map_err(|err| match err {
-                    ShellError::Io(mut err) => {
-                        err.kind = err.kind.not_found_as(NotFound::File);
-                        err.span = arg_span;
-                        err.into()
-                    }
-                    _ => err,
-                })?
-                .1
+            for path in
+                nu_engine::glob_from(&path, &cwd, call_span, None, engine_state.signals().clone())
+                    .map_err(|err| match err {
+                        ShellError::Io(mut err) => {
+                            err.kind = err.kind.not_found_as(NotFound::File);
+                            err.span = arg_span;
+                            err.into()
+                        }
+                        _ => err,
+                    })?
+                    .1
             {
                 let path = path?;
                 let path = Path::new(&path);

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -260,6 +260,7 @@ fn rm(
                 require_literal_leading_dot: true,
                 ..Default::default()
             }),
+            engine_state.signals().clone(),
         ) {
             Ok(files) => {
                 for file in files.1 {

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -193,7 +193,7 @@ impl Command for UCp {
         for mut p in paths {
             p.item = p.item.strip_ansi_string_unlikely();
             let exp_files: Vec<Result<PathBuf, ShellError>> =
-                nu_engine::glob_from(&p, &cwd, call.head, None)
+                nu_engine::glob_from(&p, &cwd, call.head, None, engine_state.signals().clone())
                     .map(|f| f.1)?
                     .collect();
             if exp_files.is_empty() {

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -134,7 +134,7 @@ impl Command for UMv {
         for mut p in paths {
             p.item = p.item.strip_ansi_string_unlikely();
             let exp_files: Vec<Result<PathBuf, ShellError>> =
-                nu_engine::glob_from(&p, &cwd, call.head, None)
+                nu_engine::glob_from(&p, &cwd, call.head, None, engine_state.signals().clone())
                     .map(|f| f.1)?
                     .collect();
             if exp_files.is_empty() {

--- a/crates/nu-command/src/filesystem/utouch.rs
+++ b/crates/nu-command/src/filesystem/utouch.rs
@@ -158,14 +158,17 @@ impl Command for UTouch {
                     continue;
                 }
 
-                let mut expanded_globs = glob(&file_path.to_string_lossy())
-                    .unwrap_or_else(|_| {
-                        panic!(
-                            "Failed to process file path: {}",
-                            &file_path.to_string_lossy()
-                        )
-                    })
-                    .peekable();
+                let mut expanded_globs = glob(
+                    &file_path.to_string_lossy(),
+                    Some(engine_state.signals().clone()),
+                )
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "Failed to process file path: {}",
+                        &file_path.to_string_lossy()
+                    )
+                })
+                .peekable();
 
                 if expanded_globs.peek().is_none() {
                     let file_name = file_path.file_name().unwrap_or_else(|| {

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -334,9 +334,14 @@ pub fn eval_external_arguments(
         match arg {
             // Expand globs passed to run-external
             Value::Glob { val, no_expand, .. } if !no_expand => args.extend(
-                expand_glob(&val, cwd.as_std_path(), span, engine_state.signals())?
-                    .into_iter()
-                    .map(|s| s.into_spanned(span)),
+                expand_glob(
+                    &val,
+                    cwd.as_std_path(),
+                    span,
+                    engine_state.signals().clone(),
+                )?
+                .into_iter()
+                .map(|s| s.into_spanned(span)),
             ),
             other => args
                 .push(OsString::from(coerce_into_string(engine_state, other)?).into_spanned(span)),
@@ -367,7 +372,7 @@ fn expand_glob(
     arg: &str,
     cwd: &Path,
     span: Span,
-    signals: &Signals,
+    signals: Signals,
 ) -> Result<Vec<OsString>, ShellError> {
     // For an argument that isn't a glob, just do the `expand_tilde`
     // and `expand_ndots` expansion
@@ -379,7 +384,7 @@ fn expand_glob(
     // We must use `nu_engine::glob_from` here, in order to ensure we get paths from the correct
     // dir
     let glob = NuGlob::Expand(arg.to_owned()).into_spanned(span);
-    if let Ok((prefix, matches)) = nu_engine::glob_from(&glob, cwd, span, None) {
+    if let Ok((prefix, matches)) = nu_engine::glob_from(&glob, cwd, span, None, signals.clone()) {
         let mut result: Vec<OsString> = vec![];
 
         for m in matches {
@@ -692,30 +697,30 @@ mod test {
 
             let cwd = dirs.test().as_std_path();
 
-            let actual = expand_glob("*.txt", cwd, Span::unknown(), &Signals::empty()).unwrap();
+            let actual = expand_glob("*.txt", cwd, Span::unknown(), Signals::empty()).unwrap();
             let expected = &["a.txt", "b.txt"];
             assert_eq!(actual, expected);
 
-            let actual = expand_glob("./*.txt", cwd, Span::unknown(), &Signals::empty()).unwrap();
+            let actual = expand_glob("./*.txt", cwd, Span::unknown(), Signals::empty()).unwrap();
             assert_eq!(actual, expected);
 
-            let actual = expand_glob("'*.txt'", cwd, Span::unknown(), &Signals::empty()).unwrap();
+            let actual = expand_glob("'*.txt'", cwd, Span::unknown(), Signals::empty()).unwrap();
             let expected = &["'*.txt'"];
             assert_eq!(actual, expected);
 
-            let actual = expand_glob(".", cwd, Span::unknown(), &Signals::empty()).unwrap();
+            let actual = expand_glob(".", cwd, Span::unknown(), Signals::empty()).unwrap();
             let expected = &["."];
             assert_eq!(actual, expected);
 
-            let actual = expand_glob("./a.txt", cwd, Span::unknown(), &Signals::empty()).unwrap();
+            let actual = expand_glob("./a.txt", cwd, Span::unknown(), Signals::empty()).unwrap();
             let expected = &["./a.txt"];
             assert_eq!(actual, expected);
 
-            let actual = expand_glob("[*.txt", cwd, Span::unknown(), &Signals::empty()).unwrap();
+            let actual = expand_glob("[*.txt", cwd, Span::unknown(), Signals::empty()).unwrap();
             let expected = &["[*.txt"];
             assert_eq!(actual, expected);
 
-            let actual = expand_glob("~/foo.txt", cwd, Span::unknown(), &Signals::empty()).unwrap();
+            let actual = expand_glob("~/foo.txt", cwd, Span::unknown(), Signals::empty()).unwrap();
             let home = dirs::home_dir().expect("failed to get home dir");
             let expected: Vec<OsString> = vec![home.join("foo.txt").into()];
             assert_eq!(actual, expected);

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -1,6 +1,6 @@
 use nu_glob::MatchOptions;
 use nu_path::{canonicalize_with, expand_path_with};
-use nu_protocol::{shell_error::io::IoError, NuGlob, ShellError, Span, Spanned};
+use nu_protocol::{shell_error::io::IoError, NuGlob, ShellError, Signals, Span, Spanned};
 use std::{
     fs,
     path::{Component, Path, PathBuf},
@@ -19,6 +19,7 @@ pub fn glob_from(
     cwd: &Path,
     span: Span,
     options: Option<MatchOptions>,
+    signals: Signals,
 ) -> Result<
     (
         Option<PathBuf>,
@@ -90,7 +91,7 @@ pub fn glob_from(
     let pattern = pattern.to_string_lossy().to_string();
     let glob_options = options.unwrap_or_default();
 
-    let glob = nu_glob::glob_with(&pattern, glob_options).map_err(|e| {
+    let glob = nu_glob::glob_with(&pattern, glob_options, signals).map_err(|e| {
         nu_protocol::ShellError::GenericError {
             error: "Error extracting glob pattern".into(),
             msg: e.to_string(),

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["filesystem"]
 [lib]
 bench = false
 
+[dependencies]
+nu-protocol = { path = "../nu-protocol", version = "0.102.1", default-features = false }
+
 [dev-dependencies]
 doc-comment = "0.3"
 

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -42,7 +42,7 @@ fn find_nu_scripts_in_folder(folder_uri: &Uri) -> Result<nu_glob::Paths> {
         return Err(miette!("\nworkspace folder does not exist."));
     }
     let pattern = format!("{}/**/*.nu", path.to_string_lossy());
-    nu_glob::glob(&pattern).into_diagnostic()
+    nu_glob::glob(&pattern, None).into_diagnostic()
 }
 
 impl LanguageServer {

--- a/crates/nu-test-support/src/playground/play.rs
+++ b/crates/nu-test-support/src/playground/play.rs
@@ -231,7 +231,7 @@ impl Playground<'_> {
     }
 
     pub fn glob_vec(pattern: &str) -> Vec<std::path::PathBuf> {
-        let glob = glob(pattern);
+        let glob = glob(pattern, None);
 
         glob.expect("invalid pattern")
             .map(|path| {


### PR DESCRIPTION
Fixes #10144

# User-Facing Changes

Long running glob expansions and `ls` runs (e.g. `ls /**/*`) can now be
interrupted with ctrl-c.