### PR TITLE
Allow `polars schema --datatype-list` to be used without pipeline input

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/core/schema.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/schema.rs
@@ -25,7 +25,7 @@ impl PluginCommand for SchemaCmd {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .switch("datatype-list", "creates a lazy dataframe", Some('l'))
-            .input_output_type(Type::Custom("dataframe".into()), Type::record())
+            .input_output_type(Type::Any, Type::record())
             .category(Category::Custom("dataframe".into()))
     }
 


### PR DESCRIPTION
# Description
Fixes the issue of listing allowed datatypes when not being used with dataframe pipeline input.