### PR TITLE
Sub operator with and

### DIFF
--- a/crates/nu-engine/src/compile/operator.rs
+++ b/crates/nu-engine/src/compile/operator.rs
@@ -70,10 +70,10 @@ pub(crate) fn compile_binary_op(
                     Boolean::Xor => unreachable!(),
                 };
 
+                // Before match against lhs_reg, it's important to collect it first
+                builder.push(Instruction::Collect { src_dst: lhs_reg }.into_spanned(lhs.span))?;
                 // Short-circuit to return `lhs_reg`. `match` op does not consume `lhs_reg`.
                 let short_circuit_label = builder.label(None);
-                // Important to collect it first
-                builder.push(Instruction::Collect { src_dst: lhs_reg }.into_spanned(op.span))?;
                 builder.r#match(
                     Pattern::Value(Value::bool(short_circuit_value, op.span)),
                     lhs_reg,

--- a/crates/nu-engine/src/compile/operator.rs
+++ b/crates/nu-engine/src/compile/operator.rs
@@ -72,6 +72,8 @@ pub(crate) fn compile_binary_op(
 
                 // Short-circuit to return `lhs_reg`. `match` op does not consume `lhs_reg`.
                 let short_circuit_label = builder.label(None);
+                // Important to collect it first
+                builder.push(Instruction::Collect { src_dst: lhs_reg }.into_spanned(op.span))?;
                 builder.r#match(
                     Pattern::Value(Value::bool(short_circuit_value, op.span)),
                     lhs_reg,

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -717,3 +717,11 @@ fn external_error_with_backtrace() {
         assert_eq!(chained_error_cnt.len(), 0);
     });
 }
+
+#[test]
+fn sub_external_expression_with_and_op_should_raise_proper_error() {
+    let actual = nu!("(nu --testbin cococo false) and true");
+    assert!(actual
+        .err
+        .contains("The 'and' operator does not work on values of type 'string'"))
+}


### PR DESCRIPTION
# Description
Fixes: #15510
I think it's introduced by #14653, which changes `and/or` to `match` expression.

After looking into `compile_match`, it's important to collect the value before matching this.
```rust
    // Important to collect it first
    builder.push(Instruction::Collect { src_dst: match_reg }.into_spanned(match_expr.span))?;
```
This pr is going to apply the logic while compiling `and/or` operation.

# User-Facing Changes
The following will raise a reasonable error:
```nushell
> (nu --testbin cococo false) and true
Error: nu::shell::operator_unsupported_type

  × The 'and' operator does not work on values of type 'string'.
   ╭─[entry #7:1:2]
 1 │ (nu --testbin cococo false) and true
   ·  ─┬                         ─┬─
   ·   │                          ╰── does not support 'string'
   ·   ╰── string
   ╰────
```

# Tests + Formatting
Added 1 test.

# After Submitting
Maybe need to update doc https://github.com/nushell/nushell.github.io/pull/1876