### PR TITLE
fix(lsp): completion label descriptions for cell_path and external values

### DIFF
--- a/crates/nu-cli/src/completions/base.rs
+++ b/crates/nu-cli/src/completions/base.rs
@@ -29,9 +29,14 @@ pub struct SemanticSuggestion {
 #[derive(Clone, Debug, PartialEq)]
 pub enum SuggestionKind {
     Command(nu_protocol::engine::CommandType),
-    Type(nu_protocol::Type),
+    Value(nu_protocol::Type),
+    CellPath,
+    Directory,
+    File,
+    Flag,
     Module,
     Operator,
+    Variable,
 }
 
 impl From<Suggestion> for SemanticSuggestion {

--- a/crates/nu-cli/src/completions/cell_path_completions.rs
+++ b/crates/nu-cli/src/completions/cell_path_completions.rs
@@ -125,12 +125,11 @@ fn get_suggestions_by_value(
         Value::List { vals, .. } => get_columns(vals.as_slice())
             .into_iter()
             .map(|s| {
-                to_suggestion(
-                    s.clone(),
-                    vals.first()
-                        .and_then(|v| v.as_record().ok())
-                        .and_then(|rv| rv.get(s)),
-                )
+                let sub_val = vals
+                    .first()
+                    .and_then(|v| v.as_record().ok())
+                    .and_then(|rv| rv.get(&s));
+                to_suggestion(s, sub_val)
             })
             .collect(),
         _ => vec![],

--- a/crates/nu-cli/src/completions/cell_path_completions.rs
+++ b/crates/nu-cli/src/completions/cell_path_completions.rs
@@ -108,23 +108,30 @@ fn get_suggestions_by_value(
     value: &Value,
     current_span: reedline::Span,
 ) -> Vec<SemanticSuggestion> {
-    let kind = SuggestionKind::Type(value.get_type());
-    let str_to_suggestion = |s: String| SemanticSuggestion {
+    let to_suggestion = |s: String, v: Option<&Value>| SemanticSuggestion {
         suggestion: Suggestion {
             value: s,
             span: current_span,
+            description: v.map(|v| v.get_type().to_string()),
             ..Suggestion::default()
         },
-        kind: Some(kind.to_owned()),
+        kind: Some(SuggestionKind::CellPath),
     };
     match value {
         Value::Record { val, .. } => val
             .columns()
-            .map(|s| str_to_suggestion(s.to_string()))
+            .map(|s| to_suggestion(s.to_string(), val.get(s)))
             .collect(),
         Value::List { vals, .. } => get_columns(vals.as_slice())
             .into_iter()
-            .map(str_to_suggestion)
+            .map(|s| {
+                to_suggestion(
+                    s.clone(),
+                    vals.first()
+                        .and_then(|v| v.as_record().ok())
+                        .and_then(|rv| rv.get(s)),
+                )
+            })
             .collect(),
         _ => vec![],
     }

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -157,6 +157,7 @@ pub struct FileSuggestion {
     pub span: nu_protocol::Span,
     pub path: String,
     pub style: Option<Style>,
+    pub is_dir: bool,
 }
 
 /// # Parameters
@@ -260,6 +261,7 @@ pub fn complete_item(
         if should_collapse_dots {
             p = collapse_ndots(p);
         }
+        let is_dir = p.isdir;
         let path = original_cwd.apply(p, path_separator);
         let style = ls_colors.as_ref().map(|lsc| {
             lsc.style_for_path_with_metadata(
@@ -275,6 +277,7 @@ pub fn complete_item(
             span,
             path: escape_path(path, want_directory),
             style,
+            is_dir,
         }
     })
     .collect()

--- a/crates/nu-cli/src/completions/directory_completions.rs
+++ b/crates/nu-cli/src/completions/directory_completions.rs
@@ -9,7 +9,7 @@ use nu_protocol::{
 use reedline::Suggestion;
 use std::path::Path;
 
-use super::{completion_common::FileSuggestion, SemanticSuggestion};
+use super::{completion_common::FileSuggestion, SemanticSuggestion, SuggestionKind};
 
 pub struct DirectoryCompletion;
 
@@ -47,8 +47,7 @@ impl Completer for DirectoryCompletion {
                 },
                 ..Suggestion::default()
             },
-            // TODO????
-            kind: None,
+            kind: Some(SuggestionKind::Directory),
         })
         .collect();
 

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -9,7 +9,7 @@ use nu_protocol::{
 use reedline::Suggestion;
 use std::path::Path;
 
-use super::{completion_common::FileSuggestion, SemanticSuggestion};
+use super::{completion_common::FileSuggestion, SemanticSuggestion, SuggestionKind};
 
 pub struct FileCompletion;
 
@@ -50,8 +50,7 @@ impl Completer for FileCompletion {
                 },
                 ..Suggestion::default()
             },
-            // TODO????
-            kind: None,
+            kind: Some(SuggestionKind::File),
         })
         .collect();
 

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -50,7 +50,11 @@ impl Completer for FileCompletion {
                 },
                 ..Suggestion::default()
             },
-            kind: Some(SuggestionKind::File),
+            kind: Some(if x.is_dir {
+                SuggestionKind::Directory
+            } else {
+                SuggestionKind::File
+            }),
         })
         .collect();
 

--- a/crates/nu-cli/src/completions/flag_completions.rs
+++ b/crates/nu-cli/src/completions/flag_completions.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
 };
 use reedline::Suggestion;
 
-use super::SemanticSuggestion;
+use super::{SemanticSuggestion, SuggestionKind};
 
 #[derive(Clone)]
 pub struct FlagCompletion {
@@ -35,8 +35,7 @@ impl Completer for FlagCompletion {
                     append_whitespace: true,
                     ..Suggestion::default()
                 },
-                // TODO????
-                kind: None,
+                kind: Some(SuggestionKind::Flag),
             });
         };
 

--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -32,10 +32,10 @@ impl Completer for VariableCompletion {
                 suggestion: Suggestion {
                     value: builtin.to_string(),
                     span: current_span,
+                    description: Some("reserved".into()),
                     ..Suggestion::default()
                 },
-                // TODO is there a way to get the VarId to get the type???
-                kind: None,
+                kind: Some(SuggestionKind::Variable),
             });
         }
 
@@ -44,11 +44,10 @@ impl Completer for VariableCompletion {
                 suggestion: Suggestion {
                     value: String::from_utf8_lossy(name).to_string(),
                     span: current_span,
+                    description: Some(working_set.get_variable(*var_id).ty.to_string()),
                     ..Suggestion::default()
                 },
-                kind: Some(SuggestionKind::Type(
-                    working_set.get_variable(*var_id).ty.clone(),
-                )),
+                kind: Some(SuggestionKind::Variable),
             })
         };
 


### PR DESCRIPTION
# Description

The type shown in the completion description is 1 level higher than the actual entry.
Also cleans some TODOs for `SuggetionKind`.

# User-Facing Changes

## Before

<img width="409" alt="image" src="https://github.com/user-attachments/assets/c7d7df02-aed9-4ea9-892a-0bca707352eb" />

<img width="491" alt="image" src="https://github.com/user-attachments/assets/9b9394d4-62ee-4924-9840-402f00d88a8a" />

## After

<img width="425" alt="image" src="https://github.com/user-attachments/assets/d8f41059-2c68-4902-9c32-d789f91b6d77" />

<img width="425" alt="image" src="https://github.com/user-attachments/assets/ce03afb9-6c1f-4a65-a1cc-cbba4655abb3" />

# Tests + Formatting

Adjusted accordingly

# After Submitting