### PR TITLE
fix(polars): swap out pivot for pivot_stable to suppress warning message

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/data/pivot.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/pivot.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
 };
 
 use chrono::DateTime;
-use polars_ops::pivot::{PivotAgg, pivot};
+use polars_ops::pivot::{PivotAgg, pivot_stable};
 
 use crate::{
     PolarsPlugin,
@@ -237,7 +237,7 @@ fn command_eager(
 
     let polars_df = df.to_polars();
     // todo add other args
-    let pivoted = pivot(
+    let pivoted = pivot_stable(
         &polars_df,
         &on_col_string,
         Some(&index_col_string),


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
The current implementation of `polars pivot` calls an unsupported version of pivot that throws a warning message in stdout (using println!) stating that "unstable pivot not yet unsupported, using stable pivot." This PR swaps out the call to `pivot` with a call to `pivot_stable`, which is being done in the underlying polars anyways.

```nushell
#  Current Implementation
> [[a b c]; [1 x 10] [1 y 10] [2 x 11] [2 y 11]] | polars into-df | polars pivot -i [a] -o [b] -v [c]
unstable pivot not yet supported, using stable pivot
╭───┬───┬────┬────╮
│ # │ a │ x  │ y  │
├───┼───┼────┼────┤
│ 0 │ 1 │ 10 │ 10 │
│ 1 │ 2 │ 11 │ 11 │

#  Proposed Implementation (no println! statement)
> [[a b c]; [1 x 10] [1 y 10] [2 x 11] [2 y 11]] | polars into-df | polars pivot -i [a] -o [b] -v [c]
╭───┬───┬────┬────╮
│ # │ a │ x  │ y  │
├───┼───┼────┼────┤
│ 0 │ 1 │ 10 │ 10 │
│ 1 │ 2 │ 11 │ 11 │
╰───┴───┴────┴────╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
None

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Current suite of tests were sufficient

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
