### PR TITLE
add the `examples` column to the `help commands` output table

### DIFF
--- a/crates/nu-command/src/help/help_commands.rs
+++ b/crates/nu-command/src/help/help_commands.rs
@@ -66,7 +66,7 @@ pub fn help_commands(
         let found_cmds_vec = highlight_search_in_table(
             all_cmds_vec,
             &f.item,
-            &["name", "description", "search_terms"],
+            &["name", "description", "search_terms", "examples"],
             &string_style,
             &highlight_style,
         )?;
@@ -201,6 +201,25 @@ fn build_help_commands(engine_state: &EngineState, span: Span) -> Vec<Value> {
             Value::list(vals, span)
         };
 
+        // Build table of examples
+        let examples_table = {
+            // decl.examples() returns Vec<Example>
+            let command_examples = decl.examples();
+            let mut example_records = Vec::with_capacity(command_examples.len());
+
+            for example in command_examples {
+                example_records.push(Value::record(
+                    record! {
+                        "description" => Value::string(example.description, span),
+                        "example" => Value::string(example.example, span),
+                    },
+                    span,
+                ));
+            }
+
+            Value::list(example_records, span)
+        };
+
         let record = record! {
             "name" => Value::string(key, span),
             "category" => Value::string(sig.category.to_string(), span),
@@ -210,6 +229,7 @@ fn build_help_commands(engine_state: &EngineState, span: Span) -> Vec<Value> {
             "input_output" => input_output_table,
             "search_terms" => Value::string(search_terms.join(", "), span),
             "is_const" => Value::bool(decl.is_const(), span),
+            "examples" => examples_table,
         };
 
         found_cmds_vec.push(Value::record(record, span));


### PR DESCRIPTION
# Description

This PR adds the column `examples` to `help commands`. I needed this column for generating markdown documentation for commands, as otherwise, I would need to parse help for each command manually.

P.S. Gemini generated this code for me. I do not understand Rust yet, though I asked Claude to check it, and I have looked through the relatively simple code many times and found that everything looks straightforward. I understand that LLMs might produce garbage, and in such cases, I would be adding unnecessary load to maintainers to check the code. Yet, I think that in this PR, everything is okay. Thanks

# User-Facing Changes
I don't think there are any.

# Tests + Formatting
All are okay.