### PR TITLE
Provide a better error for prefix-only path for PWD

### DIFF
--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -9,6 +9,7 @@ use nu_utils::IgnoreCaseExt;
 use std::{
     collections::{HashMap, HashSet},
     fs::File,
+    path::{Component, MAIN_SEPARATOR},
     sync::Arc,
 };
 
@@ -755,6 +756,19 @@ impl Stack {
         let path = path.as_ref();
 
         if !path.is_absolute() {
+            if matches!(path.components().next(), Some(Component::Prefix(_))) {
+                return Err(ShellError::GenericError {
+                    error: "Cannot set $env.PWD to a prefix-only path".to_string(),
+                    msg: "".into(),
+                    span: None,
+                    help: Some(format!(
+                        "Try to use {}{MAIN_SEPARATOR} instead",
+                        path.display()
+                    )),
+                    inner: vec![],
+                });
+            }
+
             error("Cannot set $env.PWD to a non-absolute path")
         } else if !path.exists() {
             error("Cannot set $env.PWD to a non-existent directory")


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

closes #15713

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

On Windows, when you try to `cd D:`, you get an error that is is not an absolute path. That itself is not wrong but really helpful as providing a drive letter feels like an absolute path. The real absolute path would be `D:\` in this case. To provide a better error with a help message, I check if I the first component is a prefix and if so, provide an error with a helpful note.

![image](https://github.com/user-attachments/assets/8e39a579-fe08-40fa-a883-c956abf49b6d)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

A more clear error when trying to cd in a prefix-only path.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
