### PR TITLE
Add `debug env` command

### DIFF
--- a/crates/nu-command/src/debug/env.rs
+++ b/crates/nu-command/src/debug/env.rs
@@ -30,4 +30,19 @@ impl Command for DebugEnv {
             None,
         ))
     }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Get PATH variable that externals see",
+                example: "debug env | get PATH!",
+                result: None,
+            },
+            Example {
+                description: "Create a .env file",
+                example: r#"debug env | transpose key value | each {$"($in.key)=($in.value | to json)"} | save .env"#,
+                result: None,
+            },
+        ]
+    }
 }

--- a/crates/nu-command/src/debug/env.rs
+++ b/crates/nu-command/src/debug/env.rs
@@ -1,0 +1,33 @@
+use nu_engine::{command_prelude::*, env_to_strings};
+
+#[derive(Clone)]
+pub struct DebugEnv;
+
+impl Command for DebugEnv {
+    fn name(&self) -> &str {
+        "debug env"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::new(self.name())
+            .input_output_type(Type::Nothing, Type::record())
+            .category(Category::Debug)
+    }
+
+    fn description(&self) -> &str {
+        "Show environment variables as external commands would get it."
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(PipelineData::Value(
+            env_to_strings(engine_state, stack)?.into_value(call.head),
+            None,
+        ))
+    }
+}

--- a/crates/nu-command/src/debug/mod.rs
+++ b/crates/nu-command/src/debug/mod.rs
@@ -1,5 +1,6 @@
 mod ast;
 mod debug_;
+mod env;
 mod explain;
 mod info;
 mod inspect;
@@ -19,6 +20,7 @@ mod view_span;
 
 pub use ast::Ast;
 pub use debug_::Debug;
+pub use env::DebugEnv;
 pub use explain::Explain;
 pub use info::DebugInfo;
 pub use inspect::Inspect;

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -152,6 +152,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
         bind_command! {
             Ast,
             Debug,
+            DebugEnv,
             DebugInfo,
             DebugProfile,
             Explain,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

When calling external commands, we convert our `$env`  into a map where each value is a string. If a value cannot be converted, it will be skipped or when an `ENV_CONVERSION` is defined, will be converted via that. This makes this conversion not that trivial. To ease debugging this behavior or allowing to generate `.env` files from the current environment did I add `debug env`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

New command `debug env`.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

I did not add extra tests, as I just called the function we also call in `start`, `exec` or `run-external`. 

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

I can use this to make my life easier implementing `colcon-nushell` 😉 