### PR TITLE
feat(gstat): add `state` entry (like "Clean", "Merge", "Rebase", etc.)

### DIFF
--- a/crates/nu_plugin_gstat/src/gstat.rs
+++ b/crates/nu_plugin_gstat/src/gstat.rs
@@ -133,6 +133,7 @@ impl GStat {
                 "tag" => Value::string(tag, span),
                 "branch" => Value::string(stats.branch, span),
                 "remote" => Value::string(stats.remote, span),
+                "state" => Value::string(stats.state, span),
             },
             span,
         ))
@@ -160,6 +161,7 @@ impl GStat {
                 "tag" => Value::string("no_tag", span),
                 "branch" => Value::string("no_branch", span),
                 "remote" => Value::string("no_remote", span),
+                "state" => Value::string("no_state", span),
             },
             span,
         )
@@ -206,6 +208,10 @@ pub struct Stats {
     pub branch: String,
     /// The of the upstream branch
     pub remote: String,
+
+    /// State of the repository (Clean, Merge, Rebase, etc.)
+    /// See all states at https://docs.rs/git2/latest/git2/enum.RepositoryState.html
+    pub state: String,
 }
 
 impl Stats {
@@ -214,6 +220,7 @@ impl Stats {
         let mut st: Stats = Default::default();
 
         st.read_branch(repo);
+        st.state = format!("{:?}", repo.state());
 
         let mut opts = git2::StatusOptions::new();
 


### PR DESCRIPTION
# Description

This PR adds a new `state` key to the output of `gstat` that shows the current repo state state. Like "Clean", "Merge", "Rebase", etc. The full list of possible values can be seen [here](https://docs.rs/git2/latest/git2/enum.RepositoryState.html).

This information is somewhat useful when shown in prompt. Not often needed, but sometimes really useful.

# User-Facing Changes

New key added to `gstat` output. I don't think it should cause issues to `gstat` users.

# Tests + Formatting

I couldn't find any tests for `nu_plugin_gstat`.

# After Submitting

I couldn't find any documentation about the output of `gstat`, so I don't think there is anything to be done here either.