### PR TITLE
nu-table: optimize table creation and width functions

### DIFF
--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -306,14 +306,17 @@ impl NuTable {
 
 // NOTE: Must never be called from nu-table - made only for tests
 // FIXME: remove it?
-#[cfg(test)]
+// #[cfg(test)]
 impl From<Vec<Vec<Text<String>>>> for NuTable {
     fn from(value: Vec<Vec<Text<String>>>) -> Self {
         let count_rows = value.len();
         let count_cols = if value.is_empty() { 0 } else { value[0].len() };
 
         let mut t = Self::new(count_rows, count_cols);
-        t.data = value;
+        for (i, row) in value.into_iter().enumerate() {
+            t.set_row(i, row);
+        }
+
         table_recalculate_widths(&mut t);
 
         t


### PR DESCRIPTION
> Further tests are welcomed.

It was already implemented that we precalculate widths, but nothing stops to do heights as well.
Because before all the calculus were wasted (literally).

It affects `table` and `table --expand`.
The only case when it does not work (even makes things slightly less optimal in case of `table` when `truncation` is used)

Sadly my tests are not showing the clear benefit.
I have no idea why I was expecting something :disappointed: 
But it must be there :)

Running `scope commands` + `$env.CMD_DURATION_MS`:

```log
# patch (release)
2355 2462 2210 2356 2303

# main (release)
2375 2240 2202 2297 2385
```

PS: as once mentioned all this stuff ought to be moved out `nu-table`