### PR TITLE
Add `std-rfc/config` menu defs

### DIFF
--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -105,6 +105,11 @@ pub fn load_standard_library(
         ),
         (
             "mod.nu",
+            "std-rfc/config",
+            include_str!("../std-rfc/config/mod.nu"),
+        ),
+        (
+            "mod.nu",
             "std-rfc/conversions",
             include_str!("../std-rfc/conversions/mod.nu"),
         ),

--- a/crates/nu-std/std-rfc/config/mod.nu
+++ b/crates/nu-std/std-rfc/config/mod.nu
@@ -1,0 +1,84 @@
+export def default_completion_menu [] {{
+  name: completion_menu
+  only_buffer_difference: false
+  marker: "| "
+  type: {
+      layout: columnar
+      columns: 4
+      col_width: 20
+      col_padding: 2
+  }
+  style: {
+      text: green,
+      selected_text: green_reverse
+      description_text: yellow
+  }
+}}
+
+export def default_ide_completion_menu [] {{
+  name: ide_completion_menu
+  only_buffer_difference: false
+  marker: "| "
+  type: {
+    layout: ide
+    min_completion_width: 0,
+    max_completion_width: 50,
+    max_completion_height: 10, # will be limited by the available lines in the terminal
+    padding: 0,
+    border: true,
+    cursor_offset: 0,
+    description_mode: "prefer_right"
+    min_description_width: 0
+    max_description_width: 50
+    max_description_height: 10
+    description_offset: 1
+    # If true, the cursor pos will be corrected, so the suggestions match up with the typed text
+    #
+    # C:\> str
+    #      str join
+    #      str trim
+    #      str split
+    correct_cursor_pos: false
+  }
+  style: {
+    text: green
+    selected_text: { attr: r }
+    description_text: yellow
+    match_text: { attr: u }
+    selected_match_text: { attr: ur }
+  }
+}}
+
+export def default_history_menu [] {{
+  name: history_menu
+  only_buffer_difference: true
+  marker: "? "
+  type: {
+      layout: list
+      page_size: 10
+  }
+  style: {
+      text: green,
+      selected_text: green_reverse
+      description_text: yellow
+  }
+}}
+
+export def default_help_menu [] {{
+  name: help_menu
+  only_buffer_difference: true
+  marker: "? "
+  type: {
+      layout: description
+      columns: 4
+      col_width: 20
+      col_padding: 2
+      selection_rows: 4
+      description_rows: 10
+  }
+  style: {
+      text: green,
+      selected_text: green_reverse
+      description_text: yellow
+  }
+}}


### PR DESCRIPTION
# Description

When I removed `default_config.nu` a few releases ago, that also meant that the default menu definitions were no longer readily available to modify.  This PR makes them easily accessible through `std-rfc/config`. For example:

```nushell
$env.config.menus = [
  (default_help_menu | merge deep { type: { columns: 5 }})
]
```

# User-Facing Changes

New `std-rfc` module.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

