### PR TITLE
fix(nu-command): support ACL, SELinux, e.g. in cd have_permission check

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -864,7 +864,7 @@ fn do_auto_cd(
         path.to_string_lossy().to_string()
     };
 
-    if let PermissionResult::PermissionDenied(_) = have_permission(path.clone()) {
+    if let PermissionResult::PermissionDenied = have_permission(path.clone()) {
         report_shell_error(
             engine_state,
             &ShellError::Io(IoError::new_with_additional_context(

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -132,7 +132,7 @@ impl Command for Cd {
                 stack.set_cwd(path)?;
                 Ok(PipelineData::empty())
             }
-            PermissionResult::PermissionDenied(_) => {
+            PermissionResult::PermissionDenied => {
                 Err(IoError::new(std::io::ErrorKind::PermissionDenied, call.head, path).into())
             }
         }

--- a/crates/nu-utils/src/filesystem.rs
+++ b/crates/nu-utils/src/filesystem.rs
@@ -1,5 +1,8 @@
 #[cfg(unix)]
-use nix::unistd::{access, AccessFlags};
+use nix::{
+    fcntl::AtFlags,
+    unistd::{faccessat, AccessFlags},
+};
 #[cfg(any(windows, unix))]
 use std::path::Path;
 
@@ -28,7 +31,7 @@ pub fn have_permission(dir: impl AsRef<Path>) -> PermissionResult {
 
 #[cfg(unix)]
 pub fn have_permission(dir: impl AsRef<Path>) -> PermissionResult {
-    match access(dir.as_ref(), AccessFlags::X_OK) {
+    match faccessat(None, dir.as_ref(), AccessFlags::X_OK, AtFlags::AT_EACCESS) {
         Ok(_) => PermissionResult::PermissionOk,
         Err(_) => PermissionResult::PermissionDenied,
     }

--- a/crates/nu-utils/src/filesystem.rs
+++ b/crates/nu-utils/src/filesystem.rs
@@ -30,6 +30,7 @@ pub fn have_permission(dir: impl AsRef<Path>) -> PermissionResult {
 }
 
 #[cfg(unix)]
+/// Check that the process' user id has permissions to execute or in the case of a directory traverse the particular directory
 pub fn have_permission(dir: impl AsRef<Path>) -> PermissionResult {
     // `faccessat()` from modern libc does not always take ACL into account.
     // We prefer call `access()` instead as possible.


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

fixes #8095


# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This approach is a bit straightforward, call access() check with the flag `X_OK`.

Zsh[^1], Fish perform this check by the same approach.

[^1]: https://github.com/zsh-users/zsh/blob/435cb1b748ce1f2f5c38edc1d64f4ee2424f9b3a/Src/exec.c#L6406

It could also avoid manual xattrs check on other *nix platforms.

BTW, the execution bit for directories in *nix world means permission to access it's content,
while the read bit means to list it's content. [^0]

[^0]: https://superuser.com/a/169418

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Users could face less permission check bugs in their `cd` usage.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
