### PR TITLE
Fixes `clip copy` stripping control characters when de-ansifying

### DIFF
--- a/crates/nu-std/std-rfc/clip/mod.nu
+++ b/crates/nu-std/std-rfc/clip/mod.nu
@@ -11,6 +11,9 @@ export def copy [
   --ansi (-a)                 # Copy ansi formatting
 ]: any -> nothing {
   let input = $in | collect
+  if not $ansi {
+    $env.config.use_ansi_coloring = false
+  }
   let text = match ($input | describe -d | get type) {
     $type if $type in [ table, record, list ] => {
       $input | table -e
@@ -18,18 +21,7 @@ export def copy [
     _ => {$input}
   }
 
-  let do_strip_ansi = match $ansi {
-    true  => {{||}}
-    false => {{|| ansi strip }}
-  }
-
-  let output = (
-    $text
-    | do $do_strip_ansi
-    | encode base64
-  )
-
-	print -n $'(ansi osc)52;c;($output)(ansi st)'
+  print -n $'(ansi osc)52;c;($text | encode base64)(ansi st)'
 }
 
 # Paste contents of system clipboard


### PR DESCRIPTION
# Description

Fixes #15414 by changing the method used to de-ansi-fy the input.

# User-Facing Changes

Control characters will now be kept when using `clip copy`, but ANSI escape codes will be removed (when not using `--ansi (-a)`)

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

No testing available for clipboard currently.

# After Submitting

N/A