### PR TITLE
allow `into duration` to accept space between number and unit

### DIFF
--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -217,7 +217,7 @@ fn compound_to_duration(s: &str, span: Span) -> Result<i64, ShellError> {
     Ok(duration_ns)
 }
 
-fn string_to_duration(s: &str, span: Span, flag: bool) -> Result<i64, ShellError> {
+fn string_to_duration(s: &str, span: Span, has_space: bool) -> Result<i64, ShellError> {
     if let Some(Ok(expression)) = parse_unit_value(
         s.as_bytes(),
         span,
@@ -249,7 +249,7 @@ fn string_to_duration(s: &str, span: Span, flag: bool) -> Result<i64, ShellError
         details: s.to_string(),
         dst_span: span,
         src_span: span,
-        help: Some(if flag {
+        help: Some(if has_space {
             format!("{}\n{}", whitespace_msg, units_msg)
         } else {
             units_msg

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -244,7 +244,7 @@ fn string_to_duration(s: &str, span: Span, flag: bool) -> Result<i64, ShellError
 
     let units_msg = "supported units are ns, us/µs, ms, sec, min, hr, day, and wk".to_string();
     let whitespace_msg =
-        "a number after white space should be followed by a valid unit.".to_string();
+        "a number after whitespace should be followed by a valid unit.".to_string();
     Err(ShellError::CantConvertToDuration {
         details: s.to_string(),
         dst_span: span,


### PR DESCRIPTION

<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

![image](https://github.com/user-attachments/assets/aaa17cbd-1d21-428c-bf5f-9ee3bb9a40b1)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

now you can put whitespace between the number and the unit for the pipeline input of `into duration`

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
done.
# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
