### PR TITLE
Enhance polars plugin documentation

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/stub.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/stub.rs
@@ -24,7 +24,21 @@ impl PluginCommand for PolarsCmd {
     }
 
     fn extra_description(&self) -> &str {
-        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+        r#"
+You must use one of the subcommands below. Using this command as-is will only produce this help message.
+
+The following are the main datatypes (wrapped from Polars) that are used by these subcommands:
+
+Lazy and Strict dataframes (called `NuLazyFrame` and `NuDataFrame` in error messages) are the main
+data structure.
+
+Expressions, representing various column operations (called `NuExpression`), are passed to many commands such as
+`polars filter` or `polars with-column`. Most nushell operators are supported in these expressions, importantly
+arithmetic, comparison and boolean logical.
+
+Groupbys (`NuLazyGroupBy`), the output of a `polars group-by`, represent a grouped dataframe and are typically piped
+to the `polars agg` command with some column expressions for aggregation which then returns a dataframe.
+"#
     }
 
     fn run(

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_expression/custom_value.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_expression/custom_value.rs
@@ -7,7 +7,7 @@ use std::ops::{Add, Div, Mul, Rem, Sub};
 use super::NuExpression;
 use nu_plugin::EngineInterface;
 use nu_protocol::{
-    ast::{Comparison, Math, Operator},
+    ast::{Boolean, Comparison, Math, Operator},
     CustomValue, ShellError, Span, Type, Value,
 };
 use polars::prelude::Expr;
@@ -131,6 +131,16 @@ fn with_operator(
         Operator::Comparison(Comparison::LessThanOrEqual) => Ok(left
             .clone()
             .apply_with_expr(right.clone(), Expr::lt_eq)
+            .cache(plugin, engine, lhs_span)?
+            .into_value(lhs_span)),
+        Operator::Boolean(Boolean::And) => Ok(left
+            .clone()
+            .apply_with_expr(right.clone(), Expr::logical_and)
+            .cache(plugin, engine, lhs_span)?
+            .into_value(lhs_span)),
+        Operator::Boolean(Boolean::Or) => Ok(left
+            .clone()
+            .apply_with_expr(right.clone(), Expr::logical_or)
             .cache(plugin, engine, lhs_span)?
             .into_value(lhs_span)),
         op => Err(ShellError::OperatorUnsupportedType {

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_expression/custom_value.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_expression/custom_value.rs
@@ -143,6 +143,11 @@ fn with_operator(
             .apply_with_expr(right.clone(), Expr::logical_or)
             .cache(plugin, engine, lhs_span)?
             .into_value(lhs_span)),
+        Operator::Boolean(Boolean::Xor) => Ok(left
+            .clone()
+            .apply_with_expr(right.clone(), logical_xor)
+            .cache(plugin, engine, lhs_span)?
+            .into_value(lhs_span)),
         op => Err(ShellError::OperatorUnsupportedType {
             op,
             unsupported: Type::Custom(TYPE_NAME.into()),
@@ -151,6 +156,11 @@ fn with_operator(
             help: None,
         }),
     }
+}
+
+pub fn logical_xor(a: Expr, b: Expr) -> Expr {
+    (a.clone().or(b.clone())) // A OR B
+        .and((a.and(b)).not()) // AND with NOT (A AND B)
 }
 
 fn apply_arithmetic<F>(


### PR DESCRIPTION
This PR (based on #15249 and #15248 because it mentions them) adds extra documentation to the main polars command outlining the main datatypes that are used by the plugin. The lack of a description of the types involved in `polars xxx` commands was quite confusing to me when I started using the plugin and this is a first try improving it.

I didn't find a better place but please let me know what you think.