### PR TITLE
fix(lsp): find_id for custom def in custom def

### DIFF
--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -958,6 +958,30 @@ mod tests {
     }
 
     #[test]
+    fn hover_on_custom_in_custom() {
+        let (client_connection, _recv) = initialize_language_server(None, None);
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("hover");
+        script.push("command.nu");
+        let script = path_to_uri(&script);
+
+        open_unchecked(&client_connection, script.clone());
+        let resp = send_hover_request(&client_connection, script.clone(), 9, 7);
+
+        assert_json_eq!(
+            result_from_message(resp),
+            serde_json::json!({
+                    "contents": {
+                    "kind": "markdown",
+                    "value": "\n---\n### Usage \n```nu\n  bar {flags}\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n"
+                }
+            })
+        );
+    }
+
+    #[test]
     fn hover_on_external_command() {
         let (client_connection, _recv) = initialize_language_server(None, None);
 

--- a/tests/fixtures/lsp/hover/command.nu
+++ b/tests/fixtures/lsp/hover/command.nu
@@ -5,3 +5,7 @@ hello
 
 [""] | str join
 ^sleep
+
+def foo [] {
+  def bar [] { }
+}


### PR DESCRIPTION
# Description

Enables hover/rename/references for:

```nushell
def foo [] {
  def bar [] { }
     # |____________ this custom command
}
```

# User-Facing Changes

# Tests + Formatting

+1

# After Submitting
