### PR TITLE
`into string` should not modify strings

### DIFF
--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -1,6 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
-use nu_protocol::{shell_error::into_code, Config};
+use nu_protocol::Config;
 use nu_utils::get_system_locale;
 use num_format::ToFormattedString;
 use std::sync::Arc;
@@ -215,17 +215,8 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         }
         Value::Bool { val, .. } => Value::string(val.to_string(), span),
         Value::Date { val, .. } => Value::string(val.format("%c").to_string(), span),
-        Value::String { val, .. } => {
-            if group_digits {
-                let number = val.parse::<i64>().unwrap_or_default();
-                let decimal_value = digits.unwrap_or(0) as usize;
-                Value::string(format_int(number, group_digits, decimal_value), span)
-            } else {
-                Value::string(val.to_string(), span)
-            }
-        }
-        Value::Glob { val, .. } => Value::string(val.to_string(), span),
-
+        Value::String { val, .. } => Value::string(val, span),
+        Value::Glob { val, .. } => Value::string(val, span),
         Value::Filesize { val, .. } => {
             if group_digits {
                 let decimal_value = digits.unwrap_or(0) as usize;
@@ -235,8 +226,6 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             }
         }
         Value::Duration { val: _, .. } => Value::string(input.to_expanded_string("", config), span),
-
-        Value::Error { error, .. } => Value::string(into_code(error).unwrap_or_default(), span),
         Value::Nothing { .. } => Value::string("".to_string(), span),
         Value::Record { .. } => Value::error(
             // Watch out for CantConvert's argument order
@@ -272,6 +261,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
                 })
                 .unwrap_or_else(|err| Value::error(err, span))
         }
+        Value::Error { .. } => input.clone(),
         x => Value::error(
             ShellError::CantConvert {
                 to_type: String::from("string"),

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1474,10 +1474,6 @@ impl<'de> Deserialize<'de> for ShellError {
     }
 }
 
-pub fn into_code(err: &ShellError) -> Option<String> {
-    err.code().map(|code| code.to_string())
-}
-
 #[test]
 fn shell_error_serialize_roundtrip() {
     // Ensure that we can serialize and deserialize `ShellError`, and check that it basically would


### PR DESCRIPTION
# Description

`into string` should not modify input strings (even with the `--group-digits` flag). It's a conversion command, not a formatting command.

# User-Facing Changes

- For strings, the same behavior from 0.102.0 is preserved.
- Errors are no longer turned into strings, but rather they are returned as is.

# After Submitting

Create a `format int` and/or `format float` command and so that the `--group-digits` flag can be transferred to one of those commands.