### PR TITLE
Use Default for making Suggestions in attribute_completions

### DIFF
--- a/crates/nu-cli/src/completions/attribute_completions.rs
+++ b/crates/nu-cli/src/completions/attribute_completions.rs
@@ -33,8 +33,6 @@ impl Completer for AttributeCompletion {
                 suggestion: Suggestion {
                     value: String::from_utf8_lossy(name).into_owned(),
                     description: desc,
-                    style: None,
-                    extra: None,
                     span: reedline::Span {
                         start: span.start - offset,
                         end: span.end - offset,
@@ -71,8 +69,6 @@ impl Completer for AttributableCompletion {
                 suggestion: Suggestion {
                     value: cmd.name().into(),
                     description: Some(cmd.description().into()),
-                    style: None,
-                    extra: None,
                     span: reedline::Span {
                         start: span.start - offset,
                         end: span.end - offset,

--- a/crates/nu-cli/src/completions/attribute_completions.rs
+++ b/crates/nu-cli/src/completions/attribute_completions.rs
@@ -40,6 +40,7 @@ impl Completer for AttributeCompletion {
                         end: span.end - offset,
                     },
                     append_whitespace: false,
+                    ..Default::default()
                 },
                 kind: Some(SuggestionKind::Command(ty, Some(decl_id))),
             });
@@ -77,6 +78,7 @@ impl Completer for AttributableCompletion {
                         end: span.end - offset,
                     },
                     append_whitespace: false,
+                    ..Default::default()
                 },
                 kind: Some(SuggestionKind::Command(cmd.command_type(), None)),
             });


### PR DESCRIPTION
# Description

In preparation for https://github.com/nushell/reedline/pull/798, which adds a new field to `Suggestion`, this PR makes sure that `Suggestion`s are created using `..Default::default()` inside `attribute_completions.rs`.

# User-Facing Changes

None

# Tests + Formatting

None

# After Submitting