### PR TITLE
fix(parser): comments in subexpressions of `let`/`mut`

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3331,7 +3331,7 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         spans[span.0 + 1].start,
                         &[],
                         &[],
-                        true,
+                        false,
                     );
 
                     if let Some(parse_error) = parse_error {
@@ -3613,7 +3613,7 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         spans[span.0 + 1].start,
                         &[],
                         &[],
-                        true,
+                        false,
                     );
 
                     if let Some(parse_error) = parse_error {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5208,7 +5208,7 @@ pub fn parse_assignment_expression(
         rhs_span.start,
         &[],
         &[],
-        true,
+        false,
     );
     working_set.parse_errors.extend(rhs_error);
 

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -2445,6 +2445,7 @@ mod input_types {
             working_set.add_decl(Box::new(Collect));
             working_set.add_decl(Box::new(WithColumn));
             working_set.add_decl(Box::new(IfMocked));
+            working_set.add_decl(Box::new(Mut));
 
             working_set.render()
         };
@@ -2574,6 +2575,44 @@ mod input_types {
     }
 
     #[test]
+    fn comments_within_blocks_test() {
+        // https://github.com/nushell/nushell/issues/15305
+        let mut engine_state = EngineState::new();
+        add_declarations(&mut engine_state);
+
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        let input = "def dummy []: int -> int { $in }";
+        parse(&mut working_set, None, input.as_bytes(), true);
+
+        for prefix in ["let ", "mut ", "mut foo = 1; $"] {
+            let input = format!(
+                r#"{}foo = 1 |
+                # comment
+                dummy"#,
+                prefix
+            );
+            let block = parse(&mut working_set, None, input.as_bytes(), true);
+            let last_expr = &block.pipelines.last().unwrap().elements[0].expr.expr;
+            let block_expr = match last_expr {
+                Expr::Call(call) => {
+                    assert_eq!(call.arguments.len(), 2);
+                    call.arguments[1].expr().unwrap()
+                }
+                Expr::BinaryOp(_, _, rhs) => rhs.as_ref(),
+                _ => panic!("Unexpected expression: {:?}", last_expr),
+            };
+            let block_id = match block_expr.expr {
+                Expr::Block(block_id) | Expr::Subexpression(block_id) => block_id,
+                _ => panic!("Unexpected expression: {:?}", block_expr),
+            };
+            let rhs_expr = working_set.get_block(block_id);
+            assert_eq!(rhs_expr.pipelines.len(), 1);
+            assert_eq!(rhs_expr.pipelines[0].elements.len(), 2);
+            assert!(working_set.parse_errors.is_empty());
+        }
+    }
+
+    #[test]
     fn operations_within_blocks_test() {
         let mut engine_state = EngineState::new();
         add_declarations(&mut engine_state);
@@ -2622,8 +2661,7 @@ mod input_types {
             .unwrap()
             .expr;
         let Expr::Call(call) = &element.expr else {
-            eprintln!("{:?}", element.expr);
-            panic!("Expected Expr::Call");
+            panic!("Expected Expr::Call, but found {:?}", element.expr);
         };
         let Expr::Keyword(else_kwd) = &call
             .arguments


### PR DESCRIPTION
Closes #15305

# Description

Basically turns off `skip_comments` of the lex function for right hand side expressions of `let`/`mut`, just as in `parse_const`.

# User-Facing Changes

Should be none.

# Tests + Formatting

+1

# After Submitting
