### PR TITLE
Respect system locale when formatting file sizes via config

### DIFF
--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -171,7 +171,7 @@ fn local_into_string(
         Value::Bool { val, .. } => val.to_string(),
         Value::Int { val, .. } => val.to_string(),
         Value::Float { val, .. } => val.to_string(),
-        Value::Filesize { val, .. } => config.filesize.display(val).to_string(),
+        Value::Filesize { val, .. } => config.filesize.format(val).to_string(),
         Value::Duration { val, .. } => format_duration(val),
         Value::Date { val, .. } => {
             format!("{} ({})", val.to_rfc2822(), HumanTime::from(val))

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -1,8 +1,6 @@
 use chrono_humanize::HumanTime;
 use nu_engine::command_prelude::*;
-use nu_protocol::{
-    format_duration, shell_error::io::IoError, ByteStream, Config, PipelineMetadata,
-};
+use nu_protocol::{format_duration, shell_error::io::IoError, ByteStream, PipelineMetadata};
 use std::io::Write;
 
 const LINE_ENDING: &str = if cfg!(target_os = "windows") {
@@ -50,7 +48,6 @@ impl Command for ToText {
         let no_newline = call.has_flag(engine_state, stack, "no-newline")?;
         let serialize_types = call.has_flag(engine_state, stack, "serialize")?;
         let input = input.try_expand_range()?;
-        let config = stack.get_config(engine_state);
 
         match input {
             PipelineData::Empty => Ok(Value::string(String::new(), head)
@@ -62,8 +59,7 @@ impl Command for ToText {
                         Value::Record { val, .. } => !val.is_empty(),
                         _ => false,
                     };
-                let mut str =
-                    local_into_string(engine_state, value, LINE_ENDING, &config, serialize_types);
+                let mut str = local_into_string(engine_state, value, LINE_ENDING, serialize_types);
                 if add_trailing {
                     str.push_str(LINE_ENDING);
                 }
@@ -98,7 +94,6 @@ impl Command for ToText {
                                 &engine_state_clone,
                                 val,
                                 LINE_ENDING,
-                                &config,
                                 serialize_types,
                             );
                             write!(buf, "{str}").map_err(&from_io_error)?;
@@ -113,7 +108,6 @@ impl Command for ToText {
                                 &engine_state_clone,
                                 val,
                                 LINE_ENDING,
-                                &config,
                                 serialize_types,
                             );
                             str.push_str(LINE_ENDING);
@@ -163,7 +157,6 @@ fn local_into_string(
     engine_state: &EngineState,
     value: Value,
     separator: &str,
-    config: &Config,
     serialize_types: bool,
 ) -> String {
     let span = value.span();
@@ -171,7 +164,7 @@ fn local_into_string(
         Value::Bool { val, .. } => val.to_string(),
         Value::Int { val, .. } => val.to_string(),
         Value::Float { val, .. } => val.to_string(),
-        Value::Filesize { val, .. } => config.filesize.format(val).to_string(),
+        Value::Filesize { val, .. } => val.to_string(),
         Value::Duration { val, .. } => format_duration(val),
         Value::Date { val, .. } => {
             format!("{} ({})", val.to_rfc2822(), HumanTime::from(val))
@@ -181,7 +174,7 @@ fn local_into_string(
         Value::Glob { val, .. } => val,
         Value::List { vals: val, .. } => val
             .into_iter()
-            .map(|x| local_into_string(engine_state, x, ", ", config, serialize_types))
+            .map(|x| local_into_string(engine_state, x, ", ", serialize_types))
             .collect::<Vec<_>>()
             .join(separator),
         Value::Record { val, .. } => val
@@ -191,7 +184,7 @@ fn local_into_string(
                 format!(
                     "{}: {}",
                     x,
-                    local_into_string(engine_state, y, ", ", config, serialize_types)
+                    local_into_string(engine_state, y, ", ", serialize_types)
                 )
             })
             .collect::<Vec<_>>()
@@ -221,7 +214,7 @@ fn local_into_string(
         // that critical here
         Value::Custom { val, .. } => val
             .to_base_value(span)
-            .map(|val| local_into_string(engine_state, val, separator, config, serialize_types))
+            .map(|val| local_into_string(engine_state, val, separator, serialize_types))
             .unwrap_or_else(|_| format!("<{}>", val.type_name())),
     }
 }

--- a/crates/nu-command/src/random/binary.rs
+++ b/crates/nu-command/src/random/binary.rs
@@ -46,7 +46,7 @@ impl Command for SubCommand {
             Value::Filesize { val, .. } => {
                 usize::try_from(val).map_err(|_| ShellError::InvalidValue {
                     valid: "a non-negative int or filesize".into(),
-                    actual: engine_state.get_config().filesize.display(val).to_string(),
+                    actual: engine_state.get_config().filesize.format(val).to_string(),
                     span: length_val.span(),
                 })
             }

--- a/crates/nu-command/src/random/chars.rs
+++ b/crates/nu-command/src/random/chars.rs
@@ -83,7 +83,7 @@ fn chars(
             Value::Filesize { val, .. } => {
                 usize::try_from(val).map_err(|_| ShellError::InvalidValue {
                     valid: "a non-negative int or filesize".into(),
-                    actual: engine_state.get_config().filesize.display(val).to_string(),
+                    actual: engine_state.get_config().filesize.format(val).to_string(),
                     span: length_val.span(),
                 })
             }

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -127,14 +127,12 @@ fn parse_filesize_unit(format: Spanned<String>) -> Result<FilesizeUnit, ShellErr
 fn format_value_impl(val: &Value, arg: &Arguments, span: Span) -> Value {
     let value_span = val.span();
     match val {
-        Value::Filesize { val, .. } => Value::string(
-            FilesizeFormatter::new()
-                .unit(arg.unit)
-                .precision(None)
-                .format(*val)
-                .to_string(),
-            span,
-        ),
+        Value::Filesize { val, .. } => FilesizeFormatter::new()
+            .unit(arg.unit)
+            .precision(None)
+            .format(*val)
+            .to_string()
+            .into_value(span),
         Value::Error { .. } => val.clone(),
         _ => Value::error(
             ShellError::OnlySupportsThisInputType {

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -1,6 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
-use nu_protocol::{engine::StateWorkingSet, FilesizeFormat, FilesizeUnit};
+use nu_protocol::{engine::StateWorkingSet, FilesizeFormatter, FilesizeUnit};
 
 struct Arguments {
     unit: FilesizeUnit,
@@ -128,8 +128,9 @@ fn format_value_impl(val: &Value, arg: &Arguments, span: Span) -> Value {
     let value_span = val.span();
     match val {
         Value::Filesize { val, .. } => Value::string(
-            FilesizeFormat::new()
+            FilesizeFormatter::new()
                 .unit(arg.unit)
+                .precision(None)
                 .format(*val)
                 .to_string(),
             span,

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -129,7 +129,6 @@ fn format_value_impl(val: &Value, arg: &Arguments, span: Span) -> Value {
     match val {
         Value::Filesize { val, .. } => FilesizeFormatter::new()
             .unit(arg.unit)
-            .precision(None)
             .format(*val)
             .to_string()
             .into_value(span),

--- a/crates/nu-protocol/src/config/filesize.rs
+++ b/crates/nu-protocol/src/config/filesize.rs
@@ -4,12 +4,7 @@ use nu_utils::get_system_locale;
 
 impl IntoValue for FilesizeUnitFormat {
     fn into_value(self, span: Span) -> Value {
-        match self {
-            FilesizeUnitFormat::Metric => "metric",
-            FilesizeUnitFormat::Binary => "binary",
-            FilesizeUnitFormat::Unit(unit) => unit.as_str(),
-        }
-        .into_value(span)
+        self.as_str().into_value(span)
     }
 }
 
@@ -24,12 +19,11 @@ impl FilesizeConfig {
         FilesizeFormatter::new()
             .unit(self.unit)
             .precision(self.precision)
+            .locale(get_system_locale()) // TODO: cache this somewhere or pass in as argument
     }
 
     pub fn format(&self, filesize: Filesize) -> FormattedFilesize {
-        self.formatter()
-            .locale(get_system_locale()) // TODO: cache this somewhere or pass in as argument
-            .format(filesize)
+        self.formatter().format(filesize)
     }
 }
 

--- a/crates/nu-protocol/src/config/filesize.rs
+++ b/crates/nu-protocol/src/config/filesize.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use crate::{Filesize, FilesizeFormat, FilesizeUnitFormat, FormattedFilesize};
+use crate::{Filesize, FilesizeFormatter, FilesizeUnitFormat, FormattedFilesize};
 use nu_utils::get_system_locale;
 
 impl IntoValue for FilesizeUnitFormat {
@@ -20,14 +20,14 @@ pub struct FilesizeConfig {
 }
 
 impl FilesizeConfig {
-    pub fn as_filesize_format(&self) -> FilesizeFormat {
-        FilesizeFormat::new()
+    pub fn formatter(&self) -> FilesizeFormatter {
+        FilesizeFormatter::new()
             .unit(self.unit)
             .precision(self.precision)
     }
 
     pub fn format(&self, filesize: Filesize) -> FormattedFilesize {
-        self.as_filesize_format()
+        self.formatter()
             .locale(get_system_locale()) // TODO: cache this somewhere or pass in as argument
             .format(filesize)
     }
@@ -42,9 +42,9 @@ impl Default for FilesizeConfig {
     }
 }
 
-impl From<FilesizeConfig> for FilesizeFormat {
+impl From<FilesizeConfig> for FilesizeFormatter {
     fn from(config: FilesizeConfig) -> Self {
-        config.as_filesize_format()
+        config.formatter()
     }
 }
 

--- a/crates/nu-protocol/src/config/filesize.rs
+++ b/crates/nu-protocol/src/config/filesize.rs
@@ -1,5 +1,6 @@
 use super::prelude::*;
 use crate::{Filesize, FilesizeFormat, FilesizeUnitFormat, FormattedFilesize};
+use nu_utils::get_system_locale;
 
 impl IntoValue for FilesizeUnitFormat {
     fn into_value(self, span: Span) -> Value {
@@ -26,7 +27,9 @@ impl FilesizeConfig {
     }
 
     pub fn format(&self, filesize: Filesize) -> FormattedFilesize {
-        self.as_filesize_format().format(filesize)
+        self.as_filesize_format()
+            .locale(get_system_locale()) // TODO: cache this somewhere or pass in as argument
+            .format(filesize)
     }
 }
 

--- a/crates/nu-protocol/src/config/filesize.rs
+++ b/crates/nu-protocol/src/config/filesize.rs
@@ -1,43 +1,12 @@
-use super::{config_update_string_enum, prelude::*};
-use crate::{DisplayFilesize, Filesize, FilesizeUnit};
+use super::prelude::*;
+use crate::{Filesize, FilesizeFormat, FilesizeUnitFormat, FormattedFilesize};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum FilesizeFormatUnit {
-    Metric,
-    Binary,
-    Unit(FilesizeUnit),
-}
-
-impl From<FilesizeUnit> for FilesizeFormatUnit {
-    fn from(unit: FilesizeUnit) -> Self {
-        Self::Unit(unit)
-    }
-}
-
-impl FromStr for FilesizeFormatUnit {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "metric" => Ok(Self::Metric),
-            "binary" => Ok(Self::Binary),
-            _ => {
-                if let Ok(unit) = s.parse() {
-                    Ok(Self::Unit(unit))
-                } else {
-                    Err("'metric', 'binary', 'B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', or 'EiB'")
-                }
-            }
-        }
-    }
-}
-
-impl IntoValue for FilesizeFormatUnit {
+impl IntoValue for FilesizeUnitFormat {
     fn into_value(self, span: Span) -> Value {
         match self {
-            FilesizeFormatUnit::Metric => "metric",
-            FilesizeFormatUnit::Binary => "binary",
-            FilesizeFormatUnit::Unit(unit) => unit.as_str(),
+            FilesizeUnitFormat::Metric => "metric",
+            FilesizeUnitFormat::Binary => "binary",
+            FilesizeUnitFormat::Unit(unit) => unit.as_str(),
         }
         .into_value(span)
     }
@@ -45,27 +14,34 @@ impl IntoValue for FilesizeFormatUnit {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FilesizeConfig {
-    pub unit: FilesizeFormatUnit,
+    pub unit: FilesizeUnitFormat,
     pub precision: Option<usize>,
 }
 
 impl FilesizeConfig {
-    pub fn display(&self, filesize: Filesize) -> DisplayFilesize {
-        let unit = match self.unit {
-            FilesizeFormatUnit::Metric => filesize.largest_metric_unit(),
-            FilesizeFormatUnit::Binary => filesize.largest_binary_unit(),
-            FilesizeFormatUnit::Unit(unit) => unit,
-        };
-        filesize.display(unit).precision(self.precision)
+    pub fn as_filesize_format(&self) -> FilesizeFormat {
+        FilesizeFormat::new()
+            .unit(self.unit)
+            .precision(self.precision)
+    }
+
+    pub fn format(&self, filesize: Filesize) -> FormattedFilesize {
+        self.as_filesize_format().format(filesize)
     }
 }
 
 impl Default for FilesizeConfig {
     fn default() -> Self {
         Self {
-            unit: FilesizeFormatUnit::Metric,
+            unit: FilesizeUnitFormat::Metric,
             precision: Some(1),
         }
+    }
+}
+
+impl From<FilesizeConfig> for FilesizeFormat {
+    fn from(config: FilesizeConfig) -> Self {
+        config.as_filesize_format()
     }
 }
 
@@ -84,17 +60,22 @@ impl UpdateFromValue for FilesizeConfig {
         for (col, val) in record.iter() {
             let path = &mut path.push(col);
             match col.as_str() {
-                "unit" => config_update_string_enum(&mut self.unit, val, path, errors),
+                "unit" => {
+                    if let Ok(str) = val.as_str() {
+                        match str.parse() {
+                            Ok(unit) => self.unit = unit,
+                            Err(_) => errors.invalid_value(path, "'metric', 'binary', 'B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', or 'EiB'", val),
+                        }
+                    } else {
+                        errors.type_mismatch(path, Type::String, val)
+                    }
+                }
                 "precision" => match *val {
                     Value::Nothing { .. } => self.precision = None,
                     Value::Int { val, .. } if val >= 0 => self.precision = Some(val as usize),
                     Value::Int { .. } => errors.invalid_value(path, "a non-negative integer", val),
                     _ => errors.type_mismatch(path, Type::custom("int or nothing"), val),
                 },
-                "format" | "metric" => {
-                    // TODO: remove after next release
-                    errors.deprecated_option(path, "set $env.config.filesize.unit", val.span())
-                }
                 _ => errors.unknown_option(path, val),
             }
         }

--- a/crates/nu-protocol/src/value/filesize.rs
+++ b/crates/nu-protocol/src/value/filesize.rs
@@ -751,7 +751,7 @@ impl FilesizeFormatter {
         self
     }
 
-    /// Format a [`Filesize`] into [`FormattedFilesize`] which implements [`fmt::Display`].
+    /// Format a [`Filesize`] into a [`FormattedFilesize`] which implements [`fmt::Display`].
     ///
     /// # Examples
     /// ```
@@ -801,7 +801,6 @@ impl fmt::Display for FormattedFilesize {
         let Filesize(filesize) = filesize;
         let precision = f.precision().or(precision);
 
-        // Format an exact, possibly fractional, string representation of `filesize`.
         let bytes = unit.as_bytes() as i64;
         let whole = filesize / bytes;
         let fract = (filesize % bytes).unsigned_abs();

--- a/crates/nu-protocol/src/value/filesize.rs
+++ b/crates/nu-protocol/src/value/filesize.rs
@@ -623,7 +623,7 @@ impl FromStr for FilesizeUnitFormat {
 /// let formatter = FilesizeFormatter::new();
 ///
 /// assert_eq!(formatter.unit(FilesizeUnit::B).format(filesize).to_string(), "4096 B");
-/// assert_eq!(formatter.unit(FilesizeUnit::KiB).format(filesize).to_string(), "4.0 KiB");
+/// assert_eq!(formatter.unit(FilesizeUnit::KiB).format(filesize).to_string(), "4 KiB");
 /// assert_eq!(formatter.precision(2).format(filesize).to_string(), "4.09 kB");
 /// assert_eq!(
 ///     formatter
@@ -646,13 +646,13 @@ impl FilesizeFormatter {
     ///
     /// The default formatter has:
     /// - a [`unit`](Self::unit) of [`FilesizeUnitFormat::Metric`].
-    /// - a [`precision`](Self::precision) of `Some(1)`.
+    /// - a [`precision`](Self::precision) of `None`.
     /// - a [`locale`](Self::locale) of [`Locale::en_US_POSIX`]
     ///   (a very plain format with no thousands separators).
     pub fn new() -> Self {
         FilesizeFormatter {
             unit: FilesizeUnitFormat::Metric,
-            precision: Some(1),
+            precision: None,
             locale: Locale::en_US_POSIX,
         }
     }
@@ -667,7 +667,7 @@ impl FilesizeFormatter {
     /// # Examples
     /// ```
     /// # use nu_protocol::{Filesize, FilesizeFormatter, FilesizeUnit, FilesizeUnitFormat};
-    /// let formatter = FilesizeFormatter::new();
+    /// let formatter = FilesizeFormatter::new().precision(1);
     ///
     /// let filesize = Filesize::from_unit(4, FilesizeUnit::KiB).unwrap();
     /// assert_eq!(formatter.unit(FilesizeUnit::B).format(filesize).to_string(), "4096 B");
@@ -738,7 +738,7 @@ impl FilesizeFormatter {
     /// # use nu_protocol::{Filesize, FilesizeFormatter, FilesizeUnit, FilesizeUnitFormat};
     /// # use num_format::Locale;
     /// let filesize = Filesize::from_unit(-4, FilesizeUnit::MiB).unwrap();
-    /// let formatter = FilesizeFormatter::new().unit(FilesizeUnit::KB);
+    /// let formatter = FilesizeFormatter::new().unit(FilesizeUnit::KB).precision(1);
     ///
     /// assert_eq!(formatter.format(filesize).to_string(), "-4194.3 kB");
     /// assert_eq!(formatter.locale(Locale::en).format(filesize).to_string(), "-4,194.3 kB");
@@ -759,8 +759,8 @@ impl FilesizeFormatter {
     /// let filesize = Filesize::from_unit(4, FilesizeUnit::KB).unwrap();
     /// let formatter = FilesizeFormatter::new();
     ///
-    /// assert_eq!(format!("{}", formatter.format(filesize)), "4.0 kB");
-    /// assert_eq!(formatter.format(filesize).to_string(), "4.0 kB");
+    /// assert_eq!(format!("{}", formatter.format(filesize)), "4 kB");
+    /// assert_eq!(formatter.format(filesize).to_string(), "4 kB");
     /// ```
     pub fn format(&self, filesize: Filesize) -> FormattedFilesize {
         FormattedFilesize {
@@ -860,7 +860,6 @@ mod tests {
             exp,
             FilesizeFormatter::new()
                 .unit(unit)
-                .precision(None)
                 .format(Filesize::new(bytes))
                 .to_string()
         );
@@ -875,7 +874,6 @@ mod tests {
             exp,
             FilesizeFormatter::new()
                 .unit(FilesizeUnitFormat::Binary)
-                .precision(None)
                 .format(Filesize::new(val))
                 .to_string()
         );
@@ -890,7 +888,6 @@ mod tests {
             exp,
             FilesizeFormatter::new()
                 .unit(FilesizeUnitFormat::Metric)
-                .precision(None)
                 .format(Filesize::new(val))
                 .to_string()
         );

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -936,7 +936,7 @@ impl Value {
             Value::Bool { val, .. } => val.to_string(),
             Value::Int { val, .. } => val.to_string(),
             Value::Float { val, .. } => val.to_string(),
-            Value::Filesize { val, .. } => config.filesize.display(*val).to_string(),
+            Value::Filesize { val, .. } => config.filesize.format(*val).to_string(),
             Value::Duration { val, .. } => format_duration(*val),
             Value::Date { val, .. } => match &config.datetime_format.normal {
                 Some(format) => self.format_datetime(val, format),

--- a/crates/nu-utils/src/locale.rs
+++ b/crates/nu-utils/src/locale.rs
@@ -22,9 +22,16 @@ pub fn get_system_locale() -> Locale {
 
 #[cfg(debug_assertions)]
 pub fn get_system_locale_string() -> Option<String> {
-    std::env::var(LOCALE_OVERRIDE_ENV_VAR)
-        .ok()
-        .or_else(sys_locale::get_locale)
+    std::env::var(LOCALE_OVERRIDE_ENV_VAR).ok().or_else(
+        #[cfg(not(test))]
+        {
+            sys_locale::get_locale
+        },
+        #[cfg(test)]
+        {
+            || Some(Locale::en_US_POSIX.name().to_owned())
+        },
+    )
 }
 
 #[cfg(not(debug_assertions))]


### PR DESCRIPTION
# Description

Commands and other pieces of code using `$env.config.format.filesize` to format filesizes now respect the system locale when formatting the numeric portion of a file size.

# User-Facing Changes

- System locale is respected when using `$env.config.format.filesize` to format file sizes.
- Formatting a file size with a binary unit is now exact for large file sizes and units.
- The output of `to text` is no longer dependent on the config.
