### PR TITLE
Add labeler bot

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,9 +30,11 @@ parser:
 pr:plugins:
   - changed-files:
     - any-glob-to-any-file:
+      # plugins API
       - crates/nu-plugin/**
       - crates/nu-plugin-core/**
       - crates/nu-plugin-engine/**
       - crates/nu-plugin-protocol/**
       - crates/nu-plugin-test-support/**
-
+      # specific plugins (like polars)
+      - crates/nu_plugin_*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,38 @@
+# A bot for automatically labelling pull requests 
+# See https://github.com/actions/labeler
+
+dataframe:
+  - changed-files:
+    - any-glob-to-any-file:
+      - crates/nu_plugin_polars/**
+
+std-library:
+  - changed-files:
+    - any-glob-to-any-file:
+      - crates/nu-std/**
+
+ci:
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/workflows/**
+
+
+LSP:
+  - changed-files:
+    - any-glob-to-any-file:
+      - crates/nu-lsp/**
+
+parser:
+  - changed-files:
+    - any-glob-to-any-file:
+      - crates/nu-parser/**
+
+pr:plugins:
+  - changed-files:
+    - any-glob-to-any-file:
+      - crates/nu-plugin/**
+      - crates/nu-plugin-core/**
+      - crates/nu-plugin-engine/**
+      - crates/nu-plugin-protocol/**
+      - crates/nu-plugin-test-support/**
+

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: depot-ubuntu-24.04-arm-small
+    runs-on: ubuntu-latest
     if: github.repository_owner == 'nushell'
     steps:
       - uses: actions/labeler@v5

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,19 @@
+# Automatically labels PRs based on the configuration file
+# you are probably looking for 👉 `.github/labeler.yml`
+name: Label PRs
+
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: depot-ubuntu-24.04-arm-small
+    if: github.repository_owner == 'nushell'
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
- fixes #15607 

# Description
Hi! I added a labeler bot workflow and reference to the tags. This workflow runs whenever is a change in a PR (`pull_request_target`) [source](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target)

# User-Facing Changes
Nothing here, just the CI

# Tests + Formatting
Not needed
