### PR TITLE
Update where documentation

### DIFF
--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -10,13 +10,21 @@ impl Command for Where {
     }
 
     fn description(&self) -> &str {
-        "Filter values based on a row condition."
+        "Filter values of an input list based on a condition."
     }
 
     fn extra_description(&self) -> &str {
-        r#"This command works similar to 'filter' but allows extra shorthands for working with
-tables, known as "row conditions". On the other hand, reading the condition from a variable is
-not supported."#
+        r#"A condition is evaluated for each element of the input, and only elements which meet the condition are included in the output.
+
+A condition can be either a "row condition", or a closure. A row condition is a special short-hand syntax to makes accessing fields easier.
+Each element of the input can be accessed through the $it variable.
+
+On the left hand side of a row condition, any field name is automatically expanded to use $it.
+For example, where type == dir is equivalent to where $it.type == dir. This expansion does not happen when passing a subexpression or closure to where.
+
+When using a closure, the element is passed as an argument and as pipeline input to the closure.
+
+While where supports closure literals, they can not be read from a variable. To filter using a closure stored in a variable, use the filter command."#
     }
 
     fn command_type(&self) -> CommandType {
@@ -34,9 +42,9 @@ not supported."#
                 (Type::Range, Type::Any),
             ])
             .required(
-                "row_condition",
-                SyntaxShape::RowCondition,
-                "Filter condition.",
+                "condition",
+                SyntaxShape::OneOf(vec![SyntaxShape::RowCondition, SyntaxShape::Closure(None)]),
+                "Filter row condition or closure.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Filters)
@@ -85,11 +93,9 @@ not supported."#
                 )),
             },
             Example {
-                description: "Filter items of a list according to a condition",
-                example: "[1 2] | where {|x| $x > 1}",
-                result: Some(Value::test_list(
-                    vec![Value::test_int(2)],
-                )),
+                description: "List only the files in the current directory",
+                example: "ls | where type == file",
+                result: None,
             },
             Example {
                 description: "List all files in the current directory with sizes greater than 2kb",
@@ -97,13 +103,8 @@ not supported."#
                 result: None,
             },
             Example {
-                description: "List only the files in the current directory",
-                example: "ls | where type == file",
-                result: None,
-            },
-            Example {
-                description: "List all files with names that contain \"Car\"",
-                example: "ls | where name =~ \"Car\"",
+                description: r#"List all files with names that contain "Car""#,
+                example: r#"ls | where name =~ "Car""#,
                 result: None,
             },
             Example {
@@ -112,17 +113,31 @@ not supported."#
                 result: None,
             },
             Example {
+                description: "Filter items of a list with a row condition",
+                example: "[1 2 3 4 5] | where $it > 2",
+                result: Some(Value::test_list(
+                    vec![Value::test_int(3), Value::test_int(4), Value::test_int(5)],
+                )),
+            },
+            Example {
+                description: "Filter items of a list with a closure",
+                example: "[1 2 3 4 5] | where {|x| $x > 2 }",
+                result: Some(Value::test_list(
+                    vec![Value::test_int(3), Value::test_int(4), Value::test_int(5)],
+                )),
+            },
+            Example {
                 description: "Find files whose filenames don't begin with the correct sequential number",
-                example: "ls | where type == file | sort-by name --natural | enumerate | where {|e| $e.item.name !~ $'^($e.index + 1)' } | each {|| get item }",
+                example: "ls | where type == file | sort-by name --natural | enumerate | where {|e| $e.item.name !~ $'^($e.index + 1)' } | get item",
                 result: None,
             },
             Example {
-                description: r#"Find case-insensitively files called "readme", without an explicit closure"#,
+                description: r#"Find case-insensitively files called "readme", with a subexpression"#,
                 example: "ls | where ($it.name | str downcase) =~ readme",
                 result: None,
             },
             Example {
-                description: "same as above but with regex only",
+                description: r#"Find case-insensitively files called "readme", with regex only"#,
                 example: "ls | where name =~ '(?i)readme'",
                 result: None,
             }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Updates `help where` to better explain row conditions, and provide more examples. Also, the syntax shape is changed to `one_of(condition, closure())>`. I don't think this should affect parsing at all because it should still always be parsed as `SyntaxShape::RowCondition`, but it should be more clear that you can use a row condition _or_ a closure here, even if technically we consider closures to be row conditions internally. In a similar vein, the help text makes this distinction explicitly to make it more clear to users that closures are supported.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
* Updated `where` help text

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
N/A

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A