### PR TITLE
`split list`: add streaming, closure argument, and splitting before/after a separator

### DIFF
--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -135,6 +135,34 @@ impl Command for SubCommand {
                     Span::test_data(),
                 )),
             },
+            Example {
+                description: "Split a list of numbers on multiples of 3",
+                example: r"[1 2 3 4 5 6 7 8 9] | split list {|e| $e mod 3 == 0 }",
+                result: Some(Value::test_list(vec![
+                    Value::test_list(vec![Value::test_int(1), Value::test_int(2)]),
+                    Value::test_list(vec![Value::test_int(4), Value::test_int(5)]),
+                    Value::test_list(vec![Value::test_int(7), Value::test_int(8)]),
+                ])),
+            },
+            Example {
+                description: "Split a list of numbers into lists ending with 0",
+                example: r"[1 2 0 3 4 5 0 6 0 0] | split list --split=after 0",
+                result: Some(Value::test_list(vec![
+                    Value::test_list(vec![
+                        Value::test_int(1),
+                        Value::test_int(2),
+                        Value::test_int(0),
+                    ]),
+                    Value::test_list(vec![
+                        Value::test_int(3),
+                        Value::test_int(4),
+                        Value::test_int(5),
+                        Value::test_int(0),
+                    ]),
+                    Value::test_list(vec![Value::test_int(6), Value::test_int(0)]),
+                    Value::test_list(vec![Value::test_int(0)]),
+                ])),
+            },
         ]
     }
 

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -137,16 +137,17 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Split a list of numbers on multiples of 3",
-                example: r"[1 2 3 4 5 6 7 8 9] | split list {|e| $e mod 3 == 0 }",
+                example: r"[1 2 3 4 5 6 7 8 9 10] | split list {|e| $e mod 3 == 0 }",
                 result: Some(Value::test_list(vec![
                     Value::test_list(vec![Value::test_int(1), Value::test_int(2)]),
                     Value::test_list(vec![Value::test_int(4), Value::test_int(5)]),
                     Value::test_list(vec![Value::test_int(7), Value::test_int(8)]),
+                    Value::test_list(vec![Value::test_int(10)]),
                 ])),
             },
             Example {
                 description: "Split a list of numbers into lists ending with 0",
-                example: r"[1 2 0 3 4 5 0 6 0 0] | split list --split=after 0",
+                example: r"[1 2 0 3 4 5 0 6 0 0 7] | split list --split=after 0",
                 result: Some(Value::test_list(vec![
                     Value::test_list(vec![
                         Value::test_int(1),
@@ -161,6 +162,7 @@ impl Command for SubCommand {
                     ]),
                     Value::test_list(vec![Value::test_int(6), Value::test_int(0)]),
                     Value::test_list(vec![Value::test_int(0)]),
+                    Value::test_list(vec![Value::test_int(7)]),
                 ])),
             },
         ]

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -147,7 +147,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Split a list of numbers into lists ending with 0",
-                example: r"[1 2 0 3 4 5 0 6 0 0 7] | split list --split=after 0",
+                example: r"[1 2 0 3 4 5 0 6 0 0 7] | split list --split after 0",
                 result: Some(Value::test_list(vec![
                     Value::test_list(vec![
                         Value::test_int(1),


### PR DESCRIPTION
- this PR addresses most of the points in #13153

# Description

- make `split list` support streaming
- **[BREAKING CHANGE]** if the input is split on consecutive items, the empty lists between those items are preserved.
  e.g. `[1 1 0 0 3 3 0 4 4] | split list 0` == `[[1 1] [] [2 2] [3 3]]`
- accept a closure as argument, the closure is called for each item, and if it returns `true` the list is split on that item
- added `--split` flag, which allows keeping the separator items.
  `--split=after` splits the list *after* the separator and `--split=before` splits the list *before* the separator.
  `--split=on` is the default behavior where the separator is lost

# User-Facing Changes

`split list`:
- keeps empty sublists
- allows using a closure to determine items to split on
- allows keeping the separator items with `--split=after` and `--split=before`

# Tests + Formatting

- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
N/A