### PR TITLE
refactor: command identified by name instead of span content

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -134,7 +134,7 @@ struct Context<'a> {
 /// For argument completion
 struct PositionalArguments<'a> {
     /// command name
-    command_head: &'a [u8],
+    command_head: &'a str,
     /// indices of positional arguments
     positional_arg_indices: Vec<usize>,
     /// argument list
@@ -395,7 +395,7 @@ impl NuCompleter {
                             Argument::Positional(_) if prefix == b"-" => flag_completion_helper(),
                             // complete according to expression type and command head
                             Argument::Positional(expr) => {
-                                let command_head = working_set.get_span_contents(call.head);
+                                let command_head = working_set.get_decl(call.decl_id).name();
                                 positional_arg_indices.push(arg_idx);
                                 self.argument_completion_helper(
                                     PositionalArguments {
@@ -537,19 +537,19 @@ impl NuCompleter {
         // special commands
         match command_head {
             // complete module file/directory
-            b"use" | b"export use" | b"overlay use" | b"source-env"
+            "use" | "export use" | "overlay use" | "source-env"
                 if positional_arg_indices.len() == 1 =>
             {
                 return self.process_completion(
                     &mut DotNuCompletion {
-                        std_virtual_path: command_head != b"source-env",
+                        std_virtual_path: command_head != "source-env",
                     },
                     ctx,
                 );
             }
             // NOTE: if module file already specified,
             // should parse it to get modules/commands/consts to complete
-            b"use" | b"export use" => {
+            "use" | "export use" => {
                 let Some(Argument::Positional(Expression {
                     expr: Expr::String(module_name),
                     span,
@@ -613,7 +613,7 @@ impl NuCompleter {
                     _ => return vec![],
                 }
             }
-            b"which" => {
+            "which" => {
                 let mut completer = CommandCompletion {
                     internals: true,
                     externals: true,

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -586,7 +586,8 @@ fn dotnu_stdlib_completions() {
     assert!(load_standard_library(&mut engine).is_ok());
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
-    let completion_str = "export use std/ass";
+    // `export  use` should be recognized as command `export use`
+    let completion_str = "export  use std/ass";
     let suggestions = completer.complete(completion_str, completion_str.len());
     match_suggestions(&vec!["assert"], &suggestions);
 

--- a/crates/nu-lsp/src/ast.rs
+++ b/crates/nu-lsp/src/ast.rs
@@ -25,14 +25,14 @@ fn try_find_id_in_misc(
     location: Option<&usize>,
     id_ref: Option<&Id>,
 ) -> Option<(Id, Span)> {
-    let call_name = working_set.get_span_contents(call.head);
+    let call_name = working_set.get_decl(call.decl_id).name();
     match call_name {
-        b"def" | b"export def" => try_find_id_in_def(call, working_set, location, id_ref),
-        b"module" | b"export module" => try_find_id_in_mod(call, working_set, location, id_ref),
-        b"use" | b"export use" | b"hide" => {
+        "def" | "export def" => try_find_id_in_def(call, working_set, location, id_ref),
+        "module" | "export module" => try_find_id_in_mod(call, working_set, location, id_ref),
+        "use" | "export use" | "hide" => {
             try_find_id_in_use(call, working_set, location, id_ref, call_name)
         }
-        b"overlay use" | b"overlay hide" => {
+        "overlay use" | "overlay hide" => {
             try_find_id_in_overlay(call, working_set, location, id_ref)
         }
         _ => None,
@@ -141,7 +141,7 @@ fn try_find_id_in_use(
     working_set: &StateWorkingSet,
     location: Option<&usize>,
     id: Option<&Id>,
-    call_name: &[u8],
+    call_name: &str,
 ) -> Option<(Id, Span)> {
     // TODO: for keyword `hide`, the decl/var is already hidden in working_set,
     // this function will always return None.
@@ -176,7 +176,7 @@ fn try_find_id_in_use(
     if let Some(pos) = location {
         // first argument of `use` should always be module name
         // while it is optional in `hide`
-        if span.contains(*pos) && call_name != b"hide" {
+        if span.contains(*pos) && call_name != "hide" {
             return get_matched_module_id(working_set, span, id);
         }
     }
@@ -196,7 +196,7 @@ fn try_find_id_in_use(
         })
     };
 
-    let arguments = if call_name != b"hide" {
+    let arguments = if call_name != "hide" {
         call.arguments.get(1..)?
     } else {
         call.arguments.as_slice()

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -658,7 +658,7 @@ mod tests {
 
         let message_num = 5;
         let messages =
-            send_reference_request(&client_connection, script.clone(), 6, 11, message_num);
+            send_reference_request(&client_connection, script.clone(), 6, 12, message_num);
         assert_eq!(messages.len(), message_num);
         for message in messages {
             match message {
@@ -676,7 +676,7 @@ mod tests {
                     assert!(array.contains(&serde_json::json!(
                             {
                                 "uri": script.to_string(),
-                                "range": { "start": { "line": 6, "character": 12 }, "end": { "line": 6, "character": 19 } }
+                                "range": { "start": { "line": 6, "character": 13 }, "end": { "line": 6, "character": 20 } }
                             }
                         )
                     ));
@@ -712,7 +712,7 @@ mod tests {
             &client_connection,
             script.clone(),
             6,
-            11,
+            12,
             message_num,
             false,
         );
@@ -723,8 +723,8 @@ mod tests {
                 Message::Response(r) => assert_json_eq!(
                     r.result,
                     serde_json::json!({
-                        "start": { "line": 6, "character": 12 },
-                        "end": { "line": 6, "character": 19 }
+                        "start": { "line": 6, "character": 13 },
+                        "end": { "line": 6, "character": 20 }
                     }),
                 ),
                 _ => panic!("unexpected message type"),
@@ -738,7 +738,7 @@ mod tests {
                 changes[script.to_string()],
                 serde_json::json!([
                     {
-                        "range": { "start": { "line": 6, "character": 12 }, "end": { "line": 6, "character": 19 } },
+                        "range": { "start": { "line": 6, "character": 13 }, "end": { "line": 6, "character": 20 } },
                         "newText": "new"
                     }
                 ])
@@ -860,7 +860,7 @@ mod tests {
             &client_connection,
             script.clone(),
             6,
-            11,
+            12,
             message_num,
             true,
         );

--- a/tests/fixtures/lsp/workspace/foo.nu
+++ b/tests/fixtures/lsp/workspace/foo.nu
@@ -4,4 +4,4 @@ export def foooo [
   $param
 }
 
-export def "foo str" [] { "foo" }
+export  def "foo str" [] { "foo" }


### PR DESCRIPTION
This should be a more robust method.

# Description

Previously, `export  use` with double-space in between will fail to be recognized as command `export use`.

# User-Facing Changes

minor bug fix

# Tests + Formatting

test cases made harder

# After Submitting