### PR TITLE
history table using sqlite outputs start_timestamp as datetime instead of string

### DIFF
--- a/crates/nu-cli/src/commands/history/history_.rs
+++ b/crates/nu-cli/src/commands/history/history_.rs
@@ -86,7 +86,6 @@ impl Command for History {
                         Value::record(
                             record! {
                                 fields::COMMAND_LINE => Value::string(entry.command_line, head),
-                                // TODO: This name is inconsistent with create_history_record.
                                 "index" => Value::int(idx as i64, head),
                             },
                             head,
@@ -105,10 +104,9 @@ impl Command for History {
                         .ok()
                 })
                 .map(move |entries| {
-                    entries
-                        .into_iter()
-                        .enumerate()
-                        .map(move |(idx, entry)| create_history_record(idx, entry, long, head))
+                    entries.into_iter().enumerate().map(move |(idx, entry)| {
+                        create_sqlite_history_record(idx, entry, long, head)
+                    })
                 })
                 .ok_or(IoError::new(
                     std::io::ErrorKind::NotFound,
@@ -140,7 +138,7 @@ impl Command for History {
     }
 }
 
-fn create_history_record(idx: usize, entry: HistoryItem, long: bool, head: Span) -> Value {
+fn create_sqlite_history_record(idx: usize, entry: HistoryItem, long: bool, head: Span) -> Value {
     //1. Format all the values
     //2. Create a record of either short or long columns and values
 
@@ -151,11 +149,8 @@ fn create_history_record(idx: usize, entry: HistoryItem, long: bool, head: Span)
             .unwrap_or_default(),
         head,
     );
-    let start_timestamp_value = Value::string(
-        entry
-            .start_timestamp
-            .map(|time| time.to_string())
-            .unwrap_or_default(),
+    let start_timestamp_value = Value::date(
+        entry.start_timestamp.unwrap_or_default().fixed_offset(),
         head,
     );
     let command_value = Value::string(entry.command_line, head);


### PR DESCRIPTION
Closes#13581

# Description
Before, the table you got from ``history`` had values as strings in the ``startup_timestamp`` column.
Now the values are datetimes.

# User-Facing Changes
```nushell
~\workspace_tns\nushell> history | last 5
╭───┬─────────────────┬─────────────────────┬───────────────────────────────────────────┬─────╮
│ # │ start_timestamp │       command       │                    cwd                    │ ... │
├───┼─────────────────┼─────────────────────┼───────────────────────────────────────────┼─────┤
│ 0 │ a minute ago    │ history             │ C:\Users\RIL1RT\workspace_tns\nushell-bis │ ... │
│ 1 │ 40 seconds ago  │ cd nushell          │ C:\Users\RIL1RT\workspace_tns\nushell-bis │ ... │
│ 2 │ 31 seconds ago  │ target\debug\nu.exe │ C:\Users\RIL1RT\workspace_tns\nushell     │ ... │
│ 3 │ 26 seconds ago  │ history             │ C:\Users\RIL1RT\workspace_tns\nushell     │ ... │
│ 4 │ now             │ history | last 5    │ C:\Users\RIL1RT\workspace_tns\nushell     │ ... │
╰───┴─────────────────┴─────────────────────┴───────────────────────────────────────────┴─────╯
```

# Tests + Formatting


# After Submitting
❓ 