### PR TITLE
fix: implicitly running .ps1 scripts with spaces in path

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -187,12 +187,10 @@ impl Command for External {
             }
         } else if potential_powershell_script {
             command.args([
-                "-Command",
+                "-File",
                 &path_to_ps1_executable.unwrap_or_default().to_string_lossy(),
             ]);
-            for arg in &args {
-                command.raw_arg(arg.item.clone());
-            }
+            command.args(args.into_iter().map(|s| s.item));
         } else {
             command.args(args.into_iter().map(|s| s.item));
         }

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -536,6 +536,25 @@ fn can_run_ps1_files(prefix: &str) {
     });
 }
 
+#[cfg(windows)]
+#[apply(run_external_prefixes)]
+fn can_run_ps1_files_with_space_in_path(prefix: &str) {
+    use nu_test_support::fs::Stub::FileWithContent;
+    Playground::setup("run_a_windows_ps_file", |dirs, sandbox| {
+        sandbox
+            .within("path with space")
+            .with_files(&[FileWithContent(
+                "foo.ps1",
+                r#"
+                    Write-Host Hello World
+                "#,
+            )]);
+
+        let actual = nu!(cwd: dirs.test().join("path with space"), "{}foo.ps1", prefix);
+        assert!(actual.out.contains("Hello World"));
+    });
+}
+
 #[rstest]
 #[case("^")]
 #[case("run-external ")]


### PR DESCRIPTION
- this PR should close #15757

# Description

> [!NOTE]
> [`-File <filePath> <args>`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1#-file----filepath-args)
> - Enter the script filepath and any parameters
> - All values typed after the File parameter are interpreted as the script filepath and parameters passed to that script.

> [!NOTE]
> [`-Command`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1#-command)
> - The value of Command can be -, a _script block_, or a _string_.
> - In `cmd.exe` (and other externall callers), there is no such thing as a _script block_, so the value passed to Command is always a _**string**_.
> - A string passed to Command is still executed as PowerShell code.

> [!NOTE]
> [Call operator `&`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-5.1#call-operator-)
> - Runs a command, ***script***, or script block.

Basically using `-Command` to run scripts would require _another_ layer of quoting and escaping. It looks like `-File` is the way to run powershell scripts as an external caller.

# User-Facing Changes

# Tests + Formatting

# After Submitting
