### PR TITLE
Fix `to nuon --serialize` of closure

### DIFF
--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -319,6 +319,18 @@ fn to_nuon_errs_on_closure() {
 }
 
 #[test]
+fn to_nuon_closure_coerced_to_quoted_string() {
+    let actual = nu!(pipeline(
+        r#"
+            {|| to nuon}
+            | to nuon --serialize
+        "#
+    ));
+
+    assert_eq!(actual.out, "\"{|| to nuon}\"");
+}
+
+#[test]
 fn binary_to() {
     let actual = nu!(pipeline(
         r#"

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -307,7 +307,6 @@ fn from_nuon_datetime() {
 }
 
 #[test]
-#[ignore]
 fn to_nuon_errs_on_closure() {
     let actual = nu!(pipeline(
         r#"
@@ -316,7 +315,7 @@ fn to_nuon_errs_on_closure() {
         "#
     ));
 
-    assert!(actual.err.contains("can't convert closure to NUON"));
+    assert!(actual.err.contains("not deserializable"));
 }
 
 #[test]

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -99,7 +99,9 @@ fn value_to_string(
         }
         Value::Closure { val, .. } => {
             if serialize_types {
-                Ok(val.coerce_into_string(engine_state, span)?.to_string())
+                Ok(escape_quote_string(
+                    &val.coerce_into_string(engine_state, span)?,
+                ))
             } else {
                 Err(ShellError::UnsupportedInput {
                     msg: "closures are currently not deserializable (use --serialize to serialize as a string)".into(),

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -108,7 +108,7 @@ fn literal_closure() {
 
 #[test]
 fn literal_closure_to_nuon() {
-    test_eval("{||} | to nuon --serialize", Eq("{||}"))
+    test_eval("{||} | to nuon --serialize", Eq("\"{||}\""))
 }
 
 #[test]


### PR DESCRIPTION
# Description
Closes #15351

Adds quotes that were missed in #14698 with the proper escaping.


# User-Facing Changes
`to nuon --serialize` will now produce a quoted string instead of illegal nuon when given a closure

# Tests + Formatting
Reenable the `to nuon` rejection of closures in the base state test.
Added test for quoting.
