### PR TITLE
fix(parser): don't parse closure in block position (fixes #15417)

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2034,6 +2034,10 @@ pub fn parse_brace_expr(
         } else {
             parse_record(working_set, span)
         }
+    } else if matches!(shape, SyntaxShape::Block) {
+        parse_block_expression(working_set, span)
+    } else if matches!(shape, SyntaxShape::MatchBlock) {
+        parse_match_block_expression(working_set, span)
     } else if matches!(second_token_contents, Some(TokenContents::Pipe))
         || matches!(second_token_contents, Some(TokenContents::PipePipe))
     {
@@ -2042,10 +2046,6 @@ pub fn parse_brace_expr(
         parse_full_cell_path(working_set, None, span)
     } else if matches!(shape, SyntaxShape::Closure(_)) {
         parse_closure_expression(working_set, shape, span)
-    } else if matches!(shape, SyntaxShape::Block) {
-        parse_block_expression(working_set, span)
-    } else if matches!(shape, SyntaxShape::MatchBlock) {
-        parse_match_block_expression(working_set, span)
     } else if second_token.is_some_and(|c| {
         c.len() > 3 && c.starts_with(b"...") && (c[3] == b'$' || c[3] == b'{' || c[3] == b'(')
     }) {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2034,18 +2034,22 @@ pub fn parse_brace_expr(
         } else {
             parse_record(working_set, span)
         }
-    } else if matches!(shape, SyntaxShape::Block) {
-        parse_block_expression(working_set, span)
-    } else if matches!(shape, SyntaxShape::MatchBlock) {
-        parse_match_block_expression(working_set, span)
     } else if matches!(second_token_contents, Some(TokenContents::Pipe))
         || matches!(second_token_contents, Some(TokenContents::PipePipe))
     {
+        if matches!(shape, SyntaxShape::Block) {
+            working_set.error(ParseError::Mismatch("block".into(), "closure".into(), span));
+            return Expression::garbage(working_set, span);
+        }
         parse_closure_expression(working_set, shape, span)
     } else if matches!(third_token, Some(b":")) {
         parse_full_cell_path(working_set, None, span)
     } else if matches!(shape, SyntaxShape::Closure(_)) {
         parse_closure_expression(working_set, shape, span)
+    } else if matches!(shape, SyntaxShape::Block) {
+        parse_block_expression(working_set, span)
+    } else if matches!(shape, SyntaxShape::MatchBlock) {
+        parse_match_block_expression(working_set, span)
     } else if second_token.is_some_and(|c| {
         c.len() > 3 && c.starts_with(b"...") && (c[3] == b'$' || c[3] == b'{' || c[3] == b'(')
     }) {

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -2725,6 +2725,23 @@ mod input_types {
     }
 
     #[test]
+    fn closure_in_block_position_errors_correctly() {
+        let mut engine_state = EngineState::new();
+        add_declarations(&mut engine_state);
+
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        let inputs = [
+            r#"if true { || print hi }"#,
+            r#"match true { || print hi }"#,
+        ];
+
+        for input in inputs {
+            parse(&mut working_set, None, input.as_bytes(), true);
+            assert!(!working_set.parse_errors.is_empty(), "testing: {input}");
+        }
+    }
+
+    #[test]
     fn else_errors_correctly() {
         let mut engine_state = EngineState::new();
         add_declarations(&mut engine_state);

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -2730,13 +2730,18 @@ mod input_types {
         add_declarations(&mut engine_state);
 
         let mut working_set = StateWorkingSet::new(&engine_state);
-        let input = r#"if true { || print hi }"#;
+        let inputs = [r#"if true { || print hi }"#, r#"if true { |x| $x }"#];
 
-        parse(&mut working_set, None, input.as_bytes(), true);
-        assert!(matches!(
-            working_set.parse_errors.first(),
-            Some(ParseError::Mismatch(_, _, _))
-        ));
+        for input in inputs {
+            parse(&mut working_set, None, input.as_bytes(), true);
+            assert!(
+                matches!(
+                    working_set.parse_errors.first(),
+                    Some(ParseError::Mismatch(_, _, _))
+                ),
+                "testing: {input}"
+            );
+        }
     }
 
     #[test]

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -2730,15 +2730,13 @@ mod input_types {
         add_declarations(&mut engine_state);
 
         let mut working_set = StateWorkingSet::new(&engine_state);
-        let inputs = [
-            r#"if true { || print hi }"#,
-            r#"match true { || print hi }"#,
-        ];
+        let input = r#"if true { || print hi }"#;
 
-        for input in inputs {
-            parse(&mut working_set, None, input.as_bytes(), true);
-            assert!(!working_set.parse_errors.is_empty(), "testing: {input}");
-        }
+        parse(&mut working_set, None, input.as_bytes(), true);
+        assert!(matches!(
+            working_set.parse_errors.first(),
+            Some(ParseError::Mismatch(_, _, _))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Hello!

This is my 1st contribution and an attempt at fixing #15417. 

# Description

When parsing a brace expression, check if the shape is a block or match block before attempting to parse it as a closure.
Results:
- `if true {|| print hi}` now produces a `nu::parser` error instead of executing and outputting `hi`. The `nu::parser` error is the same one produced by running `|| print hi` (`nu::parser::shell_oror`)
- `match true {|| print hi}` now fails with a `nu::parser` error instead of passing parsing and failing with `nu::compile::invalid_keyword_call`

My understanding reading the code/docs is that the shape is a contextual constraint that needs to be satisfied for parsing to succeed, in this case the `if` placing a `Block` shape constraint on next tokens. So it would need to be checked in priority (if not `Any`) to understand how the next tokens should be parsed. Is that correct? Or is there a reason I'm not aware of to ignore the shape and attempt to parse as closure like it's currently the case when the parser sees `|` or `||` as next tokens?

# User-Facing Changes

No change in behaviour, but this PR fixes parsing to fail on some incorrect syntax which could be considered a breaking change.

# Tests + Formatting
- Added corresponding tests
- `toolkit check pr` passed
