### PR TITLE
fix: inefficient select with large row number

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -310,7 +310,7 @@ impl Iterator for NthIterator {
                     return self.input.next();
                 } else {
                     self.current += 1;
-                    let _ = self.input.next();
+                    let _ = self.input.next()?;
                     continue;
                 }
             } else {

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -135,6 +135,12 @@ fn selects_a_row() {
 }
 
 #[test]
+fn selects_large_row_number() {
+    let actual = nu!("seq 1 5 | select 9999999999 | to nuon");
+    assert_eq!(actual.out, "[]");
+}
+
+#[test]
 fn selects_many_rows() {
     Playground::setup("select_test_2", |dirs, sandbox| {
         sandbox.with_files(&[EmptyFile("notes.txt"), EmptyFile("arepas.txt")]);


### PR DESCRIPTION
Fixes #15716

# Description

Returns None early if the input iterator is depleted.

# User-Facing Changes

Should be none

# Tests + Formatting

+1

# After Submitting
