### PR TITLE
Feature-gate `job unfreeze` behind "os"

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -454,7 +454,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             Job,
         };
 
-        #[cfg(unix)]
+        #[cfg(all(unix, feature = "os"))]
         bind_command! {
             JobUnfreeze,
         }

--- a/crates/nu-command/src/experimental/mod.rs
+++ b/crates/nu-command/src/experimental/mod.rs
@@ -4,7 +4,7 @@ mod job_kill;
 mod job_list;
 mod job_spawn;
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "os"))]
 mod job_unfreeze;
 
 pub use is_admin::IsAdmin;
@@ -14,5 +14,5 @@ pub use job_list::JobList;
 
 pub use job_spawn::JobSpawn;
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "os"))]
 pub use job_unfreeze::JobUnfreeze;


### PR DESCRIPTION
# Description

The `job unfreeze` command relies on the `os` feature of the `nu-protocol` crate, which means that `nu-command` doesn't compile with `--no-default-features`. This PR gates `job unfreeze` behind `nu-command`'s `os` feature to avoid this.

No user-facing changes, no tests needed.