### PR TITLE
Add lazy closure evaluation to `default` (#14160)

### DIFF
--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -36,7 +36,7 @@ impl Command for Default {
             )
             .switch(
                 "lazy-once",
-                "evaluate the closure only once, even for lists (no input)",
+                "evaluate the closure only once, even for lists (no closure input)",
                 Some('L'),
             )
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -174,12 +174,8 @@ fn default(
                 {
                     let record = record.to_mut().into_spanned(internal_span);
                     item = fill_record(record, &mut default_value, columns, default_when_empty)?;
-                    output_list.push(item);
-                } else {
-                    // To maintain the original functionality of `default`, we skip over
-                    // non-record values in the input stream instead of returning an error
-                    output_list.push(item);
                 }
+                output_list.push(item);
             }
             let ls = ListStream::new(
                 output_list.into_iter(),

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -1,4 +1,4 @@
-use nu_engine::{command_prelude::*, ClosureEval};
+use nu_engine::{ClosureEval, command_prelude::*};
 use nu_protocol::{ListStream, Signals};
 
 #[derive(Clone)]
@@ -65,8 +65,7 @@ impl Command for Default {
                 result: None,
             },
             Example {
-                description:
-                    "Get the env value of `MY_ENV` with a default value 'abc' if not present",
+                description: "Get the env value of `MY_ENV` with a default value 'abc' if not present",
                 example: "$env | get --ignore-errors MY_ENV | default 'abc'",
                 result: Some(Value::test_string("abc")),
             },

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -1,5 +1,5 @@
-use nu_engine::{command_prelude::*, ClosureEvalOnce};
-use nu_protocol::{engine::Closure, ListStream, Signals};
+use nu_engine::{command_prelude::*, ClosureEval};
+use nu_protocol::{ListStream, Signals};
 
 #[derive(Clone)]
 pub struct Default;
@@ -167,6 +167,7 @@ fn default(
             // Potential enhancement: add another branch for Value::List,
             // and collect the iterator into a Result<Value::List, ShellError>
             // so we can preemptively return an error for collected lists
+            let head = call.head;
             Ok(input
                 .into_iter()
                 .map(move |item| {

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -108,7 +108,7 @@ impl Command for Default {
             },
             Example {
                 description: r#"Fill missing column values based on other columns"#,
-                example: "[{a:1 b:2} {b:1}] | upsert a {|rc| default { $rc.b + 1 } }",
+                example: r#"[{a:1 b:2} {b:1}] | upsert a {|rc| default { $rc.b + 1 } }"#,
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
                         "a" => Value::test_int(1),
@@ -203,12 +203,14 @@ fn default(
 
 #[cfg(test)]
 mod test {
+    use crate::Upsert;
+
     use super::*;
 
     #[test]
     fn test_examples() {
-        use crate::test_examples;
+        use crate::test_examples_with_commands;
 
-        test_examples(Default {})
+        test_examples_with_commands(Default {}, &[&Upsert]);
     }
 }

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -13,19 +13,7 @@ impl Command for Default {
         Signature::build("default")
             // TODO: Give more specific type signature?
             // TODO: Declare usage of cell paths in signature? (It seems to behave as if it uses cell paths)
-            .input_output_types(vec![
-                (Type::Nothing, Type::Any),
-                (Type::String, Type::Any),
-                (Type::record(), Type::Any),
-                (Type::list(Type::Any), Type::Any),
-                (Type::Number, Type::Number),
-                (Type::Closure, Type::Closure),
-                (Type::Filesize, Type::Filesize),
-                (Type::Bool, Type::Bool),
-                (Type::Date, Type::Date),
-                (Type::Duration, Type::Duration),
-                (Type::Range, Type::Range),
-            ])
+            .input_output_types(vec![(Type::Any, Type::Any)])
             .required(
                 "default value",
                 SyntaxShape::Any,

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -113,6 +113,25 @@ impl Command for Default {
                     }),
                 ])),
             },
+            Example {
+                description: r#"Generate a default value from a closure"#,
+                example: "null | default --lazy { 1 + 2 }",
+                result: Some(Value::test_int(3)),
+            },
+            Example {
+                description: r#"Generate missing values in a column from a closure"#,
+                example: "[{a:1 b:2} {b:1}] | default -l { $in.b + 1 } a",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "a" => Value::test_int(1),
+                        "b" => Value::test_int(2),
+                    }),
+                    Value::test_record(record! {
+                        "a" => Value::test_int(2),
+                        "b" => Value::test_int(1),
+                    }),
+                ])),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -288,7 +288,7 @@ fn default(
             return default_value_or_eval_once(
                 engine_state,
                 stack,
-                PipelineData::Empty,
+                PipelineData::ListStream(ListStream::new(stream, span, Signals::empty()), metadata),
                 value,
                 lazy_eval || lazy_eval_once,
             );

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -150,7 +150,6 @@ fn default(
     // If user supplies columns, check if input is a record or list of records
     // and set the default value for the specified record columns
     if !columns.is_empty() {
-        // Single record arm
         if matches!(input, PipelineData::Value(Value::Record { .. }, _)) {
             let Value::Record {
                 val: ref mut record,
@@ -162,7 +161,6 @@ fn default(
             let record = record.to_mut().into_spanned(internal_span);
             fill_record(record, &mut default_value, columns, default_when_empty)
                 .map(|x| x.into_pipeline_data().set_metadata(metadata))
-        // List value & ListStream arm
         } else if matches!(
             input,
             PipelineData::ListStream(..) | PipelineData::Value(Value::List { .. }, _)
@@ -260,14 +258,13 @@ impl<'a> DefaultValue<'a> {
     }
 }
 
+/// Given a record, fill missing columns with a default value
 fn fill_record(
     record: Spanned<&mut Record>,
     default_value: &mut DefaultValue,
     columns: &[String],
     empty: bool,
 ) -> Result<Value, ShellError> {
-    // Only run the closure if we haven't already calculated the value
-
     for col in columns {
         if let Some(val) = record.item.get_mut(col) {
             if matches!(val, Value::Nothing { .. }) || (empty && val.is_empty()) {

--- a/crates/nu-command/tests/commands/default.rs
+++ b/crates/nu-command/tests/commands/default.rs
@@ -238,3 +238,9 @@ fn replace_multiple_columns() {
     let actual = nu!(r#"{a: ''} | default -e 1 a b | values | to json -r"#);
     assert_eq!(actual.out, "[1,1]");
 }
+
+#[test]
+fn return_closure_value() {
+    let actual = nu!(r#"null | default { {||} }"#);
+    assert!(actual.out.starts_with("closure"));
+}


### PR DESCRIPTION
# Description

This PR adds lazy closure evaluation to the `default` command (closes #14160).

- For non-closure values and without providing a column name, `default` acts the same as before
- The user can now provide multiple column names to populate if empty
- If the user provides a column name, the input must be a record or list, otherwise an error is created.
- The user can now provide a closure as a default value
  - This closure is run without any arguments or input
  - The closure is never evaluated if the value isn't needed
  - Even when column names are supplied, the closure is only run once (and cached to prevent re-calling it)

For example:

```nushell
> default { 1 + 2 } # => 3
> null | default 3 a   # => previously `null`, now errors
> 1 | default { sleep 5sec; 3 } # => `1`, without waiting 5 seconds

> let optional_var = null; $optional_var | default { input 'Enter value: ' } # => Returns user input
> 5 | default { input 'Enter value: ' } # => `5`, without prompting user

> ls | default { sleep 5sec; 'N/A' } name # => No-op since `name` column is never empty
> ls | default { sleep 5sec; 'N/A' } foo bar # => creates columns `foo` and `bar`; only takes 5 seconds since closure result is cached

# Old behavior is the same
> [] | default 'foo' # => []
> [] | default --empty 'foo' # => 'foo'
> default 5 # => 5
```

# User-Facing Changes

- Users can add default values to multiple columns now.
- Users can now use closures as the default value passed to `default`.
- To return a closure, the user must wrap the closure they want to return inside another closure, which will be run (`default { $my_closure }`).

# Tests + Formatting

All tests pass.

# After Submitting

