### PR TITLE
Math commands can work with bounded ranges and produce list of numbers

### DIFF
--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -1,6 +1,6 @@
-use nu_engine::command_prelude::*;
 use crate::math::utils::ensure_bounded;
- use nu_protocol::Range;
+use nu_engine::command_prelude::*;
+use nu_protocol::Range;
 
 #[derive(Clone)]
 pub struct MathAbs;
@@ -49,7 +49,14 @@ impl Command for MathAbs {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
@@ -65,7 +72,14 @@ impl Command for MathAbs {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,

--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -1,4 +1,6 @@
 use nu_engine::command_prelude::*;
+use crate::math::utils::ensure_bounded;
+ use nu_protocol::Range;
 
 #[derive(Clone)]
 pub struct MathAbs;
@@ -21,7 +23,7 @@ impl Command for MathAbs {
                     Type::List(Box::new(Type::Duration)),
                     Type::List(Box::new(Type::Duration)),
                 ),
-                (Type::Range, Type::Number),
+                (Type::Range, Type::List(Box::new(Type::Number))),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)
@@ -47,6 +49,12 @@ impl Command for MathAbs {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
+        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+            match &**val {
+                Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+                Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+            }
+        }
         input.map(move |value| abs_helper(value, head), engine_state.signals())
     }
 
@@ -57,6 +65,12 @@ impl Command for MathAbs {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
+        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+            match &**val {
+                Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+                Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+            }
+        }
         input.map(
             move |value| abs_helper(value, head),
             working_set.permanent().signals(),

--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -21,6 +21,7 @@ impl Command for MathAbs {
                     Type::List(Box::new(Type::Duration)),
                     Type::List(Box::new(Type::Duration)),
                 ),
+                (Type::Range, Type::Number),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -1,7 +1,7 @@
-use nu_engine::command_prelude::*;
 use crate::math::utils::ensure_bounded;
- use nu_protocol::Range;
- 
+use nu_engine::command_prelude::*;
+use nu_protocol::Range;
+
 #[derive(Clone)]
 pub struct MathCeil;
 
@@ -48,7 +48,14 @@ impl Command for MathCeil {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
@@ -68,7 +75,14 @@ impl Command for MathCeil {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -16,6 +16,7 @@ impl Command for MathCeil {
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Int)),
                 ),
+                (Type::Range, Type::Number),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -1,5 +1,5 @@
-use nu_engine::command_prelude::*;
 use crate::math::utils::ensure_bounded;
+use nu_engine::command_prelude::*;
 use nu_protocol::Range;
 
 #[derive(Clone)]
@@ -48,7 +48,14 @@ impl Command for MathFloor {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
@@ -68,7 +75,14 @@ impl Command for MathFloor {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -18,7 +18,7 @@ impl Command for MathFloor {
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Int)),
                 ),
-                (Type::Range, Type::Number),
+                (Type::Range, Type::List(Box::new(Type::Number))),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)
@@ -54,7 +54,6 @@ impl Command for MathFloor {
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
             }
         }
-
         input.map(move |value| operate(value, head), engine_state.signals())
     }
 
@@ -75,7 +74,6 @@ impl Command for MathFloor {
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
             }
         }
-
         input.map(
             move |value| operate(value, head),
             working_set.permanent().signals(),

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -1,4 +1,6 @@
 use nu_engine::command_prelude::*;
+use crate::math::utils::ensure_bounded;
+use nu_protocol::Range;
 
 #[derive(Clone)]
 pub struct MathFloor;
@@ -16,6 +18,7 @@ impl Command for MathFloor {
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Int)),
                 ),
+                (Type::Range, Type::Number),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)
@@ -45,6 +48,13 @@ impl Command for MathFloor {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
+        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+            match &**val {
+                Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+                Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+            }
+        }
+
         input.map(move |value| operate(value, head), engine_state.signals())
     }
 
@@ -59,6 +69,13 @@ impl Command for MathFloor {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
+        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+            match &**val {
+                Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+                Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+            }
+        }
+
         input.map(
             move |value| operate(value, head),
             working_set.permanent().signals(),

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -1,8 +1,8 @@
-use nu_engine::command_prelude::*;
-use nu_protocol::Signals;
 use crate::math::utils::ensure_bounded;
- use nu_protocol::Range;
- 
+use nu_engine::command_prelude::*;
+use nu_protocol::Range;
+use nu_protocol::Signals;
+
 #[derive(Clone)]
 pub struct MathLog;
 
@@ -51,7 +51,14 @@ impl Command for MathLog {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         let base: Spanned<f64> = call.req(engine_state, stack, 0)?;
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
@@ -68,7 +75,14 @@ impl Command for MathLog {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         let base: Spanned<f64> = call.req_const(working_set, 0)?;
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -1,6 +1,8 @@
 use nu_engine::command_prelude::*;
 use nu_protocol::Signals;
-
+use crate::math::utils::ensure_bounded;
+ use nu_protocol::Range;
+ 
 #[derive(Clone)]
 pub struct MathLog;
 
@@ -22,7 +24,7 @@ impl Command for MathLog {
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Float)),
                 ),
-                (Type::Range, Type::Number),
+                (Type::Range, Type::List(Box::new(Type::Number))),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)
@@ -47,7 +49,14 @@ impl Command for MathLog {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
         let base: Spanned<f64> = call.req(engine_state, stack, 0)?;
+        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+            match &**val {
+                Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+                Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+            }
+        }
         log(base, call.head, input, engine_state.signals())
     }
 
@@ -57,7 +66,14 @@ impl Command for MathLog {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
         let base: Spanned<f64> = call.req_const(working_set, 0)?;
+        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+            match &**val {
+                Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+                Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+            }
+        }
         log(base, call.head, input, working_set.permanent().signals())
     }
 

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -22,6 +22,7 @@ impl Command for MathLog {
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Float)),
                 ),
+                (Type::Range, Type::Number),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -1,7 +1,9 @@
 use crate::math::utils::run_with_function;
 use nu_engine::command_prelude::*;
 use std::{cmp::Ordering, collections::HashMap};
-
+use crate::math::utils::ensure_bounded;
+ use nu_protocol::Range;
+ 
 #[derive(Clone)]
 pub struct MathMode;
 
@@ -48,7 +50,7 @@ impl Command for MathMode {
                     Type::List(Box::new(Type::Filesize)),
                     Type::List(Box::new(Type::Filesize)),
                 ),
-                (Type::Range, Type::Number),
+                (Type::Range, Type::List(Box::new(Type::Number))),
                 (Type::table(), Type::record()),
             ])
             .allow_variants_without_examples(true)
@@ -74,6 +76,13 @@ impl Command for MathMode {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+            match &**val {
+                Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+                Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+            }
+        }
         run_with_function(call, input, mode)
     }
 
@@ -83,6 +92,13 @@ impl Command for MathMode {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+            match &**val {
+                Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+                Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+            }
+        }
         run_with_function(call, input, mode)
     }
 

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -1,9 +1,9 @@
+use crate::math::utils::ensure_bounded;
 use crate::math::utils::run_with_function;
 use nu_engine::command_prelude::*;
+use nu_protocol::Range;
 use std::{cmp::Ordering, collections::HashMap};
-use crate::math::utils::ensure_bounded;
- use nu_protocol::Range;
- 
+
 #[derive(Clone)]
 pub struct MathMode;
 
@@ -77,7 +77,14 @@ impl Command for MathMode {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
@@ -93,7 +100,14 @@ impl Command for MathMode {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -48,6 +48,7 @@ impl Command for MathMode {
                     Type::List(Box::new(Type::Filesize)),
                     Type::List(Box::new(Type::Filesize)),
                 ),
+                (Type::Range, Type::Number),
                 (Type::table(), Type::record()),
             ])
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -1,5 +1,7 @@
 use nu_engine::command_prelude::*;
-
+use crate::math::utils::ensure_bounded;
+ use nu_protocol::Range;
+ 
 #[derive(Clone)]
 pub struct MathRound;
 
@@ -16,7 +18,7 @@ impl Command for MathRound {
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Number)),
                 ),
-                (Type::Range, Type::Number),
+                (Type::Range, Type::List(Box::new(Type::Number))),
             ])
             .allow_variants_without_examples(true)
             .named(
@@ -53,6 +55,12 @@ impl Command for MathRound {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
+        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+            match &**val {
+                Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+                Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+            }
+        }
         input.map(
             move |value| operate(value, head, precision_param),
             engine_state.signals(),
@@ -70,6 +78,12 @@ impl Command for MathRound {
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
+        }
+        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+            match &**val {
+                Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+                Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+            }
         }
         input.map(
             move |value| operate(value, head, precision_param),

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -1,7 +1,7 @@
-use nu_engine::command_prelude::*;
 use crate::math::utils::ensure_bounded;
- use nu_protocol::Range;
- 
+use nu_engine::command_prelude::*;
+use nu_protocol::Range;
+
 #[derive(Clone)]
 pub struct MathRound;
 
@@ -55,7 +55,14 @@ impl Command for MathRound {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
@@ -79,7 +86,14 @@ impl Command for MathRound {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -16,6 +16,7 @@ impl Command for MathRound {
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Number)),
                 ),
+                (Type::Range, Type::Number),
             ])
             .allow_variants_without_examples(true)
             .named(

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -16,6 +16,7 @@ impl Command for MathSqrt {
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Float)),
                 ),
+                (Type::Range, Type::Number),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -1,7 +1,7 @@
-use nu_engine::command_prelude::*;
 use crate::math::utils::ensure_bounded;
- use nu_protocol::Range;
- 
+use nu_engine::command_prelude::*;
+use nu_protocol::Range;
+
 #[derive(Clone)]
 pub struct MathSqrt;
 
@@ -48,7 +48,14 @@ impl Command for MathSqrt {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
@@ -68,7 +75,14 @@ impl Command for MathSqrt {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+        if let PipelineData::Value(
+            Value::Range {
+                ref val,
+                internal_span,
+            },
+            ..,
+        ) = input
+        {
             match &**val {
                 Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
                 Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -1,5 +1,7 @@
 use nu_engine::command_prelude::*;
-
+use crate::math::utils::ensure_bounded;
+ use nu_protocol::Range;
+ 
 #[derive(Clone)]
 pub struct MathSqrt;
 
@@ -16,7 +18,7 @@ impl Command for MathSqrt {
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Float)),
                 ),
-                (Type::Range, Type::Number),
+                (Type::Range, Type::List(Box::new(Type::Number))),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)
@@ -46,6 +48,12 @@ impl Command for MathSqrt {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
+        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+            match &**val {
+                Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+                Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+            }
+        }
         input.map(move |value| operate(value, head), engine_state.signals())
     }
 
@@ -59,6 +67,12 @@ impl Command for MathSqrt {
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
+        }
+        if let PipelineData::Value(Value::Range { ref val, internal_span }, ..) = input {
+            match &**val {
+                Range::IntRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+                Range::FloatRange(range) => ensure_bounded(range.end(), internal_span, head)?,
+            }
         }
         input.map(
             move |value| operate(value, head),

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -14,6 +14,7 @@ impl Command for MathStddev {
         Signature::build("math stddev")
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::Range, Type::Number),
                 (Type::table(), Type::record()),
                 (Type::record(), Type::record()),
             ])

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -58,13 +58,12 @@ impl Command for MathStddev {
         let span = input.span().unwrap_or(name);
         let input: PipelineData = match input.try_expand_range() {
             Err(_) => {
-                let span = span;
                 return Err(ShellError::IncorrectValue {
                     msg: "Range must be bounded".to_string(),
                     val_span: span,
                     call_span: name,
-                })
-            },
+                });
+            }
             Ok(val) => val,
         };
         run_with_function(call, input, compute_stddev(sample))
@@ -81,13 +80,12 @@ impl Command for MathStddev {
         let span = input.span().unwrap_or(name);
         let input: PipelineData = match input.try_expand_range() {
             Err(_) => {
-                let span = span;
                 return Err(ShellError::IncorrectValue {
                     msg: "Range must be bounded".to_string(),
                     val_span: span,
                     call_span: name,
-                })
-            },
+                });
+            }
             Ok(val) => val,
         };
         run_with_function(call, input, compute_stddev(sample))

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -14,6 +14,7 @@ impl Command for MathStddev {
         Signature::build("math stddev")
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::Range, Type::Number),
                 (Type::table(), Type::record()),
                 (Type::record(), Type::record()),
             ])
@@ -53,6 +54,19 @@ impl Command for MathStddev {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let sample = call.has_flag(engine_state, stack, "sample")?;
+        let name = call.head;
+        let span = input.span().unwrap_or(name);
+        let input: PipelineData = match input.try_expand_range() {
+            Err(_) => {
+                let span = span;
+                return Err(ShellError::IncorrectValue {
+                    msg: "Range must be bounded".to_string(),
+                    val_span: span,
+                    call_span: name,
+                })
+            },
+            Ok(val) => val,
+        };
         run_with_function(call, input, compute_stddev(sample))
     }
 
@@ -63,6 +77,19 @@ impl Command for MathStddev {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let sample = call.has_flag_const(working_set, "sample")?;
+        let name = call.head;
+        let span = input.span().unwrap_or(name);
+        let input: PipelineData = match input.try_expand_range() {
+            Err(_) => {
+                let span = span;
+                return Err(ShellError::IncorrectValue {
+                    msg: "Range must be bounded".to_string(),
+                    val_span: span,
+                    call_span: name,
+                })
+            },
+            Ok(val) => val,
+        };
         run_with_function(call, input, compute_stddev(sample))
     }
 

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -14,7 +14,6 @@ impl Command for MathStddev {
         Signature::build("math stddev")
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Number)), Type::Number),
-                (Type::Range, Type::Number),
                 (Type::table(), Type::record()),
                 (Type::record(), Type::record()),
             ])

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -50,13 +50,12 @@ impl Command for MathVariance {
         let span = input.span().unwrap_or(name);
         let input: PipelineData = match input.try_expand_range() {
             Err(_) => {
-                let span = span;
                 return Err(ShellError::IncorrectValue {
                     msg: "Range must be bounded".to_string(),
                     val_span: span,
                     call_span: name,
-                })
-            },
+                });
+            }
             Ok(val) => val,
         };
         run_with_function(call, input, compute_variance(sample))
@@ -73,13 +72,12 @@ impl Command for MathVariance {
         let span = input.span().unwrap_or(name);
         let input: PipelineData = match input.try_expand_range() {
             Err(_) => {
-                let span = span;
                 return Err(ShellError::IncorrectValue {
                     msg: "Range must be bounded".to_string(),
                     val_span: span,
                     call_span: name,
-                })
-            },
+                });
+            }
             Ok(val) => val,
         };
         run_with_function(call, input, compute_variance(sample))

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -13,6 +13,7 @@ impl Command for MathVariance {
         Signature::build("math variance")
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::Range, Type::Number),
                 (Type::table(), Type::record()),
                 (Type::record(), Type::record()),
             ])
@@ -45,6 +46,19 @@ impl Command for MathVariance {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let sample = call.has_flag(engine_state, stack, "sample")?;
+        let name = call.head;
+        let span = input.span().unwrap_or(name);
+        let input: PipelineData = match input.try_expand_range() {
+            Err(_) => {
+                let span = span;
+                return Err(ShellError::IncorrectValue {
+                    msg: "Range must be bounded".to_string(),
+                    val_span: span,
+                    call_span: name,
+                })
+            },
+            Ok(val) => val,
+        };
         run_with_function(call, input, compute_variance(sample))
     }
 
@@ -55,6 +69,19 @@ impl Command for MathVariance {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let sample = call.has_flag_const(working_set, "sample")?;
+        let name = call.head;
+        let span = input.span().unwrap_or(name);
+        let input: PipelineData = match input.try_expand_range() {
+            Err(_) => {
+                let span = span;
+                return Err(ShellError::IncorrectValue {
+                    msg: "Range must be bounded".to_string(),
+                    val_span: span,
+                    call_span: name,
+                })
+            },
+            Ok(val) => val,
+        };
         run_with_function(call, input, compute_variance(sample))
     }
 

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -13,6 +13,7 @@ impl Command for MathVariance {
         Signature::build("math variance")
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::Range, Type::Number),
                 (Type::table(), Type::record()),
                 (Type::record(), Type::record()),
             ])

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -13,7 +13,6 @@ impl Command for MathVariance {
         Signature::build("math variance")
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Number)), Type::Number),
-                (Type::Range, Type::Number),
                 (Type::table(), Type::record()),
                 (Type::record(), Type::record()),
             ])

--- a/crates/nu-command/tests/commands/math/abs.rs
+++ b/crates/nu-command/tests/commands/math/abs.rs
@@ -7,8 +7,16 @@ fn const_abs() {
 }
 
 #[test]
-fn cannot_abs_range() {
-    let actual = nu!("0..5 | math abs");
+fn can_abs_range() {
+    let actual = nu!("-1.5..-10.5 | math abs");
+    let expected = nu!("1.5..10.5");
 
-    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
+fn cannot_abs_infinite_range() {
+    let actual = nu!("0.. | math abs");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
 }

--- a/crates/nu-command/tests/commands/math/abs.rs
+++ b/crates/nu-command/tests/commands/math/abs.rs
@@ -7,7 +7,7 @@ fn const_abs() {
 }
 
 #[test]
-fn can_abs_range() {
+fn can_abs_range_into_list() {
     let actual = nu!("-1.5..-10.5 | math abs");
     let expected = nu!("1.5..10.5");
 

--- a/crates/nu-command/tests/commands/math/ceil.rs
+++ b/crates/nu-command/tests/commands/math/ceil.rs
@@ -7,8 +7,16 @@ fn const_ceil() {
 }
 
 #[test]
-fn cannot_ceil_range() {
-    let actual = nu!("0..5 | math ceil");
+fn can_ceil_range() {
+    let actual = nu!("(1.8)..(1.9)..(2.2) | math ceil");
+    let expected = nu!("[2 2 2 3 3]");
 
-    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
+fn cannot_ceil_infinite_range() {
+    let actual = nu!("0.. | math ceil");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
 }

--- a/crates/nu-command/tests/commands/math/ceil.rs
+++ b/crates/nu-command/tests/commands/math/ceil.rs
@@ -7,7 +7,7 @@ fn const_ceil() {
 }
 
 #[test]
-fn can_ceil_range() {
+fn can_ceil_range_into_list() {
     let actual = nu!("(1.8)..(1.9)..(2.2) | math ceil");
     let expected = nu!("[2 2 2 3 3]");
 

--- a/crates/nu-command/tests/commands/math/floor.rs
+++ b/crates/nu-command/tests/commands/math/floor.rs
@@ -7,7 +7,7 @@ fn const_floor() {
 }
 
 #[test]
-fn can_floor_range() {
+fn can_floor_range_into_list() {
     let actual = nu!("(1.8)..(1.9)..(2.2) | math floor");
     let expected = nu!("[1 1 2 2 2]");
 

--- a/crates/nu-command/tests/commands/math/floor.rs
+++ b/crates/nu-command/tests/commands/math/floor.rs
@@ -7,8 +7,16 @@ fn const_floor() {
 }
 
 #[test]
-fn cannot_floor_range() {
+fn can_floor_range() {
+    let actual = nu!("(1.8)..(1.9)..(2.2) | math floor");
+    let expected = nu!("[1 1 2 2 2]");
+
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
+fn cannot_floor_infinite_range() {
     let actual = nu!("0.. | math floor");
 
-    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
 }

--- a/crates/nu-command/tests/commands/math/log.rs
+++ b/crates/nu-command/tests/commands/math/log.rs
@@ -7,7 +7,7 @@ fn const_log() {
 }
 
 #[test]
-fn can_log_range() {
+fn can_log_range_into_list() {
     let actual = nu!("1..5 | math log 2");
     let expected = nu!("[1 2 3 4 5] | math log 2");
 

--- a/crates/nu-command/tests/commands/math/log.rs
+++ b/crates/nu-command/tests/commands/math/log.rs
@@ -7,8 +7,16 @@ fn const_log() {
 }
 
 #[test]
-fn cannot_log_range() {
-    let actual = nu!("0.. | math log 2");
+fn can_log_range() {
+    let actual = nu!("1..5 | math log 2");
+    let expected = nu!("[1 2 3 4 5] | math log 2");
 
-    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
+fn cannot_log_infinite_range() {
+    let actual = nu!("1.. | math log");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
 }

--- a/crates/nu-command/tests/commands/math/mode.rs
+++ b/crates/nu-command/tests/commands/math/mode.rs
@@ -7,7 +7,7 @@ fn const_avg() {
 }
 
 #[test]
-fn can_mode_range() {
+fn can_mode_range_into_list() {
     let actual = nu!("0..5 | math mode");
     let expected = nu!("[0 1 2 3 4 5] | math mode");
 

--- a/crates/nu-command/tests/commands/math/mode.rs
+++ b/crates/nu-command/tests/commands/math/mode.rs
@@ -7,8 +7,16 @@ fn const_avg() {
 }
 
 #[test]
-fn cannot_mode_range() {
+fn can_mode_range() {
     let actual = nu!("0..5 | math mode");
+    let expected = nu!("[0 1 2 3 4 5] | math mode");
 
-    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
+fn cannot_mode_infinite_range() {
+    let actual = nu!("0.. | math mode");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
 }

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -42,7 +42,7 @@ fn const_round() {
 }
 
 #[test]
-fn can_round_range() {
+fn can_round_range_into_list() {
     let actual = nu!("(1.0)..(1.2)..(2.0) | math round");
     let expected = nu!("[1 1 1 2 2 2]");
 

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -42,8 +42,16 @@ fn const_round() {
 }
 
 #[test]
-fn cannot_round_infinite_range() {
-    let actual = nu!("0..5 | math round");
+fn can_round_range() {
+    let actual = nu!("(1.0)..(1.2)..(2.0) | math round");
+    let expected = nu!("[1 1 1 2 2 2]");
 
-    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
+fn cannot_round_infinite_range() {
+    let actual = nu!("0.. | math round");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
 }

--- a/crates/nu-command/tests/commands/math/sqrt.rs
+++ b/crates/nu-command/tests/commands/math/sqrt.rs
@@ -28,7 +28,7 @@ fn const_sqrt() {
 }
 
 #[test]
-fn can_sqrt_range_into_list() {
+fn can_sqrt_range() {
     let actual = nu!("0..5 | math sqrt");
     let expected = nu!("[0 1 2 3 4 5] | math sqrt");
 

--- a/crates/nu-command/tests/commands/math/sqrt.rs
+++ b/crates/nu-command/tests/commands/math/sqrt.rs
@@ -28,7 +28,7 @@ fn const_sqrt() {
 }
 
 #[test]
-fn can_sqrt_range() {
+fn can_sqrt_range_into_list() {
     let actual = nu!("0..5 | math sqrt");
     let expected = nu!("[0 1 2 3 4 5] | math sqrt");
 

--- a/crates/nu-command/tests/commands/math/sqrt.rs
+++ b/crates/nu-command/tests/commands/math/sqrt.rs
@@ -28,8 +28,16 @@ fn const_sqrt() {
 }
 
 #[test]
-fn cannot_sqrt_range() {
+fn can_sqrt_range() {
     let actual = nu!("0..5 | math sqrt");
+    let expected = nu!("[0 1 2 3 4 5] | math sqrt");
 
-    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
+fn cannot_sqrt_infinite_range() {
+    let actual = nu!("0.. | math sqrt");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
 }

--- a/crates/nu-command/tests/commands/math/stddev.rs
+++ b/crates/nu-command/tests/commands/math/stddev.rs
@@ -7,16 +7,8 @@ fn const_avg() {
 }
 
 #[test]
-fn can_stddev_range() {
+fn cannot_stddev_range() {
     let actual = nu!("0..5 | math stddev");
-    let expected = nu!("[0 1 2 3 4 5] | math stddev");
 
-    assert_eq!(actual.out, expected.out);
-}
-
-#[test]
-fn cannot_stddev_infinite_range() {
-    let actual = nu!("0.. | math abs");
-
-    assert!(actual.err.contains("nu::shell::incorrect_value"));
+    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
 }

--- a/crates/nu-command/tests/commands/math/stddev.rs
+++ b/crates/nu-command/tests/commands/math/stddev.rs
@@ -7,8 +7,16 @@ fn const_avg() {
 }
 
 #[test]
-fn cannot_stddev_range() {
+fn can_stddev_range() {
     let actual = nu!("0..5 | math stddev");
+    let expected = nu!("[0 1 2 3 4 5] | math stddev");
 
-    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
+fn cannot_stddev_infinite_range() {
+    let actual = nu!("0.. | math abs");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
 }

--- a/crates/nu-command/tests/commands/math/stddev.rs
+++ b/crates/nu-command/tests/commands/math/stddev.rs
@@ -7,8 +7,16 @@ fn const_avg() {
 }
 
 #[test]
-fn cannot_stddev_range() {
+fn can_stddev_range() {
     let actual = nu!("0..5 | math stddev");
+    let expected = nu!("[0 1 2 3 4 5] | math stddev");
 
-    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
+fn cannot_stddev_infinite_range() {
+    let actual = nu!("0.. | math stddev");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
 }

--- a/crates/nu-command/tests/commands/math/variance.rs
+++ b/crates/nu-command/tests/commands/math/variance.rs
@@ -7,7 +7,7 @@ fn const_variance() {
 }
 
 #[test]
-fn can_variance_range() {
+fn can_variance_range_into_list() {
     let actual = nu!("0..5 | math variance");
     let expected = nu!("[0 1 2 3 4 5] | math variance");
 

--- a/crates/nu-command/tests/commands/math/variance.rs
+++ b/crates/nu-command/tests/commands/math/variance.rs
@@ -7,16 +7,8 @@ fn const_variance() {
 }
 
 #[test]
-fn can_variance_range_into_list() {
+fn cannot_variance_range() {
     let actual = nu!("0..5 | math variance");
-    let expected = nu!("[0 1 2 3 4 5] | math variance");
 
-    assert_eq!(actual.out, expected.out);
-}
-
-#[test]
-fn cannot_variance_infinite_range() {
-    let actual = nu!("0.. | math variance");
-
-    assert!(actual.err.contains("nu::shell::incorrect_value"));
+    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
 }

--- a/crates/nu-command/tests/commands/math/variance.rs
+++ b/crates/nu-command/tests/commands/math/variance.rs
@@ -7,8 +7,16 @@ fn const_variance() {
 }
 
 #[test]
-fn cannot_variance_range() {
+fn can_variance_range() {
     let actual = nu!("0..5 | math variance");
+    let expected = nu!("[0 1 2 3 4 5] | math variance");
 
-    assert!(actual.err.contains("nu::parser::input_type_mismatch"));
+    assert_eq!(actual.out, expected.out);
+}
+
+#[test]
+fn cannot_variance_infinite_range() {
+    let actual = nu!("0.. | math variance");
+
+    assert!(actual.err.contains("nu::shell::incorrect_value"));
 }

--- a/devdocs/README.md
+++ b/devdocs/README.md
@@ -9,4 +9,4 @@ A complementary (currently stale) resource has been the [Nushell contributor boo
 - [Developer FAQ](FAQ.md)
 - [How to/SOPs](HOWTOS.md)
 - [Platform support policy](PLATFORM_SUPPORT.md)
-- [Our Rust style](devdocs/rust_style.md)
+- [Our Rust style](rust_style.md)


### PR DESCRIPTION
No associated issue, but follows up #15135. See also discussion on [discord](https://discord.com/channels/601130461678272522/1349139634281513093/1349139639356624966) with @sholderbach 

# Description

### Math commands `range -> list<number>`

This enables the following math commands:
- abs
- ceil
- floor
- log
- mode
- round

to work with ranges. When a range is given, the command will apply the command on each item of the range, thus producing a list of number as output.

Example
![image](https://github.com/user-attachments/assets/cff12724-5b26-4dbb-a979-a91c1b5652fc)

The commands still do not work work with unbounded ranges:

![image](https://github.com/user-attachments/assets/40c766a8-763f-461d-971b-2d58d11fc3a6)

### Math commands `range -> number`

This was the topic of my previous PR, but for whatever reason I didn't do `math variance` and `math stddev`.
I had to use `input.try_expand_range` to convert the range into a list before computing the variance/stddev.

![image](https://github.com/user-attachments/assets/803954e7-1c2a-4c86-8b16-e16518131138)

And same, does not work in infinite ranges:

![image](https://github.com/user-attachments/assets/8bfaae2b-34cc-453d-8764-e42c815d28d3)

### Also done:
- find link in documentation

# User-Facing Changes
- Command signatures changes
- ability to use some commands with unbounded ranges
- ability to use variance and stddev with bounded ranges

# Tests + Formatting
Cargo fmt and clippy OK
Tests OK

# After Submitting
I guess nothing, or maybe release notes?
