### PR TITLE
bugfix: math commands now return error with infinite range [#15135]

### DIFF
--- a/crates/nu-command/tests/commands/math/abs.rs
+++ b/crates/nu-command/tests/commands/math/abs.rs
@@ -5,3 +5,10 @@ fn const_abs() {
     let actual = nu!("const ABS = -5.5 | math abs; $ABS");
     assert_eq!(actual.out, "5.5");
 }
+
+#[test]
+fn cannot_abs_range() {
+    let actual = nu!("0..5 | math abs");
+
+    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+}

--- a/crates/nu-command/tests/commands/math/avg.rs
+++ b/crates/nu-command/tests/commands/math/avg.rs
@@ -22,6 +22,20 @@ fn can_average_bytes() {
 }
 
 #[test]
+fn can_average_range() {
+    let actual = nu!("0..5 | math avg");
+
+    assert_eq!(actual.out, "2.5");
+}
+
+#[test]
+fn cannot_average_infinite_range() {
+    let actual = nu!("0.. | math avg");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
+}
+
+#[test]
 fn const_avg() {
     let actual = nu!("const AVG = [1 3 5] | math avg; $AVG");
     assert_eq!(actual.out, "3");

--- a/crates/nu-command/tests/commands/math/ceil.rs
+++ b/crates/nu-command/tests/commands/math/ceil.rs
@@ -5,3 +5,10 @@ fn const_ceil() {
     let actual = nu!("const CEIL = 1.5 | math ceil; $CEIL");
     assert_eq!(actual.out, "2");
 }
+
+#[test]
+fn cannot_ceil_range() {
+    let actual = nu!("0..5 | math ceil");
+
+    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+}

--- a/crates/nu-command/tests/commands/math/floor.rs
+++ b/crates/nu-command/tests/commands/math/floor.rs
@@ -5,3 +5,10 @@ fn const_floor() {
     let actual = nu!("const FLOOR = 15.5 | math floor; $FLOOR");
     assert_eq!(actual.out, "15");
 }
+
+#[test]
+fn cannot_floor_range() {
+    let actual = nu!("0.. | math floor");
+
+    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+}

--- a/crates/nu-command/tests/commands/math/log.rs
+++ b/crates/nu-command/tests/commands/math/log.rs
@@ -5,3 +5,10 @@ fn const_log() {
     let actual = nu!("const LOG = 16 | math log 2; $LOG");
     assert_eq!(actual.out, "4");
 }
+
+#[test]
+fn cannot_log_range() {
+    let actual = nu!("0.. | math log 2");
+
+    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+}

--- a/crates/nu-command/tests/commands/math/max.rs
+++ b/crates/nu-command/tests/commands/math/max.rs
@@ -5,3 +5,10 @@ fn const_max() {
     let actual = nu!("const MAX = [1 3 5] | math max; $MAX");
     assert_eq!(actual.out, "5");
 }
+
+#[test]
+fn cannot_max_infinite_range() {
+    let actual = nu!("0.. | math max");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
+}

--- a/crates/nu-command/tests/commands/math/median.rs
+++ b/crates/nu-command/tests/commands/math/median.rs
@@ -41,3 +41,10 @@ fn const_median() {
     let actual = nu!("const MEDIAN = [1 3 5] | math median; $MEDIAN");
     assert_eq!(actual.out, "3");
 }
+
+#[test]
+fn cannot_median_infinite_range() {
+    let actual = nu!("0.. | math median");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
+}

--- a/crates/nu-command/tests/commands/math/min.rs
+++ b/crates/nu-command/tests/commands/math/min.rs
@@ -5,3 +5,10 @@ fn const_min() {
     let actual = nu!("const MIN = [1 3 5] | math min; $MIN");
     assert_eq!(actual.out, "1");
 }
+
+#[test]
+fn cannot_min_infinite_range() {
+    let actual = nu!("0.. | math min");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
+}

--- a/crates/nu-command/tests/commands/math/mode.rs
+++ b/crates/nu-command/tests/commands/math/mode.rs
@@ -5,3 +5,10 @@ fn const_avg() {
     let actual = nu!("const MODE = [1 3 3 5] | math mode; $MODE");
     assert_eq!(actual.out, "╭───┬───╮│ 0 │ 3 │╰───┴───╯");
 }
+
+#[test]
+fn cannot_mode_range() {
+    let actual = nu!("0..5 | math mode");
+
+    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+}

--- a/crates/nu-command/tests/commands/math/product.rs
+++ b/crates/nu-command/tests/commands/math/product.rs
@@ -5,3 +5,10 @@ fn const_product() {
     let actual = nu!("const PROD = [1 3 5] | math product; $PROD");
     assert_eq!(actual.out, "15");
 }
+
+#[test]
+fn cannot_product_infinite_range() {
+    let actual = nu!("0.. | math product");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
+}

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -40,3 +40,10 @@ fn const_round() {
     let actual = nu!("const ROUND = 18.345 | math round; $ROUND");
     assert_eq!(actual.out, "18");
 }
+
+#[test]
+fn cannot_round_infinite_range() {
+    let actual = nu!("0..5 | math round");
+
+    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+}

--- a/crates/nu-command/tests/commands/math/sqrt.rs
+++ b/crates/nu-command/tests/commands/math/sqrt.rs
@@ -26,3 +26,10 @@ fn const_sqrt() {
     let actual = nu!("const SQRT = 4 | math sqrt; $SQRT");
     assert_eq!(actual.out, "2");
 }
+
+#[test]
+fn cannot_sqrt_range() {
+    let actual = nu!("0..5 | math sqrt");
+
+    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+}

--- a/crates/nu-command/tests/commands/math/stddev.rs
+++ b/crates/nu-command/tests/commands/math/stddev.rs
@@ -5,3 +5,10 @@ fn const_avg() {
     let actual = nu!("const SDEV = [1 2] | math stddev; $SDEV");
     assert_eq!(actual.out, "0.5");
 }
+
+#[test]
+fn cannot_stddev_range() {
+    let actual = nu!("0..5 | math stddev");
+
+    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+}

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -81,3 +81,10 @@ fn const_sum() {
     let actual = nu!("const SUM = [1 3] | math sum; $SUM");
     assert_eq!(actual.out, "4");
 }
+
+#[test]
+fn cannot_sum_infinite_range() {
+    let actual = nu!("0.. | math sum");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
+}

--- a/crates/nu-command/tests/commands/math/variance.rs
+++ b/crates/nu-command/tests/commands/math/variance.rs
@@ -5,3 +5,10 @@ fn const_variance() {
     let actual = nu!("const VAR = [1 2 3 4 5] | math variance; $VAR");
     assert_eq!(actual.out, "2");
 }
+
+#[test]
+fn cannot_variance_range() {
+    let actual = nu!("0..5 | math variance");
+
+    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+}

--- a/crates/nu-pretty-hex/README.md
+++ b/crates/nu-pretty-hex/README.md
@@ -1,6 +1,6 @@
 # nu-pretty-hex
 
-An update of prett-hex to make it prettier
+An update of pretty-hex to make it prettier
 
 [![crates.io](https://img.shields.io/crates/v/pretty-hex.svg)](https://crates.io/crates/pretty-hex)
 [![docs.rs](https://docs.rs/pretty-hex/badge.svg)](https://docs.rs/pretty-hex)


### PR DESCRIPTION
### Description
Fixes issue #15135

Result
![image](https://github.com/user-attachments/assets/9ff4397f-db79-46df-b1da-2d09f50dd63f)

Also this works with other commands: min, max, sum, product, avg...

### User-Facing Changes
Error is returned, instead of console completely blocked and having to be killed
I chose "Incorrect value", because commands accept inputs of range type, just cannot work with unbounded ranges.

### Tests + Formatting
- ran cargo fmt, clippy
- added tests

