### PR TITLE
Fix docs typo referring to non-existant `Value::CustomValue`

### DIFF
--- a/crates/nu-protocol/src/value/custom_value.rs
+++ b/crates/nu-protocol/src/value/custom_value.rs
@@ -7,7 +7,7 @@ use crate::{ShellError, Span, Type, Value, ast::Operator};
 pub trait CustomValue: fmt::Debug + Send + Sync {
     /// Custom `Clone` implementation
     ///
-    /// This can reemit a `Value::CustomValue(Self, span)` or materialize another representation
+    /// This can reemit a `Value::Custom(Self, span)` or materialize another representation
     /// if necessary.
     fn clone_value(&self, span: Span) -> Value;
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1981,7 +1981,7 @@ impl Value {
     /// as it will point into unknown source when used in errors.
     ///
     /// Returns a `Vec` containing one of each value case (`Value::Int`, `Value::String`, etc.)
-    /// except for `Value::CustomValue`.
+    /// except for `Value::Custom`.
     pub fn test_values() -> Vec<Value> {
         vec![
             Value::test_bool(false),


### PR DESCRIPTION
# Description

I was messing around with custom types and noticed `nu-protocol` referring to a `Value::CustomValue` variant that doesn't exist. Fixed it to say `Value::Custom` instead.

# User-Facing Changes

Documentation mentions the correct variant of `Value`

# Tests + Formatting

No new tests necessary

# After Submitting