### PR TITLE
Fix improper application of local timezone offset to Unix epochs

### DIFF
--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -408,13 +408,10 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                 Err(reason) => {
                     match NaiveDateTime::parse_from_str(val, &dt.0) {
                         Ok(d) => {
-                            let local_offset = *Local::now().offset();
                             let dt_fixed =
-                                TimeZone::from_local_datetime(&local_offset, &d)
-                                    .single()
-                                    .unwrap_or_default();
+                                Local.from_local_datetime(&d).single().unwrap_or_default();
 
-                            Value::date (dt_fixed,head)
+                            Value::date (dt_fixed.into(),head)
                         }
                         Err(_) => {
                             Value::error (

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -411,7 +411,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                             let dt_fixed =
                                 Local.from_local_datetime(&d).single().unwrap_or_default();
 
-                            Value::date (dt_fixed.into(),head)
+                            Value::date(dt_fixed.into(),head)
                         }
                         Err(_) => {
                             Value::error (


### PR DESCRIPTION
# Description

After the switch to Daylight Saving Time in the US yesterday, local tests were failing when testing the second example in `into datetime`.  While I had fixed a bug in the tests last year just *after* we returned to standard time, there was also an issue in the core conversion code where the local timezone offset was being applied to Unix epochs.  This caused times to be calculated differently during DST.

This PR ignores the local offset when converting, but still displays the resulting date in the local timezone (including applicable DST offset).

# User-Facing Changes

Fix: Unix Epochs now convert consistently regardless of whether DST is in effect in the local timezone or not.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A