### PR TITLE
fix(lsp): parser_info based id detection for use/overlay keywords

### DIFF
--- a/crates/nu-lsp/src/goto.rs
+++ b/crates/nu-lsp/src/goto.rs
@@ -184,18 +184,18 @@ mod tests {
         let mut script = fixtures();
         script.push("lsp");
         script.push("hover");
-        script.push("cell_path.nu");
+        script.push("use.nu");
         let script = path_to_uri(&script);
 
         open_unchecked(&client_connection, script.clone());
 
-        let resp = send_goto_definition_request(&client_connection, script.clone(), 4, 7);
+        let resp = send_goto_definition_request(&client_connection, script.clone(), 2, 7);
         assert_json_eq!(
             result_from_message(resp).pointer("/range/start").unwrap(),
             serde_json::json!({ "line": 1, "character": 10 })
         );
 
-        let resp = send_goto_definition_request(&client_connection, script.clone(), 4, 9);
+        let resp = send_goto_definition_request(&client_connection, script.clone(), 2, 9);
         assert_json_eq!(
             result_from_message(resp).pointer("/range/start").unwrap(),
             serde_json::json!({ "line": 1, "character": 17 })

--- a/tests/fixtures/lsp/hover/cell_path.nu
+++ b/tests/fixtures/lsp/hover/cell_path.nu
@@ -1,5 +1,5 @@
-const r = {
+export const r = {
   foo: [1 {bar : 2}]
 }
 
-$r.foo.1.bar
+export def foo [] { }

--- a/tests/fixtures/lsp/hover/use.nu
+++ b/tests/fixtures/lsp/hover/use.nu
@@ -1,0 +1,4 @@
+use cell_path.nu [ r foo ]
+def test [] {
+$r.foo.1.bar
+}


### PR DESCRIPTION
# Description

Now, with PWD correctly set in #15470 , identifiers in `use/hide/overlay` commands can be identified using a more robust method, i.e. module_id from `parser_info`.

# User-Facing Changes

bug fix

# Tests + Formatting

+1 (fails without this PR)

# After Submitting
