### PR TITLE
[FIX] #15813 passing infinity to random float generate causes error

### DIFF
--- a/crates/nu-command/src/random/float.rs
+++ b/crates/nu-command/src/random/float.rs
@@ -90,7 +90,7 @@ fn float(
             let value = match range.end() {
                 Bound::Included(end) => random_range(range.start()..=end),
                 Bound::Excluded(end) => random_range(range.start()..end),
-                Bound::Unbounded => random_range(range.start()..f64::INFINITY),
+                Bound::Unbounded => random_range(range.start()..i64::MAX as f64),
             };
 
             Ok(PipelineData::Value(Value::float(value, span), None))

--- a/crates/nu-command/src/random/float.rs
+++ b/crates/nu-command/src/random/float.rs
@@ -90,7 +90,7 @@ fn float(
             let value = match range.end() {
                 Bound::Included(end) => random_range(range.start()..=end),
                 Bound::Excluded(end) => random_range(range.start()..end),
-                Bound::Unbounded => random_range(range.start()..i64::MAX as f64),
+                Bound::Unbounded => random_range(range.start()..f64::MAX),
             };
 
             Ok(PipelineData::Value(Value::float(value, span), None))

--- a/crates/nu-command/tests/commands/random/float.rs
+++ b/crates/nu-command/tests/commands/random/float.rs
@@ -24,3 +24,9 @@ fn generates_0() {
 
     assert!(actual.out.contains('0'));
 }
+
+#[test]
+fn generate_inf() {
+    let actual = nu!("random float 1.. | describe");
+    assert_eq!(actual.out, "float");
+}


### PR DESCRIPTION
# Description

This pull request addresses an issue#15813 where passing a infinite value in the random float 1.. command that causes a panic in the shell. The root cause of this problem lies within the rng library, which is responsible for generating random numbers.

Before
![image](https://github.com/user-attachments/assets/5416e23d-d5a2-40ed-aa9f-4ff46d0e5583)

# User-Facing Changes
Users where seeing panic error when passed unbounded end into range.

# Tests + Formatting
added `generate_inf`

# After Submitting
![image](https://github.com/user-attachments/assets/8453ffad-ad94-44bf-aec4-8d1090842f32)
No error should be there after 

Edit history
1. Updated `After Submitting` section