### PR TITLE
Fix Exbibyte parsing

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2784,7 +2784,7 @@ pub const FILESIZE_UNIT_GROUPS: &[UnitGroup] = &[
     (
         Unit::Filesize(FilesizeUnit::EiB),
         "EIB",
-        Some((Unit::Filesize(FilesizeUnit::EiB), 1024)),
+        Some((Unit::Filesize(FilesizeUnit::PiB), 1024)),
     ),
     (Unit::Filesize(FilesizeUnit::B), "B", None),
 ];


### PR DESCRIPTION
Closes #15502

# Description
The parsing of Exbibytes used the wrong base unit before converting.

# User-Facing Changes
`1EiB` etc. will now be parsed correctly

# Tests + Formatting
(-)
