### PR TITLE
feat(table): make missing value symbol configurable

### DIFF
--- a/crates/nu-command/tests/commands/table.rs
+++ b/crates/nu-command/tests/commands/table.rs
@@ -3359,3 +3359,36 @@ fn table_expand_big_header() {
          ╰───┴──────────────────────────────────────────────────────────────────────────╯"
     );
 }
+
+#[test]
+fn table_missing_value() {
+    let actual = nu!(r###"[{foo: null} {} {}] | table"###);
+    assert_eq!(
+        actual.out,
+        "╭───┬─────╮\
+         │ # │ foo │\
+         ├───┼─────┤\
+         │ 0 │     │\
+         │ 1 │  ❎ │\
+         │ 2 │  ❎ │\
+         ╰───┴─────╯",
+    )
+}
+
+#[test]
+fn table_missing_value_custom() {
+    let actual = nu!(r###"
+        $env.config.table.missing_value_symbol = "NULL";
+        [{foo: null} {} {}] | table
+    "###);
+    assert_eq!(
+        actual.out,
+        "╭───┬──────╮\
+         │ # │ foo  │\
+         ├───┼──────┤\
+         │ 0 │      │\
+         │ 1 │ NULL │\
+         │ 2 │ NULL │\
+         ╰───┴──────╯",
+    )
+}

--- a/crates/nu-protocol/src/config/table.rs
+++ b/crates/nu-protocol/src/config/table.rs
@@ -340,6 +340,7 @@ pub struct TableConfig {
     pub header_on_separator: bool,
     pub abbreviated_row_count: Option<usize>,
     pub footer_inheritance: bool,
+    pub missing_symbol: String,
 }
 
 impl IntoValue for TableConfig {
@@ -358,6 +359,7 @@ impl IntoValue for TableConfig {
             "header_on_separator" => self.header_on_separator.into_value(span),
             "abbreviated_row_count" => abbv_count,
             "footer_inheritance" => self.footer_inheritance.into_value(span),
+            "missing_symbol" => self.missing_symbol.into_value(span),
         }
         .into_value(span)
     }
@@ -374,6 +376,7 @@ impl Default for TableConfig {
             padding: TableIndent::default(),
             abbreviated_row_count: None,
             footer_inheritance: false,
+            missing_symbol: "❎".into(),
         }
     }
 }
@@ -411,6 +414,10 @@ impl UpdateFromValue for TableConfig {
                     _ => errors.type_mismatch(path, Type::custom("int or nothing"), val),
                 },
                 "footer_inheritance" => self.footer_inheritance.update(val, path, errors),
+                "missing_symbol" => match val.as_str() {
+                    Ok(val) => self.missing_symbol = val.to_string(),
+                    Err(_) => errors.type_mismatch(path, Type::String, val),
+                },
                 _ => errors.unknown_option(path, val),
             }
         }

--- a/crates/nu-protocol/src/config/table.rs
+++ b/crates/nu-protocol/src/config/table.rs
@@ -340,7 +340,7 @@ pub struct TableConfig {
     pub header_on_separator: bool,
     pub abbreviated_row_count: Option<usize>,
     pub footer_inheritance: bool,
-    pub missing_symbol: String,
+    pub missing_value_symbol: String,
 }
 
 impl IntoValue for TableConfig {
@@ -359,7 +359,7 @@ impl IntoValue for TableConfig {
             "header_on_separator" => self.header_on_separator.into_value(span),
             "abbreviated_row_count" => abbv_count,
             "footer_inheritance" => self.footer_inheritance.into_value(span),
-            "missing_symbol" => self.missing_symbol.into_value(span),
+            "missing_value_symbol" => self.missing_value_symbol.into_value(span),
         }
         .into_value(span)
     }
@@ -376,7 +376,7 @@ impl Default for TableConfig {
             padding: TableIndent::default(),
             abbreviated_row_count: None,
             footer_inheritance: false,
-            missing_symbol: "❎".into(),
+            missing_value_symbol: "❎".into(),
         }
     }
 }
@@ -414,8 +414,8 @@ impl UpdateFromValue for TableConfig {
                     _ => errors.type_mismatch(path, Type::custom("int or nothing"), val),
                 },
                 "footer_inheritance" => self.footer_inheritance.update(val, path, errors),
-                "missing_symbol" => match val.as_str() {
-                    Ok(val) => self.missing_symbol = val.to_string(),
+                "missing_value_symbol" => match val.as_str() {
+                    Ok(val) => self.missing_value_symbol = val.to_string(),
                     Err(_) => errors.type_mismatch(path, Type::String, val),
                 },
                 _ => errors.unknown_option(path, val),

--- a/crates/nu-table/src/common.rs
+++ b/crates/nu-table/src/common.rs
@@ -71,10 +71,9 @@ pub fn nu_value_to_string_clean(val: &Value, cfg: &Config, style_comp: &StyleCom
     (text, style)
 }
 
-pub fn error_sign(style_computer: &StyleComputer) -> (String, TextStyle) {
+pub fn error_sign(text: String, style_computer: &StyleComputer) -> (String, TextStyle) {
     // Though holes are not the same as null, the closure for "empty" is passed a null anyway.
 
-    let text = String::from("❎");
     let style = style_computer.compute("empty", &Value::nothing(Span::unknown()));
     (text, TextStyle::with_style(Alignment::Center, style))
 }
@@ -122,9 +121,9 @@ pub fn get_value_style(value: &Value, config: &Config, style_computer: &StyleCom
     }
 }
 
-pub fn get_empty_style(style_computer: &StyleComputer) -> NuText {
+pub fn get_empty_style(text: String, style_computer: &StyleComputer) -> NuText {
     (
-        String::from("❎"),
+        text,
         TextStyle::with_style(
             Alignment::Right,
             style_computer.compute("empty", &Value::nothing(Span::unknown())),

--- a/crates/nu-table/src/types/expanded.rs
+++ b/crates/nu-table/src/types/expanded.rs
@@ -507,7 +507,10 @@ fn expand_entry_with_header(item: &Value, header: &str, cfg: Cfg<'_>) -> CellOut
     match item {
         Value::Record { val, .. } => match val.get(header) {
             Some(val) => expand_entry(val, cfg),
-            None => CellOutput::styled(error_sign(&cfg.opts.style_computer)),
+            None => CellOutput::styled(error_sign(
+                cfg.opts.config.table.missing_symbol.clone(),
+                &cfg.opts.style_computer,
+            )),
         },
         _ => expand_entry(item, cfg),
     }

--- a/crates/nu-table/src/types/expanded.rs
+++ b/crates/nu-table/src/types/expanded.rs
@@ -508,7 +508,7 @@ fn expand_entry_with_header(item: &Value, header: &str, cfg: Cfg<'_>) -> CellOut
         Value::Record { val, .. } => match val.get(header) {
             Some(val) => expand_entry(val, cfg),
             None => CellOutput::styled(error_sign(
-                cfg.opts.config.table.missing_symbol.clone(),
+                cfg.opts.config.table.missing_value_symbol.clone(),
                 &cfg.opts.style_computer,
             )),
         },

--- a/crates/nu-table/src/types/general.rs
+++ b/crates/nu-table/src/types/general.rs
@@ -206,7 +206,10 @@ fn get_string_value_with_header(item: &Value, header: &str, opts: &TableOpts) ->
     match item {
         Value::Record { val, .. } => match val.get(header) {
             Some(value) => get_string_value(value, opts),
-            None => get_empty_style(&opts.style_computer),
+            None => get_empty_style(
+                opts.config.table.missing_symbol.clone(),
+                &opts.style_computer,
+            ),
         },
         value => get_string_value(value, opts),
     }

--- a/crates/nu-table/src/types/general.rs
+++ b/crates/nu-table/src/types/general.rs
@@ -207,7 +207,7 @@ fn get_string_value_with_header(item: &Value, header: &str, opts: &TableOpts) ->
         Value::Record { val, .. } => match val.get(header) {
             Some(value) => get_string_value(value, opts),
             None => get_empty_style(
-                opts.config.table.missing_symbol.clone(),
+                opts.config.table.missing_value_symbol.clone(),
                 &opts.style_computer,
             ),
         },

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -355,8 +355,8 @@ $env.config.table.abbreviated_row_count = null
 # false: Always apply `footer_mode` rules to the parent table
 $env.config.table.footer_inheritance = false
 
-# missing_symbol (string): The symbol shown for missing values
-$env.config.table.missing_symbol = "❎"
+# missing_value_symbol (string): The symbol shown for missing values
+$env.config.table.missing_value_symbol = "❎"
 
 # ----------------
 # Datetime Display

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -355,6 +355,9 @@ $env.config.table.abbreviated_row_count = null
 # false: Always apply `footer_mode` rules to the parent table
 $env.config.table.footer_inheritance = false
 
+# missing_symbol (string): The symbol shown for missing values
+$env.config.table.missing_symbol = "❎"
+
 # ----------------
 # Datetime Display
 # ----------------


### PR DESCRIPTION
# Description
Allow users to configure the symbol shown for missing values in tables.

# User-Facing Changes
New configuration option.
```nushell
$env.config.table.missing_symbol = " ∅ "
```

# Tests + Formatting

# After Submitting