### PR TITLE
feat(polars): add pow (`**`) operator for polars expressions

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/data/select.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/select.rs
@@ -72,7 +72,7 @@ impl PluginCommand for LazySelect {
             },
             Example {
                 description: "Select a column from a dataframe using a mix of expressions and record of expressions",
-                example: "[[a b]; [6 2] [4 2] [2 2]] | polars into-df | polars select a b {c: ((polars col a) * 2)}",
+                example: "[[a b]; [6 2] [4 2] [2 2]] | polars into-df | polars select a b {c: ((polars col a) ** 2)}",
                 result: Some(
                     NuDataFrame::try_from_columns(
                         vec![
@@ -84,7 +84,7 @@ impl PluginCommand for LazySelect {
                             vec![Value::test_int(2), Value::test_int(2), Value::test_int(2)]),
                             Column::new(
                             "c".to_string(),
-                            vec![Value::test_int(12), Value::test_int(8), Value::test_int(4)])
+                            vec![Value::test_int(36), Value::test_int(16), Value::test_int(4)])
                         ],
                         None,
                     )

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_expression/custom_value.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_expression/custom_value.rs
@@ -103,6 +103,9 @@ fn with_operator(
         Operator::Math(Math::FloorDivide) => {
             apply_arithmetic(plugin, engine, left, right, lhs_span, Div::div)
         }
+        Operator::Math(Math::Pow) => {
+            apply_arithmetic(plugin, engine, left, right, lhs_span, Expr::pow)
+        }
         Operator::Comparison(Comparison::Equal) => Ok(left
             .clone()
             .apply_with_expr(right.clone(), Expr::eq)


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR adds the exponent operator ("**") to polars expressions.

```nushell
  > [[a b]; [6 2] [4 2] [2 2]] | polars into-df | polars select a b {c: ((polars col a) ** 2)}
  ╭───┬───┬───┬────╮
  │ # │ a │ b │ c  │
  ├───┼───┼───┼────┤
  │ 0 │ 6 │ 2 │ 36 │
  │ 1 │ 4 │ 2 │ 16 │
  │ 2 │ 2 │ 2 │  4 │
  ╰───┴───┴───┴────╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
No breaking changes. Users are enabled to use the `**` operator in polars expressions.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
An example in `polars select` was modified to showcase the `**` operator.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
