### PR TITLE
allow --group-digits to be used in `into string`

### DIFF
--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -226,8 +226,13 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         }
         Value::Glob { val, .. } => Value::string(val.to_string(), span),
 
-        Value::Filesize { val: _, .. } => {
-            Value::string(input.to_expanded_string(", ", config), span)
+        Value::Filesize { val, .. } => {
+            if group_digits {
+                let decimal_value = digits.unwrap_or(0) as usize;
+                Value::string(format_int(val.get(), group_digits, decimal_value), span)
+            } else {
+                Value::string(input.to_expanded_string(", ", config), span)
+            }
         }
         Value::Duration { val: _, .. } => Value::string(input.to_expanded_string("", config), span),
 

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -1,15 +1,15 @@
-use std::sync::Arc;
-
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
 use nu_protocol::{shell_error::into_code, Config};
 use nu_utils::get_system_locale;
 use num_format::ToFormattedString;
+use std::sync::Arc;
 
 struct Arguments {
     decimals_value: Option<i64>,
     cell_paths: Option<Vec<CellPath>>,
     config: Arc<Config>,
+    group_digits: bool,
 }
 
 impl CmdArgument for Arguments {
@@ -51,6 +51,11 @@ impl Command for SubCommand {
                 "rest",
                 SyntaxShape::CellPath,
                 "For a data structure input, convert data at the given cell paths.",
+            )
+            .switch(
+                "group-digits",
+                "group digits together by the locale specific thousands separator",
+                Some('g'),
             )
             .named(
                 "decimals",
@@ -148,6 +153,7 @@ fn string_helper(
 ) -> Result<PipelineData, ShellError> {
     let head = call.head;
     let decimals_value: Option<i64> = call.get_flag(engine_state, stack, "decimals")?;
+    let group_digits = call.has_flag(engine_state, stack, "group-digits")?;
     if let Some(decimal_val) = decimals_value {
         if decimal_val.is_negative() {
             return Err(ShellError::TypeMismatch {
@@ -182,6 +188,7 @@ fn string_helper(
             decimals_value,
             cell_paths,
             config,
+            group_digits,
         };
         operate(action, args, input, head, engine_state.signals())
     }
@@ -190,10 +197,12 @@ fn string_helper(
 fn action(input: &Value, args: &Arguments, span: Span) -> Value {
     let digits = args.decimals_value;
     let config = &args.config;
+    let group_digits = args.group_digits;
+
     match input {
         Value::Int { val, .. } => {
             let decimal_value = digits.unwrap_or(0) as usize;
-            let res = format_int(*val, false, decimal_value);
+            let res = format_int(*val, group_digits, decimal_value);
             Value::string(res, span)
         }
         Value::Float { val, .. } => {
@@ -206,7 +215,15 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         }
         Value::Bool { val, .. } => Value::string(val.to_string(), span),
         Value::Date { val, .. } => Value::string(val.format("%c").to_string(), span),
-        Value::String { val, .. } => Value::string(val.to_string(), span),
+        Value::String { val, .. } => {
+            if group_digits {
+                let number = val.parse::<i64>().unwrap_or_default();
+                let decimal_value = digits.unwrap_or(0) as usize;
+                Value::string(format_int(number, group_digits, decimal_value), span)
+            } else {
+                Value::string(val.to_string(), span)
+            }
+        }
         Value::Glob { val, .. } => Value::string(val.to_string(), span),
 
         Value::Filesize { val: _, .. } => {


### PR DESCRIPTION
# Description

This PR allows the `into string` command to pass the `--group-digits` flag which already existed in this code but was hard coded to `false`.

Now you can do things like
```nushell
❯ 1234567890 | into string --group-digits
1,234,567,890
❯ ls | into string size --group-digits | last 5
╭─#─┬────────name─────────┬─type─┬──size──┬───modified───╮
│ 0 │ README.md           │ file │ 12,606 │ 4 weeks ago  │
│ 1 │ rust-toolchain.toml │ file │ 1,125  │ 2 weeks ago  │
│ 2 │ SECURITY.md         │ file │ 2,712  │ 7 months ago │
│ 3 │ toolkit.nu          │ file │ 21,929 │ 2 months ago │
│ 4 │ typos.toml          │ file │ 542    │ 7 months ago │
╰─#─┴────────name─────────┴─type─┴──size──┴───modified───╯
❯ "12345" | into string --group-digits
12,345
```
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
