### PR TITLE
Revert "Improve completions for exact matches (Issue #14794)"

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -98,7 +98,7 @@ fn complete_rec(
                 }
 
                 // For https://github.com/nushell/nushell/issues/13204
-                if options.match_algorithm == MatchAlgorithm::Prefix {
+                if isdir && options.match_algorithm == MatchAlgorithm::Prefix {
                     let exact_match = if options.case_sensitive {
                         entry_name.eq(base)
                     } else {

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -2224,16 +2224,6 @@ fn exact_match() {
         &vec![file(dir.join("partial").join("hello.txt")).as_str()],
         &suggestions,
     );
-
-    let target_dir = format!("open {}", file(dir.join("partial").join("hello"))); // No trailing slash
-    let suggestions = completer.complete(&target_dir, target_dir.len());
-
-    // Despite no trailing slash, since it's an exact match, only 'partial/hello.txt' should be suggested, not
-    // 'partial-a/hello' and stuff. See issue #14794 for details.
-    match_suggestions(
-        &vec![file(dir.join("partial").join("hello.txt")).as_str()],
-        &suggestions,
-    );
 }
 
 #[ignore = "was reverted, still needs fixing"]


### PR DESCRIPTION
Reverts nushell/nushell#15387

As pointed out by @132ikl in https://github.com/nushell/nushell/pull/15387#issuecomment-2764852850, #15387 had the unintended side effect of not showing all suggestions in certain cases when that wasn't desired.