### PR TITLE
Use `CARGO_CFG_FEATURE` to get feature list in `version`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,6 @@ plugin = [
 
   # features
   "nu-cli/plugin",
-  "nu-cmd-lang/plugin",
   "nu-command/plugin",
   "nu-engine/plugin",
   "nu-engine/plugin",
@@ -286,21 +285,20 @@ stable = ["default"]
 
 # Enable to statically link OpenSSL (perl is required, to build OpenSSL https://docs.rs/openssl/latest/openssl/);
 # otherwise the system version will be used. Not enabled by default because it takes a while to build
-static-link-openssl = ["dep:openssl", "nu-cmd-lang/static-link-openssl"]
+static-link-openssl = ["dep:openssl"]
 
 # Optional system clipboard support in `reedline`, this behavior has problematic compatibility with some systems.
 # Missing X server/ Wayland can cause issues
 system-clipboard = [
   "reedline/system_clipboard",
   "nu-cli/system-clipboard",
-  "nu-cmd-lang/system-clipboard",
 ]
 
 # Stable (Default)
-trash-support = ["nu-command/trash-support", "nu-cmd-lang/trash-support"]
+trash-support = ["nu-command/trash-support"]
 
 # SQLite commands for nushell
-sqlite = ["nu-command/sqlite", "nu-cmd-lang/sqlite", "nu-std/sqlite"]
+sqlite = ["nu-command/sqlite", "nu-std/sqlite"]
 
 [profile.release]
 opt-level = "s"     # Optimize for size

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,8 +259,8 @@ tempfile = { workspace = true }
 [features]
 plugin = [
   # crates
-  "nu-cmd-plugin",
-  "nu-plugin-engine",
+  "dep:nu-cmd-plugin",
+  "dep:nu-plugin-engine",
 
   # features
   "nu-cli/plugin",

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -800,12 +800,15 @@ pub fn map_value_completions<'a>(
 
 #[cfg(test)]
 mod completer_tests {
+    use nu_cmd_lang::DefaultContextInit;
+
     use super::*;
 
     #[test]
     fn test_completion_helper() {
-        let mut engine_state =
-            nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
+        let mut engine_state = nu_command::add_shell_command_context(
+            nu_cmd_lang::create_default_context(DefaultContextInit::test()),
+        );
 
         // Custom additions
         let delta = {

--- a/crates/nu-cli/src/menus/help_completions.rs
+++ b/crates/nu-cli/src/menus/help_completions.rs
@@ -134,6 +134,7 @@ impl Completer for NuHelpCompleter {
 #[cfg(test)]
 mod test {
     use super::*;
+    use nu_cmd_lang::DefaultContextInit;
     use rstest::rstest;
 
     #[rstest]
@@ -147,8 +148,9 @@ mod test {
         #[case] end: usize,
         #[case] expected: &[&str],
     ) {
-        let engine_state =
-            nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
+        let engine_state = nu_command::add_shell_command_context(
+            nu_cmd_lang::create_default_context(DefaultContextInit::test()),
+        );
         let config = engine_state.get_config().clone();
         let mut completer = NuHelpCompleter::new(engine_state.into(), config);
         let suggestions = completer.complete(line, end);

--- a/crates/nu-cli/tests/completions/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/completions/support/completions_helpers.rs
@@ -1,3 +1,4 @@
+use nu_cmd_lang::DefaultContextInit;
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_path::{AbsolutePathBuf, PathBuf};
@@ -11,7 +12,9 @@ use reedline::Suggestion;
 use std::path::MAIN_SEPARATOR;
 
 fn create_default_context() -> EngineState {
-    nu_command::add_shell_command_context(nu_cmd_lang::create_default_context())
+    nu_command::add_shell_command_context(nu_cmd_lang::create_default_context(
+        DefaultContextInit::test(),
+    ))
 }
 
 pub fn new_engine_helper(pwd: AbsolutePathBuf) -> (AbsolutePathBuf, String, EngineState, Stack) {

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -43,8 +43,3 @@ plugin = [
   "nu-protocol/plugin",
   "os",
 ]
-
-trash-support = []
-sqlite = []
-static-link-openssl = []
-system-clipboard = []

--- a/crates/nu-cmd-lang/src/core_commands/version.rs
+++ b/crates/nu-cmd-lang/src/core_commands/version.rs
@@ -9,7 +9,7 @@ shadow!(build);
 
 #[derive(Clone)]
 pub struct Version {
-    pub features: Vec<String>,
+    pub features: Vec<&'static str>,
 }
 
 impl Command for Version {
@@ -69,7 +69,7 @@ fn push_non_empty(record: &mut Record, name: &str, value: &str, span: Span) {
 pub fn version(
     engine_state: &EngineState,
     span: Span,
-    features: &[String],
+    features: &[&str],
 ) -> Result<PipelineData, ShellError> {
     // Pre-allocate the arrays in the worst case (17 items):
     // - version

--- a/crates/nu-cmd-lang/src/default_context.rs
+++ b/crates/nu-cmd-lang/src/default_context.rs
@@ -2,7 +2,15 @@ use crate::*;
 use nu_protocol::engine::{EngineState, StateWorkingSet};
 
 pub struct DefaultContextInit {
-    pub features: Vec<String>,
+    pub cargo_features: Vec<&'static str>,
+}
+
+impl DefaultContextInit {
+    pub fn test() -> Self {
+        Self {
+            cargo_features: vec![],
+        }
+    }
 }
 
 pub fn create_default_context(init: DefaultContextInit) -> EngineState {
@@ -66,7 +74,7 @@ pub fn create_default_context(init: DefaultContextInit) -> EngineState {
             ScopeVariables,
             Try,
             Use,
-            Version {features: init.features},
+            Version {features: init.cargo_features},
             While,
         };
 

--- a/crates/nu-cmd-lang/src/default_context.rs
+++ b/crates/nu-cmd-lang/src/default_context.rs
@@ -1,7 +1,11 @@
 use crate::*;
 use nu_protocol::engine::{EngineState, StateWorkingSet};
 
-pub fn create_default_context() -> EngineState {
+pub struct DefaultContextInit {
+    pub features: Vec<String>,
+}
+
+pub fn create_default_context(init: DefaultContextInit) -> EngineState {
     let mut engine_state = EngineState::new();
 
     let delta = {
@@ -62,7 +66,7 @@ pub fn create_default_context() -> EngineState {
             ScopeVariables,
             Try,
             Use,
-            Version,
+            Version {features: init.features},
             While,
         };
 

--- a/crates/nu-cmd-lang/src/parse_const_test.rs
+++ b/crates/nu-cmd-lang/src/parse_const_test.rs
@@ -1,12 +1,14 @@
 use nu_protocol::{Span, engine::StateWorkingSet};
 use quickcheck_macros::quickcheck;
 
+use crate::DefaultContextInit;
+
 #[quickcheck]
 fn quickcheck_parse(data: String) -> bool {
     let (tokens, err) = nu_parser::lex(data.as_bytes(), 0, b"", b"", true);
 
     if err.is_none() {
-        let context = crate::create_default_context();
+        let context = crate::create_default_context(DefaultContextInit::test());
         {
             let mut working_set = StateWorkingSet::new(&context);
             let _ = working_set.add_file("quickcheck".into(), data.as_bytes());

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -452,6 +452,7 @@ mod tests {
         },
         request::{HoverRequest, Initialize, Request, Shutdown},
     };
+    use nu_cmd_lang::DefaultContextInit;
     use nu_protocol::{PipelineData, ShellError, Value, debugger::WithoutDebug, engine::Stack};
     use nu_std::load_standard_library;
     use std::sync::mpsc::{self, Receiver};
@@ -466,7 +467,7 @@ mod tests {
         nu_config_code: Option<&str>,
         params: Option<serde_json::Value>,
     ) -> (Connection, Receiver<Result<()>>) {
-        let engine_state = nu_cmd_lang::create_default_context();
+        let engine_state = nu_cmd_lang::create_default_context(DefaultContextInit::test());
         let mut engine_state = nu_command::add_shell_command_context(engine_state);
         engine_state.generate_nu_constant();
         assert!(load_standard_library(&mut engine_state).is_ok());

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -500,6 +500,7 @@ mod tests {
         ReferenceParams, RenameParams, TextDocumentIdentifier, TextDocumentPositionParams, Uri,
         WorkDoneProgressParams, WorkspaceFolder, request, request::Request,
     };
+    use nu_cmd_lang::DefaultContextInit;
     use nu_test_support::fs::fixtures;
 
     fn send_reference_request(
@@ -1139,7 +1140,7 @@ mod tests {
         let mut script_path = fixtures();
         script_path.push("lsp");
         script_path.push("workspace");
-        let mut engine_state = nu_cmd_lang::create_default_context();
+        let mut engine_state = nu_cmd_lang::create_default_context(DefaultContextInit::test());
         engine_state.add_env_var(
             "PWD".into(),
             nu_protocol::Value::test_string(script_path.to_str().unwrap()),

--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, convert::Infallible, sync::Arc};
 
 use nu_ansi_term::Style;
-use nu_cmd_lang::create_default_context;
+use nu_cmd_lang::{DefaultContextInit, create_default_context};
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_plugin::{Plugin, PluginCommand};
@@ -41,7 +41,7 @@ impl PluginTest {
         name: &str,
         plugin: Arc<impl Plugin + Send + 'static>,
     ) -> Result<PluginTest, ShellError> {
-        let mut engine_state = create_default_context();
+        let mut engine_state = create_default_context(DefaultContextInit::test());
         let mut working_set = StateWorkingSet::new(&engine_state);
 
         let reg_plugin = fake_register(&mut working_set, name, plugin)?;

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -7,6 +7,7 @@ fn main() {
 
     #[cfg(windows)]
     {
+        println!("cargo:rerun-if-changed=assets/nu_logo.ico");
         let mut res = winresource::WindowsResource::new();
         res.set("ProductName", "Nushell");
         res.set("FileDescription", "Nushell");

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -1,18 +1,25 @@
-#[cfg(windows)]
 fn main() {
-    let mut res = winresource::WindowsResource::new();
-    res.set("ProductName", "Nushell");
-    res.set("FileDescription", "Nushell");
-    res.set("LegalCopyright", "Copyright (C) 2025");
-    res.set_icon("assets/nu_logo.ico");
-    res.compile()
-        .expect("Failed to run the Windows resource compiler (rc.exe)");
-}
-
-#[cfg(not(windows))]
-fn main() {
-    // Tango uses dynamic linking, to allow us to dynamically change between two bench suit at runtime.
-    // This is currently not supported on non nightly rust, on windows.
-    println!("cargo:rustc-link-arg-benches=-rdynamic");
     println!("cargo:rerun-if-changed=scripts/build.rs");
+    println!(
+        "cargo:rustc-env=NU_FEATURES={}",
+        std::env::var("CARGO_CFG_FEATURE").expect("set by cargo")
+    );
+
+    #[cfg(windows)]
+    {
+        let mut res = winresource::WindowsResource::new();
+        res.set("ProductName", "Nushell");
+        res.set("FileDescription", "Nushell");
+        res.set("LegalCopyright", "Copyright (C) 2025");
+        res.set_icon("assets/nu_logo.ico");
+        res.compile()
+            .expect("Failed to run the Windows resource compiler (rc.exe)");
+    }
+
+    #[cfg(not(windows))]
+    {
+        // Tango uses dynamic linking, to allow us to dynamically change between two bench suit at runtime.
+        // This is currently not supported on non nightly rust, on windows.
+        println!("cargo:rustc-link-arg-benches=-rdynamic");
+    }
 }

--- a/src/command_context.rs
+++ b/src/command_context.rs
@@ -2,11 +2,8 @@ use nu_cmd_lang::DefaultContextInit;
 use nu_protocol::engine::EngineState;
 
 pub(crate) fn get_engine_state() -> EngineState {
-    let features = env!("NU_FEATURES")
-        .split(",")
-        .map(ToString::to_string)
-        .collect();
-    let engine_state = nu_cmd_lang::create_default_context(DefaultContextInit { features });
+    let cargo_features = env!("NU_FEATURES").split(",").collect();
+    let engine_state = nu_cmd_lang::create_default_context(DefaultContextInit { cargo_features });
     #[cfg(feature = "plugin")]
     let engine_state = nu_cmd_plugin::add_plugin_command_context(engine_state);
     let engine_state = nu_command::add_shell_command_context(engine_state);

--- a/src/command_context.rs
+++ b/src/command_context.rs
@@ -1,7 +1,12 @@
+use nu_cmd_lang::DefaultContextInit;
 use nu_protocol::engine::EngineState;
 
 pub(crate) fn get_engine_state() -> EngineState {
-    let engine_state = nu_cmd_lang::create_default_context();
+    let features = env!("NU_FEATURES")
+        .split(",")
+        .map(ToString::to_string)
+        .collect();
+    let engine_state = nu_cmd_lang::create_default_context(DefaultContextInit { features });
     #[cfg(feature = "plugin")]
     let engine_state = nu_cmd_plugin::add_plugin_command_context(engine_state);
     let engine_state = nu_command::add_shell_command_context(engine_state);

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -222,11 +222,8 @@ fn outcome_ok(msg: String) -> ! {
 
 /// Generate a minimal engine state with just `nu-cmd-lang`, `nu-command`, and `nu-cli` commands.
 fn get_engine_state() -> EngineState {
-    let features = env!("NU_FEATURES")
-        .split(",")
-        .map(ToString::to_string)
-        .collect();
-    let engine_state = nu_cmd_lang::create_default_context(DefaultContextInit { features });
+    let cargo_features = env!("NU_FEATURES").split(",").collect();
+    let engine_state = nu_cmd_lang::create_default_context(DefaultContextInit { cargo_features });
     let engine_state = nu_command::add_shell_command_context(engine_state);
     nu_cli::add_cli_context(engine_state)
 }

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -1,4 +1,5 @@
 use nu_cmd_base::hook::{eval_env_change_hook, eval_hooks};
+use nu_cmd_lang::DefaultContextInit;
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_protocol::{
@@ -221,7 +222,11 @@ fn outcome_ok(msg: String) -> ! {
 
 /// Generate a minimal engine state with just `nu-cmd-lang`, `nu-command`, and `nu-cli` commands.
 fn get_engine_state() -> EngineState {
-    let engine_state = nu_cmd_lang::create_default_context();
+    let features = env!("NU_FEATURES")
+        .split(",")
+        .map(ToString::to_string)
+        .collect();
+    let engine_state = nu_cmd_lang::create_default_context(DefaultContextInit { features });
     let engine_state = nu_command::add_shell_command_context(engine_state);
     nu_cli::add_cli_context(engine_state)
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

I realized that in 0.105 when running `version`, you don't see which TLS feature you have enabled. This is due to the situation how features are included in the `version` command. Features for `nu` itself are not known when compiling `nu-cmd-lang` which caused also this note: https://github.com/nushell/nushell/blob/091d14f085ece78b4e05a29af4337b326d8fc029/crates/nu-cmd-lang/src/core_commands/version.rs#L170

To provide this feature list I added an argument to the `create_default_context` function in `nu-cmd-lang`. This allows passing a feature list down from `nu` into `nu-cmd-lang`. That feature list is generated using `CARGO_CFG_FEATURE` and will therefore also include all upcoming feature flags.

Since some features are coming from optional dependencies, I filtered all "dep:*" features to avoid confusion as you normally only select the features that have proper names we define manually.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Nushell embedders will now need to provide an argument to `create_default_context`.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
