### PR TITLE
chore: move 'job' to experimental category

### DIFF
--- a/crates/nu-command/src/experimental/job.rs
+++ b/crates/nu-command/src/experimental/job.rs
@@ -10,7 +10,7 @@ impl Command for Job {
 
     fn signature(&self) -> Signature {
         Signature::build("job")
-            .category(Category::Strings)
+            .category(Category::Experimental)
             .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 


### PR DESCRIPTION
# Description

The 'job' command was incorrectly placed into the "Strings" category rather than the "Experimental" category like its subcommands. This PR resolves that issues.

# User-Facing Changes

Changes to where the `job` command is found when using the `help` command or reading the documentation.

# Tests + Formatting

I got an error about an unrelated part of the code:  

```bash
error: this `repeat().take()` can be written more concisely
  --> crates/nu-table/src/util.rs:45:29
   |
45 |                 line.extend(repeat(' ').take(remain));
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(' ', remain)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n
   = note: `-D clippy::manual-repeat-n` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::manual_repeat_n)]`

error: could not compile `nu-table` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
- :green_circle: `toolkit fmt`
- :red_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`
```

I've made the change locally and all the tests pass; should I include that fix in this PR or a separate one?