### PR TITLE
bugfix: wrong display of human readable string

### DIFF
--- a/crates/nu-command/src/date/from_human.rs
+++ b/crates/nu-command/src/date/from_human.rs
@@ -103,19 +103,21 @@ fn helper(value: Value, head: Span) -> Value {
         }
     };
 
-    if let Ok(date) = from_human_time(&input_val, Local::now().naive_local()) {
+    let now = Local::now();
+
+    if let Ok(date) = from_human_time(&input_val, now.naive_local()) {
         match date {
             ParseResult::Date(date) => {
-                let time = Local::now().time();
+                let time = now.time();
                 let combined = date.and_time(time);
-                let local_offset = *Local::now().offset();
+                let local_offset = *now.offset();
                 let dt_fixed = TimeZone::from_local_datetime(&local_offset, &combined)
                     .single()
                     .unwrap_or_default();
                 return Value::date(dt_fixed, span);
             }
             ParseResult::DateTime(date) => {
-                let local_offset = *Local::now().offset();
+                let local_offset = *now.offset();
                 let dt_fixed = match local_offset.from_local_datetime(&date) {
                     chrono::LocalResult::Single(dt) => dt,
                     chrono::LocalResult::Ambiguous(_, _) => {
@@ -140,9 +142,9 @@ fn helper(value: Value, head: Span) -> Value {
                 return Value::date(dt_fixed, span);
             }
             ParseResult::Time(time) => {
-                let date = Local::now().date_naive();
+                let date = now.date_naive();
                 let combined = date.and_time(time);
-                let local_offset = *Local::now().offset();
+                let local_offset = *now.offset();
                 let dt_fixed = TimeZone::from_local_datetime(&local_offset, &combined)
                     .single()
                     .unwrap_or_default();
@@ -151,19 +153,19 @@ fn helper(value: Value, head: Span) -> Value {
         }
     }
 
-    match from_human_time(&input_val, Local::now().naive_local()) {
+    match from_human_time(&input_val, now.naive_local()) {
         Ok(date) => match date {
             ParseResult::Date(date) => {
-                let time = Local::now().time();
+                let time = now.time();
                 let combined = date.and_time(time);
-                let local_offset = *Local::now().offset();
+                let local_offset = *now.offset();
                 let dt_fixed = TimeZone::from_local_datetime(&local_offset, &combined)
                     .single()
                     .unwrap_or_default();
                 Value::date(dt_fixed, span)
             }
             ParseResult::DateTime(date) => {
-                let local_offset = *Local::now().offset();
+                let local_offset = *now.offset();
                 let dt_fixed = match local_offset.from_local_datetime(&date) {
                     chrono::LocalResult::Single(dt) => dt,
                     chrono::LocalResult::Ambiguous(_, _) => {
@@ -188,9 +190,9 @@ fn helper(value: Value, head: Span) -> Value {
                 Value::date(dt_fixed, span)
             }
             ParseResult::Time(time) => {
-                let date = Local::now().date_naive();
+                let date = now.date_naive();
                 let combined = date.and_time(time);
-                let local_offset = *Local::now().offset();
+                let local_offset = *now.offset();
                 let dt_fixed = TimeZone::from_local_datetime(&local_offset, &combined)
                     .single()
                     .unwrap_or_default();


### PR DESCRIPTION
I think after that we can close  #14790

# Description
So the issue was the tiny time delta between the moment the "date form-human" command is executed, and the moment the value gets displayed, using chrono_humanize.

When in inputing "in 30 seconds", we currently get:
```
[crates\nu-protocol\src\value\mod.rs:950:21] HumanTime::from(*val) = HumanTime(
    TimeDelta {
        secs: 29,
        nanos: 992402700,
    },
)```
And with "now":
```
crates\nu-protocol\src\value\mod.rs:950:21] HumanTime::from(*val) = HumanTime(
    TimeDelta {
        secs: -1,
        nanos: 993393200,
    },
)
```

My solution is to round this timedelta to seconds and pass this to chrono_humanize.
Example: instead of passing (-1s + 993393200ns), we pass 0s.
Example: instead of passing (29s + 992402700ns), we pass 30s


# User-Facing Changes
Before 🔴 
```nushell
~> "in 3 days" | date from-human
Fri, 11 Apr 2025 09:06:36 +0200 (in 2 days)
~> "in 30 seconds" | date from-human
Tue, 8 Apr 2025 09:07:09 +0200 (in 29 seconds)
```

After those changes 🟢 
```nushell
~> "in 3 days" | date from-human
Fri, 11 Apr 2025 09:03:47 +0200 (in 3 days)
~> "in 30 seconds" | date from-human
Tue, 8 Apr 2025 09:04:28 +0200 (in 30 seconds)
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
