### PR TITLE
fix(std/log): Don't assume env variables are set

### DIFF
--- a/crates/nu-std/std/log/mod.nu
+++ b/crates/nu-std/std/log/mod.nu
@@ -38,9 +38,14 @@ const LOG_SHORT_PREFIX = {
 
 export def log-short-prefix [] {$LOG_SHORT_PREFIX}
 
+const LOG_FORMATS = {
+    log: "%ANSI_START%%DATE%|%LEVEL%|%MSG%%ANSI_STOP%"
+    date: "%Y-%m-%dT%H:%M:%S%.3f"
+}
+
 export-env {
-    $env.NU_LOG_FORMAT = $env.NU_LOG_FORMAT? | default "%ANSI_START%%DATE%|%LEVEL%|%MSG%%ANSI_STOP%"
-    $env.NU_LOG_DATE_FORMAT = $env.NU_LOG_DATE_FORMAT? | default "%Y-%m-%dT%H:%M:%S%.3f"
+    $env.NU_LOG_FORMAT = $env.NU_LOG_FORMAT? | default $LOG_FORMATS.log
+    $env.NU_LOG_DATE_FORMAT = $env.NU_LOG_DATE_FORMAT? | default $LOG_FORMATS.date
 }
 
 const LOG_TYPES = {
@@ -142,7 +147,7 @@ def current-log-level [] {
 }
 
 def now [] {
-    date now | format date $env.NU_LOG_DATE_FORMAT
+    date now | format date ($env.NU_LOG_DATE_FORMAT? | default $LOG_FORMATS.date)
 }
 
 def handle-log [
@@ -152,7 +157,7 @@ def handle-log [
     short: bool
 ] {
     let log_format = if ($format_string | is-empty) {
-        $env.NU_LOG_FORMAT
+        $env.NU_LOG_FORMAT? | default $LOG_FORMATS.log
     } else {
         $format_string
     }

--- a/crates/nu-std/std/log/mod.nu
+++ b/crates/nu-std/std/log/mod.nu
@@ -156,11 +156,7 @@ def handle-log [
     format_string: string,
     short: bool
 ] {
-    let log_format = if ($format_string | is-empty) {
-        $env.NU_LOG_FORMAT? | default $LOG_FORMATS.log
-    } else {
-        $format_string
-    }
+    let log_format = $format_string | default -e $env.NU_LOG_FORMAT? | default $LOG_FORMATS.log
 
     let prefix = if $short {
         $formatting.short_prefix


### PR DESCRIPTION
# Description
Commands in `std/log` assume the `export-env` has been run and the relevant environment variables are set. 
However, when modules/libraries import `std/log` without defining their own `export-env` block to run `std/log`'s, logging commands will fail at runtime.

While it's on the author of the modules to include `export-env { use std/log [] }` in their modules, this is a very simple issue to solve and would make the user experience smoother.

# User-Facing Changes
`std/log` work without problem when their env vars are not set.