### PR TITLE
fix(completion): completions.external.enable config option not respected

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -486,9 +486,10 @@ impl NuCompleter {
         externals: bool,
         strip: bool,
     ) -> Vec<SemanticSuggestion> {
+        let config = self.engine_state.get_config();
         let mut command_completions = CommandCompletion {
             internals,
-            externals,
+            externals: !internals || (externals && config.completions.external.enable),
         };
         let (new_span, prefix) = strip_placeholder_if_any(working_set, &span, strip);
         let ctx = Context::new(working_set, new_span, prefix, offset);

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -411,9 +411,6 @@ fn external_commands_disabled() {
 
     let completion_str = "sleep";
     let suggestions = completer.complete(completion_str, completion_str.len());
-    #[cfg(windows)]
-    let expected: Vec<_> = vec!["sleep"];
-    #[cfg(not(windows))]
     let expected: Vec<_> = vec!["sleep"];
     match_suggestions(&expected, &suggestions);
 }


### PR DESCRIPTION
Fixes #15441 

# Description

Actually I made a small change to the original behavior:

```
^foo<tab>
```
will still show external commands, regardless of whether it's enabled or not. I think that's the only thing people want to see when they press tab with a `^` prefix.

# User-Facing Changes

# Tests + Formatting

+1

# After Submitting

Should I document that minor behavior change somewhere in GitHub.io?