### PR TITLE
fix(lsp): regression of semantic tokens of module-prefixed commands

### DIFF
--- a/crates/nu-lsp/src/semantic_tokens.rs
+++ b/crates/nu-lsp/src/semantic_tokens.rs
@@ -22,11 +22,12 @@ fn extract_semantic_tokens_from_expression(
 ) -> Vec<Span> {
     match &expr.expr {
         Expr::Call(call) => {
-            let command_name = working_set.get_decl(call.decl_id).name();
-            if command_name.contains(' ')
-                // Some keywords that are already highlighted properly, e.g. by tree-sitter-nu
-                && !command_name.starts_with("export")
-                && !command_name.starts_with("overlay")
+            let command_name = working_set.get_span_contents(call.head);
+            // Exclude some keywords that are supposed to be already highlighted properly,
+            // e.g. by tree-sitter-nu
+            if command_name.contains(&b' ')
+                && !command_name.starts_with(b"export")
+                && !command_name.starts_with(b"overlay")
             {
                 vec![call.head]
             } else {
@@ -144,7 +145,8 @@ mod tests {
                 1, 2, 10, 0, 0,
                 7, 15, 13, 0, 0,
                 0, 20, 10, 0, 0,
-                4, 0, 7, 0, 0
+                4, 0, 7, 0, 0,
+                5, 0, 12, 0, 0
             ]})
         );
     }

--- a/tests/fixtures/lsp/semantic_tokens/internals.nu
+++ b/tests/fixtures/lsp/semantic_tokens/internals.nu
@@ -13,3 +13,6 @@ export def "foo bar" [] {
 foo bar
 
 overlay use foo
+use std/assert
+
+assert equal


### PR DESCRIPTION
# Description

Fixes a regression caused by #15567, where I made the space detection in command names switched from `get_span_content` to `get_decl().name()`, which is slightly faster but it won't work in some cases:

e.g.
```nushell
use std/assert
assert equal
```

Reverted in this PR.

# User-Facing Changes

None

# Tests + Formatting

Refined

# After Submitting
