### PR TITLE
If `save`-ing with non-existing parent dir, return directory_not_found

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -460,10 +460,16 @@ fn open_file(
                 if let Some(missing_component) =
                     path.ancestors().skip(1).filter(|dir| !dir.exists()).last()
                 {
+                    let components_to_remove = path
+                        .strip_prefix(missing_component)
+                        .expect("Stripping ancestor from a path should never fail")
+                        .as_os_str()
+                        .as_encoded_bytes();
+
                     return Err(ShellError::Io(IoError::new(
                         ErrorKind::DirectoryNotFound,
                         engine_state
-                            .get_prefix_span(span, missing_component.as_os_str().as_encoded_bytes())
+                            .span_strip_postfix(span, components_to_remove)
                             .unwrap_or(span),
                         PathBuf::from(missing_component),
                     )));

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -460,6 +460,8 @@ fn open_file(
                 if let Some(missing_component) =
                     path.ancestors().skip(1).filter(|dir| !dir.exists()).last()
                 {
+                    // By looking at the postfix to remove, rather than the prefix
+                    // to keep, we are able to handle relative paths too.
                     let components_to_remove = path
                         .strip_prefix(missing_component)
                         .expect("Stripping ancestor from a path should never fail")
@@ -469,7 +471,8 @@ fn open_file(
                     return Err(ShellError::Io(IoError::new(
                         ErrorKind::DirectoryNotFound,
                         engine_state
-                            .span_strip_postfix(span, components_to_remove)
+                            .span_match_postfix(span, components_to_remove)
+                            .map(|(pre, _post)| pre)
                             .unwrap_or(span),
                         PathBuf::from(missing_component),
                     )));

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -537,6 +537,39 @@ fn parent_redirection_doesnt_affect_save() {
 }
 
 #[test]
+fn save_missing_parent_dir() {
+    Playground::setup("save_test_24", |dirs, sandbox| {
+        sandbox.with_files(&[]);
+
+        let actual = nu!(
+            cwd: dirs.root(),
+            r#"'hello' | save save_test_24/foobar/hello.txt"#,
+        );
+
+        assert!(actual.err.contains("nu::shell::io::directory_not_found"));
+        assert!(actual.err.contains("foobar' does not exist"));
+    })
+}
+
+#[test]
+fn save_missing_ancestor_dir() {
+    Playground::setup("save_test_24", |dirs, sandbox| {
+        sandbox.with_files(&[]);
+
+        std::fs::create_dir(dirs.test().join("foo"))
+            .expect("should have been able to create subdir for test");
+
+        let actual = nu!(
+            cwd: dirs.root(),
+            r#"'hello' | save save_test_24/foo/bar/baz/hello.txt"#,
+        );
+
+        assert!(actual.err.contains("nu::shell::io::directory_not_found"));
+        assert!(actual.err.contains("bar' does not exist"));
+    })
+}
+
+#[test]
 fn force_save_to_dir() {
     let actual = nu!(cwd: "crates/nu-command/tests/commands", r#"
         "aaa" | save -f ..

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -768,6 +768,18 @@ impl EngineState {
         &[0u8; 0]
     }
 
+    /// If the span's content starts with the given prefix, return a new subspan
+    /// corresponding to this prefix.
+    pub fn get_prefix_span(&self, span: Span, prefix: &[u8]) -> Option<Span> {
+        let contents = self.get_span_contents(span);
+
+        if contents.starts_with(prefix) {
+            span.subspan(0, prefix.len())
+        } else {
+            None
+        }
+    }
+
     /// Get the global config from the engine state.
     ///
     /// Use [`Stack::get_config()`] instead whenever the `Stack` is available, as it takes into

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -780,6 +780,18 @@ impl EngineState {
         }
     }
 
+    /// If the span's content ends with the given postfix, return a new subspan
+    /// corresponding to the rest of the span.
+    pub fn span_strip_postfix(&self, span: Span, postfix: &[u8]) -> Option<Span> {
+        let contents = self.get_span_contents(span);
+
+        if contents.ends_with(postfix) {
+            span.subspan(0, span.len() - postfix.len())
+        } else {
+            None
+        }
+    }
+
     /// Get the global config from the engine state.
     ///
     /// Use [`Stack::get_config()`] instead whenever the `Stack` is available, as it takes into

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -768,25 +768,25 @@ impl EngineState {
         &[0u8; 0]
     }
 
-    /// If the span's content starts with the given prefix, return a new subspan
-    /// corresponding to this prefix.
-    pub fn get_prefix_span(&self, span: Span, prefix: &[u8]) -> Option<Span> {
+    /// If the span's content starts with the given prefix, return two subspans
+    /// corresponding to this prefix, and the rest of the content.
+    pub fn span_match_prefix(&self, span: Span, prefix: &[u8]) -> Option<(Span, Span)> {
         let contents = self.get_span_contents(span);
 
         if contents.starts_with(prefix) {
-            span.subspan(0, prefix.len())
+            span.split_at(prefix.len())
         } else {
             None
         }
     }
 
-    /// If the span's content ends with the given postfix, return a new subspan
-    /// corresponding to the rest of the span.
-    pub fn span_strip_postfix(&self, span: Span, postfix: &[u8]) -> Option<Span> {
+    /// If the span's content ends with the given postfix, return two subspans
+    /// corresponding to the rest of the content, and this postfix.
+    pub fn span_match_postfix(&self, span: Span, prefix: &[u8]) -> Option<(Span, Span)> {
         let contents = self.get_span_contents(span);
 
-        if contents.ends_with(postfix) {
-            span.subspan(0, span.len() - postfix.len())
+        if contents.ends_with(prefix) {
+            span.split_at(span.len() - prefix.len())
         } else {
             None
         }

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -132,6 +132,33 @@ impl Span {
         Self::new(self.start - offset, self.end - offset)
     }
 
+    /// Return length of the slice.
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+
+    /// Indicate if slice has length 0.
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+
+    /// Return another span fully inside the [`Span`].
+    ///
+    /// `start` and `end` are relative to `self.start`, and must lie within the `Span`.
+    /// In other words, both `start` and `end` must be `<= self.len()`.
+    pub fn subspan(&self, offset_start: usize, offset_end: usize) -> Option<Self> {
+        let len = self.len();
+
+        if offset_start > len || offset_end > len || offset_start > offset_end {
+            None
+        } else {
+            Some(Self::new(
+                self.start + offset_start,
+                self.start + offset_end,
+            ))
+        }
+    }
+
     pub fn contains(&self, pos: usize) -> bool {
         self.start <= pos && pos < self.end
     }

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -159,6 +159,18 @@ impl Span {
         }
     }
 
+    /// Return two spans that split the ['Span'] at the given position.
+    pub fn split_at(&self, offset: usize) -> Option<(Self, Self)> {
+        if offset < self.len() {
+            Some((
+                Self::new(self.start, self.start + offset),
+                Self::new(self.start + offset, self.end),
+            ))
+        } else {
+            None
+        }
+    }
+
     pub fn contains(&self, pos: usize) -> bool {
         self.start <= pos && pos < self.end
     }


### PR DESCRIPTION
- adresses #15924 (at least the part about the error message)

# Description

Trying to `save` to a path if any of the ancestor dirs is missing currently gives a `not_found` error.

Take this example, assuming there's no `foobar` in my `/tmp`:
```
❯ : 'hello world' | save '/tmp/foobar/hello.txt'
Error: nu::shell::io::not_found

  × Not found
   ╭─[entry #15:1:22]
 1 │ 'hello world' | save '/tmp/foobar/hello.txt'
   ·                      ───────────┬───────────
   ·                                 ╰── Not found
   ╰────
  help: '/tmp/foobar/hello.txt' does not exist
```

Since the point of `save` in this context is to create this `hello.txt` file, this error can be confusing to users, and obscures the actual issue (maybe `foobar` was a typo?).

Instead, after the `not_found` error has already happened, we can check the path argument, to find which component might be missing, and report an error pointing at that.
(This technically introduces a race condition between failing to open the path, and checking ancestor directories, but worst case we report an inaccurate error.)

***

The above example now looks like this:
```
> 'hello world' | save /tmp/foobar/hello.txt
Error: nu::shell::io::directory_not_found

  × Directory not found
   ╭─[entry #1:1:22]
 1 │ 'hello world' | save /tmp/foobar/hello.txt
   ·                      ──────────┬──────────
   ·                                ╰── Directory not found
   ╰────
  help: '/tmp/foobar' does not exist
```

Or, with a missing directory thats not the direct parent:
```
> mkdir /tmp/foo
> 'hello world' | save /tmp/foo/bar/baz/hello.txt
Error: nu::shell::io::directory_not_found

  × Directory not found
   ╭─[entry #7:1:22]
 1 │ 'hello world' | save /tmp/foo/bar/baz/hello.txt
   ·                      ─────────────┬────────────
   ·                                   ╰── Directory not found
   ╰────
  help: '/tmp/foo/bar' does not exist
 ```

Either way, now I immediately know what to `mkdir` :)

# User-Facing Changes

- `save` may now return `nu::shell::io::directory_not_found`, pointing the user to a missing directory in the `filename` arg.

# Tests + Formatting

new tests:
1. `commands::save::save_missing_parent_dir`: direct parent dir of target file doesn't exist, verifies that:
    - `commands::save::save_missing_parent_dir` error is returned
    - help message is pointing at the missing dir, not the full target path
2. `commands::save::save_missing_parent_dir`: same as above, but for a missing ancestor dir, which isn't the direct parent of the target path
    - verifies that help message is pointing at the "top-most missing" component

# After Submitting

The documentation doesn't show any examples of `save` errors, so I don't think any changes are necessary. Correct me if I'm wrong though!