### PR TITLE
refactor(lsp): align markdown doc string with output of --help

### DIFF
--- a/crates/nu-lsp/src/hover.rs
+++ b/crates/nu-lsp/src/hover.rs
@@ -22,7 +22,7 @@ impl LanguageServer {
         // Usage
         description.push_str("---\n### Usage \n```nu\n");
         let signature = decl.signature();
-        description.push_str(&get_signature_label(&signature));
+        description.push_str(&get_signature_label(&signature, true));
         description.push_str("\n```\n");
 
         // Flags

--- a/crates/nu-lsp/src/notification.rs
+++ b/crates/nu-lsp/src/notification.rs
@@ -162,7 +162,7 @@ mod tests {
             serde_json::json!({
                 "contents": {
                     "kind": "markdown",
-                    "value": "Create a variable and give it a value.\n\nThis command is a parser keyword. For details, check:\n  https://www.nushell.sh/book/thinking_in_nu.html\n---\n### Usage \n```nu\n  let {flags} <var_name> <initial_value>\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n\n### Parameters\n\n  `var_name: any` - Variable name.\n\n  `initial_value: any` - Equals sign followed by value.\n\n\n### Input/output types\n\n```nu\n any | nothing\n\n```\n### Example(s)\n  Set a variable to a value\n```nu\n  let x = 10\n```\n  Set a variable to the result of an expression\n```nu\n  let x = 10 + 100\n```\n  Set a variable based on the condition\n```nu\n  let x = if false { -1 } else { 1 }\n```\n"
+                    "value": "Create a variable and give it a value.\n\nThis command is a parser keyword. For details, check:\n  https://www.nushell.sh/book/thinking_in_nu.html\n---\n### Usage \n```nu\n  let {flags} <var_name> = <initial_value>\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n\n### Parameters\n\n  `var_name`: `<vardecl>` - Variable name.\n\n  `initial_value`: `<variable>` - Equals sign followed by value.\n\n\n### Input/output types\n\n```nu\n any | nothing\n\n```\n### Example(s)\n  Set a variable to a value\n```nu\n  let x = 10\n```\n  Set a variable to the result of an expression\n```nu\n  let x = 10 + 100\n```\n  Set a variable based on the condition\n```nu\n  let x = if false { -1 } else { 1 }\n```\n"
                 }
             })
         );

--- a/crates/nu-lsp/src/signature.rs
+++ b/crates/nu-lsp/src/signature.rs
@@ -80,7 +80,7 @@ pub(crate) fn doc_for_arg(
     text
 }
 
-pub(crate) fn get_signature_label(signature: &Signature) -> String {
+pub(crate) fn get_signature_label(signature: &Signature, indent: bool) -> String {
     let expand_keyword = |arg: &PositionalArg, optional: bool| match &arg.shape {
         SyntaxShape::Keyword(kwd, _) => {
             format!("{} <{}>", String::from_utf8_lossy(kwd), arg.name)
@@ -93,7 +93,11 @@ pub(crate) fn get_signature_label(signature: &Signature) -> String {
             }
         }
     };
-    let mut label = format!("  {}", signature.name);
+    let mut label = String::new();
+    if indent {
+        label.push_str("  ");
+    }
+    label.push_str(&signature.name);
     if !signature.named.is_empty() {
         label.push_str(" {flags}");
     }
@@ -167,7 +171,7 @@ impl LanguageServer {
             find_active_internal_call(expr, &working_set, pos_to_search)
         })?;
         let active_signature = working_set.get_decl(active_call.decl_id).signature();
-        let label = get_signature_label(&active_signature);
+        let label = get_signature_label(&active_signature, false);
 
         let mut param_num_before_pos = 0;
         for arg in active_call.arguments.iter() {
@@ -293,7 +297,7 @@ mod tests {
             actual: result_from_message(resp),
             expected: serde_json::json!({
                 "signatures": [{
-                    "label": "  str substring {flags} <range> ...(rest)",
+                    "label": "str substring {flags} <range> ...(rest)",
                     "parameters": [ ],
                     "activeParameter": 0
                 }],
@@ -323,7 +327,7 @@ mod tests {
         assert_json_include!(
             actual: result_from_message(resp),
             expected: serde_json::json!({ "signatures": [{
-                "label": "  str substring {flags} <range> ...(rest)",
+                "label": "str substring {flags} <range> ...(rest)",
                 "activeParameter": 1
             }]})
         );
@@ -332,7 +336,7 @@ mod tests {
         assert_json_include!(
             actual: result_from_message(resp),
             expected: serde_json::json!({ "signatures": [{
-                "label": "  str substring {flags} <range> ...(rest)",
+                "label": "str substring {flags} <range> ...(rest)",
                 "activeParameter": 0
             }]})
         );
@@ -341,7 +345,7 @@ mod tests {
         assert_json_include!(
             actual: result_from_message(resp),
             expected: serde_json::json!({ "signatures": [{
-                "label": "  echo {flags} ...(rest)",
+                "label": "echo {flags} ...(rest)",
                 "activeParameter": 0
             }]})
         );
@@ -368,7 +372,7 @@ mod tests {
             actual: result_from_message(resp),
             expected: serde_json::json!({
                 "signatures": [{
-                    "label": "  foo bar {flags} <p1> <p2> (p3)",
+                    "label": "foo bar {flags} <p1> <p2> (p3)",
                     "parameters": [
                         {"label": "p1", "documentation": {"value": ": `<int>`"}},
                         {"label": "p2", "documentation": {"value": ": `<string>` - doc"}},
@@ -386,7 +390,7 @@ mod tests {
             actual: result_from_message(resp),
             expected: serde_json::json!({
                 "signatures": [{
-                    "label": "  foo baz {flags} <p1> <p2> (p3)",
+                    "label": "foo baz {flags} <p1> <p2> (p3)",
                     "parameters": [
                         {"label": "p1", "documentation": {"value": ": `<int>`"}},
                         {"label": "p2", "documentation": {"value": ": `<string>` - doc"}},

--- a/tests/fixtures/lsp/hints/signature.nu
+++ b/tests/fixtures/lsp/hints/signature.nu
@@ -11,7 +11,7 @@ foo bar 1 2 3
 foo baz 1 2 3  
 def "foo baz" [
     p1: int
-    p2: string,
-    p3?: int = 1 # doc
+    p2: string, # doc
+    p3?: int = 1
 ] {}
 echo   


### PR DESCRIPTION
#15499 reminds me of the discrepancies between lsp hover docs and `--help` outputs.

# Description

# User-Facing Changes

Before:

<img width="610" alt="image" src="https://github.com/user-attachments/assets/f73f7ace-5c1b-4380-9921-fb4783bdb187" />

After:

<img width="610" alt="image" src="https://github.com/user-attachments/assets/96de3ffe-e37b-41b1-88bb-123eeb72ced2" />

Output of `if -h` as a reference:

```
Usage:
  > if <cond> <then_block> (else <else_expression>)

Flags:
  -h, --help: Display the help message for this command

Parameters:
  cond <variable>: Condition to check.
  then_block <block>: Block to run if check succeeds.
  "else" + <one_of(block, expression)>: Expression or block to run when the condition is false. (optional)

```

# Tests + Formatting

Refined

# After Submitting
