### PR TITLE
`run-external` spreads command if it's a list

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -72,7 +72,8 @@ impl Command for External {
                         span: call.head,
                     });
                 };
-                call_args = [args.to_vec(), call_args].concat();
+                // Prepend elements in command list to the list of arguments except the first
+                call_args.splice(0..0, args.to_vec());
                 first.coerce_str()?
             }
             _ => Cow::Owned(name.clone().coerce_into_string()?),

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -53,9 +53,9 @@ impl Command for External {
     ) -> Result<PipelineData, ShellError> {
         let cwd = engine_state.cwd(Some(stack))?;
         let rest = call.rest::<Value>(engine_state, stack, 0)?;
-        let name_args = rest.split_first();
+        let name_args = rest.split_first().map(|(x, y)| (x, y.to_vec()));
 
-        let Some((name, call_args)) = name_args else {
+        let Some((name, mut call_args)) = name_args else {
             return Err(ShellError::MissingParameter {
                 param_name: "no command given".into(),
                 span: call.head,
@@ -65,6 +65,16 @@ impl Command for External {
         let name_str: Cow<str> = match &name {
             Value::Glob { val, .. } => Cow::Borrowed(val),
             Value::String { val, .. } => Cow::Borrowed(val),
+            Value::List { vals, .. } => {
+                let Some((first, args)) = vals.split_first() else {
+                    return Err(ShellError::MissingParameter {
+                        param_name: "external command given as list empty".into(),
+                        span: call.head,
+                    });
+                };
+                call_args = [args.to_vec(), call_args].concat();
+                first.coerce_str()?
+            }
             _ => Cow::Owned(name.clone().coerce_into_string()?),
         };
 
@@ -164,7 +174,7 @@ impl Command for External {
         command.envs(envs);
 
         // Configure args.
-        let args = eval_external_arguments(engine_state, stack, call_args.to_vec())?;
+        let args = eval_external_arguments(engine_state, stack, call_args)?;
         #[cfg(windows)]
         if is_cmd_internal_command(&name_str) || pathext_script_in_windows {
             // The /D flag disables execution of AutoRun commands from registry.

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -535,3 +535,32 @@ fn can_run_ps1_files(prefix: &str) {
         assert!(actual.out.contains("Hello World"));
     });
 }
+
+#[rstest]
+#[case("^")]
+#[case("run-external ")]
+fn expand_command_if_list(#[case] prefix: &str) {
+    use nu_test_support::fs::Stub::FileWithContent;
+    Playground::setup("expand command if list", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContent("foo.txt", "Hello World")]);
+        let actual = nu!(
+            cwd: dirs.test(),
+            r#"
+                let cmd = [nu `--testbin`]; {}$cmd meow foo.txt
+            "#,
+            prefix
+        );
+
+        assert!(actual.out.contains("Hello World"));
+    })
+}
+
+#[rstest]
+#[case("^")]
+#[case("run-external ")]
+fn error_when_command_list_empty(#[case] prefix: &str) {
+    Playground::setup("error when command is list with no items", |dirs, _| {
+        let actual = nu!(cwd: dirs.test(), "let cmd = []; {}$cmd", prefix);
+        assert!(actual.err.contains("missing parameter"));
+    })
+}


### PR DESCRIPTION
# Description
Nushell currently suggests setting editor variables as lists if you want to pass flags to them, like the following: `$env.config.buffer_editor = ["emacsclient", "-s", "light", "-t"]`.

This works great for using `config nu` and `config env`, but if someone wanted to use the user's editor in their own custom command, they'd have to work around the command being potentially a list or single string, resulting in workarounds.

```nushell
> let editor = $env.config.buffer_editor? | default $env.VISUAL? | default $env.EDITOR? | default 'nano'
> ^$editor foo.txt
# Previously would have to be something like below to cover both cases:
# run-external ...([$editor] | flatten) foo.txt
```

Once caveat is that you can't pass a bare list as the command to `run-external` since it's treated as a glob, but you should never need to do that in the first place.

# User-Facing Changes

# Tests + Formatting
Added tests to ensure a list at the command position is expanded, and ensure an empty list results in an error.

# After Submitting
