### PR TITLE
Add current exe directory to default `$NU_PLUGIN_DIRS`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -167,9 +167,10 @@ fn main() -> Result<()> {
     );
     working_set.set_variable_const_val(
         var_id,
-        Value::test_list(vec![Value::test_string(
-            default_nu_plugin_dirs_path.to_string_lossy(),
-        )]),
+        Value::test_list(vec![
+            Value::test_string(default_nu_plugin_dirs_path.to_string_lossy()),
+            Value::test_string(current_exe_directory().to_string_lossy()),
+        ]),
     );
     engine_state.merge_delta(working_set.render())?;
     // End: Default NU_LIB_DIRS, NU_PLUGIN_DIRS


### PR DESCRIPTION
# Description

Quality-of-life improvement - Since core plugins are installed into the same directory as the Nushell binary, this simply adds that directory to the default `$NU_PLUGIN_DIRS`.

# User-Facing Changes

## Before

Out of the box:

```nushell
plugin add nu_plugin_polars
# => Error: nu::shell::io::not_found
# => 
# =>   × Not found
# =>    ╭─[entry #1:1:12]
# =>  1 │ plugin add nu_plugin_polars
# =>    ·            ────────┬───────
# =>    ·                    ╰── Not found
# =>    ╰────
# =>   help: 'nu_plugin_polars' does not exist
```

Before using core plugins, users would have to either:

* Add the directory to the `$NU_PLUGIN_DIRS` (or older `$env.NU_PLUGIN_DIRS`)
* Reference the plugins with a fully-qualified path
* Copy/move the plugins into `$nu.default-config-dir/plugins`

## After

The default directory for core plugins is automatically added to the `$NU.PLUGIN_DIRS` with no user action necessary.  Uses can immediately, out-of-the-box:

```nushell
plugin add nu_plugin_polars
plugin use polars
```

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

I plan on doing some work in the plugin doc.