### PR TITLE
Add `default --empty` to handle empty values

### DIFF
--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -23,6 +23,11 @@ impl Command for Default {
                 SyntaxShape::String,
                 "The name of the column.",
             )
+            .switch(
+                "empty",
+                "also compact empty items like \"\", {}, and []",
+                Some('e'),
+            )
             .category(Category::Filters)
     }
 
@@ -37,7 +42,8 @@ impl Command for Default {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        default(engine_state, stack, call, input)
+        let empty = call.has_flag(engine_state, stack, "empty")?;
+        default(engine_state, stack, call, input, empty)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -89,6 +95,7 @@ fn default(
     stack: &mut Stack,
     call: &Call,
     input: PipelineData,
+    default_when_empty: bool,
 ) -> Result<PipelineData, ShellError> {
     let metadata = input.metadata();
     let value: Value = call.req(engine_state, stack, 0)?;
@@ -104,7 +111,9 @@ fn default(
                     } => {
                         let record = record.to_mut();
                         if let Some(val) = record.get_mut(&column.item) {
-                            if matches!(val, Value::Nothing { .. }) {
+                            if matches!(val, Value::Nothing { .. })
+                                || (default_when_empty && val.is_empty())
+                            {
                                 *val = value.clone();
                             }
                         } else {
@@ -118,7 +127,12 @@ fn default(
                 engine_state.signals(),
             )
             .map(|x| x.set_metadata(metadata))
-    } else if input.is_nothing() {
+    } else if input.is_nothing()
+        || (default_when_empty
+            && (matches!(input, PipelineData::Value(Value::String { ref val, .. }, _) if val.is_empty())
+                || matches!(input, PipelineData::Value(Value::Record { ref val, .. }, _) if val.is_empty())
+                || matches!(input, PipelineData::Value(Value::List { ref vals, .. }, _) if vals.is_empty())))
+    {
         Ok(value.into_pipeline_data())
     } else {
         Ok(input)

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -25,7 +25,7 @@ impl Command for Default {
             )
             .switch(
                 "empty",
-                "also compact empty items like \"\", {}, and []",
+                "also remove empty items like \"\", {}, and []",
                 Some('e'),
             )
             .category(Category::Filters)
@@ -143,9 +143,7 @@ fn default(
             .map(|x| x.set_metadata(metadata))
     } else if input.is_nothing()
         || (default_when_empty
-            && (matches!(input, PipelineData::Value(Value::String { ref val, .. }, _) if val.is_empty())
-                || matches!(input, PipelineData::Value(Value::Record { ref val, .. }, _) if val.is_empty())
-                || matches!(input, PipelineData::Value(Value::List { ref vals, .. }, _) if vals.is_empty())))
+            && matches!(input, PipelineData::Value(ref value, _) if value.is_empty()))
     {
         Ok(value.into_pipeline_data())
     } else {

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -25,7 +25,7 @@ impl Command for Default {
             )
             .switch(
                 "empty",
-                "also remove empty items like \"\", {}, and []",
+                "also replace empty items like \"\", {}, and []",
                 Some('e'),
             )
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -86,6 +86,20 @@ impl Command for Default {
                     }),
                 ])),
             },
+            Example {
+                description: r#"Replace the empty string in the "a" column of a list"#,
+                example: "[{a:1 b:2} {a:'' b:1}] | default -e 'N/A' a",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "a" => Value::test_int(1),
+                        "b" => Value::test_int(2),
+                    }),
+                    Value::test_record(record! {
+                        "a" => Value::test_string("N/A"),
+                        "b" => Value::test_int(1),
+                    }),
+                ])),
+            },
         ]
     }
 }


### PR DESCRIPTION
# Description

Adds a new `--empty/-e` flag to the `default` command.

# User-Facing Changes

Before:

```nushell
$env.FOO = ""
$env.FOO = $env.FOO? | default bar
$env.FOO
# => Empty string
```

After:

```nushell
$env.FOO = ""
$env.FOO = $env.FOO? | default -e bar
$env.FOO
# => bar
```

* Uses `val.is_empty`, which means that empty lists and records are also replaced
* Empty values in tables (with a column specifier) are also replaced.

# Tests + Formatting

7 tests added and 1 updated + 1 new example

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A