### PR TITLE
add a helpful msg to indicate a job has been frozen

### DIFF
--- a/crates/nu-protocol/src/engine/jobs.rs
+++ b/crates/nu-protocol/src/engine/jobs.rs
@@ -48,6 +48,7 @@ impl Jobs {
 
     fn assign_last_frozen_id_if_frozen(&mut self, id: JobId, job: &Job) {
         if let Job::Frozen(_) = job {
+            println!("Job {id} has been frozen");
             self.last_frozen_job_id = Some(id);
         }
     }

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -108,6 +108,12 @@ pub type VirtualPathId = Id<marker::VirtualPath>;
 pub type SpanId = Id<marker::Span>;
 pub type JobId = Id<marker::Job>;
 
+impl Display for JobId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get())
+    }
+}
+
 /// An ID for an [IR](crate::ir) register.
 ///
 /// `%n` is a common shorthand for `RegId(n)`.


### PR DESCRIPTION
# Description
As stated in the title, when pressing ctrl-z, I sometimes feel confused because I return to the REPL without any message. I don't know if the process has been killed or suspended.

This PR aims to add a message to notify the user that the process has been frozen.

# User-Facing Changes
After pressing `ctrl-z`.  A message will be printed in repl.

![图片](https://github.com/user-attachments/assets/5fe502eb-439e-4022-889f-64ba52cc2825)

# Tests + Formatting
NaN

# After Submitting
NaN
