### PR TITLE
perf: reorder cell-path member accesses to avoid clones

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1114,7 +1114,36 @@ impl Value {
         let mut store: Value = Value::test_nothing();
         let mut current: MultiLife<'out, '_, Value> = MultiLife::Out(self);
 
-        for member in cell_path {
+        let mut members: Vec<_> = cell_path.iter().map(Some).collect();
+        let mut members = members.as_mut_slice();
+
+        loop {
+            // Skip any None values at the start.
+            while let Some(None) = members.first() {
+                members = &mut members[1..];
+            }
+
+            if members.is_empty() {
+                break;
+            }
+
+            // Reorder cell-path member access by prioritizing Int members to avoid cloning unless
+            // necessary
+            let member = if let Value::List { .. } = &*current {
+                // If the value is a list, try to find an Int member
+                members
+                    .iter_mut()
+                    .find(|x| matches!(x, Some(PathMember::Int { .. })))
+                    // And take it from the list of members
+                    .and_then(Option::take)
+            } else {
+                None
+            };
+
+            let Some(member) = member.or_else(|| members.first_mut().and_then(Option::take)) else {
+                break;
+            };
+
             current = match current {
                 MultiLife::Out(current) => match get_value_member(current, member, insensitive)? {
                     ControlFlow::Break(span) => return Ok(Cow::Owned(Value::nothing(span))),


### PR DESCRIPTION
# Description

While traversing a value with a cell-path, if the value is a list, all column accesses will essentially be a `map` operation over its elements, and produce another list.

This is wasteful if there is a row access after the column accesses, as all other rows are then discarded.

```nushell
let val = [[bar]; [{foo: [A, B]}], [{foo: [C, D]}]]

$val.bar
# => [[foo]; [[A, B]], [[C, D]]]
# this is equivalent to the following, because we're
# accessing the `bar` field of all list items 
$val | each { $in.bar }

$val.bar.foo
# => [[A, B], [C, D]]
# because cell-path access works on values and not streams,
# we're actually collecting in between these
$val | each { $in.bar } | collect | each { $in.foo }

$val.bar.foo.0
# => [A, B]
# row accesses are straight forward, it's just indexing into a list
# no mapping over items required
$val | each { $in.bar } | collect | each { $in.foo.0 }

$val.bar.foo.0.0
# => A
$val | each { $in.bar } | collect | each { $in.foo.0.0 }
```

In comparison, if we reorder cell-path access to prioritize row accesses over column accesses:
```nushell
let val = [[bar]; [{foo: [A, B]}], [{foo: [C, D]}]]
# we have a list, so we can do a row access
# let's move the first row access to the front of the cell-path
# $.bar.foo.0.0 => $.0.bar.foo.0
$val.0
# => {bar: {foo: [A, B]}}
# just indexing into a list, no mapping or collecting

# $val.0 is not a list we can't move any other row access to the front
# but that's ok, accessing a field on a record is similarly cheap
$val.0.bar
# => {foo: [A, B]}

# another record field access 
$val.0.bar.foo
# => [A, B]

$val.0.bar.foo.0
# => A
# we've reached the same value!
```

This reordering works especially well with #15640, as accessing a row in a list or a field in a record can be done through references, avoiding clones.

# Caveats

```nushell
let val = [{foo: A}, {baz: B}]
$val
# => ╭───┬─────┬─────╮
# => │ # │ foo │ baz │
# => ├───┼─────┼─────┤
# => │ 0 │ A   │ ❎  │
# => │ 1 │ ❎  │ B   │
# => ╰───┴─────┴─────╯

$val.foo
# throws an error as expected

$val.foo.0
# before this PR, this also throws an error
# but due to reordering the access to `$val.0.foo`
# this works without issue and returns `A`
```
Whether this is a good thing or bad isn't really clear :shrug: 

# User-Facing Changes

# Tests + Formatting

- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
