### PR TITLE
feat(table): Add new 'single' table mode

### DIFF
--- a/crates/nu-protocol/src/config/table.rs
+++ b/crates/nu-protocol/src/config/table.rs
@@ -20,6 +20,7 @@ pub enum TableMode {
     Restructured,
     AsciiRounded,
     BasicCompact,
+    Single,
 }
 
 impl FromStr for TableMode {
@@ -44,7 +45,8 @@ impl FromStr for TableMode {
             "restructured" => Ok(Self::Restructured),
             "ascii_rounded" => Ok(Self::AsciiRounded),
             "basic_compact" => Ok(Self::BasicCompact),
-            _ => Err("'basic', 'thin', 'light', 'compact', 'with_love', 'compact_double', 'rounded', 'reinforced', 'heavy', 'none', 'psql', 'markdown', 'dots', 'restructured', 'ascii_rounded', or 'basic_compact'"),
+            "single" => Ok(Self::Single),
+            _ => Err("'basic', 'thin', 'light', 'compact', 'with_love', 'compact_double', 'rounded', 'reinforced', 'heavy', 'none', 'psql', 'markdown', 'dots', 'restructured', 'ascii_rounded', 'basic_compact' or 'single'"),
         }
     }
 }

--- a/crates/nu-table/src/common.rs
+++ b/crates/nu-table/src/common.rs
@@ -186,6 +186,7 @@ pub fn load_theme(mode: TableMode) -> TableTheme {
         TableMode::Restructured => TableTheme::restructured(),
         TableMode::AsciiRounded => TableTheme::ascii_rounded(),
         TableMode::BasicCompact => TableTheme::basic_compact(),
+        TableMode::Single => TableTheme::single(),
     }
 }
 

--- a/crates/nu-table/src/table_theme.rs
+++ b/crates/nu-table/src/table_theme.rs
@@ -156,6 +156,16 @@ impl TableTheme {
         Self::new(theme, full)
     }
 
+    pub fn single() -> TableTheme {
+        let full = Style::modern()
+            .corner_top_left('┌')
+            .corner_top_right('┐')
+            .corner_bottom_left('└')
+            .corner_bottom_right('┘');
+
+        Self::new(Style::sharp(), full)
+    }
+
     pub fn none() -> TableTheme {
         Self::new(Style::blank(), Style::blank())
     }

--- a/crates/nu-table/tests/style.rs
+++ b/crates/nu-table/tests/style.rs
@@ -451,6 +451,52 @@ fn test_with_love() {
     assert_eq!(create_table_with_size(vec![], true, theme::with_love()), "");
 }
 
+#[test]
+fn test_single() {
+    assert_eq!(
+        create_table(vec![row(4); 3], true, theme::single()),
+        "┌───┬───┬───┬───┐\n\
+         │ 0 │ 1 │ 2 │ 3 │\n\
+         ├───┼───┼───┼───┤\n\
+         │ 0 │ 1 │ 2 │ 3 │\n\
+         │ 0 │ 1 │ 2 │ 3 │\n\
+         └───┴───┴───┴───┘"
+    );
+
+    assert_eq!(
+        create_table(vec![row(4); 2], true, theme::single()),
+        "┌───┬───┬───┬───┐\n\
+         │ 0 │ 1 │ 2 │ 3 │\n\
+         ├───┼───┼───┼───┤\n\
+         │ 0 │ 1 │ 2 │ 3 │\n\
+         └───┴───┴───┴───┘"
+    );
+
+    assert_eq!(
+        create_table(vec![row(4); 1], true, theme::single()),
+        "┌───┬───┬───┬───┐\n\
+         │ 0 │ 1 │ 2 │ 3 │\n\
+         └───┴───┴───┴───┘"
+    );
+
+    assert_eq!(
+        create_table(vec![row(4); 1], false, theme::single()),
+        "┌───┬───┬───┬───┐\n\
+         │ 0 │ 1 │ 2 │ 3 │\n\
+         └───┴───┴───┴───┘"
+    );
+
+    assert_eq!(
+        create_table(vec![row(4); 2], false, theme::single()),
+        "┌───┬───┬───┬───┐\n\
+         │ 0 │ 1 │ 2 │ 3 │\n\
+         │ 0 │ 1 │ 2 │ 3 │\n\
+         └───┴───┴───┴───┘"
+    );
+
+    assert_eq!(create_table_with_size(vec![], true, theme::single()), "");
+}
+
 fn create_table(data: Vec<Vec<Text<String>>>, with_header: bool, theme: theme) -> String {
     let mut case = TestCase::new(usize::MAX).theme(theme);
     if with_header {

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -300,7 +300,7 @@ $env.config.footer_mode = 25
 # Specifies the visual display style of a table
 # One of: "default", "basic", "compact", "compact_double", "heavy", "light", "none", "reinforced",
 # "rounded", "thin", "with_love", "psql", "markdown", "dots", "restructured", "ascii_rounded",
-# or "basic_compact"
+# "basic_compact" or "single"
 # Can be overridden by passing a table to `| table --theme/-t`
 $env.config.table.mode = "default"
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->
closes #15381

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Adds a new table mode called `single`, it looks like the `heavy` mode, but the key difference is that it uses thinner lines. I decided on the name `single` because it's one of the border styles Neovim uses, and they look practically the same.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

New config option:

```nushell
$env.config.table.mode = 'single'
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Added new tests in `crates/nu-table/tests/style.rs` to cover the single table mode.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
