### PR TITLE
fix: security_audit, bump ring from 0.17.8 to 0.17.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,7 +2942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes this:

<div class="Box p-3 markdown-body f5 mb-4">
          <h2 dir="auto">Vulnerabilities</h2>
<h3 dir="auto"><a href="https://rustsec.org/advisories/RUSTSEC-2025-0009.html" rel="nofollow">RUSTSEC-2025-0009</a></h3>
<blockquote>
<p dir="auto">Some AES functions may panic when overflow checking is enabled.</p>
</blockquote>
<markdown-accessiblity-table data-catalyst=""><table role="table">
<thead>
<tr>
<th>Details</th>
<th></th>
</tr>
</thead>
<tbody>
<tr>
<td>Package</td>
<td><code class="notranslate">ring</code></td>
</tr>
<tr>
<td>Version</td>
<td><code class="notranslate">0.17.8</code></td>
</tr>
<tr>
<td>URL</td>
<td><a href="https://github.com/briansmith/ring/blob/main/RELEASES.md#version-01712-2025-03-05">https://github.com/briansmith/ring/blob/main/RELEASES.md#version-01712-2025-03-05</a></td>
</tr>
<tr>
<td>Date</td>
<td>2025-03-06</td>
</tr>
<tr>
<td>Patched versions</td>
<td><code class="notranslate">&gt;=0.17.12</code></td>
</tr>
</tbody>
</table></markdown-accessiblity-table>
<p dir="auto"><code class="notranslate">ring::aead::quic::HeaderProtectionKey::new_mask()</code> may panic when overflow<br>
checking is enabled. In the QUIC protocol, an attacker can induce this panic by<br>
sending a specially-crafted packet. Even unintentionally it is likely to occur<br>
in 1 out of every 2**32 packets sent and/or received.</p>
<p dir="auto">On 64-bit targets operations using <code class="notranslate">ring::aead::{AES_128_GCM, AES_256_GCM}</code> may<br>
panic when overflow checking is enabled, when encrypting/decrypting approximately<br>
68,719,476,700 bytes (about 64 gigabytes) of data in a single chunk. Protocols<br>
like TLS and SSH are not affected by this because those protocols break large<br>
amounts of data into small chunks. Similarly, most applications will not<br>
attempt to encrypt/decrypt 64GB of data in one chunk.</p>
<p dir="auto">Overflow checking is not enabled in release mode by default, but<br>
<code class="notranslate">RUSTFLAGS=&amp;quot;-C overflow-checks&amp;quot;</code> or <code class="notranslate">overflow-checks = true</code> in the Cargo.toml<br>
profile can override this. Overflow checking is usually enabled by default in<br>
debug mode.</p>
        </div>