### PR TITLE
Redirect stdin by default

### DIFF
--- a/crates/nu-command/tests/commands/job.rs
+++ b/crates/nu-command/tests/commands/job.rs
@@ -208,7 +208,7 @@ fn job_extern_into_value_is_not_silent() {
 fn job_extern_into_pipe_is_not_silent() {
     let actual = nu!(r#"
         job spawn { 
-            print (nu -c "10" | nu --stdin -c "($in | into int) + 1")
+            print (nu -c "10" | nu -c "($in | into int) + 1")
         }
         sleep 1sec"#);
 

--- a/crates/nu-plugin-engine/src/init.rs
+++ b/crates/nu-plugin-engine/src/init.rs
@@ -55,10 +55,7 @@ pub fn create_command(
                     Some(Path::new("sh"))
                 }
             }
-            Some("nu") => {
-                shell_args.push("--stdin");
-                Some(Path::new("nu"))
-            }
+            Some("nu") => Some(Path::new("nu")),
             Some("py") => Some(Path::new("python")),
             Some("rb") => Some(Path::new("ruby")),
             Some("jar") => {

--- a/crates/nu-protocol/src/errors/parse_warning.rs
+++ b/crates/nu-protocol/src/errors/parse_warning.rs
@@ -14,12 +14,22 @@ pub enum ParseWarning {
         span: Span,
         url: String,
     },
+    #[error("Deprecated: {old}")]
+    #[diagnostic(help("{help}"))]
+    CustomDeprecatedWarning {
+        old: String,
+        help: String,
+        label: String,
+        #[label("{label}")]
+        span: Span,
+    },
 }
 
 impl ParseWarning {
     pub fn span(&self) -> Span {
         match self {
             ParseWarning::DeprecatedWarning { span, .. } => *span,
+            ParseWarning::CustomDeprecatedWarning { span, .. } => *span,
         }
     }
 }

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -5,6 +5,7 @@
 #[cfg(feature = "os")]
 use crate::process::{ChildPipe, ChildProcess};
 use crate::{
+    location,
     shell_error::{bridge::ShellErrorBridge, io::IoError},
     IntRange, PipelineData, ShellError, Signals, Span, Type, Value,
 };
@@ -367,7 +368,9 @@ impl ByteStream {
     /// binary.
     #[cfg(feature = "os")]
     pub fn stdin(span: Span) -> Result<Self, ShellError> {
-        let stdin = os_pipe::dup_stdin().map_err(|err| IoError::new(err.kind(), span, None))?;
+        let stdin = os_pipe::dup_stdin().map_err(|err| {
+            IoError::new_internal(err.kind(), "Failed to duplicate stdin", location!())
+        })?;
         let source = ByteStreamSource::File(convert_file(stdin));
         Ok(Self::new(
             source,

--- a/crates/nu_plugin_nu_example/nu_plugin_nu_example.nu
+++ b/crates/nu_plugin_nu_example/nu_plugin_nu_example.nu
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S nu --stdin
+#!/usr/bin/env nu
 # Example of using a Nushell script as a Nushell plugin
 #
 # This is a port of the nu_plugin_python_example plugin to Nushell itself. There is probably not

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use nu_std::load_standard_library;
 use nu_utils::perf;
 use run::{run_commands, run_file, run_repl};
 use signals::ctrlc_protection;
-use std::{path::PathBuf, str::FromStr, sync::Arc};
+use std::{io::IsTerminal, path::PathBuf, str::FromStr, sync::Arc};
 
 /// Get the directory where the Nushell executable is located.
 fn current_exe_directory() -> PathBuf {
@@ -392,9 +392,9 @@ fn main() -> Result<()> {
     perf!("run test_bins", start_time, use_color);
 
     start_time = std::time::Instant::now();
-    let input = if let Some(redirect_stdin) = &parsed_nu_cli_args.redirect_stdin {
+    let input = if !std::io::stdin().is_terminal() {
         trace!("redirecting stdin");
-        PipelineData::ByteStream(ByteStream::stdin(redirect_stdin.span)?, None)
+        PipelineData::ByteStream(ByteStream::stdin(Span::unknown())?, None)
     } else {
         trace!("not redirecting stdin");
         PipelineData::empty()

--- a/tests/shell/pipeline/mod.rs
+++ b/tests/shell/pipeline/mod.rs
@@ -14,6 +14,6 @@ fn non_zero_exit_code_in_middle_of_pipeline_ignored() {
     let actual = nu!("nu -c 'print a b; exit 42' | collect");
     assert_eq!(actual.out, "ab");
 
-    let actual = nu!("nu -c 'print a b; exit 42' | nu --stdin -c 'collect'");
+    let actual = nu!("nu -c 'print a b; exit 42' | nu -c 'collect'");
     assert_eq!(actual.out, "ab");
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR removes the `--stdin` flag, and redirects standard input by default (unless stdin connected to a terminal). It throws a warning on startup, informing the user that the option will be removed in the future:

```
Warning:   × Deprecated: --stdin flag
   ╭─[source:1:4]
 1 │ nu --stdin
   ·    ───┬───
   ·       ╰── remove this
   ╰────
  help: Redirecting stdin is now the default behavior. The --stdin flag will be removed in a future release.
```

This flag was introduced during a time where Nushell read _scripts_ from stdin (there was no script argument parameter, e.g., you couldn't do `nu foo.nu`). The `--stdin` flag was only intended to be used with `nu -c` (as opposed to today, where it affects both scripts and `nu -c`). I can't find a specific rationale, but it might have been intended to make stdin redirection when using `nu -c` explicit, since that behavior might have been confusing for contemporary users who might have only expected scripts to be read from stdin.

Related: #15219 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

* Standard input is now redirected by default, meaning the `--stdin` flag is no longer necessary. A warning will be thrown if you try to use `--stdin`, letting you know to remove it.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
N/A

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
Update documentation to remove references to --stdin