### PR TITLE
feat(std): further `bench` improvements

### DIFF
--- a/crates/nu-std/std/bench/mod.nu
+++ b/crates/nu-std/std/bench/mod.nu
@@ -92,7 +92,9 @@ export def main [
             let idx = $x.index
 
             seq 1 $warmup | each {|i|
+                if $prepare != null { $idx | do $prepare $idx | ignore }
                 do --ignore-errors=$ignore_errors $code | ignore
+                if $conclude != null { $idx | do $conclude $idx | ignore }
             }
 
             let times: list<duration> = (

--- a/crates/nu-std/std/bench/mod.nu
+++ b/crates/nu-std/std/bench/mod.nu
@@ -91,15 +91,20 @@ export def main [
             let code = $x.item
             let idx = $x.index
 
+            let bench_num = if ($commands | length) > 1 { $" ($idx + 1)"}
+
             seq 1 $warmup | each {|i|
+                if $progress { print -n $"Warmup($bench_num): ($i) / ($warmup)\r" }
                 if $prepare != null { $idx | do $prepare $idx | ignore }
                 do --ignore-errors=$ignore_errors $code | ignore
                 if $conclude != null { $idx | do $conclude $idx | ignore }
             }
 
+            if $progress and $warmup > 0 { print $"Warmup($bench_num): ($warmup) / ($warmup)" }
+
             let times: list<duration> = (
                 seq 1 $rounds | each {|i|
-                    if $progress { print -n $"($i) / ($rounds)\r" }
+                    if $progress { print -n $"Benchmark($bench_num): ($i) / ($rounds)\r" }
 
                     if $prepare != null { $idx | do $prepare $idx | ignore }
                     let time = timeit { do --ignore-errors=$ignore_errors $code | ignore }
@@ -109,7 +114,7 @@ export def main [
                 }
             )
 
-            if $progress { print $"($rounds) / ($rounds)" }
+            if $progress { print $"Benchmark($bench_num): ($rounds) / ($rounds)" }
 
             {
                 mean: ($times | math avg)

--- a/crates/nu-std/std/bench/mod.nu
+++ b/crates/nu-std/std/bench/mod.nu
@@ -103,7 +103,7 @@ export def main [
 
             if $progress { print $"($rounds) / ($rounds)" }
 
-            if $cleanup != null { do $cleanup | ignore }
+            if $conclude != null { do $conclude | ignore }
 
             {
                 mean: ($times | math avg)
@@ -115,7 +115,7 @@ export def main [
         }
     )
 
-    if $conclude != null { do $conclude | ignore }
+    if $cleanup != null { do $cleanup | ignore }
 
     # One benchmark
     if ($results | length) == 1 {

--- a/crates/nu-std/std/bench/mod.nu
+++ b/crates/nu-std/std/bench/mod.nu
@@ -69,7 +69,7 @@ export def main [
     --rounds (-n): int = 50  # the number of benchmark rounds (hopefully the more rounds the less variance)
     --warmup (-w): int = 0   # the number of warmup rounds (not timed) to do before the benchmark, useful for filling the disk cache in I/O-heavy programs
     --setup (-s): closure    # command to run before all benchmarks
-    --prepare: closure       # command to run before each benchmark (same as `--setup` if only doing one benchmark)
+    --prepare (-S): closure  # command to run before each benchmark (same as `--setup` if only doing one benchmark)
     --cleanup (-c): closure  # command to run after all benchmarks
     --conclude (-C): closure # command to run after each benchmark (same as `--cleanup` if only doing one benchmark)
     --ignore-errors (-i)     # ignore errors in the command


### PR DESCRIPTION
# Description

Following #15843, I have tinkered more with it and realized that there are plenty of features from [hyperfine](https://github.com/sharkdp/hyperfine) that could be implemented pretty easily.

- `--warmup` flag to do `n` runs without benchmarking first, useful to fill disk cache
```nu
@example "use --warmup to fill the disk cache before benchmarking" { bench { fd } { jwalk . -k } -w 1 -n 10 }
```
- `--setup`, `--prepare`, `--cleanup`, `--conclude` flags to run code before/after benchmarks
```nu
@example "use `--setup` to compile before benchmarking" { bench { ./target/release/foo } --setup { cargo build --release } }
@example "use `--prepare` to benchmark rust compilation speed" { bench { cargo build --release } --prepare { cargo clean } }
```
- `--ignore-errors` to ignore any errors in the benchmarked commands
- benchmarked commands are now `| ignore` so that externals don't fill the screen