### PR TITLE
fix(custom_value) + fix(polars): map `//` operator to FloorDivide for custom values and in polars

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3056,7 +3056,7 @@ impl Value {
                 }
             }
             (Value::Custom { val: lhs, .. }, rhs) => {
-                lhs.operation(self.span(), Operator::Math(Math::Divide), op, rhs)
+                lhs.operation(self.span(), Operator::Math(Math::FloorDivide), op, rhs)
             }
             _ => Err(operator_type_error(
                 Operator::Math(Math::FloorDivide),

--- a/crates/nu_plugin_polars/Cargo.toml
+++ b/crates/nu_plugin_polars/Cargo.toml
@@ -23,18 +23,21 @@ nu-path = { path = "../nu-path", version = "0.103.1" }
 nu-utils = { path = "../nu-utils", version = "0.103.1" }
 
 # Potential dependencies for extras
-chrono = { workspace = true, features = ["std", "unstable-locales"], default-features = false }
+chrono = { workspace = true, features = [
+  "std",
+  "unstable-locales",
+], default-features = false }
 chrono-tz = "0.10"
 fancy-regex = { workspace = true }
 indexmap = { version = "2.9" }
-num = {version = "0.4"}
+num = { version = "0.4" }
 serde = { version = "1.0", features = ["derive"] }
-sqlparser = { version = "0.53"}
-polars-io = { version = "0.46", features = ["avro", "cloud", "aws"]}
-polars-arrow = { version = "0.46"}
-polars-ops = { version = "0.46", features = ["pivot", "cutqcut"]}  
-polars-plan = { version = "0.46", features = ["regex"]}
-polars-utils = { version = "0.46"}
+sqlparser = { version = "0.53" }
+polars-io = { version = "0.46", features = ["avro", "cloud", "aws"] }
+polars-arrow = { version = "0.46" }
+polars-ops = { version = "0.46", features = ["pivot", "cutqcut"] }
+polars-plan = { version = "0.46", features = ["regex"] }
+polars-utils = { version = "0.46" }
 typetag = "0.2"
 env_logger = "0.11.3"
 log.workspace = true
@@ -52,42 +55,43 @@ url.workspace = true
 
 [dependencies.polars]
 features = [
-    "arg_where",
-    "bigidx",
-    "checked_arithmetic",
-    "cloud",
-    "concat_str",
-    "cross_join",
-    "csv",
-    "cum_agg",
-    "default",
-    "dtype-categorical",
-    "dtype-datetime",
-    "dtype-struct",
-    "dtype-decimal",
-    "dtype-i8",
-    "dtype-i16",
-    "dtype-u8",
-    "dtype-u16",
-    "dynamic_group_by",
-    "ipc",
-    "is_in",
-    "json",
-    "lazy",
-    "object",
-    "parquet",
-    "pivot",
-    "random",
-    "rolling_window",
-    "rows",
-    "serde",
-    "serde-lazy",
-    "strings",
-    "string_to_integer",
-    "streaming",
-    "timezones",
-    "temporal",
-    "to_dummies",
+  "arg_where",
+  "bigidx",
+  "checked_arithmetic",
+  "cloud",
+  "concat_str",
+  "cross_join",
+  "csv",
+  "cum_agg",
+  "default",
+  "dtype-categorical",
+  "dtype-datetime",
+  "dtype-struct",
+  "dtype-decimal",
+  "dtype-i8",
+  "dtype-i16",
+  "dtype-u8",
+  "dtype-u16",
+  "dynamic_group_by",
+  "ipc",
+  "is_in",
+  "json",
+  "lazy",
+  "object",
+  "parquet",
+  "pivot",
+  "random",
+  "rolling_window",
+  "rows",
+  "round_series",
+  "serde",
+  "serde-lazy",
+  "strings",
+  "string_to_integer",
+  "streaming",
+  "timezones",
+  "temporal",
+  "to_dummies",
 ]
 optional = false
 version = "0.46"

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_expression/custom_value.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_expression/custom_value.rs
@@ -101,7 +101,7 @@ fn with_operator(
             apply_arithmetic(plugin, engine, left, right, lhs_span, Rem::rem)
         }
         Operator::Math(Math::FloorDivide) => {
-            apply_arithmetic(plugin, engine, left, right, lhs_span, Div::div)
+            apply_arithmetic(plugin, engine, left, right, lhs_span, Expr::floor_div)
         }
         Operator::Comparison(Comparison::Equal) => Ok(left
             .clone()


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR fixes an issue where, for custom values, the `//` operator was incorrectly mapped to `Math::Divide` instead of `Math::FloorDivide`. This PR also fixes the same mis-mapping in the `polars` plugin.

```nushell
> [[a b c]; [x 1 1.1] [y 2 2.2] [z 3 3.3]] | polars into-df | polars select {div: ((polars col c) / (polars col b)), floor_div: ((polars col c) // (polars col b))} | polars collect
╭───┬───────┬───────────╮
│ # │  div  │ floor_div │
├───┼───────┼───────────┤
│ 0 │ 1.100 │     1.000 │
│ 1 │ 1.100 │     1.000 │
│ 2 │ 1.100 │     1.000 │
╰───┴───────┴───────────╯
```

**Note:** the number of line changes in this PR is inflated because of auto-formatting in `nu_plugin_polars/Cargo.toml`. Substantively, I've only added the `round_series` feature to the polars dependency list.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Breaking change: users who expected the operator `//` to function the same as `/` for custom values will not get the expected result.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
No tests were yet added, but let me know if we should put something into one of the polars examples.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
