### PR TITLE
fix(parser): skip eval_const if parsing errors detected to avoid panic

### DIFF
--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1140,6 +1140,8 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         span: Span,
     },
 
+    /// TODO: Get rid of this error by moving the check before evaluation
+    ///
     /// Tried evaluating of a subexpression with parsing error
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1140,6 +1140,23 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         span: Span,
     },
 
+    /// Tried evaluating of a subexpression with parsing error
+    ///
+    /// ## Resolution
+    ///
+    /// Fix the parsing error first.
+    #[error("Found parsing error in expression.")]
+    #[diagnostic(
+        code(nu::shell::parse_error_in_constant),
+        help(
+            "This expression is supposed to be evaluated into a constant, which means error-free."
+        )
+    )]
+    ParseErrorInConstant {
+        #[label("Parsing error detected in expression")]
+        span: Span,
+    },
+
     /// Tried assigning non-constant value to a constant
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -518,10 +518,10 @@ impl Eval for EvalConst {
                 .iter()
                 .any(|error| block_span.contains_span(error.span()))
             {
-                return Err(ShellError::NotAConstant { span });
+                return Err(ShellError::ParseErrorInConstant { span });
             }
         } else if !working_set.parse_errors.is_empty() {
-            return Err(ShellError::NotAConstant { span });
+            return Err(ShellError::ParseErrorInConstant { span });
         };
         eval_const_subexpression(working_set, block, PipelineData::empty(), span)?.into_value(span)
     }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -510,6 +510,19 @@ impl Eval for EvalConst {
     ) -> Result<Value, ShellError> {
         // TODO: Allow debugging const eval
         let block = working_set.get_block(block_id);
+
+        // If parsing errors exist in the block, don't bother to evaluate it.
+        if let Some(block_span) = block.span {
+            if working_set
+                .parse_errors
+                .iter()
+                .any(|error| block_span.contains_span(error.span()))
+            {
+                return Err(ShellError::NotAConstant { span });
+            }
+        } else if !working_set.parse_errors.is_empty() {
+            return Err(ShellError::NotAConstant { span });
+        };
         eval_const_subexpression(working_set, block, PipelineData::empty(), span)?.into_value(span)
     }
 


### PR DESCRIPTION
Fixes #14972 #15321 #14706

# Description

Early returns `NotAConstant` if parsing errors exist in the subexpression.

I'm not sure when the span of a block will be None, and whether there're better ways to handle none block spans, like a more suitable ShellError type.

# User-Facing Changes

# Tests + Formatting

+1, but possibly not the easiest way to do it.

# After Submitting
