### PR TITLE
Fix unterminated loop in parse_record

### DIFF
--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -2818,4 +2818,16 @@ mod record {
             _ => panic!("Expected full cell path"),
         }
     }
+
+    /// Regression test for https://github.com/nushell/nushell/issues/15243
+    #[test]
+    fn record_terminate_loop() {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        parse(&mut working_set, None, b"{a:b}/", false);
+        assert_eq!(
+            working_set.parse_errors.first().map(|e| e.to_string()),
+            Some("Invalid characters after closing delimiter".to_string())
+        );
+    }
 }


### PR DESCRIPTION
Fixes #15243

# Description

As noted in #15243, a record with more characters after it (e.g., `{a:b}/`) will cause an OOM due to an infinite loop, introduced by #15023. This happens because the entire string `{a:b}/` is lexed as one token and passed to `parse_record`, where it repeatedly lexes until it hits the closing `}`. This PR detects such extra characters and reports an error.

# User-Facing Changes

`{a:b}/` and other such constructions will no longer cause infinite loops. Before #15023, you would've seen an "Unclosed delimiter" error message, but this PR changes that to "Invalid characters."

```
Error: nu::parser::extra_token_after_closing_delimiter

  × Invalid characters after closing delimiter
   ╭─[entry #5:1:7]
 1 │  {a:b}/
   ·       ┬
   ·       ╰── invalid characters
   ╰────
  help: Try removing them.
```

# Tests + Formatting

# After Submitting
