### PR TITLE
Allow specifying MSI version via env var and workflow input

### DIFF
--- a/.github/workflows/release-msi.nu
+++ b/.github/workflows/release-msi.nu
@@ -11,10 +11,12 @@
 
 def build-msi [] {
     let target = $env.TARGET
-    let version = (open Cargo.toml | get package.version)
+    # We should read the version from the environment variable first
+    # As we may build the MSI package for a specific version not the latest one
+    let version = $env.MSI_VERSION? | default (open Cargo.toml | get package.version)
     let arch = if $nu.os-info.arch =~ 'x86_64' { 'x64' } else { 'arm64' }
 
-    print $'Building msi package for (ansi g)($target)(ansi reset) with version (ansi g)($env.REF)(ansi reset)'
+    print $'Building msi package for (ansi g)($target)(ansi reset) with version (ansi g)($version)(ansi reset) from tag (ansi g)($env.REF)(ansi reset)...'
     fetch-nu-pkg
     # Create extra Windows msi release package if dotnet and wix are available
     let installed = [dotnet wix] | all { (which $in | length) > 0 }

--- a/.github/workflows/release-msi.yml
+++ b/.github/workflows/release-msi.yml
@@ -10,6 +10,12 @@ on:
       tag:
         required: true
         description: 'Tag to Rebuild MSI'
+      version:
+        description: 'Version of Rebuild MSI'
+
+permissions:
+  contents: write
+  packages: write
 
 defaults:
   run:
@@ -61,6 +67,7 @@ jobs:
         OS: ${{ matrix.os }}
         REF: ${{ inputs.tag }}
         TARGET: ${{ matrix.target }}
+        MSI_VERSION: ${{ inputs.version }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # REF: https://github.com/marketplace/actions/gh-release


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

This PR enhances the MSI release workflow by allowing the MSI package version to be specified either through an environment variable or a workflow input. This improvement provides greater flexibility when building MSI packages for tags that do **not** match the latest package version in `Cargo.toml`.

Fix possible **403** error while updating `SHA256SUMS` file in the nushell/nightly repo

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

None

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

A example running record: https://github.com/nushell/nightly/actions/runs/15265879087/job/42931344366#step:5:11

