### PR TITLE
fix(polars): add Value::Record to `NuExpression::can_downcast` logic

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/data/with_column.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/with_column.rs
@@ -104,9 +104,44 @@ impl PluginCommand for WithColumn {
                 ),
             },
             Example {
-                description: "Add series to the dataframe using a record",
+                description: "Add series to a lazyframe using a record",
                 example: r#"[[a b]; [1 2] [3 4]]
     | polars into-lazy
+    | polars with-column {
+        c: ((polars col a) * 2)
+        d: ((polars col a) * 3)
+      }
+    | polars collect"#,
+                result: Some(
+                    NuDataFrame::try_from_columns(
+                        vec![
+                            Column::new(
+                                "a".to_string(),
+                                vec![Value::test_int(1), Value::test_int(3)],
+                            ),
+                            Column::new(
+                                "b".to_string(),
+                                vec![Value::test_int(2), Value::test_int(4)],
+                            ),
+                            Column::new(
+                                "c".to_string(),
+                                vec![Value::test_int(2), Value::test_int(6)],
+                            ),
+                            Column::new(
+                                "d".to_string(),
+                                vec![Value::test_int(3), Value::test_int(9)],
+                            ),
+                        ],
+                        None,
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                description: "Add series to a dataframe using a record",
+                example: r#"[[a b]; [1 2] [3 4]]
+    | polars into-df
     | polars with-column {
         c: ((polars col a) * 2)
         d: ((polars col a) * 3)
@@ -177,7 +212,7 @@ fn command_eager(
     if NuExpression::can_downcast(&new_column) {
         if let Some(name) = call.get_flag::<Spanned<String>>("name")? {
             return Err(ShellError::GenericError {
-            error: "Flag 'name' is unsuppored when used with expressions. Please use the `polars as` expression to name a column".into(),
+            error: "Flag 'name' is unsupported when used with expressions. Please use the `polars as` expression to name a column".into(),
             msg: "".into(),
             span: Some(name.span),
             help: Some("Use a `polars as` expression to name a column".into()),
@@ -225,7 +260,7 @@ fn command_lazy(
 ) -> Result<PipelineData, ShellError> {
     if let Some(name) = call.get_flag::<Spanned<String>>("name")? {
         return Err(ShellError::GenericError {
-            error: "Flag 'name' is unsuppored for lazy dataframes. Please use the `polars as` expression to name a column".into(),
+            error: "Flag 'name' is unsupported for lazy dataframes. Please use the `polars as` expression to name a column".into(),
             msg: "".into(),
             span: Some(name.span),
             help: Some("Use a `polars as` expression to name a column".into()),

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_expression/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_expression/mod.rs
@@ -572,6 +572,7 @@ impl CustomValueSupport for NuExpression {
         match value {
             Value::Custom { val, .. } => val.as_any().downcast_ref::<Self::CV>().is_some(),
             Value::List { vals, .. } => vals.iter().all(Self::can_downcast),
+            Value::Record { val, .. } => val.iter().all(|(_, value)| Self::can_downcast(value)),
             Value::String { .. } | Value::Int { .. } | Value::Bool { .. } | Value::Float { .. } => {
                 true
             }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Merged PR #15553 added the ability to provide expressions in the form of records. This PR conforms the `NuExpression::can_downcast` logic to account for the newly allowed records argument type. As such, commands that rely on `can_downcast` in their implementation (e.g., `polars with-column`) will no longer err when provided with a record. See example below:

```nushell
#  Current error
> [[a b]; [1 2] [3 4]]
    | polars into-df <-- only works if cast as lazyframe
    | polars with-column {
        c: ((polars col a) * 2)
        d: ((polars col a) * 3)
      }
Error: nu::shell::cant_convert

  × Can't convert to NuDataFrame, NuLazyFrame, NuExpression, NuLazyGroupBy, NuWhen,
  │ NuDataType, NuSchema.
   ╭─[entry #24:3:26]
 2 │         | polars into-df
 3 │ ╭─▶     | polars with-column {
 4 │ │           c: ((polars col a) * 2)
 5 │ │           d: ((polars col a) * 3)
 6 │ ├─▶       }
   · ╰──── can't convert record<c: NuExpression, d: NuExpression> to NuDataFrame, NuLazyFrame, NuExpression, NuLazyGroupBy, NuWhen, NuDataType, NuSchema
   ╰────


# Fixed
> [[a b]; [1 2] [3 4]]
    | polars into-df
    | polars with-column {
        c: ((polars col a) * 2)
        d: ((polars col a) * 3)
      } | polars collect
╭───┬───┬───┬───┬───╮
│ # │ a │ b │ c │ d │
├───┼───┼───┼───┼───┤
│ 0 │ 1 │ 2 │ 2 │ 3 │
│ 1 │ 3 │ 4 │ 6 │ 9 │
╰───┴───┴───┴───┴───╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
No breaking changes


# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
An example test was added to `polars with-column`.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
