### PR TITLE
Substring Match Algorithm

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -646,7 +646,6 @@ impl NuCompleter {
             case_sensitive: config.completions.case_sensitive,
             match_algorithm: config.completions.algorithm.into(),
             sort: config.completions.sort,
-            ..Default::default()
         };
 
         completer.fetch(

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -18,17 +18,17 @@ pub enum MatchAlgorithm {
     /// "git switch" is matched by "git sw"
     Prefix,
 
-    /// Only show suggestions which contain the input chars at any place
-    ///
-    /// Example:
-    /// "git checkout" is matched by "gco"
-    Fuzzy,
-
     /// Only show suggestions which have a substring matching with the given input
     ///
     /// Example:
     /// "git checkout" is matched by "checkout"
     Substring,
+
+    /// Only show suggestions which contain the input chars at any place
+    ///
+    /// Example:
+    /// "git checkout" is matched by "gco"
+    Fuzzy,
 }
 
 pub struct NuMatcher<'a, T> {
@@ -42,15 +42,15 @@ enum State<T> {
         /// Holds (haystack, item)
         items: Vec<(String, T)>,
     },
+    Substring {
+        /// Holds (haystack, item)
+        items: Vec<(String, T)>,
+    },
     Fuzzy {
         matcher: Matcher,
         atom: Atom,
         /// Holds (haystack, item, score)
         items: Vec<(String, T, u16)>,
-    },
-    Substring {
-        /// Holds (haystack, item)
-        items: Vec<(String, T)>,
     },
 }
 
@@ -74,6 +74,18 @@ impl<T> NuMatcher<'_, T> {
                     state: State::Prefix { items: Vec::new() },
                 }
             }
+            MatchAlgorithm::Substring => {
+                let lowercase_needle = if options.case_sensitive {
+                    needle.to_owned()
+                } else {
+                    needle.to_folded_case()
+                };
+                NuMatcher {
+                    options,
+                    needle: lowercase_needle,
+                    state: State::Substring { items: Vec::new() },
+                }
+            }
             MatchAlgorithm::Fuzzy => {
                 let atom = Atom::new(
                     needle,
@@ -94,18 +106,6 @@ impl<T> NuMatcher<'_, T> {
                         atom,
                         items: Vec::new(),
                     },
-                }
-            }
-            MatchAlgorithm::Substring => {
-                let lowercase_needle = if options.case_sensitive {
-                    needle.to_owned()
-                } else {
-                    needle.to_folded_case()
-                };
-                NuMatcher {
-                    options,
-                    needle: lowercase_needle,
-                    state: State::Substring { items: Vec::new() },
                 }
             }
         }
@@ -132,6 +132,20 @@ impl<T> NuMatcher<'_, T> {
                 }
                 matches
             }
+            State::Substring { items } => {
+                let haystack_folded = if self.options.case_sensitive {
+                    Cow::Borrowed(haystack)
+                } else {
+                    Cow::Owned(haystack.to_folded_case())
+                };
+                let matches = haystack_folded.contains(self.needle.as_str());
+                if matches {
+                    if let Some(item) = item {
+                        items.push((haystack.to_string(), item));
+                    }
+                }
+                matches
+            }
             State::Fuzzy {
                 matcher,
                 atom,
@@ -147,20 +161,6 @@ impl<T> NuMatcher<'_, T> {
                     items.push((haystack.to_string(), item, score));
                 }
                 true
-            }
-            State::Substring { items } => {
-                let haystack_folded = if self.options.case_sensitive {
-                    Cow::Borrowed(haystack)
-                } else {
-                    Cow::Owned(haystack.to_folded_case())
-                };
-                let matches = haystack_folded.contains(self.needle.as_str());
-                if matches {
-                    if let Some(item) = item {
-                        items.push((haystack.to_string(), item));
-                    }
-                }
-                matches
             }
         }
     }
@@ -180,7 +180,7 @@ impl<T> NuMatcher<'_, T> {
     /// Get all the items that matched (sorted)
     pub fn results(self) -> Vec<T> {
         match self.state {
-            State::Prefix { mut items, .. } => {
+            State::Prefix { mut items, .. } | State::Substring { mut items , ..} => {
                 items.sort_by(|(haystack1, _), (haystack2, _)| {
                     let cmp_sensitive = haystack1.cmp(haystack2);
                     if self.options.case_sensitive {
@@ -212,20 +212,6 @@ impl<T> NuMatcher<'_, T> {
                     .map(|(_, item, _)| item)
                     .collect::<Vec<_>>()
             }
-            State::Substring { mut items, .. } => {
-                items.sort_by(|(haystack1, _), (haystack2, _)| {
-                    let cmp_sensitive = haystack1.cmp(haystack2);
-                    if self.options.case_sensitive {
-                        cmp_sensitive
-                    } else {
-                        haystack1
-                            .to_folded_case()
-                            .cmp(&haystack2.to_folded_case())
-                            .then(cmp_sensitive)
-                    }
-                });
-                items.into_iter().map(|(_, item)| item).collect::<Vec<_>>()
-            }
         }
     }
 }
@@ -241,8 +227,8 @@ impl From<CompletionAlgorithm> for MatchAlgorithm {
     fn from(value: CompletionAlgorithm) -> Self {
         match value {
             CompletionAlgorithm::Prefix => MatchAlgorithm::Prefix,
-            CompletionAlgorithm::Fuzzy => MatchAlgorithm::Fuzzy,
             CompletionAlgorithm::Substring => MatchAlgorithm::Substring,
+            CompletionAlgorithm::Fuzzy => MatchAlgorithm::Fuzzy,
         }
     }
 }
@@ -253,8 +239,8 @@ impl TryFrom<String> for MatchAlgorithm {
     fn try_from(value: String) -> Result<Self, Self::Error> {
         match value.as_str() {
             "prefix" => Ok(Self::Prefix),
-            "fuzzy" => Ok(Self::Fuzzy),
             "substring" => Ok(Self::Substring),
+            "fuzzy" => Ok(Self::Fuzzy),
             _ => Err(InvalidMatchAlgorithm::Unknown),
         }
     }
@@ -302,16 +288,14 @@ mod test {
     #[case(MatchAlgorithm::Prefix, "example text", "", true)]
     #[case(MatchAlgorithm::Prefix, "example text", "examp", true)]
     #[case(MatchAlgorithm::Prefix, "example text", "text", false)]
+    #[case(MatchAlgorithm::Substring, "example text", "", true)]
+    #[case(MatchAlgorithm::Substring, "example text", "text", true)]
+    #[case(MatchAlgorithm::Substring, "example text", "mplxt", false)]
     #[case(MatchAlgorithm::Fuzzy, "example text", "", true)]
     #[case(MatchAlgorithm::Fuzzy, "example text", "examp", true)]
     #[case(MatchAlgorithm::Fuzzy, "example text", "ext", true)]
     #[case(MatchAlgorithm::Fuzzy, "example text", "mplxt", true)]
     #[case(MatchAlgorithm::Fuzzy, "example text", "mpp", false)]
-    #[case(MatchAlgorithm::Substring, "example text", "", true)]
-    #[case(MatchAlgorithm::Substring, "example text", "examp", true)]
-    #[case(MatchAlgorithm::Substring, "example text", "ple", true)]
-    #[case(MatchAlgorithm::Substring, "example text", "text", true)]
-    #[case(MatchAlgorithm::Substring, "example text", "mplxt", false)]
     fn match_algorithm_simple(
         #[case] match_algorithm: MatchAlgorithm,
         #[case] haystack: &str,

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -313,6 +313,11 @@ mod test {
     #[case(MatchAlgorithm::Fuzzy, "example text", "ext", true)]
     #[case(MatchAlgorithm::Fuzzy, "example text", "mplxt", true)]
     #[case(MatchAlgorithm::Fuzzy, "example text", "mpp", false)]
+    #[case(MatchAlgorithm::Substring, "example text", "", true)]
+    #[case(MatchAlgorithm::Substring, "example text", "examp", true)]
+    #[case(MatchAlgorithm::Substring, "example text", "ple", true)]
+    #[case(MatchAlgorithm::Substring, "example text", "text", true)]
+    #[case(MatchAlgorithm::Substring, "example text", "mplxt", false)]
     fn match_algorithm_simple(
         #[case] match_algorithm: MatchAlgorithm,
         #[case] haystack: &str,

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -124,11 +124,7 @@ impl<T> NuMatcher<'_, T> {
                 } else {
                     Cow::Owned(haystack.to_folded_case())
                 };
-                let matches = if self.options.positional {
-                    haystack_folded.starts_with(self.needle.as_str())
-                } else {
-                    haystack_folded.contains(self.needle.as_str())
-                };
+                let matches = haystack_folded.starts_with(self.needle.as_str());
                 if matches {
                     if let Some(item) = item {
                         items.push((haystack.to_string(), item));
@@ -282,7 +278,6 @@ impl std::error::Error for InvalidMatchAlgorithm {}
 #[derive(Clone)]
 pub struct CompletionOptions {
     pub case_sensitive: bool,
-    pub positional: bool,
     pub match_algorithm: MatchAlgorithm,
     pub sort: CompletionSort,
 }
@@ -291,7 +286,6 @@ impl Default for CompletionOptions {
     fn default() -> Self {
         Self {
             case_sensitive: true,
-            positional: true,
             match_algorithm: MatchAlgorithm::Prefix,
             sort: Default::default(),
         }

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -23,9 +23,9 @@ pub enum MatchAlgorithm {
     /// Example:
     /// "git checkout" is matched by "gco"
     Fuzzy,
-    
+
     /// Only show suggestions which have a substring matching with the given input
-    /// 
+    ///
     /// Example:
     /// "git checkout" is matched by "checkout"
     Substring,

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -180,7 +180,7 @@ impl<T> NuMatcher<'_, T> {
     /// Get all the items that matched (sorted)
     pub fn results(self) -> Vec<T> {
         match self.state {
-            State::Prefix { mut items, .. } | State::Substring { mut items , ..} => {
+            State::Prefix { mut items, .. } | State::Substring { mut items, .. } => {
                 items.sort_by(|(haystack1, _), (haystack2, _)| {
                     let cmp_sensitive = haystack1.cmp(haystack2);
                     if self.options.case_sensitive {

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -105,6 +105,7 @@ impl<T: Completer> Completer for CustomCompletion<T> {
                         if let Some(positional) =
                             options.get("positional").and_then(|val| val.as_bool().ok())
                         {
+                            log::warn!("Use of the positional option is deprecated. Use the substring match algorithm instead.");
                             completion_options.positional = positional;
                         }
                         if let Some(algorithm) = options

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -112,10 +112,10 @@ impl<T: Completer> Completer for CustomCompletion<T> {
                             if let Some(positional) =
                                 options.get("positional").and_then(|val| val.as_bool().ok())
                             {
+                                log::warn!("Use of the positional option is deprecated. Use the substring match algorithm instead.");
                                 if !positional
                                     && completion_options.match_algorithm == MatchAlgorithm::Prefix
                                 {
-                                    log::warn!("Use of the positional option is deprecated. Use the substring match algorithm instead.");
                                     completion_options.match_algorithm = MatchAlgorithm::Substring
                                 }
                             }

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -105,7 +105,7 @@ impl<T: Completer> Completer for CustomCompletion<T> {
                         }
                         let positional =
                             options.get("positional").and_then(|val| val.as_bool().ok());
-                        if let Some(_positional) = positional {
+                        if positional.is_some() {
                             log::warn!("Use of the positional option is deprecated. Use the substring match algorithm instead.");
                         }
                         if let Some(algorithm) = options

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -103,19 +103,19 @@ impl<T: Completer> Completer for CustomCompletion<T> {
                         {
                             completion_options.case_sensitive = case_sensitive;
                         }
+                        let positional =
+                            options.get("positional").and_then(|val| val.as_bool().ok());
+                        if let Some(_positional) = positional {
+                            log::warn!("Use of the positional option is deprecated. Use the substring match algorithm instead.");
+                        }
                         if let Some(algorithm) = options
                             .get("completion_algorithm")
                             .and_then(|option| option.coerce_string().ok())
                             .and_then(|option| option.try_into().ok())
                         {
                             completion_options.match_algorithm = algorithm;
-                            if let Some(positional) =
-                                options.get("positional").and_then(|val| val.as_bool().ok())
-                            {
-                                log::warn!("Use of the positional option is deprecated. Use the substring match algorithm instead.");
-                                if !positional
-                                    && completion_options.match_algorithm == MatchAlgorithm::Prefix
-                                {
+                            if let Some(false) = positional {
+                                if completion_options.match_algorithm == MatchAlgorithm::Prefix {
                                     completion_options.match_algorithm = MatchAlgorithm::Substring
                                 }
                             }

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -234,7 +234,6 @@ fn customcompletions_override_options() {
         &["Foo Abcdef", "Abcdef", "Acd Bar"],
     );
 
-    // positional: false should make it do substring matching
     // sort: true should force sorting
     let expected: Vec<_> = vec!["Abcdef", "Foo Abcdef"];
     let suggestions = completer.complete("my-command Abcd", 15);

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -228,8 +228,7 @@ fn customcompletions_override_options() {
     let mut completer = custom_completer_with_options(
         r#"$env.config.completions.algorithm = "fuzzy"
            $env.config.completions.case_sensitive = false"#,
-        r#"completion_algorithm: "prefix",
-           positional: false,
+        r#"completion_algorithm: "substring",
            case_sensitive: true,
            sort: true"#,
         &["Foo Abcdef", "Abcdef", "Acd Bar"],

--- a/crates/nu-protocol/src/config/completions.rs
+++ b/crates/nu-protocol/src/config/completions.rs
@@ -6,8 +6,8 @@ use crate::engine::Closure;
 pub enum CompletionAlgorithm {
     #[default]
     Prefix,
-    Fuzzy,
     Substring,
+    Fuzzy,
 }
 
 impl FromStr for CompletionAlgorithm {
@@ -16,8 +16,8 @@ impl FromStr for CompletionAlgorithm {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_ascii_lowercase().as_str() {
             "prefix" => Ok(Self::Prefix),
-            "fuzzy" => Ok(Self::Fuzzy),
             "substring" => Ok(Self::Substring),
+            "fuzzy" => Ok(Self::Fuzzy),
             _ => Err("'prefix' or 'fuzzy' or 'substring'"),
         }
     }

--- a/crates/nu-protocol/src/config/completions.rs
+++ b/crates/nu-protocol/src/config/completions.rs
@@ -7,6 +7,7 @@ pub enum CompletionAlgorithm {
     #[default]
     Prefix,
     Fuzzy,
+    Substring,
 }
 
 impl FromStr for CompletionAlgorithm {
@@ -16,7 +17,8 @@ impl FromStr for CompletionAlgorithm {
         match s.to_ascii_lowercase().as_str() {
             "prefix" => Ok(Self::Prefix),
             "fuzzy" => Ok(Self::Fuzzy),
-            _ => Err("'prefix' or 'fuzzy'"),
+            "substring" => Ok(Self::Substring),
+            _ => Err("'prefix' or 'fuzzy' or 'substring'"),
         }
     }
 }

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -115,12 +115,13 @@ $env.config.cursor_shape.vi_normal = "underscore"  # Cursor shape in normal vi m
 # $env.config.completions.*
 # Apply to the Nushell completion system
 
-# algorithm (string): Either "prefix" or "fuzzy"
+# algorithm (string): "prefix", "substring" or "fuzzy"
 $env.config.completions.algorithm = "prefix"
 
 # sort (string): One of "smart" or "alphabetical"
 # In "smart" mode sort order is based on the "algorithm" setting.
 # When using the "prefix" algorithm, results are alphabetically sorted.
+# When using the "substring" algorithm, results are alphabetically sorted.
 # When using the "fuzzy" algorithm, results are sorted based on their fuzzy score.
 $env.config.completions.sort = "smart"
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR should close #15474 .

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
When users set the match algorithm to 'substring' by modifying `$env.config` to `$env.config.completions.algorithm = "substring"``), completions are done based on substring matches. 
This was previously possible by setting `positional` to be false in custom completers, but doing so now logs a warning as this feature is set to be deprecated and replaced by the new way of setting the matching algorithm to substring based.
