### PR TITLE
try to fix `datetime-diff` for ms, us, ns

### DIFF
--- a/crates/nu-std/std/dt/mod.nu
+++ b/crates/nu-std/std/dt/mod.nu
@@ -104,7 +104,7 @@ def borrow-microsecond [from: record, current: record] {
     $current.nanosecond = $current.nanosecond + 1_000
     $current.microsecond = $current.microsecond - 1
     if $current.microsecond < 0 {
-        $current = (borrow-borrow-millisecond $from $current)
+        $current = (borrow-millisecond $from $current)
     }
 
     $current

--- a/crates/nu-std/tests/test_dt.nu
+++ b/crates/nu-std/tests/test_dt.nu
@@ -35,6 +35,13 @@ def earlier_arg_must_be_less_or_equal_later [] {
 }
 
 @test
+def banner_math_with_ms_us_ns [] {
+    let t1 = 2023-05-07T04:08:45.582926123+12:00
+    let t2 = 2019-05-10T09:59:12.967486456-07:00
+    assert equal (datetime-diff $t1 $t2) ({year:3, month:11, day:26, hour:23, minute:9, second:32, millisecond:615, microsecond:439 nanosecond:667})
+}
+
+@test
 def pp_skips_zeros [] {
     assert equal (pretty-print-duration {year:1, month:0, day:0, hour:0, minute:0, second:0, millisecond:0, microsecond:0 nanosecond:0}) "1yr "
 }


### PR DESCRIPTION
# Description

This PR tries to fix the datetime-diff custom command so that it includes ms, us, ns.

Difference in the banner in 2 separate starts.

### Old
```nushell
It's been this long since Nushell's first commit:
5yrs 10months 29days 9hrs 1min 47secs
```

### New
```nushell
It's been this long since Nushell's first commit:
5yrs 10months 29days 9hrs 1min 22secs 49ms 885µs
```

There should be ns above on the new one, not sure why there isn't. It could have something to do with how the banner works but i'll save that for another PR. 

🤔 It could be because there are no fractional seconds in the math? `datetime-diff (date now) 2019-05-10T09:59:12-07:00`. However, I'm not sure why `date now` has no nanoseconds. Oh, wait. I think that's because MacOS doesn't have nanosecond precision?
```
❯ ^date +%s.%N
1744251636.365003000
```

Closes https://github.com/nushell/nushell/issues/15524

/cc @NotTheDr01ds 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
