### PR TITLE
nu-table: (table -e) Reuse NuRecordsValue::width in some cases

### DIFF
--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -92,6 +92,16 @@ impl NuTable {
         self.count_cols
     }
 
+    pub fn create(text: String) -> NuRecordsValue {
+        Text::new(text)
+    }
+
+    pub fn insert_value(&mut self, pos: (usize, usize), value: NuRecordsValue) {
+        let width = value.width() + indent_sum(self.config.indent);
+        self.widths[pos.1] = max(self.widths[pos.1], width);
+        self.data[pos.0][pos.1] = value;
+    }
+
     pub fn insert(&mut self, pos: (usize, usize), text: String) {
         let text = Text::new(text);
         let width = text.width() + indent_sum(self.config.indent);

--- a/crates/nu-table/src/types/expanded.rs
+++ b/crates/nu-table/src/types/expanded.rs
@@ -3,6 +3,7 @@ use std::cmp::max;
 use nu_color_config::{Alignment, StyleComputer, TextStyle};
 use nu_engine::column::get_columns;
 use nu_protocol::{Config, Record, ShellError, Span, Value};
+use tabled::grid::records::vec_records::Cell;
 
 use crate::{
     NuTable, TableOpts, TableOutput,
@@ -186,13 +187,14 @@ fn expand_list(input: &[Value], cfg: Cfg<'_>) -> TableResult {
                 .and_then(|val| val.get(INDEX_COLUMN_NAME))
                 .map(|value| value.to_expanded_string("", cfg.opts.config))
                 .unwrap_or_else(|| index.to_string());
-            let index_width = string_width(&index_value);
+            let index_value = NuTable::create(index_value);
+            let index_width = index_value.width();
             if available_width <= index_width + extra_width + pad_width {
                 // NOTE: we don't wanna wrap index; so we return
                 return Ok(None);
             }
 
-            table.insert((row, 0), index_value);
+            table.insert_value((row, 0), index_value);
 
             index_column_width = max(index_column_width, index_width);
         }
@@ -241,9 +243,10 @@ fn expand_list(input: &[Value], cfg: Cfg<'_>) -> TableResult {
                 .and_then(|val| val.get(INDEX_COLUMN_NAME))
                 .map(|value| value.to_expanded_string("", cfg.opts.config))
                 .unwrap_or_else(|| index.to_string());
-            let index_width = string_width(&index_value);
+            let index_value = NuTable::create(index_value);
+            let index_width = index_value.width();
 
-            table.insert((row + 1, 0), index_value);
+            table.insert_value((row + 1, 0), index_value);
             index_column_width = max(index_column_width, index_width);
         }
 
@@ -294,11 +297,13 @@ fn expand_list(input: &[Value], cfg: Cfg<'_>) -> TableResult {
 
             let inner_cfg = cfg_expand_reset_table(cfg.clone(), available);
             let cell = expand_entry_with_header(item, &header, inner_cfg);
-            let value_width = string_width(&cell.text); // TODO: optimize cause when we expand we alrready know the width (most of the time or all)
+            // TODO: optimize cause when we expand we alrready know the width (most of the time or all)
+            let value = NuTable::create(cell.text);
+            let value_width = value.width();
 
             column_width = max(column_width, value_width);
 
-            table.insert((row + 1, column), cell.text);
+            table.insert_value((row + 1, column), value);
             table.insert_style((row + 1, column), cell.style);
 
             total_column_rows = total_column_rows.saturating_add(cell.size);


### PR DESCRIPTION
Just remove a few calculations of width for values which will be inserted anyhow.
So it must be just a bit faster (in base case).