### PR TITLE
add `like`, `not-like` to `help operators`

### DIFF
--- a/crates/nu-command/src/help/help_operators.rs
+++ b/crates/nu-command/src/help/help_operators.rs
@@ -68,16 +68,40 @@ impl Command for HelpOperators {
         ]
         .into_iter()
         .map(|op| {
-            Value::record(
-                record! {
-                    "type" => Value::string(op_type(&op), head),
-                    "operator" => Value::string(op.to_string(), head),
-                    "name" => Value::string(name(&op), head),
-                    "description" => Value::string(description(&op), head),
-                    "precedence" => Value::int(op.precedence().into(), head),
-                },
-                head,
-            )
+            if op == Operator::Comparison(Comparison::RegexMatch) {
+                Value::record(
+                    record! {
+                        "type" => Value::string(op_type(&op), head),
+                        "operator" => Value::string("=~, like", head),
+                        "name" => Value::string(name(&op), head),
+                        "description" => Value::string(description(&op), head),
+                        "precedence" => Value::int(op.precedence().into(), head),
+                    },
+                    head,
+                )
+            } else if op == Operator::Comparison(Comparison::NotRegexMatch) {
+                Value::record(
+                    record! {
+                        "type" => Value::string(op_type(&op), head),
+                        "operator" => Value::string("!~, not-like", head),
+                        "name" => Value::string(name(&op), head),
+                        "description" => Value::string(description(&op), head),
+                        "precedence" => Value::int(op.precedence().into(), head),
+                    },
+                    head,
+                )
+            } else {
+                Value::record(
+                    record! {
+                        "type" => Value::string(op_type(&op), head),
+                        "operator" => Value::string(op.to_string(), head),
+                        "name" => Value::string(name(&op), head),
+                        "description" => Value::string(description(&op), head),
+                        "precedence" => Value::int(op.precedence().into(), head),
+                    },
+                    head,
+                )
+            }
         })
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
# Description

This PR adds `like` and `not-like` to the `help operators` command. Now it at least lists them. I wasn't sure if I should say `=~ or like` so I just separated them with a comma.
![image](https://github.com/user-attachments/assets/1165d900-80a2-4633-9b75-109fcb617c75)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
