### PR TITLE
replace repeat().take() with repeat_n()

### DIFF
--- a/crates/nu-command/src/experimental/job.rs
+++ b/crates/nu-command/src/experimental/job.rs
@@ -10,7 +10,7 @@ impl Command for Job {
 
     fn signature(&self) -> Signature {
         Signature::build("job")
-            .category(Category::Strings)
+            .category(Category::Experimental)
             .input_output_types(vec![(Type::Nothing, Type::String)])
     }
 

--- a/crates/nu-table/src/util.rs
+++ b/crates/nu-table/src/util.rs
@@ -32,7 +32,7 @@ pub fn string_wrap(text: &str, width: usize, keep_words: bool) -> String {
 }
 
 pub fn string_expand(text: &str, width: usize) -> String {
-    use std::{borrow::Cow, iter::repeat};
+    use std::{borrow::Cow, iter::repeat_n};
     use tabled::grid::util::string::{get_line_width, get_lines};
 
     get_lines(text)
@@ -42,7 +42,7 @@ pub fn string_expand(text: &str, width: usize) -> String {
             if length < width {
                 let mut line = line.into_owned();
                 let remain = width - length;
-                line.extend(repeat(' ').take(remain));
+                line.extend(repeat_n(' ', remain));
                 Cow::Owned(line)
             } else {
                 line


### PR DESCRIPTION
# Description

This updates `string_expand()` in nu-table's util.rs to use the `std::iter` library's `repeat_n()` function, which was suggested as a more readable version of the existing `repeat().take()` implementation.

# User-Facing Changes
 
Should have no user facing changes.

# Tests + Formatting

All green circles!
```
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib
```