### PR TITLE
Creates col and nth expressions when using paths on lazy frames.

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/custom_value.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/custom_value.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use nu_plugin::EngineInterface;
 use nu_protocol::{CustomValue, ShellError, Span, Value};
-use polars::prelude::col;
+use polars::prelude::{col, nth};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -101,12 +101,12 @@ impl PolarsPluginCustomValue for NuLazyFrameCustomValue {
     fn custom_value_follow_path_int(
         &self,
         plugin: &PolarsPlugin,
-        _engine: &EngineInterface,
+        engine: &EngineInterface,
         _self_span: Span,
         index: nu_protocol::Spanned<usize>,
     ) -> Result<Value, ShellError> {
-        let eager = NuLazyFrame::try_from_custom_value(plugin, self)?.collect(Span::unknown())?;
-        eager.get_value(index.item, index.span)
+        let expr = NuExpression::from(nth(index.item as i64));
+        expr.cache_and_to_value(plugin, engine, index.span)
     }
 
     fn custom_value_follow_path_string(


### PR DESCRIPTION
# Description
Instead of collecting the frame and returning the columns of the collected frame when using paths $df.column_name or $df.0 this creates expressions:

```nu
> ❯ : let df = polars open /tmp/foo.parquet
> ❯ : $df | polars select $df.pid | polars first 5 | polars collect
╭───┬───────╮
│ # │  pid  │
├───┼───────┤
│ 0 │ 45280 │
│ 1 │ 45252 │
│ 2 │ 45242 │
│ 3 │ 45241 │
│ 4 │ 45207 │
╰───┴───────╯

> ❯ : $df | polars select $df.0 | polars first 5 | polars collect
╭───┬───────╮
│ # │  pid  │
├───┼───────┤
│ 0 │ 45280 │
│ 1 │ 45252 │
│ 2 │ 45242 │
│ 3 │ 45241 │
│ 4 │ 45207 │
╰───┴───────╯
```
