### PR TITLE
fix(parser): namespace pollution of constants by `use module.nu`

### DIFF
--- a/crates/nu-protocol/src/module.rs
+++ b/crates/nu-protocol/src/module.rs
@@ -128,7 +128,6 @@ impl Module {
         } else {
             // Import pattern was just name without any members
             let mut decls = vec![];
-            let mut const_vids = vec![];
             let mut const_rows = vec![];
             let mut errors = vec![];
 
@@ -154,7 +153,6 @@ impl Module {
                     decls.push((new_name, sub_decl_id));
                 }
 
-                const_vids.extend(sub_results.constants);
                 const_rows.extend(sub_results.constant_values);
             }
 
@@ -162,10 +160,7 @@ impl Module {
 
             for (name, var_id) in self.consts() {
                 match working_set.get_constant(var_id) {
-                    Ok(const_val) => {
-                        const_vids.push((name.clone(), var_id));
-                        const_rows.push((name, const_val.clone()))
-                    }
+                    Ok(const_val) => const_rows.push((name, const_val.clone())),
                     Err(err) => errors.push(err),
                 }
             }
@@ -192,7 +187,7 @@ impl Module {
                 ResolvedImportPattern::new(
                     decls,
                     vec![(final_name.clone(), self_id)],
-                    const_vids,
+                    vec![],
                     constant_values,
                 ),
                 errors,

--- a/tests/repl/test_modules.rs
+++ b/tests/repl/test_modules.rs
@@ -143,6 +143,10 @@ fn export_module_which_defined_const() -> TestResult {
     run_test(
         r#"module spam { export const b = 3; export const c = 4 }; use spam; $spam.b + $spam.c"#,
         "7",
+    )?;
+    fail_test(
+        r#"module spam { export const b = 3; export const c = 4 }; use spam; $b"#,
+        "variable not found",
     )
 }
 


### PR DESCRIPTION
A bug introduced by #14920 

When `use module.nu` is called, all exported constants defined in it are added to the scope.

# Description

On the branch of empty arguments, the constant var_id vector should be empty, only constant_values (for  `$module.foo` access) are injected.

# User-Facing Changes

# Tests + Formatting

~todo!~

adjusted

# After Submitting
