### PR TITLE
std-rfc/kv: optimize kv get by only selecting one row from the stor db

### DIFF
--- a/crates/nu-std/std-rfc/kv/mod.nu
+++ b/crates/nu-std/std-rfc/kv/mod.nu
@@ -111,16 +111,12 @@ export def "kv get" [
 ] {
   let db_open = (db_setup --universal=$universal)
   do $db_open
-    # Hack to turn a SQLiteDatabase into a table
-    | $in.std_kv_store | wrap temp | get temp
-    | where key == $key
-    # Should only be one occurrence of each key in the stor
-    | get -i value.0
+    | query db "SELECT value FROM std_kv_store WHERE key = :key" --params { key: $key }
     | match $in {
-      # Key not found
-      null => null
-      # Key found
-      _ => { from nuon }
+      # Match should be exactly one row
+      [$el] => { $el.value | from nuon }
+      # Otherwise no match
+      _ => null
     }
 }
 


### PR DESCRIPTION
# Description

Optimize std-rfc/kv, kv get to only read one row from the sqlite db.

The old implementation read every row in the table, which can be inefficient if the table is large.


# User-Facing Changes

None

# Tests + Formatting

Change covered by existing std-rfc/kv test