### PR TITLE
Add PipelineType enum to better express input/output types

### DIFF
--- a/crates/nu-cli/src/commands/commandline/edit.rs
+++ b/crates/nu-cli/src/commands/commandline/edit.rs
@@ -10,7 +10,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .switch(
                 "append",
                 "appends the string to the end of the buffer",

--- a/crates/nu-cli/src/commands/commandline/set_cursor.rs
+++ b/crates/nu-cli/src/commands/commandline/set_cursor.rs
@@ -12,7 +12,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .switch(
                 "end",
                 "set the current cursor position to the end of the buffer",

--- a/crates/nu-cli/src/commands/history/history_.rs
+++ b/crates/nu-cli/src/commands/history/history_.rs
@@ -21,7 +21,7 @@ impl Command for History {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("history")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .allow_variants_without_examples(true)
             .switch("clear", "Clears out the history entries", Some('c'))
             .switch(

--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -24,7 +24,7 @@ impl Command for KeybindingsListen {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Platform)
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
     }
 

--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -12,8 +12,8 @@ impl Command for Print {
     fn signature(&self) -> Signature {
         Signature::build("print")
             .input_output_types(vec![
-                (Type::Nothing, Type::Nothing),
-                (Type::Any, Type::Nothing),
+                (PipelineType::Empty, PipelineType::Empty),
+                (Type::Any.into(), PipelineType::Empty),
             ])
             .allow_variants_without_examples(true)
             .rest("rest", SyntaxShape::Any, "the values to print")

--- a/crates/nu-cmd-lang/src/core_commands/alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/alias.rs
@@ -15,7 +15,7 @@ impl Command for Alias {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("alias")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .required("name", SyntaxShape::String, "Name of the alias.")
             .required(
                 "initial_value",

--- a/crates/nu-cmd-lang/src/core_commands/break_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/break_.rs
@@ -15,7 +15,7 @@ impl Command for Break {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("break")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/const_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/const_.rs
@@ -15,7 +15,7 @@ impl Command for Const {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("const")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
             .required("const_name", SyntaxShape::VarWithOptType, "Constant name.")
             .required(

--- a/crates/nu-cmd-lang/src/core_commands/continue_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/continue_.rs
@@ -15,7 +15,7 @@ impl Command for Continue {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("continue")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -15,7 +15,7 @@ impl Command for Def {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("def")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .required("def_name", SyntaxShape::String, "Command name.")
             .required("params", SyntaxShape::Signature, "Parameters.")
             .required("block", SyntaxShape::Closure(None), "Body of the definition.")

--- a/crates/nu-cmd-lang/src/core_commands/echo.rs
+++ b/crates/nu-cmd-lang/src/core_commands/echo.rs
@@ -14,7 +14,7 @@ impl Command for Echo {
 
     fn signature(&self) -> Signature {
         Signature::build("echo")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .rest("rest", SyntaxShape::Any, "The values to echo.")
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -11,7 +11,7 @@ impl Command for ErrorMake {
 
     fn signature(&self) -> Signature {
         Signature::build("error make")
-            .input_output_types(vec![(Type::Nothing, Type::Error)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Error)])
             .required(
                 "error_struct",
                 SyntaxShape::Record(vec![]),

--- a/crates/nu-cmd-lang/src/core_commands/export.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export.rs
@@ -11,7 +11,7 @@ impl Command for ExportCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("export")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/export_alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_alias.rs
@@ -15,7 +15,7 @@ impl Command for ExportAlias {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export alias")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .required("name", SyntaxShape::String, "Name of the alias.")
             .required(
                 "initial_value",

--- a/crates/nu-cmd-lang/src/core_commands/export_const.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_const.rs
@@ -15,7 +15,7 @@ impl Command for ExportConst {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export const")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
             .required("const_name", SyntaxShape::VarWithOptType, "Constant name.")
             .required(

--- a/crates/nu-cmd-lang/src/core_commands/export_def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_def.rs
@@ -15,7 +15,7 @@ impl Command for ExportDef {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export def")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .required("def_name", SyntaxShape::String, "Command name.")
             .required("params", SyntaxShape::Signature, "Parameters.")
             .required("block", SyntaxShape::Block, "Body of the definition.")

--- a/crates/nu-cmd-lang/src/core_commands/export_extern.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_extern.rs
@@ -15,7 +15,7 @@ impl Command for ExportExtern {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export extern")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .required("def_name", SyntaxShape::String, "Definition name.")
             .required("params", SyntaxShape::Signature, "Parameters.")
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/export_module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_module.rs
@@ -15,7 +15,7 @@ impl Command for ExportModule {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export module")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
             .required("module", SyntaxShape::String, "Module name or module path.")
             .optional(

--- a/crates/nu-cmd-lang/src/core_commands/export_use.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_use.rs
@@ -15,7 +15,7 @@ impl Command for ExportUse {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export use")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .required("module", SyntaxShape::String, "Module or module file.")
             .rest(
                 "members",

--- a/crates/nu-cmd-lang/src/core_commands/extern_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/extern_.rs
@@ -15,7 +15,7 @@ impl Command for Extern {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("extern")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .required("def_name", SyntaxShape::String, "Definition name.")
             .required("params", SyntaxShape::Signature, "Parameters.")
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -15,7 +15,7 @@ impl Command for For {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("for")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
             .required(
                 "var_name",

--- a/crates/nu-cmd-lang/src/core_commands/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide.rs
@@ -11,7 +11,7 @@ impl Command for Hide {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("hide")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .required("module", SyntaxShape::String, "Module or module file.")
             .optional(
                 "members",

--- a/crates/nu-cmd-lang/src/core_commands/hide_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide_env.rs
@@ -11,7 +11,7 @@ impl Command for HideEnv {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("hide-env")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .rest(
                 "name",
                 SyntaxShape::String,

--- a/crates/nu-cmd-lang/src/core_commands/loop_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/loop_.rs
@@ -15,7 +15,7 @@ impl Command for Loop {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("loop")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
             .required("block", SyntaxShape::Block, "Block to loop.")
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/module.rs
@@ -15,7 +15,7 @@ impl Command for Module {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("module")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
             .required("module", SyntaxShape::String, "Module name or module path.")
             .optional(

--- a/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
@@ -15,7 +15,7 @@ impl Command for OverlayHide {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("overlay hide")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .optional("name", SyntaxShape::String, "Overlay to hide.")
             .switch(
                 "keep-custom",

--- a/crates/nu-cmd-lang/src/core_commands/overlay/new.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/new.rs
@@ -15,7 +15,7 @@ impl Command for OverlayNew {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("overlay new")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
             .required("name", SyntaxShape::String, "Name of the overlay.")
             // TODO:

--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -20,7 +20,7 @@ impl Command for OverlayUse {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("overlay use")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
             .required(
                 "name",

--- a/crates/nu-cmd-lang/src/core_commands/return_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/return_.rs
@@ -15,7 +15,7 @@ impl Command for Return {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("return")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .optional(
                 "return_value",
                 SyntaxShape::Any,

--- a/crates/nu-cmd-lang/src/core_commands/scope/aliases.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/aliases.rs
@@ -10,7 +10,7 @@ impl Command for ScopeAliases {
 
     fn signature(&self) -> Signature {
         Signature::build("scope aliases")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .allow_variants_without_examples(true)
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/scope/engine_stats.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/engine_stats.rs
@@ -10,7 +10,7 @@ impl Command for ScopeEngineStats {
 
     fn signature(&self) -> Signature {
         Signature::build("scope engine-stats")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .allow_variants_without_examples(true)
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/scope/externs.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/externs.rs
@@ -10,7 +10,7 @@ impl Command for ScopeExterns {
 
     fn signature(&self) -> Signature {
         Signature::build("scope externs")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .allow_variants_without_examples(true)
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/scope/modules.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/modules.rs
@@ -10,7 +10,7 @@ impl Command for ScopeModules {
 
     fn signature(&self) -> Signature {
         Signature::build("scope modules")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .allow_variants_without_examples(true)
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/scope/variables.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/variables.rs
@@ -10,7 +10,7 @@ impl Command for ScopeVariables {
 
     fn signature(&self) -> Signature {
         Signature::build("scope variables")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .allow_variants_without_examples(true)
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/use_.rs
@@ -20,7 +20,7 @@ impl Command for Use {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("use")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
             .required(
                 "module",

--- a/crates/nu-cmd-lang/src/core_commands/while_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/while_.rs
@@ -15,7 +15,7 @@ impl Command for While {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("while")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
             .required("cond", SyntaxShape::MathExpression, "Condition to check.")
             .required(

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -1,7 +1,8 @@
 use itertools::Itertools;
 use nu_engine::{command_prelude::*, compile};
 use nu_protocol::{
-    ast::Block, debugger::WithoutDebug, engine::StateWorkingSet, report_shell_error, Range,
+    ast::Block, debugger::WithoutDebug, engine::StateWorkingSet, report_shell_error, PipelineType,
+    Range,
 };
 use std::{
     sync::Arc,
@@ -176,7 +177,7 @@ pub fn check_example_evaluates_to_expected_output(
 
 pub fn check_all_signature_input_output_types_entries_have_examples(
     signature: Signature,
-    witnessed_type_transformations: HashSet<(Type, Type)>,
+    witnessed_type_transformations: HashSet<(PipelineType, PipelineType)>,
 ) {
     let declared_type_transformations = HashSet::from_iter(signature.input_output_types);
     assert!(

--- a/crates/nu-cmd-plugin/src/commands/plugin/mod.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/mod.rs
@@ -22,7 +22,7 @@ impl Command for PluginCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("plugin")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .category(Category::Plugin)
     }
 

--- a/crates/nu-cmd-plugin/src/commands/plugin/use_.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/use_.rs
@@ -15,7 +15,7 @@ impl Command for PluginUse {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .named(
                 "plugin-config",
                 SyntaxShape::Filepath,

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -59,17 +59,14 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("into datetime")
         .input_output_types(vec![
-            (Type::Date, Type::Date),
-            (Type::Int, Type::Date),
-            (Type::String, Type::Date),
-            (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Date))),
-            (Type::table(), Type::table()),
-            (Type::record(), Type::record()),
-            (Type::Nothing, Type::table()),
-            // FIXME Type::Any input added to disable pipeline input type checking, as run-time checks can raise undesirable type errors
-            // which aren't caught by the parser. see https://github.com/nushell/nushell/pull/14922 for more details
+            (Type::Date.into(), Type::Date),
+            (Type::Int.into(), Type::Date),
+            (Type::String.into(), Type::Date),
+            (Type::List(Box::new(Type::String)).into(), Type::List(Box::new(Type::Date))),
+            (Type::table().into(), Type::table()),
+            (Type::record().into(), Type::record()),
             // only applicable for --list flag
-            (Type::Any, Type::table()),
+            (PipelineType::Empty, Type::table()),
         ])
         .allow_variants_without_examples(true)
         .named(

--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -11,7 +11,7 @@ impl Command for ConfigEnv {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Env)
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .switch(
                 "default",
                 "Print the internal default `env.nu` file instead.",

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -12,7 +12,7 @@ impl Command for ConfigNu {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Env)
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .switch(
                 "default",
                 "Print the internal default `config.nu` file instead.",

--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -16,7 +16,7 @@ impl Command for ConfigReset {
             .switch("nu", "reset only nu config, config.nu", Some('n'))
             .switch("env", "reset only env config, env.nu", Some('e'))
             .switch("without-backup", "do not make a backup", Some('w'))
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
             .category(Category::Env)
     }

--- a/crates/nu-command/src/env/export_env.rs
+++ b/crates/nu-command/src/env/export_env.rs
@@ -11,7 +11,7 @@ impl Command for ExportEnv {
 
     fn signature(&self) -> Signature {
         Signature::build("export-env")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .required(
                 "block",
                 SyntaxShape::Block,

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -15,11 +15,8 @@ impl Command for LoadEnv {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("load-env")
             .input_output_types(vec![
-                (Type::record(), Type::Nothing),
-                (Type::Nothing, Type::Nothing),
-                // FIXME Type::Any input added to disable pipeline input type checking, as run-time checks can raise undesirable type errors
-                // which aren't caught by the parser. see https://github.com/nushell/nushell/pull/14922 for more details
-                (Type::Any, Type::Nothing),
+                (Type::record().into(), PipelineType::Empty),
+                (PipelineType::Empty, PipelineType::Empty),
             ])
             .allow_variants_without_examples(true)
             .optional(

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -22,7 +22,7 @@ impl Command for Cd {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("cd")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .switch("physical", "use the physical directory structure; resolve symbolic links before processing instances of ..", Some('P'))
             .optional("path", SyntaxShape::Directory, "The path to change to.")
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -36,11 +36,8 @@ impl Command for Open {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("open")
             .input_output_types(vec![
-                (Type::Nothing, Type::Any),
-                (Type::String, Type::Any),
-                // FIXME Type::Any input added to disable pipeline input type checking, as run-time checks can raise undesirable type errors
-                // which aren't caught by the parser. see https://github.com/nushell/nushell/pull/14922 for more details
-                (Type::Any, Type::Any),
+                (PipelineType::Empty, Type::Any),
+                (Type::String.into(), Type::Any),
             ])
             .rest(
                 "files",

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -39,7 +39,7 @@ impl Command for Rm {
 
     fn signature(&self) -> Signature {
         Signature::build("rm")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .rest("paths", SyntaxShape::OneOf(vec![SyntaxShape::GlobPattern, SyntaxShape::String]), "The file paths(s) to remove.")
             .switch(
                 "trash",

--- a/crates/nu-command/src/filesystem/start.rs
+++ b/crates/nu-command/src/filesystem/start.rs
@@ -24,7 +24,7 @@ impl Command for Start {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("start")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .required("path", SyntaxShape::String, "Path or URL to open.")
             .category(Category::FileSystem)
     }

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -30,7 +30,7 @@ impl Command for UCp {
 
     fn signature(&self) -> Signature {
         Signature::build("cp")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .switch("recursive", "copy directories recursively", Some('r'))
             .switch("verbose", "explicitly state what is being done", Some('v'))
             .switch(

--- a/crates/nu-command/src/filesystem/umkdir.rs
+++ b/crates/nu-command/src/filesystem/umkdir.rs
@@ -36,7 +36,7 @@ impl Command for UMkdir {
 
     fn signature(&self) -> Signature {
         Signature::build("mkdir")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .rest(
                 "rest",
                 SyntaxShape::OneOf(vec![SyntaxShape::GlobPattern, SyntaxShape::Directory]),

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -53,7 +53,7 @@ impl Command for UMv {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("mv")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .switch("force", "do not prompt before overwriting", Some('f'))
             .switch("verbose", "explain what is being done.", Some('v'))
             .switch("progress", "display a progress bar", Some('p'))

--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -14,7 +14,7 @@ impl Command for Help {
 
     fn signature(&self) -> Signature {
         Signature::build("help")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .rest(
                 "rest",
                 SyntaxShape::String,

--- a/crates/nu-command/src/misc/panic.rs
+++ b/crates/nu-command/src/misc/panic.rs
@@ -18,7 +18,7 @@ impl Command for Panic {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("panic")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .optional(
                 "msg",
                 SyntaxShape::String,

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -17,7 +17,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http get")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .allow_variants_without_examples(true)
             .required(
                 "URL",

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -17,7 +17,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http head")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .allow_variants_without_examples(true)
             .required(
                 "URL",

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -16,7 +16,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http options")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .allow_variants_without_examples(true)
             .required(
                 "URL",

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -504,7 +504,7 @@ impl Command for AnsiCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("ansi")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .optional(
                 "code",
                 SyntaxShape::Any,

--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -27,7 +27,7 @@ impl Command for Clear {
     fn signature(&self) -> Signature {
         Signature::build("clear")
             .category(Category::Platform)
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .switch(
                 "keep-scrollback",
                 "Do not clear the scrollback history",

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -29,7 +29,7 @@ impl Command for Input {
 
     fn signature(&self) -> Signature {
         Signature::build("input")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .allow_variants_without_examples(true)
             .optional("prompt", SyntaxShape::String, "Prompt to show the user.")
             .named(

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -15,7 +15,7 @@ impl Command for Kill {
 
     fn signature(&self) -> Signature {
         let signature = Signature::build("kill")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .allow_variants_without_examples(true)
             .required(
                 "pid",

--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -21,7 +21,7 @@ impl Command for Sleep {
 
     fn signature(&self) -> Signature {
         Signature::build("sleep")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .required("duration", SyntaxShape::Duration, "Time to sleep.")
             .rest("rest", SyntaxShape::Duration, "Additional time.")
             .category(Category::Platform)

--- a/crates/nu-command/src/platform/ulimit.rs
+++ b/crates/nu-command/src/platform/ulimit.rs
@@ -509,7 +509,7 @@ impl Command for ULimit {
 
     fn signature(&self) -> Signature {
         let mut sig = Signature::build("ulimit")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .switch("soft", "Sets soft resource limit", Some('S'))
             .switch("hard", "Sets hard resource limit", Some('H'))
             .switch("all", "Prints all current limits", Some('a'))

--- a/crates/nu-command/src/removed/let_env.rs
+++ b/crates/nu-command/src/removed/let_env.rs
@@ -10,7 +10,7 @@ impl Command for LetEnv {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .allow_variants_without_examples(true)
             .optional("var_name", SyntaxShape::String, "Variable name.")
             .optional(

--- a/crates/nu-command/src/shells/exit.rs
+++ b/crates/nu-command/src/shells/exit.rs
@@ -10,7 +10,7 @@ impl Command for Exit {
 
     fn signature(&self) -> Signature {
         Signature::build("exit")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
             .optional(
                 "exit_code",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/stor/insert.rs
+++ b/crates/nu-command/src/stor/insert.rs
@@ -14,12 +14,9 @@ impl Command for StorInsert {
     fn signature(&self) -> Signature {
         Signature::build("stor insert")
             .input_output_types(vec![
-                (Type::Nothing, Type::table()),
-                (Type::record(), Type::table()),
-                (Type::table(), Type::table()),
-                // FIXME Type::Any input added to disable pipeline input type checking, as run-time checks can raise undesirable type errors
-                // which aren't caught by the parser. see https://github.com/nushell/nushell/pull/14922 for more details
-                (Type::Any, Type::table()),
+                (PipelineType::Empty, Type::table()),
+                (Type::record().into(), Type::table()),
+                (Type::table().into(), Type::table()),
             ])
             .required_named(
                 "table-name",

--- a/crates/nu-command/src/stor/update.rs
+++ b/crates/nu-command/src/stor/update.rs
@@ -14,11 +14,8 @@ impl Command for StorUpdate {
     fn signature(&self) -> Signature {
         Signature::build("stor update")
             .input_output_types(vec![
-                (Type::Nothing, Type::table()),
-                (Type::record(), Type::table()),
-                // FIXME Type::Any input added to disable pipeline input type checking, as run-time checks can raise undesirable type errors
-                // which aren't caught by the parser. see https://github.com/nushell/nushell/pull/14922 for more details
-                (Type::Any, Type::table()),
+                (PipelineType::Empty, Type::table()),
+                (Type::record().into(), Type::table()),
             ])
             .required_named(
                 "table-name",

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -188,7 +188,7 @@ impl Command for Char {
 
     fn signature(&self) -> Signature {
         Signature::build("char")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .optional(
                 "character",
                 SyntaxShape::Any,

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -16,13 +16,10 @@ impl Command for FormatDate {
     fn signature(&self) -> Signature {
         Signature::build("format date")
             .input_output_types(vec![
-                (Type::Date, Type::String),
-                (Type::String, Type::String),
-                (Type::Nothing, Type::table()),
-                // FIXME Type::Any input added to disable pipeline input type checking, as run-time checks can raise undesirable type errors
-                // which aren't caught by the parser. see https://github.com/nushell/nushell/pull/14922 for more details
+                (Type::Date.into(), Type::String),
+                (Type::String.into(), Type::String),
                 // only applicable for --list flag
-                (Type::Any, Type::table()),
+                (PipelineType::Empty, Type::table()),
             ])
             .allow_variants_without_examples(true) // https://github.com/nushell/nushell/issues/7032
             .switch("list", "lists strftime cheatsheet", Some('l'))

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -12,7 +12,7 @@ impl Command for Exec {
 
     fn signature(&self) -> Signature {
         Signature::build("exec")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .rest(
                 "command",
                 SyntaxShape::OneOf(vec![SyntaxShape::GlobPattern, SyntaxShape::Any]),

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -17,12 +17,9 @@ impl Command for NuCheck {
     fn signature(&self) -> Signature {
         Signature::build("nu-check")
             .input_output_types(vec![
-                (Type::Nothing, Type::Bool),
-                (Type::String, Type::Bool),
-                (Type::List(Box::new(Type::Any)), Type::Bool),
-                // FIXME Type::Any input added to disable pipeline input type checking, as run-time checks can raise undesirable type errors
-                // which aren't caught by the parser. see https://github.com/nushell/nushell/pull/14922 for more details
-                (Type::Any, Type::Bool),
+                (PipelineType::Empty, Type::Bool),
+                (Type::String.into(), Type::Bool),
+                (Type::List(Box::new(Type::Any)).into(), Type::Bool),
             ])
             // type is string to avoid automatically canonicalizing the path
             .optional("path", SyntaxShape::String, "File path to parse.")

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -14,7 +14,7 @@ impl Command for RegistryQuery {
 
     fn signature(&self) -> Signature {
         Signature::build("registry query")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(PipelineType::Empty, Type::Any)])
             .switch("hkcr", "query the hkey_classes_root hive", None)
             .switch("hkcu", "query the hkey_current_user hive", None)
             .switch("hklm", "query the hkey_local_machine hive", None)

--- a/crates/nu-engine/src/command_prelude.rs
+++ b/crates/nu-engine/src/command_prelude.rs
@@ -5,6 +5,6 @@ pub use nu_protocol::{
     record,
     shell_error::io::*,
     ByteStream, ByteStreamType, Category, ErrSpan, Example, IntoInterruptiblePipelineData,
-    IntoPipelineData, IntoSpanned, IntoValue, PipelineData, Record, ShellError, Signature, Span,
-    Spanned, SyntaxShape, Type, Value,
+    IntoPipelineData, IntoSpanned, IntoValue, PipelineData, PipelineType, Record, ShellError,
+    Signature, Span, Spanned, SyntaxShape, Type, Value,
 };

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -1,7 +1,7 @@
 use nu_protocol::{
     ast::Expr,
     engine::{Command, EngineState, Stack, Visibility},
-    record, DeclId, ModuleId, Signature, Span, SyntaxShape, Type, Value, VarId,
+    record, DeclId, ModuleId, PipelineType, Signature, Span, SyntaxShape, Type, Value, VarId,
 };
 use std::{cmp::Ordering, collections::HashMap};
 
@@ -151,7 +151,7 @@ impl<'e, 's> ScopeData<'e, 's> {
             .iter()
             .map(|(input_type, output_type)| {
                 (
-                    input_type.to_shape().to_string(),
+                    input_type.to_shape_string(),
                     Value::list(
                         self.collect_signature_entries(input_type, output_type, signature, span),
                         span,
@@ -165,9 +165,9 @@ impl<'e, 's> ScopeData<'e, 's> {
         // a little bit better. If sigs is empty, we're pretty sure that we're dealing
         // with a custom command.
         if sigs.is_empty() {
-            let any_type = &Type::Any;
+            let any_type = &PipelineType::Type(Type::Any);
             sigs.push((
-                any_type.to_shape().to_string(),
+                any_type.to_shape_string(),
                 Value::list(
                     self.collect_signature_entries(any_type, any_type, signature, span),
                     span,
@@ -189,8 +189,8 @@ impl<'e, 's> ScopeData<'e, 's> {
 
     fn collect_signature_entries(
         &self,
-        input_type: &Type,
-        output_type: &Type,
+        input_type: &PipelineType,
+        output_type: &PipelineType,
         signature: &Signature,
         span: Span,
     ) -> Vec<Value> {
@@ -201,7 +201,7 @@ impl<'e, 's> ScopeData<'e, 's> {
             record! {
                 "parameter_name" => Value::nothing(span),
                 "parameter_type" => Value::string("input", span),
-                "syntax_shape" => Value::string(input_type.to_shape().to_string(), span),
+                "syntax_shape" => Value::string(input_type.to_shape_string(), span),
                 "is_optional" => Value::bool(false, span),
                 "short_flag" => Value::nothing(span),
                 "description" => Value::nothing(span),
@@ -327,7 +327,7 @@ impl<'e, 's> ScopeData<'e, 's> {
             record! {
                 "parameter_name" => Value::nothing(span),
                 "parameter_type" => Value::string("output", span),
-                "syntax_shape" => Value::string(output_type.to_shape().to_string(), span),
+                "syntax_shape" => Value::string(output_type.to_shape_string(), span),
                 "is_optional" => Value::bool(false, span),
                 "short_flag" => Value::nothing(span),
                 "description" => Value::nothing(span),

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -748,7 +748,7 @@ fn parse_def_inner(
                 block
                     .signature
                     .input_output_types
-                    .push((Type::Any, Type::Any));
+                    .push((Type::Any.into(), Type::Any.into()));
             }
 
             let block = working_set.get_block(block_id);

--- a/crates/nu-parser/src/parse_shape_specs.rs
+++ b/crates/nu-parser/src/parse_shape_specs.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::byte_char_slices)]
 
 use crate::{lex::lex_signature, parser::parse_value, trim_quotes, TokenContents};
-use nu_protocol::{engine::StateWorkingSet, ParseError, Span, SyntaxShape, Type};
+use nu_protocol::{engine::StateWorkingSet, ParseError, PipelineType, Span, SyntaxShape, Type};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ShapeDescriptorUse {
@@ -9,6 +9,17 @@ pub enum ShapeDescriptorUse {
     Argument,
     /// Used to define the type of a variable or input/output types
     Type,
+}
+
+pub fn parse_pipeline_type(
+    working_set: &mut StateWorkingSet,
+    bytes: &[u8],
+    span: Span,
+) -> PipelineType {
+    match bytes {
+        b"empty" => PipelineType::Empty,
+        _ => PipelineType::Type(parse_type(working_set, bytes, span)),
+    }
 }
 
 /// equivalent to [`parse_shape_name`] with [`ShapeDescriptorUse::Type`] converting the

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -2075,7 +2075,7 @@ mod mock {
 
         fn signature(&self) -> nu_protocol::Signature {
             Signature::build("def")
-                .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+                .input_output_types(vec![(PipelineType::Empty, PipelineType::Empty)])
                 .required("def_name", SyntaxShape::String, "definition name")
                 .required("params", SyntaxShape::Signature, "parameters")
                 .required("body", SyntaxShape::Closure(None), "body of the definition")

--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -1,4 +1,4 @@
-use crate::{ast::RedirectionSource, did_you_mean, Span, Type};
+use crate::{ast::RedirectionSource, did_you_mean, PipelineType, Span, Type};
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -60,13 +60,16 @@ pub enum ParseError {
 
     #[error("Command does not support {0} input.")]
     #[diagnostic(code(nu::parser::input_type_mismatch))]
-    InputMismatch(Type, #[label("command doesn't support {0} input")] Span),
+    InputMismatch(
+        PipelineType,
+        #[label("command doesn't support {0} input")] Span,
+    ),
 
     #[error("Command output doesn't match {0}.")]
     #[diagnostic(code(nu::parser::output_type_mismatch))]
     OutputMismatch(
-        Type,
-        Type,
+        PipelineType,
+        PipelineType,
         #[label("expected {0}, but command outputs {1}")] Span,
     ),
 

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -211,6 +211,48 @@ impl Display for Type {
     }
 }
 
+/// Types corresponding to pipeline input/output types.
+///
+/// Can be thought of as representing the type of [`PipelineData`](crate::PipelineData).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub enum PipelineType {
+    Empty,
+    Type(Type),
+}
+
+impl PipelineType {
+    /// Convert PipelineType to string representation, using SyntaxShape's ToString for Type variants
+    pub fn to_shape_string(&self) -> String {
+        match self {
+            PipelineType::Empty => "empty".to_string(),
+            PipelineType::Type(ty) => ty.to_shape().to_string(),
+        }
+    }
+
+    /// Collapse into a [`Type`] value
+    pub fn into_type(self) -> Type {
+        match self {
+            PipelineType::Empty => Type::Nothing,
+            PipelineType::Type(ty) => ty,
+        }
+    }
+}
+
+impl From<Type> for PipelineType {
+    fn from(value: Type) -> Self {
+        Self::Type(value)
+    }
+}
+
+impl Display for PipelineType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PipelineType::Empty => write!(f, "empty"),
+            PipelineType::Type(ty) => ty.fmt(f),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Type;

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/when.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/when.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, Signature, Span, SyntaxShape, Type, Value,
+    Category, Example, LabeledError, PipelineData, PipelineType, Signature, Span, SyntaxShape,
+    Type, Value,
 };
 use polars::prelude::when;
 
@@ -36,14 +37,11 @@ impl PluginCommand for ExprWhen {
                 "expression that will be applied when predicate is true",
             )
             .input_output_types(vec![
-                (Type::Nothing, Type::Custom("expression".into())),
+                (PipelineType::Empty, Type::Custom("expression".into())),
                 (
-                    Type::Custom("expression".into()),
+                    Type::Custom("expression".into()).into(),
                     Type::Custom("expression".into()),
                 ),
-                // FIXME Type::Any input added to disable pipeline input type checking, as run-time checks can raise undesirable type errors
-                // which aren't caught by the parser. see https://github.com/nushell/nushell/pull/14922 for more details
-                (Type::Any, Type::Custom("expression".into())),
             ])
             .category(Category::Custom("expression".into()))
     }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

When working through #14741 and #14922, I discovered that there's a bit of a tension between `PipelineData` and `Type`. Namely, `Type` neatly maps onto `Value`, but we have no way of expressing the additional information of `PipelineData` as part of input/output type signatures. This caused problems for run-time type checking being able to differentiate between `Value::Nothing` and `PipelineData::Empty`, as described in #14922. This PR adds a new enum, `PipelineType`, which allows us to better express command input/output types by providing a closer analogue to `PipelineData`.

This allows us to differentiate between `Value::Nothing` and `PipelineData::Empty`, which makes it possible prevent run-time type checking where it makes sense, while preserving run-time type checking:

Before PR (for context behind this example see #14922):
```nushell
ls | where type == file | sort-by { open -r $in.name | lines | length }
# => ╭────┬─────────────────────┬──────┬───────────┬──────────────╮
# => │  # │        name         │ type │   size    │   modified   │
# => ├────┼─────────────────────┼──────┼───────────┼──────────────┤
# => │  0 │ Cross.toml          │ file │     666 B │ 7 hours ago  │
# => │  1 │ rust-toolchain.toml │ file │   1.1 KiB │ 7 hours ago  │
# => │  2 │ LICENSE             │ file │   1.1 KiB │ 7 hours ago  │
# => │  3 │ CITATION.cff        │ file │     812 B │ 7 hours ago  │
# => │  4 │ SECURITY.md         │ file │   2.6 KiB │ 7 hours ago  │
# => │  5 │ typos.toml          │ file │     513 B │ 7 hours ago  │
# => │  6 │ CODE_OF_CONDUCT.md  │ file │   3.4 KiB │ 3 months ago │
# => │  7 │ CONTRIBUTING.md     │ file │  11.0 KiB │ 7 hours ago  │
# => │  8 │ README.md           │ file │  12.1 KiB │ 7 hours ago  │
# => │  9 │ Cargo.toml          │ file │   9.4 KiB │ 7 hours ago  │
# => │ 10 │ toolkit.nu          │ file │  20.8 KiB │ 7 hours ago  │
# => │ 11 │ Cargo.lock          │ file │ 197.4 KiB │ 7 hours ago  │
# => ╰────┴─────────────────────┴──────┴───────────┴──────────────╯
123 | open foo
Error: nu::shell::io::not_found

  × I/O error
   ╭─[entry #11:1:12]
 1 │ 123 | open foo
   ·            ─┬─
   ·             ╰── Entity not found
   ╰────
  help: The error occurred at '/home/rose/src/nushell/foo'
```

After PR:
```nushell
ls | where type == file | sort-by { open -r $in.name | lines | length }
# => ╭────┬─────────────────────┬──────┬───────────┬──────────────╮
# => │  # │        name         │ type │   size    │   modified   │
# => ├────┼─────────────────────┼──────┼───────────┼──────────────┤
# => │  0 │ Cross.toml          │ file │     666 B │ 7 hours ago  │
# => │  1 │ rust-toolchain.toml │ file │   1.1 KiB │ 7 hours ago  │
# => │  2 │ LICENSE             │ file │   1.1 KiB │ 7 hours ago  │
# => │  3 │ CITATION.cff        │ file │     812 B │ 7 hours ago  │
# => │  4 │ SECURITY.md         │ file │   2.6 KiB │ 7 hours ago  │
# => │  5 │ typos.toml          │ file │     513 B │ 7 hours ago  │
# => │  6 │ CODE_OF_CONDUCT.md  │ file │   3.4 KiB │ 3 months ago │
# => │  7 │ CONTRIBUTING.md     │ file │  11.0 KiB │ 7 hours ago  │
# => │  8 │ README.md           │ file │  12.1 KiB │ 7 hours ago  │
# => │  9 │ Cargo.toml          │ file │   9.4 KiB │ 7 hours ago  │
# => │ 10 │ toolkit.nu          │ file │  20.8 KiB │ 7 hours ago  │
# => │ 11 │ Cargo.lock          │ file │ 197.4 KiB │ 7 hours ago  │
# => ╰────┴─────────────────────┴──────┴───────────┴──────────────╯
123 | open foo
# => Error: nu::parser::input_type_mismatch
# => 
# =>   × Command does not support int input.
# =>    ╭─[entry #11:1:7]
# =>  1 │ 123 | open foo
# =>    ·       ──┬─
# =>    ·         ╰── command doesn't support int input
# =>    ╰────
```

Additionally, we can differentiate between empty pipeline input and nothing types _at parse-time_:

Before PR:
```nushell
null | get -i 0
print | get -i 0
# => Error: nu::shell::pipeline_mismatch
# => 
# =>   × Pipeline empty.
# =>    ╭─[entry #3:1:9]
# =>  1 │ print | get -i 0
# =>    ·         ─┬─
# =>    ·          ╰── no input value was piped in
# =>    ╰────
```

After PR (note the error code as `parser` rather than `shell`):

```nushell
null | get -i 0
print | get -i 0
# => Error: nu::parser::input_type_mismatch
# => 
# =>   × Command does not support empty input.
# =>    ╭─[entry #17:1:9]
# =>  1 │ print | get -i 0
# =>    ·         ─┬─
# =>    ·          ╰── command doesn't support empty input
# =>    ╰────
```

It's also possible to add an `empty` type annotation to a custom command:

```nushell
def foo []: empty -> int { 2 }
foo
# => 2
null | foo
# => Error: nu::parser::input_type_mismatch
# => 
# =>   × Command does not support nothing input.
# =>    ╭─[entry #10:1:8]
# =>  1 │ null | foo
# =>    ·        ─┬─
# =>    ·         ╰── command doesn't support nothing input
# =>    ╰────
```

This might be problematic, since users might already have `nothing -> T` type annotations on their commands, which might not work after this, depending on the commands. It _might_ be possible to make this into a warning?

We could potentially expand `PipelineType` in the future to express streams as well? Where say `stream<int>` ( :bike: :hut: ) would be a subtype of `list<int>`, but not vice versa.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
TODO

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
TODO

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
TODO