### PR TITLE
`polars into-df`/`polars into-lazy`: `--schema` will not throw error if only some columns are defined

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/core/to_df.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/to_df.rs
@@ -35,7 +35,7 @@ impl PluginCommand for ToDataFrame {
             .named(
                 "schema",
                 SyntaxShape::Record(vec![]),
-                r#"Polars Schema in format [{name: str}]. CSV, JSON, and JSONL files"#,
+                r#"Polars Schema in format [{name: str}]."#,
                 Some('s'),
             )
             .switch(
@@ -189,6 +189,16 @@ impl PluginCommand for ToDataFrame {
                         Series::new("a".into(), [1u8, 2]),
                         Series::new("b".into(), ["foo", "bar"]),
                         Series::new("c".into(), [3i64, 3]),
+                    ], Span::test_data())
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                description: "If a provided schema specifies a subset of columns, only those columns are selected",
+                example: r#"[[a b]; [1 "foo"] [2 "bar"]] | polars into-df -s {a: str}"#,
+                result: Some(NuDataFrame::try_from_series_vec(vec![
+                        Series::new("a".into(), ["1", "2"]),
                     ], Span::test_data())
                     .expect("simple df for test should not fail")
                     .into_value(Span::test_data()),

--- a/crates/nu_plugin_polars/src/dataframe/command/core/to_lazy.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/to_lazy.rs
@@ -3,7 +3,9 @@ use crate::{dataframe::values::NuSchema, values::CustomValueSupport, Cacheable, 
 use crate::values::{NuDataFrame, NuLazyFrame};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, SyntaxShape, Type};
+use nu_protocol::{
+    record, Category, Example, LabeledError, PipelineData, Signature, SyntaxShape, Type, Value,
+};
 
 #[derive(Clone)]
 pub struct ToLazyFrame;
@@ -24,7 +26,7 @@ impl PluginCommand for ToLazyFrame {
             .named(
                 "schema",
                 SyntaxShape::Record(vec![]),
-                r#"Polars Schema in format [{name: str}]. CSV, JSON, and JSONL files"#,
+                r#"Polars Schema in format [{name: str}]."#,
                 Some('s'),
             )
             .input_output_type(Type::Any, Type::Custom("dataframe".into()))
@@ -40,7 +42,7 @@ impl PluginCommand for ToLazyFrame {
         Example {
             description: "Takes a table, creates a lazyframe, assigns column 'b' type str, displays the schema",
             example: "[[a b];[1 2] [3 4]] | polars into-lazy --schema {b: str} | polars schema",
-            result: None
+            result: Some(Value::test_record(record! {"b" => Value::test_string("str")})),
         },
         ]
     }
@@ -70,6 +72,7 @@ impl PluginCommand for ToLazyFrame {
 
 #[cfg(test)]
 mod tests {
+    use crate::test::test_polars_plugin_command;
     use std::sync::Arc;
 
     use nu_plugin_test_support::PluginTest;
@@ -86,5 +89,10 @@ mod tests {
         let df = NuLazyFrame::try_from_value(&plugin, &value)?;
         assert!(!df.from_eager);
         Ok(())
+    }
+
+    #[test]
+    fn test_examples() -> Result<(), ShellError> {
+        test_polars_plugin_command(&ToLazyFrame)
     }
 }


### PR DESCRIPTION
# Description
The current implementation of `polars into-df` and `polars into-lazy` will throw an error if `--schema` is provided but not all columns are defined. This PR seeks to remove this requirement so that when a partial `--schema` is provided, the types on the defined columns are overridden while the remaining columns take on their default types. 

**Current Implementation**
```
$ [[a b]; [1 "foo"] [2 "bar"]] | polars into-df -s {a: str} | polars schema
Error:   × Schema does not contain column: b
   ╭─[entry #88:1:12]
 1 │ [[a b]; [1 "foo"] [2 "bar"]] | polars into-df -s {a: str} | polars schema
   ·            ─────
   ╰────
```

**New Implementation (no error thrown on partial schema definition)**
Column b is not defined in `--schema`
```
$ [[a b]; [1 "foo"] [2 "bar"]] | polars into-df --schema {a: str} | polars schema
╭───┬─────╮
│ a │ str │
│ b │ str │
╰───┴─────╯
```

# User-Facing Changes
Soft breaking change: The user's previous (erroneous) code that would have thrown an error would no longer throw an error. The user's previous working code will still work.

# Tests + Formatting


# After Submitting
