### PR TITLE
Partial workaround and deprecation warning for breaking change usage of #15654

### DIFF
--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -1,3 +1,5 @@
+use std::{borrow::Cow, ops::Deref};
+
 use nu_engine::{command_prelude::*, ClosureEval};
 use nu_protocol::{
     ast::{Expr, Expression},
@@ -320,7 +322,14 @@ fn closure_variable_warning(
         // this is a closure from inside a variable
         (Value::Closure { .. }, true) => {
             let span_contents = String::from_utf8_lossy(engine_state.get_span_contents(span));
-            let suggestion = format!("change this to {{ {} }}", span_contents).to_string();
+            let carapace_suggestion = "re-run carapace init with version v1.3.3 or later\nor change to `{ $carapace_completer }`";
+            let suggestion = match span_contents {
+                Cow::Borrowed("$carapace_completer") => carapace_suggestion.to_string(),
+                Cow::Owned(s) if s.deref() == "$carapace_completer" => {
+                    carapace_suggestion.to_string()
+                }
+                _ => format!("change this to {{ {} }}", span_contents).to_string(),
+            };
 
             report_shell_warning(
             engine_state,

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -1,5 +1,8 @@
-use nu_engine::{ClosureEval, command_prelude::*};
-use nu_protocol::{ListStream, Signals};
+use nu_engine::{command_prelude::*, ClosureEval};
+use nu_protocol::{
+    ast::{Expr, Expression},
+    report_shell_warning, ListStream, Signals,
+};
 
 #[derive(Clone)]
 pub struct Default;
@@ -32,6 +35,11 @@ impl Command for Default {
             .category(Category::Filters)
     }
 
+    // FIXME remove once deprecation warning is no longer needed
+    fn requires_ast_for_arguments(&self) -> bool {
+        true
+    }
+
     fn description(&self) -> &str {
         "Sets a default value if a row's column is missing or null."
     }
@@ -46,14 +54,19 @@ impl Command for Default {
         let default_value: Value = call.req(engine_state, stack, 0)?;
         let columns: Vec<String> = call.rest(engine_state, stack, 1)?;
         let empty = call.has_flag(engine_state, stack, "empty")?;
+
+        // FIXME for deprecation of closure passed via variable
+        let default_value_expr = call.positional_nth(stack, 0);
+        let default_value =
+            DefaultValue::new(engine_state, stack, default_value, default_value_expr);
+
         default(
-            engine_state,
-            stack,
             call,
             input,
             default_value,
             empty,
             columns,
+            engine_state.signals(),
         )
     }
 
@@ -65,7 +78,8 @@ impl Command for Default {
                 result: None,
             },
             Example {
-                description: "Get the env value of `MY_ENV` with a default value 'abc' if not present",
+                description:
+                    "Get the env value of `MY_ENV` with a default value 'abc' if not present",
                 example: "$env | get --ignore-errors MY_ENV | default 'abc'",
                 result: Some(Value::test_string("abc")),
             },
@@ -134,16 +148,14 @@ impl Command for Default {
 }
 
 fn default(
-    engine_state: &EngineState,
-    stack: &mut Stack,
     call: &Call,
     input: PipelineData,
-    default_value: Value,
+    mut default_value: DefaultValue,
     default_when_empty: bool,
     columns: Vec<String>,
+    signals: &Signals,
 ) -> Result<PipelineData, ShellError> {
     let input_span = input.span().unwrap_or(call.head);
-    let mut default_value = DefaultValue::new(engine_state, stack, default_value);
     let metadata = input.metadata();
 
     // If user supplies columns, check if input is a record or list of records
@@ -184,7 +196,7 @@ fn default(
                         item
                     }
                 })
-                .into_pipeline_data_with_metadata(head, engine_state.signals().clone(), metadata))
+                .into_pipeline_data_with_metadata(head, signals.clone(), metadata))
         // If columns are given, but input does not use columns, return an error
         } else {
             Err(ShellError::PipelineMismatch {
@@ -227,8 +239,20 @@ enum DefaultValue {
 }
 
 impl DefaultValue {
-    fn new(engine_state: &EngineState, stack: &Stack, value: Value) -> Self {
+    fn new(
+        engine_state: &EngineState,
+        stack: &Stack,
+        value: Value,
+        expr: Option<&Expression>,
+    ) -> Self {
         let span = value.span();
+
+        // FIXME temporary workaround to warn people of breaking change from #15654
+        let value = match closure_variable_warning(engine_state, value, expr) {
+            Ok(val) => val,
+            Err(default_value) => return default_value,
+        };
+
         match value {
             Value::Closure { val, .. } => {
                 let closure_eval = ClosureEval::new(engine_state, stack, *val);
@@ -275,6 +299,43 @@ fn fill_record(
         }
     }
     Ok(Value::record(record, span))
+}
+
+fn closure_variable_warning(
+    engine_state: &EngineState,
+    value: Value,
+    value_expr: Option<&Expression>,
+) -> Result<Value, DefaultValue> {
+    // only warn if we are passed a closure inside a variable
+    let from_variable = matches!(
+        value_expr,
+        Some(Expression {
+            expr: Expr::FullCellPath(_),
+            ..
+        })
+    );
+
+    let span = value.span();
+    match (&value, from_variable) {
+        // this is a closure from inside a variable
+        (Value::Closure { .. }, true) => {
+            let span_contents = String::from_utf8_lossy(engine_state.get_span_contents(span));
+            let suggestion = format!("change this to {{ {} }}", span_contents).to_string();
+
+            report_shell_warning(
+            engine_state,
+            &ShellError::Deprecated {
+                deprecated: "passing closure values to default",
+                suggestion,
+                 span,
+                help: Some("default now has lazy evaluation, so closure values should be wrapped in a closure"),
+            });
+
+            // bypass the normal DefaultValue::new logic
+            Err(DefaultValue::Calculated(value))
+        }
+        _ => Ok(value),
+    }
 }
 
 #[cfg(test)]

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1,7 +1,7 @@
 use super::chained_error::ChainedError;
 use crate::{
-    ast::Operator, engine::StateWorkingSet, format_shell_error, record, ConfigError, LabeledError,
-    ParseError, Span, Spanned, Type, Value,
+    ConfigError, LabeledError, ParseError, Span, Spanned, Type, Value, ast::Operator,
+    engine::StateWorkingSet, format_shell_error, record,
 };
 use job::JobError;
 use miette::Diagnostic;
@@ -905,9 +905,7 @@ pub enum ShellError {
     /// creation of the custom value and its use.
     #[error("Custom value failed to decode")]
     #[diagnostic(code(nu::shell::custom_value_failed_to_decode))]
-    #[diagnostic(help(
-        "the plugin may have been updated and no longer support this custom value"
-    ))]
+    #[diagnostic(help("the plugin may have been updated and no longer support this custom value"))]
     CustomValueFailedToDecode {
         msg: String,
         #[label("{msg}")]
@@ -1221,10 +1219,10 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         span: Span,
     },
 
-    #[error("{deprecated} is deprecated and will be removed in a future release")]
-    #[diagnostic()]
-    Deprecated {
-        deprecated: &'static str,
+    #[error("{deprecation_type} deprecated.")]
+    #[diagnostic(code(nu::shell::deprecated))]
+    DeprecationWarning {
+        deprecation_type: &'static str,
         suggestion: String,
         #[label("{suggestion}")]
         span: Span,

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1226,7 +1226,7 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
     Deprecated {
         deprecated: &'static str,
         suggestion: String,
-        #[label("{deprecated} is deprecated. {suggestion}")]
+        #[label("{suggestion}")]
         span: Span,
         #[help]
         help: Option<&'static str>,

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1,7 +1,7 @@
 use super::chained_error::ChainedError;
 use crate::{
-    ConfigError, LabeledError, ParseError, Span, Spanned, Type, Value, ast::Operator,
-    engine::StateWorkingSet, format_shell_error, record,
+    ast::Operator, engine::StateWorkingSet, format_shell_error, record, ConfigError, LabeledError,
+    ParseError, Span, Spanned, Type, Value,
 };
 use job::JobError;
 use miette::Diagnostic;
@@ -905,7 +905,9 @@ pub enum ShellError {
     /// creation of the custom value and its use.
     #[error("Custom value failed to decode")]
     #[diagnostic(code(nu::shell::custom_value_failed_to_decode))]
-    #[diagnostic(help("the plugin may have been updated and no longer support this custom value"))]
+    #[diagnostic(help(
+        "the plugin may have been updated and no longer support this custom value"
+    ))]
     CustomValueFailedToDecode {
         msg: String,
         #[label("{msg}")]
@@ -1223,7 +1225,7 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
     #[diagnostic()]
     Deprecated {
         deprecated: &'static str,
-        suggestion: &'static str,
+        suggestion: String,
         #[label("{deprecated} is deprecated. {suggestion}")]
         span: Span,
         #[help]


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Adds a temporary workaround to prevent #15654 from being a breaking change when using a closure stored in a variable, and issues a warning. Also has a special case related to https://github.com/carapace-sh/carapace-bin/pull/2796 which suggests re-running `carapace init`

![image](https://github.com/user-attachments/assets/783f3dbf-2a85-4aa5-ac66-efc584ac77fd)

![image](https://github.com/user-attachments/assets/c8fb5ae1-66a8-474c-8244-a22600f4da43)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
