### PR TITLE
Add env-conversions helpers to std

### DIFF
--- a/crates/nu-std/std/config/mod.nu
+++ b/crates/nu-std/std/config/mod.nu
@@ -133,3 +133,13 @@ export def light-theme [] {
         shape_raw_string: light_purple
     }
 }
+
+# Returns helper closures that can be used for ENV_CONVERSIONS and other purposes
+export def env-conversions [] {
+    {
+        "path": {
+            from_string: {|s| $s | split row (char esep) | path expand --no-symlink }
+            to_string: {|v| $v | path expand --no-symlink | str join (char esep) }
+        }
+    }
+}


### PR DESCRIPTION
When combined with [the Cookbook update](https://github.com/nushell/nushell.github.io/pull/1878), this resolves #15452

# Description

When we removed the startup `ENV_CONVERSION` for path, as noted in the issue above, we removed the ability for users to access this closure for other purposes. This PR adds the PATH closures back as a `std` commands that outputs a record of closures (similar to `ENV_CONVERSIONS`).

# User-Facing Changes

Doc will be updated and users can once again easily access `direnv`

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

Doc PR to be merged when released in 0.104