### PR TITLE
Enable socks proxy support in ureq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6798,6 +6798,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "sqlparser"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7627,6 +7638,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+ "socks",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ update-informer = { version = "1.2.0", default-features = false, features = ["gi
 umask = "2.1"
 unicode-segmentation = "1.12"
 unicode-width = "0.2"
-ureq = { version = "2.12", default-features = false }
+ureq = { version = "2.12", default-features = false, features = ["socks-proxy"] }
 url = "2.2"
 uu_cp = "0.0.30"
 uu_mkdir = "0.0.30"


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Enable socks-proxy feature in ureq.
This allows use of socks protocol in proxy env variables when using nushell http client.
eg. to use a socks5 proxy on localhost
``` 
ALL_PROXY=socks5://localhost:8080 http get ...
```
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
None
# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
