### PR TITLE
Bugfix/loss of precision when parsing value with unit

### DIFF
--- a/crates/nu-command/tests/commands/into_duration.rs
+++ b/crates/nu-command/tests/commands/into_duration.rs
@@ -1,0 +1,10 @@
+use nu_test_support::nu;
+
+// Tests happy paths
+
+#[test]
+fn into_duration_float() {
+    let actual = nu!(r#"1.07min | into duration"#);
+
+    assert_eq!("1min 4sec 200ms", actual.out);
+}

--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -375,7 +375,7 @@ fn duration_decimal_math_with_nanoseconds() {
         "#
     ));
 
-    assert_eq!(actual.out, "1wk 3day 10ns");
+    assert_eq!(actual.out, "1wk 3day 12hr 10ns");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -54,6 +54,7 @@ mod insert;
 mod inspect;
 mod interleave;
 mod into_datetime;
+mod into_duration;
 mod into_filesize;
 mod into_int;
 mod join;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2716,8 +2716,14 @@ pub fn parse_unit_value<'res>(
         // Convert all durations to nanoseconds to not lose precision
         let num = match unit_to_ns_factor(&unit) {
             Some(factor) => {
-                unit = Unit::Nanosecond;
-                (num_float * factor) as i64
+                let num_ns = num_float * factor;
+                if i64::MIN as f64 <= num_ns && num_ns <= i64::MAX as f64 {
+                    unit = Unit::Nanosecond;
+                    num_ns as i64
+                } else {
+                    // not safe to convert, because of the overflow
+                    num_float as i64
+                }
             }
             None => num_float as i64,
         };

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -300,7 +300,7 @@ fn parse_long_duration() {
             "78.797877879789789sec" | into duration
         "#);
 
-    assert_eq!(actual.out, "1min 18sec 797ms");
+    assert_eq!(actual.out, "1min 18sec 797ms 877µs 879ns");
 }
 
 #[rstest]


### PR DESCRIPTION
Closes #12858

# Description
As explained in the ticket, easy to reproduce. Example: 1.07 minute is 1.07*60=64.2 secondes
```nushell
# before - wrong
> 1.07min
1min 4sec

# now - right
> 1.07min
1min 4sec 200ms
```

# User-Facing Changes
Bug is fixed when using ``into duration``.

# Tests + Formatting
Added a test for ``into duration``
Fixed ``parse_long_duration`` test: we gained precision 😄 

# After Submitting
Release notes? Or blog is enough? Let me know
