### PR TITLE
Remove BACKTRACE message for non-panic errors

### DIFF
--- a/crates/nu-protocol/src/errors/cli_error.rs
+++ b/crates/nu-protocol/src/errors/cli_error.rs
@@ -50,10 +50,6 @@ pub fn report_compile_error(working_set: &StateWorkingSet, error: &CompileError)
 
 fn report_error(working_set: &StateWorkingSet, error: &dyn miette::Diagnostic) {
     eprintln!("Error: {:?}", CliError(error, working_set));
-    let have_no_backtrace = working_set.get_env_var("NU_BACKTRACE").is_none();
-    if have_no_backtrace {
-        eprintln!("set the `NU_BACKTRACE=1` environment variable to display a backtrace.")
-    }
     // reset vt processing, aka ansi because illbehaved externals can break it
     #[cfg(windows)]
     {

--- a/crates/nu-protocol/tests/test_config.rs
+++ b/crates/nu-protocol/tests/test_config.rs
@@ -60,7 +60,7 @@ fn fancy_default_errors() {
 
     assert_eq!(
         actual.err,
-        "Error:   \u{1b}[31m×\u{1b}[0m oh no!\n   ╭─[\u{1b}[36;1;4mline2:1:13\u{1b}[0m]\n \u{1b}[2m1\u{1b}[0m │ force_error \"My error\"\n   · \u{1b}[35;1m            ─────┬────\u{1b}[0m\n   ·                  \u{1b}[35;1m╰── \u{1b}[35;1mhere's the error\u{1b}[0m\u{1b}[0m\n   ╰────\n\nset the `NU_BACKTRACE=1` environment variable to display a backtrace.\n"
+        "Error:   \u{1b}[31m×\u{1b}[0m oh no!\n   ╭─[\u{1b}[36;1;4mline2:1:13\u{1b}[0m]\n \u{1b}[2m1\u{1b}[0m │ force_error \"My error\"\n   · \u{1b}[35;1m            ─────┬────\u{1b}[0m\n   ·                  \u{1b}[35;1m╰── \u{1b}[35;1mhere's the error\u{1b}[0m\u{1b}[0m\n   ╰────\n\n"
     );
 }
 
@@ -92,7 +92,6 @@ snippet line 1: force_error "my error"
     label at line 1, columns 13 to 22: here's the error
 
 
-set the `NU_BACKTRACE=1` environment variable to display a backtrace.
 "#,
     );
 }


### PR DESCRIPTION
# Description

Resolves #15070 by removing the `BACKTRACE` message from all Nushell (non-panic) errors.  This was added in #14945 and is useful for debugging, but not all that helpful to the typical shell user, especially since most shell errors won't have a backtrace anyway.

At some point it would be nice to display this message only when there *is* a backtrace available.

# User-Facing Changes

Error messages will be more concise.

# Tests + Formatting

Updated tests.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

We should include information in the *"Custom Commands"* chapter of the documentation on how to enable this for debugging.