### PR TITLE
Add ansi codes to move cursor position

### DIFF
--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -466,6 +466,14 @@ static CODE_LIST: LazyLock<Vec<AnsiCode>> = LazyLock::new(|| { vec![
 
     // Cursor position in ESC [ <r>;<c>R where r = row and c = column
     AnsiCode{ short_name: None, long_name:"cursor_position", code: "\x1b[6n".to_string()},
+    // Move cursor one character left
+    AnsiCode{ short_name: None, long_name:"cursor_left", code: "\x1b[D".to_string()},
+    // Move cursor one character right
+    AnsiCode{ short_name: None, long_name:"cursor_right", code: "\x1b[C".to_string()},
+    // Move cursor one line up
+    AnsiCode{ short_name: None, long_name:"cursor_up", code: "\x1b[A".to_string()},
+    // Move cursor one line down
+    AnsiCode{ short_name: None, long_name:"cursor_down", code: "\x1b[B".to_string()},
 
     // Report Terminal Identity
     AnsiCode{ short_name: None, long_name:"identity", code: "\x1b[0c".to_string()},

--- a/crates/nu-command/tests/commands/platform/ansi_.rs
+++ b/crates/nu-command/tests/commands/platform/ansi_.rs
@@ -11,7 +11,7 @@ fn test_ansi_shows_error_on_escape() {
 fn test_ansi_list_outputs_table() {
     let actual = nu!("ansi --list | length");
 
-    assert_eq!(actual.out, "425");
+    assert_eq!(actual.out, "429");
 }
 
 #[test]


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Add ansi codes to move cursor position: `ansi cursor_left`, `ansi cursor_right`, `ansi cursor_up`, `ansi cursor_down`
Why I add these? I'm trying to add a spinner to the message end for a long running task, just to find that I need to move the cursor left to make it work as expected: `with-progress 'Waiting for the task to finish' { sleep 10sec }`
```nu
def with-progress [
  message: string,         # Message to display
  action: closure,         # Action to perform
  --success: string,       # Success message
  --error: string          # Error message
] {
  print -n $'($message)   '
  # ASCII spinner frames
  let frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']

  # Start the spinner in the background
  let spinner_pid = job spawn {
    mut i = 0
    print -n (ansi cursor_off)
    loop {
      print -n (ansi cursor_left)
      print -n ($frames | get $i)
      sleep 100ms
      $i = ($i + 1) mod ($frames | length)
    }
  }

  # Run the action and capture result
  let result = try {
    do $action
    { success: true }
  } catch {
    { success: false }
  }

  # Stop the spinner
  job kill $spinner_pid
  print "\r                                                  \r"

  # Show appropriate message
  if $result.success {
    print ($success | default '✓ Done!')
  } else {
    print ($error | default '✗ Failed!')
    exit 1
  }
}
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
