### PR TITLE
feat: default http protocol when none used in http request

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -89,12 +89,22 @@ pub fn http_parse_url(
     span: Span,
     raw_url: Value,
 ) -> Result<(String, Url), ShellError> {
-    let requested_url = raw_url.coerce_into_string()?;
+    let mut requested_url = raw_url.coerce_into_string()?;
+    if requested_url.starts_with(':') {
+        requested_url = format!("http://localhost{}", requested_url);
+    } else if !requested_url.starts_with("http://") && !requested_url.starts_with("https://") {
+        requested_url = format!("http://{}", requested_url);
+    }
+
     let url = match url::Url::parse(&requested_url) {
         Ok(u) => u,
         Err(_e) => {
-            return Err(ShellError::UnsupportedInput { msg: "Incomplete or incorrect URL. Expected a full URL, e.g., https://www.example.com"
-                    .to_string(), input: format!("value: '{requested_url:?}'"), msg_span: call.head, input_span: span });
+            return Err(ShellError::UnsupportedInput {
+                msg: "Incomplete or incorrect URL. Expected a full URL, e.g., https://www.example.com".to_string(),
+                input: format!("value: '{requested_url:?}'"),
+                msg_span: call.head,
+                input_span: span
+            });
         }
     };
 


### PR DESCRIPTION
https://github.com/nushell/nushell/issues/10957

Hello, this PR propose a solution for some requested feature mentionned in https://github.com/nushell/nushell/issues/10957. I personnaly think those are very simple change that bring significant quality of life improvement.
It gives the possibility to do `http get google.com` instead of `http get http://google.com` and `http get :8080` instead of `http get http://localhost:8080`.
I did not address the other part of the issue (data managing) as those are more controversial.

I have a problem to run the tests no matter the changes : 
```
Error: nu::shell::variable_not_found

  × Variable not found
    ╭─[/nix/store/1yh51z1k1rpl4srl4bh86p7m664x60jd-carapace-nushell-config.nu:9:55]
  8 │   # if the current command is an alias, get it's expansion
  9 │   let expanded_alias = (scope aliases | where name == $spans.0 | get -i 0 | get -i expansion)
    ·                                                       ───┬──
    ·                                                          ╰── variable not found
 10 │ 
    ╰────
```

I someone can indicating me the issue I would gladly test them, even 
However I tested this function in local in a toy program and it works fine.