### PR TITLE
feat(lsp): parse_warnings in diagnostics report

### DIFF
--- a/crates/nu-lsp/src/diagnostics.rs
+++ b/crates/nu-lsp/src/diagnostics.rs
@@ -38,6 +38,17 @@ impl LanguageServer {
             });
         }
 
+        for warn in working_set.parse_warnings.iter() {
+            let message = warn.to_string();
+
+            diagnostics.diagnostics.push(Diagnostic {
+                range: span_to_range(&warn.span(), file, span.start),
+                severity: Some(DiagnosticSeverity::WARNING),
+                message,
+                ..Default::default()
+            });
+        }
+
         self.connection
             .sender
             .send(lsp_server::Message::Notification(


### PR DESCRIPTION
# Description

Add parse warnings to LSP diagnostics, not particularly useful but technically should be done.

# User-Facing Changes

# Tests + Formatting

There's no deprecated command to test for now.

# After Submitting