### PR TITLE
feat(polars): expand `polars shift` to allow expressions inputs

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs
@@ -37,10 +37,16 @@ impl PluginCommand for Shift {
                 "Expression used to fill the null values (lazy df)",
                 Some('f'),
             )
-            .input_output_type(
-                Type::Custom("dataframe".into()),
-                Type::Custom("dataframe".into()),
-            )
+            .input_output_types(vec![
+                (
+                    Type::Custom("dataframe".into()),
+                    Type::Custom("dataframe".into()),
+                ),
+                (
+                    Type::Custom("expression".into()),
+                    Type::Custom("expression".into()),
+                ),
+            ])
             .category(Category::Custom("dataframe or lazyframe".into()))
     }
 
@@ -82,6 +88,42 @@ impl PluginCommand for Shift {
                     .into_value(Span::test_data()),
                 ),
             },
+            Example {
+                description: "Shift values of a column, fill absent values with 0",
+                example: "[[a]; [1] [2] [2] [3] [3]]
+                    | polars into-lazy
+                    | polars with-column {b: (polars col a | polars shift 2 --fill 0)}
+                    | polars collect",
+                result: Some(
+                    NuDataFrame::try_from_columns(
+                        vec![
+                            Column::new(
+                                "a".to_string(),
+                                vec![
+                                    Value::test_int(1),
+                                    Value::test_int(2),
+                                    Value::test_int(2),
+                                    Value::test_int(3),
+                                    Value::test_int(3),
+                                ],
+                            ),
+                            Column::new(
+                                "b".to_string(),
+                                vec![
+                                    Value::test_int(0),
+                                    Value::test_int(0),
+                                    Value::test_int(1),
+                                    Value::test_int(2),
+                                    Value::test_int(2),
+                                ],
+                            ),
+                        ],
+                        None,
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
         ]
     }
 
@@ -98,11 +140,28 @@ impl PluginCommand for Shift {
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),
+            PolarsPluginObject::NuExpression(expr) => {
+                let shift: i64 = call.req(0)?;
+                let fill: Option<Value> = call.get_flag("fill")?;
+
+                let res: NuExpression = match fill {
+                    Some(ref fill) => {
+                        let fill_expr = NuExpression::try_from_value(plugin, fill)?.into_polars();
+                        expr.into_polars()
+                            .shift_and_fill(lit(shift), fill_expr)
+                            .into()
+                    }
+                    None => expr.into_polars().shift(lit(shift)).into(),
+                };
+
+                res.to_pipeline_data(plugin, engine, call.head)
+            }
             _ => Err(cant_convert_err(
                 &value,
                 &[
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyGroupBy,
+                    PolarsPluginType::NuExpression,
                 ],
             )),
         }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR seeks to expand the `polars shift` command to take expression inputs. See third example below:

```nushell
Examples:
  Shifts the values by a given period
  > [1 2 2 3 3] | polars into-df | polars shift 2 | polars drop-nulls
  ╭───┬───╮
  │ # │ 0 │
  ├───┼───┤
  │ 0 │ 1 │
  │ 1 │ 2 │
  │ 2 │ 2 │
  ╰───┴───╯

  Shifts the values by a given period, fill absent values with 0
  > [1 2 2 3 3] | polars into-lazy | polars shift 2 --fill 0 | polars collect
  ╭───┬───╮
  │ # │ 0 │
  ├───┼───┤
  │ 0 │ 0 │
  │ 1 │ 0 │
  │ 2 │ 1 │
  │ 3 │ 2 │
  │ 4 │ 2 │
  ╰───┴───╯

  Shift values of a column, fill absent values with 0
  > [[a]; [1] [2] [2] [3] [3]]
                    | polars into-lazy
                    | polars with-column {b: (polars col a | polars shift 2 --fill 0)}
                    | polars collect
  ╭───┬───┬───╮
  │ # │ a │ b │
  ├───┼───┼───┤
  │ 0 │ 1 │ 0 │
  │ 1 │ 2 │ 0 │
  │ 2 │ 2 │ 1 │
  │ 3 │ 3 │ 2 │
  │ 4 │ 3 │ 2 │
  ╰───┴───┴───╯

```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
No breaking changes.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
An example test was added to `polars shift`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
