### PR TITLE
feat(autoload): implement conditional vendor autoloading during command

### DIFF
--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -173,6 +173,20 @@ fn read_and_sort_directory(path: &Path) -> Result<Vec<String>> {
     Ok(entries)
 }
 
+pub(crate) fn should_run_autoload(engine_state: &EngineState, stack: &Stack) -> bool {
+    let env_vars = stack.get_env_vars(engine_state);
+    env_vars
+        .get("NU_AUTOLOAD_ON_COMMAND")
+        .and_then(|val| {
+            if let Ok(val_str) = val.as_str() {
+                Some(val_str.to_lowercase() == "true")
+            } else {
+                None
+            }
+        })
+        .unwrap_or(false)
+}
+
 pub(crate) fn read_vendor_autoload_files(engine_state: &mut EngineState, stack: &mut Stack) {
     warn!(
         "read_vendor_autoload_files() {}:{}:{}",
@@ -180,10 +194,20 @@ pub(crate) fn read_vendor_autoload_files(engine_state: &mut EngineState, stack: 
         line!(),
         column!()
     );
+    let mut autoload_dirs = get_vendor_autoload_dirs(engine_state);
+    if should_run_autoload(engine_state, stack) {
+        // Check for custom autoload dir in Nushell's environment
+        let env_vars = stack.get_env_vars(engine_state);
+        if let Some(val) = env_vars.get("NU_VENDOR_AUTOLOAD_DIR") {
+            if let Ok(path_str) = val.as_str() {
+                let path = std::path::PathBuf::from(path_str);
+                autoload_dirs.push(path);
+            }
+        }
+    }
 
-    // The evaluation order is first determined by the semantics of `get_vendor_autoload_dirs`
-    // to determine the order of directories to evaluate
-    get_vendor_autoload_dirs(engine_state)
+    // Use our modified autoload_dirs list
+    autoload_dirs // Changed: use our modified list instead of calling get_vendor_autoload_dirs again
         .iter()
         // User autoload directories are evaluated after vendor, which means that
         // the user can override vendor autoload files
@@ -206,6 +230,11 @@ pub(crate) fn read_vendor_autoload_files(engine_state: &mut EngineState, stack: 
                 }
             }
         });
+
+    // Add environment merging here to ensure changes take effect
+    if let Err(e) = engine_state.merge_env(stack) {
+        report_shell_error(engine_state, &e);
+    }
 }
 
 fn eval_default_config(

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,6 +1,6 @@
 use crate::{
     command,
-    config_files::{self, setup_config},
+    config_files::{self, read_vendor_autoload_files, setup_config, should_run_autoload},
 };
 use log::trace;
 #[cfg(feature = "plugin")]
@@ -76,6 +76,15 @@ pub(crate) fn run_commands(
         }
 
         perf!("read login.nu", start_time, use_color);
+        // Only run vendor autoload if NU_AUTOLOAD_ON_COMMAND is set to true
+
+        if should_run_autoload(engine_state, &stack) {
+            read_vendor_autoload_files(engine_state, &mut stack);
+            if let Err(e) = engine_state.merge_env(&mut stack) {
+                report_shell_error(engine_state, &e);
+            }
+            perf!("read vendor autoload", start_time, use_color);
+        }
     }
 
     // Before running commands, set up the startup time


### PR DESCRIPTION
implement conditional vendor autoloading during command based on environement variable

# Description

This PR fixes the issue #13635 by introducing the possibitity to load `NU_VENDOR_AUTOLOAD_DIR` variable during running the arg  `-c` 

# User-Facing Changes

User can now use the environement variable `NU_AUTOLOAD_ON_COMMAND` to force nushell to read the variable `NU_VENDOR_AUTOLOAD_DIR` during the execution of a command with argument `-c`

# Tests + Formatting
The function `read_vendor_autoload_files` or `run_commands` are not actually tested. It do make sense to introduce new test for this change.

General test run localy

# After Submitting

