### PR TITLE
remove mimalloc allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,16 +2952,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libproc"
 version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,15 +3247,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mimalloc"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
-dependencies = [
- "libmimalloc-sys",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3475,7 +3456,6 @@ dependencies = [
  "fancy-regex",
  "log",
  "miette",
- "mimalloc",
  "multipart-rs",
  "nix 0.29.0",
  "nu-cli",
@@ -4132,7 +4112,6 @@ dependencies = [
  "hashbrown 0.15.2",
  "indexmap",
  "log",
- "mimalloc",
  "nu-cmd-lang",
  "nu-command",
  "nu-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,7 +220,6 @@ ctrlc = { workspace = true }
 dirs = { workspace = true }
 log = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-backtrace", "fancy"] }
-mimalloc = { version = "0.1.42", default-features = false, optional = true }
 multipart-rs = { workspace = true }
 serde_json = { workspace = true }
 simplelog = "0.12"
@@ -274,7 +273,6 @@ default = [
   "plugin",
   "trash-support",
   "sqlite",
-  "mimalloc",
 ]
 stable = ["default"]
 # NOTE: individual features are also passed to `nu-cmd-lang` that uses them to generate the feature matrix in the `version` command
@@ -283,7 +281,6 @@ stable = ["default"]
 # otherwise the system version will be used. Not enabled by default because it takes a while to build
 static-link-openssl = ["dep:openssl", "nu-cmd-lang/static-link-openssl"]
 
-mimalloc = ["nu-cmd-lang/mimalloc", "dep:mimalloc"]
 # Optional system clipboard support in `reedline`, this behavior has problematic compatibility with some systems.
 # Missing X server/ Wayland can cause issues
 system-clipboard = [

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -42,7 +42,6 @@ plugin = [
   "os",
 ]
 
-mimalloc = []
 trash-support = []
 sqlite = []
 static-link-openssl = []

--- a/crates/nu-cmd-lang/src/core_commands/version.rs
+++ b/crates/nu-cmd-lang/src/core_commands/version.rs
@@ -161,11 +161,7 @@ fn push_version_numbers(record: &mut Record, head: Span) {
 }
 
 fn global_allocator() -> &'static str {
-    if cfg!(feature = "mimalloc") {
-        "mimalloc"
-    } else {
-        "standard"
-    }
+    "standard"
 }
 
 fn features_enabled() -> Vec<String> {

--- a/crates/nu_plugin_polars/Cargo.toml
+++ b/crates/nu_plugin_polars/Cargo.toml
@@ -27,7 +27,6 @@ chrono = { workspace = true, features = ["std", "unstable-locales"], default-fea
 chrono-tz = "0.10"
 fancy-regex = { workspace = true }
 indexmap = { version = "2.7" }
-mimalloc = { version = "0.1.42" }
 num = {version = "0.4"}
 serde = { version = "1.0", features = ["derive"] }
 sqlparser = { version = "0.53"}

--- a/crates/nu_plugin_polars/src/main.rs
+++ b/crates/nu_plugin_polars/src/main.rs
@@ -1,9 +1,6 @@
 use nu_plugin::{serve_plugin, MsgPackSerializer};
 use nu_plugin_polars::PolarsPlugin;
 
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 fn main() {
     env_logger::init();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,6 @@ mod signals;
 mod terminal;
 mod test_bins;
 
-#[cfg(feature = "mimalloc")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 use crate::{
     command::parse_commandline_args,
     config_files::set_config_path,


### PR DESCRIPTION
# Description

This PR removes the mimalloc allocator due to run-away memory leaks recently found.

closes #15311

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
