### PR TITLE
Add @deprecated attribute

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1,8 +1,8 @@
 pub mod support;
 
 use std::{
-    fs::{FileType, ReadDir, read_dir},
-    path::{MAIN_SEPARATOR, PathBuf},
+    fs::{read_dir, FileType, ReadDir},
+    path::{PathBuf, MAIN_SEPARATOR},
     sync::Arc,
 };
 
@@ -10,7 +10,7 @@ use nu_cli::NuCompleter;
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_path::expand_tilde;
-use nu_protocol::{Config, PipelineData, debugger::WithoutDebug, engine::StateWorkingSet};
+use nu_protocol::{debugger::WithoutDebug, engine::StateWorkingSet, Config, PipelineData};
 use nu_std::load_standard_library;
 use reedline::{Completer, Suggestion};
 use rstest::{fixture, rstest};
@@ -1589,7 +1589,7 @@ fn attribute_completions() {
         .collect();
 
     // Make sure we actually found some attributes so the test is valid
-    assert!(attribute_names.contains(&String::from("examples")));
+    assert!(attribute_names.contains(&String::from("example")));
 
     // Instantiate a new completer
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1,8 +1,8 @@
 pub mod support;
 
 use std::{
-    fs::{read_dir, FileType, ReadDir},
-    path::{PathBuf, MAIN_SEPARATOR},
+    fs::{FileType, ReadDir, read_dir},
+    path::{MAIN_SEPARATOR, PathBuf},
     sync::Arc,
 };
 
@@ -10,7 +10,7 @@ use nu_cli::NuCompleter;
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_path::expand_tilde;
-use nu_protocol::{debugger::WithoutDebug, engine::StateWorkingSet, Config, PipelineData};
+use nu_protocol::{Config, PipelineData, debugger::WithoutDebug, engine::StateWorkingSet};
 use nu_std::load_standard_library;
 use reedline::{Completer, Suggestion};
 use rstest::{fixture, rstest};

--- a/crates/nu-cmd-lang/src/core_commands/attr/deprecated.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/deprecated.rs
@@ -1,0 +1,83 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct AttrDeprecated;
+
+impl Command for AttrDeprecated {
+    fn name(&self) -> &str {
+        "attr category"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("attr category")
+            .input_output_types(vec![
+                (Type::Nothing, Type::Nothing),
+                (Type::Nothing, Type::String),
+            ])
+            .optional(
+                "message",
+                SyntaxShape::String,
+                "Message to include with deprecation warning.",
+            )
+            .category(Category::Core)
+    }
+
+    fn description(&self) -> &str {
+        "Attribute for marking a command as deprecated."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Also consider setting the category to deprecated."
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let message: Option<Value> = call.opt(engine_state, stack, 0)?;
+        match message {
+            Some(message) => Ok(message.into_pipeline_data()),
+            None => Ok(PipelineData::Empty),
+        }
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let message: Option<Value> = call.opt_const(working_set, 0)?;
+        match message {
+            Some(message) => Ok(message.into_pipeline_data()),
+            None => Ok(PipelineData::Empty),
+        }
+    }
+
+    fn is_const(&self) -> bool {
+        true
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Add a deprecation warning to a custom command",
+                example: r###"@deprecated
+    def outdated [] {}"###,
+                result: Some(Value::nothing(Span::test_data())),
+            },
+            Example {
+                description: "Add a deprecation warning with a custom message",
+                example: r###"@deprecated "Use my-new-command instead."
+    def my-old-command [] {}"###,
+                result: Some(Value::string(
+                    "Use my-new-command instead.",
+                    Span::test_data(),
+                )),
+            },
+        ]
+    }
+}

--- a/crates/nu-cmd-lang/src/core_commands/attr/deprecated.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/deprecated.rs
@@ -5,11 +5,11 @@ pub struct AttrDeprecated;
 
 impl Command for AttrDeprecated {
     fn name(&self) -> &str {
-        "attr category"
+        "attr deprecated"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("attr category")
+        Signature::build("attr deprecated")
             .input_output_types(vec![
                 (Type::Nothing, Type::Nothing),
                 (Type::Nothing, Type::String),
@@ -27,7 +27,7 @@ impl Command for AttrDeprecated {
     }
 
     fn extra_description(&self) -> &str {
-        "Also consider setting the category to deprecated."
+        "Also consider setting the category to deprecated with @category deprecated"
     }
 
     fn run(
@@ -72,6 +72,7 @@ impl Command for AttrDeprecated {
             Example {
                 description: "Add a deprecation warning with a custom message",
                 example: r###"@deprecated "Use my-new-command instead."
+    @category deprecated
     def my-old-command [] {}"###,
                 result: Some(Value::string(
                     "Use my-new-command instead.",

--- a/crates/nu-cmd-lang/src/core_commands/attr/mod.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/mod.rs
@@ -1,7 +1,9 @@
 mod category;
+mod deprecated;
 mod example;
 mod search_terms;
 
 pub use category::AttrCategory;
+pub use deprecated::AttrDeprecated;
 pub use example::AttrExample;
 pub use search_terms::AttrSearchTerms;

--- a/crates/nu-cmd-lang/src/default_context.rs
+++ b/crates/nu-cmd-lang/src/default_context.rs
@@ -17,6 +17,7 @@ pub fn create_default_context() -> EngineState {
         bind_command! {
             Alias,
             AttrCategory,
+            AttrDeprecated,
             AttrExample,
             AttrSearchTerms,
             Break,

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -8,17 +8,17 @@ use itertools::Itertools;
 use log::trace;
 use nu_path::canonicalize_with;
 use nu_protocol::{
+    Alias, BlockId, CustomExample, DeclId, FromValue, Module, ModuleId, ParseError, ParseWarning,
+    PositionalArg, ResolvedImportPattern, ShellError, Signature, Span, Spanned, SyntaxShape, Type,
+    Value, VarId,
     ast::{
         Argument, AttributeBlock, Block, Call, Expr, Expression, ImportPattern, ImportPatternHead,
         ImportPatternMember, Pipeline, PipelineElement,
     },
     category_from_string,
-    engine::{StateWorkingSet, DEFAULT_OVERLAY_NAME},
+    engine::{DEFAULT_OVERLAY_NAME, StateWorkingSet},
     eval_const::eval_constant,
     parser_path::ParserPath,
-    Alias, BlockId, CustomExample, DeclId, FromValue, Module, ModuleId, ParseError, ParseWarning,
-    PositionalArg, ResolvedImportPattern, ShellError, Signature, Span, Spanned, SyntaxShape, Type,
-    Value, VarId,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -31,16 +31,16 @@ pub const LIB_DIRS_VAR: &str = "NU_LIB_DIRS";
 pub const PLUGIN_DIRS_VAR: &str = "NU_PLUGIN_DIRS";
 
 use crate::{
-    is_math_expression_like,
+    Token, TokenContents, is_math_expression_like,
     known_external::KnownExternal,
     lex,
-    lite_parser::{lite_parse, LiteCommand},
+    lite_parser::{LiteCommand, lite_parse},
     parser::{
-        check_call, garbage, garbage_pipeline, parse, parse_call, parse_expression,
-        parse_full_signature, parse_import_pattern, parse_internal_call, parse_string, parse_value,
-        parse_var_with_opt_type, trim_quotes, ParsedInternalCall,
+        ParsedInternalCall, check_call, garbage, garbage_pipeline, parse, parse_call,
+        parse_expression, parse_full_signature, parse_import_pattern, parse_internal_call,
+        parse_string, parse_value, parse_var_with_opt_type, trim_quotes,
     },
-    unescape_unquote_string, Token, TokenContents,
+    unescape_unquote_string,
 };
 
 /// These parser keywords can be aliased

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1,8 +1,8 @@
 use nu_parser::*;
 use nu_protocol::{
+    DeclId, ParseError, ParseWarning, Signature, Span, SyntaxShape, Type,
     ast::{Argument, Expr, Expression, ExternalArgument, PathMember, Range},
     engine::{Command, EngineState, Stack, StateWorkingSet},
-    DeclId, ParseError, ParseWarning, Signature, Span, SyntaxShape, Type,
 };
 use rstest::rstest;
 
@@ -2114,7 +2114,7 @@ mod mock {
     use super::*;
     use nu_engine::CallExt;
     use nu_protocol::{
-        engine::Call, Category, IntoPipelineData, PipelineData, ShellError, Type, Value,
+        Category, IntoPipelineData, PipelineData, ShellError, Type, Value, engine::Call,
     };
 
     #[derive(Clone)]

--- a/crates/nu-protocol/src/errors/parse_warning.rs
+++ b/crates/nu-protocol/src/errors/parse_warning.rs
@@ -5,16 +5,21 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Error, Diagnostic, Serialize, Deserialize)]
 pub enum ParseWarning {
-    #[error("Deprecated: {old_command}")]
-    #[diagnostic(help("for more info see {url}"))]
+    #[error("Command deprecated.")]
+    #[diagnostic(code(nu::parser::deprecated))]
     DeprecatedWarning {
         old_command: String,
-        new_suggestion: String,
-        #[label(
-            "`{old_command}` is deprecated and will be removed in a future release. Please {new_suggestion} instead."
-        )]
+        #[label("{old_command} is deprecated and will be removed in a future release.")]
         span: Span,
-        url: String,
+    },
+    #[error("Command deprecated.")]
+    #[diagnostic(code(nu::parser::deprecated))]
+    #[diagnostic(help("{help}"))]
+    DeprecatedWarningWithMessage {
+        old_command: String,
+        #[label("{old_command} is deprecated and will be removed in a future release.")]
+        span: Span,
+        help: String,
     },
 }
 
@@ -22,6 +27,7 @@ impl ParseWarning {
     pub fn span(&self) -> Span {
         match self {
             ParseWarning::DeprecatedWarning { span, .. } => *span,
+            ParseWarning::DeprecatedWarningWithMessage { span, .. } => *span,
         }
     }
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR adds the ability for users to mark commands as deprecated with a `@deprecated` attribute. The attribute can be invoked with or without an extra explanation message. 

Without a message:
![image](https://github.com/user-attachments/assets/359c3f29-dde1-4d21-9501-4ebc9918a156)


With a message:
![image](https://github.com/user-attachments/assets/df3983b1-3ca3-4b60-836b-501d633a3724)


I also changed the deprecated warnings a bit to make them look a bit nicer in my opinion:
- Added an error code (looks nicer with `Warning: ` text)
- Removed command name from error description (it's already in the label)
- Removed suggestion from label and made it optional (it's already in the help text)
- Removed backticks surrounding command names (errors seem to be split on whether they use backticks or not, but we have no special formatting for them which I think leads to unnecessary noise)
- Removed the hardcoded "for more info see" in the help text, so users of the deprecation warning can set the help text however they would like

Here's what a previous deprecation warning looked like, for reference 

![image](https://github.com/user-attachments/assets/39bd6e14-9f7b-4c98-9198-afadb9f8a0cb)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
* Adds the `@deprecated` attribute, which can be used to mark a custom command as deprecated. You can optionally supply a message to suggest a new command.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Changed the attributes completions test to not be hard-coded (so if we add any more attributes they don't need to be manually added) and added a test for `@deprecated`.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A