### PR TITLE
overlay new: add `--reload(-r)` flag

### DIFF
--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -1378,6 +1378,23 @@ fn alias_overlay_new() {
 }
 
 #[test]
+fn overlay_new_with_reload() {
+    let inp = &[
+        "overlay new spam",
+        "$env.foo = 'bar'",
+        "overlay hide spam",
+        "overlay new spam -r",
+        "'foo' in $env",
+    ];
+
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
+
+    assert_eq!(actual.out, "false");
+    assert_eq!(actual_repl.out, "false");
+}
+
+#[test]
 fn overlay_use_module_dir() {
     let import = "overlay use samples/spam";
 


### PR DESCRIPTION
# Description
Close: #15747

To support `reload` feature, we just need to save `caller_stack` before adding overlay, then redirect_env back after the overlay is added.

# User-Facing Changes
NaN

# Tests + Formatting
Added 1 test

# After Submitting
NaN
