### PR TITLE
More precise `ErrorKind::NotFound` errors

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -8,7 +8,7 @@ use nu_protocol::{
     debugger::WithoutDebug,
     engine::{EngineState, Stack, StateWorkingSet},
     report_parse_error, report_parse_warning,
-    shell_error::io::IoError,
+    shell_error::io::*,
     PipelineData, ShellError, Span, Value,
 };
 use std::{path::PathBuf, sync::Arc};
@@ -28,7 +28,7 @@ pub fn evaluate_file(
 
     let file_path = canonicalize_with(&path, cwd).map_err(|err| {
         IoError::new_internal_with_path(
-            err.kind(),
+            err.kind().not_found_as(NotFound::File),
             "Could not access file",
             nu_protocol::location!(),
             PathBuf::from(&path),
@@ -47,7 +47,7 @@ pub fn evaluate_file(
 
     let file = std::fs::read(&file_path).map_err(|err| {
         IoError::new_internal_with_path(
-            err.kind(),
+            err.kind().not_found_as(NotFound::File),
             "Could not read file",
             nu_protocol::location!(),
             file_path.clone(),
@@ -57,7 +57,7 @@ pub fn evaluate_file(
 
     let parent = file_path.parent().ok_or_else(|| {
         IoError::new_internal_with_path(
-            std::io::ErrorKind::NotFound,
+            ErrorKind::DirectoryNotFound,
             "The file path does not have a parent",
             nu_protocol::location!(),
             file_path.clone(),

--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -1,7 +1,5 @@
 use chrono::Local;
 use nu_engine::command_prelude::*;
-
-use nu_protocol::shell_error::io::IoError;
 use nu_utils::{get_scaffold_config, get_scaffold_env};
 use std::{io::Write, path::PathBuf};
 
@@ -61,7 +59,7 @@ impl Command for ConfigReset {
                 ));
                 if let Err(err) = std::fs::rename(nu_config.clone(), &backup_path) {
                     return Err(ShellError::Io(IoError::new_with_additional_context(
-                        err.kind(),
+                        err.kind().not_found_as(NotFound::Directory),
                         span,
                         PathBuf::from(backup_path),
                         "config.nu could not be backed up",
@@ -71,7 +69,7 @@ impl Command for ConfigReset {
             if let Ok(mut file) = std::fs::File::create(&nu_config) {
                 if let Err(err) = writeln!(&mut file, "{config_file}") {
                     return Err(ShellError::Io(IoError::new_with_additional_context(
-                        err.kind(),
+                        err.kind().not_found_as(NotFound::File),
                         span,
                         PathBuf::from(nu_config),
                         "config.nu could not be written to",
@@ -88,7 +86,7 @@ impl Command for ConfigReset {
                 backup_path.push(format!("oldenv-{}.nu", Local::now().format("%F-%H-%M-%S"),));
                 if let Err(err) = std::fs::rename(env_config.clone(), &backup_path) {
                     return Err(ShellError::Io(IoError::new_with_additional_context(
-                        err.kind(),
+                        err.kind().not_found_as(NotFound::Directory),
                         span,
                         PathBuf::from(backup_path),
                         "env.nu could not be backed up",
@@ -98,7 +96,7 @@ impl Command for ConfigReset {
             if let Ok(mut file) = std::fs::File::create(&env_config) {
                 if let Err(err) = writeln!(&mut file, "{config_file}") {
                     return Err(ShellError::Io(IoError::new_with_additional_context(
-                        err.kind(),
+                        err.kind().not_found_as(NotFound::File),
                         span,
                         PathBuf::from(env_config),
                         "env.nu could not be written to",

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -86,7 +86,7 @@ impl Command for Cd {
                             path
                         } else {
                             return Err(shell_error::io::IoError::new(
-                                std::io::ErrorKind::NotFound,
+                                ErrorKind::DirectoryNotFound,
                                 v.span,
                                 PathBuf::from(path_no_whitespace),
                             )
@@ -96,7 +96,7 @@ impl Command for Cd {
                         let path = nu_path::expand_path_with(path_no_whitespace, &cwd, true);
                         if !path.exists() {
                             return Err(shell_error::io::IoError::new(
-                                std::io::ErrorKind::NotFound,
+                                ErrorKind::DirectoryNotFound,
                                 v.span,
                                 PathBuf::from(path_no_whitespace),
                             )

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -98,6 +98,7 @@ impl Command for Open {
             for path in nu_engine::glob_from(&path, &cwd, call_span, None)
                 .map_err(|err| match err {
                     ShellError::Io(mut err) => {
+                        err.kind = err.kind.not_found_as(NotFound::File);
                         err.span = arg_span;
                         err.into()
                     }

--- a/crates/nu-command/src/misc/source.rs
+++ b/crates/nu-command/src/misc/source.rs
@@ -55,8 +55,13 @@ impl Command for Source {
         let cwd = engine_state.cwd_as_string(Some(stack))?;
         let pb = std::path::PathBuf::from(block_id_name);
         let parent = pb.parent().unwrap_or(std::path::Path::new(""));
-        let file_path = canonicalize_with(pb.as_path(), cwd)
-            .map_err(|err| IoError::new(err.kind(), call.head, pb.clone()))?;
+        let file_path = canonicalize_with(pb.as_path(), cwd).map_err(|err| {
+            IoError::new(
+                err.kind().not_found_as(NotFound::File),
+                call.head,
+                pb.clone(),
+            )
+        })?;
 
         // Note: We intentionally left out PROCESS_PATH since it's supposed to
         // to work like argv[0] in C, which is the name of the program being executed.

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -98,7 +98,7 @@ impl Command for NuCheck {
                         Ok(Some(path)) => path,
                         Ok(None) => {
                             return Err(ShellError::Io(IoError::new(
-                                std::io::ErrorKind::NotFound,
+                                ErrorKind::FileNotFound,
                                 path_span,
                                 PathBuf::from(path_str.item),
                             )))
@@ -255,7 +255,7 @@ fn parse_file_script(
     match std::fs::read(path) {
         Ok(contents) => parse_script(working_set, Some(&filename), &contents, is_debug, call_head),
         Err(err) => Err(ShellError::Io(IoError::new(
-            err.kind(),
+            err.kind().not_found_as(NotFound::File),
             path_span,
             PathBuf::from(path),
         ))),

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -210,7 +210,7 @@ fn filesystem_directory_not_found() {
             actual.err
         );
         assert!(
-            actual.err.contains("nu::shell::io::not_found"),
+            actual.err.contains("nu::shell::io::directory_not_found"),
             "actual={:?}",
             actual.err
         );

--- a/crates/nu-command/tests/commands/nu_check.rs
+++ b/crates/nu-command/tests/commands/nu_check.rs
@@ -172,7 +172,7 @@ fn file_not_exist() {
             "
         ));
 
-        assert!(actual.err.contains("nu::shell::io::not_found"));
+        assert!(actual.err.contains("nu::shell::io::file_not_found"));
     })
 }
 

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -251,7 +251,7 @@ fn errors_if_file_not_found() {
     // This seems to be not directly affected by localization compared to the OS
     // provided error message
 
-    assert!(actual.err.contains("nu::shell::io::not_found"));
+    assert!(actual.err.contains("nu::shell::io::file_not_found"));
     assert!(actual.err.contains(
         &PathBuf::from_iter(["tests", "fixtures", "formats", "i_dont_exist.txt"])
             .display()

--- a/crates/nu-engine/src/command_prelude.rs
+++ b/crates/nu-engine/src/command_prelude.rs
@@ -3,7 +3,7 @@ pub use nu_protocol::{
     ast::CellPath,
     engine::{Call, Command, EngineState, Stack, StateWorkingSet},
     record,
-    shell_error::io::IoError,
+    shell_error::io::*,
     ByteStream, ByteStreamType, Category, ErrSpan, Example, IntoInterruptiblePipelineData,
     IntoPipelineData, IntoSpanned, IntoValue, PipelineData, Record, ShellError, Signature, Span,
     Spanned, SyntaxShape, Type, Value,

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -3,7 +3,7 @@ use nu_path::canonicalize_with;
 use nu_protocol::{
     ast::Expr,
     engine::{Call, EngineState, Stack, StateWorkingSet},
-    shell_error::io::IoError,
+    shell_error::io::{ErrorKindExt, IoError, NotFound},
     ShellError, Span, Type, Value, VarId,
 };
 use std::{
@@ -221,7 +221,7 @@ pub fn current_dir(engine_state: &EngineState, stack: &Stack) -> Result<PathBuf,
     // be an absolute path already.
     canonicalize_with(&cwd, ".").map_err(|err| {
         ShellError::Io(IoError::new_internal_with_path(
-            err.kind(),
+            err.kind().not_found_as(NotFound::Directory),
             "Could not canonicalize current dir",
             nu_protocol::location!(),
             PathBuf::from(cwd),
@@ -241,7 +241,7 @@ pub fn current_dir_const(working_set: &StateWorkingSet) -> Result<PathBuf, Shell
     // be an absolute path already.
     canonicalize_with(&cwd, ".").map_err(|err| {
         ShellError::Io(IoError::new_internal_with_path(
-            err.kind(),
+            err.kind().not_found_as(NotFound::Directory),
             "Could not canonicalize current dir",
             nu_protocol::location!(),
             PathBuf::from(cwd),

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -492,3 +492,12 @@ impl ErrorKindExt for std::io::ErrorKind {
         }
     }
 }
+
+impl ErrorKindExt for ErrorKind {
+    fn not_found_as(self, kind: NotFound) -> ErrorKind {
+        match self {
+            Self::Std(std_kind) => std_kind.not_found_as(kind),
+            _ => self,
+        }
+    }
+}

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -4,7 +4,7 @@ use nu_parser::{flatten_block, parse, FlatShape};
 use nu_protocol::{
     engine::{EngineState, Stack, StateWorkingSet},
     report_shell_error,
-    shell_error::io::IoError,
+    shell_error::io::{ErrorKindExt, IoError, NotFound},
     DeclId, ShellError, Span, Value, VarId,
 };
 use reedline::Completer;
@@ -58,7 +58,7 @@ fn read_in_file<'a>(
     let file = std::fs::read(file_path)
         .map_err(|err| {
             ShellError::Io(IoError::new_with_additional_context(
-                err.kind(),
+                err.kind().not_found_as(NotFound::File),
                 Span::unknown(),
                 PathBuf::from(file_path),
                 "Could not read file",


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

With my I/O error refactor #14927 I removed a lot of custom error variants and merged them all into `ShellError::Io`. This also removed variants that described that either a file or directory wasn't found. Often that error is too specific as the OS doesn't know what it should have found, so it just returns a `NotFound` error kind. But we as the application sometimes know what we expected and in these cases we should provide more details.

Hence in this PR, the two new variants for `ErrorKind`, `FileNotFound` and `DirectoryNotFound` with a nice `not_found_as` method for the `ErrorKind` to easily specify the `NotFound` errors. I also updated some places where I could of think of with these new variants and the message for `NotFound` is no longer "Entity not found" but "Not found" to be less strange.

Relevant [Discord #drawing-board Thread](https://discord.com/channels/601130461678272522/1341856247410065408).

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Some errors now return `nu::shell::io::file_not_found` or `nu::shell::io::directory_not_found` error codes instead of `nu::shell::io::not_found`.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

The behavior of `not_found_as` is tested inside the doc example.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

closes #15142
closes #15055