### PR TITLE
Fix typo in examples of the table command

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -152,7 +152,7 @@ impl Command for Table {
             },
             Example {
                 description: "Render data in table view (expanded)",
-                example: r#"[[a b]; [1 2] [2 [4 4]]] | table --expand"#,
+                example: r#"[[a b]; [1 2] [3 [4 4]]] | table --expand"#,
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
                         "a" =>  Value::test_int(1),
@@ -169,7 +169,7 @@ impl Command for Table {
             },
             Example {
                 description: "Render data in table view (collapsed)",
-                example: r#"[[a b]; [1 2] [2 [4 4]]] | table --collapse"#,
+                example: r#"[[a b]; [1 2] [3 [4 4]]] | table --collapse"#,
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
                         "a" =>  Value::test_int(1),
@@ -186,22 +186,22 @@ impl Command for Table {
             },
             Example {
                 description: "Change the table theme to the specified theme for a single run",
-                example: r#"[[a b]; [1 2] [2 [4 4]]] | table --theme basic"#,
+                example: r#"[[a b]; [1 2] [3 [4 4]]] | table --theme basic"#,
                 result: None,
             },
             Example {
                 description: "Force showing of the #/index column for a single run",
-                example: r#"[[a b]; [1 2] [2 [4 4]]] | table -i true"#,
+                example: r#"[[a b]; [1 2] [3 [4 4]]] | table -i true"#,
                 result: None,
             },
             Example {
                 description: "Set the starting number of the #/index column to 100 for a single run",
-                example: r#"[[a b]; [1 2] [2 [4 4]]] | table -i 100"#,
+                example: r#"[[a b]; [1 2] [3 [4 4]]] | table -i 100"#,
                 result: None,
             },
             Example {
                 description: "Force hiding of the #/index column for a single run",
-                example: r#"[[a b]; [1 2] [2 [4 4]]] | table -i false"#,
+                example: r#"[[a b]; [1 2] [3 [4 4]]] | table -i false"#,
                 result: None,
             },
         ]


### PR DESCRIPTION
# Description

Currently, the examples for `table` have a small typo (notice row 1, column a):
```
  Render data in table view
  > [[a b]; [1 2] [3 4]] | table
  ╭───┬───┬───╮
  │ # │ a │ b │
  ├───┼───┼───┤
  │ 0 │ 1 │ 2 │
  │ 1 │ 3 │ 4 │
  ╰───┴───┴───╯

  Render data in table view (expanded)
  > [[a b]; [1 2] [2 [4 4]]] | table --expand
  ╭───┬───┬───────────╮
  │ # │ a │     b     │
  ├───┼───┼───────────┤
  │ 0 │ 1 │         2 │
  │ 1 │ 3 │ ╭───┬───╮ │
  │   │   │ │ 0 │ 4 │ │
  │   │   │ │ 1 │ 4 │ │
  │   │   │ ╰───┴───╯ │
  ╰───┴───┴───────────╯

  Render data in table view (collapsed)
  > [[a b]; [1 2] [2 [4 4]]] | table --collapse
  ╭───┬───╮
  │ a │ b │
  ├───┼───┤
  │ 1 │ 2 │
  ├───┼───┤
  │ 3 │ 4 │
  │   ├───┤
  │   │ 4 │
  ╰───┴───╯
  ```

I changed the example commands to match their outputs, and swapped the 2 for a 3 in all the following examples too, for consistency.

# User-Facing Changes

More accurate examples for the `table` command.

# Tests + Formatting

No changes

# After Submitting

