### PR TITLE
docs: Add vfox to list of tools supporting Nushell

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Please submit an issue or PR to be added to this list.
 -   [Dorothy](http://github.com/bevry/dorothy)
 -   [Direnv](https://github.com/direnv/direnv/blob/master/docs/hook.md#nushell)
 -   [x-cmd](https://x-cmd.com/mod/nu)
+-   [vfox](https://github.com/version-fox/vfox)
 
 ## Contributing
 


### PR DESCRIPTION
This change adds [vfox](https://github.com/version-fox/vfox) to the list of tools that support Nushell in the readme.

This is a tool for managing multiple versions of SDKs (similar to [asdf](https://asdf-vm.com/), but cross-platform). After some work by me and another contributor (see https://github.com/version-fox/vfox/issues/207), vfox now works in Nushell!