### PR TITLE
Handle multiple exact matches

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -2346,6 +2346,32 @@ fn exact_match() {
     assert!(suggestions.len() > 1);
 }
 
+#[cfg(all(not(windows), not(target_os = "macos")))]
+#[test]
+fn exact_match_case_insensitive() {
+    use nu_test_support::playground::Playground;
+    use support::completions_helpers::new_engine_helper;
+
+    Playground::setup("exact_match_case_insensitive", |dirs, playground| {
+        playground.mkdir("AA/foo");
+        playground.mkdir("aa/foo");
+        playground.mkdir("aaa/foo");
+
+        let (dir, _, engine, stack) = new_engine_helper(dirs.test().into());
+        let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+
+        let target = format!("open {}", folder(dir.join("aa")));
+        match_suggestions(
+            &vec![
+                folder(dir.join("AA").join("foo")).as_str(),
+                folder(dir.join("aa").join("foo")).as_str(),
+                folder(dir.join("aaa").join("foo")).as_str(),
+            ],
+            &completer.complete(&target, target.len()),
+        );
+    });
+}
+
 #[ignore = "was reverted, still needs fixing"]
 #[rstest]
 fn alias_offset_bug_7648() {

--- a/crates/nu-cli/tests/completions/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/completions/support/completions_helpers.rs
@@ -14,11 +14,8 @@ fn create_default_context() -> EngineState {
     nu_command::add_shell_command_context(nu_cmd_lang::create_default_context())
 }
 
-/// creates a new engine with the current path into the completions fixtures folder
-pub fn new_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
-    // Target folder inside assets
-    let dir = fs::fixtures().join("completions");
-    let dir_str = dir
+pub fn new_engine_helper(pwd: AbsolutePathBuf) -> (AbsolutePathBuf, String, EngineState, Stack) {
+    let pwd_str = pwd
         .clone()
         .into_os_string()
         .into_string()
@@ -36,13 +33,13 @@ pub fn new_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
     // Add pwd as env var
     stack.add_env_var(
         "PWD".to_string(),
-        Value::string(dir_str.clone(), nu_protocol::Span::new(0, dir_str.len())),
+        Value::string(pwd_str.clone(), nu_protocol::Span::new(0, pwd_str.len())),
     );
     stack.add_env_var(
         "TEST".to_string(),
         Value::string(
             "NUSHELL".to_string(),
-            nu_protocol::Span::new(0, dir_str.len()),
+            nu_protocol::Span::new(0, pwd_str.len()),
         ),
     );
     #[cfg(windows)]
@@ -58,7 +55,7 @@ pub fn new_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
         "PATH".to_string(),
         Value::string(
             "/some/path:/some/other/path".to_string(),
-            nu_protocol::Span::new(0, dir_str.len()),
+            nu_protocol::Span::new(0, pwd_str.len()),
         ),
     );
 
@@ -66,7 +63,12 @@ pub fn new_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
     let merge_result = engine_state.merge_env(&mut stack);
     assert!(merge_result.is_ok());
 
-    (dir, dir_str, engine_state, stack)
+    (pwd, pwd_str, engine_state, stack)
+}
+
+/// creates a new engine with the current path in the completions fixtures folder
+pub fn new_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
+    new_engine_helper(fs::fixtures().join("completions"))
 }
 
 /// Adds pseudo PATH env for external completion tests
@@ -88,22 +90,12 @@ pub fn new_external_engine() -> EngineState {
     engine
 }
 
-/// creates a new engine with the current path into the completions fixtures folder
+/// creates a new engine with the current path in the dotnu_completions fixtures folder
 pub fn new_dotnu_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
     // Target folder inside assets
     let dir = fs::fixtures().join("dotnu_completions");
-    let dir_str = dir
-        .clone()
-        .into_os_string()
-        .into_string()
-        .unwrap_or_default();
+    let (dir, dir_str, mut engine_state, mut stack) = new_engine_helper(dir);
     let dir_span = nu_protocol::Span::new(0, dir_str.len());
-
-    // Create a new engine with default context
-    let mut engine_state = create_default_context();
-
-    // Add $nu
-    engine_state.generate_nu_constant();
 
     // const $NU_LIB_DIRS
     let mut working_set = StateWorkingSet::new(&engine_state);
@@ -122,15 +114,6 @@ pub fn new_dotnu_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
     );
     let _ = engine_state.merge_delta(working_set.render());
 
-    // New stack
-    let mut stack = Stack::new();
-
-    // Add pwd as env var
-    stack.add_env_var("PWD".to_string(), Value::string(dir_str.clone(), dir_span));
-    stack.add_env_var(
-        "TEST".to_string(),
-        Value::string("NUSHELL".to_string(), dir_span),
-    );
     stack.add_env_var(
         "NU_LIB_DIRS".into(),
         Value::test_list(vec![
@@ -147,73 +130,11 @@ pub fn new_dotnu_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
 }
 
 pub fn new_quote_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
-    // Target folder inside assets
-    let dir = fs::fixtures().join("quoted_completions");
-    let dir_str = dir
-        .clone()
-        .into_os_string()
-        .into_string()
-        .unwrap_or_default();
-
-    // Create a new engine with default context
-    let mut engine_state = create_default_context();
-
-    // New stack
-    let mut stack = Stack::new();
-
-    // Add pwd as env var
-    stack.add_env_var(
-        "PWD".to_string(),
-        Value::string(dir_str.clone(), nu_protocol::Span::new(0, dir_str.len())),
-    );
-    stack.add_env_var(
-        "TEST".to_string(),
-        Value::string(
-            "NUSHELL".to_string(),
-            nu_protocol::Span::new(0, dir_str.len()),
-        ),
-    );
-
-    // Merge environment into the permanent state
-    let merge_result = engine_state.merge_env(&mut stack);
-    assert!(merge_result.is_ok());
-
-    (dir, dir_str, engine_state, stack)
+    new_engine_helper(fs::fixtures().join("quoted_completions"))
 }
 
 pub fn new_partial_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
-    // Target folder inside assets
-    let dir = fs::fixtures().join("partial_completions");
-    let dir_str = dir
-        .clone()
-        .into_os_string()
-        .into_string()
-        .unwrap_or_default();
-
-    // Create a new engine with default context
-    let mut engine_state = create_default_context();
-
-    // New stack
-    let mut stack = Stack::new();
-
-    // Add pwd as env var
-    stack.add_env_var(
-        "PWD".to_string(),
-        Value::string(dir_str.clone(), nu_protocol::Span::new(0, dir_str.len())),
-    );
-    stack.add_env_var(
-        "TEST".to_string(),
-        Value::string(
-            "NUSHELL".to_string(),
-            nu_protocol::Span::new(0, dir_str.len()),
-        ),
-    );
-
-    // Merge environment into the permanent state
-    let merge_result = engine_state.merge_env(&mut stack);
-    assert!(merge_result.is_ok());
-
-    (dir, dir_str, engine_state, stack)
+    new_engine_helper(fs::fixtures().join("partial_completions"))
 }
 
 /// match a list of suggestions with the expected values


### PR DESCRIPTION
# Description

Fixes #15734. With case-insensitive matching, when completing a file/folder, there can be multiple exact matches. For example, if you have three folders `aa/`, `AA/`, and `aaa/`, `aa/<TAB>` should match all of them. But, as reported in #15734, when using prefix matching, only `AA/` will be shown. This is because when there's an exact match in prefix match mode, we only show the first exact match.

There are two options for fixing this:
- Show all matched suggestions (`aa/`, `AA/`, and `aaa/`)
  - I chose this option
- Show only the suggestions that matched exactly (`aa/` and `AA/`) but not others (`aaa/`)
  - This felt unintuitive

# User-Facing Changes

As mentioned above, when:
- you have multiple folders with the same name but in different cases
- and you're using prefix matching
- and you're using case-insensitive matching
- and you type in the name of one of these folders exactly

then you'll be suggested every folder matching the typed text, rather than just exact matches

# Tests + Formatting

I added a test that doesn't run on Windows or MacOS (to avoid case-insensitive filesystems). While adding this test, I felt like using `Playground` rather than adding files to `tests/fixtures`. To make this easier, I refactored the `new_*_engine()` helpers in `completion_helpers.rs` a bit. There was quite a bit of code duplication there.

# After Submitting

N/A