### PR TITLE
Improve error handling for unsupported --theme in to html command

### DIFF
--- a/crates/nu-cmd-extra/src/extra/formats/to/html.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html.rs
@@ -755,15 +755,11 @@ mod tests {
 
     #[test]
     fn returns_a_valid_theme() {
-
         let theme_name = "Dracula".to_string().into_spanned(Span::new(0, 7));
-
         let result = super::get_theme_from_asset_file(false, Some(&theme_name));
 
         assert!(result.is_ok(), "Expected Ok result for valid theme");
-
         let theme_map = result.unwrap();
-
         let required_keys = [
             "background",
             "foreground",

--- a/crates/nu-cmd-extra/src/extra/formats/to/html.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html.rs
@@ -101,7 +101,7 @@ impl Command for ToHtml {
             .named(
                 "theme",
                 SyntaxShape::String,
-                "the name of the theme to use (github, blulocolight, ...)",
+                "the name of the theme to use (github, blulocolight, ...); case-insensitive",
                 Some('t'),
             )
             .switch(

--- a/crates/nu-cmd-extra/src/extra/formats/to/html.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html.rs
@@ -163,7 +163,12 @@ fn get_theme_from_asset_file(
 ) -> Result<HashMap<&'static str, String>, ShellError> {
     let theme_name = match theme {
         Some(s) => &s.item,
-        None => "default", // There is no theme named "default" so this will be HtmlTheme::default(), which is "nu_default".
+        None => {
+            return Ok(convert_html_theme_to_hash_map(
+                is_dark,
+                &HtmlTheme::default(),
+            ));
+        }
     };
 
     let theme_span = theme.map(|s| s.span).unwrap_or(Span::unknown());
@@ -271,7 +276,10 @@ fn to_html(
     let color_hm = match get_theme_from_asset_file(dark, theme.as_ref()) {
         Ok(c) => c,
         Err(e) => match e {
-            ShellError::TypeMismatch { err_message, span } => {
+            ShellError::TypeMismatch {
+                err_message,
+                span: _,
+            } => {
                 return Err(ShellError::TypeMismatch {
                     err_message,
                     span: theme_span,


### PR DESCRIPTION
Related to discussion in `to html` error handling.
[to html doesn't error on non-existent theme names #15740
](https://github.com/nushell/nushell/issues/15740)

# Description

This PR improves error handling for the `--theme` flag in the `to html` command. Previously, invalid theme names silently fell back to the default theme. This change aligns behavior with other commands like `ansi`, and now returns a `ShellError::TypeMismatch` if the specified theme does not exist.

Example:

`[[foo bar]; [1 2]] | to html --theme doesnt-exist`

Now results in a proper error message highlighting the invalid theme.
```Error: nu::shell::type_mismatch

  × Type mismatch.
   ╭─[entry #1:1:30]
 1 │ [[foo bar]; [1 2]] | to html --theme doesnt-exist
   ·                              ──────────┬─────────
   ·                                        ╰── Unknown HTML theme 'doesnt-exist'
   ╰────
```

# User-Facing Changes

- `to html` now returns an error if an invalid `--theme` value is provided.
- This avoids silent fallback and improves discoverability and consistency across commands.
- Updated help message for --theme option

# Tests + Formatting

- ✅ Added unit tests:
  - returns an error for unknown themes
  - accepts and returns default theme when `--theme` is omitted
  - verifies known themes return expected color keys
- ✅ Ran `cargo fmt --all -- --check`
- ✅ Ran `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used`
- ✅ Verified `cargo test --workspace` passes

# After Submitting

No documentation changes are required at this time, but the behavior is now clearer and more consistent for users using `--theme` with `to html`.
