### PR TITLE
Improve completions for exact matches (Issue #14794)

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -98,7 +98,7 @@ fn complete_rec(
                 }
 
                 // For https://github.com/nushell/nushell/issues/13204
-                if isdir && options.match_algorithm == MatchAlgorithm::Prefix {
+                if options.match_algorithm == MatchAlgorithm::Prefix {
                     let exact_match = if options.case_sensitive {
                         entry_name.eq(base)
                     } else {

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -2199,6 +2199,16 @@ fn exact_match() {
         &vec![file(dir.join("partial").join("hello.txt")).as_str()],
         &suggestions,
     );
+
+    let target_dir_2 = format!("open {}", file(dir.join("partial").join("hello"))); // No trailing slash
+    let suggestions_2 = completer.complete(&target_dir_2, target_dir_2.len());
+
+    // Despite no trailing slash, since it's an exact match, only 'partial/hello.txt' should be suggested, not
+    // 'partial-a/hello' and stuff. Implemented in #15387
+    match_suggestions(
+        &vec![file(dir.join("partial").join("hello.txt")).as_str()],
+        &suggestions_2,
+    );
 }
 
 #[ignore = "was reverted, still needs fixing"]

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -2200,14 +2200,14 @@ fn exact_match() {
         &suggestions,
     );
 
-    let target_dir_2 = format!("open {}", file(dir.join("partial").join("hello"))); // No trailing slash
-    let suggestions_2 = completer.complete(&target_dir_2, target_dir_2.len());
+    let target_dir = format!("open {}", file(dir.join("partial").join("hello"))); // No trailing slash
+    let suggestions = completer.complete(&target_dir, target_dir.len());
 
     // Despite no trailing slash, since it's an exact match, only 'partial/hello.txt' should be suggested, not
     // 'partial-a/hello' and stuff. Implemented in #15387
     match_suggestions(
         &vec![file(dir.join("partial").join("hello.txt")).as_str()],
-        &suggestions_2,
+        &suggestions,
     );
 }
 

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -2204,7 +2204,7 @@ fn exact_match() {
     let suggestions = completer.complete(&target_dir, target_dir.len());
 
     // Despite no trailing slash, since it's an exact match, only 'partial/hello.txt' should be suggested, not
-    // 'partial-a/hello' and stuff. Implemented in #15387
+    // 'partial-a/hello' and stuff. See issue #14794 for details.
     match_suggestions(
         &vec![file(dir.join("partial").join("hello.txt")).as_str()],
         &suggestions,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->
Fixes #14794.
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Makes it so that (even if) the command ends in a slash, exact matches are still preferred over partial matches.
For example, `foo/bar/as` -> `foo/bar/asdf` but not `foo/bars/asdf`.
# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
