### PR TITLE
Fix update with closure on nested list

### DIFF
--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -115,29 +115,52 @@ fn update(
     match input {
         PipelineData::Value(mut value, metadata) => {
             if let Value::Closure { val, .. } = replacement {
-                match (cell_path.members.first(), &mut value) {
-                    (Some(PathMember::String { .. }), Value::List { vals, .. }) => {
+                // follow before last cell_path.
+                let (mut last_value, last_member) = match cell_path.members.split_last() {
+                    None => {
+                        return Err(ShellError::GenericError {
+                            error: "cell path can't be empty".to_string(),
+                            msg: "found an empty cell path".to_string(),
+                            span: None,
+                            help: Some(
+                                "This should not happened, please file an issue".to_string(),
+                            ),
+                            inner: vec![],
+                        });
+                    }
+                    Some((last, members)) => {
+                        if members.is_empty() {
+                            (value, last)
+                        } else {
+                            (value.follow_cell_path(members)?.into_owned(), last)
+                        }
+                    }
+                };
+
+                match (last_member, &mut last_value) {
+                    (PathMember::String { .. }, Value::List { vals, .. }) => {
                         let mut closure = ClosureEval::new(engine_state, stack, *val);
                         for val in vals {
                             update_value_by_closure(
                                 val,
                                 &mut closure,
                                 head,
-                                &cell_path.members,
+                                &[last_member.clone()],
                                 false,
                             )?;
                         }
                     }
                     (first, _) => {
                         update_single_value_by_closure(
-                            &mut value,
+                            &mut last_value,
                             ClosureEvalOnce::new(engine_state, stack, *val),
                             head,
-                            &cell_path.members,
-                            matches!(first, Some(PathMember::Int { .. })),
+                            &[last_member.clone()],
+                            matches!(first, PathMember::Int { .. }),
                         )?;
                     }
                 }
+                return Ok(last_value.into_pipeline_data_with_metadata(metadata));
             } else {
                 value.update_data_at_cell_path(&cell_path.members, replacement)?;
             }

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -153,14 +153,18 @@ fn update(
                         }
                         if !prev_members.is_empty() {
                             value.update_data_at_cell_path(prev_members, last_value)?;
+                        } else {
+                            // no prev_members, so last_value is actually
+                            // the value itself.
+                            value = last_value;
                         }
                     }
                     (first, _) => {
                         update_single_value_by_closure(
-                            &mut last_value,
+                            &mut value,
                             ClosureEvalOnce::new(engine_state, stack, *val),
                             head,
-                            &[last_member.clone()],
+                            &cell_path.members,
                             matches!(first, PathMember::Int { .. }),
                         )?;
                     }

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -110,18 +110,17 @@ fn update_value_with_closure(
     members: Vec<PathMember>,
     head: Span,
 ) -> Result<Value, ShellError> {
-    // Make sure the whole path accessable.
-    // let _ = value.follow_cell_path(&members)?;
     // follow cell_path until last_cell(exclusive).
     let (mut last_value, last_member, prev_members) = match members.split_last() {
         None => {
-            return Err(ShellError::GenericError {
-                error: "cell path can't be empty".to_string(),
-                msg: "found an empty cell path".to_string(),
-                span: None,
-                help: Some("This should not happened, please file an issue".to_string()),
-                inner: vec![],
-            });
+            update_single_value_by_closure(
+                &mut value,
+                ClosureEvalOnce::new(engine_state, stack, *closure),
+                head,
+                &members,
+                false,
+            )?;
+            return Ok(value);
         }
         Some((last, members)) => {
             if members.is_empty() {

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -184,13 +184,17 @@ fn update_value_with_closure(
                 if is_value_list && !is_first_member_int {
                     let rows = match value {
                         Value::List { ref mut vals, .. } => vals,
-                        _ => panic!("the i"),
+                        _ => panic!(
+                            "Alreay checked the value is a list, please fire an issue if you get this message"
+                        ),
                     };
                     let last_value_rows = match last_value {
                         Value::List { vals, .. } => vals,
-                        _ => todo!("fill"),
+                        _ => panic!(
+                            "The input value is a list, so last_value must be a list, please fire an issue if you get this message"
+                        ),
                     };
-                    for (value_row, last_value_row) in rows.into_iter().zip(last_value_rows) {
+                    for (value_row, last_value_row) in rows.iter_mut().zip(last_value_rows) {
                         value_row.update_data_at_cell_path(prev_members, last_value_row)?;
                     }
                 } else {

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -106,7 +106,7 @@ fn update_value_with_closure(
     engine_state: &EngineState,
     stack: &mut Stack,
     mut value: Value,
-    closure: Box<Closure>,
+    closure: Closure,
     members: Vec<PathMember>,
     head: Span,
 ) -> Result<Value, ShellError> {
@@ -115,7 +115,7 @@ fn update_value_with_closure(
         None => {
             update_single_value_by_closure(
                 &mut value,
-                ClosureEvalOnce::new(engine_state, stack, *closure),
+                ClosureEvalOnce::new(engine_state, stack, closure),
                 head,
                 &members,
                 false,
@@ -143,7 +143,7 @@ fn update_value_with_closure(
     // update `last_value` first, then set last value back to `value`.
     match (last_member, &mut last_value) {
         (PathMember::String { .. }, Value::List { vals, .. }) => {
-            let mut closure = ClosureEval::new(engine_state, stack, *closure);
+            let mut closure = ClosureEval::new(engine_state, stack, closure);
             if is_value_list && !is_first_member_int {
                 // `vals` is always a list, it's required to check elements
                 // to get **real last value**.
@@ -209,7 +209,7 @@ fn update_value_with_closure(
         (first, _) => {
             update_single_value_by_closure(
                 &mut value,
-                ClosureEvalOnce::new(engine_state, stack, *closure),
+                ClosureEvalOnce::new(engine_state, stack, closure),
                 head,
                 &members,
                 matches!(first, PathMember::Int { .. }),
@@ -236,7 +236,7 @@ fn update(
                     engine_state,
                     stack,
                     value,
-                    closure,
+                    *closure,
                     cell_path.members,
                     head,
                 )?;

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -185,7 +185,7 @@ fn update_value_with_closure(
                     let rows = match value {
                         Value::List { ref mut vals, .. } => vals,
                         _ => panic!(
-                            "Alreay checked the value is a list, please fire an issue if you get this message"
+                            "Already checked the value is a list, please fire an issue if you get this message"
                         ),
                     };
                     let last_value_rows = match last_value {

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -111,7 +111,7 @@ fn update_value_with_closure(
     head: Span,
 ) -> Result<Value, ShellError> {
     // Make sure the whole path accessable.
-    let _ = value.follow_cell_path(&members)?;
+    // let _ = value.follow_cell_path(&members)?;
     // follow cell_path until last_cell(exclusive).
     let (mut last_value, last_member, prev_members) = match members.split_last() {
         None => {

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -149,5 +149,5 @@ fn list_stream_replacement_closure() {
 fn nested_list_replacement_closure() {
     let actual =
         nu!("{ w: { x: [ { y: '1' } { y: '2' } ] } } | update w.x.y {into float} | to nuon");
-    assert_eq!(actual.out, "[1.0, 2.0]")
+    assert_eq!(actual.out, "{w: {x: [[y]; [1.0], [2.0]]}}")
 }

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -144,3 +144,10 @@ fn list_stream_replacement_closure() {
     let actual = nu!("[[a]; [text]] | every 1 | update a { str upcase } | to nuon");
     assert_eq!(actual.out, "[[a]; [TEXT]]");
 }
+
+#[test]
+fn nested_list_replacement_closure() {
+    let actual =
+        nu!("{ w: { x: [ { y: '1' } { y: '2' } ] } } | update w.x.y {into float} | to nuon");
+    assert_eq!(actual.out, "[1.0, 2.0]")
+}

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -149,5 +149,17 @@ fn list_stream_replacement_closure() {
 fn nested_list_replacement_closure() {
     let actual =
         nu!("{ w: { x: [ { y: '1' } { y: '2' } ] } } | update w.x.y {into float} | to nuon");
-    assert_eq!(actual.out, "{w: {x: [[y]; [1.0], [2.0]]}}")
+    assert_eq!(actual.out, "{w: {x: [[y]; [1.0], [2.0]]}}");
+
+    let actual =
+        nu!("[{ w: { x: [ { y: '1' } { y: '2' } ] } }] | update w.x.y {into float} | to nuon");
+    assert_eq!(actual.out, "[{w: {x: [[y]; [1.0], [2.0]]}}]");
+
+    // Two elements in outermost nested list
+    let actual =
+        nu!("[{ w: { x: [ { y: '1' } { y: '2' } ] } }, { w: { x: [ { y: '3' } { y: '4' } ] } }] | update w.x.y {into float} | to nuon");
+    assert_eq!(actual.out, "[{w: {x: [[y]; [1.0], [2.0]]}}, {w: {x: [[y]; [3.0], [4.0]]}}]")
+    let actual =
+        nu!("[{ w: { x: [ { y: '1' } { y: '2' } ] } }, { w: { x: [ { y: '3' } { y: '4' } ] } }] | update 0.w.x.y {into float} | to nuon");
+    assert_eq!(actual.out, "[{w: {x: [[y]; [1.0], [2.0]]}}, {w: {x: [[y]; ['3'], ['4']}}]")
 }

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -153,7 +153,7 @@ fn nested_list_replacement_closure() {
 
     let actual =
         nu!("[{ w: { x: [ { y: '1' } { y: '2' } ] } }] | update w.x.y {into float} | to nuon");
-    assert_eq!(actual.out, "[{w: {x: [[y]; [1.0], [2.0]]}}]");
+    assert_eq!(actual.out, "[[w]; [{x: [[y]; [1.0], [2.0]]}]]");
 
     // Two elements in outermost nested list
     let actual = nu!(
@@ -161,13 +161,13 @@ fn nested_list_replacement_closure() {
     );
     assert_eq!(
         actual.out,
-        "[{w: {x: [[y]; [1.0], [2.0]]}}, {w: {x: [[y]; [3.0], [4.0]]}}]"
+        "[[w]; [{x: [[y]; [1.0], [2.0]]}], [{x: [[y]; [3.0], [4.0]]}]]"
     );
     let actual = nu!(
         "[{ w: { x: [ { y: '1' } { y: '2' } ] } }, { w: { x: [ { y: '3' } { y: '4' } ] } }] | update 0.w.x.y {into float} | to nuon"
     );
     assert_eq!(
         actual.out,
-        "[{w: {x: [[y]; [1.0], [2.0]]}}, {w: {x: [[y]; ['3'], ['4']}}]"
+        "[[w]; [{x: [[y]; [1.0], [2.0]]}], [{x: [[y]; [\"3\"], [\"4\"]]}]]"
     );
 }

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -156,10 +156,18 @@ fn nested_list_replacement_closure() {
     assert_eq!(actual.out, "[{w: {x: [[y]; [1.0], [2.0]]}}]");
 
     // Two elements in outermost nested list
-    let actual =
-        nu!("[{ w: { x: [ { y: '1' } { y: '2' } ] } }, { w: { x: [ { y: '3' } { y: '4' } ] } }] | update w.x.y {into float} | to nuon");
-    assert_eq!(actual.out, "[{w: {x: [[y]; [1.0], [2.0]]}}, {w: {x: [[y]; [3.0], [4.0]]}}]")
-    let actual =
-        nu!("[{ w: { x: [ { y: '1' } { y: '2' } ] } }, { w: { x: [ { y: '3' } { y: '4' } ] } }] | update 0.w.x.y {into float} | to nuon");
-    assert_eq!(actual.out, "[{w: {x: [[y]; [1.0], [2.0]]}}, {w: {x: [[y]; ['3'], ['4']}}]")
+    let actual = nu!(
+        "[{ w: { x: [ { y: '1' } { y: '2' } ] } }, { w: { x: [ { y: '3' } { y: '4' } ] } }] | update w.x.y {into float} | to nuon"
+    );
+    assert_eq!(
+        actual.out,
+        "[{w: {x: [[y]; [1.0], [2.0]]}}, {w: {x: [[y]; [3.0], [4.0]]}}]"
+    );
+    let actual = nu!(
+        "[{ w: { x: [ { y: '1' } { y: '2' } ] } }, { w: { x: [ { y: '3' } { y: '4' } ] } }] | update 0.w.x.y {into float} | to nuon"
+    );
+    assert_eq!(
+        actual.out,
+        "[{w: {x: [[y]; [1.0], [2.0]]}}, {w: {x: [[y]; ['3'], ['4']}}]"
+    );
 }

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -148,26 +148,32 @@ fn list_stream_replacement_closure() {
 #[test]
 fn nested_list_replacement_closure() {
     let actual =
-        nu!("{ w: { x: [ { y: '1' } { y: '2' } ] } } | update w.x.y {into float} | to nuon");
-    assert_eq!(actual.out, "{w: {x: [[y]; [1.0], [2.0]]}}");
+        nu!("{ w: { x: [ { y: '1' } { y: '2' } ] } } | update w.x.y {into float} | to json --raw");
+    assert_eq!(actual.out, r#"{"w":{"x":[{"y":1.0},{"y":2.0}]}}"#);
 
-    let actual =
-        nu!("[{ w: { x: [ { y: '1' } { y: '2' } ] } }] | update w.x.y {into float} | to nuon");
-    assert_eq!(actual.out, "[[w]; [{x: [[y]; [1.0], [2.0]]}]]");
+    let actual = nu!(
+        "[{ w: { x: [ { y: '1' } { y: '2' } ] } }] | update w.x.y {into float} | to json --raw"
+    );
+    assert_eq!(actual.out, r#"[{"w":{"x":[{"y":1.0},{"y":2.0}]}}]"#);
 
     // Two elements in outermost nested list
     let actual = nu!(
-        "[{ w: { x: [ { y: '1' } { y: '2' } ] } }, { w: { x: [ { y: '3' } { y: '4' } ] } }] | update w.x.y {into float} | to nuon"
+        "[{ w: { x: [ { y: '1' } { y: '2' } ] } }, { w: { x: [ { y: '3' } { y: '4' } ] } }] | update w.x.y {into float} | to json --raw"
     );
     assert_eq!(
         actual.out,
-        "[[w]; [{x: [[y]; [1.0], [2.0]]}], [{x: [[y]; [3.0], [4.0]]}]]"
+        r#"[{"w":{"x":[{"y":1.0},{"y":2.0}]}},{"w":{"x":[{"y":3.0},{"y":4.0}]}}]"#
     );
     let actual = nu!(
-        "[{ w: { x: [ { y: '1' } { y: '2' } ] } }, { w: { x: [ { y: '3' } { y: '4' } ] } }] | update 0.w.x.y {into float} | to nuon"
+        "[{ w: { x: [ { y: '1' } { y: '2' } ] } }, { w: { x: [ { y: '3' } { y: '4' } ] } }] | update 0.w.x.y {into float} | to json --raw"
     );
     assert_eq!(
         actual.out,
-        "[[w]; [{x: [[y]; [1.0], [2.0]]}], [{x: [[y]; [\"3\"], [\"4\"]]}]]"
+        r#"[{"w":{"x":[{"y":1.0},{"y":2.0}]}},{"w":{"x":[{"y":"3"},{"y":"4"}]}}]"#
     );
+    let actual = nu!("[{a: 1}, {a: 2}] | to json --raw");
+    assert_eq!(actual.out, r#"[{"a":1},{"a":2}]"#);
+
+    let actual = nu!(r#"[[{"a":1.0},{"a":2.0}]] | update a {into float} | to json --raw"#);
+    assert_eq!(actual.out, r#"[[{"a":1.0},{"a":2.0}]]"#);
 }


### PR DESCRIPTION
# Description
Fixes: #15726

When nushell update a value, instead of checking if the value is a list.  We should follow cell path until the last one, and check if that value is a list.
Given the example: `{ w: { x: [ { y: "1" } { y: "2" } ] } } | update w.x.y { into float }`, we should follow `w.x` first, this gives us `[ { y: "1" } { y: "2" } ]`, which is a list, and we need to update on the value `[ {y: 1.0} {y: 2.0} ]`
After updated, we need to set `w.x` to the updated value, so the result will be `{ w: { x: [ { y: 1.0 } { y: 2.0 } ] } }`

# User-Facing Changes
### Before
```nushell
> { w: { x: [ { y: "1" } { y: "2" } ] } } | update w.x.y { into float } | to yaml
w:
  x:
  - y:
    - 1.0
    - 2.0
  - y:
    - 1.0
    - 2.0
```
### After
```nushell
> { w: { x: [ { y: "1" } { y: "2" } ] } } | update w.x.y { into float } | to yaml
w:
  x:
  - y: 1.0
  - y: 2.0
```

# Tests + Formatting
Added 1 test.

# After Submitting
NaN