### PR TITLE
Add warning when using $in at the beginning of a block

### DIFF
--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1132,6 +1132,21 @@ impl<'a> GetSpan for &'a StateWorkingSet<'a> {
     }
 }
 
+impl GetSpan for StateWorkingSet<'_> {
+    fn get_span(&self, span_id: SpanId) -> Span {
+        let num_permanent_spans = self.permanent_state.num_spans();
+        if span_id.get() < num_permanent_spans {
+            self.permanent_state.get_span(span_id)
+        } else {
+            *self
+                .delta
+                .spans
+                .get(span_id.get() - num_permanent_spans)
+                .expect("internal error: missing span")
+        }
+    }
+}
+
 impl miette::SourceCode for &StateWorkingSet<'_> {
     fn read_span<'b>(
         &'b self,

--- a/crates/nu-protocol/src/errors/parse_warning.rs
+++ b/crates/nu-protocol/src/errors/parse_warning.rs
@@ -14,12 +14,20 @@ pub enum ParseWarning {
         span: Span,
         url: String,
     },
+
+    #[error("Found $in at the start of a command.")]
+    #[diagnostic(help("Using $in at the start of a command collects the pipeline input.\nIf you did mean to collect the pipeline input, replace this with the `collect` command."))]
+    UnnecessaryInVariable {
+        #[label("try removing this")]
+        span: Span,
+    },
 }
 
 impl ParseWarning {
     pub fn span(&self) -> Span {
         match self {
             ParseWarning::DeprecatedWarning { span, .. } => *span,
+            ParseWarning::UnnecessaryInVariable { span, .. } => *span,
         }
     }
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR adds a warning when you try to use `$in` at the beginning of a block, followed by another pipe. This is to prevent people from accidentally writing `$in | foo`, which incidentally collects, instead of simply `foo`. For example:

```
def foo [] {
  $in | str reverse | str upcase
}
Warning:   × Found $in at the start of a command.
   ╭─[entry #2:4:3]
 3 │ def foo [] {
 4 │   $in | str reverse | str upcase
   ·   ─┬─
   ·    ╰── try removing this
 5 │ }
   ╰────
  help: Using $in at the start of a command collects the pipeline input.
        If you did mean to collect the pipeline input, replace this with the `collect` command.
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
