### PR TITLE
(gstat): add config option to disable tag calculation

### DIFF
--- a/crates/nu_plugin_gstat/src/gstat.rs
+++ b/crates/nu_plugin_gstat/src/gstat.rs
@@ -21,6 +21,7 @@ impl GStat {
         value: &Value,
         current_dir: &str,
         path: Option<Spanned<String>>,
+        calculate_tag: bool,
         span: Span,
     ) -> Result<Value, LabeledError> {
         // use std::any::Any;
@@ -92,14 +93,14 @@ impl GStat {
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_else(|| "".to_string());
 
-        let mut desc_opts = DescribeOptions::new();
-        desc_opts.describe_tags();
-
-        let tag = if let Ok(Ok(s)) = repo.describe(&desc_opts).map(|d| d.format(None)) {
-            s
-        } else {
-            "no_tag".to_string()
-        };
+        let tag = calculate_tag
+            .then(|| {
+                let mut desc_opts = DescribeOptions::new();
+                desc_opts.describe_tags();
+                repo.describe(&desc_opts).ok()?.format(None).ok()
+            })
+            .flatten()
+            .unwrap_or_else(|| "no_tag".to_string());
 
         // Leave this in case we want to turn it into a table instead of a list
         // Ok(Value::List {

--- a/crates/nu_plugin_gstat/src/nu/mod.rs
+++ b/crates/nu_plugin_gstat/src/nu/mod.rs
@@ -41,6 +41,17 @@ impl SimplePluginCommand for GStat {
         let repo_path: Option<Spanned<String>> = call.opt(0)?;
         // eprintln!("input value: {:#?}", &input);
         let current_dir = engine.get_current_dir()?;
-        self.gstat(input, &current_dir, repo_path, call.head)
+
+        let calculate_tag = engine
+            .get_plugin_config()?
+            .map(|config| {
+                config
+                    .get_data_by_key("tag")
+                    .map(|tag| tag.as_bool())
+                    .unwrap_or(Ok(true))
+            })
+            .unwrap_or(Ok(true))?;
+
+        self.gstat(input, &current_dir, repo_path, calculate_tag, call.head)
     }
 }

--- a/crates/nu_plugin_gstat/src/nu/mod.rs
+++ b/crates/nu_plugin_gstat/src/nu/mod.rs
@@ -27,6 +27,7 @@ impl SimplePluginCommand for GStat {
 
     fn signature(&self) -> Signature {
         Signature::build(PluginCommand::name(self))
+            .switch("disable-tag", "Disable git tag resolving", None)
             .optional("path", SyntaxShape::Filepath, "path to repo")
             .category(Category::Custom("prompt".to_string()))
     }
@@ -41,17 +42,8 @@ impl SimplePluginCommand for GStat {
         let repo_path: Option<Spanned<String>> = call.opt(0)?;
         // eprintln!("input value: {:#?}", &input);
         let current_dir = engine.get_current_dir()?;
+        let disable_tag = call.has_flag("disable-tag")?;
 
-        let calculate_tag = engine
-            .get_plugin_config()?
-            .map(|config| {
-                config
-                    .get_data_by_key("tag")
-                    .map(|tag| tag.as_bool())
-                    .unwrap_or(Ok(true))
-            })
-            .unwrap_or(Ok(true))?;
-
-        self.gstat(input, &current_dir, repo_path, calculate_tag, call.head)
+        self.gstat(input, &current_dir, repo_path, !disable_tag, call.head)
     }
 }

--- a/crates/nu_plugin_gstat/src/nu/mod.rs
+++ b/crates/nu_plugin_gstat/src/nu/mod.rs
@@ -27,7 +27,7 @@ impl SimplePluginCommand for GStat {
 
     fn signature(&self) -> Signature {
         Signature::build(PluginCommand::name(self))
-            .switch("disable-tag", "Disable git tag resolving", None)
+            .switch("no-tag", "Disable git tag resolving", None)
             .optional("path", SyntaxShape::Filepath, "path to repo")
             .category(Category::Custom("prompt".to_string()))
     }
@@ -42,7 +42,7 @@ impl SimplePluginCommand for GStat {
         let repo_path: Option<Spanned<String>> = call.opt(0)?;
         // eprintln!("input value: {:#?}", &input);
         let current_dir = engine.get_current_dir()?;
-        let disable_tag = call.has_flag("disable-tag")?;
+        let disable_tag = call.has_flag("no-tag")?;
 
         self.gstat(input, &current_dir, repo_path, !disable_tag, call.head)
     }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Fixes #15884.
Adds `--disable-tag` flag to the `gstat` plugin that disables expensive calculations. Instead `gstat` reports `no_tag`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
There is no change in behaviour if the flag is not provided.

If the flag is provided, it will behave like there is no tags in the repo, so no existing config will break.