### PR TITLE
Promote clip from `std-rfc` to `std`

### DIFF
--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -64,6 +64,7 @@ pub fn load_standard_library(
             "std/testing",
             include_str!("../std/testing/mod.nu"),
         ),
+        ("mod.nu", "std/clip", include_str!("../std/clip/mod.nu")),
     ];
 
     for (filename, std_subdir_name, content) in std_submodules.drain(..) {

--- a/crates/nu-std/std-rfc/clip/mod.nu
+++ b/crates/nu-std/std-rfc/clip/mod.nu
@@ -29,17 +29,17 @@ export def copy [
   clip paste
 } --result "Hello"
 export def paste []: [nothing -> string] {
-	try {
-		term query $'(ansi osc)52;c;?(ansi st)' -p $'(ansi osc)52;c;' -t (ansi st)
-	} catch {
-		error make -u {
-			msg: "Terminal did not responds to OSC 52 paste request."
-			help: $"Check if your terminal supports OSC 52."
-		}
-	}
-	| decode
-	| decode base64
-	| decode
+  try {
+    term query $'(ansi osc)52;c;?(ansi st)' -p $'(ansi osc)52;c;' -t (ansi st)
+  } catch {
+    error make -u {
+      msg: "Terminal did not responds to OSC 52 paste request."
+      help: $"Check if your terminal supports OSC 52."
+    }
+  }
+  | decode
+  | decode base64
+  | decode
 }
 
 # Add a prefix to each line of the content to be copied

--- a/crates/nu-std/std/clip/mod.nu
+++ b/crates/nu-std/std/clip/mod.nu
@@ -1,38 +1,48 @@
-# The clip module has been added to std. This std-rfc module is deprecated and will be removed.
-#
 # Commands for interacting with the system clipboard
 #
 # > These commands require your terminal to support OSC 52
 # > Terminal multiplexers such as screen, tmux, zellij etc may interfere with this command
 
-module std-clip {
-  export use std/clip *
-}
-
-use std-clip
-
 # Copy input to system clipboard
-@deprecated "The clip module has been moved to std. Please use the std version instead of the std-rfc version." --since 0.105.0 --remove 0.107.0
 @example "Copy a string to the clipboard" {
   "Hello" | clip copy
 }
 export def copy [
   --ansi (-a)                 # Copy ansi formatting
 ]: any -> nothing {
-  std-clip copy --ansi=$ansi
+  let input = $in | collect
+  if not $ansi {
+    $env.config.use_ansi_coloring = false
+  }
+  let text = match ($input | describe -d | get type) {
+    $type if $type in [ table, record, list ] => {
+      $input | table -e
+    }
+    _ => {$input}
+  }
+
+  print -n $'(ansi osc)52;c;($text | encode base64)(ansi st)'
 }
 
 # Paste contents of system clipboard
-@deprecated "The clip module has been moved to std. Please use the std version instead of the std-rfc version." --since 0.105.0 --remove 0.107.0
 @example "Paste a string from the clipboard" {
   clip paste
 } --result "Hello"
 export def paste []: [nothing -> string] {
-  std-clip paste
+  try {
+    term query $'(ansi osc)52;c;?(ansi st)' -p $'(ansi osc)52;c;' -t (ansi st)
+  } catch {
+    error make -u {
+      msg: "Terminal did not responds to OSC 52 paste request."
+      help: $"Check if your terminal supports OSC 52."
+    }
+  }
+  | decode
+  | decode base64
+  | decode
 }
 
 # Add a prefix to each line of the content to be copied
-@deprecated "The clip module has been moved to std. Please use the std version instead of the std-rfc version." --since 0.105.0 --remove 0.107.0
 @example "Format output for Nushell doc" {
   [1 2 3] | clip prefix '# => '
 } --result "# => ╭───┬───╮
@@ -45,5 +55,12 @@ export def paste []: [nothing -> string] {
   ls | clip prefix '# => ' | clip copy
 }
 export def prefix [prefix: string]: any -> string {
-  std-clip prefix $prefix
+  let input = $in | collect
+  match ($input | describe -d | get type) {
+    $type if $type in [ table, record, list ] => {
+      $input | table -e
+    }
+    _ => {$input}
+  }
+  | str replace -r --all '(?m)(.*)' $'($prefix)$1'
 }

--- a/crates/nu-std/testing.nu
+++ b/crates/nu-std/testing.nu
@@ -37,11 +37,16 @@ def get-annotated [
         source `($file)`
         scope commands
         | select name attributes
-        | where attributes != []
         | to nuon
     '
     | from nuon
-    | update attributes { get name | each {|x| $valid_annotations | get -i $x } | first }
+    | each {|e|
+        # filter commands with test attributes, and map attributes to annotation name
+        let test_attributes = $e.attributes.name | each {|x| $valid_annotations | get -i $x }
+        if ($test_attributes | is-not-empty) {
+          $e | update attributes $test_attributes.0
+        }
+      }
     | rename function_name annotation
 }
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Promotes the clip module from `std-rfc` to `std`. Whether we want to promote other modules as well (probably?) is up for discussion but I thought I would get the ball rolling with this one.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
* The `clip` module has been promoted from `std-rfc` to `std`. Using the `std-rfc` version of clip modules will give a deprecation warning instructing you to switch to the `std` version.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
N/A

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A