### PR TITLE
`polars`: update `get-` datetime components commands to allow expressions as inputs

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_day.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_day.rs
@@ -1,13 +1,17 @@
-use crate::{values::CustomValueSupport, PolarsPlugin};
-
-use super::super::super::values::NuDataFrame;
+use crate::{
+    values::{
+        cant_convert_err, CustomValueSupport, NuDataFrame, NuExpression, NuLazyFrame,
+        PolarsPluginObject, PolarsPluginType,
+    },
+    PolarsPlugin,
+};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type,
 };
 use polars::{
-    prelude::{DatetimeMethods, IntoSeries, NamedFrom},
+    prelude::{col, DatetimeMethods, IntoSeries, NamedFrom},
     series::Series,
 };
 
@@ -27,25 +31,50 @@ impl PluginCommand for GetDay {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_type(
-                Type::Custom("dataframe".into()),
-                Type::Custom("dataframe".into()),
-            )
+            .input_output_types(vec![
+                (
+                    Type::Custom("dataframe".into()),
+                    Type::Custom("dataframe".into()),
+                ),
+                (
+                    Type::Custom("expression".into()),
+                    Type::Custom("expression".into()),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Returns day from a date",
-            example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+        vec![
+            Example {
+                description: "Returns day from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
     let df = ([$dt $dt] | polars into-df);
     $df | polars get-day"#,
-            result: Some(
-                NuDataFrame::try_from_series(Series::new("0".into(), &[4i8, 4]), Span::test_data())
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[4i8, 4]),
+                        Span::test_data(),
+                    )
                     .expect("simple df for test should not fail")
                     .into_value(Span::test_data()),
-            ),
-        }]
+                ),
+            },
+            Example {
+                description: "Returns day from a date in an expression",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+    let df = ([$dt $dt] | polars into-df);
+    $df | polars select (polars col 0 | polars get-day)"#,
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[4i8, 4]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
     }
 
     fn run(
@@ -73,7 +102,42 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let df = NuDataFrame::try_from_pipeline_coerce(plugin, input, call.head)?;
+    let value = input.into_value(call.head)?;
+
+    match PolarsPluginObject::try_from_value(plugin, &value)? {
+        PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),
+        PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
+        PolarsPluginObject::NuExpression(expr) => {
+            let res: NuExpression = expr.into_polars().dt().day().into();
+            res.to_pipeline_data(plugin, engine, call.head)
+        }
+        _ => Err(cant_convert_err(
+            &value,
+            &[
+                PolarsPluginType::NuDataFrame,
+                PolarsPluginType::NuLazyFrame,
+                PolarsPluginType::NuExpression,
+            ],
+        )),
+    }
+}
+
+fn command_lazy(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    lazy: NuLazyFrame,
+) -> Result<PipelineData, ShellError> {
+    NuLazyFrame::new(false, lazy.to_polars().select([col("*").dt().day()]))
+        .to_pipeline_data(plugin, engine, call.head)
+}
+
+fn command_eager(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    df: NuDataFrame,
+) -> Result<PipelineData, ShellError> {
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| ShellError::GenericError {

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_hour.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_hour.rs
@@ -1,4 +1,10 @@
-use crate::{values::CustomValueSupport, PolarsPlugin};
+use crate::{
+    values::{
+        cant_convert_err, CustomValueSupport, NuExpression, NuLazyFrame, PolarsPluginObject,
+        PolarsPluginType,
+    },
+    PolarsPlugin,
+};
 
 use super::super::super::values::NuDataFrame;
 
@@ -7,7 +13,7 @@ use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type,
 };
 use polars::{
-    prelude::{DatetimeMethods, IntoSeries, NamedFrom},
+    prelude::{col, DatetimeMethods, IntoSeries, NamedFrom},
     series::Series,
 };
 
@@ -22,33 +28,69 @@ impl PluginCommand for GetHour {
     }
 
     fn description(&self) -> &str {
-        "Gets hour from date."
+        "Gets hour from datetime."
     }
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_type(
-                Type::Custom("dataframe".into()),
-                Type::Custom("dataframe".into()),
-            )
+            .input_output_types(vec![
+                (
+                    Type::Custom("dataframe".into()),
+                    Type::Custom("dataframe".into()),
+                ),
+                (
+                    Type::Custom("expression".into()),
+                    Type::Custom("expression".into()),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Returns hour from a date",
-            example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+        vec![
+            Example {
+                description: "Returns hour from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
     let df = ([$dt $dt] | polars into-df);
     $df | polars get-hour"#,
-            result: Some(
-                NuDataFrame::try_from_series(
-                    Series::new("0".into(), &[16i8, 16]),
-                    Span::test_data(),
-                )
-                .expect("simple df for test should not fail")
-                .into_value(Span::test_data()),
-            ),
-        }]
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[16i8, 16]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                description: "Returns hour from a date in a lazyframe",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+    let df = ([$dt $dt] | polars into-lazy);
+    $df | polars get-hour"#,
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[16i8, 16]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                description: "Returns hour from a date in an expression",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+    let df = ([$dt $dt] | polars into-df);
+    $df | polars select (polars col 0 | polars get-hour)"#,
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[16i8, 16]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
     }
 
     fn run(
@@ -68,7 +110,42 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let df = NuDataFrame::try_from_pipeline_coerce(plugin, input, call.head)?;
+    let value = input.into_value(call.head)?;
+
+    match PolarsPluginObject::try_from_value(plugin, &value)? {
+        PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),
+        PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
+        PolarsPluginObject::NuExpression(expr) => {
+            let res: NuExpression = expr.into_polars().dt().hour().into();
+            res.to_pipeline_data(plugin, engine, call.head)
+        }
+        _ => Err(cant_convert_err(
+            &value,
+            &[
+                PolarsPluginType::NuDataFrame,
+                PolarsPluginType::NuLazyFrame,
+                PolarsPluginType::NuExpression,
+            ],
+        )),
+    }
+}
+
+fn command_lazy(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    lazy: NuLazyFrame,
+) -> Result<PipelineData, ShellError> {
+    NuLazyFrame::new(false, lazy.to_polars().select([col("*").dt().hour()]))
+        .to_pipeline_data(plugin, engine, call.head)
+}
+
+fn command_eager(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    df: NuDataFrame,
+) -> Result<PipelineData, ShellError> {
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| ShellError::GenericError {

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_minute.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_minute.rs
@@ -1,13 +1,19 @@
-use crate::{values::CustomValueSupport, PolarsPlugin};
-use polars::{prelude::NamedFrom, series::Series};
-
-use super::super::super::values::NuDataFrame;
+use crate::{
+    values::{
+        cant_convert_err, CustomValueSupport, NuDataFrame, NuExpression, NuLazyFrame,
+        PolarsPluginObject, PolarsPluginType,
+    },
+    PolarsPlugin,
+};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type,
 };
-use polars::prelude::{DatetimeMethods, IntoSeries};
+use polars::{
+    prelude::{col, DatetimeMethods, IntoSeries, NamedFrom},
+    series::Series,
+};
 
 #[derive(Clone)]
 pub struct GetMinute;
@@ -25,28 +31,50 @@ impl PluginCommand for GetMinute {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_type(
-                Type::Custom("dataframe".into()),
-                Type::Custom("dataframe".into()),
-            )
+            .input_output_types(vec![
+                (
+                    Type::Custom("dataframe".into()),
+                    Type::Custom("dataframe".into()),
+                ),
+                (
+                    Type::Custom("expression".into()),
+                    Type::Custom("expression".into()),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Returns minute from a date",
-            example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+        vec![
+            Example {
+                description: "Returns minute from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
     let df = ([$dt $dt] | polars into-df);
     $df | polars get-minute"#,
-            result: Some(
-                NuDataFrame::try_from_series(
-                    Series::new("0".into(), &[39i8, 39]),
-                    Span::test_data(),
-                )
-                .expect("simple df for test should not fail")
-                .into_value(Span::test_data()),
-            ),
-        }]
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[39i8, 39]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                description: "Returns minute from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+    let df = ([$dt $dt] | polars into-df);
+    $df | polars select (polars col 0 | polars get-minute)"#,
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[39i8, 39]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
     }
 
     fn run(
@@ -66,7 +94,42 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let df = NuDataFrame::try_from_pipeline_coerce(plugin, input, call.head)?;
+    let value = input.into_value(call.head)?;
+
+    match PolarsPluginObject::try_from_value(plugin, &value)? {
+        PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),
+        PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
+        PolarsPluginObject::NuExpression(expr) => {
+            let res: NuExpression = expr.into_polars().dt().minute().into();
+            res.to_pipeline_data(plugin, engine, call.head)
+        }
+        _ => Err(cant_convert_err(
+            &value,
+            &[
+                PolarsPluginType::NuDataFrame,
+                PolarsPluginType::NuLazyFrame,
+                PolarsPluginType::NuExpression,
+            ],
+        )),
+    }
+}
+
+fn command_lazy(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    lazy: NuLazyFrame,
+) -> Result<PipelineData, ShellError> {
+    NuLazyFrame::new(false, lazy.to_polars().select([col("*").dt().minute()]))
+        .to_pipeline_data(plugin, engine, call.head)
+}
+
+fn command_eager(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    df: NuDataFrame,
+) -> Result<PipelineData, ShellError> {
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| ShellError::GenericError {

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_month.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_month.rs
@@ -1,13 +1,17 @@
-use crate::{values::CustomValueSupport, PolarsPlugin};
-
-use super::super::super::values::NuDataFrame;
+use crate::{
+    values::{
+        cant_convert_err, CustomValueSupport, NuDataFrame, NuExpression, NuLazyFrame,
+        PolarsPluginObject, PolarsPluginType,
+    },
+    PolarsPlugin,
+};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type,
 };
 use polars::{
-    prelude::{DatetimeMethods, IntoSeries, NamedFrom},
+    prelude::{col, DatetimeMethods, IntoSeries, NamedFrom},
     series::Series,
 };
 
@@ -27,25 +31,50 @@ impl PluginCommand for GetMonth {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_type(
-                Type::Custom("dataframe".into()),
-                Type::Custom("dataframe".into()),
-            )
+            .input_output_types(vec![
+                (
+                    Type::Custom("dataframe".into()),
+                    Type::Custom("dataframe".into()),
+                ),
+                (
+                    Type::Custom("expression".into()),
+                    Type::Custom("expression".into()),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Returns month from a date",
-            example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+        vec![
+            Example {
+                description: "Returns month from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
     let df = ([$dt $dt] | polars into-df);
     $df | polars get-month"#,
-            result: Some(
-                NuDataFrame::try_from_series(Series::new("0".into(), &[8i8, 8]), Span::test_data())
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[8i8, 8]),
+                        Span::test_data(),
+                    )
                     .expect("simple df for test should not fail")
                     .into_value(Span::test_data()),
-            ),
-        }]
+                ),
+            },
+            Example {
+                description: "Returns month from a date in an expression",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+    let df = ([$dt $dt] | polars into-df);
+    $df | polars select (polars col 0 | polars get-month)"#,
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[8i8, 8]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
     }
 
     fn run(
@@ -65,7 +94,42 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let df = NuDataFrame::try_from_pipeline_coerce(plugin, input, call.head)?;
+    let value = input.into_value(call.head)?;
+
+    match PolarsPluginObject::try_from_value(plugin, &value)? {
+        PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),
+        PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
+        PolarsPluginObject::NuExpression(expr) => {
+            let res: NuExpression = expr.into_polars().dt().month().into();
+            res.to_pipeline_data(plugin, engine, call.head)
+        }
+        _ => Err(cant_convert_err(
+            &value,
+            &[
+                PolarsPluginType::NuDataFrame,
+                PolarsPluginType::NuLazyFrame,
+                PolarsPluginType::NuExpression,
+            ],
+        )),
+    }
+}
+
+fn command_lazy(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    lazy: NuLazyFrame,
+) -> Result<PipelineData, ShellError> {
+    NuLazyFrame::new(false, lazy.to_polars().select([col("*").dt().month()]))
+        .to_pipeline_data(plugin, engine, call.head)
+}
+
+fn command_eager(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    df: NuDataFrame,
+) -> Result<PipelineData, ShellError> {
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| ShellError::GenericError {

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_nanosecond.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_nanosecond.rs
@@ -1,13 +1,17 @@
-use crate::{values::CustomValueSupport, PolarsPlugin};
-
-use super::super::super::values::NuDataFrame;
+use crate::{
+    values::{
+        cant_convert_err, CustomValueSupport, NuDataFrame, NuExpression, NuLazyFrame,
+        PolarsPluginObject, PolarsPluginType,
+    },
+    PolarsPlugin,
+};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type,
 };
 use polars::{
-    prelude::{DatetimeMethods, IntoSeries, NamedFrom},
+    prelude::{col, DatetimeMethods, IntoSeries, NamedFrom},
     series::Series,
 };
 
@@ -27,28 +31,50 @@ impl PluginCommand for GetNanosecond {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_type(
-                Type::Custom("dataframe".into()),
-                Type::Custom("dataframe".into()),
-            )
+            .input_output_types(vec![
+                (
+                    Type::Custom("dataframe".into()),
+                    Type::Custom("dataframe".into()),
+                ),
+                (
+                    Type::Custom("expression".into()),
+                    Type::Custom("expression".into()),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Returns nanosecond from a date",
-            example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+        vec![
+            Example {
+                description: "Returns nanosecond from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
     let df = ([$dt $dt] | polars into-df);
     $df | polars get-nanosecond"#,
-            result: Some(
-                NuDataFrame::try_from_series(
-                    Series::new("0".into(), &[0i32, 0]),
-                    Span::test_data(),
-                )
-                .expect("simple df for test should not fail")
-                .into_value(Span::test_data()),
-            ),
-        }]
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[0i32, 0]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                description: "Returns nanosecond from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+    let df = ([$dt $dt] | polars into-df);
+    $df | polars select (polars col 0 | polars get-nanosecond)"#,
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[0i32, 0]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
     }
 
     fn run(
@@ -68,7 +94,42 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let df = NuDataFrame::try_from_pipeline_coerce(plugin, input, call.head)?;
+    let value = input.into_value(call.head)?;
+
+    match PolarsPluginObject::try_from_value(plugin, &value)? {
+        PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),
+        PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
+        PolarsPluginObject::NuExpression(expr) => {
+            let res: NuExpression = expr.into_polars().dt().nanosecond().into();
+            res.to_pipeline_data(plugin, engine, call.head)
+        }
+        _ => Err(cant_convert_err(
+            &value,
+            &[
+                PolarsPluginType::NuDataFrame,
+                PolarsPluginType::NuLazyFrame,
+                PolarsPluginType::NuExpression,
+            ],
+        )),
+    }
+}
+
+fn command_lazy(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    lazy: NuLazyFrame,
+) -> Result<PipelineData, ShellError> {
+    NuLazyFrame::new(false, lazy.to_polars().select([col("*").dt().nanosecond()]))
+        .to_pipeline_data(plugin, engine, call.head)
+}
+
+fn command_eager(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    df: NuDataFrame,
+) -> Result<PipelineData, ShellError> {
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| ShellError::GenericError {

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_ordinal.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_ordinal.rs
@@ -1,13 +1,17 @@
-use crate::{values::CustomValueSupport, PolarsPlugin};
-
-use super::super::super::values::NuDataFrame;
+use crate::{
+    values::{
+        cant_convert_err, CustomValueSupport, NuDataFrame, NuExpression, NuLazyFrame,
+        PolarsPluginObject, PolarsPluginType,
+    },
+    PolarsPlugin,
+};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type,
 };
 use polars::{
-    prelude::{DatetimeMethods, IntoSeries, NamedFrom},
+    prelude::{col, DatetimeMethods, IntoSeries, NamedFrom},
     series::Series,
 };
 
@@ -27,28 +31,50 @@ impl PluginCommand for GetOrdinal {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_type(
-                Type::Custom("dataframe".into()),
-                Type::Custom("dataframe".into()),
-            )
+            .input_output_types(vec![
+                (
+                    Type::Custom("dataframe".into()),
+                    Type::Custom("dataframe".into()),
+                ),
+                (
+                    Type::Custom("expression".into()),
+                    Type::Custom("expression".into()),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Returns ordinal from a date",
-            example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+        vec![
+            Example {
+                description: "Returns ordinal from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
     let df = ([$dt $dt] | polars into-df);
     $df | polars get-ordinal"#,
-            result: Some(
-                NuDataFrame::try_from_series(
-                    Series::new("0".into(), &[217i16, 217]),
-                    Span::test_data(),
-                )
-                .expect("simple df for test should not fail")
-                .into_value(Span::test_data()),
-            ),
-        }]
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[217i16, 217]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                description: "Returns ordinal from a date in an expression",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+    let df = ([$dt $dt] | polars into-df);
+    $df | polars select (polars col 0 | polars get-ordinal)"#,
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[217i16, 217]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
     }
 
     fn run(
@@ -68,7 +94,45 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let df = NuDataFrame::try_from_pipeline_coerce(plugin, input, call.head)?;
+    let value = input.into_value(call.head)?;
+
+    match PolarsPluginObject::try_from_value(plugin, &value)? {
+        PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),
+        PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
+        PolarsPluginObject::NuExpression(expr) => {
+            let res: NuExpression = expr.into_polars().dt().ordinal_day().into();
+            res.to_pipeline_data(plugin, engine, call.head)
+        }
+        _ => Err(cant_convert_err(
+            &value,
+            &[
+                PolarsPluginType::NuDataFrame,
+                PolarsPluginType::NuLazyFrame,
+                PolarsPluginType::NuExpression,
+            ],
+        )),
+    }
+}
+
+fn command_lazy(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    lazy: NuLazyFrame,
+) -> Result<PipelineData, ShellError> {
+    NuLazyFrame::new(
+        false,
+        lazy.to_polars().select([col("*").dt().ordinal_day()]),
+    )
+    .to_pipeline_data(plugin, engine, call.head)
+}
+
+fn command_eager(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    df: NuDataFrame,
+) -> Result<PipelineData, ShellError> {
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| ShellError::GenericError {

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_second.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_second.rs
@@ -1,13 +1,17 @@
-use crate::{values::CustomValueSupport, PolarsPlugin};
-
-use super::super::super::values::NuDataFrame;
+use crate::{
+    values::{
+        cant_convert_err, CustomValueSupport, NuDataFrame, NuExpression, NuLazyFrame,
+        PolarsPluginObject, PolarsPluginType,
+    },
+    PolarsPlugin,
+};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type,
 };
 use polars::{
-    prelude::{DatetimeMethods, IntoSeries, NamedFrom},
+    prelude::{col, DatetimeMethods, IntoSeries, NamedFrom},
     series::Series,
 };
 
@@ -27,28 +31,50 @@ impl PluginCommand for GetSecond {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_type(
-                Type::Custom("dataframe".into()),
-                Type::Custom("dataframe".into()),
-            )
+            .input_output_types(vec![
+                (
+                    Type::Custom("dataframe".into()),
+                    Type::Custom("dataframe".into()),
+                ),
+                (
+                    Type::Custom("expression".into()),
+                    Type::Custom("expression".into()),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Returns second from a date",
-            example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+        vec![
+            Example {
+                description: "Returns second from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
     let df = ([$dt $dt] | polars into-df);
     $df | polars get-second"#,
-            result: Some(
-                NuDataFrame::try_from_series(
-                    Series::new("0".into(), &[18i8, 18]),
-                    Span::test_data(),
-                )
-                .expect("simple df for test should not fail")
-                .into_value(Span::test_data()),
-            ),
-        }]
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[18i8, 18]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                description: "Returns second from a date in an expression",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+    let df = ([$dt $dt] | polars into-df);
+    $df | polars select (polars col 0 | polars get-second)"#,
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[18i8, 18]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
     }
 
     fn run(
@@ -68,7 +94,42 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let df = NuDataFrame::try_from_pipeline_coerce(plugin, input, call.head)?;
+    let value = input.into_value(call.head)?;
+
+    match PolarsPluginObject::try_from_value(plugin, &value)? {
+        PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),
+        PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
+        PolarsPluginObject::NuExpression(expr) => {
+            let res: NuExpression = expr.into_polars().dt().second().into();
+            res.to_pipeline_data(plugin, engine, call.head)
+        }
+        _ => Err(cant_convert_err(
+            &value,
+            &[
+                PolarsPluginType::NuDataFrame,
+                PolarsPluginType::NuLazyFrame,
+                PolarsPluginType::NuExpression,
+            ],
+        )),
+    }
+}
+
+fn command_lazy(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    lazy: NuLazyFrame,
+) -> Result<PipelineData, ShellError> {
+    NuLazyFrame::new(false, lazy.to_polars().select([col("*").dt().second()]))
+        .to_pipeline_data(plugin, engine, call.head)
+}
+
+fn command_eager(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    df: NuDataFrame,
+) -> Result<PipelineData, ShellError> {
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| ShellError::GenericError {

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_week.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_week.rs
@@ -1,13 +1,17 @@
-use crate::{values::CustomValueSupport, PolarsPlugin};
-
-use super::super::super::values::NuDataFrame;
+use crate::{
+    values::{
+        cant_convert_err, CustomValueSupport, NuDataFrame, NuExpression, NuLazyFrame,
+        PolarsPluginObject, PolarsPluginType,
+    },
+    PolarsPlugin,
+};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type,
 };
 use polars::{
-    prelude::{DatetimeMethods, IntoSeries, NamedFrom},
+    prelude::{col, DatetimeMethods, IntoSeries, NamedFrom},
     series::Series,
 };
 
@@ -27,28 +31,50 @@ impl PluginCommand for GetWeek {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_type(
-                Type::Custom("dataframe".into()),
-                Type::Custom("dataframe".into()),
-            )
+            .input_output_types(vec![
+                (
+                    Type::Custom("dataframe".into()),
+                    Type::Custom("dataframe".into()),
+                ),
+                (
+                    Type::Custom("expression".into()),
+                    Type::Custom("expression".into()),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Returns week from a date",
-            example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+        vec![
+            Example {
+                description: "Returns week from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
     let df = ([$dt $dt] | polars into-df);
     $df | polars get-week"#,
-            result: Some(
-                NuDataFrame::try_from_series(
-                    Series::new("0".into(), &[32i8, 32]),
-                    Span::test_data(),
-                )
-                .expect("simple df for test should not fail")
-                .into_value(Span::test_data()),
-            ),
-        }]
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[32i8, 32]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                description: "Returns week from a date in an expression",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+    let df = ([$dt $dt] | polars into-df);
+    $df | polars select (polars col 0 | polars get-week)"#,
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[32i8, 32]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
     }
 
     fn run(
@@ -68,7 +94,42 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let df = NuDataFrame::try_from_pipeline_coerce(plugin, input, call.head)?;
+    let value = input.into_value(call.head)?;
+
+    match PolarsPluginObject::try_from_value(plugin, &value)? {
+        PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),
+        PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
+        PolarsPluginObject::NuExpression(expr) => {
+            let res: NuExpression = expr.into_polars().dt().week().into();
+            res.to_pipeline_data(plugin, engine, call.head)
+        }
+        _ => Err(cant_convert_err(
+            &value,
+            &[
+                PolarsPluginType::NuDataFrame,
+                PolarsPluginType::NuLazyFrame,
+                PolarsPluginType::NuExpression,
+            ],
+        )),
+    }
+}
+
+fn command_lazy(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    lazy: NuLazyFrame,
+) -> Result<PipelineData, ShellError> {
+    NuLazyFrame::new(false, lazy.to_polars().select([col("*").dt().week()]))
+        .to_pipeline_data(plugin, engine, call.head)
+}
+
+fn command_eager(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    df: NuDataFrame,
+) -> Result<PipelineData, ShellError> {
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| ShellError::GenericError {

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs
@@ -1,13 +1,17 @@
-use crate::{values::CustomValueSupport, PolarsPlugin};
-
-use super::super::super::values::NuDataFrame;
+use crate::{
+    values::{
+        cant_convert_err, CustomValueSupport, NuDataFrame, NuExpression, NuLazyFrame,
+        PolarsPluginObject, PolarsPluginType,
+    },
+    PolarsPlugin,
+};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type,
 };
 use polars::{
-    prelude::{DatetimeMethods, IntoSeries, NamedFrom},
+    prelude::{col, DatetimeMethods, IntoSeries, NamedFrom},
     series::Series,
 };
 
@@ -27,25 +31,50 @@ impl PluginCommand for GetWeekDay {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_type(
-                Type::Custom("dataframe".into()),
-                Type::Custom("dataframe".into()),
-            )
+            .input_output_types(vec![
+                (
+                    Type::Custom("dataframe".into()),
+                    Type::Custom("dataframe".into()),
+                ),
+                (
+                    Type::Custom("expression".into()),
+                    Type::Custom("expression".into()),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Returns weekday from a date",
-            example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+        vec![
+            Example {
+                description: "Returns weekday from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
     let df = ([$dt $dt] | polars into-df);
     $df | polars get-weekday"#,
-            result: Some(
-                NuDataFrame::try_from_series(Series::new("0".into(), &[2i8, 2]), Span::test_data())
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[2i8, 2]),
+                        Span::test_data(),
+                    )
                     .expect("simple df for test should not fail")
                     .into_value(Span::test_data()),
-            ),
-        }]
+                ),
+            },
+            Example {
+                description: "Returns weekday from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+    let df = ([$dt $dt] | polars into-df);
+    $df | polars select (polars col 0 | polars get-weekday)"#,
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[2i8, 2]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
     }
 
     fn run(
@@ -65,7 +94,42 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let df = NuDataFrame::try_from_pipeline_coerce(plugin, input, call.head)?;
+    let value = input.into_value(call.head)?;
+
+    match PolarsPluginObject::try_from_value(plugin, &value)? {
+        PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),
+        PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
+        PolarsPluginObject::NuExpression(expr) => {
+            let res: NuExpression = expr.into_polars().dt().weekday().into();
+            res.to_pipeline_data(plugin, engine, call.head)
+        }
+        _ => Err(cant_convert_err(
+            &value,
+            &[
+                PolarsPluginType::NuDataFrame,
+                PolarsPluginType::NuLazyFrame,
+                PolarsPluginType::NuExpression,
+            ],
+        )),
+    }
+}
+
+fn command_lazy(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    lazy: NuLazyFrame,
+) -> Result<PipelineData, ShellError> {
+    NuLazyFrame::new(false, lazy.to_polars().select([col("*").dt().weekday()]))
+        .to_pipeline_data(plugin, engine, call.head)
+}
+
+fn command_eager(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    df: NuDataFrame,
+) -> Result<PipelineData, ShellError> {
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| ShellError::GenericError {

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs
@@ -1,13 +1,17 @@
-use crate::{values::CustomValueSupport, PolarsPlugin};
-
-use super::super::super::values::NuDataFrame;
+use crate::{
+    values::{
+        cant_convert_err, CustomValueSupport, NuDataFrame, NuExpression, NuLazyFrame,
+        PolarsPluginObject, PolarsPluginType,
+    },
+    PolarsPlugin,
+};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type,
 };
 use polars::{
-    prelude::{DatetimeMethods, IntoSeries, NamedFrom},
+    prelude::{col, DatetimeMethods, IntoSeries, NamedFrom},
     series::Series,
 };
 
@@ -27,28 +31,50 @@ impl PluginCommand for GetYear {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_type(
-                Type::Custom("dataframe".into()),
-                Type::Custom("dataframe".into()),
-            )
+            .input_output_types(vec![
+                (
+                    Type::Custom("dataframe".into()),
+                    Type::Custom("dataframe".into()),
+                ),
+                (
+                    Type::Custom("expression".into()),
+                    Type::Custom("expression".into()),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Returns year from a date",
-            example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+        vec![
+            Example {
+                description: "Returns year from a date",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
     let df = ([$dt $dt] | polars into-df);
     $df | polars get-year"#,
-            result: Some(
-                NuDataFrame::try_from_series(
-                    Series::new("0".into(), &[2020i32, 2020]),
-                    Span::test_data(),
-                )
-                .expect("simple df for test should not fail")
-                .into_value(Span::test_data()),
-            ),
-        }]
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[2020i32, 2020]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                description: "Returns year from a date in an expression",
+                example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
+    let df = ([$dt $dt] | polars into-df);
+    $df | polars select (polars col 0 | polars get-year)"#,
+                result: Some(
+                    NuDataFrame::try_from_series(
+                        Series::new("0".into(), &[2020i32, 2020]),
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
     }
 
     fn run(
@@ -68,7 +94,42 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let df = NuDataFrame::try_from_pipeline_coerce(plugin, input, call.head)?;
+    let value = input.into_value(call.head)?;
+
+    match PolarsPluginObject::try_from_value(plugin, &value)? {
+        PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),
+        PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
+        PolarsPluginObject::NuExpression(expr) => {
+            let res: NuExpression = expr.into_polars().dt().year().into();
+            res.to_pipeline_data(plugin, engine, call.head)
+        }
+        _ => Err(cant_convert_err(
+            &value,
+            &[
+                PolarsPluginType::NuDataFrame,
+                PolarsPluginType::NuLazyFrame,
+                PolarsPluginType::NuExpression,
+            ],
+        )),
+    }
+}
+
+fn command_lazy(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    lazy: NuLazyFrame,
+) -> Result<PipelineData, ShellError> {
+    NuLazyFrame::new(false, lazy.to_polars().select([col("*").dt().year()]))
+        .to_pipeline_data(plugin, engine, call.head)
+}
+
+fn command_eager(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    df: NuDataFrame,
+) -> Result<PipelineData, ShellError> {
     let series = df.as_series(call.head)?;
 
     let casted = series.datetime().map_err(|e| ShellError::GenericError {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR updates the following functions so they may also be used in a polars expression:

- `polars get-day`
- `polars get-hour`
- `polars get-minute`
- `polars get-month`
- `polars get-nanosecond`
- `polars get-ordinal`
- `polars get-second`
- `polars get-week`
- `polars get-weekday`
- `polars get-year`

Below examples provide a comparison of the two contexts in which each of these commands may be used:

```nushell
# Returns day from a date (current use case)
  > let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
    let df = ([$dt $dt] | polars into-df);
    $df | polars get-day
  ╭───┬───╮
  │ # │ 0 │
  ├───┼───┤
  │ 0 │ 4 │
  │ 1 │ 4 │
  ╰───┴───╯

# Returns day from a date in an expression (additional use case provided by this PR)
  > let dt = ('2020-08-04T16:39:18+00:00' | into datetime --timezone 'UTC');
    let df = ([$dt $dt] | polars into-df);
    $df | polars select (polars col 0 | polars get-day)
  ╭───┬───╮
  │ # │ 0 │
  ├───┼───┤
  │ 0 │ 4 │
  │ 1 │ 4 │
  ╰───┴───╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
No breaking changes. Each of these functions retains its current behavior and gains the benefit that they can now be used in an expression as well.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Tests have been added to each of the examples.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
