### PR TITLE
Add Xor to polars plugin nu_expressions

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/nu_expression/custom_value.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_expression/custom_value.rs
@@ -143,6 +143,11 @@ fn with_operator(
             .apply_with_expr(right.clone(), Expr::logical_or)
             .cache(plugin, engine, lhs_span)?
             .into_value(lhs_span)),
+        Operator::Boolean(Boolean::Xor) => Ok(left
+            .clone()
+            .apply_with_expr(right.clone(), logical_xor)
+            .cache(plugin, engine, lhs_span)?
+            .into_value(lhs_span)),
         op => Err(ShellError::OperatorUnsupportedType {
             op,
             unsupported: Type::Custom(TYPE_NAME.into()),
@@ -151,6 +156,11 @@ fn with_operator(
             help: None,
         }),
     }
+}
+
+pub fn logical_xor(a: Expr, b: Expr) -> Expr {
+    (a.clone().or(b.clone())) // A OR B
+        .and((a.and(b)).not()) // AND with NOT (A AND B)
 }
 
 fn apply_arithmetic<F>(


### PR DESCRIPTION
solution for #15242 ,  based on PR #15248 .

Allows doing this:

```
~/Projects/nushell> [[a, b]; [1., 2.], [3.,3.], [4., 6.]] | polars into-df | polars filter (((polars col a) < 2) xor ((polars col b) > 5))
╭───┬──────┬──────╮
│ # │  a   │  b   │
├───┼──────┼──────┤
│ 0 │ 1.00 │ 2.00 │
│ 1 │ 4.00 │ 6.00 │
╰───┴──────┴──────╯
```
