### PR TITLE
Fix #15788 . Special case for list<null> in polars dataframes.

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
@@ -1158,7 +1158,13 @@ fn series_to_values(
                     }
                     .map(|ca| {
                         let sublist: Vec<Value> = if let Some(ref s) = ca {
-                            series_to_values(s, None, None, Span::unknown())?
+                            if s.dtype() == &DataType::Null {
+                                // handle list[null] case
+                                let len = s.len();
+                                vec![Value::nothing(span); len]
+                            } else {
+                                series_to_values(s, None, None, Span::unknown())?
+                            }
                         } else {
                             // empty item
                             vec![]


### PR DESCRIPTION
# Description

A first attempts at fixing #15788.

Although it superficially fixes the bug, I am unsure whether it's the right
approach. What confuses me is that Null *is* handles in `series_to_values`
and I therefore still don't understand 100% why this throws an error.

Also I'm unsure whether it preserves several null values in a list element.
I thought I'd open the PR nevertheless as draft to initiate conversation.
