### PR TITLE
Limit Allowed `serde_json` Versions to Match Usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ rusqlite = "0.31"
 rust-embed = "8.6.0"
 scopeguard = { version = "1.2.0" }
 serde = { version = "1.0" }
-serde_json = "1.0"
+serde_json = "1.0.97"
 serde_urlencoded = "0.7.1"
 serde_yaml = "0.9.33"
 sha2 = "0.10"


### PR DESCRIPTION
Fixes #15503 

# Description

Our usage of `serde_json::Error::io_error_kind` is improperly handled in the workspace version specifier.

We use this method in `nu-plugin-core`

https://github.com/nushell/nushell/blob/f25525be6cc0343d77f232f8ccecde25798d56aa/crates/nu-plugin-core/src/serializers/json.rs#L77-L106

It was added in [`serde_json` v1.0.97](https://github.com/serde-rs/json/releases/tag/v1.0.97). Previously, we specified our version requirement only as `1.0`. Now, it is `>=1.0.97,<1.1`, which correctly describes our maximum range of compatibility.

# User-Facing Changes
None

# Tests + Formatting
No code has changed. Recent releases are identical. This only effect usage of nushell as a library

# After Submitting
No doc changes should be needed. This prevents certain compiler errors, but will not change the behavior of any compiled project.
