### PR TITLE
Disable flaky killing_job_kills_pids test on macOS

### DIFF
--- a/crates/nu-command/tests/commands/job.rs
+++ b/crates/nu-command/tests/commands/job.rs
@@ -285,7 +285,10 @@ fn killing_job_removes_it_from_table() {
     assert_eq!(actual.out, "[true, true, true, true]");
 }
 
+// this test is unreliable on the macOS CI, but it worked fine for a couple months.
+// still works on other operating systems.
 #[test]
+#[cfg(not(target_os = "macos"))]
 fn killing_job_kills_pids() {
     let actual = nu!(format!(
         r#"


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This test has failed a number of times specifically on macOS. I'm not exactly sure what the issue is, it seemed to work fine before. We should probably actually fix it, but flaky CI is worse than missing this one test on macOS

cc @cosineblast 