### PR TITLE
Add `filesize.show_unit` config option

### DIFF
--- a/crates/nu-protocol/src/config/filesize.rs
+++ b/crates/nu-protocol/src/config/filesize.rs
@@ -11,6 +11,7 @@ impl IntoValue for FilesizeUnitFormat {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FilesizeConfig {
     pub unit: FilesizeUnitFormat,
+    pub show_unit: bool,
     pub precision: Option<usize>,
 }
 
@@ -18,6 +19,7 @@ impl FilesizeConfig {
     pub fn formatter(&self) -> FilesizeFormatter {
         FilesizeFormatter::new()
             .unit(self.unit)
+            .show_unit(self.show_unit)
             .precision(self.precision)
             .locale(get_system_locale()) // TODO: cache this somewhere or pass in as argument
     }
@@ -31,6 +33,7 @@ impl Default for FilesizeConfig {
     fn default() -> Self {
         Self {
             unit: FilesizeUnitFormat::Metric,
+            show_unit: true,
             precision: Some(1),
         }
     }
@@ -67,6 +70,7 @@ impl UpdateFromValue for FilesizeConfig {
                         errors.type_mismatch(path, Type::String, val)
                     }
                 }
+                "show_unit" => self.show_unit.update(val, path, errors),
                 "precision" => match *val {
                     Value::Nothing { .. } => self.precision = None,
                     Value::Int { val, .. } if val >= 0 => self.precision = Some(val as usize),
@@ -83,6 +87,7 @@ impl IntoValue for FilesizeConfig {
     fn into_value(self, span: Span) -> Value {
         record! {
             "unit" => self.unit.into_value(span),
+            "show_unit" => self.show_unit.into_value(span),
             "precision" => self.precision.map(|x| x as i64).into_value(span),
         }
         .into_value(span)

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -381,9 +381,14 @@ $env.config.datetime_format.normal = "%m/%d/%y %I:%M:%S%p"
 # Otherwise, setting this to one of the filesize units will use that particular unit when displaying all file sizes.
 $env.config.filesize.unit = 'metric'
 
+# filesize.show_unit (bool):
+# Whether to show or hide the file size unit. Useful if `$env.config.filesize.unit` is set to a fixed unit,
+# and you don't want that same unit repeated over and over again in which case you can set this to `false`.
+$env.config.filesize.show_unit = true
+
 # filesize.precision (int or nothing):
 # The number of digits to display after the decimal point for file sizes.
-# When set to `null`, all digits after the decimal point will be displayed.
+# When set to `null`, all digits after the decimal point, if any, will be displayed.
 $env.config.filesize.precision = 1
 
 # ---------------------

--- a/crates/nu-utils/src/locale.rs
+++ b/crates/nu-utils/src/locale.rs
@@ -29,6 +29,8 @@ pub fn get_system_locale_string() -> Option<String> {
         },
         #[cfg(test)]
         {
+            // For tests, we use the same locale on all systems.
+            // To override this, set `LOCALE_OVERRIDE_ENV_VAR`.
             || Some(Locale::en_US_POSIX.name().to_owned())
         },
     )


### PR DESCRIPTION
# Description

Continuation of #15271. This PR adds the `$env.config.filesize.show_unit` option to allow the ability to omit the filesize unit. Useful if `$env.config.filesize.unit` is set to a fixed unit, and you don't want the same unit repeated over and over.

# User-Facing Changes

- Adds the `$env.config.filesize.show_unit` option.
