### PR TITLE
make `date humanize` use `human_time_from_now()`

### DIFF
--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -1,6 +1,5 @@
 use crate::date::utils::parse_date_from_string;
 use chrono::{DateTime, FixedOffset, Local};
-use chrono_humanize::HumanTime;
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -90,7 +90,7 @@ fn helper(value: Value, head: Span) -> Value {
 }
 
 fn humanize_date(dt: DateTime<FixedOffset>) -> String {
-    HumanTime::from(dt).to_string()
+    nu_protocol::human_time_from_now(&dt).to_string()
 }
 
 #[cfg(test)]

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -4078,7 +4078,7 @@ fn operator_type_error(
     }
 }
 
-fn human_time_from_now(val: &DateTime<FixedOffset>) -> HumanTime {
+pub fn human_time_from_now(val: &DateTime<FixedOffset>) -> HumanTime {
     let now = Local::now().with_timezone(val.offset());
     let delta = *val - now;
     match delta.num_nanoseconds() {


### PR DESCRIPTION
# Description

This PR fixes a `date humanize` bug and makes it use @LoicRiegel's newer function `human_time_from_now()`.

### Before
```nushell
❯ (date now) + 3day
Wed, 11 Jun 2025 07:15:48 -0500 (in 3 days)
❯ (date now) + 3day | date humanize
in 2 days
```

### After
```nushell
❯ (date now) + 3day
Wed, 11 Jun 2025 07:23:10 -0500 (in 3 days)
❯ (date now) + 3day | date humanize
in 3 days
```

Closes #15916


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
