### PR TITLE
update reedline editcommands in nushell

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -1284,14 +1284,14 @@ fn edit_from_record(
         #[cfg(feature = "system-clipboard")]
         "pastesystem" => EditCommand::PasteSystem,
         "cutinside" => {
-            let value = extract_value("value", record, span)?;
+            let value = extract_value("left", record, span)?;
             let left = extract_char(value)?;
             let value = extract_value("right", record, span)?;
             let right = extract_char(value)?;
             EditCommand::CutInside { left, right }
         }
-        "yankinsider" => {
-            let value = extract_value("value", record, span)?;
+        "yankinside" => {
+            let value = extract_value("left", record, span)?;
             let left = extract_char(value)?;
             let value = extract_value("right", record, span)?;
             let right = extract_char(value)?;

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -1008,9 +1008,15 @@ fn event_from_record(
         "submit" => ReedlineEvent::Submit,
         "submitornewline" => ReedlineEvent::SubmitOrNewline,
         "esc" | "escape" => ReedlineEvent::Esc,
-        "mouse" => ReedlineEvent::Mouse,
-        // TODO: resize
-        // TODO: edit
+        // Non-sensical for user configuration:
+        //
+        // `ReedlineEvent::Mouse` - itself a no-op
+        // `ReedlineEvent::Resize` - requires size info specifically from the ANSI resize
+        // event
+        //
+        // Handled above in `parse_event`:
+        //
+        // `ReedlineEvent::Edit`
         "repaint" => ReedlineEvent::Repaint,
         "previoushistory" => ReedlineEvent::PreviousHistory,
         "up" => ReedlineEvent::Up,
@@ -1019,8 +1025,10 @@ fn event_from_record(
         "left" => ReedlineEvent::Left,
         "nexthistory" => ReedlineEvent::NextHistory,
         "searchhistory" => ReedlineEvent::SearchHistory,
-        // TODO: multiple
-        // TODO: untilfound
+        // Handled above in `parse_event`:
+        //
+        // `ReedlineEvent::Multiple`
+        // `ReedlineEvent::UntilFound`
         "menu" => {
             let menu = extract_value("name", record, span)?;
             ReedlineEvent::Menu(menu.to_expanded_string("", config))
@@ -1148,7 +1156,8 @@ fn edit_from_record(
             let char = extract_char(value)?;
             EditCommand::ReplaceChar(char)
         }
-        // TODO: not sure how to write replacechars
+        // `EditCommand::ReplaceChars` - Internal hack not sanely implementable as a
+        // standalone binding
         "backspace" => EditCommand::Backspace,
         "delete" => EditCommand::Delete,
         "cutchar" => EditCommand::CutChar,

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -1009,8 +1009,8 @@ fn event_from_record(
         "submitornewline" => ReedlineEvent::SubmitOrNewline,
         "esc" | "escape" => ReedlineEvent::Esc,
         "mouse" => ReedlineEvent::Mouse,
-        // resize
-        // edit
+        // TODO: resize
+        // TODO: edit
         "repaint" => ReedlineEvent::Repaint,
         "previoushistory" => ReedlineEvent::PreviousHistory,
         "up" => ReedlineEvent::Up,
@@ -1019,8 +1019,8 @@ fn event_from_record(
         "left" => ReedlineEvent::Left,
         "nexthistory" => ReedlineEvent::NextHistory,
         "searchhistory" => ReedlineEvent::SearchHistory,
-        // multiple
-        // untilfound
+        // TODO: multiple
+        // TODO: untilfound
         "menu" => {
             let menu = extract_value("name", record, span)?;
             ReedlineEvent::Menu(menu.to_expanded_string("", config))
@@ -1148,7 +1148,7 @@ fn edit_from_record(
             let char = extract_char(value)?;
             EditCommand::ReplaceChar(char)
         }
-        // TODO: not sure how to write replace chars
+        // TODO: not sure how to write replacechars
         "backspace" => EditCommand::Backspace,
         "delete" => EditCommand::Delete,
         "cutchar" => EditCommand::CutChar,

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -998,41 +998,46 @@ fn event_from_record(
 ) -> Result<ReedlineEvent, ShellError> {
     let event = match name {
         "none" => ReedlineEvent::None,
-        "clearscreen" => ReedlineEvent::ClearScreen,
-        "clearscrollback" => ReedlineEvent::ClearScrollback,
         "historyhintcomplete" => ReedlineEvent::HistoryHintComplete,
         "historyhintwordcomplete" => ReedlineEvent::HistoryHintWordComplete,
         "ctrld" => ReedlineEvent::CtrlD,
         "ctrlc" => ReedlineEvent::CtrlC,
+        "clearscreen" => ReedlineEvent::ClearScreen,
+        "clearscrollback" => ReedlineEvent::ClearScrollback,
         "enter" => ReedlineEvent::Enter,
         "submit" => ReedlineEvent::Submit,
         "submitornewline" => ReedlineEvent::SubmitOrNewline,
         "esc" | "escape" => ReedlineEvent::Esc,
+        "mouse" => ReedlineEvent::Mouse,
+        // resize
+        // edit
+        "repaint" => ReedlineEvent::Repaint,
+        "previoushistory" => ReedlineEvent::PreviousHistory,
         "up" => ReedlineEvent::Up,
         "down" => ReedlineEvent::Down,
         "right" => ReedlineEvent::Right,
         "left" => ReedlineEvent::Left,
-        "searchhistory" => ReedlineEvent::SearchHistory,
         "nexthistory" => ReedlineEvent::NextHistory,
-        "previoushistory" => ReedlineEvent::PreviousHistory,
-        "repaint" => ReedlineEvent::Repaint,
-        "menudown" => ReedlineEvent::MenuDown,
-        "menuup" => ReedlineEvent::MenuUp,
-        "menuleft" => ReedlineEvent::MenuLeft,
-        "menuright" => ReedlineEvent::MenuRight,
-        "menunext" => ReedlineEvent::MenuNext,
-        "menuprevious" => ReedlineEvent::MenuPrevious,
-        "menupagenext" => ReedlineEvent::MenuPageNext,
-        "menupageprevious" => ReedlineEvent::MenuPagePrevious,
-        "openeditor" => ReedlineEvent::OpenEditor,
+        "searchhistory" => ReedlineEvent::SearchHistory,
+        // multiple
+        // untilfound
         "menu" => {
             let menu = extract_value("name", record, span)?;
             ReedlineEvent::Menu(menu.to_expanded_string("", config))
         }
+        "menunext" => ReedlineEvent::MenuNext,
+        "menuprevious" => ReedlineEvent::MenuPrevious,
+        "menuup" => ReedlineEvent::MenuUp,
+        "menudown" => ReedlineEvent::MenuDown,
+        "menuleft" => ReedlineEvent::MenuLeft,
+        "menuright" => ReedlineEvent::MenuRight,
+        "menupagenext" => ReedlineEvent::MenuPageNext,
+        "menupageprevious" => ReedlineEvent::MenuPagePrevious,
         "executehostcommand" => {
             let cmd = extract_value("cmd", record, span)?;
             ReedlineEvent::ExecuteHostCommand(cmd.to_expanded_string("", config))
         }
+        "openeditor" => ReedlineEvent::OpenEditor,
         str => {
             return Err(ShellError::InvalidValue {
                 valid: "a reedline event".into(),
@@ -1062,7 +1067,6 @@ fn edit_from_record(
                 .and_then(|value| value.as_bool())
                 .unwrap_or(false),
         },
-
         "movetoend" => EditCommand::MoveToEnd {
             select: extract_value("select", record, span)
                 .and_then(|value| value.as_bool())
@@ -1098,22 +1102,22 @@ fn edit_from_record(
                 .and_then(|value| value.as_bool())
                 .unwrap_or(false),
         },
-        "movewordrightend" => EditCommand::MoveWordRightEnd {
-            select: extract_value("select", record, span)
-                .and_then(|value| value.as_bool())
-                .unwrap_or(false),
-        },
-        "movebigwordrightend" => EditCommand::MoveBigWordRightEnd {
-            select: extract_value("select", record, span)
-                .and_then(|value| value.as_bool())
-                .unwrap_or(false),
-        },
         "movewordrightstart" => EditCommand::MoveWordRightStart {
             select: extract_value("select", record, span)
                 .and_then(|value| value.as_bool())
                 .unwrap_or(false),
         },
         "movebigwordrightstart" => EditCommand::MoveBigWordRightStart {
+            select: extract_value("select", record, span)
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false),
+        },
+        "movewordrightend" => EditCommand::MoveWordRightEnd {
+            select: extract_value("select", record, span)
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false),
+        },
+        "movebigwordrightend" => EditCommand::MoveBigWordRightEnd {
             select: extract_value("select", record, span)
                 .and_then(|value| value.as_bool())
                 .unwrap_or(false),
@@ -1139,6 +1143,12 @@ fn edit_from_record(
             EditCommand::InsertString(value.to_expanded_string("", config))
         }
         "insertnewline" => EditCommand::InsertNewline,
+        "replacechar" => {
+            let value = extract_value("value", record, span)?;
+            let char = extract_char(value)?;
+            EditCommand::ReplaceChar(char)
+        }
+        // TODO: not sure how to write replace chars
         "backspace" => EditCommand::Backspace,
         "delete" => EditCommand::Delete,
         "cutchar" => EditCommand::CutChar,
@@ -1146,6 +1156,7 @@ fn edit_from_record(
         "deleteword" => EditCommand::DeleteWord,
         "clear" => EditCommand::Clear,
         "cleartolineend" => EditCommand::ClearToLineEnd,
+        "complete" => EditCommand::Complete,
         "cutcurrentline" => EditCommand::CutCurrentLine,
         "cutfromstart" => EditCommand::CutFromStart,
         "cutfromlinestart" => EditCommand::CutFromLineStart,
@@ -1162,6 +1173,7 @@ fn edit_from_record(
         "uppercaseword" => EditCommand::UppercaseWord,
         "lowercaseword" => EditCommand::LowercaseWord,
         "capitalizechar" => EditCommand::CapitalizeChar,
+        "switchcasechar" => EditCommand::SwitchcaseChar,
         "swapwords" => EditCommand::SwapWords,
         "swapgraphemes" => EditCommand::SwapGraphemes,
         "undo" => EditCommand::Undo,
@@ -1218,17 +1230,64 @@ fn edit_from_record(
                 .unwrap_or(false);
             EditCommand::MoveLeftBefore { c: char, select }
         }
-        "complete" => EditCommand::Complete,
+        "selectall" => EditCommand::SelectAll,
         "cutselection" => EditCommand::CutSelection,
+        "copyselection" => EditCommand::CopySelection,
+        "paste" => EditCommand::Paste,
+        "copyfromstart" => EditCommand::CopyFromStart,
+        "copyfromlinestart" => EditCommand::CopyFromLineStart,
+        "copytoend" => EditCommand::CopyToEnd,
+        "copytolineend" => EditCommand::CopyToLineEnd,
+        "copycurrentline" => EditCommand::CopyCurrentLine,
+        "copywordleft" => EditCommand::CopyWordLeft,
+        "copybigwordleft" => EditCommand::CopyBigWordLeft,
+        "copywordright" => EditCommand::CopyWordRight,
+        "copybigwordright" => EditCommand::CopyBigWordRight,
+        "copywordrighttonext" => EditCommand::CopyWordRightToNext,
+        "copybigwordrighttonext" => EditCommand::CopyBigWordRightToNext,
+        "copyleft" => EditCommand::CopyLeft,
+        "copyright" => EditCommand::CopyRight,
+        "copyrightuntil" => {
+            let value = extract_value("value", record, span)?;
+            let char = extract_char(value)?;
+            EditCommand::CopyRightUntil(char)
+        }
+        "copyrightbefore" => {
+            let value = extract_value("value", record, span)?;
+            let char = extract_char(value)?;
+            EditCommand::CopyRightBefore(char)
+        }
+        "copyleftuntil" => {
+            let value = extract_value("value", record, span)?;
+            let char = extract_char(value)?;
+            EditCommand::CopyLeftUntil(char)
+        }
+        "copyleftbefore" => {
+            let value = extract_value("value", record, span)?;
+            let char = extract_char(value)?;
+            EditCommand::CopyLeftBefore(char)
+        }
+        "swapcursorandanchor" => EditCommand::SwapCursorAndAnchor,
         #[cfg(feature = "system-clipboard")]
         "cutselectionsystem" => EditCommand::CutSelectionSystem,
-        "copyselection" => EditCommand::CopySelection,
         #[cfg(feature = "system-clipboard")]
         "copyselectionsystem" => EditCommand::CopySelectionSystem,
-        "paste" => EditCommand::Paste,
         #[cfg(feature = "system-clipboard")]
         "pastesystem" => EditCommand::PasteSystem,
-        "selectall" => EditCommand::SelectAll,
+        "cutinside" => {
+            let value = extract_value("value", record, span)?;
+            let left = extract_char(value)?;
+            let value = extract_value("right", record, span)?;
+            let right = extract_char(value)?;
+            EditCommand::CutInside { left, right }
+        }
+        "yankinsider" => {
+            let value = extract_value("value", record, span)?;
+            let left = extract_char(value)?;
+            let value = extract_value("right", record, span)?;
+            let right = extract_char(value)?;
+            EditCommand::YankInside { left, right }
+        }
         str => {
             return Err(ShellError::InvalidValue {
                 valid: "a reedline EditCommand".into(),


### PR DESCRIPTION
# Description

This PR tries to update the EditCommands and ReedlineEvents by adding missing items and ordering them to the same order that the reedline enum has them listed.

@sholderbach When you have time, would you mind looking at this please. I left some TODOs because I wasn't sure how to implement them. I also guessed at some of the other implementations. I don't use vim much so I'm not really sure how these are supposed to act. I was really just trying to fill in the blanks.

# User-Facing Changes
Closes #15167

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
