### PR TITLE
bugfix: add "to yml" command

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -314,6 +314,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             Where,
             ToXml,
             ToYaml,
+            ToYml,
         };
 
         // Viewers

--- a/crates/nu-command/src/formats/to/mod.rs
+++ b/crates/nu-command/src/formats/to/mod.rs
@@ -23,6 +23,6 @@ pub use nuon::ToNuon;
 pub use text::ToText;
 pub use tsv::ToTsv;
 pub use xml::ToXml;
-pub use yaml::ToYaml;
+pub use yaml::{ToYaml, ToYml};
 
 pub(crate) use json::value_to_json_value;

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -72,7 +72,7 @@ impl Command for ToYml {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Outputs an YML string representing the contents of this table",
+            description: "Outputs a YAML string representing the contents of this table",
             example: r#"[[foo bar]; ["1" "2"]] | to yml"#,
             result: Some(Value::test_string("- foo: '1'\n  bar: '2'\n")),
         }]

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -26,8 +26,54 @@ impl Command for ToYaml {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Outputs an YAML string representing the contents of this table",
+            description: "Outputs a YAML string representing the contents of this table",
             example: r#"[[foo bar]; ["1" "2"]] | to yaml"#,
+            result: Some(Value::test_string("- foo: '1'\n  bar: '2'\n")),
+        }]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        let serialize_types = call.has_flag(engine_state, stack, "serialize")?;
+        let input = input.try_expand_range()?;
+
+        to_yaml(engine_state, input, head, serialize_types)
+    }
+}
+
+#[derive(Clone)]
+pub struct ToYml;
+
+impl Command for ToYml {
+    fn name(&self) -> &str {
+        "to yml"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("to yml")
+            .input_output_types(vec![(Type::Any, Type::String)])
+            .switch(
+                "serialize",
+                "serialize nushell types that cannot be deserialized",
+                Some('s'),
+            )
+            .category(Category::Formats)
+    }
+
+    fn description(&self) -> &str {
+        "Convert table into .yaml/.yml text."
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Outputs an YML string representing the contents of this table",
+            example: r#"[[foo bar]; ["1" "2"]] | to yml"#,
             result: Some(Value::test_string("- foo: '1'\n  bar: '2'\n")),
         }]
     }

--- a/crates/nu-command/tests/format_conversions/yaml.rs
+++ b/crates/nu-command/tests/format_conversions/yaml.rs
@@ -16,6 +16,21 @@ fn table_to_yaml_text_and_from_yaml_text_back_into_table() {
 }
 
 #[test]
+fn table_to_yml_text_and_from_yml_text_back_into_table() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            open appveyor.yml
+            | to yml
+            | from yml
+            | get environment.global.PROJECT_NAME
+        "#
+    ));
+
+    assert_eq!(actual.out, "nushell");
+}
+
+#[test]
 fn convert_dict_to_yaml_with_boolean_key() {
     let actual = nu!(pipeline(
         r#"


### PR DESCRIPTION
# Description
This fixes #15240, which can be closed after merge.

# User-Facing Changes
- user get now use `to yml` -> exactly the same as `to yaml`

![2025-03-06_00h01_27](https://github.com/user-attachments/assets/e002a96a-26dd-4f9c-9b45-b456a95be158)

# Tests + Formatting
Cargo fmt and clippy 🆗 
I added a test in the only place I could find where `to yaml` was already tested.

I didn't see the `save.rs::convert_to_extension` function tested anywhere, but maybe I missed it.

# After Submitting

Not sure this needs an update on the documentation ❓ What do you suggest?
