### PR TITLE
IR: allow subexpression with redirection.

### DIFF
--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -482,7 +482,7 @@ fn subexpression_redirection(#[case] redir: &str, #[case] stdout_file_body: &str
     Playground::setup("file redirection with subexpression", |dirs, _| {
         let actual = nu!(
             cwd: dirs.test(),
-            format!("$env.BAR = 'bar'; $env.BAZ = 'baz'; nu --testbin echo_env_mixed out-err BAR BAZ {redir} result.txt")
+            format!("$env.BAR = 'bar'; $env.BAZ = 'baz'; (nu --testbin echo_env_mixed out-err BAR BAZ) {redir} result.txt")
         );
         assert!(actual.status.success());
         assert!(file_contents(dirs.test().join("result.txt")).contains(stdout_file_body));

--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -473,3 +473,18 @@ fn pipe_redirection_in_let_and_mut(
     );
     assert_eq!(actual.out, output);
 }
+
+#[rstest::rstest]
+#[case("o>", "bar")]
+#[case("e>", "")]
+#[case("o+e>", "bar\nbaz")] // in subexpression, the stderr is go to the terminal
+fn subexpression_redirection(#[case] redir: &str, #[case] stdout_file_body: &str) {
+    Playground::setup("file redirection with subexpression", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(),
+            format!("$env.BAR = 'bar'; $env.BAZ = 'baz'; nu --testbin echo_env_mixed out-err BAR BAZ {redir} result.txt")
+        );
+        assert!(actual.status.success());
+        assert!(file_contents(dirs.test().join("result.txt")).contains(stdout_file_body));
+    })
+}

--- a/crates/nu-engine/src/compile/mod.rs
+++ b/crates/nu-engine/src/compile/mod.rs
@@ -212,6 +212,7 @@ fn is_subexpression(expr: &Expr) -> bool {
         Expr::FullCellPath(inner) => {
             matches!(&inner.head.expr, &Expr::Subexpression(..))
         }
+        Expr::Subexpression(..) => true,
         _ => false,
     }
 }


### PR DESCRIPTION
# Description
Try to fixes https://github.com/nushell/nushell/issues/15326 in another way.

The main point of this change is to avoid duplicate `write` and `close` a redirected file.  So during compile, if compiler know current element is a sub-expression(defined by private `is_subexpression` function), it will no longer invoke `finish_redirection`.

In this way, we can avoid duplicate `finish_redirection`.

# User-Facing Changes
`(^echo aa) o> /tmp/aaa` will no longer raise an error.

Here is the IR after the pr:
```
# 3 registers, 12 instructions, 11 bytes of data
# 1 file used for redirection
   0: load-literal           %1, string("aaa")
   1: open-file              file(0), %1, append = false
   2: load-literal           %1, glob-pattern("echo", no_expand = false)
   3: load-literal           %2, glob-pattern("true", no_expand = false)
   4: push-positional        %1
   5: push-positional        %2
   6: redirect-out           file(0)
   7: redirect-err           caller
   8: call                   decl 135 "run-external", %0
   9: write-file             file(0), %0
  10: close-file             file(0)
  11: return                 %0
```

# Tests + Formatting
Added 3 tests.

# After Submitting
Maybe need to update doc https://github.com/nushell/nushell.github.io/pull/1876
