### PR TITLE
fix(lsp): a panic caused by completion with decl_id out of range

### DIFF
--- a/crates/nu-cli/src/completions/exportable_completions.rs
+++ b/crates/nu-cli/src/completions/exportable_completions.rs
@@ -69,7 +69,8 @@ impl Completer for ExportableCompletion<'_> {
                     wrapped_name(name),
                     Some(cmd.description().to_string()),
                     None,
-                    SuggestionKind::Command(cmd.command_type(), Some(*decl_id)),
+                    // `None` here avoids arguments being expanded by snippet edit style for lsp
+                    SuggestionKind::Command(cmd.command_type(), None),
                 );
             }
         }

--- a/tests/fixtures/lsp/completion/command.nu
+++ b/tests/fixtures/lsp/completion/command.nu
@@ -10,3 +10,5 @@ def "config n foo bar" [
   echo "🤔🐘"
   | str substring (str substring -)
 }
+
+config n # don't panic!


### PR DESCRIPTION
Fixes a bug caused by #15536 
Sorry about that, @fdncred 

# Description

I've made the panic reproducible in the test case.

TLDR: completer will sometimes return new decl_ids outside of the range of the engine_state passed in.

# User-Facing Changes

bug fix

# Tests + Formatting

+1

# After Submitting
