### PR TITLE
Better error handling for negative integer exponents in ** operator

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3296,10 +3296,10 @@ impl Value {
             (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
                 if *rhs < 0 {
                     return Err(ShellError::IncorrectValue {
-        msg: "Negative exponent for integer power is unsupported; use floats instead.".into(),
-        val_span: span,
-        call_span: op,  // or `span` again if `op` is not available or suitable
-    });
+                        msg: "Negative exponent for integer power is unsupported; use floats instead.".into(),
+                        val_span: span,
+                        call_span: op,  
+                    });
                 }
 
                 if let Some(val) = lhs.checked_pow(*rhs as u32) {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3294,6 +3294,14 @@ impl Value {
     pub fn pow(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
             (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
+                if *rhs < 0 {
+                    return Err(ShellError::IncorrectValue {
+        msg: "Negative exponent for integer power is unsupported; use floats instead.".into(),
+        val_span: span,
+        call_span: op,  // or `span` again if `op` is not available or suitable
+    });
+                }
+
                 if let Some(val) = lhs.checked_pow(*rhs as u32) {
                     Ok(Value::int(val, span))
                 } else {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3293,16 +3293,16 @@ impl Value {
 
     pub fn pow(&self, op: Span, rhs: &Value, span: Span) -> Result<Value, ShellError> {
         match (self, rhs) {
-            (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => {
-                if *rhs < 0 {
+            (Value::Int { val: lhs, .. }, Value::Int { val: rhsv, .. }) => {
+                if *rhsv < 0 {
                     return Err(ShellError::IncorrectValue {
                         msg: "Negative exponent for integer power is unsupported; use floats instead.".into(),
-                        val_span: span,
+                        val_span: rhs.span(),
                         call_span: op,
                     });
                 }
 
-                if let Some(val) = lhs.checked_pow(*rhs as u32) {
+                if let Some(val) = lhs.checked_pow(*rhsv as u32) {
                     Ok(Value::int(val, span))
                 } else {
                     Err(ShellError::OperatorOverflow {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3298,7 +3298,7 @@ impl Value {
                     return Err(ShellError::IncorrectValue {
                         msg: "Negative exponent for integer power is unsupported; use floats instead.".into(),
                         val_span: span,
-                        call_span: op,  
+                        call_span: op,
                     });
                 }
 


### PR DESCRIPTION
**Title**: Better error handling for negative integer exponents in `**` operator

---

### 🐛 Bug Fix

This PR addresses an issue where attempting to raise an integer to a negative power (e.g. `10 ** -1`) incorrectly triggered an `OperatorOverflow` error. This behavior was misleading since the overflow isn't actually the root problem — it's the unsupported operation of raising integers to negative powers.

---

### ✅ Fix Summary

* Updated `Value::pow` to:

  * Check for negative exponents when both operands are integers.
  * Return a `ShellError::IncorrectValue` with a helpful message guiding users to use floating point values instead.

#### Example:

```bash
> 10 ** -1
Error: nu::shell::incorrect_value

  × Incorrect value.
   ╝─[entry #2:1:4]
 1 │ 10 ** -1
   ·    ─┬┬
   ·     │╰── encountered here
   ·     ╰── Negative exponent for integer power is unsupported; use floats instead.
```

---

### 🔪 Testing

Manual testing:

* `10 ** -1` → now returns a clear and appropriate `IncorrectValue` error.
* `10.0 ** -1`, `10 ** -1.0`, etc. continue to work as expected.

---

### 🧹 Related

Fixes #15860

---

Let me know if you'd like a test case or doc update included in the PR too!
