### PR TITLE
docs: update ubuntu version in PLATFORM_SUPPORT.md

### DIFF
--- a/devdocs/PLATFORM_SUPPORT.md
+++ b/devdocs/PLATFORM_SUPPORT.md
@@ -15,7 +15,7 @@ The Nushell team runs **testing of Nushell for the following platforms** through
 
 - macOS (latest version available through GitHub CI)
 - Windows (10 and 11)
-- Linux (our test runners use `ubuntu-20.04` to represent distributions with not the latest glibc versions.)
+- Linux (our test runners use `ubuntu-22.04` to represent distributions with not the latest glibc versions.)
 
 All PR level tests are performed on x86/AMD64 (at least at the time of writing the default macOS runner was not yet using arm64).
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

I was interested in how nu-shell handles glibc, especially older versions of it. I figured out from the docs that ubuntu 20.04 is utilized. However, in reality, github has deprecated ubuntu 20.04, and the code for ci.yaml in github workflow clearly states that it is 22.04.

This is just a minor doc update to clarify forgotten information 
