### PR TITLE
fix: empty tables now respect `$env.config.use_ansi_coloring` (closes #14896)

### DIFF
--- a/crates/nu-command/tests/commands/table.rs
+++ b/crates/nu-command/tests/commands/table.rs
@@ -3848,6 +3848,30 @@ fn table_colors() {
 }
 
 #[test]
+fn table_empty_colors() {
+    let actual = nu!("$env.config.use_ansi_coloring = true; []");
+    assert_eq!(
+        actual.out,
+        "\u{1b}[37m╭────────────╮\u{1b}[0m\u{1b}[37m│\u{1b}[0m \u{1b}[2mempty list\u{1b}[0m \u{1b}[37m│\u{1b}[0m\u{1b}[37m╰────────────╯\u{1b}[0m"
+    );
+
+    let actual = nu!("$env.config.use_ansi_coloring = true; {}");
+    assert_eq!(
+        actual.out,
+        "\u{1b}[37m╭──────────────╮\u{1b}[0m\u{1b}[37m│\u{1b}[0m \u{1b}[2mempty record\u{1b}[0m \u{1b}[37m│\u{1b}[0m\u{1b}[37m╰──────────────╯\u{1b}[0m"
+    );
+
+    let actual = nu!("$env.config.use_ansi_coloring = false; []");
+    assert_eq!(actual.out, "╭────────────╮│ empty list │╰────────────╯");
+
+    let actual = nu!("$env.config.use_ansi_coloring = false; {}");
+    assert_eq!(
+        actual.out,
+        "╭──────────────╮│ empty record │╰──────────────╯",
+    );
+}
+
+#[test]
 fn table_index() {
     let actual = nu!(
         "[[ index     var ]; [ abc         1 ] [ def         2 ] [ ghi         3 ]] | table --width=80"

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -16,7 +16,8 @@ use tabled::{
         ansi::ANSIBuf,
         colors::Colors,
         config::{
-            AlignmentHorizontal, ColoredConfig, Entity, Indent, Position, Sides, SpannedConfig,
+            AlignmentHorizontal, ColoredConfig, Entity, EntityMap, Indent, Position, Sides,
+            SpannedConfig,
         },
         dimension::{CompleteDimensionVecRecords, SpannedGridDimension},
         records::{
@@ -228,10 +229,19 @@ impl NuTable {
         self.config.border_color = (!color.is_plain()).then_some(color);
     }
 
+    pub fn clear_border_color(&mut self) {
+        self.config.border_color = None;
+    }
+
     // NOTE: BE CAREFUL TO KEEP WIDTH UNCHANGED
     // TODO: fix interface
     pub fn get_records_mut(&mut self) -> &mut [Vec<NuRecordsValue>] {
         &mut self.data
+    }
+
+    pub fn clear_all_colors(&mut self) {
+        self.clear_border_color();
+        self.styles.cfg.set_colors(EntityMap::default());
     }
 
     /// Converts a table to a String.


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

- fixes #14896
- related to #15163

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR fixes the presence of ansi color codes in empty tables, when `$env.config.table.show_empty = true` and `$env.config.use_ansi_coloring = false`

# User-Facing Changes
Empty tables respect `$env.config.use_ansi_coloring`

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Added a test for this case.

# After Submitting