### PR TITLE
fix: flatten of empty closures

### DIFF
--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -232,7 +232,8 @@ fn flatten_expression_into(
                     None
                 }
             } else {
-                None
+                // for empty closures
+                Some((outer_span, FlatShape::Closure))
             };
 
             output.extend(flattened);


### PR DESCRIPTION
Closes #15373

# Description

Now `ast -f "{||}"` will return

```
╭─content─┬─────shape─────┬─────span──────╮
│ {||}    │ shape_closure │ ╭───────┬───╮ │
│         │               │ │ start │ 0 │ │
│         │               │ │ end   │ 4 │ │
│         │               │ ╰───────┴───╯ │
╰─────────┴───────────────┴───────────────╯
```

Similar to those of `ast -f "[]"`/`ast -f "{}"`

# User-Facing Changes

# Tests + Formatting

I didn't find the right place to do the test, except for the examples of `ast` command.

# After Submitting
