### PR TITLE
Job: reset next_job_id when there are no jobs available

### DIFF
--- a/crates/nu-protocol/src/engine/jobs.rs
+++ b/crates/nu-protocol/src/engine/jobs.rs
@@ -43,7 +43,11 @@ impl Jobs {
             self.last_frozen_job_id = None;
         }
 
-        self.jobs.remove(&id)
+        let result = self.jobs.remove(&id);
+        if self.jobs.is_empty() {
+            self.next_job_id = 1;
+        }
+        result
     }
 
     fn assign_last_frozen_id_if_frozen(&mut self, id: JobId, job: &Job) {


### PR DESCRIPTION
# Description
While playing with the job feature, I found something that can be improved.

When we move a job into the background, restore it, and quit the job, and then move a job into the background again, it reports that `Job 2 is frozen`. I think it would be better to report `Job 1 is frozen`.

This helps me understand if it's the first job in the job list after I press `Ctrl+Z`.

# User-Facing Changes

## Before
![图片](https://github.com/user-attachments/assets/c086060f-39b9-4887-8382-3e8f9ecf887f)

## After
![图片](https://github.com/user-attachments/assets/217336dd-58b9-4145-92ad-a25c27cd1a6d)

# Tests + Formatting
Sorry I think it's hard to add a test.

# After Submitting
NaN