### PR TITLE
Support `printf`-compatible pattern in `format pattern`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2847,6 +2847,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3593,6 +3602,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_urlencoded",
+ "uucore",
  "v_htmlescape",
 ]
 
@@ -7787,6 +7797,7 @@ dependencies = [
  "dunce",
  "glob",
  "iana-time-zone",
+ "itertools 0.14.0",
  "libc",
  "nix 0.29.0",
  "number_prefix",

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -35,6 +35,7 @@ serde_urlencoded = { workspace = true }
 v_htmlescape = { workspace = true }
 itertools = { workspace = true }
 mime = { workspace = true }
+uucore = {workspace = true, features = ["format"]}
 
 [dev-dependencies]
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.103.1" }

--- a/crates/nu-cmd-extra/src/extra/strings/format/command.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/command.rs
@@ -21,9 +21,9 @@ impl Command for FormatPattern {
             .required(
                 "pattern",
                 SyntaxShape::String,
-                "The pattern to output. e.g.) \"{foo}: {bar}\".",
+                "The pattern used to format the input values.",
             )
-            .switch("printf", "Use printf style pattern.", None)
+            .switch("printf", "Use `printf`-compatible pattern.", None)
             .allow_variants_without_examples(true)
             .category(Category::Strings)
     }
@@ -31,7 +31,7 @@ impl Command for FormatPattern {
     fn description(&self) -> &str {
         r"Format values into a string using either a simple pattern or `printf`-compatible pattern.
 Simple pattern supports input of type list<any>, table, and record;
-`printf` pattern supports a limited set of primitive types as input, namely string, int and float, and composite types such as list, table 
+`printf` pattern supports input types that are coercible to string, namely bool, int, float, string, glob, binary and date, and also list of a mix of those types.
         "
     }
 
@@ -91,11 +91,6 @@ Simple pattern supports input of type list<any>, table, and record;
                 description: "Unescape a fully quoted json using printf",
                 example: r#""\{\\\"foo\\\": \\\"bar\\\"\}" | format pattern --printf "%b""#,
                 result: Some(Value::test_string(r#"{"foo": "bar"}"#)),
-            },
-            Example {
-                description: "Using printf to substitute multiple args",
-                example: r#"["a", 1] | format pattern --printf "first = %s, second = %d""#,
-                result: Some(Value::test_string("first = a, second = 1")),
             },
         ]
     }
@@ -292,7 +287,7 @@ fn assert_specifier_count_eq_arg_count(
     if spec_count != arg_count {
         Err(ShellError::IncompatibleParametersSingle {
             msg: format!(
-                "Number of arguments ({}) provided does not match the number of specifiers ({}) within the pattern.",
+                "Number of arguments ({}) provided does not match the number of specifiers ({}) given in the pattern.",
                 arg_count, spec_count,
             )
             .into(),


### PR DESCRIPTION
Closes #15624.

<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR enables `format pattern` to accept `printf`-style pattern with a `--printf` flag.

The implementation is powered by `uucore::format` which is also used by `uu_printf` crate.

The behaviors of uutils' `printf` closely matches that of GNU `printf`, some of which doesn't fit well with Nushell
and I try to disallow them in this PR. Specifically:

1. whenever the number of arguments does not match the number of specifiers given in the pattern, `printf`
will perform the formatting without error, by filling either the missing specifiers or arguments. This is
not allowed in this PR: a check is performed to ensure the two are always equal.

2. there exists some edge cases where `printf` will report warning/error to `stderr`, but continue to format
the string and write to stdout.

Some of those cases can be captured and are disallowed, e.g.:

``` nushell
❯ uutils-printf "hello %7b" "world" | complete
╭───────────┬──────────────────────────────────────────────────────────────╮
│ stdout    │ hello                                                        │
│ stderr    │ /nix/store/c1k934lrli5x5brj2x1qlz8zwr1m8l43-uutils-coreutils │
│           │ -0.0.30/bin/uutils-printf: %7b: invalid conversion           │
│           │ specification                                                │
│           │                                                              │
│ exit_code │ 1                                                            │
╰───────────┴──────────────────────────────────────────────────────────────╯

❯ "world" | format pattern --printf "hello %7b"
Error: nu::shell::incompatible_parameters

  × Incompatible parameters.
   ╭─[entry #1:1:1]
 1 │ "world" | format pattern --printf "hello %7b"
   · ───┬───
   ·    ╰── Number of arguments (1) provided does not match the number of specifiers (0) within the pattern.
   ╰────
```

But a few others are not, e.g.:
```nushell
❯ uutils-printf  "%.2f is %s" "42.03x" "a lot" | complete
╭───────────┬──────────────────────────────────────────────────────────────╮
│ stdout    │ 42.03 is a lot                                               │
│ stderr    │ /nix/store/c1k934lrli5x5brj2x1qlz8zwr1m8l43-uutils-coreutils │
│           │ -0.0.30/bin/uutils-printf: '42.03x': value not completely    │
│           │ converted                                                    │
│           │                                                              │
│ exit_code │ 1                                                            │
╰───────────┴──────────────────────────────────────────────────────────────╯

❯ ["42.03x", "a lot"] | format pattern --printf  "%.2f is %s"
/home/yjx/Projects/_contrib/nushell/./target/debug/nu: '42.03x': value not completely converted
42.03 is a lot
```

This is because some errors are directly consumed (i.e. writing to stderr) by functions
from `uucore` without returning them. We may need to send PRs to `uutils` to properly handle them.


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Added a `--printf` flag. Otherwise the behavior should be identical.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
