### PR TITLE
Fix build failure of aarch64 and armv7 musl targets

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -79,14 +79,14 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
             cargo-build-nu
         }
         'aarch64-unknown-linux-musl' => {
-            aria2c https://musl.cc/aarch64-linux-musl-cross.tgz
+            aria2c https://github.com/nushell/integrations/releases/download/build-tools/aarch64-linux-musl-cross.tgz
             tar -xf aarch64-linux-musl-cross.tgz -C $env.HOME
             $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.HOME)/aarch64-linux-musl-cross/bin')
             $env.CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = 'aarch64-linux-musl-gcc'
             cargo-build-nu
         }
         'armv7-unknown-linux-musleabihf' => {
-            aria2c https://musl.cc/armv7r-linux-musleabihf-cross.tgz
+            aria2c https://github.com/nushell/integrations/releases/download/build-tools/armv7r-linux-musleabihf-cross.tgz
             tar -xf armv7r-linux-musleabihf-cross.tgz -C $env.HOME
             $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.HOME)/armv7r-linux-musleabihf-cross/bin')
             $env.CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER = 'armv7r-linux-musleabihf-gcc'


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

Fix build failure of aarch64 and armv7 musl targets: https://github.com/nushell/nushell/actions/runs/15288712454/job/43005766777#step:7:462

The failure was caused by downloading error of related assets

I just downloaded the assets and uploaded to `nushell/integrations` without any modification

https://github.com/nushell/integrations/releases/tag/build-tools
