### PR TITLE
Allow setting span and extra in custom completions

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -783,6 +783,36 @@ pub fn map_value_completions<'a>(
                             _ => None,
                         };
                     }
+                    "extra" => {
+                        // Convert the value to string
+                        if let Ok(extras) = value.as_list().and_then(|extras| {
+                            extras
+                                .iter()
+                                .map(|extra| extra.coerce_string())
+                                .collect::<Result<Vec<_>, _>>()
+                        }) {
+                            // Update the suggestion value
+                            suggestion.extra = Some(extras);
+                        }
+                    }
+                    "span" => {
+                        if let Value::Record { val: span, .. } = value {
+                            let start = span
+                                .get("start")
+                                .and_then(|val| val.as_int().ok())
+                                .and_then(|x| usize::try_from(x).ok());
+                            let end = span
+                                .get("end")
+                                .and_then(|val| val.as_int().ok())
+                                .and_then(|x| usize::try_from(x).ok());
+                            if let (Some(start), Some(end)) = (start, end) {
+                                suggestion.span = reedline::Span {
+                                    start: start.min(end),
+                                    end,
+                                };
+                            }
+                        }
+                    }
                     _ => (),
                 }
             });


### PR DESCRIPTION
# Description

This PR allows custom and extern completers to set the `span` and `extra` fields for the `Suggestion`s they provide.

The motivation for this is mainly making it easier to make completers for Zoxide.

# User-Facing Changes

Users will be able to choose which part of the buffer to replace. This is useful if you also want to replace one of the previous arguments to a command, or if you only want to replace part of an expression.

# Tests + Formatting

Didn't add any tests, but did manually try the following:
```
> def comp [context, pos] { [{value: mwahahaha, description: bar, span: {start: 0, end: $pos}}] }
> def foo [arg: string@comp] {}
```
After creating those definitions, `foo <TAB>` will replace the command line with `mwahahaha`.

The code for extracting `extra` from each record remains untested. The main reason I included it in this PR is because I intend to have the [custom menu source code](https://github.com/nushell/nushell/blob/main/crates/nu-cli/src/menus/menu_completions.rs) also use `map_value_completions` to reduce inconsistency.

# After Submitting

Needs to be mentioned in the completer docs.