### PR TITLE
Start improving mutable capture error

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6522,7 +6522,12 @@ pub fn discover_captures_in_expr(
                     if !seen.contains(var_id) {
                         if let Some(variable) = working_set.get_variable_if_possible(*var_id) {
                             if variable.mutable {
-                                return Err(ParseError::CaptureOfMutableVar(*span));
+                                let var_name = working_set.get_span_contents(*span);
+                                return Err(ParseError::CaptureOfMutableVar {
+                                    var: String::from_utf8_lossy(var_name).into_owned(),
+                                    var_span: span.before(),
+                                    closure_span: block.span,
+                                });
                             }
                         }
                     }

--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -145,9 +145,15 @@ pub enum ParseError {
         help: Option<&'static str>,
     },
 
-    #[error("Capture of mutable variable.")]
-    #[diagnostic(code(nu::parser::expected_keyword))]
-    CaptureOfMutableVar(#[label("capture of mutable variable")] Span),
+    #[error("Cannot capture mutable variables inside closures.")]
+    #[diagnostic(code(nu::parser::mutable_capture))]
+    CaptureOfMutableVar {
+        var: String,
+        #[label("could not capture within this closure")]
+        closure_span: Option<Span>,
+        #[label("attempted to capture mutable variable {var}")]
+        var_span: Span,
+    },
 
     #[error("Expected keyword.")]
     #[diagnostic(code(nu::parser::expected_keyword))]
@@ -570,7 +576,7 @@ impl ParseError {
             ParseError::BuiltinCommandInPipeline(_, s) => *s,
             ParseError::AssignInPipeline(_, _, _, s) => *s,
             ParseError::NameIsBuiltinVar(_, s) => *s,
-            ParseError::CaptureOfMutableVar(s) => *s,
+            ParseError::CaptureOfMutableVar { var_span, .. } => *var_span,
             ParseError::IncorrectValue(_, s, _) => *s,
             ParseError::MultipleRestParams(s) => *s,
             ParseError::VariableNotFound(_, s) => *s,

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -140,6 +140,14 @@ impl Span {
         self.start <= span.start && span.end <= self.end && span.end != 0
     }
 
+    /// Point to the space just before this span
+    pub fn before(&self) -> Self {
+        Self {
+            start: self.start,
+            end: self.start,
+        }
+    }
+
     /// Point to the space just past this span, useful for missing values
     pub fn past(&self) -> Self {
         Self {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

WIP. Attempt to improve mutable capture error. Currently looks a bit weird for single lines, since the spans overlap (I think related to this miette issue: https://github.com/zkat/miette/issues/268)

![image](https://github.com/user-attachments/assets/6b38855f-a28e-4fe1-baca-d318b7b4411e)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
