### PR TITLE
Fix examples about RFC3339 format in `date now` and `format date`.

### DIFF
--- a/crates/nu-command/src/date/now.rs
+++ b/crates/nu-command/src/date/now.rs
@@ -58,6 +58,12 @@ impl Command for DateNow {
                 example: r#"(date now) - 2019-05-01T04:12:05.20+08:00"#,
                 result: None,
             },
+            Example {
+                description:
+                    "Get current time and format it in the debug format (RFC 2822 with timezone)",
+                example: r#"date now | debug"#,
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/date/now.rs
+++ b/crates/nu-command/src/date/now.rs
@@ -43,6 +43,11 @@ impl Command for DateNow {
                 result: None,
             },
             Example {
+                description: "Get the current date and display it in RFC3339 format string.",
+                example: r#"date now | format date "%+""#,
+                result: None,
+            },
+            Example {
                 description: "Get the time duration since 2019-04-30.",
                 example: r#"(date now) - 2019-05-01"#,
                 result: None,
@@ -50,11 +55,6 @@ impl Command for DateNow {
             Example {
                 description: "Get the time duration since a more specific time.",
                 example: r#"(date now) - 2019-05-01T04:12:05.20+08:00"#,
-                result: None,
-            },
-            Example {
-                description: "Get current time in full RFC 3339 format with time zone.",
-                example: r#"date now | debug"#,
                 result: None,
             },
         ]

--- a/crates/nu-command/src/date/now.rs
+++ b/crates/nu-command/src/date/now.rs
@@ -38,12 +38,13 @@ impl Command for DateNow {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Get the current date and display it in a given format string.",
+                description: "Get the current date and format it in a given format string.",
                 example: r#"date now | format date "%Y-%m-%d %H:%M:%S""#,
                 result: None,
             },
             Example {
-                description: "Get the current date and display it in RFC3339 format string.",
+                description:
+                    "Get the current date and format it according to the RFC 3339 standard.",
                 example: r#"date now | format date "%+""#,
                 result: None,
             },

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -62,6 +62,14 @@ impl Command for FormatDate {
                 )),
             },
             Example {
+                description: "Format a given date-time using the RFC3339 format.",
+                example: r#"'2021-10-22 20:00:12 +01:00' | into datetime | format date "%+""#,
+                result: Some(Value::string(
+                    "2021-10-22T20:00:12+01:00".to_string(),
+                    Span::test_data(),
+                )),
+            },
+            Example {
                 description: "Format the current date-time using a given format string.",
                 example: r#"date now | format date "%Y-%m-%d %H:%M:%S""#,
                 result: None,

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -62,7 +62,7 @@ impl Command for FormatDate {
                 )),
             },
             Example {
-                description: "Format a given date-time using the RFC3339 format.",
+                description: "Format a given date-time according to the RFC 3339 standard.",
                 example: r#"'2021-10-22 20:00:12 +01:00' | into datetime | format date "%+""#,
                 result: Some(Value::string(
                     "2021-10-22T20:00:12+01:00".to_string(),


### PR DESCRIPTION
Replace example on `date now | debug` with `date now | format date "%+"`. Add RFC3339 "%+" format string example on `format date`.

Users can now find how to format date-time to RFC3339.

FIXES: #15168

<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Documentation will now provide users examples on how to print RFC3339 strings.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Corrects documentation.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
