### PR TITLE
change `http get` header example to use a record

### DIFF
--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -122,6 +122,11 @@ impl Command for HttpDelete {
                 result: None,
             },
             Example {
+                description: "http delete from example.com, with custom header using a list",
+                example: "http delete --headers [my-header-key-A my-header-value-A my-header-key-B my-header-value-B] https://www.example.com",
+                result: None,
+            },
+            Example {
                 description: "http delete from example.com, with body",
                 example: "http delete --data 'body' https://www.example.com",
                 result: None,

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -117,8 +117,8 @@ impl Command for HttpDelete {
                 result: None,
             },
             Example {
-                description: "http delete from example.com, with custom header",
-                example: "http delete --headers [my-header-key my-header-value] https://www.example.com",
+                description: "http delete from example.com, with custom header using a record",
+                example: "http delete --headers {my-header-key: my-header-value} https://www.example.com",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -116,7 +116,7 @@ impl Command for HttpGet {
             },
             Example {
                 description: "Get content from example.com, with custom header",
-                example: "http get --headers [my-header-key my-header-value] https://www.example.com",
+                example: "http get --headers {my-header-key: my-header-value} https://www.example.com",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -115,12 +115,12 @@ impl Command for HttpGet {
                 result: None,
             },
             Example {
-                description: "Get content from example.com, with custom header",
+                description: "Get content from example.com, with custom header using a record",
                 example: "http get --headers {my-header-key: my-header-value} https://www.example.com",
                 result: None,
             },
             Example {
-                description: "Get content from example.com, with custom headers",
+                description: "Get content from example.com, with custom headers using a list",
                 example: "http get --headers [my-header-key-A my-header-value-A my-header-key-B my-header-value-B] https://www.example.com",
                 result: None,
             },

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -97,9 +97,9 @@ impl Command for HttpHead {
                 result: None,
             },
             Example {
-                description: "Get headers from example.com, with custom header",
+                description: "Get headers from example.com, with custom header using a record",
                 example:
-                    "http head --headers [my-header-key my-header-value] https://www.example.com",
+                    "http head --headers {my-header-key: my-header-value} https://www.example.com",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -102,6 +102,12 @@ impl Command for HttpHead {
                     "http head --headers {my-header-key: my-header-value} https://www.example.com",
                 result: None,
             },
+            Example {
+                description: "Get headers from example.com, with custom header using a list",
+                example:
+                    "http head --headers [my-header-key-A my-header-value-A my-header-key-B my-header-value-B] https://www.example.com",
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -96,12 +96,12 @@ impl Command for HttpOptions {
                 result: None,
             },
             Example {
-                description: "Get options from example.com, with custom header",
-                example: "http options --headers [my-header-key my-header-value] https://www.example.com",
+                description: "Get options from example.com, with custom header using a record",
+                example: "http options --headers {my-header-key: my-header-value} https://www.example.com",
                 result: None,
             },
             Example {
-                description: "Get options from example.com, with custom headers",
+                description: "Get options from example.com, with custom headers using a list",
                 example: "http options --headers [my-header-key-A my-header-value-A my-header-key-B my-header-value-B] https://www.example.com",
                 result: None,
             },

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -120,6 +120,12 @@ impl Command for HttpPatch {
                 result: None,
             },
             Example {
+                description: "Patch content to example.com, with custom header using a list",
+                example:
+                    "http patch --headers [my-header-key-A my-header-value-A my-header-key-B my-header-value-B] https://www.example.com",
+                result: None,
+            },
+            Example {
                 description: "Patch content to example.com, with JSON body",
                 example: "http patch --content-type application/json https://www.example.com { field: value }",
                 result: None,

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -114,9 +114,9 @@ impl Command for HttpPatch {
                 result: None,
             },
             Example {
-                description: "Patch content to example.com, with custom header",
+                description: "Patch content to example.com, with custom header using a record",
                 example:
-                    "http patch --headers [my-header-key my-header-value] https://www.example.com",
+                    "http patch --headers {my-header-key: my-header-value} https://www.example.com",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -118,6 +118,11 @@ impl Command for HttpPost {
                 result: None,
             },
             Example {
+                description: "Post content to example.com, with custom header using a list",
+                example: "http post --headers [my-header-key-A my-header-value-A my-header-key-B my-header-value-B] https://www.example.com",
+                result: None,
+            },
+            Example {
                 description: "Post content to example.com, with JSON body",
                 example: "http post --content-type application/json https://www.example.com { field: value }",
                 result: None,

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -113,8 +113,8 @@ impl Command for HttpPost {
                 result: None,
             },
             Example {
-                description: "Post content to example.com, with custom header",
-                example: "http post --headers [my-header-key my-header-value] https://www.example.com",
+                description: "Post content to example.com, with custom header using a record",
+                example: "http post --headers {my-header-key: my-header-value} https://www.example.com",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -113,8 +113,8 @@ impl Command for HttpPut {
                 result: None,
             },
             Example {
-                description: "Put content to example.com, with custom header",
-                example: "http put --headers [my-header-key my-header-value] https://www.example.com",
+                description: "Put content to example.com, with custom header using a record",
+                example: "http put --headers {my-header-key: my-header-value} https://www.example.com",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -118,6 +118,11 @@ impl Command for HttpPut {
                 result: None,
             },
             Example {
+                description: "Put content to example.com, with custom header using a list",
+                example: "http put --headers [my-header-key-A my-header-value-A my-header-key-B my-header-value-B] https://www.example.com",
+                result: None,
+            },
+            Example {
                 description: "Put content to example.com, with JSON body",
                 example: "http put --content-type application/json https://www.example.com { field: value }",
                 result: None,


### PR DESCRIPTION
# Description

When first using `http get`, I was confused that all the examples used a list for headers, leading me to believe this was the only way, and it seemed a little weird having records in the language. Then, I found out that you can indeed use record, so I changed the example to show this behavior in a way users can find. There still is another examples that uses a list so there should be no problem there.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
