### PR TITLE
Improve error handling for negative integer exponents in ** operator

### DIFF
--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -14,7 +14,7 @@ impl Command for Which {
         Signature::build("which")
             .input_output_types(vec![(Type::Nothing, Type::table())])
             .allow_variants_without_examples(true)
-            .rest("rest", SyntaxShape::String, "Additional applications.")
+            .rest("applications", SyntaxShape::String, "Application(s)")
             .switch("all", "list all executables", Some('a'))
             .category(Category::System)
     }

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -14,7 +14,7 @@ impl Command for Which {
         Signature::build("which")
             .input_output_types(vec![(Type::Nothing, Type::table())])
             .allow_variants_without_examples(true)
-            .rest("applications", SyntaxShape::String, "Application(s)")
+            .rest("applications", SyntaxShape::String, "Application(s).")
             .switch("all", "list all executables", Some('a'))
             .category(Category::System)
     }

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -14,7 +14,6 @@ impl Command for Which {
         Signature::build("which")
             .input_output_types(vec![(Type::Nothing, Type::table())])
             .allow_variants_without_examples(true)
-            .required("application", SyntaxShape::String, "Application.")
             .rest("rest", SyntaxShape::String, "Additional applications.")
             .switch("all", "list all executables", Some('a'))
             .category(Category::System)

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -107,7 +107,7 @@ fn do_not_show_hidden_commands() {
 }
 
 #[test]
-fn which_accepts_splatted_list() {
+fn which_accepts_spread_list() {
     let actual = nu!(
         cwd: ".",  // or any valid path
         r#"

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -105,3 +105,16 @@ fn do_not_show_hidden_commands() {
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 0);
 }
+
+#[test]
+fn which_accepts_splatted_list() {
+    let actual = nu!(
+        cwd: ".",  // or any valid path
+        r#"
+        let apps = [ls]; 
+        $apps | which ...$in | get command.0
+        "#
+    );
+
+    assert_eq!(actual.out, "ls");
+}

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3296,10 +3296,10 @@ impl Value {
             (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
                 if *rhs < 0 {
                     return Err(ShellError::IncorrectValue {
-        msg: "Negative exponent for integer power is unsupported; use floats instead.".into(),
-        val_span: span,
-        call_span: op,  // or `span` again if `op` is not available or suitable
-    });
+                        msg: "Negative exponent for integer power is unsupported; use floats instead.".into(),
+                        val_span: span,
+                        call_span: op,  // or `span` again if `op` is not available or suitable
+                    });
                 }
 
                 if let Some(val) = lhs.checked_pow(*rhs as u32) {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3294,6 +3294,14 @@ impl Value {
     pub fn pow(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
+                if *rhs < 0 {
+                    return Err(ShellError::IncorrectValue {
+        msg: "Negative exponent for integer power is unsupported; use floats instead.".into(),
+        val_span: span,
+        call_span: op,  // or `span` again if `op` is not available or suitable
+    });
+                }
+
                 if let Some(val) = lhs.checked_pow(*rhs as u32) {
                     Ok(Value::int(val, span))
                 } else {


### PR DESCRIPTION
**Title**: Improve error handling for negative integer exponents in `**` operator

---

### 🐛 Bug Fix

This PR addresses an issue where attempting to raise an integer to a negative power (e.g. `10 ** -1`) incorrectly triggered an `OperatorOverflow` error. This behavior was misleading since the overflow isn't actually the root problem — it's the unsupported operation of raising integers to negative powers.

---

### ✅ Fix Summary

* Updated `Value::pow` to:

  * Check for negative exponents when both operands are integers.
  * Return a `ShellError::IncorrectValue` with a helpful message guiding users to use floating point values instead.

#### Example:

```bash
> 10 ** -1
Error: nu::shell::incorrect_value

  × Incorrect value.
   ╝─[entry #2:1:4]
 1 │ 10 ** -1
   ·    ─┬┬
   ·     │╰── encountered here
   ·     ╰── Negative exponent for integer power is unsupported; use floats instead.
```

---

### 🔪 Testing

Manual testing:

* `10 ** -1` → now returns a clear and appropriate `IncorrectValue` error.
* `10.0 ** -1`, `10 ** -1.0`, etc. continue to work as expected.

![nu](https://github.com/user-attachments/assets/7de744e5-4f62-4b50-8256-64200d37c268)

---

### 🧹 Related

Fixes #15860
