### PR TITLE
add more columns to macos `ps -l`

### DIFF
--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -176,11 +176,14 @@ fn run_ps(
             }
             #[cfg(target_os = "macos")]
             {
-                record.push("cwd", Value::string(proc.cwd(), span));
                 let timestamp = Local
                     .timestamp_nanos(proc.start_time * 1_000_000_000)
                     .into();
                 record.push("start_time", Value::date(timestamp, span));
+                record.push("user_id", Value::int(proc.user_id, span));
+                record.push("priority", Value::int(proc.priority, span));
+                record.push("process_threads", Value::int(proc.task_thread_num, span));
+                record.push("cwd", Value::string(proc.cwd(), span));
             }
         }
 


### PR DESCRIPTION
# Description

This PR adds a few more columns to the macos version of `ps -l` to bring it more inline with the Linux and Windows version.

Columns added: user_id, priority, process_threads

I also added some comments that describe the TaskInfo structure. I couldn't find any good information to add to the BSDInfo structure.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
