### PR TITLE
Fix output type of `polars schema`

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/core/schema.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/schema.rs
@@ -25,10 +25,7 @@ impl PluginCommand for SchemaCmd {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .switch("datatype-list", "creates a lazy dataframe", Some('l'))
-            .input_output_type(
-                Type::Custom("dataframe".into()),
-                Type::Custom("dataframe".into()),
-            )
+            .input_output_type(Type::Custom("dataframe".into()), Type::record())
             .category(Category::Custom("dataframe".into()))
     }
 


### PR DESCRIPTION
# Description
Output type of `polars schema` signature output type is of dataframe. It should be of type record.

# User-Facing Changes
- `polars schema` - how has an output type of record