### PR TITLE
Add --follow-symlinks flag to glob command (fixes #15559)

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -264,7 +264,7 @@ impl Command for Glob {
                     WalkBehavior {
                         depth: folder_depth,
                         link: link_behavior,
-                    }
+                    },
                 )
                 .into_owned()
                 .flatten();

--- a/crates/nu-command/tests/commands/glob.rs
+++ b/crates/nu-command/tests/commands/glob.rs
@@ -179,16 +179,17 @@ fn glob_follow_symlinks() {
     Playground::setup("glob_follow_symlinks", |dirs, sandbox| {
         // Create a directory with some files
         sandbox.mkdir("target_dir");
-        sandbox.within("target_dir").with_files(&[
-            EmptyFile("target_file.txt"),
-        ]);
-        
+        sandbox
+            .within("target_dir")
+            .with_files(&[EmptyFile("target_file.txt")]);
+
         let target_dir = dirs.test().join("target_dir");
         let symlink_path = dirs.test().join("symlink_dir");
         #[cfg(unix)]
         std::os::unix::fs::symlink(target_dir, &symlink_path).expect("Failed to create symlink");
         #[cfg(windows)]
-        std::os::windows::fs::symlink_dir(target_dir, &symlink_path).expect("Failed to create symlink");
+        std::os::windows::fs::symlink_dir(target_dir, &symlink_path)
+            .expect("Failed to create symlink");
 
         // on some systems/filesystems, symlinks are followed by default
         // on others (like Linux /sys), they aren't
@@ -198,6 +199,9 @@ fn glob_follow_symlinks() {
             "glob 'symlink_dir/*.txt' --follow-symlinks | length",
         );
 
-        assert_eq!(with_flag.out, "1", "Should find file with --follow-symlinks flag");
+        assert_eq!(
+            with_flag.out, "1",
+            "Should find file with --follow-symlinks flag"
+        );
     })
 }

--- a/crates/nu-command/tests/commands/glob.rs
+++ b/crates/nu-command/tests/commands/glob.rs
@@ -173,3 +173,31 @@ fn glob_files_in_parent(
         assert_eq!(actual.out, expected, "\n  test: {}", tag);
     });
 }
+
+#[test]
+fn glob_follow_symlinks() {
+    Playground::setup("glob_follow_symlinks", |dirs, sandbox| {
+        // Create a directory with some files
+        sandbox.mkdir("target_dir");
+        sandbox.within("target_dir").with_files(&[
+            EmptyFile("target_file.txt"),
+        ]);
+        
+        let target_dir = dirs.test().join("target_dir");
+        let symlink_path = dirs.test().join("symlink_dir");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(target_dir, &symlink_path).expect("Failed to create symlink");
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(target_dir, &symlink_path).expect("Failed to create symlink");
+
+        // on some systems/filesystems, symlinks are followed by default
+        // on others (like Linux /sys), they aren't
+        // Test that with the --follow-symlinks flag, files are found for sure
+        let with_flag = nu!(
+            cwd: dirs.test(),
+            "glob 'symlink_dir/*.txt' --follow-symlinks | length",
+        );
+
+        assert_eq!(with_flag.out, "1", "Should find file with --follow-symlinks flag");
+    })
+}


### PR DESCRIPTION
Fixes #15559

# Description
The glob command wasn't working correctly with symlinks in the /sys filesystem. This commit adds a new flag that allows users to explicitly control whether symlinks should be followed, with special handling for the /sys directory.

The issue was that the glob command didn't follow symbolic links when traversing the /sys filesystem, resulting in an empty list even though paths should be found. This implementation adds a new `--follow-symlinks` flag that explicitly enables following symlinks. By default, it now follows symlinks in most paths but has special handling for /sys paths where the flag is required.

Example:
`
# Before: This would return an empty list on Linux systems
glob /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor

# Now: This works as expected with the new flag
glob /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor --follow-symlinks
`

# User-Facing Changes

1. Added the --follow-symlinks (-l) flag to the glob command that allows users to explicitly control whether symbolic links should be followed
2. Added a new example to the glob command help text demonstrating the use of this flag

# Tests + Formatting

1. Added a test for the new --follow-symlinks flag

