### PR TITLE
fix eval_ir error

### DIFF
--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -476,8 +476,11 @@ fn pipe_redirection_in_let_and_mut(
 
 #[test]
 fn redirect_file_with_subexpression() {
-    let actual = nu!(format!(
-        "$env.BAZ = 'foo'; (nu --testbin echo_env BAZ) o> out_file; open -r out_file"
-    ));
-    assert_eq!(actual.out, "foo");
+    Playground::setup("redirection_file_with_subexpression", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(),
+            "$env.BAZ = 'foo'; (nu --testbin echo_env BAZ) o> out_file; open -r out_file"
+        );
+        assert_eq!(actual.out, "foo");
+    })
 }

--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -473,3 +473,11 @@ fn pipe_redirection_in_let_and_mut(
     );
     assert_eq!(actual.out, output);
 }
+
+#[test]
+fn redirect_file_with_subexpression() {
+    let actual = nu!(format!(
+        "$env.BAZ = 'foo'; (nu --testbin echo_env BAZ) o> out_file; open -r out_file"
+    ));
+    assert_eq!(actual.out, "foo");
+}

--- a/crates/nu-engine/src/compile/expression.rs
+++ b/crates/nu-engine/src/compile/expression.rs
@@ -202,7 +202,14 @@ pub(crate) fn compile_expression(
         }
         Expr::Subexpression(block_id) => {
             let block = working_set.get_block(*block_id);
-            compile_block(working_set, builder, block, redirect_modes, in_reg, out_reg)
+            compile_block(
+                working_set,
+                builder,
+                block,
+                RedirectModes::value(expr.span),
+                in_reg,
+                out_reg,
+            )
         }
         Expr::Block(block_id) => lit(builder, Literal::Block(*block_id)),
         Expr::Closure(block_id) => lit(builder, Literal::Closure(*block_id)),

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -1,4 +1,3 @@
-use nix::NixPath;
 use nu_test_support::fs::Stub::{EmptyFile, FileWithContent};
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -1,3 +1,4 @@
+use nix::NixPath;
 use nu_test_support::fs::Stub::{EmptyFile, FileWithContent};
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
@@ -212,9 +213,9 @@ fn run_glob_if_pass_variable_to_external() {
 }
 
 #[test]
-fn subexpression_does_not_implicitly_capture() {
+fn subexpression_does_should_capture() {
     let actual = nu!("(nu --testbin cococo); null");
-    assert_eq!(actual.out, "cococo");
+    assert!(actual.out.is_empty());
 }
 
 mod it_evaluation {


### PR DESCRIPTION
# Description
Fixes: #15326

It applies the suggestion from @blindFS .
In detail, all subexpression's result should be redirected to a value.

# User-Facing Changes
`("test") o> out.txt` no longer results to an error

# Tests + Formatting
Added 1 test.

# After Submitting
NaN
