### PR TITLE
doc: clarify trailing line ending in 'to json -r' documentation

### DIFF
--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -12,7 +12,11 @@ impl Command for ToJson {
     fn signature(&self) -> Signature {
         Signature::build("to json")
             .input_output_types(vec![(Type::Any, Type::String)])
-            .switch("raw", "remove all of the whitespace", Some('r'))
+            .switch(
+                "raw",
+                "remove all of the whitespace and trailing line ending",
+                Some('r'),
+            )
             .named(
                 "indent",
                 SyntaxShape::Number,


### PR DESCRIPTION
# Description

Fixes issue  #15215

# User-Facing Changes

Change in help msg in "to json" command with -r flag

# Tests + Formatting
cargo fmt 🆗 

# After Submitting
Doc for that is generated from code I think, so 🆗 
