### PR TITLE
Update Nu for release and nightly workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -46,7 +46,7 @@ jobs:
         uses: hustcer/setup-nu@v3
         if: github.repository == 'nushell/nightly'
         with:
-          version: 0.103.0
+          version: 0.105.1
 
       # Synchronize the main branch of nightly repo with the main branch of Nushell official repo
       - name: Prepare for Nightly Release
@@ -183,31 +183,16 @@ jobs:
 
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
-      if: ${{ matrix.os != 'windows-11-arm' }}
       with:
-        version: 0.103.0
+        version: 0.105.1
 
     - name: Release Nu Binary
       id: nu
-      if: ${{ matrix.os != 'windows-11-arm' }}
       run: nu .github/workflows/release-pkg.nu
       env:
         OS: ${{ matrix.os }}
         REF: ${{ github.ref }}
         TARGET: ${{ matrix.target }}
-
-    - name: Build Nu for Windows ARM64
-      id: nu0
-      shell: pwsh
-      if: ${{ matrix.os == 'windows-11-arm' }}
-      run: |
-        $env:OS = 'windows'
-        $env:REF = '${{ github.ref }}'
-        $env:TARGET = '${{ matrix.target }}'
-        cargo build --release --all --target aarch64-pc-windows-msvc
-        cp ./target/${{ matrix.target }}/release/nu.exe .
-        ./nu.exe -c 'version'
-        ./nu.exe ${{github.workspace}}/.github/workflows/release-pkg.nu
 
     - name: Create an Issue for Release Failure
       if: ${{ failure() }}
@@ -228,9 +213,7 @@ jobs:
         prerelease: true
         files: |
           ${{ steps.nu.outputs.msi }}
-          ${{ steps.nu0.outputs.msi }}
           ${{ steps.nu.outputs.archive }}
-          ${{ steps.nu0.outputs.archive }}
         tag_name: ${{ needs.prepare.outputs.nightly_tag }}
         name: ${{ needs.prepare.outputs.build_date }}-${{ needs.prepare.outputs.nightly_tag }}
       env:
@@ -276,7 +259,7 @@ jobs:
       - name: Setup Nushell
         uses: hustcer/setup-nu@v3
         with:
-          version: 0.103.0
+          version: 0.105.1
 
       # Keep the last a few releases
       - name: Delete Older Releases

--- a/.github/workflows/release-msi.yml
+++ b/.github/workflows/release-msi.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
       with:
-        version: nightly
+        version: 0.105.1
 
     - name: Release MSI Packages
       id: nu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,31 +90,16 @@ jobs:
 
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
-      if: ${{ matrix.os != 'windows-11-arm' }}
       with:
-        version: 0.103.0
+        version: 0.105.1
 
     - name: Release Nu Binary
       id: nu
-      if: ${{ matrix.os != 'windows-11-arm' }}
       run: nu .github/workflows/release-pkg.nu
       env:
         OS: ${{ matrix.os }}
         REF: ${{ github.ref }}
         TARGET: ${{ matrix.target }}
-
-    - name: Build Nu for Windows ARM64
-      id: nu0
-      shell: pwsh
-      if: ${{ matrix.os == 'windows-11-arm' }}
-      run: |
-        $env:OS = 'windows'
-        $env:REF = '${{ github.ref }}'
-        $env:TARGET = '${{ matrix.target }}'
-        cargo build --release --all --target aarch64-pc-windows-msvc
-        cp ./target/${{ matrix.target }}/release/nu.exe .
-        ./nu.exe -c 'version'
-        ./nu.exe ${{github.workspace}}/.github/workflows/release-pkg.nu
 
     # WARN: Don't upgrade this action due to the release per asset issue.
     # See: https://github.com/softprops/action-gh-release/issues/445
@@ -125,9 +110,7 @@ jobs:
         draft: true
         files: |
           ${{ steps.nu.outputs.msi }}
-          ${{ steps.nu0.outputs.msi }}
           ${{ steps.nu.outputs.archive }}
-          ${{ steps.nu0.outputs.archive }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ unstable_cargo_features.txt
 # Helix configuration folder
 .helix/*
 .helix
+wix/bin/
+wix/obj/
+wix/nu/
 
 # Coverage tools
 lcov.info


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

1. Upgrade Nushell to 0.105.1 for release and nightly workflow
2. Use `hustcer/setup-nu` Action for `windows-11-arm` runner to simplify the workflow

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

None

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Looks fine here: https://github.com/hustcer/nushell/actions/runs/15657383788/job/44110173668#step:7:1357

