### PR TITLE
Update deprecation warnings

### DIFF
--- a/crates/nu-command/src/filters/filter.rs
+++ b/crates/nu-command/src/filters/filter.rs
@@ -14,8 +14,8 @@ impl Command for Filter {
     }
 
     fn extra_description(&self) -> &str {
-        r#"This command works similar to 'where' but allows reading the predicate closure from
-a variable. On the other hand, the "row condition" syntax is not supported."#
+        r#"This command works similar to 'where' but can only use a closure as a predicate.
+The "row condition" syntax is not supported."#
     }
 
     fn signature(&self) -> nu_protocol::Signature {
@@ -48,6 +48,18 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
     ) -> Result<PipelineData, ShellError> {
         use super::where_::Where;
         <Where as Command>::run(&Where, engine_state, stack, call, input)
+    }
+
+    fn deprecation_info(&self) -> Vec<nu_protocol::DeprecationEntry> {
+        vec![
+            DeprecationEntry {
+                ty: DeprecationType::Command,
+                report_mode: ReportMode::FirstUse,
+                since: Some("0.105.0".into()),
+                expected_removal: None,
+                help: Some("`where` command can be used instead, as it can now read the predicate closure from a variable".into()),
+            }
+        ]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/tests/commands/filter.rs
+++ b/crates/nu-command/tests/commands/filter.rs
@@ -14,5 +14,5 @@ fn filter_with_return_in_closure() {
     ));
 
     assert_eq!(actual.out, "[2, 4, 6, 8, 10]");
-    assert!(actual.err.is_empty());
+    assert!(actual.err.contains("deprecated"));
 }

--- a/crates/nu-std/std/iter/mod.nu
+++ b/crates/nu-std/std/iter/mod.nu
@@ -18,7 +18,7 @@
 export def find [
     fn: closure # the closure used to perform the search 
 ] {
-    filter {|e| try {do $fn $e} } | try { first }
+    where {|e| try {do $fn $e} } | try { first }
 }
 
 # Returns the index of the first element that matches the predicate or -1 if none
@@ -87,7 +87,7 @@ export def scan [ # -> list<any>
 #
 # This is equivalent to 
 #
-#     $in | each $fn | filter $fn
+#     $in | each $fn | where $fn
 @example "Get the squares of elements that can be squared" {
     [2 5 "4" 7] | iter filter-map {|e| $e ** 2}
 } --result [4, 25, 49]
@@ -101,7 +101,7 @@ export def filter-map [
             null 
         }
     } 
-    | filter {|e|
+    | where {|e|
         $e != null
     }
 }

--- a/crates/nu-std/std/xml/mod.nu
+++ b/crates/nu-std/std/xml/mod.nu
@@ -62,7 +62,7 @@ def xupdate-string-step [ step: string rest: list updater: closure ] {
     let input = $in
 
     # Get a list of elements to be updated and their indices
-    let to_update = ($input.content | enumerate | filter {|it|
+    let to_update = ($input.content | enumerate | where {|it|
         let item = $it.item
         $step == '*' or $item.tag == $step
     })

--- a/crates/nu-std/testing.nu
+++ b/crates/nu-std/testing.nu
@@ -333,20 +333,20 @@ export def run-tests [
                 commands: (get-annotated $row.name)
             }
         }
-        | filter {|x| ($x.commands|length) > 0}
+        | where {|x| ($x.commands|length) > 0}
         | upsert commands {|module|
             $module.commands
             | create-test-record
         }
         | flatten
-        | filter {|x| ($x.test|length) > 0}
-        | filter {|x| if ($exclude_module|is-empty) {true} else {$x.name !~ $exclude_module}}
-        | filter {|x| if ($test|is-empty) {true} else {$x.test|any {|y| $y =~ $test}}}
-        | filter {|x| if ($module|is-empty) {true} else {$module == $x.name}}
+        | where {|x| ($x.test|length) > 0}
+        | where {|x| if ($exclude_module|is-empty) {true} else {$x.name !~ $exclude_module}}
+        | where {|x| if ($test|is-empty) {true} else {$x.test|any {|y| $y =~ $test}}}
+        | where {|x| if ($module|is-empty) {true} else {$module == $x.name}}
         | update test {|x|
             $x.test
-            | filter {|y| if ($test|is-empty) {true} else {$y =~ $test}}
-            | filter {|y| if ($exclude|is-empty) {true} else {$y !~ $exclude}}
+            | where {|y| if ($test|is-empty) {true} else {$y =~ $test}}
+            | where {|y| if ($exclude|is-empty) {true} else {$y !~ $exclude}}
         }
     )
     if $list {


### PR DESCRIPTION
# Description
- Use #15770 to
  - improve `get --sensitive` deprecation warning
  - add deprecation warning for `filter`
- refactor `filter` to use `where` as its implementation
- replace usages of `filter` with `where` in `std`

# User-Facing Changes
- `get --sensitive` will raise a warning only once, during parsing whereas before it was raised during runtime for each usage.
- using `filter` will raise a deprecation warning, once

# Tests + Formatting
No existing test broke or required tweaking. Additional tests covering this case was added.
- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
N/A