### PR TITLE
Disallow DTD by default in `from xml`

### DIFF
--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -17,8 +17,8 @@ impl Command for FromXml {
             .input_output_types(vec![(Type::String, Type::record())])
             .switch("keep-comments", "add comment nodes to result", None)
             .switch(
-                "disallow-dtd",
-                "disallow parsing documents with DTDs (prevents exponential entity expansion attacks)",
+                "allow-dtd",
+                "allow parsing documents with DTDs (may result in exponential entity expansion)",
                 None,
             )
             .switch(
@@ -55,7 +55,7 @@ string. This way content of every tag is always a table and is easier to parse"#
         let head = call.head;
         let keep_comments = call.has_flag(engine_state, stack, "keep-comments")?;
         let keep_processing_instructions = call.has_flag(engine_state, stack, "keep-pi")?;
-        let allow_dtd = !call.has_flag(engine_state, stack, "disallow-dtd")?;
+        let allow_dtd = call.has_flag(engine_state, stack, "allow-dtd")?;
         let info = ParsingInfo {
             span: head,
             keep_comments,
@@ -278,7 +278,7 @@ fn process_xml_parse_error(source: String, err: roxmltree::Error, span: Span) ->
             make_xml_error("The root node was opened but never closed.", span)
         }
         roxmltree::Error::DtdDetected => make_xml_error(
-            "XML document with DTD detected.",
+            "XML document with DTD detected.\nDTDs are disabled by default to prevent denial-of-serivce attacks (use --allow-dtd to parse anyway)",
             span
         ),
         roxmltree::Error::NodesLimitReached => {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.



Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Follow-up to #15272, changing default to disallow DTD as discussed. Especially applicable for the `http get` case.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Changes behavior introduced in #15272, so release notes need to be updated to reflect this

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
