### PR TITLE
Reminder comment to update doc when adding `$nu` constants

### DIFF
--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -17,6 +17,8 @@ use std::{
 };
 
 /// Create a Value for `$nu`.
+// Note: When adding new constants to $nu, please update the doc at https://nushell.sh/book/special_variables.html
+// or at least add a TODO/reminder issue in nushell.github.io so we don't lose track of it.
 pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Value {
     fn canonicalize_path(engine_state: &EngineState, path: &Path) -> PathBuf {
         #[allow(deprecated)]


### PR DESCRIPTION
# Description

As requested in review on https://github.com/nushell/nushell.github.io/pull/1860 - This adds a reminder comment requesting that contributors update that doc page when adding new constants.

# User-Facing Changes

None

# Tests + Formatting

Comment-only

# After Submitting

This PR should only be merged after https://github.com/nushell/nushell.github.io/pull/1860 is merged into the doc.