### PR TITLE
Set content_type for `view span` output

### DIFF
--- a/crates/nu-command/src/debug/view_span.rs
+++ b/crates/nu-command/src/debug/view_span.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::{DataSource, PipelineMetadata};
 
 #[derive(Clone)]
 pub struct ViewSpan;
@@ -34,7 +35,7 @@ impl Command for ViewSpan {
         let start_span: Spanned<usize> = call.req(engine_state, stack, 0)?;
         let end_span: Spanned<usize> = call.req(engine_state, stack, 1)?;
 
-        if start_span.item < end_span.item {
+        let source = if start_span.item < end_span.item {
             let bin_contents =
                 engine_state.get_span_contents(Span::new(start_span.item, end_span.item));
             Ok(
@@ -49,7 +50,14 @@ impl Command for ViewSpan {
                 help: None,
                 inner: vec![],
             })
-        }
+        };
+
+        source.map(|x| {
+            x.set_metadata(Some(PipelineMetadata {
+                data_source: DataSource::None,
+                content_type: Some("application/x-nuscript".into()),
+            }))
+        })
     }
 
     fn examples(&self) -> Vec<Example> {


### PR DESCRIPTION
# Description

Adds the content type for `view span` output. Allows the display hook to add syntax highlighting.

# User-Facing Changes

`view span` output will now have a content type set. 

# Tests + Formatting

All pass, except for those that never pass on my machine.
