### PR TITLE
refactor(lsp): span fix made easy by bumping lsp-textdocument to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,9 +3105,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-textdocument"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a17dcde15cae78fb2e54166da22cd6c53f48033a0391cc392b22f2437805792"
+checksum = "2d564d595f4e3dcd3c071bf472dbd2cac53bc3665ae7222d2abfecd18feaed2c"
 dependencies = [
  "lsp-types",
  "serde_json",
@@ -8078,7 +8078,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ lru = "0.12"
 lscolors = { version = "0.17", default-features = false }
 lsp-server = "0.7.8"
 lsp-types = { version = "0.97.0", features = ["proposed"] }
-lsp-textdocument = "0.4.1"
+lsp-textdocument = "0.4.2"
 mach2 = "0.4"
 md5 = { version = "0.10", package = "md-5" }
 miette = "7.5"

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -307,9 +307,8 @@ impl NuCompleter {
                 let need_externals = !prefix_str.contains(' ');
                 let need_internals = !prefix_str.starts_with('^');
                 let mut span = element_expression.span;
-                span.end = std::cmp::min(span.end, pos + 1);
                 if !need_internals {
-                    span = Span::new(span.start + 1, span.end)
+                    span.start += 1;
                 };
                 suggestions.extend(self.command_completion_helper(
                     working_set,

--- a/crates/nu-lsp/src/semantic_tokens.rs
+++ b/crates/nu-lsp/src/semantic_tokens.rs
@@ -80,27 +80,21 @@ impl LanguageServer {
             if sp < last_span {
                 continue;
             }
-            // in case the start position is at the end of lastline
-            let real_start_char = if range.end.line != range.start.line {
-                0
-            } else {
-                range.start.character
-            };
-            let mut delta_start = real_start_char;
+            let mut delta_start = range.start.character;
             if range.end.line == last_token_line {
                 delta_start -= last_token_char;
             }
             tokens.push(SemanticToken {
                 delta_start,
                 delta_line: range.end.line.saturating_sub(last_token_line),
-                length: range.end.character.saturating_sub(real_start_char),
+                length: range.end.character.saturating_sub(range.start.character),
                 // 0 means function in semantic_token_legend
                 token_type: 0,
                 token_modifiers_bitset: 0,
             });
             last_span = sp;
             last_token_line = range.end.line;
-            last_token_char = real_start_char;
+            last_token_char = range.start.character;
         }
         tokens
     }


### PR DESCRIPTION
# Description

The upstream crate fixed a bug of position calc, which made some extra checking in lsp unnecessary.
Also moved some follow-up fixing of #15238 from #15270 here, as it has something to do with previous position calc bug. 

# User-Facing Changes

# Tests + Formatting

Adjusted

# After Submitting
