### PR TITLE
Add a lightweight MSI packages release workflow for winget

### DIFF
--- a/.github/workflows/release-msi.nu
+++ b/.github/workflows/release-msi.nu
@@ -2,7 +2,7 @@
 
 # Created: 2025/05/21 19:05:20
 # Description:
-#   A script to build a Windows MSI package for NuShell. Need wix 6.0 or later.
+#   A script to build Windows MSI packages for NuShell. Need wix 6.0 to be installed.
 #   The script will download the specified NuShell release, extract it, and create an MSI package.
 
 def build-msi [] {
@@ -33,7 +33,7 @@ def build-msi [] {
 
 def fetch-nu-pkg [] {
     mkdir wix/nu
-    gh release download $env.REF --repo nushell/nightly --pattern $'*-($env.TARGET).zip' --dir wix/nu
+    gh release download $env.REF --pattern $'*-($env.TARGET).zip' --dir wix/nu
     cd wix/nu
     let pkg = ls *.zip | get name.0
     unzip $pkg

--- a/.github/workflows/release-msi.yml
+++ b/.github/workflows/release-msi.yml
@@ -1,0 +1,101 @@
+#
+# REF:
+#   1. https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
+#
+name: Create Windows MSI
+
+on:
+  push:
+    branches:
+      - feature/winget-publish
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        default: 'v0.103.0'
+        description: 'Tag to Rebuild MSI'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release:
+    name: Nu
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+        - x86_64-pc-windows-msvc
+        - aarch64-pc-windows-msvc
+        extra: ['bin']
+
+        include:
+        - target: x86_64-pc-windows-msvc
+          os: windows-latest
+        - target: aarch64-pc-windows-msvc
+          os: windows-11-arm
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Wix Toolset 6 for Windows
+      shell: pwsh
+      if: ${{ startsWith(matrix.os, 'windows') }}
+      run: |
+        dotnet tool install --global wix --version 6.0.0
+        dotnet workload install wix
+        $wixPath = "$env:USERPROFILE\.dotnet\tools"
+        echo "$wixPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        $env:PATH = "$wixPath;$env:PATH"
+        wix --version
+
+    - name: Setup Nushell
+      uses: hustcer/setup-nu@v3
+      with:
+        version: nightly
+
+    - name: Release MSI Packages
+      id: nu
+      run: nu .github/workflows/release-msi.nu
+      env:
+        OS: ${{ matrix.os }}
+        REF: ${{ inputs.tag || 'v0.103.0' }}
+        TARGET: ${{ matrix.target }}
+        _EXTRA_: ${{ matrix.extra }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # REF: https://github.com/marketplace/actions/gh-release
+    - name: Publish Archive
+      uses: softprops/action-gh-release@v2.0.5
+      with:
+        tag_name: ${{ inputs.tag || 'v0.103.0' }}
+        files: ${{ steps.nu.outputs.msi }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  sha256sum:
+    needs: release
+    name: Create Sha256sum
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download Release Archives
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: >-
+        gh release download ${{ inputs.tag || 'v0.103.0' }}
+        --repo ${{ github.repository }}
+        --pattern '*'
+        --dir release
+    - name: Create Checksums
+      run: cd release && rm -f SHA256SUMS && shasum -a 256 * > ../SHA256SUMS
+    - name: Publish Checksums
+      uses: softprops/action-gh-release@v2.0.5
+      with:
+        files: SHA256SUMS
+        tag_name: ${{ inputs.tag || 'v0.103.0' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-msi.yml
+++ b/.github/workflows/release-msi.yml
@@ -2,12 +2,9 @@
 # REF:
 #   1. https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
 #
-name: Create Windows MSI
+name: Build Windows MSI
 
 on:
-  push:
-    branches:
-      - feature/winget-release
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release-msi.yml
+++ b/.github/workflows/release-msi.yml
@@ -7,12 +7,11 @@ name: Create Windows MSI
 on:
   push:
     branches:
-      - feature/winget-publish
+      - feature/winget-release
   workflow_dispatch:
     inputs:
       tag:
         required: true
-        default: 'v0.103.0'
         description: 'Tag to Rebuild MSI'
 
 defaults:
@@ -63,16 +62,15 @@ jobs:
       run: nu .github/workflows/release-msi.nu
       env:
         OS: ${{ matrix.os }}
-        REF: ${{ inputs.tag || 'v0.103.0' }}
+        REF: ${{ inputs.tag }}
         TARGET: ${{ matrix.target }}
-        _EXTRA_: ${{ matrix.extra }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # REF: https://github.com/marketplace/actions/gh-release
     - name: Publish Archive
       uses: softprops/action-gh-release@v2.0.5
       with:
-        tag_name: ${{ inputs.tag || 'v0.103.0' }}
+        tag_name: ${{ inputs.tag }}
         files: ${{ steps.nu.outputs.msi }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -86,7 +84,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: >-
-        gh release download ${{ inputs.tag || 'v0.103.0' }}
+        gh release download ${{ inputs.tag }}
         --repo ${{ github.repository }}
         --pattern '*'
         --dir release
@@ -96,6 +94,6 @@ jobs:
       uses: softprops/action-gh-release@v2.0.5
       with:
         files: SHA256SUMS
-        tag_name: ${{ inputs.tag || 'v0.103.0' }}
+        tag_name: ${{ inputs.tag }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

## Winget Publishing Process Improvement ✨

​**Current Situation**​  
Our current process for publishing updates to the winget repository feels a bit cumbersome. This PR introduces a more streamlined approach!

​**What's Changing**​  
🚀 We're decoupling the winget packaging from Nushell's core release cycle. Now we can:
- Build MSI packages directly from pre-compiled Nushell binaries
- Push urgent winget fixes independently
- Maintain MSIs release agility without rebuilding from source

​**Why This Matters**​  
🔧 Should any winget-specific issues arise (like installer quirks or metadata glitches), we can deploy targeted fixes within hours instead of waiting for full Nushell releases.

​**Peace of Mind**​  
🔒 Rest assured, the existing release workflow remains unchanged for building MSI packages. This new pipeline simply gives us an extra "express lane" for winget updates.


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

None

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

See the workflow running record here: https://github.com/nushell/nightly/actions/runs/15186299093/job/42707431403
the MSIs & SHA256SUMS file will be updated after the workflow finished: https://github.com/nushell/nightly/releases/tag/0.104.1-nightly.20%2B6906a0c

