### PR TITLE
Add boolean examples to `any` and `all`

### DIFF
--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -31,6 +31,11 @@ impl Command for All {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
+                description: "Check if a list contains only true values",
+                example: "[false true true false] | all {}",
+                result: Some(Value::test_bool(false)),
+            },
+            Example {
                 description: "Check if each row's status is the string 'UP'",
                 example: "[[status]; [UP] [UP]] | all {|el| $el.status == UP }",
                 result: Some(Value::test_bool(true)),

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -31,6 +31,11 @@ impl Command for Any {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
+                description: "Check if a list contains any true values",
+                example: "[false true true false] | any {}",
+                result: Some(Value::test_bool(true)),
+            },
+            Example {
                 description: "Check if any row's status is the string 'DOWN'",
                 example: "[[status]; [UP] [DOWN] [UP]] | any {|el| $el.status == DOWN }",
                 result: Some(Value::test_bool(true)),


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Follow-up to #15277 and #15392.

Adds examples to `any` and `all` demonstrating using `any {}` or `all {}` with lists of booleans.

We have a couple options that work for this use-case, but not sure which we should recommend. The PR currently uses (1).
1. `any {}` / `all {}`
2. `any { $in }` / `all { $in }`
3. `any { $in == true }` / `all { $in == true }`

Would love to hear your thoughts on the above @fennewald @mtimaN @fdncred @NotTheDr01ds @ysthakur 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
* Added an extra example for `any` and `all`

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
N/A
# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A