### PR TITLE
allow bench to handle larger numbers

### DIFF
--- a/crates/nu-command/src/conversions/into/float.rs
+++ b/crates/nu-command/src/conversions/into/float.rs
@@ -148,7 +148,7 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
         Value::Error { .. } => input.clone(),
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "string, int, or bool".into(),
+                exp_input_type: "float, string, int, bool, duration, or filesize".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-command/src/conversions/into/float.rs
+++ b/crates/nu-command/src/conversions/into/float.rs
@@ -12,43 +12,12 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("into float")
             .input_output_types(vec![
-                (Type::String, Type::Float),
                 (Type::Int, Type::Float),
-                (Type::Number, Type::Float),
+                (Type::String, Type::Float),
                 (Type::Bool, Type::Float),
                 (Type::Float, Type::Float),
-                (Type::Duration, Type::Float),
-                (Type::Filesize, Type::Float),
                 (Type::table(), Type::table()),
                 (Type::record(), Type::record()),
-                (
-                    Type::List(Box::new(Type::String)),
-                    Type::List(Box::new(Type::Float)),
-                ),
-                (
-                    Type::List(Box::new(Type::Int)),
-                    Type::List(Box::new(Type::Float)),
-                ),
-                (
-                    Type::List(Box::new(Type::Number)),
-                    Type::List(Box::new(Type::Float)),
-                ),
-                (
-                    Type::List(Box::new(Type::Bool)),
-                    Type::List(Box::new(Type::Float)),
-                ),
-                (
-                    Type::List(Box::new(Type::Float)),
-                    Type::List(Box::new(Type::Float)),
-                ),
-                (
-                    Type::List(Box::new(Type::Duration)),
-                    Type::List(Box::new(Type::Float)),
-                ),
-                (
-                    Type::List(Box::new(Type::Filesize)),
-                    Type::List(Box::new(Type::Float)),
-                ),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Float)),
@@ -142,13 +111,11 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
             },
             span,
         ),
-        Value::Duration { val, .. } => Value::float(*val as f64, span),
-        Value::Filesize { val, .. } => Value::float(val.get() as f64, span),
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "float, string, int, bool, duration, or filesize".into(),
+                exp_input_type: "string, int or bool".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-command/src/conversions/into/float.rs
+++ b/crates/nu-command/src/conversions/into/float.rs
@@ -12,12 +12,43 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("into float")
             .input_output_types(vec![
-                (Type::Int, Type::Float),
                 (Type::String, Type::Float),
+                (Type::Int, Type::Float),
+                (Type::Number, Type::Float),
                 (Type::Bool, Type::Float),
                 (Type::Float, Type::Float),
+                (Type::Duration, Type::Float),
+                (Type::Filesize, Type::Float),
                 (Type::table(), Type::table()),
                 (Type::record(), Type::record()),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+                (
+                    Type::List(Box::new(Type::Int)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+                (
+                    Type::List(Box::new(Type::Bool)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+                (
+                    Type::List(Box::new(Type::Float)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+                (
+                    Type::List(Box::new(Type::Duration)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+                (
+                    Type::List(Box::new(Type::Filesize)),
+                    Type::List(Box::new(Type::Float)),
+                ),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Float)),
@@ -111,11 +142,13 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
             },
             span,
         ),
+        Value::Duration { val, .. } => Value::float(*val as f64, span),
+        Value::Filesize { val, .. } => Value::float(val.get() as f64, span),
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "string, int or bool".into(),
+                exp_input_type: "string, int, or bool".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-std/std/bench/mod.nu
+++ b/crates/nu-std/std/bench/mod.nu
@@ -43,7 +43,7 @@ export def main [
         mean: ($times | math avg)
         min: ($times | math min)
         max: ($times | math max)
-        std: ($times | into int | math stddev | into int | into duration)
+        std: ($times | into float | math stddev | into int | into duration)
         times: ($times)
     }
 

--- a/crates/nu-std/std/bench/mod.nu
+++ b/crates/nu-std/std/bench/mod.nu
@@ -43,7 +43,7 @@ export def main [
         mean: ($times | math avg)
         min: ($times | math min)
         max: ($times | math max)
-        std: ($times | into float | math stddev | into int | into duration)
+        std: ($times | into int | into float | math stddev | into int | into duration)
         times: ($times)
     }
 


### PR DESCRIPTION
# Description

This PR allows `bench` to handle larger numbers by using `into float` instead of `into int`. I also had to make some changes to `into float` to allow handling of durations and other data types that seemed reasonable. `into float` now more closely matches `into int`.

### Way Before (overflow)
```nushell
❯ def "compact keys" [--empty(-e)]: record -> record { transpose key value | filter (if $empty { {|rc| $rc.value | is-not-empty } } else {|rc| $rc.value != null }) | transpose -rd }
❯ use std/bench
❯ bench { open playlist.m3u8
| parse -r '^(?:(?:#EXT-X-PROGRAM-DATE-TIME:(?P<t>.+Z))|(?:#EXT-X-BYTERANGE:(?P<rng>\d+@\d+))|(?:#EXTINF:(?P<inf>\d+.?\d*),)|(?P<name>.+\.mp4))$' | par-each { if ($in.name? | is-not-empty) { [$in null] } else { [$in] } } | flatten | split list null | par-each {|rows|
    | each { compact keys -e }
    | into record
}} --pretty --rounds 4
Error: nu::shell::operator_overflow

  × Operator overflow.
    ╭─[std/bench/mod.nu:46:24]
 45 │         max: ($times | math max)
 46 │         std: ($times | into int | math stddev | into int | into duration)
    ·                        ────┬───
    ·                            ╰── multiply operation overflowed
 47 │         times: ($times)
    ╰────
  help: Consider using floating point values for increased range by promoting operand with 'into float'. Note: float has reduced
        precision!
```
### Before (into float datatypes)
```nushell
❯ def "compact keys" [--empty(-e)]: record -> record { transpose key value | filter (if $empty { {|rc| $rc.value | is-not-empty } } else {|rc| $rc.value != null }) | transpose -rd }
❯ use std/bench
❯ bench { open playlist.m3u8
| parse -r '^(?:(?:#EXT-X-PROGRAM-DATE-TIME:(?P<t>.+Z))|(?:#EXT-X-BYTERANGE:(?P<rng>\d+@\d+))|(?:#EXTINF:(?P<inf>\d+.?\d*),)|(?P<name>.+\.mp4))$' | par-each { if ($in.name? | is-not-empty) { [$in null] } else { [$in] } } | flatten | split list null | par-each {|rows|
    | each { compact keys -e }
    | into record
}} --pretty --rounds 10
Error: nu::shell::only_supports_this_input_type

  × Input type not supported.
    ╭─[std/bench/mod.nu:36:13]
 35 │             if $verbose { print -n $"($i) / ($rounds)\r" }
 36 │             timeit { do $code }
    ·             ───┬──
    ·                ╰── input type: duration
 37 │         }
 38 │     )
 39 │
 40 │     if $verbose { print $"($rounds) / ($rounds)" }
 41 │
 42 │     let report = {
 43 │         mean: ($times | math avg)
 44 │         min: ($times | math min)
 45 │         max: ($times | math max)
 46 │         std: ($times | into float | math stddev | into int | into duration)
    ·                        ─────┬────
    ·                             ╰── only string, int or bool input data is supported
 47 │         times: ($times)
    ╰────
```

### After
```nushell
❯ use std/bench
❯ def "compact keys" [--empty(-e)]: record -> record { transpose key value | filter (if $empty { {|rc| $rc.value | is-not-empty } } else {|rc| $rc.value != null }) | transpose -rd }
❯ bench { open playlist.m3u8
| parse -r '^(?:(?:#EXT-X-PROGRAM-DATE-TIME:(?P<t>.+Z))|(?:#EXT-X-BYTERANGE:(?P<rng>\d+@\d+))|(?:#EXTINF:(?P<inf>\d+.?\d*),)|(?P<name>.+\.mp4))$' | par-each { if ($in.name? | is-not-empty) { [$in null] } else { [$in] } } | flatten | split list null | par-each {|rows|
    | each { compact keys -e }
    | into record
}} --pretty --rounds 10
1sec 349ms 124µs 124ns +/- 94ms 544µs 81ns
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
