### PR TITLE
bugfix: `str join` outputs dates consistently (RFC2822 when possible)

### DIFF
--- a/crates/nu-command/src/strings/str_/join.rs
+++ b/crates/nu-command/src/strings/str_/join.rs
@@ -1,3 +1,4 @@
+use chrono::Datelike;
 use nu_engine::command_prelude::*;
 use nu_protocol::{shell_error::io::IoError, Signals};
 
@@ -109,9 +110,14 @@ fn run(
                     Value::Error { error, .. } => {
                         return Err(*error);
                     }
-                    // Hmm, not sure what we actually want.
-                    // `to_expanded_string` formats dates as human readable which feels funny.
-                    Value::Date { val, .. } => write!(buffer, "{val:?}").map_err(&from_io_error)?,
+                    Value::Date { val, .. } => {
+                        let date_str = if val.year() >= 0 {
+                            val.to_rfc2822()
+                        } else {
+                            val.to_rfc3339()
+                        };
+                        write!(buffer, "{date_str}").map_err(&from_io_error)?
+                    }
                     value => write!(buffer, "{}", value.to_expanded_string("\n", &config))
                         .map_err(&from_io_error)?,
                 }


### PR DESCRIPTION
Closes #11265

# Description
``str join`` outputs dates just other commands: RFC2822 by default otherwise RFC3339 for negative dates

# User-Facing Changes

```nushell
~> 2024-01-01
# => Mon, 1 Jan 2024 00:00:00 +0000 (a year ago)
~> '3000 years ago' | date from-human
# => -0975-04-23T20:57:07.217711700+02:00 (3000 years ago)
~> [ 2024-01-01 ] | str join
# => Mon, 1 Jan 2024 00:00:00 +0000
~> [ ('3000 years ago' | date from-human) ] | str join
# => -0975-04-23T20:57:56.221269600+02:00
```

# Tests + Formatting
OK
# After Submitting
Nothing
