### PR TITLE
fix(lsp): more accurate PWD: from env -> parent dir of current file

### DIFF
--- a/crates/nu-lsp/src/completion.rs
+++ b/crates/nu-lsp/src/completion.rs
@@ -29,7 +29,7 @@ impl LanguageServer {
                 .is_some_and(|c| c.is_whitespace() || "|(){}[]<>,:;".contains(c));
 
         self.need_parse |= need_fallback;
-        let engine_state = Arc::new(self.new_engine_state());
+        let engine_state = Arc::new(self.new_engine_state(Some(&path_uri)));
         let completer = NuCompleter::new(engine_state.clone(), Arc::new(Stack::new()));
         let results = if need_fallback {
             completer.fetch_completions_at(&file_text[..location], location)
@@ -264,10 +264,10 @@ mod tests {
         let resp = send_complete_request(&client_connection, script.clone(), 2, 18);
         assert!(result_from_message(resp).as_array().unwrap().contains(
             &serde_json::json!({
-                "label": "LICENSE",
+                "label": "command.nu",
                 "labelDetails": { "description": "" },
                 "textEdit": { "range": { "start": { "line": 2, "character": 17 }, "end": { "line": 2, "character": 18 }, },
-                    "newText": "LICENSE"
+                    "newText": "command.nu"
                 },
                 "kind": 17
             })
@@ -337,10 +337,10 @@ mod tests {
         let resp = send_complete_request(&client_connection, script, 5, 4);
         assert!(result_from_message(resp).as_array().unwrap().contains(
             &serde_json::json!({
-                "label": "LICENSE",
+                "label": "cell_path.nu",
                 "labelDetails": { "description": "" },
                 "textEdit": { "range": { "start": { "line": 5, "character": 3 }, "end": { "line": 5, "character": 4 }, },
-                    "newText": "LICENSE"
+                    "newText": "cell_path.nu"
                 },
                 "kind": 17
             })

--- a/crates/nu-lsp/src/diagnostics.rs
+++ b/crates/nu-lsp/src/diagnostics.rs
@@ -7,7 +7,7 @@ use miette::{miette, IntoDiagnostic, Result};
 
 impl LanguageServer {
     pub(crate) fn publish_diagnostics_for_file(&mut self, uri: Uri) -> Result<()> {
-        let mut engine_state = self.new_engine_state();
+        let mut engine_state = self.new_engine_state(Some(&uri));
         engine_state.generate_nu_constant();
 
         let Some((_, span, working_set)) = self.parse_file(&mut engine_state, &uri, true) else {

--- a/crates/nu-lsp/src/goto.rs
+++ b/crates/nu-lsp/src/goto.rs
@@ -77,13 +77,12 @@ impl LanguageServer {
         &mut self,
         params: &GotoDefinitionParams,
     ) -> Option<GotoDefinitionResponse> {
-        let mut engine_state = self.new_engine_state();
-
         let path_uri = params
             .text_document_position_params
             .text_document
             .uri
             .to_owned();
+        let mut engine_state = self.new_engine_state(Some(&path_uri));
         let (working_set, id, _, _) = self
             .parse_and_find(
                 &mut engine_state,

--- a/crates/nu-lsp/src/hover.rs
+++ b/crates/nu-lsp/src/hover.rs
@@ -129,13 +129,12 @@ impl LanguageServer {
     }
 
     pub(crate) fn hover(&mut self, params: &HoverParams) -> Option<Hover> {
-        let mut engine_state = self.new_engine_state();
-
         let path_uri = params
             .text_document_position_params
             .text_document
             .uri
             .to_owned();
+        let mut engine_state = self.new_engine_state(Some(&path_uri));
         let (working_set, id, _, _) = self
             .parse_and_find(
                 &mut engine_state,

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -363,7 +363,7 @@ impl LanguageServer {
         engine_state: &'a mut EngineState,
         uri: &Uri,
         pos: Position,
-    ) -> Result<(StateWorkingSet<'a>, Id, Span, usize)> {
+    ) -> Result<(StateWorkingSet<'a>, Id, Span, Span)> {
         let (block, file_span, working_set) = self
             .parse_file(engine_state, uri, false)
             .ok_or_else(|| miette!("\nFailed to parse current file"))?;
@@ -378,7 +378,7 @@ impl LanguageServer {
         let location = file.offset_at(pos) as usize + file_span.start;
         let (id, span) = ast::find_id(&block, &working_set, &location)
             .ok_or_else(|| miette!("\nFailed to find current name"))?;
-        Ok((working_set, id, span, file_span.start))
+        Ok((working_set, id, span, file_span))
     }
 
     pub(crate) fn parse_file<'a>(

--- a/crates/nu-lsp/src/signature.rs
+++ b/crates/nu-lsp/src/signature.rs
@@ -78,7 +78,7 @@ impl LanguageServer {
         let file_text = file.get_content(None).to_owned();
         drop(docs);
 
-        let engine_state = self.new_engine_state();
+        let engine_state = self.new_engine_state(Some(&path_uri));
         let mut working_set = StateWorkingSet::new(&engine_state);
 
         // NOTE: in case the cursor is at the end of the call expression

--- a/crates/nu-lsp/src/symbols.rs
+++ b/crates/nu-lsp/src/symbols.rs
@@ -270,8 +270,8 @@ impl LanguageServer {
         &mut self,
         params: &DocumentSymbolParams,
     ) -> Option<DocumentSymbolResponse> {
-        let engine_state = self.new_engine_state();
         let uri = params.text_document.uri.to_owned();
+        let engine_state = self.new_engine_state(Some(&uri));
         let docs = self.docs.lock().ok()?;
         self.symbol_cache.update(&uri, &engine_state, &docs);
         self.symbol_cache
@@ -284,7 +284,7 @@ impl LanguageServer {
         params: &WorkspaceSymbolParams,
     ) -> Option<WorkspaceSymbolResponse> {
         if self.symbol_cache.any_dirty() {
-            let engine_state = self.new_engine_state();
+            let engine_state = self.new_engine_state(None);
             let docs = self.docs.lock().ok()?;
             self.symbol_cache.update_all(&engine_state, &docs);
         }

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -55,7 +55,10 @@ fn find_nu_scripts_in_folder(folder_uri: &Uri) -> Result<nu_glob::Paths> {
 /// FIXME: cross-file shadowing can still cause false-positive/false-negative cases
 fn pseudo_path() -> Result<PathBuf> {
     let mut path = std::env::current_dir().into_diagnostic()?;
-    path.push("non-existing-dir");
+    path = path
+        .parent()
+        .ok_or_else(|| miette!("Failed to create pseudo path."))?
+        .to_path_buf();
     path.push("non-existing-file");
     Ok(path)
 }

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -295,14 +295,16 @@ impl LanguageServer {
             file.get_content(None).as_bytes(),
             false,
         );
-        // renew the id if there's a module with the same span as the original file
+        // NOTE: Renew the id if there's a module with the same span as the original file.
+        // This requires that the initial parsing results get merged in the engine_state,
+        // typically they're cached with diagnostics before the prepare_rename/references requests,
+        // so that we don't need to clone and merge delta again.
         if (!id_tracker.renewed)
             && working_set
                 .find_module_by_span(id_tracker.file_span)
                 .is_some()
         {
-            let new_block = working_set.find_block_by_span(id_tracker.file_span);
-            if let Some(new_block) = new_block {
+            if let Some(new_block) = working_set.find_block_by_span(id_tracker.file_span) {
                 if let Some((new_id, _)) =
                     ast::find_id(&new_block, working_set, &id_tracker.span.start)
                 {

--- a/tests/fixtures/lsp/completion/command.nu
+++ b/tests/fixtures/lsp/completion/command.nu
@@ -1,6 +1,6 @@
 config n
 config n foo bar -
-config n foo bar l --l
+config n foo bar c --l
 
 # detail
 def "config n foo bar" [

--- a/tests/fixtures/lsp/completion/fallback.nu
+++ b/tests/fixtures/lsp/completion/fallback.nu
@@ -3,6 +3,6 @@ let greeting = "Hello"
 echo $gre
 | st
 
-ls l
+ls c
 
 $greeting not-h


### PR DESCRIPTION
# Description

Some editors like neovim will provide "workspace root" as PWD, which can mess up file completion results.

# User-Facing Changes

bug fix

# Tests + Formatting

adjusted

# After Submitting
