### PR TITLE
Fix highlighting of aliases to external commands

### DIFF
--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -30,9 +30,8 @@ impl Highlighter for NuHighlighter {
             // externals may slow down things too much.
             if highlight_resolved_externals {
                 for (span, shape) in shapes.iter_mut() {
-                    if *shape == FlatShape::External {
-                        let str_contents =
-                            working_set.get_span_contents(Span::new(span.start, span.end));
+                    if let FlatShape::External(aliased_command_span) = *shape {
+                        let str_contents = working_set.get_span_contents(aliased_command_span);
 
                         let str_word = String::from_utf8_lossy(str_contents).to_string();
                         let paths = env::path_str(&self.engine_state, &self.stack, *span).ok();
@@ -99,7 +98,7 @@ impl Highlighter for NuHighlighter {
                 FlatShape::Float => add_colored_token(&shape.1, next_token),
                 FlatShape::Range => add_colored_token(&shape.1, next_token),
                 FlatShape::InternalCall(_) => add_colored_token(&shape.1, next_token),
-                FlatShape::External => add_colored_token(&shape.1, next_token),
+                FlatShape::External(_) => add_colored_token(&shape.1, next_token),
                 FlatShape::ExternalArg => add_colored_token(&shape.1, next_token),
                 FlatShape::ExternalResolved => add_colored_token(&shape.1, next_token),
                 FlatShape::Keyword => add_colored_token(&shape.1, next_token),

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -1,3 +1,4 @@
+use core::str;
 use nu_protocol::{
     ast::{
         Argument, Block, Expr, Expression, ExternalArgument, ImportPatternMember, ListItem,
@@ -5,7 +6,7 @@ use nu_protocol::{
         RecordItem,
     },
     engine::StateWorkingSet,
-    DeclId, Span, SyntaxShape, VarId,
+    DeclId, GetSpan, Span, SyntaxShape, VarId,
 };
 use std::fmt::{Display, Formatter, Result};
 
@@ -18,7 +19,7 @@ pub enum FlatShape {
     Custom(DeclId),
     DateTime,
     Directory,
-    External,
+    External(Span),
     ExternalArg,
     ExternalResolved,
     Filepath,
@@ -58,7 +59,7 @@ impl FlatShape {
             FlatShape::Custom(_) => "shape_custom",
             FlatShape::DateTime => "shape_datetime",
             FlatShape::Directory => "shape_directory",
-            FlatShape::External => "shape_external",
+            FlatShape::External(_) => "shape_external",
             FlatShape::ExternalArg => "shape_externalarg",
             FlatShape::ExternalResolved => "shape_external_resolved",
             FlatShape::Filepath => "shape_filepath",
@@ -326,7 +327,10 @@ fn flatten_expression_into(
         }
         Expr::ExternalCall(head, args) => {
             if let Expr::String(..) | Expr::GlobPattern(..) = &head.expr {
-                output.push((head.span, FlatShape::External));
+                output.push((
+                    head.span,
+                    FlatShape::External(working_set.get_span(head.span_id)),
+                ));
             } else {
                 flatten_expression_into(working_set, head, output);
             }

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -329,6 +329,9 @@ fn flatten_expression_into(
             if let Expr::String(..) | Expr::GlobPattern(..) = &head.expr {
                 output.push((
                     head.span,
+                    // If this external call is through an alias, then head.span points to the
+                    // name of the alias, but we also need the name of the aliased command. We
+                    // recover this from the span referenced by head.span_id.
                     FlatShape::External(working_set.get_span(head.span_id)),
                 ));
             } else {

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -403,7 +403,7 @@ pub fn hover(engine_state: &mut EngineState, file_path: &str, location: &Value) 
                     }
                 })
             ),
-            FlatShape::External => println!(
+            FlatShape::External(_) => println!(
                 "{}",
                 json!({
                     "hover": "external",


### PR DESCRIPTION
Fixes #12965.

# Description
The syntax highlighter currently can't tell the difference between external command calls and _alias_ calls to external commands. This leads to unexpected behavior when `highlight_resolved_externals` is enabled. Specifically, when this option is enabled, alias calls aliasing external commands are highlighted according to `color_config.shape_external_resolved` if and only if a command exists in the PATH directories whose name happens to be the same as the name of the alias.

The syntax highlighter also can't tell the difference between internal command calls and alias calls aliasing internal commands, but this just results in these alias calls being highlighted like normal internal command calls, which isn't too unexpected.

It is ambiguous what the correct behavior should be. The three options I can think of are:

1. Treat all alias calls (both aliasing internal and external commands) as a new shape, like `shape_alias`, and highlight accordingly.
2. Highlight all alias calls like internal command calls, including those aliasing external commands.
3. Highlight alias calls aliasing external commands according to how the aliased command would have been highlighted.

I personally like 3. and it was easy to implement (unless I missed something), so that's what this PR does right now. I'll be happy to implement a different solution if appropriate. Discussion welcome :)

# User-Facing Changes
All changes are in syntax highlighting only.

Behavior _before_ this PR:
![image](https://github.com/user-attachments/assets/1dc855df-fde8-489e-8c5e-c02979874289)

Behavior _after_ this PR:
![image](https://github.com/user-attachments/assets/9e3a03bf-6730-4849-9123-42bd6b08dd39)

# Tests + Formatting
I didn't write any tests because I couldn't find any existing tests for syntax highlighting.
