### PR TITLE
Fix `kv set` with a closure argument

### DIFF
--- a/crates/nu-std/std-rfc/kv/mod.nu
+++ b/crates/nu-std/std-rfc/kv/mod.nu
@@ -38,7 +38,7 @@ export def "kv set" [
   # If passed a closure, execute it
   let arg_type = ($value_or_closure | describe)
   let value = match $arg_type {
-    closure => { $input | do $value_or_closure }
+    closure => { kv get $key --universal=$universal | do $value_or_closure }
     _ => ($value_or_closure | default $input)
   }
 

--- a/crates/nu-std/tests/test_std-rfc_kv.nu
+++ b/crates/nu-std/tests/test_std-rfc_kv.nu
@@ -83,6 +83,30 @@ def local-transpose_to_record [] {
 }
 
 @test
+def local-using_cellpaths [] {
+    if ('sqlite' not-in (version).features) { return }
+
+    let key = (random uuid)
+    let name_key = (random uuid)
+    let size_key = (random uuid)
+
+    ls
+    | kv set $name_key $in.name
+    | kv set $size_key $in.size
+
+    let expected = "list<string>"
+    let actual = (kv get $name_key | describe)
+    assert equal $actual $expected
+
+    let expected = "list<filesize>"
+    let actual = (kv get $size_key | describe)
+    assert equal $actual $expected
+
+    kv drop $name_key
+    kv drop $size_key
+}
+
+@test
 def local-using_closure [] {
     if ('sqlite' not-in (version).features) { return }
 
@@ -221,6 +245,33 @@ def universal-transpose_to_record [] {
     kv drop -u $key1
     kv drop -u $key2
     kv drop -u $key3
+    rm $env.NU_UNIVERSAL_KV_PATH
+}
+
+@test
+def universal-using_cellpaths [] {
+    if ('sqlite' not-in (version).features) { return }
+
+    let key = (random uuid)
+    $env.NU_UNIVERSAL_KV_PATH = (mktemp -t --suffix .sqlite3)
+
+    let name_key = (random uuid)
+    let size_key = (random uuid)
+
+    ls
+    | kv set -u $name_key $in.name
+    | kv set -u $size_key $in.size
+
+    let expected = "list<string>"
+    let actual = (kv get -u $name_key | describe)
+    assert equal $actual $expected
+
+    let expected = "list<filesize>"
+    let actual = (kv get -u $size_key | describe)
+    assert equal $actual $expected
+
+    kv drop -u $name_key
+    kv drop -u $size_key
     rm $env.NU_UNIVERSAL_KV_PATH
 }
 

--- a/crates/nu-std/tests/test_std-rfc_kv.nu
+++ b/crates/nu-std/tests/test_std-rfc_kv.nu
@@ -153,7 +153,7 @@ def local-return_value_only [] {
     let key = (random uuid)
 
     let expected = 'VALUE'
-    let actual = ('value' | kv set -r v $key {str upcase})
+    let actual = ('value' | kv set -r v $key ($in | str upcase))
 
     assert equal $actual $expected
 
@@ -329,7 +329,7 @@ def universal-return_value_only [] {
     let key = (random uuid)
 
     let expected = 'VALUE'
-    let actual = ('value' | kv set --universal -r v $key {str upcase})
+    let actual = ('value' | kv set --universal -r v $key ($in | str upcase))
 
     assert equal $actual $expected
 

--- a/crates/nu-std/tests/test_std-rfc_kv.nu
+++ b/crates/nu-std/tests/test_std-rfc_kv.nu
@@ -87,23 +87,15 @@ def local-using_closure [] {
     if ('sqlite' not-in (version).features) { return }
 
     let key = (random uuid)
-    let name_key = (random uuid)
-    let size_key = (random uuid)
 
-    ls
-    | kv set $name_key { get name }
-    | kv set $size_key { get size }
+    kv set $key 5
+    kv set $key { $in + 1 }
 
-    let expected = "list<string>"
-    let actual = (kv get $name_key | describe)
+    let expected = 6
+    let actual = (kv get $key)
     assert equal $actual $expected
 
-    let expected = "list<filesize>"
-    let actual = (kv get $size_key | describe)
-    assert equal $actual $expected
-
-    kv drop $name_key
-    kv drop $size_key
+    kv drop $key
 }
 
 @test
@@ -239,23 +231,14 @@ def universal-using_closure [] {
     let key = (random uuid)
     $env.NU_UNIVERSAL_KV_PATH = (mktemp -t --suffix .sqlite3)
 
-    let name_key = (random uuid)
-    let size_key = (random uuid)
+    kv set -u $key 5
+    kv set -u $key { $in + 1 }
 
-    ls
-    | kv set -u $name_key { get name }
-    | kv set -u $size_key { get size }
-
-    let expected = "list<string>"
-    let actual = (kv get -u $name_key | describe)
+    let expected = 6
+    let actual = (kv get -u $key)
     assert equal $actual $expected
 
-    let expected = "list<filesize>"
-    let actual = (kv get -u $size_key | describe)
-    assert equal $actual $expected
-
-    kv drop -u $name_key
-    kv drop -u $size_key
+    kv drop -u $key
     rm $env.NU_UNIVERSAL_KV_PATH
 }
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->
Fixes #15528 
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Fixed `kv set` passing the pipeline input to the closure instead of the value stored in that key.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Now `kv set` will pass the value in that key to the closure.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
