### PR TITLE
drop nth command supports spreadable arguments

### DIFF
--- a/crates/nu-command/src/filters/drop/nth.rs
+++ b/crates/nu-command/src/filters/drop/nth.rs
@@ -124,7 +124,7 @@ impl Command for DropNth {
 
         Ok(DropNthIterator {
             input: input.into_iter(),
-            rows: rows_to_drop.into(),
+            rows: VecDeque::from(rows_to_drop),
             current: 0,
         }
         .into_pipeline_data_with_metadata(head, engine_state.signals().clone(), metadata))
@@ -219,7 +219,7 @@ fn get_rows_to_drop(
 
 struct DropNthIterator {
     input: PipelineIterator,
-    rows: Vec<usize>,
+    rows: VecDeque<usize>,
     current: usize,
 }
 
@@ -228,9 +228,9 @@ impl Iterator for DropNthIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if let Some(row) = self.rows.first() {
+            if let Some(row) = self.rows.front() {
                 if self.current == *row {
-                    self.rows.remove(0);
+                    self.rows.pop_front();
                     self.current += 1;
                     let _ = self.input.next();
                     continue;

--- a/crates/nu-command/src/filters/drop/nth.rs
+++ b/crates/nu-command/src/filters/drop/nth.rs
@@ -124,7 +124,7 @@ impl Command for DropNth {
 
         Ok(DropNthIterator {
             input: input.into_iter(),
-            rows: VecDeque::from(rows_to_drop),
+            rows: rows_to_drop,
             current: 0,
         }
         .into_pipeline_data_with_metadata(head, engine_state.signals().clone(), metadata))

--- a/crates/nu-command/src/filters/drop/nth.rs
+++ b/crates/nu-command/src/filters/drop/nth.rs
@@ -1,5 +1,6 @@
 use nu_engine::command_prelude::*;
 use nu_protocol::{PipelineIterator, Range};
+use std::collections::VecDeque;
 use std::ops::Bound;
 
 #[derive(Clone)]
@@ -99,110 +100,14 @@ impl Command for DropNth {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let metadata = input.metadata().as_ref().cloned();
+        let metadata = input.metadata();
 
         let args: Vec<Value> = call.rest(engine_state, stack, 0)?;
-
         if args.is_empty() {
             return Ok(input);
         }
 
-        let mut rows_to_drop = vec![];
-        let mut min_unbounded_start: Option<usize> = None;
-
-        for value in args {
-            if let Ok(i) = value.as_int() {
-                if i < 0 {
-                    return Err(ShellError::UnsupportedInput {
-                        msg: "drop nth accepts only positive ints".into(),
-                        input: "value originates from here".into(),
-                        msg_span: head,
-                        input_span: value.span(),
-                    });
-                }
-                rows_to_drop.push(i as usize);
-            } else if let Ok(range) = value.as_range() {
-                match range {
-                    Range::IntRange(range) => {
-                        let start = range.start();
-                        if start < 0 {
-                            return Err(ShellError::UnsupportedInput {
-                                msg: "drop nth accepts only positive ints".into(),
-                                input: "value originates from here".into(),
-                                msg_span: head,
-                                input_span: value.span(),
-                            });
-                        }
-
-                        match range.end() {
-                            Bound::Included(end) => {
-                                if end < start {
-                                    return Err(ShellError::UnsupportedInput {
-                                    msg: "The upper bound must be greater than or equal to the lower bound".into(),
-                                    input: "value originates from here".into(),
-                                    msg_span: head,
-                                    input_span: value.span(),
-                                });
-                                }
-
-                                let end = if let PipelineData::Value(Value::List { vals, .. }, _) =
-                                    &input
-                                {
-                                    end.min((vals.len() as i64) - 1)
-                                } else {
-                                    end
-                                };
-
-                                rows_to_drop.extend((start as usize)..=(end as usize));
-                            }
-                            Bound::Excluded(end) => {
-                                if end <= start {
-                                    return Err(ShellError::UnsupportedInput {
-                                        msg: "The upper bound must be greater than the lower bound"
-                                            .into(),
-                                        input: "value originates from here".into(),
-                                        msg_span: head,
-                                        input_span: value.span(),
-                                    });
-                                }
-
-                                let end = if let PipelineData::Value(Value::List { vals, .. }, _) =
-                                    &input
-                                {
-                                    (end - 1).min((vals.len() as i64) - 1)
-                                } else {
-                                    end - 1
-                                };
-
-                                rows_to_drop.extend((start as usize)..=(end as usize));
-                            }
-                            Bound::Unbounded => {
-                                let start_usize = start as usize;
-                                min_unbounded_start = Some(
-                                    min_unbounded_start.map_or(start_usize, |s| s.min(start_usize)),
-                                );
-                            }
-                        }
-                    }
-                    Range::FloatRange(_) => {
-                        return Err(ShellError::UnsupportedInput {
-                            msg: "float range not supported".into(),
-                            input: "value originates from here".into(),
-                            msg_span: head,
-                            input_span: value.span(),
-                        });
-                    }
-                }
-            } else {
-                return Err(ShellError::TypeMismatch {
-                    err_message: "Expected int or range".into(),
-                    span: value.span(),
-                });
-            }
-        }
-
-        rows_to_drop.sort_unstable();
-        rows_to_drop.dedup();
+        let (rows_to_drop, min_unbounded_start) = get_rows_to_drop(&args, head)?;
 
         let input = if let Some(cutoff) = min_unbounded_start {
             input
@@ -219,15 +124,97 @@ impl Command for DropNth {
 
         Ok(DropNthIterator {
             input: input.into_iter(),
-            rows: rows_to_drop,
+            rows: rows_to_drop.into(),
             current: 0,
         }
-        .into_pipeline_data_with_metadata(
-            head,
-            engine_state.signals().clone(),
-            metadata.clone(),
-        ))
+        .into_pipeline_data_with_metadata(head, engine_state.signals().clone(), metadata))
     }
+}
+
+fn get_rows_to_drop(
+    args: &[Value],
+    head: Span,
+) -> Result<(VecDeque<usize>, Option<usize>), ShellError> {
+    let mut rows_to_drop = Vec::new();
+    let mut min_unbounded_start: Option<usize> = None;
+
+    for value in args {
+        if let Ok(i) = value.as_int() {
+            if i < 0 {
+                return Err(ShellError::UnsupportedInput {
+                    msg: "drop nth accepts only positive ints".into(),
+                    input: "value originates from here".into(),
+                    msg_span: head,
+                    input_span: value.span(),
+                });
+            }
+            rows_to_drop.push(i as usize);
+        } else if let Ok(range) = value.as_range() {
+            match range {
+                Range::IntRange(range) => {
+                    let start = range.start();
+                    if start < 0 {
+                        return Err(ShellError::UnsupportedInput {
+                            msg: "drop nth accepts only positive ints".into(),
+                            input: "value originates from here".into(),
+                            msg_span: head,
+                            input_span: value.span(),
+                        });
+                    }
+
+                    match range.end() {
+                        Bound::Included(end) => {
+                            if end < start {
+                                return Err(ShellError::UnsupportedInput {
+                                    msg: "The upper bound must be greater than or equal to the lower bound".into(),
+                                    input: "value originates from here".into(),
+                                    msg_span: head,
+                                    input_span: value.span(),
+                                });
+                            }
+                            rows_to_drop.extend((start as usize)..=(end as usize));
+                        }
+                        Bound::Excluded(end) => {
+                            if end <= start {
+                                return Err(ShellError::UnsupportedInput {
+                                    msg: "The upper bound must be greater than the lower bound"
+                                        .into(),
+                                    input: "value originates from here".into(),
+                                    msg_span: head,
+                                    input_span: value.span(),
+                                });
+                            }
+                            rows_to_drop.extend((start as usize)..(end as usize));
+                        }
+                        Bound::Unbounded => {
+                            let start_usize = start as usize;
+                            min_unbounded_start = Some(
+                                min_unbounded_start.map_or(start_usize, |s| s.min(start_usize)),
+                            );
+                        }
+                    }
+                }
+                Range::FloatRange(_) => {
+                    return Err(ShellError::UnsupportedInput {
+                        msg: "float range not supported".into(),
+                        input: "value originates from here".into(),
+                        msg_span: head,
+                        input_span: value.span(),
+                    });
+                }
+            }
+        } else {
+            return Err(ShellError::TypeMismatch {
+                err_message: "Expected int or range".into(),
+                span: value.span(),
+            });
+        }
+    }
+
+    rows_to_drop.sort_unstable();
+    rows_to_drop.dedup();
+
+    Ok((VecDeque::from(rows_to_drop), min_unbounded_start))
 }
 
 struct DropNthIterator {

--- a/crates/nu-command/tests/commands/drop.rs
+++ b/crates/nu-command/tests/commands/drop.rs
@@ -135,3 +135,75 @@ fn more_columns_than_record_has() {
 
     assert_eq!(actual.out, "{}");
 }
+
+#[test]
+fn drop_single_index() {
+    let actual = nu!("echo 10..15 | drop nth 2 | to json --raw");
+    assert_eq!(actual.out, "[10,11,13,14,15]");
+}
+
+#[test]
+fn drop_multiple_indices() {
+    let actual = nu!("echo 0..10 | drop nth 1 3 | to json --raw");
+    assert_eq!(actual.out, "[0,2,4,5,6,7,8,9,10]");
+}
+
+#[test]
+fn drop_inclusive_range() {
+    let actual = nu!("echo 10..15 | drop nth (2..4) | to json --raw");
+    assert_eq!(actual.out, "[10,11,15]");
+}
+
+#[test]
+fn drop_exclusive_range() {
+    let actual = nu!("echo 10..15 | drop nth (2..<4) | to json --raw");
+    assert_eq!(actual.out, "[10,11,14,15]");
+}
+
+#[test]
+fn drop_unbounded_range() {
+    let actual = nu!("echo 0..5 | drop nth 3.. | to json --raw");
+    assert_eq!(actual.out, "[0,1,2]");
+}
+
+#[test]
+fn drop_multiple_ranges_including_unbounded() {
+    let actual = nu!(pipeline(
+        r#"
+        0..30
+        | drop nth 0..10 20..
+        | to json --raw
+        "#
+    ));
+
+    assert_eq!(actual.out, "[11,12,13,14,15,16,17,18,19]");
+}
+
+#[test]
+fn drop_combination_of_unbounded_range_and_single_index() {
+    let actual = nu!(pipeline(
+        r#"
+            echo 0..15
+            | drop nth 10.. 5
+            | to json --raw
+            "#
+    ));
+
+    assert_eq!(actual.out, "[0,1,2,3,4,6,7,8,9]");
+}
+
+#[test]
+fn drop_combination_of_two_unbounded_ranges() {
+    let actual = nu!(pipeline(
+        r#"
+            echo 0..150
+            | drop nth 0..100 999..
+            | to json --raw
+            "#
+    ));
+
+    let expected: Vec<u32> = (101..=150).collect();
+    let expected_json = serde_json::to_string(&expected).unwrap();
+
+    assert_eq!(actual.out, expected_json);
+}


### PR DESCRIPTION
## ✅ Improve `drop nth` command to support spreadable arguments

### Summary

This PR updates the `drop nth` command to support **spreadable arguments** in a way consistent with other commands like `which`, enabling:

```nu
[1 2 3 4 5] | drop nth 0 2 4
```

### What's Changed

* **Previously**: only a single index or a single range was accepted as the first argument, with rest arguments ignored for ranges.

* **Now**: the command accepts any combination of:

  * Integers: to drop individual rows
  * Ranges: to drop slices of rows
  * Unbounded ranges: like `3..`, to drop from index onward

Example:

```nu
[one two three four five six] | drop nth 0 2 4..5
# drops "one", "three", "five", and "six"
```

### Test 

Manual Test:
![nu-dron_n](https://github.com/user-attachments/assets/02f3988c-ac02-4245-967c-16a9604be406)


### Notes

As per feedback:

* We **only collect the list of indices** to drop, not the input stream.
* Unbounded ranges are handled by terminating the stream early.

Let me know if you'd like further changes
