### PR TITLE
Move job errors into `ShellError::Job` variant

### DIFF
--- a/crates/nu-command/src/experimental/job_recv.rs
+++ b/crates/nu-command/src/experimental/job_recv.rs
@@ -145,7 +145,7 @@ fn recv_instantly(
 ) -> Result<PipelineData, ShellError> {
     match mailbox.try_recv(tag) {
         Ok(value) => Ok(value),
-        Err(TryRecvError::Empty) => Err(ShellError::RecvTimeout { span }),
+        Err(TryRecvError::Empty) => Err(JobError::RecvTimeout { span }.into()),
         Err(TryRecvError::Disconnected) => Err(ShellError::Interrupted { span }),
     }
 }
@@ -175,7 +175,7 @@ fn recv_with_time_limit(
         }
 
         if time_until_deadline.is_zero() {
-            return Err(ShellError::RecvTimeout { span });
+            return Err(JobError::RecvTimeout { span }.into());
         }
     }
 }

--- a/crates/nu-command/src/experimental/job_unfreeze.rs
+++ b/crates/nu-command/src/experimental/job_unfreeze.rs
@@ -45,7 +45,7 @@ impl Command for JobUnfreeze {
         let id = id
             .map(JobId::new)
             .or_else(|| jobs.most_recent_frozen_job_id())
-            .ok_or_else(|| JobError::NoneToUnfreeze { span: head })?;
+            .ok_or(JobError::NoneToUnfreeze { span: head })?;
 
         let job = match jobs.lookup(id) {
             None => return Err(JobError::NotFound { span: head, id }.into()),

--- a/crates/nu-command/src/experimental/job_unfreeze.rs
+++ b/crates/nu-command/src/experimental/job_unfreeze.rs
@@ -39,33 +39,18 @@ impl Command for JobUnfreeze {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
 
-        let option_id: Option<Spanned<i64>> = call.opt(engine_state, stack, 0)?;
-
         let mut jobs = engine_state.jobs.lock().expect("jobs lock is poisoned!");
 
-        if let Some(id_arg) = option_id {
-            if id_arg.item < 0 {
-                return Err(ShellError::NeedsPositiveValue { span: id_arg.span });
-            }
-        }
-
-        let id = option_id
-            .map(|it| JobId::new(it.item as usize))
+        let id: Option<usize> = call.opt(engine_state, stack, 0)?;
+        let id = id
+            .map(JobId::new)
             .or_else(|| jobs.most_recent_frozen_job_id())
-            .ok_or_else(|| ShellError::NoFrozenJob { span: head })?;
+            .ok_or_else(|| JobError::NoneToUnfreeze { span: head })?;
 
         let job = match jobs.lookup(id) {
-            None => {
-                return Err(ShellError::JobNotFound {
-                    id: id.get(),
-                    span: head,
-                });
-            }
+            None => return Err(JobError::NotFound { span: head, id }.into()),
             Some(Job::Thread(ThreadJob { .. })) => {
-                return Err(ShellError::JobNotFrozen {
-                    id: id.get(),
-                    span: head,
-                });
+                return Err(JobError::CannotUnfreeze { span: head, id }.into());
             }
             Some(Job::Frozen(FrozenJob { .. })) => jobs
                 .remove_job(id)
@@ -107,11 +92,7 @@ fn unfreeze_job(
     span: Span,
 ) -> Result<(), ShellError> {
     match job {
-        Job::Thread(ThreadJob { .. }) => Err(ShellError::JobNotFrozen {
-            id: old_id.get(),
-            span,
-        }),
-
+        Job::Thread(ThreadJob { .. }) => Err(JobError::CannotUnfreeze { span, id: old_id }.into()),
         Job::Frozen(FrozenJob {
             unfreeze: handle,
             tag,

--- a/crates/nu-engine/src/command_prelude.rs
+++ b/crates/nu-engine/src/command_prelude.rs
@@ -6,5 +6,5 @@ pub use nu_protocol::{
     ast::CellPath,
     engine::{Call, Command, EngineState, Stack, StateWorkingSet},
     record,
-    shell_error::io::*,
+    shell_error::{io::*, job::*},
 };

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use crate::Span;
 
-use super::{ShellError, location::Location};
+use super::location::Location;
 
 /// Represents an I/O error in the [`ShellError::Io`] variant.
 ///

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -494,12 +494,6 @@ impl Diagnostic for IoError {
     }
 }
 
-impl From<IoError> for ShellError {
-    fn from(value: IoError) -> Self {
-        ShellError::Io(value)
-    }
-}
-
 impl From<IoError> for std::io::Error {
     fn from(value: IoError) -> Self {
         Self::new(value.kind.into(), value)

--- a/crates/nu-protocol/src/errors/shell_error/job.rs
+++ b/crates/nu-protocol/src/errors/shell_error/job.rs
@@ -13,46 +13,33 @@ pub enum JobError {
             "The operation could not be completed, there is no job currently running with this id"
         )
     )]
-    NotFound {
-        span: Span,
-        id: JobId,
-    },
+    NotFound { span: Span, id: JobId },
 
     #[error("No frozen job to unfreeze")]
     #[diagnostic(
         code(nu::shell::job::none_to_unfreeze),
         help("There is currently no frozen job to unfreeze")
     )]
-    NoneToUnfreeze {
-        span: Span,
-    },
+    NoneToUnfreeze { span: Span },
 
     #[error("Job {id} is not frozen")]
     #[diagnostic(
         code(nu::shell::job::cannot_unfreeze),
         help("You tried to unfreeze a job which is not frozen")
     )]
-    CannotUnfreeze {
-        span: Span,
-        id: JobId,
-    },
+    CannotUnfreeze { span: Span, id: JobId },
 
     #[error("The job {id} is frozen")]
     #[diagnostic(
         code(nu::shell::job::already_frozen),
         help("This operation cannot be performed because the job is frozen")
     )]
-    AlreadyFrozen {
-        span: Span,
-        id: JobId,
-    },
-    
+    AlreadyFrozen { span: Span, id: JobId },
+
     #[error("No message was received in the requested time interval")]
     #[diagnostic(
         code(nu::shell::job::recv_timeout),
         help("No message arrived within the specified time limit")
     )]
-    RecvTimeout {
-        span: Span,
-    }
+    RecvTimeout { span: Span },
 }

--- a/crates/nu-protocol/src/errors/shell_error/job.rs
+++ b/crates/nu-protocol/src/errors/shell_error/job.rs
@@ -1,0 +1,58 @@
+use miette::Diagnostic;
+use thiserror::Error;
+
+use crate::{JobId, Span};
+
+/// Errors when working working with jobs.
+#[derive(Debug, Clone, Copy, PartialEq, Error, Diagnostic)]
+pub enum JobError {
+    #[error("Job {id} not found")]
+    #[diagnostic(
+        code(nu::shell::job::not_found),
+        help(
+            "The operation could not be completed, there is no job currently running with this id"
+        )
+    )]
+    NotFound {
+        span: Span,
+        id: JobId,
+    },
+
+    #[error("No frozen job to unfreeze")]
+    #[diagnostic(
+        code(nu::shell::job::none_to_unfreeze),
+        help("There is currently no frozen job to unfreeze")
+    )]
+    NoneToUnfreeze {
+        span: Span,
+    },
+
+    #[error("Job {id} is not frozen")]
+    #[diagnostic(
+        code(nu::shell::job::cannot_unfreeze),
+        help("You tried to unfreeze a job which is not frozen")
+    )]
+    CannotUnfreeze {
+        span: Span,
+        id: JobId,
+    },
+
+    #[error("The job {id} is frozen")]
+    #[diagnostic(
+        code(nu::shell::job::already_frozen),
+        help("This operation cannot be performed because the job is frozen")
+    )]
+    AlreadyFrozen {
+        span: Span,
+        id: JobId,
+    },
+    
+    #[error("No message was received in the requested time interval")]
+    #[diagnostic(
+        code(nu::shell::job::recv_timeout),
+        help("No message arrived within the specified time limit")
+    )]
+    RecvTimeout {
+        span: Span,
+    }
+}

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -917,7 +917,7 @@ pub enum ShellError {
     /// This is the main I/O error, for further details check the error kind and additional context.
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Io(io::IoError),
+    Io(#[from] io::IoError),
 
     /// A name was not found. Did you mean a different name?
     ///

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     ConfigError, LabeledError, ParseError, Span, Spanned, Type, Value, ast::Operator,
     engine::StateWorkingSet, format_shell_error, record,
 };
+use job::JobError;
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroI32;
@@ -11,6 +12,7 @@ use thiserror::Error;
 pub mod bridge;
 pub mod io;
 pub mod location;
+pub mod job;
 
 /// The fundamental error type for the evaluation engine. These cases represent different kinds of errors
 /// the evaluator might face, along with helpful spans to label. An error renderer will take this error value
@@ -1381,6 +1383,11 @@ On Windows, this would be %USERPROFILE%\AppData\Roaming"#
         span: Option<Span>,
     },
 
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Job(#[from] JobError),
+
+    #[deprecated]
     #[error("Job {id} not found")]
     #[diagnostic(
         code(nu::shell::job_not_found),
@@ -1394,6 +1401,7 @@ On Windows, this would be %USERPROFILE%\AppData\Roaming"#
         span: Span,
     },
 
+    #[deprecated]
     #[error("No frozen job to unfreeze")]
     #[diagnostic(
         code(nu::shell::no_frozen_job),
@@ -1404,6 +1412,7 @@ On Windows, this would be %USERPROFILE%\AppData\Roaming"#
         span: Span,
     },
 
+    #[deprecated]
     #[error("Job {id} is not frozen")]
     #[diagnostic(
         code(nu::shell::job_not_frozen),
@@ -1415,6 +1424,7 @@ On Windows, this would be %USERPROFILE%\AppData\Roaming"#
         span: Span,
     },
 
+    #[deprecated]
     #[error("The job {id} is frozen")]
     #[diagnostic(
         code(nu::shell::job_is_frozen),
@@ -1426,6 +1436,7 @@ On Windows, this would be %USERPROFILE%\AppData\Roaming"#
         span: Span,
     },
 
+    #[deprecated]
     #[error("No message was received in the requested time interval")]
     #[diagnostic(
         code(nu::shell::recv_timeout),

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -11,8 +11,8 @@ use thiserror::Error;
 
 pub mod bridge;
 pub mod io;
-pub mod location;
 pub mod job;
+pub mod location;
 
 /// The fundamental error type for the evaluation engine. These cases represent different kinds of errors
 /// the evaluator might face, along with helpful spans to label. An error renderer will take this error value
@@ -1386,66 +1386,6 @@ On Windows, this would be %USERPROFILE%\AppData\Roaming"#
     #[error(transparent)]
     #[diagnostic(transparent)]
     Job(#[from] JobError),
-
-    #[deprecated]
-    #[error("Job {id} not found")]
-    #[diagnostic(
-        code(nu::shell::job_not_found),
-        help(
-            "The operation could not be completed, there is no job currently running with this id"
-        )
-    )]
-    JobNotFound {
-        id: usize,
-        #[label = "job not found"]
-        span: Span,
-    },
-
-    #[deprecated]
-    #[error("No frozen job to unfreeze")]
-    #[diagnostic(
-        code(nu::shell::no_frozen_job),
-        help("There is currently no frozen job to unfreeze")
-    )]
-    NoFrozenJob {
-        #[label = "no frozen job"]
-        span: Span,
-    },
-
-    #[deprecated]
-    #[error("Job {id} is not frozen")]
-    #[diagnostic(
-        code(nu::shell::job_not_frozen),
-        help("You tried to unfreeze a job which is not frozen")
-    )]
-    JobNotFrozen {
-        id: usize,
-        #[label = "job not frozen"]
-        span: Span,
-    },
-
-    #[deprecated]
-    #[error("The job {id} is frozen")]
-    #[diagnostic(
-        code(nu::shell::job_is_frozen),
-        help("This operation cannot be performed because the job is frozen")
-    )]
-    JobIsFrozen {
-        id: usize,
-        #[label = "This job is frozen"]
-        span: Span,
-    },
-
-    #[deprecated]
-    #[error("No message was received in the requested time interval")]
-    #[diagnostic(
-        code(nu::shell::recv_timeout),
-        help("No message arrived within the specified time limit")
-    )]
-    RecvTimeout {
-        #[label = "timeout"]
-        span: Span,
-    },
 
     #[error(transparent)]
     #[diagnostic(transparent)]

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -37,6 +37,10 @@ where
     }
 }
 
+impl<M> Id<M, usize> {
+    pub const ZERO: Self = Self::new(0);
+}
+
 impl<M, V> Debug for Id<M, V>
 where
     V: Display,

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -115,6 +115,12 @@ pub type JobId = Id<marker::Job>;
 /// Note: `%0` is allocated with the block input at the beginning of a compiled block.
 pub type RegId = Id<marker::Reg, u32>;
 
+impl Display for JobId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
 impl Display for RegId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "%{}", self.get())


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

- related #10698

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

In my endeavor to make the `ShellError` less crowded I moved the job related errors into `ShellError::Job` with a `JobError` enum. Mostly I just moved the codes, errors and labels over to the new enum. 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
