### PR TITLE
feat: add set in the core library

### DIFF
--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -1,4 +1,4 @@
-use crate::{DeclId, Type};
+use crate::{DeclId, Type, set::SetType};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -78,6 +78,9 @@ pub enum SyntaxShape {
 
     /// A specific match to a word or symbol
     Keyword(Vec<u8>, Box<SyntaxShape>),
+
+    // A set of unique and unordered values
+    Set(Box<SyntaxShape>),
 
     /// A list is allowed, eg `[first second]`
     List(Box<SyntaxShape>),
@@ -161,6 +164,10 @@ impl SyntaxShape {
             SyntaxShape::Error => Type::Error,
             SyntaxShape::ImportPattern => Type::Any,
             SyntaxShape::Int => Type::Int,
+            SyntaxShape::Set(x) => {
+                let contents = x.to_type();
+                Type::Set(Box::new(SetType::from_type(contents)))
+            }
             SyntaxShape::List(x) => {
                 let contents = x.to_type();
                 Type::List(Box::new(contents))
@@ -220,6 +227,7 @@ impl Display for SyntaxShape {
                 }
             }
             SyntaxShape::Binary => write!(f, "binary"),
+            SyntaxShape::Set(x) => write!(f, "set<{x}>"),
             SyntaxShape::List(x) => write!(f, "list<{x}>"),
             SyntaxShape::Table(columns) => {
                 if columns.is_empty() {

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -1,4 +1,5 @@
 use crate::SyntaxShape;
+use crate::set::SetType;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 #[cfg(test)]
@@ -19,6 +20,7 @@ pub enum Type {
     Filesize,
     Float,
     Int,
+    Set(Box<SetType>),
     List(Box<Type>),
     #[default]
     Nothing,
@@ -33,6 +35,10 @@ pub enum Type {
 impl Type {
     pub fn list(inner: Type) -> Self {
         Self::List(Box::new(inner))
+    }
+
+    pub fn set(inner: Type) -> Self {
+        Self::Set(Box::new(SetType::from_type(inner)))
     }
 
     pub fn record() -> Self {
@@ -115,6 +121,7 @@ impl Type {
             Type::Duration => SyntaxShape::Duration,
             Type::Date => SyntaxShape::DateTime,
             Type::Filesize => SyntaxShape::Filesize,
+            Type::Set(x) => SyntaxShape::Set(Box::new(x.to_shape())),
             Type::List(x) => SyntaxShape::List(Box::new(x.to_shape())),
             Type::Number => SyntaxShape::Number,
             Type::Nothing => SyntaxShape::Nothing,
@@ -143,6 +150,7 @@ impl Type {
             Type::Range => String::from("range"),
             Type::Record(_) => String::from("record"),
             Type::Table(_) => String::from("table"),
+            Type::Set(_) => String::from("set"),
             Type::List(_) => String::from("list"),
             Type::Nothing => String::from("nothing"),
             Type::Number => String::from("number"),
@@ -198,6 +206,7 @@ impl Display for Type {
                     )
                 }
             }
+            Type::Set(l) => write!(f, "set<{l}>"),
             Type::List(l) => write!(f, "list<{l}>"),
             Type::Nothing => write!(f, "nothing"),
             Type::Number => write!(f, "number"),

--- a/crates/nu-protocol/src/value/set.rs
+++ b/crates/nu-protocol/src/value/set.rs
@@ -1,0 +1,131 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::hash::Hash;
+
+use crate::Value;
+use crate::{Span, SyntaxShape, Type};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CustomSet {
+    vals: HashSet<SetValue>,
+}
+
+impl CustomSet {
+    pub fn new(vals: Vec<Value>) -> Self {
+        Self {
+            vals: vals.iter().filter_map(SetValue::from_value).collect(),
+        }
+    }
+
+    pub fn iter(&self) -> std::collections::hash_set::Iter<SetValue> {
+        self.vals.iter()
+    }
+}
+
+impl PartialOrd for CustomSet {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.vals.len().partial_cmp(&other.vals.len())
+    }
+}
+
+impl PartialEq for CustomSet {
+    fn eq(&self, other: &Self) -> bool {
+        self.vals == other.vals
+    }
+}
+
+impl Eq for CustomSet {}
+
+// TODO:  add more
+#[derive(Debug, Serialize, Deserialize, Hash, Clone, PartialEq, PartialOrd, Eq)]
+pub enum SetValue {
+    Int(i64),
+}
+
+impl SetValue {
+    pub fn is_subtype_of(&self, other: &SetType) -> bool {
+        SetType::from_value(self)
+            .to_type()
+            .is_subtype_of(&other.to_type())
+    }
+
+    pub fn to_value(&self) -> Value {
+        match self {
+            SetValue::Int(val) => Value::int(*val, Span::unknown()), // TODO : is unknown the best ?
+        }
+    }
+
+    pub fn from_value(value: &Value) -> Option<Self> {
+        match value {
+            Value::Int { val, .. } => Some(SetValue::Int(*val)),
+            Value::Bool { .. }
+            | Value::Float { .. }
+            | Value::String { .. }
+            | Value::Glob { .. }
+            | Value::Filesize { .. }
+            | Value::Duration { .. }
+            | Value::Date { .. }
+            | Value::Range { .. }
+            | Value::Record { .. }
+            | Value::Set { .. }
+            | Value::List { .. }
+            | Value::Closure { .. }
+            | Value::Error { .. }
+            | Value::Binary { .. }
+            | Value::CellPath { .. }
+            | Value::Custom { .. }
+            | Value::Nothing { .. } => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub enum SetType {
+    Int,
+    Any,
+    #[default]
+    Nothing,
+}
+
+// TODO : sure about any ?
+impl SetType {
+    pub fn to_type(&self) -> Type {
+        match self {
+            SetType::Int => Type::Int,
+            SetType::Any => Type::Any,
+            SetType::Nothing => Type::Nothing,
+        }
+    }
+
+    pub fn from_type(ty: Type) -> Self {
+        match ty {
+            Type::Int => SetType::Int,
+            Type::Any => SetType::Any,
+            _ => SetType::Nothing,
+        }
+    }
+
+    pub fn from_value(value: &SetValue) -> Self {
+        match value {
+            SetValue::Int(_) => SetType::Int,
+        }
+    }
+
+    pub fn to_shape(&self) -> SyntaxShape {
+        match self {
+            SetType::Int => todo!(),
+            SetType::Any => todo!(),
+            SetType::Nothing => todo!(),
+        }
+    }
+}
+
+impl std::fmt::Display for SetType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SetType::Int => write!(f, "Int"),
+            SetType::Any => write!(f, "Any"),
+            SetType::Nothing => write!(f, "Nothing"),
+        }
+    }
+}


### PR DESCRIPTION
Should close : https://github.com/nushell/nushell/issues/15807

Hello,

This PR is a draft of an implementation of a Set structure based on HashSet. The advantages are :
- useful unique property with potential operation (union, intersection, difference)
- it's fast


However this PR is not finished at all and is a draft because I would like to discuss first the relevance of this PR, second design choice that has to made. For example, how to create a new set ? Some implementation, like in python use curly braces, however as in Nushell, this starts a new scopes, this might creates some difficulties in the parsing.

About the implementations, as we must ensure that the type are hashable, we cannot use the default `Value` and `Type`. Because of this I created dedicated enum with `from` and `to` functions where the logic of filtering the hashable type will be handled. Is it ok for you ? 
Currently only a minimal core implementation is done so it isn't usable yet, but I would be glad to have your opinion on this.

