### PR TITLE
Add metadata to HTTP responses

### DIFF
--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -133,7 +133,7 @@ pub(super) fn build_metadata_record(
     if let Some(x) = metadata {
         let source: Option<String> = match &x.data_source {
             DataSource::Ls => Some("ls".into()),
-            DataSource::HtmlThemes => Some("into html --list".into()),
+            DataSource::HtmlThemes => Some("to html --list".into()),
             DataSource::FilePath(path) => Some(path.to_string_lossy().into()),
             DataSource::Uri(uri) => Some(uri.into()),
             DataSource::None => None,

--- a/crates/nu-command/src/debug/metadata_access.rs
+++ b/crates/nu-command/src/debug/metadata_access.rs
@@ -1,7 +1,7 @@
 use nu_engine::{command_prelude::*, get_eval_block_with_early_return};
 use nu_protocol::{
     engine::{Call, Closure, Command, EngineState, Stack},
-    DataSource, PipelineData, PipelineMetadata, ShellError, Signature, SyntaxShape, Type, Value,
+    PipelineData, PipelineMetadata, ShellError, Signature, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -65,33 +65,7 @@ impl Command for MetadataAccess {
 }
 
 fn build_metadata_record(metadata: Option<&PipelineMetadata>, head: Span) -> Value {
-    let mut record = Record::new();
-
-    if let Some(x) = metadata {
-        match x {
-            PipelineMetadata {
-                data_source: DataSource::Ls,
-                ..
-            } => record.push("source", Value::string("ls", head)),
-            PipelineMetadata {
-                data_source: DataSource::HtmlThemes,
-                ..
-            } => record.push("source", Value::string("into html --list", head)),
-            PipelineMetadata {
-                data_source: DataSource::FilePath(path),
-                ..
-            } => record.push(
-                "source",
-                Value::string(path.to_string_lossy().to_string(), head),
-            ),
-            _ => {}
-        }
-        if let Some(ref content_type) = x.content_type {
-            record.push("content_type", Value::string(content_type, head));
-        }
-    }
-
-    Value::record(record, head)
+    super::metadata::build_metadata_record(None, metadata, head)
 }
 
 #[cfg(test)]

--- a/crates/nu-protocol/src/pipeline/metadata.rs
+++ b/crates/nu-protocol/src/pipeline/metadata.rs
@@ -33,7 +33,11 @@ impl PipelineMetadata {
 pub enum DataSource {
     Ls,
     HtmlThemes,
+    // TODO: get rid of this by using `file://` protocol
     FilePath(PathBuf),
+    // maybe use a more strict URI type here, in our dependency graph we would already have
+    // `fluent_uri::Uri`
+    Uri(String),
     #[default]
     None,
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR adds metadata to http responses when they aren't converted via `from {ext}`. To accomodate the discussions of #15231 I added a new `DataSource` called `Uri` which currently only holds a string. A proper URI type might be useful in the future but I think is outside of the scope of this PR. Also handled printing it via `metadata` and `metadata access`.

This supersedes #15231 and therefore closes #15231.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Only API changes, nothing on the commands.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Tests did not work for me but not for these commands. I need to investigate this further.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

We should investigate the `DataSource::FilePath` variant and if we want to have a better URI type. `fluent-uri` already provides one and lives in our dependency graph as a starter.