### PR TITLE
fix(compact): compact empty list or record in column

### DIFF
--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -108,10 +108,15 @@ pub fn compact(
                                         return false;
                                     }
                                     if compact_empties {
-                                        if let Value::String { val, .. } = x {
-                                            if val.is_empty() {
-                                                return false;
-                                            }
+                                        // check if the value is one of the empty value
+                                        if match x {
+                                            Value::String { val, .. } => val.is_empty(),
+                                            Value::Record { val, .. } => val.is_empty(),
+                                            Value::List { vals, .. } => vals.is_empty(),
+                                            _ => false,
+                                        } {
+                                            // one of the empty value found so skip now
+                                            return false;
                                         }
                                     }
                                 }

--- a/crates/nu-command/tests/commands/compact.rs
+++ b/crates/nu-command/tests/commands/compact.rs
@@ -37,3 +37,58 @@ fn discards_empty_rows_by_default() {
 
     assert_eq!(actual.out, "4");
 }
+
+#[test]
+fn discard_empty_list_in_table() {
+    let actual = nu!(pipeline(
+        r#"
+           [["a", "b"]; ["c", "d"], ["h", []]] | compact -e b | length
+        "#
+    ));
+
+    assert_eq!(actual.out, "1");
+}
+
+#[test]
+fn discard_empty_record_in_table() {
+    let actual = nu!(pipeline(
+        r#"
+           [["a", "b"]; ["c", "d"], ["h", {}]] | compact -e b | length
+        "#
+    ));
+
+    assert_eq!(actual.out, "1");
+}
+
+#[test]
+fn dont_discard_empty_record_in_table_if_column_not_set() {
+    let actual = nu!(pipeline(
+        r#"
+           [["a", "b"]; ["c", "d"], ["h", {}]] | compact -e | length
+        "#
+    ));
+
+    assert_eq!(actual.out, "2");
+}
+
+#[test]
+fn dont_discard_empty_list_in_table_if_column_not_set() {
+    let actual = nu!(pipeline(
+        r#"
+           [["a", "b"]; ["c", "d"], ["h", []]] | compact -e | length
+        "#
+    ));
+
+    assert_eq!(actual.out, "2");
+}
+
+#[test]
+fn dont_discard_null_in_table_if_column_not_set() {
+    let actual = nu!(pipeline(
+        r#"
+           [["a", "b"]; ["c", "d"], ["h", null]] | compact -e | length
+        "#
+    ));
+
+    assert_eq!(actual.out, "2");
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
if a table contains empty list or record in one column and both column and -e flags are used then skip that row

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
now compact will skip empty values in column where as before this was ignored. ex.
 ```nu
[["a", "b"]; ["c", "d"], ["h", []]] 
| compact -e b
```
before
```plain
 #   a         b
────────────────────────
 0   c   d
 1   h   [list 0 items]
```
after
```plain
 #   a   b
───────────
 0   c   d
```


# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
