### PR TITLE
Fix `path add` bug when given a record

### DIFF
--- a/crates/nu-std/std/util/mod.nu
+++ b/crates/nu-std/std/util/mod.nu
@@ -7,8 +7,8 @@
         path add "returned" --ret
     }
 } --result [returned bar baz foo fooo]
-@example "adding paths based on the operating system" {
-    path add {linux: "foo", windows: "bar", darwin: "baz"}
+@example "adding paths based on $nu.os-info.name" {
+    path add {linux: "foo", windows: "bar", macos: "baz"}
 }
 export def --env "path add" [
     --ret (-r)  # return $env.PATH, useful in pipelines to avoid scoping.
@@ -28,12 +28,12 @@ export def --env "path add" [
     let path_name = if "PATH" in $env { "PATH" } else { "Path" }
 
     let paths = $paths | each {|p|
-        let p = match ($p | describe | str replace --regex '<.*' '') {
+        let p = match ($p | describe -d).type {
             "string" => $p,
             "record" => { $p | get --ignore-errors $nu.os-info.name },
         }
 
-        $p | path expand --no-symlink
+        if $p != null { $p | path expand --no-symlink }
     }
 
     if null in $paths or ($paths | is-empty) {

--- a/crates/nu-std/std/util/mod.nu
+++ b/crates/nu-std/std/util/mod.nu
@@ -49,6 +49,7 @@ export def --env "path add" [
 
     load-env {$path_name: (
         $env | get $path_name
+        | split row (char esep)
         | if $append { append $paths } else { prepend $paths }
         | uniq
     )}

--- a/crates/nu-std/tests/test_std_util.nu
+++ b/crates/nu-std/tests/test_std_util.nu
@@ -40,7 +40,10 @@ def path_add [] {
         assert equal (get_path) ([($target_paths | get $nu.os-info.name)] | path expand)
 
         load-env {$path_name: []}
-        assert error {|| path add {} }
+        path add {}
+        assert equal (get_path) []
+
+        assert error {|| path add 1 }
 
         load-env {$path_name: [$"(["/foo", "/bar"] | path expand | str join (char esep))"]}
         path add "~/foo"

--- a/crates/nu-std/tests/test_std_util.nu
+++ b/crates/nu-std/tests/test_std_util.nu
@@ -39,6 +39,9 @@ def path_add [] {
         path add $target_paths
         assert equal (get_path) ([($target_paths | get $nu.os-info.name)] | path expand)
 
+        load-env {$path_name: []}
+        assert error {|| path add {} }
+
         load-env {$path_name: [$"(["/foo", "/bar"] | path expand | str join (char esep))"]}
         path add "~/foo"
         assert equal (get_path) (["~/foo", "/foo", "/bar"] | path expand)

--- a/crates/nu-std/tests/test_util.nu
+++ b/crates/nu-std/tests/test_util.nu
@@ -40,7 +40,10 @@ def path_add [] {
         assert equal (get_path) ([($target_paths | get $nu.os-info.name)] | path expand)
 
         load-env {$path_name: []}
-        assert error {|| path add {} }
+        path add {}
+        assert equal (get_path) ([])
+
+        assert error {|| path add 1 }
 
         load-env {$path_name: [$"(["/foo", "/bar"] | path expand | str join (char esep))"]}
         path add "~/foo"

--- a/crates/nu-std/tests/test_util.nu
+++ b/crates/nu-std/tests/test_util.nu
@@ -39,6 +39,9 @@ def path_add [] {
         path add $target_paths
         assert equal (get_path) ([($target_paths | get $nu.os-info.name)] | path expand)
 
+        load-env {$path_name: []}
+        assert error {|| path add {} }
+
         load-env {$path_name: [$"(["/foo", "/bar"] | path expand | str join (char esep))"]}
         path add "~/foo"
         assert equal (get_path) (["~/foo", "/foo", "/bar"] | path expand)


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
`path add`, when given a record, sets `$env.PATH` according to the value of the key matching `$nu.os-info.name`. There already existed  a check in place to ensure the correct column existed, but it was never reached because of an early error on `path expand`ing `null`. This has been fixed, as well as the out-of-date reference to "darwin" instead of "macos" in the example.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
`path add` now correctly errors as intended when passed a record without a key matching the current value of `$nu.os-info.name` instead of adding that error to the `$env.PATH` variable, which only showed itself when trying to access the values in that list.

# Tests + Formatting
All tests pass. Also added the test `assert error {|| path add {} }` to confirm `path add` errors when the right column is missing.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
