### PR TITLE
Replace all OnlySupportsThisInputType by PipelineMismatch shell error (was duplicate)

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/mod.rs
@@ -171,9 +171,8 @@ where
         // Propagate errors by explicitly matching them before the final case.
         (e @ Value::Error { .. }, _) | (_, e @ Value::Error { .. }) => e.clone(),
         (other, Value::Int { .. } | Value::Binary { .. }) | (_, other) => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "int or binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/bits/not.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/not.rs
@@ -172,9 +172,8 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "int or binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: other.span(),
                 src_span: span,
             },

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -199,9 +199,8 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "int or binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -203,9 +203,8 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "int or binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
@@ -217,9 +217,8 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "int or binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -188,9 +188,8 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "int or binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/arccos.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccos.rs
@@ -95,9 +95,8 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/arccosh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccosh.rs
@@ -81,9 +81,8 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/arcsin.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arcsin.rs
@@ -96,9 +96,8 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/arcsinh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arcsinh.rs
@@ -69,9 +69,8 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/arctan.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arctan.rs
@@ -83,9 +83,8 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/arctanh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arctanh.rs
@@ -82,9 +82,8 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/cos.rs
+++ b/crates/nu-cmd-extra/src/extra/math/cos.rs
@@ -89,9 +89,8 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/cosh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/cosh.rs
@@ -69,9 +69,8 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/exp.rs
+++ b/crates/nu-cmd-extra/src/extra/math/exp.rs
@@ -74,9 +74,8 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/ln.rs
+++ b/crates/nu-cmd-extra/src/extra/math/ln.rs
@@ -81,9 +81,8 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/sin.rs
+++ b/crates/nu-cmd-extra/src/extra/math/sin.rs
@@ -89,9 +89,8 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/sinh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/sinh.rs
@@ -68,9 +68,8 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/tan.rs
+++ b/crates/nu-cmd-extra/src/extra/math/tan.rs
@@ -87,9 +87,8 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/math/tanh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/tanh.rs
@@ -67,9 +67,8 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
@@ -224,9 +224,8 @@ fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "int, filesize, string, duration, binary, or bool".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/strings/format/command.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/command.rs
@@ -209,9 +209,8 @@ fn format(
                     },
                     Value::Error { error, .. } => return Err(*error.clone()),
                     _ => {
-                        return Err(ShellError::OnlySupportsThisInputType {
+                        return Err(ShellError::PipelineMismatch {
                             exp_input_type: "record".to_string(),
-                            wrong_type: val.get_type().to_string(),
                             dst_span: head_span,
                             src_span: val.span(),
                         })
@@ -224,9 +223,8 @@ fn format(
         // Unwrapping this ShellError is a bit unfortunate.
         // Ideally, its Span would be preserved.
         Value::Error { error, .. } => Err(*error),
-        _ => Err(ShellError::OnlySupportsThisInputType {
+        _ => Err(ShellError::PipelineMismatch {
             exp_input_type: "record".to_string(),
-            wrong_type: data_as_value.get_type().to_string(),
             dst_span: head_span,
             src_span: data_as_value.span(),
         }),

--- a/crates/nu-cmd-extra/src/extra/strings/format/number.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/number.rs
@@ -70,9 +70,8 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "float, int, or filesize".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/mod.rs
@@ -56,9 +56,8 @@ where
         Value::String { val, .. } => Value::string(case_operation(val), head),
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/bytes/add.rs
+++ b/crates/nu-command/src/bytes/add.rs
@@ -122,9 +122,8 @@ fn add(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/bytes/collect.rs
+++ b/crates/nu-command/src/bytes/collect.rs
@@ -48,9 +48,8 @@ impl Command for BytesCollect {
                     // Explicitly propagate errors instead of dropping them.
                     Value::Error { error, .. } => Err(*error),
                     Value::Binary { val, .. } => Ok(val),
-                    other => Err(ShellError::OnlySupportsThisInputType {
+                    other => Err(ShellError::PipelineMismatch {
                         exp_input_type: "binary".into(),
-                        wrong_type: other.get_type().to_string(),
                         dst_span: span,
                         src_span: other.span(),
                     }),

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -135,9 +135,8 @@ fn ends_with(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/bytes/index_of.rs
+++ b/crates/nu-command/src/bytes/index_of.rs
@@ -124,9 +124,8 @@ fn index_of(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/bytes/length.rs
+++ b/crates/nu-command/src/bytes/length.rs
@@ -75,9 +75,8 @@ fn length(val: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -128,9 +128,8 @@ fn remove(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/bytes/replace.rs
+++ b/crates/nu-command/src/bytes/replace.rs
@@ -114,9 +114,8 @@ fn replace(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/bytes/reverse.rs
+++ b/crates/nu-command/src/bytes/reverse.rs
@@ -75,9 +75,8 @@ fn reverse(val: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/bytes/starts_with.rs
+++ b/crates/nu-command/src/bytes/starts_with.rs
@@ -112,9 +112,8 @@ fn starts_with(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "binary".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -173,9 +173,8 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "int, filesize, float, string".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -157,10 +157,9 @@ fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "int, float, filesize, string, date, duration, binary, or bool"
                     .into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -169,9 +169,8 @@ fn strict_string_to_boolean(s: &str, span: Span) -> Result<bool, ShellError> {
 fn action(input: &Value, args: &IntoBoolCmdArgument, span: Span) -> Value {
     let err = || {
         Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "bool, int, float or string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: span,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/conversions/into/cell_path.rs
+++ b/crates/nu-command/src/conversions/into/cell_path.rs
@@ -109,9 +109,8 @@ fn into_cell_path(call: &Call, input: PipelineData) -> Result<PipelineData, Shel
             let list: Vec<_> = stream.into_iter().collect();
             Ok(list_to_cell_path(&list, head)?.into_pipeline_data())
         }
-        PipelineData::ByteStream(stream, ..) => Err(ShellError::OnlySupportsThisInputType {
+        PipelineData::ByteStream(stream, ..) => Err(ShellError::PipelineMismatch {
             exp_input_type: "list, int".into(),
-            wrong_type: stream.type_().describe().into(),
             dst_span: head,
             src_span: stream.span(),
         }),
@@ -183,9 +182,8 @@ fn value_to_cell_path(value: Value, span: Span) -> Result<Value, ShellError> {
         Value::CellPath { .. } => Ok(value),
         Value::Int { val, .. } => Ok(int_to_cell_path(val, span)),
         Value::List { vals, .. } => list_to_cell_path(&vals, span),
-        other => Err(ShellError::OnlySupportsThisInputType {
+        other => Err(ShellError::PipelineMismatch {
             exp_input_type: "int, list".into(),
-            wrong_type: other.get_type().to_string(),
             dst_span: span,
             src_span: other.span(),
         }),

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -332,9 +332,8 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         Value::Error { .. } => return input.clone(),
         other => {
             return Value::error(
-                ShellError::OnlySupportsThisInputType {
+                ShellError::PipelineMismatch {
                     exp_input_type: "string and int".into(),
-                    wrong_type: other.get_type().to_string(),
                     dst_span: head,
                     src_span: other.span(),
                 },
@@ -443,9 +442,8 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -257,9 +257,8 @@ fn action(input: &Value, unit: &str, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string or duration".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -127,10 +127,9 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
             Err(error) => Value::error(error, value_span),
         },
         Value::Nothing { .. } => Value::filesize(0, value_span),
-        other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+        _ => Value::error(
+            ShellError::PipelineMismatch {
                 exp_input_type: "string and int".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: value_span,
             },

--- a/crates/nu-command/src/conversions/into/float.rs
+++ b/crates/nu-command/src/conversions/into/float.rs
@@ -114,9 +114,8 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string, int or bool".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -364,10 +364,9 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "int, float, filesize, date, string, binary, duration, or bool"
                     .into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),
             },
@@ -413,9 +412,8 @@ fn convert_int(input: &Value, head: Span, radix: u32) -> Value {
         Value::Error { .. } => return input.clone(),
         other => {
             return Value::error(
-                ShellError::OnlySupportsThisInputType {
+                ShellError::PipelineMismatch {
                     exp_input_type: "string and int".into(),
-                    wrong_type: other.get_type().to_string(),
                     dst_span: head,
                     src_span: other.span(),
                 },

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -206,9 +206,8 @@ fn action(
         PipelineData::Value(val, _) => {
             insert_in_transaction(std::iter::once(val), span, table, signals)
         }
-        _ => Err(ShellError::OnlySupportsThisInputType {
+        _ => Err(ShellError::PipelineMismatch {
             exp_input_type: "list".into(),
-            wrong_type: "".into(),
             dst_span: span,
             src_span: span,
         }),
@@ -319,9 +318,8 @@ fn insert_value(
 
             Ok(())
         }
-        val => Err(ShellError::OnlySupportsThisInputType {
+        val => Err(ShellError::PipelineMismatch {
             exp_input_type: "record".into(),
-            wrong_type: val.get_type().to_string(),
             dst_span: Span::unknown(),
             src_span: val.span(),
         }),
@@ -361,9 +359,8 @@ fn nu_value_to_sqlite_type(val: &Value) -> Result<&'static str, ShellError> {
         | Type::Range
         | Type::Record(_)
         | Type::Glob
-        | Type::Table(_) => Err(ShellError::OnlySupportsThisInputType {
+        | Type::Table(_) => Err(ShellError::PipelineMismatch {
             exp_input_type: "sql".into(),
-            wrong_type: val.get_type().to_string(),
             dst_span: Span::unknown(),
             src_span: val.span(),
         }),

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -429,10 +429,9 @@ pub fn value_to_sql(value: Value) -> Result<Box<dyn rusqlite::ToSql>, ShellError
         Value::Binary { val, .. } => Box::new(val),
         Value::Nothing { .. } => Box::new(rusqlite::types::Null),
         val => {
-            return Err(ShellError::OnlySupportsThisInputType {
+            return Err(ShellError::PipelineMismatch {
                 exp_input_type:
                     "bool, int, float, filesize, duration, date, string, nothing, binary".into(),
-                wrong_type: val.get_type().to_string(),
                 dst_span: Span::unknown(),
                 src_span: val.span(),
             })

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -78,9 +78,8 @@ fn helper(value: Value, head: Span) -> Value {
         }
         Value::Date { val, .. } => Value::string(humanize_date(val), head),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "date, string (that represents datetime), or nothing".into(),
-                wrong_type: value.get_type().to_string(),
                 dst_span: head,
                 src_span: span,
             },

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -115,9 +115,8 @@ fn helper(value: Value, head: Span, timezone: &Spanned<String>) -> Value {
             _to_timezone(dt.with_timezone(dt.offset()), timezone, head)
         }
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "date, string (that represents datetime), or nothing".into(),
-                wrong_type: value.get_type().to_string(),
                 dst_span: head,
                 src_span: val_span,
             },

--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -101,9 +101,8 @@ fn getcol(head: Span, input: PipelineData) -> Result<PipelineData, ShellError> {
                 // Propagate errors
                 Value::Error { error, .. } => return Err(*error),
                 other => {
-                    return Err(ShellError::OnlySupportsThisInputType {
+                    return Err(ShellError::PipelineMismatch {
                         exp_input_type: "record or table".into(),
-                        wrong_type: other.get_type().to_string(),
                         dst_span: head,
                         src_span: other.span(),
                     })
@@ -125,9 +124,8 @@ fn getcol(head: Span, input: PipelineData) -> Result<PipelineData, ShellError> {
                 .into_pipeline_data()
                 .set_metadata(metadata))
         }
-        PipelineData::ByteStream(stream, ..) => Err(ShellError::OnlySupportsThisInputType {
+        PipelineData::ByteStream(stream, ..) => Err(ShellError::PipelineMismatch {
             exp_input_type: "record or table".into(),
-            wrong_type: "byte stream".into(),
             dst_span: head,
             src_span: stream.span(),
         }),

--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -137,9 +137,8 @@ fn drop_cols(
             }
         }
         PipelineData::Empty => Ok(PipelineData::Empty),
-        PipelineData::ByteStream(stream, ..) => Err(ShellError::OnlySupportsThisInputType {
+        PipelineData::ByteStream(stream, ..) => Err(ShellError::PipelineMismatch {
             exp_input_type: "table or record".into(),
-            wrong_type: stream.type_().describe().into(),
             dst_span: head,
             src_span: stream.span(),
         }),
@@ -169,9 +168,8 @@ fn drop_record_cols(
 }
 
 fn unsupported_value_error(val: &Value, head: Span) -> ShellError {
-    ShellError::OnlySupportsThisInputType {
+    ShellError::PipelineMismatch {
         exp_input_type: "table or record".into(),
-        wrong_type: val.get_type().to_string(),
         dst_span: head,
         src_span: val.span(),
     }

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -151,9 +151,8 @@ fn first_helper(
                 }
                 // Propagate errors by explicitly matching them before the final case.
                 Value::Error { error, .. } => Err(*error),
-                other => Err(ShellError::OnlySupportsThisInputType {
+                other => Err(ShellError::PipelineMismatch {
                     exp_input_type: "list, binary or range".into(),
-                    wrong_type: other.get_type().to_string(),
                     dst_span: head,
                     src_span: other.span(),
                 }),
@@ -205,17 +204,15 @@ fn first_helper(
                     Ok(PipelineData::Empty)
                 }
             } else {
-                Err(ShellError::OnlySupportsThisInputType {
+                Err(ShellError::PipelineMismatch {
                     exp_input_type: "list, binary or range".into(),
-                    wrong_type: stream.type_().describe().into(),
                     dst_span: head,
                     src_span: stream.span(),
                 })
             }
         }
-        PipelineData::Empty => Err(ShellError::OnlySupportsThisInputType {
+        PipelineData::Empty => Err(ShellError::PipelineMismatch {
             exp_input_type: "list, binary or range".into(),
-            wrong_type: "null".into(),
             dst_span: call.head,
             src_span: call.head,
         }),

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -168,9 +168,8 @@ fn action(
         PipelineData::Empty => return Err(ShellError::PipelineEmpty { dst_span: span }),
         // Allow chaining of get -i
         PipelineData::Value(val @ Value::Nothing { .. }, ..) if !ignore_errors => {
-            return Err(ShellError::OnlySupportsThisInputType {
+            return Err(ShellError::PipelineMismatch {
                 exp_input_type: "table or record".into(),
-                wrong_type: "nothing".into(),
                 dst_span: span,
                 src_span: val.span(),
             })

--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -69,23 +69,20 @@ impl Command for Items {
                             .into_pipeline_data(head, engine_state.signals().clone()))
                     }
                     Value::Error { error, .. } => Err(*error),
-                    other => Err(ShellError::OnlySupportsThisInputType {
+                    other => Err(ShellError::PipelineMismatch {
                         exp_input_type: "record".into(),
-                        wrong_type: other.get_type().to_string(),
                         dst_span: head,
                         src_span: other.span(),
                     }),
                 }
             }
-            PipelineData::ListStream(stream, ..) => Err(ShellError::OnlySupportsThisInputType {
+            PipelineData::ListStream(stream, ..) => Err(ShellError::PipelineMismatch {
                 exp_input_type: "record".into(),
-                wrong_type: "stream".into(),
                 dst_span: call.head,
                 src_span: stream.span(),
             }),
-            PipelineData::ByteStream(stream, ..) => Err(ShellError::OnlySupportsThisInputType {
+            PipelineData::ByteStream(stream, ..) => Err(ShellError::PipelineMismatch {
                 exp_input_type: "record".into(),
-                wrong_type: stream.type_().describe().into(),
                 dst_span: call.head,
                 src_span: stream.span(),
             }),

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -148,9 +148,8 @@ impl Command for Last {
                     }
                     // Propagate errors by explicitly matching them before the final case.
                     Value::Error { error, .. } => Err(*error),
-                    other => Err(ShellError::OnlySupportsThisInputType {
+                    other => Err(ShellError::PipelineMismatch {
                         exp_input_type: "list, binary or range".into(),
-                        wrong_type: other.get_type().to_string(),
                         dst_span: head,
                         src_span: other.span(),
                     }),
@@ -189,17 +188,15 @@ impl Command for Last {
                         Ok(PipelineData::Empty)
                     }
                 } else {
-                    Err(ShellError::OnlySupportsThisInputType {
+                    Err(ShellError::PipelineMismatch {
                         exp_input_type: "list, binary or range".into(),
-                        wrong_type: stream.type_().describe().into(),
                         dst_span: head,
                         src_span: stream.span(),
                     })
                 }
             }
-            PipelineData::Empty => Err(ShellError::OnlySupportsThisInputType {
+            PipelineData::Empty => Err(ShellError::PipelineMismatch {
                 exp_input_type: "list, binary or range".into(),
-                wrong_type: "null".into(),
                 dst_span: call.head,
                 src_span: call.head,
             }),

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -89,9 +89,8 @@ fn length_row(call: &Call, input: PipelineData) -> Result<PipelineData, ShellErr
             )
             .into_pipeline_data())
         }
-        _ => Err(ShellError::OnlySupportsThisInputType {
+        _ => Err(ShellError::PipelineMismatch {
             exp_input_type: "list, table, binary, and nothing".into(),
-            wrong_type: input.get_type().to_string(),
             dst_span: call.head,
             src_span: span,
         }),

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -50,9 +50,8 @@ impl Command for Lines {
                 }
                 // Propagate existing errors
                 Value::Error { error, .. } => Err(*error),
-                value => Err(ShellError::OnlySupportsThisInputType {
+                value => Err(ShellError::PipelineMismatch {
                     exp_input_type: "string or byte stream".into(),
-                    wrong_type: value.get_type().to_string(),
                     dst_span: head,
                     src_span: value.span(),
                 }),

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -211,9 +211,8 @@ fn rename(
                     // Propagate errors by explicitly matching them before the final case.
                     Value::Error { .. } => item,
                     other => Value::error(
-                        ShellError::OnlySupportsThisInputType {
+                        ShellError::PipelineMismatch {
                             exp_input_type: "record".into(),
-                            wrong_type: other.get_type().to_string(),
                             dst_span: head,
                             src_span: other.span(),
                         },

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -99,9 +99,8 @@ impl Command for Skip {
                         metadata,
                     ))
                 } else {
-                    Err(ShellError::OnlySupportsThisInputType {
+                    Err(ShellError::PipelineMismatch {
                         exp_input_type: "list, binary or range".into(),
-                        wrong_type: stream.type_().describe().into(),
                         dst_span: call.head,
                         src_span: stream.span(),
                     })

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -74,9 +74,8 @@ impl Command for Take {
                         )),
                     // Propagate errors by explicitly matching them before the final case.
                     Value::Error { error, .. } => Err(*error),
-                    other => Err(ShellError::OnlySupportsThisInputType {
+                    other => Err(ShellError::PipelineMismatch {
                         exp_input_type: "list, binary or range".into(),
-                        wrong_type: other.get_type().to_string(),
                         dst_span: head,
                         src_span: other.span(),
                     }),
@@ -94,17 +93,15 @@ impl Command for Take {
                         metadata,
                     ))
                 } else {
-                    Err(ShellError::OnlySupportsThisInputType {
+                    Err(ShellError::PipelineMismatch {
                         exp_input_type: "list, binary or range".into(),
-                        wrong_type: stream.type_().describe().into(),
                         dst_span: head,
                         src_span: stream.span(),
                     })
                 }
             }
-            PipelineData::Empty => Err(ShellError::OnlySupportsThisInputType {
+            PipelineData::Empty => Err(ShellError::PipelineMismatch {
                 exp_input_type: "list, binary or range".into(),
-                wrong_type: "null".into(),
                 dst_span: head,
                 src_span: head,
             }),

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -184,9 +184,8 @@ pub fn transpose(
             }
             Value::Record { .. } => {} // go on, this is what we're looking for
             _ => {
-                return Err(ShellError::OnlySupportsThisInputType {
+                return Err(ShellError::PipelineMismatch {
                     exp_input_type: "table or record".into(),
-                    wrong_type: "list<any>".into(),
                     dst_span: call.head,
                     src_span: value.span(),
                 })

--- a/crates/nu-command/src/filters/values.rs
+++ b/crates/nu-command/src/filters/values.rs
@@ -116,9 +116,8 @@ pub fn get_values<'a>(
             }
             Value::Error { error, .. } => return Err(*error.clone()),
             _ => {
-                return Err(ShellError::OnlySupportsThisInputType {
+                return Err(ShellError::PipelineMismatch {
                     exp_input_type: "record or table".into(),
-                    wrong_type: item.get_type().to_string(),
                     dst_span: head,
                     src_span: input_span,
                 })
@@ -163,9 +162,8 @@ fn values(
                     .into_pipeline_data_with_metadata(head, signals, metadata)),
                 // Propagate errors
                 Value::Error { error, .. } => Err(*error),
-                other => Err(ShellError::OnlySupportsThisInputType {
+                other => Err(ShellError::PipelineMismatch {
                     exp_input_type: "record or table".into(),
-                    wrong_type: other.get_type().to_string(),
                     dst_span: head,
                     src_span: other.span(),
                 }),
@@ -180,9 +178,8 @@ fn values(
                 Err(err) => Err(err),
             }
         }
-        PipelineData::ByteStream(stream, ..) => Err(ShellError::OnlySupportsThisInputType {
+        PipelineData::ByteStream(stream, ..) => Err(ShellError::PipelineMismatch {
             exp_input_type: "record or table".into(),
-            wrong_type: stream.type_().describe().into(),
             dst_span: head,
             src_span: stream.span(),
         }),

--- a/crates/nu-command/src/formats/from/delimited.rs
+++ b/crates/nu-command/src/formats/from/delimited.rs
@@ -104,9 +104,8 @@ pub(super) fn from_delimited_data(
                 metadata,
             ))
         }
-        PipelineData::ListStream(list_stream, _) => Err(ShellError::OnlySupportsThisInputType {
+        PipelineData::ListStream(list_stream, _) => Err(ShellError::PipelineMismatch {
             exp_input_type: "string".into(),
-            wrong_type: "list".into(),
             dst_span: name,
             src_span: list_stream.span(),
         }),

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -97,9 +97,8 @@ impl Command for FromJson {
                         Ok(PipelineData::Empty)
                     }
                 }
-                _ => Err(ShellError::OnlySupportsThisInputType {
+                _ => Err(ShellError::PipelineMismatch {
                     exp_input_type: "string".into(),
-                    wrong_type: input.get_type().to_string(),
                     dst_span: call.head,
                     src_span: input.span().unwrap_or(call.head),
                 }),

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -117,9 +117,8 @@ where
             let span = input.span();
 
             return Value::error(
-                ShellError::OnlySupportsThisInputType {
+                ShellError::PipelineMismatch {
                     exp_input_type: "string or binary".into(),
-                    wrong_type: other.get_type().to_string(),
                     dst_span: span,
                     src_span: other.span(),
                 },

--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -115,9 +115,8 @@ fn abs_helper(val: Value, head: Span) -> Value {
         Value::Duration { val, .. } => Value::duration(val.abs(), span),
         Value::Error { .. } => val,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -113,9 +113,8 @@ fn operate(value: Value, head: Span) -> Value {
         Value::Float { val, .. } => Value::int(val.ceil() as i64, span),
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -113,9 +113,8 @@ fn operate(value: Value, head: Span) -> Value {
         Value::Float { val, .. } => Value::int(val.floor() as i64, span),
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -171,9 +171,8 @@ fn operate(value: Value, head: Span, base: f64) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -163,9 +163,8 @@ fn operate(value: Value, head: Span, precision: Option<i64>) -> Value {
         },
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -125,9 +125,8 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),
             },

--- a/crates/nu-command/src/network/url/decode.rs
+++ b/crates/nu-command/src/network/url/decode.rs
@@ -95,9 +95,8 @@ fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -92,9 +92,8 @@ fn action_all(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },
@@ -111,9 +110,8 @@ fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/path/mod.rs
+++ b/crates/nu-command/src/path/mod.rs
@@ -53,9 +53,8 @@ fn err_from_value(rest: &Value, name: Span) -> ShellError {
         Value::Error { error, .. } => *error.clone(),
         _ => {
             if rest.is_nothing() {
-                ShellError::OnlySupportsThisInputType {
+                ShellError::PipelineMismatch {
                     exp_input_type: "string, record or list".into(),
-                    wrong_type: "nothing".into(),
                     dst_span: name,
                     src_span: rest.span(),
                 }

--- a/crates/nu-command/src/stor/insert.rs
+++ b/crates/nu-command/src/stor/insert.rs
@@ -126,9 +126,8 @@ fn handle(
         PipelineData::Value(Value::List { vals, .. }, ..) => vals,
         PipelineData::Value(val, ..) => vec![val],
         _ => {
-            return Err(ShellError::OnlySupportsThisInputType {
+            return Err(ShellError::PipelineMismatch {
                 exp_input_type: "list or record".into(),
-                wrong_type: "".into(),
                 dst_span: span,
                 src_span: span,
             })
@@ -139,9 +138,8 @@ fn handle(
         .into_iter()
         .map(|val| match val {
             Value::Record { val, .. } => Ok(val.into_owned()),
-            other => Err(ShellError::OnlySupportsThisInputType {
+            other => Err(ShellError::PipelineMismatch {
                 exp_input_type: "record".into(),
-                wrong_type: other.get_type().to_string(),
                 dst_span: Span::unknown(),
                 src_span: other.span(),
             }),

--- a/crates/nu-command/src/stor/update.rs
+++ b/crates/nu-command/src/stor/update.rs
@@ -121,9 +121,8 @@ fn handle(
             }
             match value {
                 Value::Record { val, .. } => Ok(val.into_owned()),
-                val => Err(ShellError::OnlySupportsThisInputType {
+                val => Err(ShellError::PipelineMismatch {
                     exp_input_type: "record".into(),
-                    wrong_type: val.get_type().to_string(),
                     dst_span: Span::unknown(),
                     src_span: val.span(),
                 }),
@@ -139,9 +138,8 @@ fn handle(
                     inner: vec![],
                 });
             }
-            Err(ShellError::OnlySupportsThisInputType {
+            Err(ShellError::PipelineMismatch {
                 exp_input_type: "record".into(),
-                wrong_type: "".into(),
                 dst_span: span,
                 src_span: span,
             })

--- a/crates/nu-command/src/strings/encode_decode/decode.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode.rs
@@ -133,9 +133,8 @@ fn run(
                 }
                 .map(|val| val.into_pipeline_data()),
                 Value::Error { error, .. } => Err(*error),
-                _ => Err(ShellError::OnlySupportsThisInputType {
+                _ => Err(ShellError::PipelineMismatch {
                     exp_input_type: "binary".into(),
-                    wrong_type: v.get_type().to_string(),
                     dst_span: head,
                     src_span: v.span(),
                 }),

--- a/crates/nu-command/src/strings/encode_decode/encode.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode.rs
@@ -120,9 +120,8 @@ fn run(
                         .map(|val| val.into_pipeline_data())
                 }
                 Value::Error { error, .. } => Err(*error),
-                _ => Err(ShellError::OnlySupportsThisInputType {
+                _ => Err(ShellError::PipelineMismatch {
                     exp_input_type: "string".into(),
-                    wrong_type: v.get_type().to_string(),
                     dst_span: head,
                     src_span: v.span(),
                 }),

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -214,9 +214,8 @@ fn format_helper(
             }
         }
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "date, string (that represents datetime)".into(),
-                wrong_type: value.get_type().to_string(),
                 dst_span: head_span,
                 src_span: value.span(),
             },
@@ -237,9 +236,8 @@ fn format_helper_rfc2822(value: Value, span: Span) -> Value {
             }
         }
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "date, string (that represents datetime)".into(),
-                wrong_type: value.get_type().to_string(),
                 dst_span: span,
                 src_span: val_span,
             },

--- a/crates/nu-command/src/strings/format/duration.rs
+++ b/crates/nu-command/src/strings/format/duration.rs
@@ -160,9 +160,8 @@ fn format_value_impl(val: &Value, arg: &Arguments, span: Span) -> Value {
         }
         Value::Error { .. } => val.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "filesize".into(),
-                wrong_type: val.get_type().to_string(),
                 dst_span: span,
                 src_span: val.span(),
             },

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -134,9 +134,8 @@ fn format_value_impl(val: &Value, arg: &Arguments, span: Span) -> Value {
             .into_value(span),
         Value::Error { .. } => val.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "filesize".into(),
-                wrong_type: val.get_type().to_string(),
                 dst_span: span,
                 src_span: value_span,
             },

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -117,9 +117,8 @@ fn action(input: &Value, head: Span) -> Value {
         Value::String { val, .. } => Value::string(uppercase_helper(val), head),
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -125,9 +125,8 @@ fn action(input: &Value, head: Span) -> Value {
         Value::String { val, .. } => Value::string(val.to_lowercase(), head),
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/strings/str_/case/mod.rs
+++ b/crates/nu-command/src/strings/str_/case/mod.rs
@@ -50,9 +50,8 @@ where
         Value::String { val, .. } => Value::string(case_operation(val), head),
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/strings/str_/case/upcase.rs
+++ b/crates/nu-command/src/strings/str_/case/upcase.rs
@@ -102,9 +102,8 @@ fn action(input: &Value, head: Span) -> Value {
         Value::String { val: s, .. } => Value::string(s.to_uppercase(), head),
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -168,9 +168,8 @@ fn action(
         ),
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -129,9 +129,8 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -130,9 +130,8 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -230,9 +230,8 @@ fn action(
         }
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -145,9 +145,8 @@ fn action(input: &Value, arg: &Arguments, head: Span) -> Value {
         ),
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -290,9 +290,8 @@ fn action(
         }
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -98,9 +98,8 @@ fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
         Value::String { val, .. } => Value::string(val.chars().rev().collect::<String>(), head),
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -142,9 +142,8 @@ fn action(
         }
         Value::Error { .. } => input.clone(),
         _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
+            ShellError::PipelineMismatch {
                 exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.span(),
             },

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1336,9 +1336,8 @@ fn check_input_types(
 
     match input {
         PipelineData::Empty => Err(ShellError::PipelineEmpty { dst_span: head }),
-        _ => Err(ShellError::OnlySupportsThisInputType {
+        _ => Err(ShellError::PipelineMismatch {
             exp_input_type: expected_string,
-            wrong_type: input.get_type().to_string(),
             dst_span: head,
             src_span: input.span().unwrap_or(Span::unknown()),
         }),

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -80,26 +80,6 @@ pub enum ShellError {
         src_span: Span,
     },
 
-    // TODO: properly unify
-    /// The pipelined input into a command was not of the expected type. For example, it might
-    /// expect a string input, but received a table instead.
-    ///
-    /// (duplicate of [`ShellError::PipelineMismatch`] that reports the observed type)
-    ///
-    /// ## Resolution
-    ///
-    /// Check the relevant pipeline and extract or convert values as needed.
-    #[error("Input type not supported.")]
-    #[diagnostic(code(nu::shell::only_supports_this_input_type))]
-    OnlySupportsThisInputType {
-        exp_input_type: String,
-        wrong_type: String,
-        #[label("only {exp_input_type} input data is supported")]
-        dst_span: Span,
-        #[label("input type: {wrong_type}")]
-        src_span: Span,
-    },
-
     /// No input value was piped into the command.
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -341,10 +341,9 @@ impl PipelineData {
                     ),
                     // Propagate errors by explicitly matching them before the final case.
                     Value::Error { error, .. } => return Err(*error),
-                    other => {
-                        return Err(ShellError::OnlySupportsThisInputType {
+                    _ => {
+                        return Err(ShellError::PipelineMismatch {
                             exp_input_type: "list, binary, range, or byte stream".into(),
-                            wrong_type: other.get_type().to_string(),
                             dst_span: span,
                             src_span: val_span,
                         })
@@ -355,9 +354,8 @@ impl PipelineData {
                 PipelineIteratorInner::ListStream(stream.into_iter())
             }
             PipelineData::Empty => {
-                return Err(ShellError::OnlySupportsThisInputType {
+                return Err(ShellError::PipelineMismatch {
                     exp_input_type: "list, binary, range, or byte stream".into(),
-                    wrong_type: "null".into(),
                     dst_span: span,
                     src_span: span,
                 })
@@ -740,21 +738,18 @@ impl PipelineData {
     ) -> ShellError {
         match self {
             PipelineData::Empty => ShellError::PipelineEmpty { dst_span: span },
-            PipelineData::Value(value, ..) => ShellError::OnlySupportsThisInputType {
+            PipelineData::Value(value, ..) => ShellError::PipelineMismatch {
                 exp_input_type: expected_type.into(),
-                wrong_type: value.get_type().get_non_specified_string(),
                 dst_span: span,
                 src_span: value.span(),
             },
-            PipelineData::ListStream(stream, ..) => ShellError::OnlySupportsThisInputType {
+            PipelineData::ListStream(stream, ..) => ShellError::PipelineMismatch {
                 exp_input_type: expected_type.into(),
-                wrong_type: "list (stream)".into(),
                 dst_span: span,
                 src_span: stream.span(),
             },
-            PipelineData::ByteStream(stream, ..) => ShellError::OnlySupportsThisInputType {
+            PipelineData::ByteStream(stream, ..) => ShellError::PipelineMismatch {
                 exp_input_type: expected_type.into(),
-                wrong_type: stream.type_().describe().into(),
                 dst_span: span,
                 src_span: stream.span(),
             },


### PR DESCRIPTION
no linked issue

# Description
Context: `ShellError::OnlySupportsThisInputType` was a duplicate of `ShellError::PipelineMismatch`

so replaced all occurences of OnlySupportsThisInputType by PipelineMismatch.


# User-Facing Changes
The error message will be different -> but consistent

```nushell
# before
> let p = pwd | path parse
> $p | into datetime
Error: nu::shell::only_supports_this_input_type

  × Input type not supported.
   ╭─[entry #3:1:1]
 1 │ $p | into datetime
   · ─┬   ──────┬──────
   ·  │         ╰── only string and int input data is supported
   ·  ╰── input type: record<prefix: string, parent: string, stem: string, extension: string>
   ╰────

# after

> $p | into datetime
Error: nu::shell::pipeline_mismatch

  × Pipeline mismatch.
   ╭─[entry #2:1:1]
 1 │ $p | into datetime
   · ─┬   ──────┬──────
   ·  │         ╰── expected: string and int
   ·  ╰── value originates from here
   ╰────

```

# Tests + Formatting
OK

# After Submitting
Nothing required
