### PR TITLE
Update lscolors from 0.17 to 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,10 +3088,11 @@ dependencies = [
 
 [[package]]
 name = "lscolors"
-version = "0.17.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53304fff6ab1e597661eee37e42ea8c47a146fca280af902bb76bff8a896e523"
+checksum = "61183da5de8ba09a58e330d55e5ea796539d8443bd00fdeb863eac39724aa4ab"
 dependencies = [
+ "aho-corasick",
  "nu-ansi-term",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ libc = "0.2"
 libproc = "0.14"
 log = "0.4"
 lru = "0.12"
-lscolors = { version = "0.17", default-features = false }
+lscolors = { version = "0.20", default-features = false }
 lsp-server = "0.7.8"
 lsp-types = { version = "0.97.0", features = ["proposed"] }
 lsp-textdocument = "0.4.2"


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Update `lscolors` from 0.17.0 to 0.20.0.

- [0.20.0](https://github.com/sharkdp/lscolors/releases/tag/v0.20.0): Updated `crossterm` dependency
- [0.19.0](https://github.com/sharkdp/lscolors/releases/tag/v0.19.0): Fast extension matching
- [0.18.0](https://github.com/sharkdp/lscolors/releases/tag/v0.18.0): Add `owo-colors` as an ansi backend; make `fi=0` disable fallback to no

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

N/A

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

`cargo test --workspace` and `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` still pass

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

N/A