### PR TITLE
Correctly quote `nu.exe` and `nu.ico` path containing spaces in WiX

### DIFF
--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -278,7 +278,7 @@
     <SetProperty Id="ReplacePathsInWindowsTerminalProfile"
                  Sequence="execute"
                  After="CostFinalize"
-                 Value="&quot;[#nu.exe]&quot; -c &quot;let doc = (open `[#WindowsTerminalProfileFile]` | update profiles.commandline `[#nu.exe]` | update profiles.icon `[#nu.ico]`); $doc | save -f `[#WindowsTerminalProfileFile]`&quot;"
+                 Value="&quot;[#nu.exe]&quot; -c &quot;let doc = (open `[#WindowsTerminalProfileFile]` | update profiles.commandline `\&quot;[#nu.exe]\&quot;` | update profiles.icon `\&quot;[#nu.ico]\&quot;`); $doc | save -f `[#WindowsTerminalProfileFile]`&quot;"
                  Condition="&amp;WindowsTerminalProfileFeature=3" />
 
     <!-- Defines the custom action that updates paths in the Windows Terminal profile JSON file -->


### PR DESCRIPTION
# Description

This PR improves the installation process of Nushell's Windows Terminal Profile by adding proper quoting when refilling the path to `nu.exe` and `nu.ico`.

**Crossref:** https://github.com/microsoft/terminal/issues/6082#issuecomment-1001226003

**Affected lines:**

https://github.com/nushell/nushell/blob/222c30764859a5c78c11c233ae1c1521356c026b/wix/main.wxs#L278-L282

Currently, when any part of the installation path of `nu.exe` contains spaces, the auto-generated profile would contain a truncated path due to improper quoting. At best, this would cause failures when launching the profile. At worst, this could lead to executable hijacks.

Assume this default-generated profile with the username "Mantle Bao":

```json
{
  "profiles": [
    {
      "guid": "{47302f9c-1ac4-566c-aa3e-8cf29889d6ab}",
      "name": "Nushell",
      "commandline": "C:\\Users\\Mantle Bao\\AppData\\Local\\Programs\\nu\\bin\\nu.exe",
      "icon": "C:\\Users\\Mantle Bao\\AppData\\Local\\Programs\\nu\\nu.ico",
      "startingDirectory": "%USERPROFILE%"
    }
  ]
}
```

And a file named "Mantle" exists under `C:\Users\`:

```nushell
> sudo nu -c `touch C:\Users\Mantle`
> ls `C:\Users\` | find "Mantle" | select name type
╭───┬─────────────────────────────────────────────────┬──────╮
│ # │                      name                       │ type │
├───┼─────────────────────────────────────────────────┼──────┤
│ 0 │ C:\Users\Mantle                                 │ file │
│ 1 │ C:\Users\Mantle Bao                             │ dir  │
╰───┴─────────────────────────────────────────────────┴──────╯
>
```

Launching this profile produces this error in Windows Terminal 1.22.11141.0:

```plain-text
[error 2147942593 (0x800700c1) when launching `C:\Users\Mantle Bao\AppData\Local\Programs\nu\bin\nu.exe']
```

![Error 0x800700c1 pops up when launching the profile](https://github.com/user-attachments/assets/7cb0d175-299c-4fb0-aa43-2185675e12ae)

[Looking up](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-code-lookup-tool) this error code would yield its name as `ERROR_BAD_EXE_FORMAT`, since the Windows shell will try to execute `C:\\Users\\Mantle` but not the actual `nu.exe`.

## Hijacking PoC

![Running Calc](https://github.com/user-attachments/assets/a7ab9ea4-680b-441f-8a7f-26eaad1b7942)

# User-Facing Changes

None. It should only affect the installation phase without any user-facing changes.

# Tests + Formatting

This PR does not modify Rust or Nu code, and all its improvements belong to the packaging system. Thus, no conventional tests or formatting apply. But in case there exists preferred ways to test the packaging process, please inform me of those, and I would make appropriate changes.

# After Submitting

None. It should only affect the installation phase without any post-submission edits.