### PR TITLE
auto-expand `.` to `pwd` in `path relative-to`

### DIFF
--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -57,9 +57,12 @@ path."#
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let args = Arguments {
-            path: call.req(engine_state, stack, 0)?,
-        };
+        let mut path_arg: Spanned<String> = call.req(engine_state, stack, 0)?;
+        // If the path is ".", replace it with the current working directory
+        if path_arg.item == "." {
+            path_arg.item = engine_state.cwd(Some(stack))?.display().to_string();
+        }
+        let args = Arguments { path: path_arg };
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
@@ -78,9 +81,12 @@ path."#
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let args = Arguments {
-            path: call.req_const(working_set, 0)?,
-        };
+        let mut path_arg: Spanned<String> = call.req_const(working_set, 0)?;
+        // If the path is ".", replace it with the current working directory
+        if path_arg.item == "." {
+            path_arg.item = working_set.permanent().cwd(None)?.display().to_string();
+        }
+        let args = Arguments { path: path_arg };
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {


### PR DESCRIPTION
# Description

This PR auto-expands `.` to the cwd so you don't have to do `('.' | path expand)`.

I'm not sure if this is a good idea or not. I assume there are a lot of places that `.` does not get expanded and doing it here my just make things inconsistent. What do you think?

### Before
```nushell
❯ glob crat* | path relative-to '.'
Error: nu::shell::cant_convert

  × Can't convert to prefix not found.
   ╭─[entry #1:1:1]
 1 │ glob crat* | path relative-to '.'
   · ──┬─
   ·   ╰── can't convert string to prefix not found
   ╰────
```

### After
```nushell
❯ glob crat* | path relative-to '.'
╭───┬────────╮
│ 0 │ crates │
╰───┴────────╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
