### PR TITLE
fix(polars): cast as date now returns Date type instead of Datetime<ns>

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/as_date.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/as_date.rs
@@ -4,7 +4,8 @@ use super::super::super::values::NuDataFrame;
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, SyntaxShape, Type,
+    record, Category, Example, LabeledError, PipelineData, ShellError, Signature, Span,
+    SyntaxShape, Type, Value,
 };
 use polars::prelude::{IntoSeries, StringMethods};
 
@@ -51,6 +52,16 @@ impl PluginCommand for AsDate {
                 description: "Converts string to date",
                 example: r#"["2021-12-30" "2021-12-31 21:00:00"] | polars into-df | polars as-date "%Y-%m-%d" --not-exact"#,
                 result: None,
+            },
+            Example {
+                description: "Output is of date type",
+                example: r#"["2021-12-30" "2021-12-31 21:00:00"] | polars into-df | polars as-date "%Y-%m-%d" --not-exact | polars schema"#,
+                result: Some(Value::record(
+                    record! {
+                        "date" => Value::string("date", Span::test_data()),
+                    },
+                    Span::test_data(),
+                )),
             },
         ]
     }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR fixes the bug where various commands that cast a column as a `date` type would return `datetime<ns>` rather than the intended type `date`. Affected commands include `polars into-df --schema`, `polars into-lazy --schema`, `polars as-date`, and `polars cast date`.

This bug derives from the fact that Nushell uses the `date` type to denote a datetime type whereas polars differentiates between `Date` and `Datetime` types. By default, this PR retains the behavior that a Nushell `date` type will be mapped to a polars `Datetime<ns>` unless otherwise specified.

```nushell
#  Current (erroneous) implementation
> [[a]; [2025-03-20]] | polars into-df --schema {a: "date"} | polars schema
╭───┬──────────────╮
│ a │ datetime<ns> │
╰───┴──────────────╯

#  Fixed implementation
> [[a]; [2025-03-20]] | polars into-df --schema {a: "date"} | polars schema
╭───┬──────╮
│ a │ date │
╰───┴──────╯

#  Fixed implementation: by default, Nushell dates map to datetime<ns>
> [[a]; [2025-03-20]] | polars into-df | polars schema
╭───┬───────────────────╮
│ a │ datetime<ns, UTC> │
╰───┴───────────────────╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Soft breaking change: users previously who wanted to cast a date column to type `date` can now expect the output to be type `date` instead of `datetime<ns>`.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Example test added to `polars as-date` command.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
