### PR TITLE
Transpose now rejects streams with non-record values

### DIFF
--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -182,6 +182,19 @@ pub fn transpose(
         }
     }
 
+    let first_non_record_value = input
+        .iter()
+        .find(|value| !matches!(value, Value::Record { .. }));
+
+    if let Some(non_record_value) = first_non_record_value {
+        return Err(ShellError::OnlySupportsThisInputType {
+            exp_input_type: "table or record".into(),
+            wrong_type: "list<any>".into(),
+            dst_span: call.head,
+            src_span: non_record_value.span(),
+        });
+    }
+
     let descs = get_columns(&input);
 
     let mut headers: Vec<String> = Vec::with_capacity(input.len());

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -179,14 +179,18 @@ pub fn transpose(
     // Ensure error values are propagated and non-record values are rejected
     for value in input.iter() {
         match value {
-            Value::Error { .. } => return Ok(value.clone().into_pipeline_data_with_metadata(metadata)),
-            Value::Record { .. } => { } // go on, this is what we're looking for
-            _ => return Err(ShellError::OnlySupportsThisInputType {
-                exp_input_type: "table or record".into(),
-                wrong_type: "list<any>".into(),
-                dst_span: call.head,
-                src_span: value.span(),
-            })
+            Value::Error { .. } => {
+                return Ok(value.clone().into_pipeline_data_with_metadata(metadata))
+            }
+            Value::Record { .. } => {} // go on, this is what we're looking for
+            _ => {
+                return Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "table or record".into(),
+                    wrong_type: "list<any>".into(),
+                    dst_span: call.head,
+                    src_span: value.span(),
+                })
+            }
         }
     }
 

--- a/crates/nu-command/tests/commands/transpose.rs
+++ b/crates/nu-command/tests/commands/transpose.rs
@@ -32,3 +32,11 @@ fn throw_inner_error() {
 
     assert!(actual.err.contains(error.as_str()));
 }
+
+#[test]
+fn rejects_non_table_stream_input() {
+    let actual = nu!("[1 2 3] | each { |it| ($it * 2) } | transpose | to nuon");
+
+    assert!(actual.out.is_empty());
+    assert!(actual.err.contains("only table"));
+}


### PR DESCRIPTION

<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

Closes #13765

Transpose now checks if the input consists entirely of records before doing its things, which is fine since it already `.collects()` all of its input already.

<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting

Adds `rejects_non_table_stream_input` test to cover regressions.
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
