### PR TITLE
Polars: Map pq extension to parquet files

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/file_type.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/file_type.rs
@@ -52,7 +52,7 @@ impl From<&str> for PolarsFileType {
         match file_type {
             "csv" => PolarsFileType::Csv,
             "tsv" => PolarsFileType::Tsv,
-            "parquet" | "parq" => PolarsFileType::Parquet,
+            "parquet" | "parq" | "pq" => PolarsFileType::Parquet,
             "ipc" | "arrow" => PolarsFileType::Arrow,
             "json" => PolarsFileType::Json,
             "avro" => PolarsFileType::Avro,


### PR DESCRIPTION
# Description
Files with the extension pq will automatically be treated as parquet files.