### PR TITLE
fix duplicate short_name in `ansi` command

### DIFF
--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -47,13 +47,13 @@ static CODE_LIST: LazyLock<Vec<AnsiCode>> = LazyLock::new(|| { vec![
     AnsiCode{ short_name: Some("lrr"), long_name: "light_red_reverse", code: Color::LightRed.reverse().prefix().to_string()},
     AnsiCode{ short_name: Some("bg_lr"), long_name: "bg_light_red", code: Style::new().on(Color::LightRed).prefix().to_string()},
 
-    AnsiCode{ short_name: Some("u"), long_name: "blue", code: Color::Blue.prefix().to_string()},
-    AnsiCode{ short_name: Some("ub"), long_name: "blue_bold", code: Color::Blue.bold().prefix().to_string()},
-    AnsiCode{ short_name: Some("uu"), long_name: "blue_underline", code: Color::Blue.underline().prefix().to_string()},
-    AnsiCode{ short_name: Some("ui"), long_name: "blue_italic", code: Color::Blue.italic().prefix().to_string()},
-    AnsiCode{ short_name: Some("ud"), long_name: "blue_dimmed", code: Color::Blue.dimmed().prefix().to_string()},
-    AnsiCode{ short_name: Some("ur"), long_name: "blue_reverse", code: Color::Blue.reverse().prefix().to_string()},
-    AnsiCode{ short_name: Some("bg_u"), long_name: "bg_blue", code: Style::new().on(Color::Blue).prefix().to_string()},
+    AnsiCode{ short_name: Some("b"), long_name: "blue", code: Color::Blue.prefix().to_string()},
+    AnsiCode{ short_name: Some("bb"), long_name: "blue_bold", code: Color::Blue.bold().prefix().to_string()},
+    AnsiCode{ short_name: Some("bu"), long_name: "blue_underline", code: Color::Blue.underline().prefix().to_string()},
+    AnsiCode{ short_name: Some("bi"), long_name: "blue_italic", code: Color::Blue.italic().prefix().to_string()},
+    AnsiCode{ short_name: Some("bd"), long_name: "blue_dimmed", code: Color::Blue.dimmed().prefix().to_string()},
+    AnsiCode{ short_name: Some("br"), long_name: "blue_reverse", code: Color::Blue.reverse().prefix().to_string()},
+    AnsiCode{ short_name: Some("bg_b"), long_name: "bg_blue", code: Style::new().on(Color::Blue).prefix().to_string()},
 
     AnsiCode{ short_name: Some("lu"), long_name: "light_blue", code: Color::LightBlue.prefix().to_string()},
     AnsiCode{ short_name: Some("lub"), long_name: "light_blue_bold", code: Color::LightBlue.bold().prefix().to_string()},
@@ -63,13 +63,13 @@ static CODE_LIST: LazyLock<Vec<AnsiCode>> = LazyLock::new(|| { vec![
     AnsiCode{ short_name: Some("lur"), long_name: "light_blue_reverse", code: Color::LightBlue.reverse().prefix().to_string()},
     AnsiCode{ short_name: Some("bg_lu"), long_name: "bg_light_blue", code: Style::new().on(Color::LightBlue).prefix().to_string()},
 
-    AnsiCode{ short_name: Some("b"), long_name: "black", code: Color::Black.prefix().to_string()},
-    AnsiCode{ short_name: Some("bb"), long_name: "black_bold", code: Color::Black.bold().prefix().to_string()},
-    AnsiCode{ short_name: Some("bu"), long_name: "black_underline", code: Color::Black.underline().prefix().to_string()},
-    AnsiCode{ short_name: Some("bi"), long_name: "black_italic", code: Color::Black.italic().prefix().to_string()},
-    AnsiCode{ short_name: Some("bd"), long_name: "black_dimmed", code: Color::Black.dimmed().prefix().to_string()},
-    AnsiCode{ short_name: Some("br"), long_name: "black_reverse", code: Color::Black.reverse().prefix().to_string()},
-    AnsiCode{ short_name: Some("bg_b"), long_name: "bg_black", code: Style::new().on(Color::Black).prefix().to_string()},
+    AnsiCode{ short_name: Some("k"), long_name: "black", code: Color::Black.prefix().to_string()},
+    AnsiCode{ short_name: Some("kb"), long_name: "black_bold", code: Color::Black.bold().prefix().to_string()},
+    AnsiCode{ short_name: Some("ku"), long_name: "black_underline", code: Color::Black.underline().prefix().to_string()},
+    AnsiCode{ short_name: Some("ki"), long_name: "black_italic", code: Color::Black.italic().prefix().to_string()},
+    AnsiCode{ short_name: Some("kd"), long_name: "black_dimmed", code: Color::Black.dimmed().prefix().to_string()},
+    AnsiCode{ short_name: Some("kr"), long_name: "black_reverse", code: Color::Black.reverse().prefix().to_string()},
+    AnsiCode{ short_name: Some("bg_k"), long_name: "bg_black", code: Style::new().on(Color::Black).prefix().to_string()},
 
     AnsiCode{ short_name: Some("ligr"), long_name: "light_gray", code: Color::LightGray.prefix().to_string()},
     AnsiCode{ short_name: Some("ligrb"), long_name: "light_gray_bold", code: Color::LightGray.bold().prefix().to_string()},
@@ -911,5 +911,50 @@ mod tests {
         use crate::test_examples;
 
         test_examples(Ansi {})
+    }
+
+    #[test]
+    fn no_duplicate_short_names() {
+        use crate::platform::ansi::ansi_::CODE_LIST;
+        use std::collections::HashSet;
+
+        let mut seen = HashSet::new();
+        let mut duplicates = Vec::new();
+
+        for ansi in CODE_LIST.iter() {
+            if let Some(name) = ansi.short_name {
+                if !seen.insert(name) {
+                    duplicates.push(name);
+                }
+            }
+        }
+
+        assert!(
+            duplicates.is_empty(),
+            "Duplicate short_names found: {:?}",
+            duplicates
+        );
+    }
+
+    #[test]
+    fn no_duplicate_long_names() {
+        use crate::platform::ansi::ansi_::CODE_LIST;
+        use std::collections::HashSet;
+
+        let mut seen = HashSet::new();
+        let mut duplicates = Vec::new();
+
+        for ansi in CODE_LIST.iter() {
+            let name = ansi.long_name;
+            if !seen.insert(name) {
+                duplicates.push(name);
+            }
+        }
+
+        assert!(
+            duplicates.is_empty(),
+            "Duplicate long_names found: {:?}",
+            duplicates
+        );
     }
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
I found that both `underline` and `blue` have the same `short_name` (`u`) in the `ansi` command. To fix this, I have changed the black `short_names` to use the letter `k` as is convention and then blue to the letter `b`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Now, the `short_names` for black use `k` instead of `b`, and the `short_names` for blue use `b` instead of `u`.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
I have added the tests `no_duplicate_short_names` and `no_duplicate_long_names` to catch this.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
