### PR TITLE
fix(which): remove required positional argument to allow spread input

### DIFF
--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -14,7 +14,7 @@ impl Command for Which {
         Signature::build("which")
             .input_output_types(vec![(Type::Nothing, Type::table())])
             .allow_variants_without_examples(true)
-            .rest("rest", SyntaxShape::String, "Additional applications.")
+            .rest("applications", SyntaxShape::String, "Application(s)")
             .switch("all", "list all executables", Some('a'))
             .category(Category::System)
     }

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -14,7 +14,7 @@ impl Command for Which {
         Signature::build("which")
             .input_output_types(vec![(Type::Nothing, Type::table())])
             .allow_variants_without_examples(true)
-            .rest("applications", SyntaxShape::String, "Application(s)")
+            .rest("applications", SyntaxShape::String, "Application(s).")
             .switch("all", "list all executables", Some('a'))
             .category(Category::System)
     }

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -14,7 +14,6 @@ impl Command for Which {
         Signature::build("which")
             .input_output_types(vec![(Type::Nothing, Type::table())])
             .allow_variants_without_examples(true)
-            .required("application", SyntaxShape::String, "Application.")
             .rest("rest", SyntaxShape::String, "Additional applications.")
             .switch("all", "list all executables", Some('a'))
             .category(Category::System)

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -107,7 +107,7 @@ fn do_not_show_hidden_commands() {
 }
 
 #[test]
-fn which_accepts_splatted_list() {
+fn which_accepts_spread_list() {
     let actual = nu!(
         cwd: ".",  // or any valid path
         r#"

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -105,3 +105,16 @@ fn do_not_show_hidden_commands() {
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 0);
 }
+
+#[test]
+fn which_accepts_splatted_list() {
+    let actual = nu!(
+        cwd: ".",  // or any valid path
+        r#"
+        let apps = [ls]; 
+        $apps | which ...$in | get command.0
+        "#
+    );
+
+    assert_eq!(actual.out, "ls");
+}


### PR DESCRIPTION
## Summary

This PR removes the required positional argument from the `which` command, allowing it to accept input via the spread (`...`) operator. This enables expressions like:

```nu
[notepad cmd] | which ...$in
```

Previously, this failed due to a missing required positional argument. The Nushell runtime already handles empty input gracefully, so the change aligns with existing behavior.

---

## Motivation

Making `which` compatible with splatted input improves composability and aligns with user expectations in scriptable environments. It supports patterns where the input may be constructed dynamically or piped in from earlier commands.

---

## Changes

* Removed the `required` attribute from the positional argument in the `which` command signature.
* No additional runtime logic required since empty input is handled gracefully already.

---

## Examples

### Before

```nu
[notepad cmd] | which ...$in
# ❌ Error: Missing required positional argument
```

### After

```nu
[notepad cmd] | which ...$in
# ✅ Executes correctly
```

---

## Testing

* Ran `cargo test --all` and `cargo test -p nu-command`
* Manually tested using spread input with the `which` command
* Confirmed that empty and non-empty inputs behave correctly

---

## Related Issues

Closes [[#15801](https://github.com/nushell/nushell/issues/15801)](https://github.com/nushell/nushell/issues/15801)