### PR TITLE
feat(std/help): Add `--help` for external-commands

### DIFF
--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -789,7 +789,6 @@ def external-commands [
     } else {
         ^($env.NU_HELPER? | default "man") $target_command
     }
-
 }
 
 # Show help on commands.

--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -782,7 +782,7 @@ def scope-commands [
 def external-commands [
     ...command: string@"nu-complete list-commands",
 ] {
-    let target_command = $command | str join " "
+    let target_command = $command | str join " " | str replace "^" ""
     print $"(ansi default_italic)Help pages from external command ($target_command | pretty-cmd):(ansi reset)"
     if $env.NU_HELPER? == "--help" {
         run-external ($target_command | split row " ") "--help"

--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -784,7 +784,12 @@ def external-commands [
 ] {
     let target_command = $command | str join " "
     print $"(ansi default_italic)Help pages from external command ($target_command | pretty-cmd):(ansi reset)"
-    ^($env.NU_HELPER? | default "man") $target_command
+    if $env.NU_HELPER? == "--help" {
+        run-external $target_command "--help"
+    } else {
+        ^($env.NU_HELPER? | default "man") $target_command
+    }
+
 }
 
 # Show help on commands.

--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -785,7 +785,7 @@ def external-commands [
     let target_command = $command | str join " "
     print $"(ansi default_italic)Help pages from external command ($target_command | pretty-cmd):(ansi reset)"
     if $env.NU_HELPER? == "--help" {
-        run-external $target_command "--help"
+        run-external ($target_command | split row " ") "--help"
     } else {
         ^($env.NU_HELPER? | default "man") $target_command
     }

--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -812,6 +812,11 @@ def pretty-cmd [] {
 # Display help information about different parts of Nushell.
 #
 # `help word` searches for "word" in commands, aliases and modules, in that order.
+# If not found as internal to nushell, you can set `$env.NU_HELPER` to a program
+# (default: man) and "word" will be passed as the first argument.
+# Alternatively, you can set `$env.NU_HELPER` to `--help` and it will run "word" as
+# an external and pass `--help` as the last argument (this could cause unintended
+# behaviour if it doesn't support the flag, use it carefully).
 #
 # Examples:
 #   show help for single command, alias, or module


### PR DESCRIPTION
# Description
I have just discovered the `std/help` command and that it can use `man` or other programs for externals. Coming from windows, I don't have `man` so what I want is just to run `external_program --help` in most cases. This pr adds that option, if you set `$env.NU_HELPER = "--help"`, it will run the command you passed with `--help` added as the last argument.

![image](https://github.com/user-attachments/assets/60d25dda-718b-4cb5-b540-808de000b221)

# User-Facing Changes
None

# Tests + Formatting


# After Submitting
