### PR TITLE
refactor(completion, lsp): include decl_id in suggetion_kind for later usage

### DIFF
--- a/crates/nu-cli/src/completions/attribute_completions.rs
+++ b/crates/nu-cli/src/completions/attribute_completions.rs
@@ -27,7 +27,7 @@ impl Completer for AttributeCompletion {
         let attr_commands =
             working_set.find_commands_by_predicate(|s| s.starts_with(b"attr "), true);
 
-        for (name, desc, ty) in attr_commands {
+        for (decl_id, name, desc, ty) in attr_commands {
             let name = name.strip_prefix(b"attr ").unwrap_or(&name);
             matcher.add_semantic_suggestion(SemanticSuggestion {
                 suggestion: Suggestion {
@@ -41,7 +41,7 @@ impl Completer for AttributeCompletion {
                     },
                     append_whitespace: false,
                 },
-                kind: Some(SuggestionKind::Command(ty)),
+                kind: Some(SuggestionKind::Command(ty, Some(decl_id))),
             });
         }
 
@@ -78,7 +78,7 @@ impl Completer for AttributableCompletion {
                     },
                     append_whitespace: false,
                 },
-                kind: Some(SuggestionKind::Command(cmd.command_type())),
+                kind: Some(SuggestionKind::Command(cmd.command_type(), None)),
             });
         }
 

--- a/crates/nu-cli/src/completions/base.rs
+++ b/crates/nu-cli/src/completions/base.rs
@@ -1,7 +1,7 @@
 use crate::completions::CompletionOptions;
 use nu_protocol::{
     engine::{Stack, StateWorkingSet},
-    Span,
+    DeclId, Span,
 };
 use reedline::Suggestion;
 
@@ -28,7 +28,7 @@ pub struct SemanticSuggestion {
 // TODO: think about name: maybe suggestion context?
 #[derive(Clone, Debug, PartialEq)]
 pub enum SuggestionKind {
-    Command(nu_protocol::engine::CommandType),
+    Command(nu_protocol::engine::CommandType, Option<DeclId>),
     Value(nu_protocol::Type),
     CellPath,
     Directory,

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -75,7 +75,10 @@ impl CommandCompletion {
                                             append_whitespace: true,
                                             ..Default::default()
                                         },
-                                        kind: Some(SuggestionKind::Command(CommandType::External)),
+                                        kind: Some(SuggestionKind::Command(
+                                            CommandType::External,
+                                            None,
+                                        )),
                                     },
                                 );
                             }
@@ -112,7 +115,7 @@ impl Completer for CommandCompletion {
                 },
                 true,
             );
-            for (name, description, typ) in filtered_commands {
+            for (decl_id, name, description, typ) in filtered_commands {
                 let name = String::from_utf8_lossy(&name);
                 internal_suggs.insert(
                     name.to_string(),
@@ -124,7 +127,7 @@ impl Completer for CommandCompletion {
                             append_whitespace: true,
                             ..Suggestion::default()
                         },
-                        kind: Some(SuggestionKind::Command(typ)),
+                        kind: Some(SuggestionKind::Command(typ, Some(decl_id))),
                     },
                 );
             }

--- a/crates/nu-cli/src/completions/exportable_completions.rs
+++ b/crates/nu-cli/src/completions/exportable_completions.rs
@@ -69,7 +69,7 @@ impl Completer for ExportableCompletion<'_> {
                     wrapped_name(name),
                     Some(cmd.description().to_string()),
                     None,
-                    SuggestionKind::Command(cmd.command_type()),
+                    SuggestionKind::Command(cmd.command_type(), Some(*decl_id)),
                 );
             }
         }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -731,18 +731,19 @@ impl EngineState {
         &self,
         mut predicate: impl FnMut(&[u8]) -> bool,
         ignore_deprecated: bool,
-    ) -> Vec<(Vec<u8>, Option<String>, CommandType)> {
+    ) -> Vec<(DeclId, Vec<u8>, Option<String>, CommandType)> {
         let mut output = vec![];
 
         for overlay_frame in self.active_overlays(&[]).rev() {
-            for decl in &overlay_frame.decls {
-                if overlay_frame.visibility.is_decl_id_visible(decl.1) && predicate(decl.0) {
-                    let command = self.get_decl(*decl.1);
+            for (name, decl_id) in &overlay_frame.decls {
+                if overlay_frame.visibility.is_decl_id_visible(decl_id) && predicate(name) {
+                    let command = self.get_decl(*decl_id);
                     if ignore_deprecated && command.signature().category == Category::Removed {
                         continue;
                     }
                     output.push((
-                        decl.0.clone(),
+                        *decl_id,
+                        name.clone(),
                         Some(command.description().to_string()),
                         command.command_type(),
                     ));

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -780,21 +780,22 @@ impl<'a> StateWorkingSet<'a> {
         &self,
         mut predicate: impl FnMut(&[u8]) -> bool,
         ignore_deprecated: bool,
-    ) -> Vec<(Vec<u8>, Option<String>, CommandType)> {
+    ) -> Vec<(DeclId, Vec<u8>, Option<String>, CommandType)> {
         let mut output = vec![];
 
         for scope_frame in self.delta.scope.iter().rev() {
             for overlay_id in scope_frame.active_overlays.iter().rev() {
                 let overlay_frame = scope_frame.get_overlay(*overlay_id);
 
-                for decl in &overlay_frame.decls {
-                    if overlay_frame.visibility.is_decl_id_visible(decl.1) && predicate(decl.0) {
-                        let command = self.get_decl(*decl.1);
+                for (name, decl_id) in &overlay_frame.decls {
+                    if overlay_frame.visibility.is_decl_id_visible(decl_id) && predicate(name) {
+                        let command = self.get_decl(*decl_id);
                         if ignore_deprecated && command.signature().category == Category::Removed {
                             continue;
                         }
                         output.push((
-                            decl.0.clone(),
+                            *decl_id,
+                            name.clone(),
                             Some(command.description().to_string()),
                             command.command_type(),
                         ));


### PR DESCRIPTION
# Description

Should be more performant, calling for `find_decl` by name for all entries is generally a heavy op.

# User-Facing Changes

NA

# Tests + Formatting

# After Submitting
