### PR TITLE
refactor: tree-sitter-nu friendly alternative expressions

### DIFF
--- a/crates/nu-std/std-rfc/tables/mod.nu
+++ b/crates/nu-std/std-rfc/tables/mod.nu
@@ -55,7 +55,7 @@ export def aggregate [
       }
   }
 
-  def "error not-a-table" [span: record<start: int, end:int>] {
+  def error-not-a-table [span: record<start: int, end:int>] {
       error make {
           msg: "input must be a table",
           label: {
@@ -69,9 +69,9 @@ export def aggregate [
     let IN = $in
     let md = metadata $in
 
-    let first = try { $IN | first } catch { error not-a-table $md.span }
+    let first = try { $IN | first } catch { error-not-a-table $md.span }
     if not (($first | describe) starts-with record) {
-        error not-a-table $md.span
+        error-not-a-table $md.span
     }
 
     let grouped = "items" in $first

--- a/crates/nu-std/std-rfc/tables/mod.nu
+++ b/crates/nu-std/std-rfc/tables/mod.nu
@@ -55,7 +55,7 @@ export def aggregate [
       }
   }
 
-  def error-not-a-table [span: record<start: int, end:int>] {
+  def "error-make not-a-table" [span: record<start: int, end:int>] {
       error make {
           msg: "input must be a table",
           label: {
@@ -69,9 +69,9 @@ export def aggregate [
     let IN = $in
     let md = metadata $in
 
-    let first = try { $IN | first } catch { error-not-a-table $md.span }
+    let first = try { $IN | first } catch { error-make not-a-table $md.span }
     if not (($first | describe) starts-with record) {
-        error-not-a-table $md.span
+        error-make not-a-table $md.span
     }
 
     let grouped = "items" in $first

--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -109,7 +109,7 @@ def "nu-complete main-help" [] {
 }
 
 def "nu-complete list-externs" [] {
-    scope commands | where is_extern | select name description | rename value description
+    scope commands | where is_extern == true | select name description | rename value description
 }
 
 def build-help-header [
@@ -397,7 +397,7 @@ export def externs [
 ] {
     let externs = (
         scope commands
-        | where is_extern
+        | where is_extern == true
         | select name module_name description
         | sort-by name
         | str trim
@@ -761,7 +761,7 @@ Here are some tips to help you get started.
   * ('help <name>' | pretty-cmd) - display help about a particular command, alias, or module
   * ('help --find <text to search>' | pretty-cmd) - search through all help commands table
 
-Nushell works on the idea of a "(ansi default_italic)pipeline(ansi reset)". Pipelines are commands connected with the '|' character.
+Nushell works on the idea of a '(ansi default_italic)pipeline(ansi reset)'. Pipelines are commands connected with the '|' character.
 Each stage in the pipeline works together to load, parse, and display information to you.
 
 (ansi green)Examples(ansi reset):

--- a/scripts/build-all.nu
+++ b/scripts/build-all.nu
@@ -1,4 +1,4 @@
-use std log warning
+use std/log warning
 
 print '-------------------------------------------------------------------'
 print 'Building nushell (nu) and all the plugins'

--- a/scripts/coverage-local.nu
+++ b/scripts/coverage-local.nu
@@ -1,5 +1,5 @@
 #!/usr/bin/env nu
-use std log warning
+use std/log warning
 
 warning "./scripts/coverage-local.nu will be deprecated, please use the `toolkit cov` command instead"
 

--- a/scripts/test_virtualenv.nu
+++ b/scripts/test_virtualenv.nu
@@ -19,14 +19,14 @@ let exe = $paths.1
 
 let test_lines = [
     "python -c 'import sys; print(sys.executable)'"                                  # 1
-    "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'" # 2
+    `python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'` # 2
     $"overlay use '([$env.PWD $env_name $subdir activate.nu] | path join)'"
     "python -c 'import sys; print(sys.executable)'"                                  # 3
-    "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'" # 4
+    `python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'` # 4
     "print $env.VIRTUAL_ENV_PROMPT"                                                  # 5
     "deactivate"
     "python -c 'import sys; print(sys.executable)'"                                  # 6
-    "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'" # 7
+    `python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'` # 7
 ]
 
 def main [] {


### PR DESCRIPTION
# Description

Choose more tree-sitter-nu-friendly (if not better) expressions in nu scripts.
The changes made in this PR all come from known issues of `tree-sitter-nu`.

1. nested single/double quotes: https://github.com/nushell/tree-sitter-nu/issues/125
2. module path of `use` command: https://github.com/nushell/tree-sitter-nu/issues/165
3. where predicates of boolean column: https://github.com/nushell/tree-sitter-nu/issues/177
4. `error make` keyword: https://github.com/nushell/tree-sitter-nu/issues/179

Those issues are either hard to fix or "not planned" for syntactical precision considerations ATM.

# User-Facing Changes

Should be none

# Tests + Formatting

# After Submitting
