### PR TITLE
feat(polars): add `polars horizontal` aggregation command

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/horizontal.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/horizontal.rs
@@ -1,0 +1,191 @@
+use crate::{
+    values::{Column, CustomValueSupport, NuDataFrame, NuExpression},
+    PolarsPlugin,
+};
+
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Spanned,
+    SyntaxShape, Type, Value,
+};
+
+use polars::lazy::dsl::{
+    all_horizontal, any_horizontal, max_horizontal, mean_horizontal, min_horizontal, sum_horizontal,
+};
+use polars::prelude::Expr;
+
+enum HorizontalType {
+    All,
+    Any,
+    Min,
+    Max,
+    Sum,
+    Mean,
+}
+
+impl HorizontalType {
+    fn from_str(roll_type: &str, span: Span) -> Result<Self, ShellError> {
+        match roll_type {
+            "all" => Ok(Self::All),
+            "any" => Ok(Self::Any),
+            "min" => Ok(Self::Min),
+            "max" => Ok(Self::Max),
+            "sum" => Ok(Self::Sum),
+            "mean" => Ok(Self::Mean),
+            _ => Err(ShellError::GenericError {
+                error: "Wrong operation".into(),
+                msg: "Operation not valid for cumulative".into(),
+                span: Some(span),
+                help: Some("Allowed values: all, any, max, min, sum, mean".into()),
+                inner: vec![],
+            }),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Horizontal;
+
+impl PluginCommand for Horizontal {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars horizontal"
+    }
+
+    fn description(&self) -> &str {
+        "Horizontal calculation across multiple columns."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, Type::Custom("expression".into()))
+            .required(
+                "type",
+                SyntaxShape::String,
+                "horizontal operation. Values of all, any, min, max, sum, and mean are accepted.",
+            )
+            .rest(
+                "Group-by expressions",
+                SyntaxShape::Any,
+                "Expression(s) that define the lazy group-by",
+            )
+            .switch(
+                "nulls",
+                "If set, null value in the input will lead to null output",
+                Some('n'),
+            )
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Horizontal sum across two columns (ignore nulls by default)",
+                example: "[[a b]; [1 2] [2 3] [3 4] [4 5] [5 null]]
+                    | polars into-df
+                    | polars select (polars horizontal sum a b)
+                    | polars collect",
+                result: Some(
+                    NuDataFrame::try_from_columns(
+                        vec![Column::new(
+                            "sum".to_string(),
+                            vec![
+                                Value::test_int(3),
+                                Value::test_int(5),
+                                Value::test_int(7),
+                                Value::test_int(9),
+                                Value::test_int(5),
+                            ],
+                        )],
+                        None,
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                description: "Horizontal sum across two columns while accounting for nulls",
+                example: "[[a b]; [1 2] [2 3] [3 4] [4 5] [5 null]]
+                    | polars into-df
+                    | polars select (polars horizontal sum a b --nulls)
+                    | polars collect",
+                result: Some(
+                    NuDataFrame::try_from_columns(
+                        vec![Column::new(
+                            "sum".to_string(),
+                            vec![
+                                Value::test_int(3),
+                                Value::test_int(5),
+                                Value::test_int(7),
+                                Value::test_int(9),
+                                Value::test_nothing(),
+                            ],
+                        )],
+                        None,
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        _input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let func_type: Spanned<String> = call.req(0)?;
+        let func_type = HorizontalType::from_str(&func_type.item, func_type.span)?;
+
+        let vals: Vec<Value> = call.rest(1)?;
+        let expr_value = Value::list(vals, call.head);
+        let exprs = NuExpression::extract_exprs(plugin, expr_value)?;
+
+        let ignore_nulls = !call.has_flag("nulls")?;
+
+        command(plugin, engine, call, func_type, exprs, ignore_nulls).map_err(LabeledError::from)
+    }
+}
+
+fn command(
+    plugin: &PolarsPlugin,
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+    func_type: HorizontalType,
+    exprs: Vec<Expr>,
+    ignore_nulls: bool,
+) -> Result<PipelineData, ShellError> {
+    let res: NuExpression = match func_type {
+        HorizontalType::All => all_horizontal(exprs),
+        HorizontalType::Any => any_horizontal(exprs),
+        HorizontalType::Max => max_horizontal(exprs),
+        HorizontalType::Min => min_horizontal(exprs),
+        HorizontalType::Sum => sum_horizontal(exprs, ignore_nulls),
+        HorizontalType::Mean => mean_horizontal(exprs, ignore_nulls),
+    }
+    .map_err(|e| ShellError::GenericError {
+        error: "Cannot apply horizontal aggregation".to_string(),
+        msg: "".into(),
+        span: Some(call.head),
+        help: Some(e.to_string()),
+        inner: vec![],
+    })?
+    .into();
+
+    res.to_pipeline_data(plugin, engine, call.head)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), ShellError> {
+        test_polars_plugin_command(&Horizontal)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/mod.rs
@@ -3,6 +3,7 @@ mod aggregate;
 mod count;
 mod cumulative;
 pub mod groupby;
+mod horizontal;
 mod implode;
 mod max;
 mod mean;
@@ -25,6 +26,7 @@ use nu_plugin::PluginCommand;
 pub use aggregate::LazyAggregate;
 use count::ExprCount;
 pub use cumulative::Cumulative;
+pub use horizontal::Horizontal;
 use implode::ExprImplode;
 use max::ExprMax;
 use mean::ExprMean;
@@ -45,19 +47,20 @@ pub(crate) fn aggregation_commands() -> Vec<Box<dyn PluginCommand<Plugin = Polar
         Box::new(ExprCount),
         Box::new(ExprImplode),
         Box::new(ExprMax),
-        Box::new(ExprMin),
-        Box::new(ExprSum),
         Box::new(ExprMean),
+        Box::new(ExprMin),
         Box::new(ExprStd),
+        Box::new(ExprSum),
         Box::new(ExprVar),
+        Box::new(Horizontal),
         Box::new(LazyAggregate),
-        Box::new(median::LazyMedian),
-        Box::new(quantile::LazyQuantile),
-        Box::new(groupby::ToLazyGroupBy),
+        Box::new(NNull),
+        Box::new(NUnique),
         Box::new(Over),
         Box::new(Rolling),
         Box::new(ValueCount),
-        Box::new(NNull),
-        Box::new(NUnique),
+        Box::new(groupby::ToLazyGroupBy),
+        Box::new(median::LazyMedian),
+        Box::new(quantile::LazyQuantile),
     ]
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR seeks to port over the `*_horizontal` commands in polars rust/python (e.g., https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.sum_horizontal.html), which aggregate across multiple columns (as opposed to rows). See below for several examples.

```nushell
#  Horizontal sum across two columns (ignore nulls by default)
  > [[a b]; [1 2] [2 3] [3 4] [4 5] [5 null]]
                    | polars into-df
                    | polars select (polars horizontal sum a b)
                    | polars collect
  ╭───┬─────╮
  │ # │ sum │
  ├───┼─────┤
  │ 0 │   3 │
  │ 1 │   5 │
  │ 2 │   7 │
  │ 3 │   9 │
  │ 4 │   5 │
  ╰───┴─────╯

#  Horizontal sum across two columns while accounting for nulls
  > [[a b]; [1 2] [2 3] [3 4] [4 5] [5 null]]
                    | polars into-df
                    | polars select (polars horizontal sum a b --nulls)
                    | polars collect
  ╭───┬─────╮
  │ # │ sum │
  ├───┼─────┤
  │ 0 │   3 │
  │ 1 │   5 │
  │ 2 │   7 │
  │ 3 │   9 │
  │ 4 │     │
  ╰───┴─────╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
No breaking changes. Users have access to a new command, `polars horizontal`.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Example tests were added to `polars horizontal`.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
