### PR TITLE
Set match_indices for fuzzy-matched suggestions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5973,9 +5973,8 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5cdfab7494d13ebfb6ce64828648518205d3ce8541ef1f94a27887f29d2d50b"
+version = "0.39.0"
+source = "git+https://github.com/ysthakur/reedline?branch=fuzzy-select-underline"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ getrandom = "0.2" # pick same version that rand requires
 rand_chacha = "0.9"
 ratatui = "0.29"
 rayon = "1.10"
-reedline = "0.40.0"
+reedline = "0.39.0"
 rmp = "0.8"
 rmp-serde = "1.3"
 roxmltree = "0.20"
@@ -330,7 +330,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+reedline = { git = "https://github.com/ysthakur/reedline", branch = "fuzzy-select-underline" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Run all benchmarks with `cargo bench`

--- a/crates/nu-cli/src/completions/attribute_completions.rs
+++ b/crates/nu-cli/src/completions/attribute_completions.rs
@@ -44,7 +44,7 @@ impl Completer for AttributeCompletion {
             });
         }
 
-        matcher.results()
+        matcher.suggestion_results()
     }
 }
 
@@ -80,6 +80,6 @@ impl Completer for AttributableCompletion {
             });
         }
 
-        matcher.results()
+        matcher.suggestion_results()
     }
 }

--- a/crates/nu-cli/src/completions/cell_path_completions.rs
+++ b/crates/nu-cli/src/completions/cell_path_completions.rs
@@ -75,7 +75,7 @@ impl Completer for CellPathCompletion<'_> {
         for suggestion in get_suggestions_by_value(&value, current_span) {
             matcher.add_semantic_suggestion(suggestion);
         }
-        matcher.results()
+        matcher.suggestion_results()
     }
 }
 

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -145,11 +145,12 @@ impl Completer for CommandCompletion {
         };
 
         let mut res = Vec::new();
-        for cmd_name in matcher.results() {
-            if let Some(sugg) = internal_suggs
+        for (cmd_name, indices) in matcher.results() {
+            if let Some(mut sugg) = internal_suggs
                 .remove(&cmd_name)
                 .or_else(|| external_suggs.remove(&cmd_name))
             {
+                sugg.suggestion.match_indices = indices;
                 res.push(sugg);
             }
         }

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -38,7 +38,7 @@ fn complete_rec(
     want_directory: bool,
     isdir: bool,
     enable_exact_match: bool,
-) -> Vec<PathBuiltFromString> {
+) -> Vec<(PathBuiltFromString, Option<Vec<usize>>)> {
     let has_more = !partial.is_empty() && (partial.len() > 1 || isdir);
 
     if let Some((&base, rest)) = partial.split_first() {
@@ -124,7 +124,7 @@ fn complete_rec(
 
     if has_more {
         let mut completions = vec![];
-        for built in matcher.results() {
+        for (built, _) in matcher.results() {
             completions.extend(complete_rec(
                 &partial[1..],
                 &[built],
@@ -182,6 +182,7 @@ pub struct FileSuggestion {
     pub path: String,
     pub style: Option<Style>,
     pub is_dir: bool,
+    pub match_indices: Option<Vec<usize>>,
 }
 
 /// # Parameters
@@ -281,7 +282,7 @@ pub fn complete_item(
         options.match_algorithm == MatchAlgorithm::Prefix,
     )
     .into_iter()
-    .map(|mut p| {
+    .map(|(mut p, match_indices)| {
         if should_collapse_dots {
             p = collapse_ndots(p);
         }
@@ -299,6 +300,7 @@ pub fn complete_item(
             path: escape_path(path),
             style,
             is_dir,
+            match_indices,
         }
     })
     .collect()

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -5,6 +5,7 @@ use nucleo_matcher::{
     Config, Matcher, Utf32Str,
     pattern::{Atom, AtomKind, CaseMatching, Normalization},
 };
+use reedline::Suggestion;
 use std::{borrow::Cow, fmt::Display};
 
 use super::SemanticSuggestion;
@@ -49,8 +50,8 @@ enum State<T> {
     Fuzzy {
         matcher: Matcher,
         atom: Atom,
-        /// Holds (haystack, item, score)
-        items: Vec<(String, T, u16)>,
+        /// Holds (haystack, item, score, match_indices)
+        items: Vec<(String, T, u16, Vec<usize>)>,
     },
 }
 
@@ -158,7 +159,8 @@ impl<T> NuMatcher<'_, T> {
                     return false;
                 };
                 if let Some(item) = item {
-                    items.push((haystack.to_string(), item, score));
+                    let indices = indices.iter().map(|i| *i as usize).collect();
+                    items.push((haystack.to_string(), item, score, indices));
                 }
                 true
             }
@@ -177,10 +179,9 @@ impl<T> NuMatcher<'_, T> {
         self.matches_aux(haystack, None)
     }
 
-    /// Get all the items that matched (sorted)
-    pub fn results(self) -> Vec<T> {
-        match self.state {
-            State::Prefix { mut items, .. } | State::Substring { mut items, .. } => {
+    fn sort(&mut self) {
+        match &mut self.state {
+            State::Prefix { items, .. } | State::Substring { items, .. } => {
                 items.sort_by(|(haystack1, _), (haystack2, _)| {
                     let cmp_sensitive = haystack1.cmp(haystack2);
                     if self.options.case_sensitive {
@@ -192,26 +193,33 @@ impl<T> NuMatcher<'_, T> {
                             .then(cmp_sensitive)
                     }
                 });
-                items.into_iter().map(|(_, item)| item).collect::<Vec<_>>()
             }
-            State::Fuzzy { mut items, .. } => {
-                match self.options.sort {
-                    CompletionSort::Alphabetical => {
-                        items.sort_by(|(haystack1, _, _), (haystack2, _, _)| {
-                            haystack1.cmp(haystack2)
-                        });
-                    }
-                    CompletionSort::Smart => {
-                        items.sort_by(|(haystack1, _, score1), (haystack2, _, score2)| {
-                            score2.cmp(score1).then(haystack1.cmp(haystack2))
-                        });
-                    }
+            State::Fuzzy { items, .. } => match self.options.sort {
+                CompletionSort::Alphabetical => {
+                    items.sort_by(|(haystack1, _, _, _), (haystack2, _, _, _)| {
+                        haystack1.cmp(haystack2)
+                    });
                 }
-                items
-                    .into_iter()
-                    .map(|(_, item, _)| item)
-                    .collect::<Vec<_>>()
-            }
+                CompletionSort::Smart => {
+                    items.sort_by(|(haystack1, _, score1, _), (haystack2, _, score2, _)| {
+                        score2.cmp(score1).then(haystack1.cmp(haystack2))
+                    });
+                }
+            },
+        }
+    }
+
+    pub fn results(mut self) -> Vec<(T, Option<Vec<usize>>)> {
+        self.sort();
+        match self.state {
+            State::Prefix { items, .. } | State::Substring { items, .. } => items
+                .into_iter()
+                .map(|(_, item)| (item, None))
+                .collect::<Vec<_>>(),
+            State::Fuzzy { items, .. } => items
+                .into_iter()
+                .map(|(_, item, _, indices)| (item, Some(indices)))
+                .collect::<Vec<_>>(),
         }
     }
 }
@@ -220,6 +228,26 @@ impl NuMatcher<'_, SemanticSuggestion> {
     pub fn add_semantic_suggestion(&mut self, sugg: SemanticSuggestion) -> bool {
         let value = sugg.suggestion.value.to_string();
         self.add(value, sugg)
+    }
+
+    /// Get all the items that matched (sorted)
+    pub fn suggestion_results(mut self) -> Vec<SemanticSuggestion> {
+        self.sort();
+        match self.state {
+            State::Prefix { items, .. } | State::Substring { items, .. } => {
+                items.into_iter().map(|(_, item)| item).collect::<Vec<_>>()
+            }
+            State::Fuzzy { items, .. } => items
+                .into_iter()
+                .map(|(_, item, _, indices)| SemanticSuggestion {
+                    suggestion: Suggestion {
+                        match_indices: Some(indices),
+                        ..item.suggestion
+                    },
+                    kind: item.kind,
+                })
+                .collect::<Vec<_>>(),
+        }
     }
 }
 
@@ -308,10 +336,11 @@ mod test {
         };
         let mut matcher = NuMatcher::new(needle, &options);
         matcher.add(haystack, haystack);
+        let results: Vec<_> = matcher.results().iter().map(|r| r.0).collect();
         if should_match {
-            assert_eq!(vec![haystack], matcher.results());
+            assert_eq!(vec![haystack], results);
         } else {
-            assert_ne!(vec![haystack], matcher.results());
+            assert_ne!(vec![haystack], results);
         }
     }
 
@@ -326,7 +355,14 @@ mod test {
             matcher.add(item, item);
         }
         // Sort by score, then in alphabetical order
-        assert_eq!(vec!["fob", "foo bar", "foo/bar"], matcher.results());
+        assert_eq!(
+            vec![
+                ("fob", Some(vec![0, 1, 2])),
+                ("foo bar", Some(vec![0, 1, 4])),
+                ("foo/bar", Some(vec![0, 1, 4]))
+            ],
+            matcher.results()
+        );
     }
 
     #[test]
@@ -344,6 +380,12 @@ mod test {
             matcher.add(item, item);
         }
         // Make sure the spaces are respected
-        assert_eq!(vec!["'i love spaces' so much"], matcher.results());
+        assert_eq!(
+            vec![(
+                "'i love spaces' so much",
+                Some(vec![0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
+            )],
+            matcher.results()
+        );
     }
 }

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -157,7 +157,7 @@ impl<T: Completer> Completer for CustomCompletion<T> {
             for sugg in suggestions {
                 matcher.add_semantic_suggestion(sugg);
             }
-            matcher.results()
+            matcher.suggestion_results()
         } else {
             suggestions
                 .into_iter()

--- a/crates/nu-cli/src/completions/directory_completions.rs
+++ b/crates/nu-cli/src/completions/directory_completions.rs
@@ -45,6 +45,7 @@ impl Completer for DirectoryCompletion {
                     start: x.span.start - offset,
                     end: x.span.end - offset,
                 },
+                match_indices: x.match_indices,
                 ..Suggestion::default()
             },
             kind: Some(SuggestionKind::Directory),

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -137,6 +137,7 @@ impl Completer for DotNuCompletion {
                             path,
                             style: None,
                             is_dir: true,
+                            match_indices: None,
                         },
                     );
                 }
@@ -156,11 +157,15 @@ impl Completer for DotNuCompletion {
                             span,
                             style: None,
                             is_dir: matches!(sub_vp, VirtualPath::Dir(_)),
+                            match_indices: None,
                         },
                     );
                 }
             }
-            completions.extend(matcher.results());
+            for (mut sugg, inds) in matcher.results() {
+                sugg.match_indices = inds;
+                completions.push(sugg);
+            }
         }
 
         completions
@@ -199,6 +204,7 @@ impl Completer for DotNuCompletion {
                         style: x.style,
                         span: reedline::Span { start, end },
                         append_whitespace,
+                        match_indices: x.match_indices,
                         ..Suggestion::default()
                     },
                     kind: Some(SuggestionKind::Module),

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -48,6 +48,7 @@ impl Completer for FileCompletion {
                     start: x.span.start - offset,
                     end: x.span.end - offset,
                 },
+                match_indices: x.match_indices,
                 ..Suggestion::default()
             },
             kind: Some(if x.is_dir {

--- a/crates/nu-cli/src/completions/flag_completions.rs
+++ b/crates/nu-cli/src/completions/flag_completions.rs
@@ -53,6 +53,6 @@ impl Completer for FlagCompletion {
             }
             add_suggestion(format!("--{}", named.long), named.desc.clone());
         }
-        matcher.results()
+        matcher.suggestion_results()
     }
 }

--- a/crates/nu-cli/src/completions/operator_completions.rs
+++ b/crates/nu-cli/src/completions/operator_completions.rs
@@ -272,6 +272,6 @@ impl Completer for OperatorCompletion<'_> {
                 kind: Some(SuggestionKind::Operator),
             });
         }
-        matcher.results()
+        matcher.suggestion_results()
     }
 }

--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -74,6 +74,6 @@ impl Completer for VariableCompletion {
             }
         }
 
-        matcher.results()
+        matcher.suggestion_results()
     }
 }


### PR DESCRIPTION
# Description

Requires https://github.com/nushell/reedline/pull/798, which adds a `match_indices` field to `Suggestion` that allows completers to specify exactly which graphemes in the suggestion matched the typed text. This PR takes advantage of this field to accurately underline fuzzily-matched suggestions.

![image](https://github.com/user-attachments/assets/68b7ee06-cf54-4cc5-b554-3c745a6cb53e)

I modified Cargo.toml/lock just so people could try this out easily and workflows would run, but those changes will have to be reverted before merging.

# User-Facing Changes

Users will see sensible highlighting for suggestions when using fuzzy matching, nothing else.

# Tests + Formatting

Just manually triggered completions to make sure things look okay.

# After Submitting

No need to update docs for this.