### PR TITLE
feat(format number): add `--no-prefix` flag

### DIFF
--- a/crates/nu-cmd-extra/src/extra/strings/format/number.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/number.rs
@@ -18,7 +18,7 @@ impl Command for FormatNumber {
             .input_output_types(vec![(Type::Number, Type::record())])
             .switch(
                 "no-prefix",
-                "don't include the binary, hex and octal prefixes",
+                "don't include the binary, hex or octal prefixes",
                 Some('n'),
             )
             .category(Category::Conversions)


### PR DESCRIPTION
# Description
I have added a `--no-prefix` flag to the `format number` command to not include the `0b`, `0x` and `0o` prefixes in the output. Also, I've changed the order in which the formats are displayed to one I thinks makes it easier to read, with the upper and lower alternatives next to each other.

![image](https://github.com/user-attachments/assets/cd50631d-1b27-40d4-84d9-f2ac125586d4)

# User-Facing Changes
The formatting of floats previously did not include prefixes while integers did. Now prefixes are on by default for both, while including the new flag removes them. Changing the order of the record shouldn't have any effect on previous code.

# Tests + Formatting
I have added an additional example that test this behavior.

# After Submitting
