### PR TITLE
bump to the latest rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://www.nushell.sh"
 license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
-rust-version = "1.83.0"
+rust-version = "1.84.1"
 version = "0.103.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/nu-path/src/trailing_slash.rs
+++ b/crates/nu-path/src/trailing_slash.rs
@@ -40,7 +40,7 @@ pub fn has_trailing_slash(path: &Path) -> bool {
 #[cfg(target_arch = "wasm32")]
 pub fn has_trailing_slash(path: &Path) -> bool {
     // in the web paths are often just URLs, they are separated by forward slashes
-    path.to_str().map_or(false, |s| s.ends_with('/'))
+    path.to_str().is_some_and(|s| s.ends_with('/'))
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/mod.rs
@@ -71,7 +71,7 @@ impl Default for DataFrameValue {
 
 impl PartialEq for DataFrameValue {
     fn eq(&self, other: &Self) -> bool {
-        self.0.partial_cmp(&other.0).map_or(false, Ordering::is_eq)
+        self.0.partial_cmp(&other.0).is_some_and(Ordering::is_eq)
     }
 }
 impl Eq for DataFrameValue {}

--- a/crates/nu_plugin_query/src/web_tables.rs
+++ b/crates/nu_plugin_query/src/web_tables.rs
@@ -66,7 +66,7 @@ impl WebTable {
         let mut tables = html
             .select(&sel_table)
             .filter(|table| {
-                table.select(&sel_tr).next().map_or(false, |tr| {
+                table.select(&sel_tr).next().is_some_and(|tr| {
                     let cells = select_cells(tr, &sel_th, true);
                     if inspect_mode {
                         eprintln!("Potential HTML Headers = {:?}\n", &cells);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,4 +16,4 @@ profile = "default"
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 4 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.83.0"
+channel = "1.84.1"


### PR DESCRIPTION
# Description

This PR bumps nushell to use the latest rust version 1.84.1.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
