### PR TITLE
Add category to pwd and banner commands

### DIFF
--- a/crates/nu-std/std/prelude/mod.nu
+++ b/crates/nu-std/std/prelude/mod.nu
@@ -1,6 +1,8 @@
 use std/dt [datetime-diff, pretty-print-duration]
 
 # Print a banner for Nushell with information about the project
+@category "default"
+@search-terms "welcome" "startup"
 export def banner [
     --short    # Only show startup time
 ] {
@@ -40,8 +42,9 @@ match (config use-colors) {
 }
 
 # Return the current working directory
+@category "default"
 export def pwd [
-    --physical (-P) # resolve symbolic links
+    --physical (-P) # Resolve symbolic links
 ] {
     if $physical {
         $env.PWD | path expand


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Add category to `pwd` and `banner` commands, fix broken of command docs updating here: https://github.com/nushell/nushell.github.io/actions/runs/13884819349/job/38848104064#step:5:18
The error was caused by these two commands have no category


