### PR TITLE
Environment-aware help for `open` and `save`

### DIFF
--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -281,6 +281,16 @@ impl Command for Open {
                 example: r#"def "from ndjson" [] { from json -o }; open myfile.ndjson"#,
                 result: None,
             },
+            Example {
+                description: "Show the extensions for which the `open` command will automatically parse",
+                example: r#"scope commands
+    | where name starts-with "from "
+    | insert extension { get name | str replace -r "^from " "" | $"*.($in)" }
+    | select extension name
+    | rename --column { name: command }
+"#,
+                result: None,
+            }
         ]
     }
 }

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -287,7 +287,7 @@ impl Command for Open {
     | where name starts-with "from "
     | insert extension { get name | str replace -r "^from " "" | $"*.($in)" }
     | select extension name
-    | rename --column { name: command }
+    | rename extension command
 "#,
                 result: None,
             }

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -270,7 +270,7 @@ impl Command for Save {
     | where name starts-with "to "
     | insert extension { get name | str replace -r "^to " "" | $"*.($in)" }
     | select extension name
-    | rename --column { name: command }
+    | rename extension command
 "#,
                 result: None,
             },

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -263,6 +263,17 @@ impl Command for Save {
                 example: r#"do -i {} | save foo.txt --stderr bar.txt"#,
                 result: None,
             },
+            Example {
+                description:
+                    "Show the extensions for which the `save` command will automatically serialize",
+                example: r#"scope commands
+    | where name starts-with "to "
+    | insert extension { get name | str replace -r "^to " "" | $"*.($in)" }
+    | select extension name
+    | rename --column { name: command }
+"#,
+                result: None,
+            },
         ]
     }
 

--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -492,7 +492,6 @@ def get-extension-by-prefix [prefix: string] {
   | rename --column { name: command }
 }
 
-
 def get-command-extensions [command: string] {
   # low-tech version of `nu-highlight`, which produces suboptimal results with unknown commands
   def hl [shape: string] {
@@ -710,6 +709,8 @@ def build-command-page [command: record] {
         ] | flatten)
     } else { [] })
 
+    # This section documents how the command can be extended
+    # E.g. `open` can be extended by adding more `from ...` commands
     let extensions = (
       get-command-extensions $command.name
       | if ($in | is-not-empty) {


### PR DESCRIPTION
# Description

This extends the documentation on the commands `open` and `save` can run under the hood, and explicitly lists those, based on the current user environment.

Also see [this discord thread](https://discord.com/channels/601130461678272522/988303282931912704/1364930487092777020)

# User-Facing Changes

Users will be able to see the list of commands that `open` and `save` can run, and the extensions that each command is run for, in `help open` and `help save` respectively:

## `help open`
![image](https://github.com/user-attachments/assets/b245d12c-c6ef-4c6d-a9f1-6c5111cb0684)

## `help save`
![image](https://github.com/user-attachments/assets/e92ddb6b-6a1e-40cc-9139-78db8a921d4a)


# Tests + Formatting

All pass except for the ones that don't (and never did pass for me before).

# After Submitting

No updates needed.
