### PR TITLE
Update Nu to 0.103.0 for release workflow and improve Windows OS checks

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,6 +8,7 @@
 name: Nightly Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - nightly   # Just for test purpose only with the nightly repo
@@ -39,7 +40,7 @@ jobs:
         uses: hustcer/setup-nu@v3
         if: github.repository == 'nushell/nightly'
         with:
-          version: 0.101.0
+          version: 0.103.0
 
       # Synchronize the main branch of nightly repo with the main branch of Nushell official repo
       - name: Prepare for Nightly Release
@@ -139,7 +140,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
       with:
-        version: 0.101.0
+        version: 0.103.0
 
     - name: Release Nu Binary
       id: nu
@@ -197,7 +198,7 @@ jobs:
       - name: Setup Nushell
         uses: hustcer/setup-nu@v3
         with:
-          version: 0.101.0
+          version: 0.103.0
 
       # Keep the last a few releases
       - name: Delete Older Releases

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -117,14 +117,14 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
 # ----------------------------------------------------------------------------
 # Build for Windows without static-link-openssl feature
 # ----------------------------------------------------------------------------
-if $os in ['windows-latest'] {
+if $os =~ 'windows' {
     cargo-build-nu
 }
 
 # ----------------------------------------------------------------------------
 # Prepare for the release archive
 # ----------------------------------------------------------------------------
-let suffix = if $os == 'windows-latest' { '.exe' }
+let suffix = if $os =~ 'windows' { '.exe' }
 # nu, nu_plugin_* were all included
 let executable = $'target/($target)/release/($bin)*($suffix)'
 print $'Current executable file: ($executable)'
@@ -148,10 +148,10 @@ For more information, refer to https://www.nushell.sh/book/plugins.html
 [LICENSE ...(glob $executable)] | each {|it| cp -rv $it $dist } | flatten
 
 print $'(char nl)Check binary release version detail:'; hr-line
-let ver = if $os == 'windows-latest' {
-    (do -i { .\output\nu.exe -c 'version' }) | str join
+let ver = if $os =~ 'windows' {
+    (do -i { .\output\nu.exe -c 'version' }) | default '' | str join
 } else {
-    (do -i { ./output/nu -c 'version' }) | str join
+    (do -i { ./output/nu -c 'version' }) | default '' | str join
 }
 if ($ver | str trim | is-empty) {
     print $'(ansi r)Incompatible Nu binary: The binary cross compiled is not runnable on current arch...(ansi reset)'
@@ -177,7 +177,7 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
     # REF: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
     echo $"archive=($archive)" | save --append $env.GITHUB_OUTPUT
 
-} else if $os == 'windows-latest' {
+} else if $os =~ 'windows' {
 
     let releaseStem = $'($bin)-($version)-($target)'
 
@@ -221,7 +221,7 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
 }
 
 def 'cargo-build-nu' [] {
-    if $os == 'windows-latest' {
+    if $os =~ 'windows' {
         cargo build --release --all --target $target
     } else {
         cargo build --release --all --target $target --features=static-link-openssl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
       with:
-        version: 0.101.0
+        version: 0.103.0
 
     - name: Release Nu Binary
       id: nu


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

1. Upgrade Nushell to v0.103.0 for the release workflow
2. Update Windows OS checks for the release script to make it work for runners like `windows-11-arm`
3. The release script works well here: https://github.com/hustcer/nushell/actions/runs/14619218636/job/41014603487 and we can test it in the nightly repo for the following a few days

Related issue: https://github.com/nushell/nushell/issues/14815
