### PR TITLE
fix: clear jobs _after_ traversing jobs for kill_all

### DIFF
--- a/crates/nu-protocol/src/engine/jobs.rs
+++ b/crates/nu-protocol/src/engine/jobs.rs
@@ -112,12 +112,12 @@ impl Jobs {
     pub fn kill_all(&mut self) -> std::io::Result<()> {
         self.last_frozen_job_id = None;
 
-        self.jobs.clear();
-
         let first_err = self
             .iter()
             .map(|(_, job)| job.kill().err())
             .fold(None, |acc, x| acc.or(x));
+
+        self.jobs.clear();
 
         if let Some(err) = first_err {
             Err(err)


### PR DESCRIPTION
# Description

Move clear jobs to _after_ traversing them, in order to kill them.

# User-Facing Changes

None

# Tests + Formatting

It looks like it's only used once, in crates/nu-engine/src/exit.rs