### PR TITLE
Allow `path join` to read ByteStream input (#15128)

### DIFF
--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -175,6 +175,9 @@ fn run(call: &Call, args: &Arguments, input: PipelineData) -> Result<PipelineDat
             handle_value(stream.into_value(), args, head),
             metadata,
         )),
+        PipelineData::ByteStream(stream, ..) if stream.type_().is_string_coercible() => Ok(
+            PipelineData::Value(handle_value(stream.into_value()?, args, head), metadata),
+        ),
         PipelineData::Empty => Err(ShellError::PipelineEmpty { dst_span: head }),
         _ => Err(ShellError::UnsupportedInput {
             msg: "Input value cannot be joined".to_string(),

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -175,16 +175,11 @@ fn run(call: &Call, args: &Arguments, input: PipelineData) -> Result<PipelineDat
             handle_value(stream.into_value(), args, head),
             metadata,
         )),
-        PipelineData::ByteStream(stream, ..) if stream.type_().is_string_coercible() => Ok(
-            PipelineData::Value(handle_value(stream.into_value()?, args, head), metadata),
-        ),
+        PipelineData::ByteStream(stream, ..) => Ok(PipelineData::Value(
+            handle_value(stream.into_value()?, args, head),
+            metadata,
+        )),
         PipelineData::Empty => Err(ShellError::PipelineEmpty { dst_span: head }),
-        _ => Err(ShellError::UnsupportedInput {
-            msg: "Input value cannot be joined".to_string(),
-            input: "value originates from here".into(),
-            msg_span: head,
-            input_span: input.span().unwrap_or(call.head),
-        }),
     }
 }
 


### PR DESCRIPTION
# Description
Fixes #15128. Allows `path join` to use ByteStream pipeline data to join on if it's coercible to string. Binary ByteStream input still results in an error. Tested with `^$nu.current-exe -c '$nu.config-path' | path join foo` and `^tar.exe -c assets/nu_logo.ico | path join foo`

# User-Facing Changes
If an external command returns a path, users would previously need to use `^show-path-cmd | collect | path join 'foo'`, now they can drop the intermediate `collect`.

# Tests + Formatting


# After Submitting