### PR TITLE
Add job wait

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -453,6 +453,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             JobList,
             JobKill,
             JobTag,
+            JobWait,
             Job,
         };
 

--- a/crates/nu-command/src/experimental/job_wait.rs
+++ b/crates/nu-command/src/experimental/job_wait.rs
@@ -60,12 +60,12 @@ impl Command for JobWait {
             }
 
             Some(Job::Thread(job)) => {
-                let on_termination = job.on_termination().clone();
+                let waiter = job.on_termination().clone();
 
-                // .join() blocks so we drop our mutex guard
+                // .wait() blocks so we drop our mutex guard
                 drop(jobs);
 
-                let result = on_termination.join().clone().with_span(head);
+                let result = waiter.wait().clone().with_span(head);
 
                 Ok(result.into_pipeline_data())
             }

--- a/crates/nu-command/src/experimental/job_wait.rs
+++ b/crates/nu-command/src/experimental/job_wait.rs
@@ -10,7 +10,15 @@ impl Command for JobWait {
     }
 
     fn description(&self) -> &str {
-        "Wait for a job to complete and return its result value"
+        r#"Wait for a job to complete and return its result value.
+
+        Given the id of a running job currently in the job table, this command
+        waits for it to complete and returns the value returned
+        by the closure passed down to `job spawn`.
+
+        Note that this command fails if a job is currently not in the job table
+        (as seen by `job list`), so it is not possible to wait for jobs that have already finished.
+        "#
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/experimental/job_wait.rs
+++ b/crates/nu-command/src/experimental/job_wait.rs
@@ -1,0 +1,82 @@
+use nu_engine::command_prelude::*;
+use nu_protocol::{engine::Job, JobId};
+
+#[derive(Clone)]
+pub struct JobWait;
+
+impl Command for JobWait {
+    fn name(&self) -> &str {
+        "job wait"
+    }
+
+    fn description(&self) -> &str {
+        "Wait for a job to complete and return its result value"
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("job wait")
+            .category(Category::Experimental)
+            .required("id", SyntaxShape::Int, "The id of the running to wait for.")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["join"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+
+        let id_arg: Spanned<i64> = call.req(engine_state, stack, 0)?;
+
+        if id_arg.item < 0 {
+            return Err(ShellError::NeedsPositiveValue { span: id_arg.span });
+        }
+
+        let id: JobId = JobId::new(id_arg.item as usize);
+
+        let mut jobs = engine_state.jobs.lock().expect("jobs lock is poisoned!");
+
+        match jobs.lookup_mut(id) {
+            None => {
+                return Err(ShellError::JobNotFound {
+                    id: id.get(),
+                    span: head,
+                });
+            }
+
+            Some(Job::Frozen { .. }) => {
+                return Err(ShellError::UnsupportedJobType {
+                    id: id.get() as usize,
+                    span: head,
+                    kind: "frozen".to_string(),
+                });
+            }
+
+            Some(Job::Thread(job)) => {
+                let on_termination = job.on_termination().clone();
+
+                // .join() blocks so we drop our mutex guard
+                drop(jobs);
+
+                let result = on_termination.join().clone().with_span(head);
+
+                Ok(result.into_pipeline_data())
+            }
+        }
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            example: "let id = job spawn { sleep 5sec; 'hi there' }; job wait $id",
+            description: "Wait for a job to complete",
+            result: Some(Value::test_string("hi there")),
+        }]
+    }
+}

--- a/crates/nu-command/src/experimental/mod.rs
+++ b/crates/nu-command/src/experimental/mod.rs
@@ -4,6 +4,7 @@ mod job_kill;
 mod job_list;
 mod job_spawn;
 mod job_tag;
+mod job_wait;
 
 #[cfg(all(unix, feature = "os"))]
 mod job_unfreeze;
@@ -14,6 +15,7 @@ pub use job_kill::JobKill;
 pub use job_list::JobList;
 pub use job_spawn::JobSpawn;
 pub use job_tag::JobTag;
+pub use job_wait::JobWait;
 
 #[cfg(all(unix, feature = "os"))]
 pub use job_unfreeze::JobUnfreeze;

--- a/crates/nu-protocol/src/engine/jobs.rs
+++ b/crates/nu-protocol/src/engine/jobs.rs
@@ -5,7 +5,7 @@ use std::{
 
 use nu_system::{kill_by_pid, UnfreezeHandle};
 
-use crate::Signals;
+use crate::{Signals, Value};
 
 use crate::JobId;
 
@@ -139,14 +139,20 @@ pub struct ThreadJob {
     signals: Signals,
     pids: Arc<Mutex<HashSet<u32>>>,
     tag: Option<String>,
+    on_termination: Arc<WaitSignal<Value>>,
 }
 
 impl ThreadJob {
-    pub fn new(signals: Signals, tag: Option<String>) -> Self {
+    pub fn new(
+        signals: Signals,
+        tag: Option<String>,
+        on_termination: Arc<WaitSignal<Value>>,
+    ) -> Self {
         ThreadJob {
             signals,
             pids: Arc::new(Mutex::new(HashSet::default())),
             tag,
+            on_termination,
         }
     }
 
@@ -194,6 +200,10 @@ impl ThreadJob {
 
         pids.remove(&pid);
     }
+
+    pub fn on_termination(&self) -> &Arc<WaitSignal<Value>> {
+        return &self.on_termination;
+    }
 }
 
 impl Job {
@@ -236,5 +246,204 @@ impl FrozenJob {
         {
             Ok(())
         }
+    }
+}
+
+use std::sync::OnceLock;
+
+/// A synchronization primitive that allows multiple threads to wait for a single event to occur.
+///
+/// Threads that call the [`join`] method will block until the [`signal`] method is called.
+/// Once [`signal`] is called, all currently waiting threads will be woken up and will return from their `join` calls.
+/// Subsequent calls to [`join`] will not block and will return immediately.
+///
+/// The [`was_signaled`] method can be used to check if the signal has been emitted without blocking.
+pub struct WaitSignal<T> {
+    mutex: std::sync::Mutex<bool>,
+    value: std::sync::OnceLock<T>,
+    var: std::sync::Condvar,
+}
+
+impl<T> WaitSignal<T> {
+    /// Creates a new `WaitSignal` in an unsignaled state.
+    ///
+    /// No threads will be woken up initially.
+    pub fn new() -> Self {
+        WaitSignal {
+            mutex: std::sync::Mutex::new(false),
+            value: OnceLock::new(),
+            var: std::sync::Condvar::new(),
+        }
+    }
+
+    /// Blocks the current thread until this `WaitSignal` is signaled.
+    ///
+    /// If the signal has already been emitted, this method returns immediately.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the underlying mutex is poisoned. This can happen if another
+    /// thread holding the mutex panics.
+    pub fn join(&self) -> &T {
+        let mut guard = self.mutex.lock().expect("mutex is poisoned!");
+
+        while !*guard {
+            match self.var.wait(guard) {
+                Ok(it) => guard = it,
+                Err(_) => panic!("mutex is poisoned!"),
+            }
+        }
+
+        return self.value.get().unwrap();
+    }
+
+    /// Signals all threads currently waiting on this `WaitSignal`.
+    ///
+    /// This method sets the internal state to "signaled" and wakes up all threads that are blocked
+    /// in the [`join`] method. Subsequent calls to [`join`] from any thread will return immediately.
+    /// This operation has no effect if the signal has already been emitted.
+    pub fn signal(&self, value: T) {
+        let mut guard = self.mutex.lock().expect("mutex is poisoned!");
+
+        *guard = true;
+        let _ = self.value.set(value);
+
+        self.var.notify_all();
+    }
+
+    /// Checks if this `WaitSignal` has been signaled.
+    ///
+    /// This method returns `true` if the [`signal`] method has been called at least once,
+    /// and `false` otherwise. This method does not block the current thread.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the underlying mutex is poisoned. This can happen if another
+    /// thread holding the mutex panics.
+    pub fn was_signaled(&self) -> bool {
+        let guard = self.mutex.lock().expect("mutex is poisoned!");
+
+        *guard
+    }
+}
+
+// TODO: move to testing directory
+#[cfg(test)]
+mod test {
+
+    use std::{
+        sync::{mpsc, Arc},
+        thread::{self, sleep},
+        time::Duration,
+    };
+
+    use pretty_assertions::assert_eq;
+
+    use crate::engine::jobs::WaitSignal;
+
+    fn run_with_timeout<F>(duration: Duration, lambda: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let (send, recv) = std::sync::mpsc::channel();
+
+        let send_ = send.clone();
+
+        thread::spawn(move || {
+            lambda();
+
+            let send = send_;
+
+            send.send(true).expect("send failed");
+        });
+
+        thread::spawn(move || {
+            thread::sleep(duration);
+
+            send.send(false).expect("send failed");
+        });
+
+        let result = recv.recv().expect("recv failed!");
+
+        assert!(result == true, "timeout!");
+    }
+
+    #[test]
+    fn join_returns_when_signaled_from_another_thread() {
+        run_with_timeout(Duration::from_secs(1), || {
+            let signal = Arc::new(WaitSignal::new());
+
+            let thread_signal = signal.clone();
+
+            thread::spawn(move || {
+                sleep(Duration::from_millis(200));
+                assert!(!thread_signal.was_signaled());
+                thread_signal.signal(123);
+            });
+
+            let result = signal.join();
+
+            assert!(signal.was_signaled());
+
+            assert_eq!(*result, 123);
+        });
+    }
+
+    #[test]
+    fn join_works_from_multiple_threads() {
+        run_with_timeout(Duration::from_secs(1), || {
+            let signal = Arc::new(WaitSignal::new());
+
+            let (send, recv) = mpsc::channel();
+
+            let thread_count = 4;
+
+            for _ in 0..thread_count {
+                let signal_ = signal.clone();
+                let send_ = send.clone();
+
+                thread::spawn(move || {
+                    let value = signal_.join();
+                    send_.send(*value).expect("send failed");
+                });
+            }
+
+            signal.signal(321);
+
+            for _ in 0..thread_count {
+                let result = recv.recv().expect("recv failed");
+
+                assert_eq!(result, 321);
+            }
+        })
+    }
+
+    #[test]
+    fn was_signaled_returns_false_when_struct_is_initalized() {
+        let signal = Arc::new(WaitSignal::<()>::new());
+
+        assert!(!signal.was_signaled())
+    }
+
+    #[test]
+    fn was_signaled_returns_true_when_signal_is_called() {
+        let signal = Arc::new(WaitSignal::new());
+
+        signal.signal(());
+
+        assert!(signal.was_signaled())
+    }
+
+    #[test]
+    fn join_returns_when_own_thread_signals() {
+        run_with_timeout(Duration::from_secs(1), || {
+            let signal = Arc::new(WaitSignal::new());
+
+            signal.signal(());
+
+            signal.join();
+
+            assert!(signal.was_signaled())
+        })
     }
 }

--- a/crates/nu-protocol/src/engine/jobs.rs
+++ b/crates/nu-protocol/src/engine/jobs.rs
@@ -139,15 +139,11 @@ pub struct ThreadJob {
     signals: Signals,
     pids: Arc<Mutex<HashSet<u32>>>,
     tag: Option<String>,
-    on_termination: Arc<WaitSignal<Value>>,
+    on_termination: Waiter<Value>,
 }
 
 impl ThreadJob {
-    pub fn new(
-        signals: Signals,
-        tag: Option<String>,
-        on_termination: Arc<WaitSignal<Value>>,
-    ) -> Self {
+    pub fn new(signals: Signals, tag: Option<String>, on_termination: Waiter<Value>) -> Self {
         ThreadJob {
             signals,
             pids: Arc::new(Mutex::new(HashSet::default())),
@@ -201,7 +197,7 @@ impl ThreadJob {
         pids.remove(&pid);
     }
 
-    pub fn on_termination(&self) -> &Arc<WaitSignal<Value>> {
+    pub fn on_termination(&self) -> &Waiter<Value> {
         return &self.on_termination;
     }
 }
@@ -251,95 +247,129 @@ impl FrozenJob {
 
 use std::sync::OnceLock;
 
-/// A synchronization primitive that allows multiple threads to wait for a single event to occur.
+/// A synchronization primitive that allows multiple threads to wait for a single event to be completed.
 ///
-/// Threads that call the [`join`] method will block until the [`signal`] method is called.
-/// Once [`signal`] is called, all currently waiting threads will be woken up and will return from their `join` calls.
-/// Subsequent calls to [`join`] will not block and will return immediately.
+/// A Waiter/Completer pair is similar to a Receiver/Sender pair from std::sync::mpsc, with a few important differences:
+/// - Only one value can only be sent/completed, subsequent completions are ignored
+/// - Multiple threads can wait for the completion of an event (`Waiter` is `Clone` unlike `Receiver`)
 ///
-/// The [`was_signaled`] method can be used to check if the signal has been emitted without blocking.
-pub struct WaitSignal<T> {
-    mutex: std::sync::Mutex<bool>,
-    value: std::sync::OnceLock<T>,
-    var: std::sync::Condvar,
+/// This type differs from `OnceLock` only in a few regards:
+/// - It is split into `Waiter` and `Completer` halfs
+/// - It allows users to `wait` on the completion event with a timeout
+///
+/// Threads that call the [`wait`] method of the `Waiter` block until the [`complete`] method of a matching `Completer` is called.
+/// Once [`complete`] is called, all currently waiting threads will be woken up and will return from their `wait` calls.
+/// Subsequent calls to [`wait`] will not block and will return immediately.
+///
+pub fn completion_signal<T>() -> (Completer<T>, Waiter<T>) {
+    let inner = Arc::new(InnerWaitCompleteSignal::new());
+
+    return (
+        Completer {
+            inner: inner.clone(),
+        },
+        Waiter { inner },
+    );
 }
 
-impl<T> WaitSignal<T> {
-    /// Creates a new `WaitSignal` in an unsignaled state.
-    ///
-    /// No threads will be woken up initially.
+/// Waiter and Completer are effectively just `Arc` wrappers around this type.
+struct InnerWaitCompleteSignal<T> {
+    // One may ask: "Why the mutex and the convar"?
+    // It turns out OnceLock doesn't have a `wait_timeout` method, so
+    // we use the one from the condvar.
+    //
+    // We once again, assume acquire-release semamntics for Rust mutexes
+    mutex: std::sync::Mutex<()>,
+    var: std::sync::Condvar,
+    value: std::sync::OnceLock<T>,
+}
+
+impl<T> InnerWaitCompleteSignal<T> {
     pub fn new() -> Self {
-        WaitSignal {
-            mutex: std::sync::Mutex::new(false),
+        InnerWaitCompleteSignal {
+            mutex: std::sync::Mutex::new(()),
             value: OnceLock::new(),
             var: std::sync::Condvar::new(),
         }
     }
+}
 
-    /// Blocks the current thread until this `WaitSignal` is signaled.
+#[derive(Clone)]
+pub struct Waiter<T> {
+    inner: Arc<InnerWaitCompleteSignal<T>>,
+}
+
+pub struct Completer<T> {
+    inner: Arc<InnerWaitCompleteSignal<T>>,
+}
+
+impl<T> Waiter<T> {
+    /// Blocks the current thread until a completion signal is sent.
     ///
     /// If the signal has already been emitted, this method returns immediately.
     ///
-    /// # Panics
-    ///
-    /// This method will panic if the underlying mutex is poisoned. This can happen if another
-    /// thread holding the mutex panics.
-    pub fn join(&self) -> &T {
-        let mut guard = self.mutex.lock().expect("mutex is poisoned!");
+    pub fn wait(&self) -> &T {
+        let inner: &InnerWaitCompleteSignal<T> = self.inner.as_ref();
 
-        while !*guard {
-            match self.var.wait(guard) {
-                Ok(it) => guard = it,
-                Err(_) => panic!("mutex is poisoned!"),
+        let mut guard = inner.mutex.lock().expect("mutex is poisoned!");
+
+        loop {
+            match inner.value.get() {
+                None => match inner.var.wait(guard) {
+                    Ok(it) => guard = it,
+                    Err(_) => panic!("mutex is poisoned!"),
+                },
+                Some(value) => return value,
             }
         }
-
-        return self.value.get().unwrap();
     }
 
-    /// Signals all threads currently waiting on this `WaitSignal`.
-    ///
-    /// This method sets the internal state to "signaled" and wakes up all threads that are blocked
-    /// in the [`join`] method. Subsequent calls to [`join`] from any thread will return immediately.
-    /// This operation has no effect if the signal has already been emitted.
-    pub fn signal(&self, value: T) {
-        let mut guard = self.mutex.lock().expect("mutex is poisoned!");
+    // TODO: add wait_timeout
 
-        *guard = true;
-        let _ = self.value.set(value);
-
-        self.var.notify_all();
-    }
-
-    /// Checks if this `WaitSignal` has been signaled.
+    /// Checks if this completion signal has been signaled.
     ///
     /// This method returns `true` if the [`signal`] method has been called at least once,
     /// and `false` otherwise. This method does not block the current thread.
     ///
-    /// # Panics
-    ///
-    /// This method will panic if the underlying mutex is poisoned. This can happen if another
-    /// thread holding the mutex panics.
-    pub fn was_signaled(&self) -> bool {
-        let guard = self.mutex.lock().expect("mutex is poisoned!");
+    pub fn is_completed(&self) -> bool {
+        self.try_get().is_some()
+    }
 
-        *guard
+    /// Returns the completed value, or None if none was sent.
+    pub fn try_get(&self) -> Option<&T> {
+        let _guard = self.inner.mutex.lock().expect("mutex is poisoned!");
+
+        self.inner.value.get()
     }
 }
 
-// TODO: move to testing directory
+impl<T> Completer<T> {
+    /// Signals all threads currently waiting on this completion signal.
+    ///
+    /// This method sets wakes up all threads that are blocked in the [`wait`] method
+    /// of an attached `Waiter`. Subsequent calls to [`wait`] from any thread will return immediately.
+    /// This operation has no effect if this completion signal has already been completed.
+    pub fn complete(&self, value: T) {
+        let inner: &InnerWaitCompleteSignal<T> = self.inner.as_ref();
+
+        let mut _guard = inner.mutex.lock().expect("mutex is poisoned!");
+
+        let _ = inner.value.set(value);
+
+        inner.var.notify_all();
+    }
+}
+
 #[cfg(test)]
-mod test {
+mod completion_signal_tests {
 
     use std::{
-        sync::{mpsc, Arc},
+        sync::mpsc,
         thread::{self, sleep},
         time::Duration,
     };
 
-    use pretty_assertions::assert_eq;
-
-    use crate::engine::jobs::WaitSignal;
+    use crate::engine::completion_signal;
 
     fn run_with_timeout<F>(duration: Duration, lambda: F)
     where
@@ -363,52 +393,51 @@ mod test {
             send.send(false).expect("send failed");
         });
 
-        let result = recv.recv().expect("recv failed!");
+        let ok = recv.recv().expect("recv failed!");
 
-        assert!(result == true, "timeout!");
+        assert!(ok, "got timeout!");
     }
 
     #[test]
-    fn join_returns_when_signaled_from_another_thread() {
+    fn wait_returns_when_signaled_from_another_thread() {
         run_with_timeout(Duration::from_secs(1), || {
-            let signal = Arc::new(WaitSignal::new());
+            let (complete, wait) = completion_signal();
 
-            let thread_signal = signal.clone();
+            let wait_ = wait.clone();
 
             thread::spawn(move || {
                 sleep(Duration::from_millis(200));
-                assert!(!thread_signal.was_signaled());
-                thread_signal.signal(123);
+                assert!(!wait_.is_completed());
+                complete.complete(123);
             });
 
-            let result = signal.join();
+            let result = wait.wait();
 
-            assert!(signal.was_signaled());
+            assert!(wait.is_completed());
 
             assert_eq!(*result, 123);
         });
     }
 
     #[test]
-    fn join_works_from_multiple_threads() {
+    fn wait_works_from_multiple_threads() {
         run_with_timeout(Duration::from_secs(1), || {
-            let signal = Arc::new(WaitSignal::new());
-
+            let (complete, wait) = completion_signal();
             let (send, recv) = mpsc::channel();
 
             let thread_count = 4;
 
             for _ in 0..thread_count {
-                let signal_ = signal.clone();
+                let wait_ = wait.clone();
                 let send_ = send.clone();
 
                 thread::spawn(move || {
-                    let value = signal_.join();
+                    let value = wait_.wait();
                     send_.send(*value).expect("send failed");
                 });
             }
 
-            signal.signal(321);
+            complete.complete(321);
 
             for _ in 0..thread_count {
                 let result = recv.recv().expect("recv failed");
@@ -420,30 +449,30 @@ mod test {
 
     #[test]
     fn was_signaled_returns_false_when_struct_is_initalized() {
-        let signal = Arc::new(WaitSignal::<()>::new());
+        let (_, wait) = completion_signal::<()>();
 
-        assert!(!signal.was_signaled())
+        assert!(!wait.is_completed())
     }
 
     #[test]
     fn was_signaled_returns_true_when_signal_is_called() {
-        let signal = Arc::new(WaitSignal::new());
+        let (complete, wait) = completion_signal();
 
-        signal.signal(());
+        complete.complete(());
 
-        assert!(signal.was_signaled())
+        assert!(wait.is_completed())
     }
 
     #[test]
-    fn join_returns_when_own_thread_signals() {
+    fn wait_returns_when_own_thread_signals() {
         run_with_timeout(Duration::from_secs(1), || {
-            let signal = Arc::new(WaitSignal::new());
+            let (complete, wait) = completion_signal();
 
-            signal.signal(());
+            complete.complete(());
 
-            signal.join();
+            wait.wait();
 
-            assert!(signal.was_signaled())
+            assert!(wait.is_completed())
         })
     }
 }

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1379,6 +1379,13 @@ On Windows, this would be %USERPROFILE%\AppData\Roaming"#
         span: Span,
     },
 
+    #[error("Job {id} is a job of type {kind}")]
+    #[diagnostic(
+        code(nu::shell::os_disabled),
+        help("This operation does not support the given job type")
+    )]
+    UnsupportedJobType { id: usize, span: Span, kind: String },
+
     #[error(transparent)]
     #[diagnostic(transparent)]
     ChainedError(ChainedError),


### PR DESCRIPTION
# Description

This PR implements a `job wait` command which allows users to wait for the completion of existing jobs.

Since `JoinHandle` is not `Clone`, this also implements a `Waiter/Completer` completion signal synchronization primitive to allow multiple jobs to wait for the completion of a single one.

Closes #15198 

# User-Facing Changes

Adds a new `job wait` command.

# Tests + Formatting

This PR adds integration tests to cover the new `job wait` command, and also unit tests for the `completion_signal` API.

# After Submitting

Add this to the documentation for jobs