### PR TITLE
Add `match` examples for simple value and alternative values

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/match_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/match_.rs
@@ -50,6 +50,17 @@ impl Command for Match {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
+                description: "Match on a value",
+                example: "match 3 { 1 => 'one', 2 => 'two', 3 => 'three' }",
+                result: Some(Value::test_string("three")),
+            },
+            Example {
+                description: "Match against alternative values",
+                example:
+                    "match 'three' { 1 | 'one' => '-', 2 | 'two' => '--', 3 | 'three' => '---' }",
+                result: Some(Value::test_string("---")),
+            },
+            Example {
                 description: "Match on a value in range",
                 example: "match 3 { 1..10 => 'yes!' }",
                 result: Some(Value::test_string("yes!")),


### PR DESCRIPTION
Even with some experience in Nushell I did not find information about the match syntax for alternative value matches. The `match` command help does not mention it at all. I suggest we add an example.

Previously, the examples only had "advanced" matching operations. It seems appropriate to start with the simplest one: Matching by value.

Add both of these examples.

# User-Facing Changes

`help match` and the [command reference docs](https://www.nushell.sh/commands/docs/match.html) now have examples for

* simple value matching
* alternative value matching
