### PR TITLE
fix(explore): do not create extra layer for empty entries

### DIFF
--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -779,19 +779,19 @@ mod tests {
         // Before transpose
         assert_eq!(layer.count_rows(), 2);
         assert_eq!(layer.count_columns(), 3);
-        assert_eq!(layer.was_transposed, false);
+        assert!(!layer.was_transposed);
 
         // After transpose
         transpose_table(&mut layer);
         assert_eq!(layer.count_rows(), 3);
         assert_eq!(layer.count_columns(), 3); // Now includes header row
-        assert_eq!(layer.was_transposed, true);
+        assert!(layer.was_transposed);
 
         // After transpose back
         transpose_table(&mut layer);
         assert_eq!(layer.count_rows(), 2);
         assert_eq!(layer.count_columns(), 3);
-        assert_eq!(layer.was_transposed, false);
+        assert!(!layer.was_transposed);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #15329

# Description

Stops entering empty list/record with the following message:

<img width="283" alt="image" src="https://github.com/user-attachments/assets/99cf5ab0-7fd3-4cf7-9db9-00554815a2a7" />

# User-Facing Changes

# Tests + Formatting

+5, all vibe coded.

# After Submitting
