### PR TITLE
Refactor: Construct `IoError` from `std::io::Error` instead of `std::io::ErrorKind`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3996,6 +3996,7 @@ dependencies = [
  "thiserror 2.0.12",
  "typetag",
  "web-time",
+ "windows 0.56.0",
  "windows-sys 0.48.0",
 ]
 

--- a/crates/nu-cli/src/commands/history/history_.rs
+++ b/crates/nu-cli/src/commands/history/history_.rs
@@ -1,5 +1,8 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::{HistoryFileFormat, shell_error::io::IoError};
+use nu_protocol::{
+    HistoryFileFormat,
+    shell_error::{self, io::IoError},
+};
 use reedline::{
     FileBackedHistory, History as ReedlineHistory, HistoryItem, SearchDirection, SearchQuery,
     SqliteBackedHistory,
@@ -94,7 +97,7 @@ impl Command for History {
                     })
                 })
                 .ok_or(IoError::new(
-                    std::io::ErrorKind::NotFound,
+                    shell_error::io::ErrorKind::FileNotFound,
                     head,
                     history_path,
                 ))?
@@ -110,7 +113,7 @@ impl Command for History {
                     })
                 })
                 .ok_or(IoError::new(
-                    std::io::ErrorKind::NotFound,
+                    shell_error::io::ErrorKind::FileNotFound,
                     head,
                     history_path,
                 ))?

--- a/crates/nu-cli/src/commands/history/history_import.rs
+++ b/crates/nu-cli/src/commands/history/history_import.rs
@@ -287,7 +287,7 @@ fn backup(path: &Path, span: Span) -> Result<Option<PathBuf>, ShellError> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => {
             return Err(IoError::new_internal(
-                e.kind(),
+                e,
                 "Could not get metadata",
                 nu_protocol::location!(),
             )
@@ -297,7 +297,7 @@ fn backup(path: &Path, span: Span) -> Result<Option<PathBuf>, ShellError> {
     let bak_path = find_backup_path(path, span)?;
     std::fs::copy(path, &bak_path).map_err(|err| {
         IoError::new_internal(
-            err.kind(),
+            err.not_found_as(NotFound::File),
             "Could not copy backup",
             nu_protocol::location!(),
         )

--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -42,7 +42,7 @@ impl Command for KeybindingsListen {
             Err(e) => {
                 terminal::disable_raw_mode().map_err(|err| {
                     IoError::new_internal(
-                        err.kind(),
+                        err,
                         "Could not disable raw mode",
                         nu_protocol::location!(),
                     )
@@ -71,18 +71,10 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
     let config = engine_state.get_config();
 
     stdout().flush().map_err(|err| {
-        IoError::new_internal(
-            err.kind(),
-            "Could not flush stdout",
-            nu_protocol::location!(),
-        )
+        IoError::new_internal(err, "Could not flush stdout", nu_protocol::location!())
     })?;
     terminal::enable_raw_mode().map_err(|err| {
-        IoError::new_internal(
-            err.kind(),
-            "Could not enable raw mode",
-            nu_protocol::location!(),
-        )
+        IoError::new_internal(err, "Could not enable raw mode", nu_protocol::location!())
     })?;
 
     if config.use_kitty_protocol {
@@ -114,7 +106,7 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
 
     loop {
         let event = crossterm::event::read().map_err(|err| {
-            IoError::new_internal(err.kind(), "Could not read event", nu_protocol::location!())
+            IoError::new_internal(err, "Could not read event", nu_protocol::location!())
         })?;
         if event == Event::Key(KeyCode::Esc.into()) {
             break;
@@ -136,7 +128,7 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
         };
         stdout.queue(crossterm::style::Print(o)).map_err(|err| {
             IoError::new_internal(
-                err.kind(),
+                err,
                 "Could not print output record",
                 nu_protocol::location!(),
             )
@@ -144,14 +136,10 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
         stdout
             .queue(crossterm::style::Print("\r\n"))
             .map_err(|err| {
-                IoError::new_internal(
-                    err.kind(),
-                    "Could not print linebreak",
-                    nu_protocol::location!(),
-                )
+                IoError::new_internal(err, "Could not print linebreak", nu_protocol::location!())
             })?;
         stdout.flush().map_err(|err| {
-            IoError::new_internal(err.kind(), "Could not flush", nu_protocol::location!())
+            IoError::new_internal(err, "Could not flush", nu_protocol::location!())
         })?;
     }
 
@@ -163,11 +151,7 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
     }
 
     terminal::disable_raw_mode().map_err(|err| {
-        IoError::new_internal(
-            err.kind(),
-            "Could not disable raw mode",
-            nu_protocol::location!(),
-        )
+        IoError::new_internal(err, "Could not disable raw mode", nu_protocol::location!())
     })?;
 
     Ok(Value::nothing(Span::unknown()))

--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -80,7 +80,7 @@ pub fn read_plugin_file(engine_state: &mut EngineState, plugin_file: Option<Span
                     report_shell_error(
                         engine_state,
                         &ShellError::Io(IoError::new_internal_with_path(
-                            err.kind(),
+                            err,
                             "Could not open plugin registry file",
                             nu_protocol::location!(),
                             plugin_path,
@@ -323,7 +323,7 @@ pub fn migrate_old_plugin_file(engine_state: &EngineState) -> bool {
     if let Err(err) = std::fs::File::create(&new_plugin_file_path)
         .map_err(|err| {
             IoError::new_internal_with_path(
-                err.kind(),
+                err,
                 "Could not create new plugin file",
                 nu_protocol::location!(),
                 new_plugin_file_path.clone(),

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -28,7 +28,7 @@ pub fn evaluate_file(
 
     let file_path = canonicalize_with(&path, cwd).map_err(|err| {
         IoError::new_internal_with_path(
-            err.kind().not_found_as(NotFound::File),
+            err.not_found_as(NotFound::File),
             "Could not access file",
             nu_protocol::location!(),
             PathBuf::from(&path),
@@ -47,7 +47,7 @@ pub fn evaluate_file(
 
     let file = std::fs::read(&file_path).map_err(|err| {
         IoError::new_internal_with_path(
-            err.kind().not_found_as(NotFound::File),
+            err.not_found_as(NotFound::File),
             "Could not read file",
             nu_protocol::location!(),
             file_path.clone(),

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -22,6 +22,7 @@ use nu_color_config::StyleComputer;
 use nu_engine::env_to_strings;
 use nu_engine::exit::cleanup_exit;
 use nu_parser::{lex, parse, trim_quotes_str};
+use nu_protocol::shell_error;
 use nu_protocol::shell_error::io::IoError;
 use nu_protocol::{
     HistoryConfig, HistoryFileFormat, PipelineData, ShellError, Span, Spanned, Value,
@@ -854,7 +855,7 @@ fn do_auto_cd(
             report_shell_error(
                 engine_state,
                 &ShellError::Io(IoError::new_with_additional_context(
-                    std::io::ErrorKind::NotFound,
+                    shell_error::io::ErrorKind::DirectoryNotFound,
                     span,
                     PathBuf::from(&path),
                     "Cannot change directory",
@@ -868,7 +869,7 @@ fn do_auto_cd(
         report_shell_error(
             engine_state,
             &ShellError::Io(IoError::new_with_additional_context(
-                std::io::ErrorKind::PermissionDenied,
+                shell_error::io::ErrorKind::from_std(std::io::ErrorKind::PermissionDenied),
                 span,
                 PathBuf::from(path),
                 "Cannot change directory",

--- a/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
@@ -134,7 +134,7 @@ fn byte_stream_to_bits(stream: ByteStream, head: Span) -> ByteStream {
                 let mut byte = [0];
                 if reader
                     .read(&mut byte[..])
-                    .map_err(|err| IoError::new(err.kind(), head, None))?
+                    .map_err(|err| IoError::new(err, head, None))?
                     > 0
                 {
                     // Format the byte as bits

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -107,14 +107,14 @@ impl Command for Do {
                                         let mut buf = Vec::new();
                                         stdout.read_to_end(&mut buf).map_err(|err| {
                                             IoError::new_internal(
-                                                err.kind(),
+                                                err,
                                                 "Could not read stdout to end",
                                                 nu_protocol::location!(),
                                             )
                                         })?;
                                         Ok::<_, ShellError>(buf)
                                     })
-                                    .map_err(|err| IoError::new(err.kind(), head, None))
+                                    .map_err(|err| IoError::new(err, head, None))
                             })
                             .transpose()?;
 
@@ -126,7 +126,7 @@ impl Command for Do {
                                 let mut buf = String::new();
                                 stderr
                                     .read_to_string(&mut buf)
-                                    .map_err(|err| IoError::new(err.kind(), span, None))?;
+                                    .map_err(|err| IoError::new(err, span, None))?;
                                 buf
                             }
                         };

--- a/crates/nu-cmd-plugin/src/commands/plugin/add.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/add.rs
@@ -88,13 +88,19 @@ apparent the next time `nu` is next launched with that plugin registry file.
         let filename_expanded = nu_path::locate_in_dirs(&filename.item, &cwd, || {
             get_plugin_dirs(engine_state, stack)
         })
-        .map_err(|err| IoError::new(err.kind(), filename.span, PathBuf::from(filename.item)))?;
+        .map_err(|err| {
+            IoError::new(
+                err.not_found_as(NotFound::File),
+                filename.span,
+                PathBuf::from(filename.item),
+            )
+        })?;
 
         let shell_expanded = shell
             .as_ref()
             .map(|s| {
                 nu_path::canonicalize_with(&s.item, &cwd)
-                    .map_err(|err| IoError::new(err.kind(), s.span, None))
+                    .map_err(|err| IoError::new(err, s.span, None))
             })
             .transpose()?;
 

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -77,7 +77,7 @@ impl Command for BytesEndsWith {
                     Ok(&[]) => break,
                     Ok(buf) => buf,
                     Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
-                    Err(e) => return Err(IoError::new(e.kind(), span, None).into()),
+                    Err(e) => return Err(IoError::new(e, span, None).into()),
                 };
                 let len = buf.len();
                 if len >= cap {

--- a/crates/nu-command/src/bytes/starts_with.rs
+++ b/crates/nu-command/src/bytes/starts_with.rs
@@ -72,7 +72,7 @@ impl Command for BytesStartsWith {
             reader
                 .take(pattern.len() as u64)
                 .read_to_end(&mut start)
-                .map_err(|err| IoError::new(err.kind(), span, None))?;
+                .map_err(|err| IoError::new(err, span, None))?;
 
             Ok(Value::bool(start == pattern, head).into_pipeline_data())
         } else {

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -41,12 +41,11 @@ impl SQLiteDatabase {
     }
 
     pub fn try_from_path(path: &Path, span: Span, signals: Signals) -> Result<Self, ShellError> {
-        let mut file =
-            File::open(path).map_err(|e| IoError::new(e.kind(), span, PathBuf::from(path)))?;
+        let mut file = File::open(path).map_err(|e| IoError::new(e, span, PathBuf::from(path)))?;
 
         let mut buf: [u8; 16] = [0; 16];
         file.read_exact(&mut buf)
-            .map_err(|e| ShellError::Io(IoError::new(e.kind(), span, PathBuf::from(path))))
+            .map_err(|e| ShellError::Io(IoError::new(e, span, PathBuf::from(path))))
             .and_then(|_| {
                 if buf == SQLITE_MAGIC_BYTES {
                     Ok(SQLiteDatabase::new(path, signals))

--- a/crates/nu-command/src/env/config/config_.rs
+++ b/crates/nu-command/src/env/config/config_.rs
@@ -115,7 +115,7 @@ pub(super) fn start_editor(
 
     let child = child.map_err(|err| {
         IoError::new_with_additional_context(
-            err.kind(),
+            err,
             call.head,
             None,
             "Could not spawn foreground child",

--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -59,7 +59,7 @@ impl Command for ConfigReset {
                 ));
                 if let Err(err) = std::fs::rename(nu_config.clone(), &backup_path) {
                     return Err(ShellError::Io(IoError::new_with_additional_context(
-                        err.kind().not_found_as(NotFound::Directory),
+                        err.not_found_as(NotFound::Directory),
                         span,
                         PathBuf::from(backup_path),
                         "config.nu could not be backed up",
@@ -69,7 +69,7 @@ impl Command for ConfigReset {
             if let Ok(mut file) = std::fs::File::create(&nu_config) {
                 if let Err(err) = writeln!(&mut file, "{config_file}") {
                     return Err(ShellError::Io(IoError::new_with_additional_context(
-                        err.kind().not_found_as(NotFound::File),
+                        err.not_found_as(NotFound::File),
                         span,
                         PathBuf::from(nu_config),
                         "config.nu could not be written to",
@@ -86,7 +86,7 @@ impl Command for ConfigReset {
                 backup_path.push(format!("oldenv-{}.nu", Local::now().format("%F-%H-%M-%S"),));
                 if let Err(err) = std::fs::rename(env_config.clone(), &backup_path) {
                     return Err(ShellError::Io(IoError::new_with_additional_context(
-                        err.kind().not_found_as(NotFound::Directory),
+                        err.not_found_as(NotFound::Directory),
                         span,
                         PathBuf::from(backup_path),
                         "env.nu could not be backed up",
@@ -96,7 +96,7 @@ impl Command for ConfigReset {
             if let Ok(mut file) = std::fs::File::create(&env_config) {
                 if let Err(err) = writeln!(&mut file, "{config_file}") {
                     return Err(ShellError::Io(IoError::new_with_additional_context(
-                        err.kind().not_found_as(NotFound::File),
+                        err.not_found_as(NotFound::File),
                         span,
                         PathBuf::from(env_config),
                         "env.nu could not be written to",

--- a/crates/nu-command/src/env/source_env.rs
+++ b/crates/nu-command/src/env/source_env.rs
@@ -2,7 +2,11 @@ use nu_engine::{
     command_prelude::*, find_in_dirs_env, get_dirs_var_from_call, get_eval_block_with_early_return,
     redirect_env,
 };
-use nu_protocol::{BlockId, engine::CommandType, shell_error::io::IoError};
+use nu_protocol::{
+    BlockId,
+    engine::CommandType,
+    shell_error::{self, io::IoError},
+};
 use std::path::PathBuf;
 
 /// Source a file for environment variables.
@@ -66,7 +70,7 @@ impl Command for SourceEnv {
             PathBuf::from(&path)
         } else {
             return Err(ShellError::Io(IoError::new(
-                std::io::ErrorKind::NotFound,
+                shell_error::io::ErrorKind::FileNotFound,
                 source_filename.span,
                 PathBuf::from(source_filename.item),
             )));

--- a/crates/nu-command/src/experimental/job_kill.rs
+++ b/crates/nu-command/src/experimental/job_kill.rs
@@ -53,7 +53,7 @@ impl Command for JobKill {
 
         jobs.kill_and_remove(id).map_err(|err| {
             ShellError::Io(IoError::new_internal(
-                err.kind(),
+                err,
                 "Failed to kill the requested job",
                 nu_protocol::location!(),
             ))

--- a/crates/nu-command/src/experimental/job_spawn.rs
+++ b/crates/nu-command/src/experimental/job_spawn.rs
@@ -121,7 +121,7 @@ impl Command for JobSpawn {
             Err(err) => {
                 jobs.remove_job(id);
                 Err(ShellError::Io(IoError::new_with_additional_context(
-                    err.kind(),
+                    err,
                     call.head,
                     None,
                     "Failed to spawn thread for job",

--- a/crates/nu-command/src/experimental/job_unfreeze.rs
+++ b/crates/nu-command/src/experimental/job_unfreeze.rs
@@ -123,7 +123,7 @@ fn unfreeze_job(
                 if !thread_job.try_add_pid(pid) {
                     kill_by_pid(pid.into()).map_err(|err| {
                         ShellError::Io(IoError::new_internal(
-                            err.kind(),
+                            err,
                             "job was interrupted; could not kill foreground process",
                             nu_protocol::location!(),
                         ))

--- a/crates/nu-command/src/experimental/job_unfreeze.rs
+++ b/crates/nu-command/src/experimental/job_unfreeze.rs
@@ -3,7 +3,6 @@ use nu_protocol::{
     JobId,
     engine::{FrozenJob, Job, ThreadJob},
     process::check_ok,
-    shell_error,
 };
 use nu_system::{ForegroundWaitStatus, kill_by_pid};
 
@@ -163,7 +162,7 @@ fn unfreeze_job(
                 Ok(ForegroundWaitStatus::Finished(status)) => check_ok(status, false, span),
 
                 Err(err) => Err(ShellError::Io(IoError::new_internal(
-                    shell_error::io::ErrorKind::Std(err.kind()),
+                    err,
                     "Failed to unfreeze foreground process",
                     nu_protocol::location!(),
                 ))),

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -77,7 +77,8 @@ impl Command for Cd {
                         if let Ok(path) = nu_path::canonicalize_with(path_no_whitespace, &cwd) {
                             if !path.is_dir() {
                                 return Err(shell_error::io::IoError::new(
-                                    shell_error::io::ErrorKind::Std(
+                                    #[allow(deprecated, reason = "we don't necessarily have a NotADirectory variant here, so we provide one")]
+                                    shell_error::io::ErrorKind::from_std(
                                         std::io::ErrorKind::NotADirectory,
                                     ),
                                     v.span,
@@ -106,7 +107,8 @@ impl Command for Cd {
                         };
                         if !path.is_dir() {
                             return Err(shell_error::io::IoError::new(
-                                shell_error::io::ErrorKind::Std(std::io::ErrorKind::NotADirectory),
+                                #[allow(deprecated, reason = "we don't necessarily have a NotADirectory variant here, so we provide one")]
+                                shell_error::io::ErrorKind::from_std(std::io::ErrorKind::NotADirectory),
                                 v.span,
                                 path,
                             )

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -77,7 +77,6 @@ impl Command for Cd {
                         if let Ok(path) = nu_path::canonicalize_with(path_no_whitespace, &cwd) {
                             if !path.is_dir() {
                                 return Err(shell_error::io::IoError::new(
-                                    #[allow(deprecated, reason = "we don't necessarily have a NotADirectory variant here, so we provide one")]
                                     shell_error::io::ErrorKind::from_std(
                                         std::io::ErrorKind::NotADirectory,
                                     ),
@@ -107,8 +106,9 @@ impl Command for Cd {
                         };
                         if !path.is_dir() {
                             return Err(shell_error::io::IoError::new(
-                                #[allow(deprecated, reason = "we don't necessarily have a NotADirectory variant here, so we provide one")]
-                                shell_error::io::ErrorKind::from_std(std::io::ErrorKind::NotADirectory),
+                                shell_error::io::ErrorKind::from_std(
+                                    std::io::ErrorKind::NotADirectory,
+                                ),
                                 v.span,
                                 path,
                             )
@@ -134,9 +134,12 @@ impl Command for Cd {
                 stack.set_cwd(path)?;
                 Ok(PipelineData::empty())
             }
-            PermissionResult::PermissionDenied => {
-                Err(IoError::new(std::io::ErrorKind::PermissionDenied, call.head, path).into())
-            }
+            PermissionResult::PermissionDenied => Err(IoError::new(
+                shell_error::io::ErrorKind::from_std(std::io::ErrorKind::PermissionDenied),
+                call.head,
+                path,
+            )
+            .into()),
         }
     }
 

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -121,7 +121,7 @@ impl Command for Open {
 
                 if permission_denied(path) {
                     let err = IoError::new(
-                        std::io::ErrorKind::PermissionDenied,
+                        shell_error::io::ErrorKind::from_std(std::io::ErrorKind::PermissionDenied),
                         arg_span,
                         PathBuf::from(path),
                     );
@@ -173,7 +173,7 @@ impl Command for Open {
                     }
 
                     let file = std::fs::File::open(path)
-                        .map_err(|err| IoError::new(err.kind(), arg_span, PathBuf::from(path)))?;
+                        .map_err(|err| IoError::new(err, arg_span, PathBuf::from(path)))?;
 
                     // No content_type by default - Is added later if no converter is found
                     let stream = PipelineData::ByteStream(

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -162,7 +162,11 @@ impl Command for Open {
                         // At least under windows this check ensures that we don't get a
                         // permission denied error on directories
                         return Err(ShellError::Io(IoError::new(
-                            shell_error::io::ErrorKind::Std(std::io::ErrorKind::IsADirectory),
+                            #[allow(
+                                deprecated,
+                                reason = "we don't have a IsADirectory variant here, so we provide one"
+                            )]
+                            shell_error::io::ErrorKind::from_std(std::io::ErrorKind::IsADirectory),
                             arg_span,
                             PathBuf::from(path),
                         )));

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -304,7 +304,7 @@ fn rm(
                     && matches!(
                         e,
                         ShellError::Io(IoError {
-                            kind: shell_error::io::ErrorKind::Std(std::io::ErrorKind::NotFound),
+                            kind: shell_error::io::ErrorKind::Std(std::io::ErrorKind::NotFound, ..),
                             ..
                         })
                     ))

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -420,7 +420,7 @@ fn rm(
                 };
 
                 if let Err(e) = result {
-                    Err(ShellError::Io(IoError::new(e.kind(), span, f)))
+                    Err(ShellError::Io(IoError::new(e, span, f)))
                 } else if verbose {
                     let msg = if interactive && !confirmed {
                         "not deleted"

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -130,7 +130,7 @@ impl Command for Save {
                                         io::copy(&mut tee, &mut io::stderr())
                                     }
                                 }
-                                .map_err(|err| IoError::new(err.kind(), span, None))?;
+                                .map_err(|err| IoError::new(err, span, None))?;
                             }
                             Ok(())
                         }
@@ -428,7 +428,7 @@ fn open_file(path: &Path, span: Span, append: bool) -> Result<File, ShellError> 
         (true, true) => std::fs::OpenOptions::new()
             .append(true)
             .open(path)
-            .map_err(|err| err.kind().into()),
+            .map_err(|err| err.into()),
         _ => {
             // This is a temporary solution until `std::fs::File::create` is fixed on Windows (rust-lang/rust#134893)
             // A TOCTOU problem exists here, which may cause wrong error message to be shown
@@ -442,10 +442,10 @@ fn open_file(path: &Path, span: Span, append: bool) -> Result<File, ShellError> 
                     std::io::ErrorKind::IsADirectory,
                 ))
             } else {
-                std::fs::File::create(path).map_err(|err| err.kind().into())
+                std::fs::File::create(path).map_err(|err| err.into())
             }
             #[cfg(not(target_os = "windows"))]
-            std::fs::File::create(path).map_err(|err| err.kind().into())
+            std::fs::File::create(path).map_err(|err| err.into())
         }
     };
 

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -434,7 +434,11 @@ fn open_file(path: &Path, span: Span, append: bool) -> Result<File, ShellError> 
             // A TOCTOU problem exists here, which may cause wrong error message to be shown
             #[cfg(target_os = "windows")]
             if path.is_dir() {
-                Err(nu_protocol::shell_error::io::ErrorKind::Std(
+                #[allow(
+                    deprecated,
+                    reason = "we don't get a IsADirectory error, so we need to provide it"
+                )]
+                Err(nu_protocol::shell_error::io::ErrorKind::from_std(
                     std::io::ErrorKind::IsADirectory,
                 ))
             } else {

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -1,6 +1,9 @@
 #[allow(deprecated)]
 use nu_engine::{command_prelude::*, current_dir};
-use nu_protocol::{NuGlob, shell_error::io::IoError};
+use nu_protocol::{
+    NuGlob,
+    shell_error::{self, io::IoError},
+};
 use std::path::PathBuf;
 use uu_cp::{BackupMode, CopyMode, UpdateMode};
 
@@ -198,7 +201,7 @@ impl Command for UCp {
                     .collect();
             if exp_files.is_empty() {
                 return Err(ShellError::Io(IoError::new(
-                    std::io::ErrorKind::NotFound,
+                    shell_error::io::ErrorKind::FileNotFound,
                     p.span,
                     PathBuf::from(p.item.to_string()),
                 )));

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -1,7 +1,10 @@
 #[allow(deprecated)]
 use nu_engine::{command_prelude::*, current_dir};
 use nu_path::expand_path_with;
-use nu_protocol::{NuGlob, shell_error::io::IoError};
+use nu_protocol::{
+    NuGlob,
+    shell_error::{self, io::IoError},
+};
 use std::{ffi::OsString, path::PathBuf};
 use uu_mv::{BackupMode, UpdateMode};
 
@@ -139,7 +142,7 @@ impl Command for UMv {
                     .collect();
             if exp_files.is_empty() {
                 return Err(ShellError::Io(IoError::new(
-                    std::io::ErrorKind::NotFound,
+                    shell_error::io::ErrorKind::FileNotFound,
                     p.span,
                     PathBuf::from(p.item.to_string()),
                 )));

--- a/crates/nu-command/src/filesystem/utouch.rs
+++ b/crates/nu-command/src/filesystem/utouch.rs
@@ -227,7 +227,7 @@ impl Command for UTouch {
                 TouchError::ReferenceFileInaccessible(reference_path, io_err) => {
                     let span = reference_span.expect("touch should've been given a reference file");
                     ShellError::Io(IoError::new_with_additional_context(
-                        io_err.kind(),
+                        io_err,
                         span,
                         reference_path,
                         "failed to read metadata",

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -86,7 +86,7 @@ impl Command for Watch {
             Ok(p) => p,
             Err(err) => {
                 return Err(ShellError::Io(IoError::new(
-                    err.kind(),
+                    err,
                     path_arg.span,
                     PathBuf::from(path_no_whitespace),
                 )));

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -37,7 +37,7 @@ pub fn empty(
                             .bytes()
                             .next()
                             .transpose()
-                            .map_err(|err| IoError::new(err.kind(), span, None))?
+                            .map_err(|err| IoError::new(err, span, None))?
                             .is_none();
                         if negate {
                             Ok(Value::bool(!is_empty, head).into_pipeline_data())

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -182,7 +182,7 @@ fn first_helper(
                         let mut byte = [0u8];
                         if reader
                             .read(&mut byte)
-                            .map_err(|err| IoError::new(err.kind(), span, None))?
+                            .map_err(|err| IoError::new(err, span, None))?
                             > 0
                         {
                             Ok(Value::int(byte[0] as i64, head).into_pipeline_data())

--- a/crates/nu-command/src/filters/interleave.rs
+++ b/crates/nu-command/src/filters/interleave.rs
@@ -137,7 +137,7 @@ interleave
                             }
                         })
                         .map(|_| ())
-                        .map_err(|err| IoError::new(err.kind(), head, None).into())
+                        .map_err(|err| IoError::new(err, head, None).into())
                 })
             })?;
 

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -166,7 +166,7 @@ impl Command for Last {
                         let mut buf = VecDeque::with_capacity(rows + TAKE as usize);
                         loop {
                             let taken = std::io::copy(&mut (&mut reader).take(TAKE), &mut buf)
-                                .map_err(|err| IoError::new(err.kind(), span, None))?;
+                                .map_err(|err| IoError::new(err, span, None))?;
                             if buf.len() > rows {
                                 buf.drain(..(buf.len() - rows));
                             }

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -134,7 +134,7 @@ fn read_json_lines(
         .lines()
         .filter(|line| line.as_ref().is_ok_and(|line| !line.trim().is_empty()) || line.is_err())
         .map(move |line| {
-            let line = line.map_err(|err| IoError::new(err.kind(), span, None))?;
+            let line = line.map_err(|err| IoError::new(err, span, None))?;
             if strict {
                 convert_string_to_value_strict(&line, span)
             } else {

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -8,7 +8,7 @@ use std::{iter, sync::Arc};
 
 fn make_csv_error(error: csv::Error, format_name: &str, head: Span) -> ShellError {
     if let csv::ErrorKind::Io(error) = error.kind() {
-        IoError::new(error.kind(), head, None).into()
+        IoError::new(error, head, None).into()
     } else {
         ShellError::GenericError {
             error: format!("Failed to generate {format_name} data"),

--- a/crates/nu-command/src/formats/to/msgpack.rs
+++ b/crates/nu-command/src/formats/to/msgpack.rs
@@ -152,7 +152,7 @@ impl From<WriteError> for ShellError {
                 help: None,
                 inner: vec![],
             },
-            WriteError::Io(err, span) => ShellError::Io(IoError::new(err.kind(), span, None)),
+            WriteError::Io(err, span) => ShellError::Io(IoError::new(err, span, None)),
             WriteError::Shell(err) => *err,
         }
     }

--- a/crates/nu-command/src/formats/to/msgpackz.rs
+++ b/crates/nu-command/src/formats/to/msgpackz.rs
@@ -95,7 +95,7 @@ impl Command for ToMsgpackz {
             serialize_types,
         )?;
         out.flush()
-            .map_err(|err| IoError::new(err.kind(), call.head, None))?;
+            .map_err(|err| IoError::new(err, call.head, None))?;
         drop(out);
 
         Ok(Value::binary(out_buf, call.head).into_pipeline_data())

--- a/crates/nu-command/src/misc/source.rs
+++ b/crates/nu-command/src/misc/source.rs
@@ -55,13 +55,8 @@ impl Command for Source {
         let cwd = engine_state.cwd_as_string(Some(stack))?;
         let pb = std::path::PathBuf::from(block_id_name);
         let parent = pb.parent().unwrap_or(std::path::Path::new(""));
-        let file_path = canonicalize_with(pb.as_path(), cwd).map_err(|err| {
-            IoError::new(
-                err.kind().not_found_as(NotFound::File),
-                call.head,
-                pb.clone(),
-            )
-        })?;
+        let file_path = canonicalize_with(pb.as_path(), cwd)
+            .map_err(|err| IoError::new(err.not_found_as(NotFound::File), call.head, pb.clone()))?;
 
         // Note: We intentionally left out PROCESS_PATH since it's supposed to
         // to work like argv[0] in C, which is the name of the program being executed.

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -374,9 +374,7 @@ fn send_multipart_request(
             let mut builder = MultipartWriter::new();
 
             let err = |e: std::io::Error| {
-                ShellErrorOrRequestError::ShellError(
-                    IoError::new_with_additional_context(e.kind(), span, None, e).into(),
-                )
+                ShellErrorOrRequestError::ShellError(IoError::new(e, span, None).into())
             };
 
             for (col, val) in val.into_owned() {
@@ -466,12 +464,7 @@ fn send_cancellable_request(
             let _ = tx.send(ret); // may fail if the user has cancelled the operation
         })
         .map_err(|err| {
-            IoError::new_with_additional_context(
-                err.kind(),
-                span,
-                None,
-                "Could not spawn HTTP requester",
-            )
+            IoError::new_with_additional_context(err, span, None, "Could not spawn HTTP requester")
         })
         .map_err(ShellError::from)?;
 
@@ -529,12 +522,7 @@ fn send_cancellable_request_bytes(
             let _ = tx.send(ret);
         })
         .map_err(|err| {
-            IoError::new_with_additional_context(
-                err.kind(),
-                span,
-                None,
-                "Could not spawn HTTP requester",
-            )
+            IoError::new_with_additional_context(err, span, None, "Could not spawn HTTP requester")
         })
         .map_err(ShellError::from)?;
 
@@ -685,7 +673,7 @@ fn handle_response_error(span: Span, requested_url: &str, response_err: Error) -
                         break 'io generic_network_failure();
                     };
 
-                    ShellError::Io(IoError::new(io_error.kind(), span, None))
+                    ShellError::Io(IoError::new(io_error, span, None))
                 }
                 _ => generic_network_failure(),
             }

--- a/crates/nu-command/src/network/port.rs
+++ b/crates/nu-command/src/network/port.rs
@@ -132,7 +132,7 @@ fn get_free_port(
             }
 
             Err(IoError::new_with_additional_context(
-                last_err.expect("range not empty, validated before").kind(),
+                last_err.expect("range not empty, validated before"),
                 range_span,
                 None,
                 "Every port has been tried, but no valid one was found",

--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -153,7 +153,7 @@ fn exists(path: &Path, span: Span, args: &Arguments) -> Value {
     Value::bool(
         match exists {
             Ok(exists) => exists,
-            Err(err) => return Value::error(IoError::new(err.kind(), span, path).into(), span),
+            Err(err) => return Value::error(IoError::new(err, span, path).into(), span),
         },
         span,
     )

--- a/crates/nu-command/src/path/self_.rs
+++ b/crates/nu-command/src/path/self_.rs
@@ -1,6 +1,9 @@
 use nu_engine::command_prelude::*;
 use nu_path::expand_path_with;
-use nu_protocol::{engine::StateWorkingSet, shell_error::io::IoError};
+use nu_protocol::{
+    engine::StateWorkingSet,
+    shell_error::{self, io::IoError},
+};
 
 #[derive(Clone)]
 pub struct PathSelf;
@@ -56,7 +59,7 @@ impl Command for PathSelf {
         let cwd = working_set.permanent_state.cwd(None)?;
         let current_file = working_set.files.top().ok_or_else(|| {
             IoError::new_with_additional_context(
-                std::io::ErrorKind::NotFound,
+                shell_error::io::ErrorKind::FileNotFound,
                 call.head,
                 None,
                 "Couldn't find current file",
@@ -67,7 +70,7 @@ impl Command for PathSelf {
             let dir = expand_path_with(
                 current_file.parent().ok_or_else(|| {
                     IoError::new_with_additional_context(
-                        std::io::ErrorKind::NotFound,
+                        shell_error::io::ErrorKind::FileNotFound,
                         call.head,
                         current_file.to_owned(),
                         "Couldn't find current file's parent.",

--- a/crates/nu-command/src/path/type.rs
+++ b/crates/nu-command/src/path/type.rs
@@ -108,7 +108,7 @@ fn path_type(path: &Path, span: Span, args: &Arguments) -> Value {
     match path.symlink_metadata() {
         Ok(metadata) => Value::string(get_file_type(&metadata), span),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Value::nothing(span),
-        Err(err) => Value::error(IoError::new(err.kind(), span, None).into(), span),
+        Err(err) => Value::error(IoError::new(err, span, None).into(), span),
     }
 }
 

--- a/crates/nu-command/src/platform/dir_info.rs
+++ b/crates/nu-command/src/platform/dir_info.rs
@@ -77,7 +77,7 @@ impl FileInfo {
                     long,
                 })
             }
-            Err(e) => Err(IoError::new(e.kind(), tag, path).into()),
+            Err(e) => Err(IoError::new(e, tag, path).into()),
         }
     }
 }

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -7,7 +7,7 @@ use crossterm::{
 };
 use itertools::Itertools;
 use nu_engine::command_prelude::*;
-use nu_protocol::shell_error::io::IoError;
+use nu_protocol::shell_error::{self, io::IoError};
 
 use std::{io::Write, time::Duration};
 
@@ -116,7 +116,9 @@ impl Command for Input {
                                         crossterm::terminal::disable_raw_mode()
                                             .map_err(&from_io_error)?;
                                         return Err(IoError::new(
-                                            std::io::ErrorKind::Interrupted,
+                                            shell_error::io::ErrorKind::from_std(
+                                                std::io::ErrorKind::Interrupted,
+                                            ),
                                             call.head,
                                             None,
                                         )
@@ -156,7 +158,7 @@ impl Command for Input {
                     terminal::Clear(ClearType::CurrentLine),
                     cursor::MoveToColumn(0),
                 )
-                .map_err(|err| IoError::new(err.kind(), call.head, None))?;
+                .map_err(|err| IoError::new(err, call.head, None))?;
                 if let Some(prompt) = &prompt {
                     execute!(std::io::stdout(), Print(prompt.to_string()))
                         .map_err(&from_io_error)?;

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -84,7 +84,7 @@ There are 4 `key_type` variants:
         let add_raw = call.has_flag(engine_state, stack, "raw")?;
         let config = engine_state.get_config();
 
-        terminal::enable_raw_mode().map_err(|err| IoError::new(err.kind(), head, None))?;
+        terminal::enable_raw_mode().map_err(|err| IoError::new(err, head, None))?;
 
         if config.use_kitty_protocol {
             if let Ok(false) = crossterm::terminal::supports_keyboard_enhancement() {
@@ -123,7 +123,7 @@ There are 4 `key_type` variants:
             })?;
             let event = parse_event(head, &event, &event_type_filter, add_raw);
             if let Some(event) = event {
-                terminal::disable_raw_mode().map_err(|err| IoError::new(err.kind(), head, None))?;
+                terminal::disable_raw_mode().map_err(|err| IoError::new(err, head, None))?;
                 if config.use_kitty_protocol {
                     let _ = execute!(
                         std::io::stdout(),
@@ -230,17 +230,17 @@ impl EventTypeFilter {
     fn enable_events(&self, span: Span) -> Result<DeferredConsoleRestore, ShellError> {
         if self.listen_mouse {
             crossterm::execute!(stdout(), EnableMouseCapture)
-                .map_err(|err| IoError::new(err.kind(), span, None))?;
+                .map_err(|err| IoError::new(err, span, None))?;
         }
 
         if self.listen_paste {
             crossterm::execute!(stdout(), EnableBracketedPaste)
-                .map_err(|err| IoError::new(err.kind(), span, None))?;
+                .map_err(|err| IoError::new(err, span, None))?;
         }
 
         if self.listen_focus {
             crossterm::execute!(stdout(), crossterm::event::EnableFocusChange)
-                .map_err(|err| IoError::new(err.kind(), span, None))?;
+                .map_err(|err| IoError::new(err, span, None))?;
         }
 
         Ok(DeferredConsoleRestore {

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -142,12 +142,7 @@ impl Command for InputList {
                 .report(false)
                 .interact_on_opt(&Term::stderr())
                 .map_err(|dialoguer::Error::IO(err)| {
-                    IoError::new_with_additional_context(
-                        err.kind(),
-                        call.head,
-                        None,
-                        INTERACT_ERROR,
-                    )
+                    IoError::new_with_additional_context(err, call.head, None, INTERACT_ERROR)
                 })?,
             )
         } else if fuzzy {
@@ -164,12 +159,7 @@ impl Command for InputList {
                 .report(false)
                 .interact_on_opt(&Term::stderr())
                 .map_err(|dialoguer::Error::IO(err)| {
-                    IoError::new_with_additional_context(
-                        err.kind(),
-                        call.head,
-                        None,
-                        INTERACT_ERROR,
-                    )
+                    IoError::new_with_additional_context(err, call.head, None, INTERACT_ERROR)
                 })?,
             )
         } else {
@@ -185,12 +175,7 @@ impl Command for InputList {
                 .report(false)
                 .interact_on_opt(&Term::stderr())
                 .map_err(|dialoguer::Error::IO(err)| {
-                    IoError::new_with_additional_context(
-                        err.kind(),
-                        call.head,
-                        None,
-                        INTERACT_ERROR,
-                    )
+                    IoError::new_with_additional_context(err, call.head, None, INTERACT_ERROR)
                 })?,
             )
         };

--- a/crates/nu-command/src/platform/term/term_query.rs
+++ b/crates/nu-command/src/platform/term/term_query.rs
@@ -99,19 +99,17 @@ The `prefix` is not included in the output."
         let prefix = prefix.unwrap_or_default();
         let terminator: Option<Vec<u8>> = call.get_flag(engine_state, stack, "terminator")?;
 
-        crossterm::terminal::enable_raw_mode()
-            .map_err(|err| IoError::new(err.kind(), call.head, None))?;
+        crossterm::terminal::enable_raw_mode().map_err(|err| IoError::new(err, call.head, None))?;
         scopeguard::defer! {
             let _ = crossterm::terminal::disable_raw_mode();
         }
 
         // clear terminal events
         while crossterm::event::poll(Duration::from_secs(0))
-            .map_err(|err| IoError::new(err.kind(), call.head, None))?
+            .map_err(|err| IoError::new(err, call.head, None))?
         {
             // If there's an event, read it to remove it from the queue
-            let _ = crossterm::event::read()
-                .map_err(|err| IoError::new(err.kind(), call.head, None))?;
+            let _ = crossterm::event::read().map_err(|err| IoError::new(err, call.head, None))?;
         }
 
         let mut b = [0u8; 1];
@@ -122,17 +120,17 @@ The `prefix` is not included in the output."
             let mut stdout = std::io::stdout().lock();
             stdout
                 .write_all(&query)
-                .map_err(|err| IoError::new(err.kind(), call.head, None))?;
+                .map_err(|err| IoError::new(err, call.head, None))?;
             stdout
                 .flush()
-                .map_err(|err| IoError::new(err.kind(), call.head, None))?;
+                .map_err(|err| IoError::new(err, call.head, None))?;
         }
 
         // Validate and skip prefix
         for bc in prefix {
             stdin
                 .read_exact(&mut b)
-                .map_err(|err| IoError::new(err.kind(), call.head, None))?;
+                .map_err(|err| IoError::new(err, call.head, None))?;
             if b[0] != bc {
                 return Err(ShellError::GenericError {
                     error: "Input did not begin with expected sequence".into(),
@@ -151,7 +149,7 @@ The `prefix` is not included in the output."
             loop {
                 stdin
                     .read_exact(&mut b)
-                    .map_err(|err| IoError::new(err.kind(), call.head, None))?;
+                    .map_err(|err| IoError::new(err, call.head, None))?;
 
                 if b[0] == CTRL_C {
                     return Err(ShellError::InterruptedByUser {
@@ -173,7 +171,7 @@ The `prefix` is not included in the output."
             loop {
                 stdin
                     .read_exact(&mut b)
-                    .map_err(|err| IoError::new(err.kind(), call.head, None))?;
+                    .map_err(|err| IoError::new(err, call.head, None))?;
 
                 if b[0] == CTRL_C {
                     break;

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -255,7 +255,7 @@ fn parse_file_script(
     match std::fs::read(path) {
         Ok(contents) => parse_script(working_set, Some(&filename), &contents, is_debug, call_head),
         Err(err) => Err(ShellError::Io(IoError::new(
-            err.kind().not_found_as(NotFound::File),
+            err.not_found_as(NotFound::File),
             path_span,
             PathBuf::from(path),
         ))),

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -93,7 +93,7 @@ fn registry_query(
     let reg_hive = get_reg_hive(engine_state, stack, call)?;
     let reg_key = reg_hive
         .open_subkey(registry_key.item)
-        .map_err(|err| IoError::new(err.kind(), *registry_key_span, None))?;
+        .map_err(|err| IoError::new(err, *registry_key_span, None))?;
 
     if registry_value.is_none() {
         let mut reg_values = vec![];

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -194,11 +194,11 @@ impl Command for External {
         let stderr = stack.stderr();
         let merged_stream = if matches!(stdout, OutDest::Pipe) && matches!(stderr, OutDest::Pipe) {
             let (reader, writer) =
-                os_pipe::pipe().map_err(|err| IoError::new(err.kind(), call.head, None))?;
+                os_pipe::pipe().map_err(|err| IoError::new(err, call.head, None))?;
             command.stdout(
                 writer
                     .try_clone()
-                    .map_err(|err| IoError::new(err.kind(), call.head, None))?,
+                    .map_err(|err| IoError::new(err, call.head, None))?,
             );
             command.stderr(writer);
             Some(reader)
@@ -209,8 +209,7 @@ impl Command for External {
                 command.stdout(Stdio::null());
             } else {
                 command.stdout(
-                    Stdio::try_from(stdout)
-                        .map_err(|err| IoError::new(err.kind(), call.head, None))?,
+                    Stdio::try_from(stdout).map_err(|err| IoError::new(err, call.head, None))?,
                 );
             }
 
@@ -220,8 +219,7 @@ impl Command for External {
                 command.stderr(Stdio::null());
             } else {
                 command.stderr(
-                    Stdio::try_from(stderr)
-                        .map_err(|err| IoError::new(err.kind(), call.head, None))?,
+                    Stdio::try_from(stderr).map_err(|err| IoError::new(err, call.head, None))?,
                 );
             }
 
@@ -269,7 +267,7 @@ impl Command for External {
 
         let mut child = child.map_err(|err| {
             IoError::new_internal(
-                err.kind(),
+                err,
                 "Could not spawn foreground child",
                 nu_protocol::location!(),
             )
@@ -279,7 +277,7 @@ impl Command for External {
             if !thread_job.try_add_pid(child.pid()) {
                 kill_by_pid(child.pid().into()).map_err(|err| {
                     ShellError::Io(IoError::new_internal(
-                        err.kind(),
+                        err,
                         "Could not spawn external stdin worker",
                         nu_protocol::location!(),
                     ))
@@ -299,7 +297,7 @@ impl Command for External {
                 })
                 .map_err(|err| {
                     IoError::new_with_additional_context(
-                        err.kind(),
+                        err,
                         call.head,
                         None,
                         "Could not spawn external stdin worker",
@@ -487,7 +485,7 @@ fn write_pipeline_data(
     } else if let PipelineData::Value(Value::Binary { val, .. }, ..) = data {
         writer.write_all(&val).map_err(|err| {
             IoError::new_internal(
-                err.kind(),
+                err,
                 "Could not write pipeline data",
                 nu_protocol::location!(),
             )
@@ -507,7 +505,7 @@ fn write_pipeline_data(
             let bytes = value.coerce_into_binary()?;
             writer.write_all(&bytes).map_err(|err| {
                 IoError::new_internal(
-                    err.kind(),
+                    err,
                     "Could not write pipeline data",
                     nu_protocol::location!(),
                 )

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -518,7 +518,7 @@ fn pretty_hex_stream(stream: ByteStream, span: Span) -> ByteStream {
                 (&mut reader)
                     .take(cfg.width as u64)
                     .read_to_end(&mut read_buf)
-                    .map_err(|err| IoError::new(err.kind(), span, None))?;
+                    .map_err(|err| IoError::new(err, span, None))?;
 
                 if !read_buf.is_empty() {
                     nu_pretty_hex::hex_write(&mut write_buf, &read_buf, cfg, Some(true))

--- a/crates/nu-command/tests/commands/path/self_.rs
+++ b/crates/nu-command/tests/commands/path/self_.rs
@@ -60,5 +60,5 @@ fn self_path_runtime() {
 fn self_path_repl() {
     let actual = nu!("const foo = path self; $foo");
     assert!(!actual.status.success());
-    assert!(actual.err.contains("nu::shell::io::not_found"));
+    assert!(actual.err.contains("nu::shell::io::file_not_found"));
 }

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -4,7 +4,7 @@ use nu_protocol::{
     ShellError, Span, Type, Value, VarId,
     ast::Expr,
     engine::{Call, EngineState, Stack, StateWorkingSet},
-    shell_error::io::{ErrorKindExt, IoError, NotFound},
+    shell_error::io::{IoError, IoErrorExt, NotFound},
 };
 use std::{
     collections::HashMap,
@@ -221,7 +221,7 @@ pub fn current_dir(engine_state: &EngineState, stack: &Stack) -> Result<PathBuf,
     // be an absolute path already.
     canonicalize_with(&cwd, ".").map_err(|err| {
         ShellError::Io(IoError::new_internal_with_path(
-            err.kind().not_found_as(NotFound::Directory),
+            err.not_found_as(NotFound::Directory),
             "Could not canonicalize current dir",
             nu_protocol::location!(),
             PathBuf::from(cwd),
@@ -241,7 +241,7 @@ pub fn current_dir_const(working_set: &StateWorkingSet) -> Result<PathBuf, Shell
     // be an absolute path already.
     canonicalize_with(&cwd, ".").map_err(|err| {
         ShellError::Io(IoError::new_internal_with_path(
-            err.kind().not_found_as(NotFound::Directory),
+            err.not_found_as(NotFound::Directory),
             "Could not canonicalize current dir",
             nu_protocol::location!(),
             PathBuf::from(cwd),

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1529,7 +1529,7 @@ fn open_file(ctx: &EvalContext<'_>, path: &Value, append: bool) -> Result<Arc<Fi
     let file = options
         .create(true)
         .open(&path_expanded)
-        .map_err(|err| IoError::new(err.kind(), path.span(), path_expanded))?;
+        .map_err(|err| IoError::new(err, path.span(), path_expanded))?;
     Ok(Arc::new(file))
 }
 

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -81,7 +81,7 @@ pub fn glob_from(
                 }
                 Ok(p) => p,
                 Err(err) => {
-                    return Err(IoError::new(err.kind(), pattern_span, path).into());
+                    return Err(IoError::new(err, pattern_span, path).into());
                 }
             };
             (path.parent().map(|parent| parent.to_path_buf()), path)

--- a/crates/nu-plugin-core/src/communication_mode/mod.rs
+++ b/crates/nu-plugin-core/src/communication_mode/mod.rs
@@ -87,7 +87,7 @@ impl CommunicationMode {
                     .and_then(|name| ListenerOptions::new().name(name).create_sync())
                     .map_err(|err| {
                         IoError::new_internal(
-                            err.kind(),
+                            err,
                             format!(
                                 "Could not interpret local socket name {:?}",
                                 name.to_string_lossy()
@@ -117,7 +117,7 @@ impl CommunicationMode {
                         .and_then(|name| ls::Stream::connect(name))
                         .map_err(|err| {
                             ShellError::Io(IoError::new_internal(
-                                err.kind(),
+                                err,
                                 format!(
                                     "Could not interpret local socket name {:?}",
                                     name.to_string_lossy()
@@ -190,7 +190,7 @@ impl PreparedServerCommunication {
                     .set_nonblocking(ListenerNonblockingMode::Accept)
                     .map_err(|err| {
                         IoError::new_internal(
-                            err.kind(),
+                            err,
                             "Could not set non-blocking mode accept for listener",
                             nu_protocol::location!(),
                         )
@@ -204,7 +204,7 @@ impl PreparedServerCommunication {
                                 // good measure. Had an issue without this on macOS.
                                 stream.set_nonblocking(false).map_err(|err| {
                                     IoError::new_internal(
-                                        err.kind(),
+                                        err,
                                         "Could not disable non-blocking mode for listener",
                                         nu_protocol::location!(),
                                     )
@@ -217,7 +217,7 @@ impl PreparedServerCommunication {
                                     // `WouldBlock` is ok, just means it's not ready yet, but some other
                                     // kind of error should be reported
                                     return Err(ShellError::Io(IoError::new_internal(
-                                        err.kind(),
+                                        err,
                                         "Accepting new data from listener failed",
                                         nu_protocol::location!(),
                                     )));

--- a/crates/nu-plugin-core/src/interface/mod.rs
+++ b/crates/nu-plugin-core/src/interface/mod.rs
@@ -82,7 +82,7 @@ where
     fn flush(&self) -> Result<(), ShellError> {
         self.0.lock().flush().map_err(|err| {
             ShellError::Io(IoError::new_internal(
-                err.kind(),
+                err,
                 "PluginWrite could not flush",
                 nu_protocol::location!(),
             ))
@@ -112,7 +112,7 @@ where
         })?;
         lock.flush().map_err(|err| {
             ShellError::Io(IoError::new_internal(
-                err.kind(),
+                err,
                 "PluginWrite could not flush",
                 nu_protocol::location!(),
             ))
@@ -340,7 +340,7 @@ where
                 writer.write_all(std::iter::from_fn(move || match reader.read(buf) {
                     Ok(0) => None,
                     Ok(len) => Some(Ok(buf[..len].to_vec())),
-                    Err(err) => Some(Err(ShellError::from(IoError::new(err.kind(), span, None)))),
+                    Err(err) => Some(Err(ShellError::from(IoError::new(err, span, None)))),
                 }))?;
                 Ok(())
             }
@@ -368,7 +368,7 @@ where
                     })
                     .map_err(|err| {
                         IoError::new_internal(
-                            err.kind(),
+                            err,
                             "Could not spawn plugin stream background writer",
                             nu_protocol::location!(),
                         )

--- a/crates/nu-plugin-core/src/interface/tests.rs
+++ b/crates/nu-plugin-core/src/interface/tests.rs
@@ -246,7 +246,7 @@ fn read_pipeline_data_byte_stream() -> Result<(), ShellError> {
                 ByteStreamSource::Read(mut read) => {
                     let mut buf = Vec::new();
                     read.read_to_end(&mut buf)
-                        .map_err(|err| IoError::new(err.kind(), test_span, None))?;
+                        .map_err(|err| IoError::new(err, test_span, None))?;
                     let iter = buf.chunks_exact(out_pattern.len());
                     assert_eq!(iter.len(), iterations);
                     for chunk in iter {

--- a/crates/nu-plugin-core/src/serializers/msgpack.rs
+++ b/crates/nu-plugin-core/src/serializers/msgpack.rs
@@ -1,7 +1,10 @@
 use std::io::ErrorKind;
 
 use nu_plugin_protocol::{PluginInput, PluginOutput};
-use nu_protocol::{ShellError, shell_error::io::IoError};
+use nu_protocol::{
+    ShellError,
+    shell_error::{self, io::IoError},
+};
 use serde::Deserialize;
 
 use crate::{Encoder, PluginEncoder};
@@ -66,7 +69,7 @@ fn rmp_encode_err(err: rmp_serde::encode::Error) -> ShellError {
             // I/O error
             ShellError::Io(IoError::new_internal(
                 // TODO: get a better kind here
-                std::io::ErrorKind::Other,
+                shell_error::io::ErrorKind::from_std(std::io::ErrorKind::Other),
                 "Could not encode with rmp",
                 nu_protocol::location!(),
             ))
@@ -92,7 +95,7 @@ fn rmp_decode_err<T>(err: rmp_serde::decode::Error) -> Result<Option<T>, ShellEr
                 // I/O error
                 Err(ShellError::Io(IoError::new_internal(
                     // TODO: get a better kind here
-                    std::io::ErrorKind::Other,
+                    shell_error::io::ErrorKind::from_std(std::io::ErrorKind::Other),
                     "Could not decode with rmp",
                     nu_protocol::location!(),
                 )))

--- a/crates/nu-plugin-core/src/serializers/tests.rs
+++ b/crates/nu-plugin-core/src/serializers/tests.rs
@@ -379,7 +379,7 @@ macro_rules! generate_tests {
                 .with_help("some help")
                 .with_label("msg", Span::new(2, 30))
                 .with_inner(ShellError::Io(IoError::new(
-                    std::io::ErrorKind::NotFound,
+                    shell_error::io::ErrorKind::from_std(std::io::ErrorKind::NotFound),
                     Span::test_data(),
                     None,
                 )));

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -20,6 +20,7 @@ use nu_protocol::{
     Spanned, Value,
     ast::{Math, Operator},
     engine::Closure,
+    shell_error,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -87,7 +88,7 @@ fn manager_consume_all_exits_after_streams_and_interfaces_are_dropped() -> Resul
 
 fn test_io_error() -> ShellError {
     ShellError::Io(IoError::new_with_additional_context(
-        std::io::ErrorKind::Other,
+        shell_error::io::ErrorKind::from_std(std::io::ErrorKind::Other),
         Span::test_data(),
         None,
         "test io error",

--- a/crates/nu-plugin-engine/src/persistent.rs
+++ b/crates/nu-plugin-engine/src/persistent.rs
@@ -190,11 +190,7 @@ impl PersistentPlugin {
 
         // Start the plugin garbage collector
         let gc = PluginGc::new(mutable.gc_config.clone(), &self).map_err(|err| {
-            IoError::new_internal(
-                err.kind(),
-                "Could not start plugin gc",
-                nu_protocol::location!(),
-            )
+            IoError::new_internal(err, "Could not start plugin gc", nu_protocol::location!())
         })?;
 
         let pid = child.id();

--- a/crates/nu-plugin-test-support/src/spawn_fake_plugin.rs
+++ b/crates/nu-plugin-test-support/src/spawn_fake_plugin.rs
@@ -66,7 +66,7 @@ pub(crate) fn spawn_fake_plugin(
         .spawn(move || manager.consume_all(output_read).expect("Plugin read error"))
         .map_err(|err| {
             IoError::new_internal(
-                err.kind(),
+                err,
                 format!("Could not spawn fake plugin interface reader ({name})"),
                 nu_protocol::location!(),
             )
@@ -87,7 +87,7 @@ pub(crate) fn spawn_fake_plugin(
         })
         .map_err(|err| {
             IoError::new_internal(
-                err.kind(),
+                err,
                 format!("Could not spawn fake plugin runner ({name})"),
                 nu_protocol::location!(),
             )

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -1048,7 +1048,7 @@ impl ForegroundGuard {
                 // This should always succeed, frankly, but handle the error just in case
                 setpgid(Pid::from_raw(0), Pid::from_raw(0)).map_err(|err| {
                     nu_protocol::shell_error::io::IoError::new_internal(
-                        std::io::Error::from(err).kind(),
+                        std::io::Error::from(err),
                         "Could not set pgid",
                         nu_protocol::location!(),
                     )

--- a/crates/nu-plugin/src/plugin/interface/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/tests.rs
@@ -12,7 +12,7 @@ use nu_plugin_protocol::{
 use nu_protocol::{
     BlockId, ByteStreamType, Config, CustomValue, IntoInterruptiblePipelineData, LabeledError,
     PipelineData, PluginSignature, ShellError, Signals, Span, Spanned, Value, VarId,
-    engine::Closure,
+    engine::Closure, shell_error,
 };
 use std::{
     collections::HashMap,
@@ -91,7 +91,7 @@ fn manager_consume_all_exits_after_streams_and_interfaces_are_dropped() -> Resul
 
 fn test_io_error() -> ShellError {
     ShellError::Io(IoError::new_with_additional_context(
-        std::io::ErrorKind::Other,
+        shell_error::io::ErrorKind::from_std(std::io::ErrorKind::Other),
         Span::test_data(),
         None,
         "test io error",

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -51,6 +51,7 @@ nix = { workspace = true, default-features = false, features = ["signal"] }
 [target.'cfg(windows)'.dependencies]
 dirs-sys = { workspace = true }
 windows-sys = { workspace = true }
+windows = { workspace = true }
 
 [features]
 default = ["os"]

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -353,7 +353,7 @@ impl EngineState {
 
         let cwd = self.cwd(Some(stack))?;
         std::env::set_current_dir(cwd).map_err(|err| {
-            IoError::new_internal(err.kind(), "Could not set current dir", crate::location!())
+            IoError::new_internal(err, "Could not set current dir", crate::location!())
         })?;
 
         if let Some(config) = stack.config.take() {
@@ -546,7 +546,7 @@ impl EngineState {
                     Ok(PluginRegistryFile::default())
                 } else {
                     Err(ShellError::Io(IoError::new_internal_with_path(
-                        err.kind(),
+                        err,
                         "Failed to open plugin file",
                         crate::location!(),
                         PathBuf::from(plugin_path),
@@ -563,7 +563,7 @@ impl EngineState {
         // Write it to the same path
         let plugin_file = File::create(plugin_path.as_path()).map_err(|err| {
             IoError::new_internal_with_path(
-                err.kind(),
+                err,
                 "Failed to write plugin file",
                 crate::location!(),
                 PathBuf::from(plugin_path),

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -143,11 +143,11 @@ impl LabeledError {
     /// [`ShellError`] implements `miette::Diagnostic`:
     ///
     /// ```rust
-    /// # use nu_protocol::{ShellError, LabeledError, shell_error::io::IoError, Span};
+    /// # use nu_protocol::{ShellError, LabeledError, shell_error::{self, io::IoError}, Span};
     /// #
     /// let error = LabeledError::from_diagnostic(
     ///     &ShellError::Io(IoError::new_with_additional_context(
-    ///         std::io::ErrorKind::other(),
+    ///         shell_error::io::ErrorKind::from_std(std::io::ErrorKind::Other),
     ///         Span::test_data(),
     ///         None,
     ///         "some error"

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -147,7 +147,7 @@ impl LabeledError {
     /// #
     /// let error = LabeledError::from_diagnostic(
     ///     &ShellError::Io(IoError::new_with_additional_context(
-    ///         std::io::ErrorKind::Other,
+    ///         std::io::ErrorKind::other(),
     ///         Span::test_data(),
     ///         None,
     ///         "some error"

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -360,6 +360,19 @@ impl IoError {
     }
 }
 
+impl From<std::io::Error> for ErrorKind {
+    fn from(ref err: std::io::Error) -> Self {
+        err.into()
+    }
+}
+
+impl<'e> From<&'e std::io::Error> for ErrorKind {
+    fn from(err: &'e std::io::Error) -> Self {
+        // TODO: do the full match here
+        ErrorKind::Std(err.kind(), Sealed)
+    }
+}
+
 impl StdError for IoError {}
 impl Display for IoError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -482,6 +495,7 @@ impl From<IoError> for std::io::Error {
     }
 }
 
+// TODO: remove this
 impl From<std::io::ErrorKind> for ErrorKind {
     fn from(value: std::io::ErrorKind) -> Self {
         ErrorKind::Std(value, Sealed)

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -350,13 +350,13 @@ impl IoError {
 }
 
 impl From<std::io::Error> for ErrorKind {
-    fn from(ref err: std::io::Error) -> Self {
-        err.into()
+    fn from(err: std::io::Error) -> Self {
+        (&err).into()
     }
 }
 
-impl<'e> From<&'e std::io::Error> for ErrorKind {
-    fn from(err: &'e std::io::Error) -> Self {
+impl From<&std::io::Error> for ErrorKind {
+    fn from(err: &std::io::Error) -> Self {
         // TODO: do the full match here
         ErrorKind::Std(err.kind(), Sealed)
     }
@@ -559,6 +559,12 @@ impl IoErrorExt for ErrorKind {
 }
 
 impl IoErrorExt for std::io::Error {
+    fn not_found_as(self, kind: NotFound) -> ErrorKind {
+        ErrorKind::from(self).not_found_as(kind)
+    }
+}
+
+impl IoErrorExt for &std::io::Error {
     fn not_found_as(self, kind: NotFound) -> ErrorKind {
         ErrorKind::from(self).not_found_as(kind)
     }

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -38,7 +38,7 @@ use super::{ShellError, location::Location};
 ///
 /// # let span = Span::test_data();
 /// let path = PathBuf::from("/some/missing/file");
-/// let error = IoError::new(std::io::ErrorKind::NotFound, span, path);
+/// let error = IoError::new(ErrorKind::FileNotFound, span, path);
 /// println!("Error: {:?}", error);
 /// ```
 ///
@@ -47,7 +47,7 @@ use super::{ShellError, location::Location};
 /// # use nu_protocol::shell_error::io::{IoError, ErrorKind};
 //  #
 /// let error = IoError::new_internal(
-///     std::io::ErrorKind::UnexpectedEof,
+///     ErrorKind::from_std(std::io::ErrorKind::UnexpectedEof),
 ///     "Failed to read data from buffer",
 ///     nu_protocol::location!()
 /// );
@@ -278,10 +278,10 @@ impl IoError {
     ///
     /// # Examples
     /// ```rust
-    /// use nu_protocol::shell_error::io::IoError;
+    /// use nu_protocol::shell_error::{self, io::IoError};
     ///
     /// let error = IoError::new_internal(
-    ///     std::io::ErrorKind::UnexpectedEof,
+    ///     shell_error::io::ErrorKind::from_std(std::io::ErrorKind::UnexpectedEof),
     ///     "Failed to read from buffer",
     ///     nu_protocol::location!(),
     /// );
@@ -309,11 +309,11 @@ impl IoError {
     ///
     /// # Examples
     /// ```rust
-    /// use nu_protocol::shell_error::io::IoError;
+    /// use nu_protocol::shell_error::{self, io::IoError};
     /// use std::path::PathBuf;
     ///
     /// let error = IoError::new_internal_with_path(
-    ///     std::io::ErrorKind::NotFound,
+    ///     shell_error::io::ErrorKind::FileNotFound,
     ///     "Could not find special file",
     ///     nu_protocol::location!(),
     ///     PathBuf::from("/some/file"),

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -495,13 +495,6 @@ impl From<IoError> for std::io::Error {
     }
 }
 
-// TODO: remove this
-impl From<std::io::ErrorKind> for ErrorKind {
-    fn from(value: std::io::ErrorKind) -> Self {
-        ErrorKind::Std(value, Sealed)
-    }
-}
-
 impl From<ErrorKind> for std::io::ErrorKind {
     fn from(value: ErrorKind) -> Self {
         match value {
@@ -579,6 +572,26 @@ impl ErrorKindExt for ErrorKind {
         match self {
             Self::Std(std_kind, Sealed) => std_kind.not_found_as(kind),
             _ => self,
+        }
+    }
+}
+
+#[cfg(test)]
+mod assert_not_impl {
+    use super::*;
+
+    /// Assertion that `ErrorKind` does not implement `From<std::io::ErrorKind>`.
+    ///
+    /// This implementation exists only in tests to make sure that no crate,
+    /// including ours, accidentally adds a `From<std::io::ErrorKind>` impl for `ErrorKind`.
+    /// If someone tries, it will fail due to conflicting implementations.
+    ///
+    /// We want to force usage of [`IoError::new`] with a full [`std::io::Error`] instead of
+    /// allowing conversion from just an [`std::io::ErrorKind`].
+    /// That way, we can properly inspect and classify uncategorized I/O errors.
+    impl From<std::io::ErrorKind> for ErrorKind {
+        fn from(_: std::io::ErrorKind) -> Self {
+            unimplemented!("ErrorKind should not implement From<std::io::ErrorKind>")
         }
     }
 }

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -368,6 +368,7 @@ impl From<&std::io::Error> for ErrorKind {
         if let Some(raw_os_error) = err.raw_os_error() {
             use windows::Win32::Foundation;
 
+            #[allow(clippy::single_match, reason = "in the future we can expand here")]
             match Foundation::WIN32_ERROR(raw_os_error as u32) {
                 Foundation::ERROR_SHARING_VIOLATION => return ErrorKind::AlreadyInUse,
                 _ => {}

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -222,14 +222,14 @@ impl PipelineData {
                 let bytes = value_to_bytes(value)?;
                 dest.write_all(&bytes).map_err(|err| {
                     IoError::new_internal(
-                        err.kind(),
+                        err,
                         "Could not write PipelineData to dest",
                         crate::location!(),
                     )
                 })?;
                 dest.flush().map_err(|err| {
                     IoError::new_internal(
-                        err.kind(),
+                        err,
                         "Could not flush PipelineData to dest",
                         crate::location!(),
                     )
@@ -241,14 +241,14 @@ impl PipelineData {
                     let bytes = value_to_bytes(value)?;
                     dest.write_all(&bytes).map_err(|err| {
                         IoError::new_internal(
-                            err.kind(),
+                            err,
                             "Could not write PipelineData to dest",
                             crate::location!(),
                         )
                     })?;
                     dest.write_all(b"\n").map_err(|err| {
                         IoError::new_internal(
-                            err.kind(),
+                            err,
                             "Could not write linebreak after PipelineData to dest",
                             crate::location!(),
                         )
@@ -256,7 +256,7 @@ impl PipelineData {
                 }
                 dest.flush().map_err(|err| {
                     IoError::new_internal(
-                        err.kind(),
+                        err,
                         "Could not flush PipelineData to dest",
                         crate::location!(),
                     )
@@ -778,11 +778,9 @@ where
     let io_error_map = |err: std::io::Error, location: Location| {
         let context = format!("Writing to {} failed", destination_name);
         match span {
-            None => IoError::new_internal(err.kind(), context, location),
-            Some(span) if span == Span::unknown() => {
-                IoError::new_internal(err.kind(), context, location)
-            }
-            Some(span) => IoError::new_with_additional_context(err.kind(), span, None, context),
+            None => IoError::new_internal(err, context, location),
+            Some(span) if span == Span::unknown() => IoError::new_internal(err, context, location),
+            Some(span) => IoError::new_with_additional_context(err, span, None, context),
         }
     };
 

--- a/crates/nu-protocol/src/process/child.rs
+++ b/crates/nu-protocol/src/process/child.rs
@@ -81,7 +81,7 @@ impl ExitStatusFuture {
                     }
                     Ok(Ok(status)) => Ok(status),
                     Ok(Err(err)) => Err(ShellError::Io(IoError::new_with_additional_context(
-                        err.kind(),
+                        err,
                         span,
                         None,
                         "failed to get exit code",
@@ -276,7 +276,7 @@ impl ChildProcess {
             })
             .map_err(|err| {
                 IoError::new_with_additional_context(
-                    err.kind(),
+                    err,
                     span,
                     None,
                     "Could now spawn exit status waiter",
@@ -325,7 +325,7 @@ impl ChildProcess {
         }
 
         let bytes = if let Some(stdout) = self.stdout {
-            collect_bytes(stdout).map_err(|err| IoError::new(err.kind(), self.span, None))?
+            collect_bytes(stdout).map_err(|err| IoError::new(err, self.span, None))?
         } else {
             Vec::new()
         };

--- a/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
@@ -10,7 +10,8 @@ use nu_utils::perf;
 use nu_plugin::{EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Type, Value, shell_error::io::IoError,
+    SyntaxShape, Type, Value,
+    shell_error::{self, io::IoError},
 };
 
 use std::{fs::File, io::BufReader, num::NonZeroUsize, path::PathBuf, sync::Arc};
@@ -193,7 +194,7 @@ fn command(
             )),
         },
         None => Err(ShellError::Io(IoError::new_with_additional_context(
-            std::io::ErrorKind::NotFound,
+            shell_error::io::ErrorKind::from_std(std::io::ErrorKind::Other),
             spanned_file.span,
             PathBuf::from(spanned_file.item),
             "File without extension",

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
@@ -16,7 +16,8 @@ use log::debug;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Type, shell_error::io::IoError,
+    SyntaxShape, Type,
+    shell_error::{self, io::IoError},
 };
 use polars::error::PolarsError;
 
@@ -212,7 +213,7 @@ fn command(
             )),
         },
         None => Err(ShellError::Io(IoError::new_with_additional_context(
-            std::io::ErrorKind::NotFound,
+            shell_error::io::ErrorKind::FileNotFound,
             resource.span,
             Some(PathBuf::from(resource.path)),
             "File without extension",

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
     DeclId, ShellError, Span, Value, VarId,
     engine::{EngineState, Stack, StateWorkingSet},
     report_shell_error,
-    shell_error::io::{ErrorKindExt, IoError, NotFound},
+    shell_error::io::{IoError, IoErrorExt, NotFound},
 };
 use reedline::Completer;
 use serde_json::{Value as JsonValue, json};
@@ -58,7 +58,7 @@ fn read_in_file<'a>(
     let file = std::fs::read(file_path)
         .map_err(|err| {
             ShellError::Io(IoError::new_with_additional_context(
-                err.kind().not_found_as(NotFound::File),
+                err.not_found_as(NotFound::File),
                 Span::unknown(),
                 PathBuf::from(file_path),
                 "Could not read file",

--- a/src/main.rs
+++ b/src/main.rs
@@ -417,7 +417,7 @@ fn main() -> Result<()> {
             let filename = canonicalize_with(&plugin_filename.item, &init_cwd)
                 .map_err(|err| {
                     nu_protocol::shell_error::io::IoError::new(
-                        err.kind(),
+                        err,
                         plugin_filename.span,
                         PathBuf::from(&plugin_filename.item),
                     )


### PR DESCRIPTION
<!--  
if this PR closes one or more issues, you can automatically link the PR with  
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue-using-a-keyword), e.g.  
- this PR should close #xxxx  
- fixes #xxxx  

you can also mention related issues, PRs or discussions!  
-->

Oh boy, time for another IO error refactor. 🫠

- fixes #15762

# Description

<!--  
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.  

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.  
-->

This PR changes what types can be passed to `IoError::new` and its variants. We no longer accept just `std::io::ErrorKind`, instead, you now need to pass a full `std::io::Error`. That way, we keep access to the raw OS error, which gets lost if we only work with the kind. This helps in cases like when we get an [`Uncategorized`](https://github.com/rust-lang/rust/blob/777d372772aa3b39ba7273fcb8208a89f2ab0afd/library/std/src/io/error.rs#L437-L444) error.

To fix #15762, we check the raw OS error while converting from `std::io::Error` to our own `ErrorKind`. If it matches [`ERROR_SHARING_VIOLATION`](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-#ERROR_SHARING_VIOLATION), we now emit the `ErrorKind::AlreadyInUse` variant (naming up for debate). There's a Windows-only test for this in `rm.rs`, I'm not sure if this needs handling on Linux or if that’s already covered elsewhere.

To make sure nobody adds a `From<std::io::ErrorKind>` for `ErrorKind` by accident, I added a dummy impl in a test module to cause a compile error if someone tries. I also added a private `Sealed` struct to stop folks from creating the `ErrorKind::Std` variant directly. You can still match on it, but you can't construct it. If you *really* want to do that, there's `ErrorKind::from_std`, which is hopefully enough friction to discourage casual use.

# User-Facing Changes

<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->  

No changes for regular Nushell users. But plugin authors and embedders will see breaking changes:

* removed `From<std::io::ErrorKind> for ErrorKind`
* added `From<std::io::Error> for ErrorKind`
* renamed `ErrorKindExt` to `IoErrorExt`
* implemented it for `std::io::Error` instead of `std::io::ErrorKind`
* added `ErrorKind::AlreadyInUse`

# Tests + Formatting

<!--  
Don't forget to add tests that cover your changes.  

Make sure you've run and fixed any issues with these commands:  

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)  
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style  
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))  
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library  

> **Note**  
> from `nushell` you can also use the `toolkit` as follows  
> ```bash  
> use toolkit.nu  # or use an `env_change` hook to activate it automatically  
> toolkit check pr  
> ```  
-->

Added the `nu_command::tests::rm::rm_already_in_use` test.

* :green_circle: `toolkit fmt`
* :green_circle: `toolkit clippy`
* :green_circle: `toolkit test`
* :green_circle: `toolkit test stdlib`

# After Submitting

<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

