### PR TITLE
Adjust std-rfc/clip deprecation window

### DIFF
--- a/crates/nu-std/std-rfc/clip/mod.nu
+++ b/crates/nu-std/std-rfc/clip/mod.nu
@@ -12,7 +12,7 @@ module std-clip {
 use std-clip
 
 # Copy input to system clipboard
-@deprecated "The clip module has been moved to std. Please use the std version instead of the std-rfc version." --since 0.105.0 --remove 0.107.0
+@deprecated "The clip module has been moved to std. Please use the std version instead of the std-rfc version." --since 0.106.0 --remove 0.108.0
 @example "Copy a string to the clipboard" {
   "Hello" | clip copy
 }
@@ -23,7 +23,7 @@ export def copy [
 }
 
 # Paste contents of system clipboard
-@deprecated "The clip module has been moved to std. Please use the std version instead of the std-rfc version." --since 0.105.0 --remove 0.107.0
+@deprecated "The clip module has been moved to std. Please use the std version instead of the std-rfc version." --since 0.106.0 --remove 0.108.0
 @example "Paste a string from the clipboard" {
   clip paste
 } --result "Hello"
@@ -32,7 +32,7 @@ export def paste []: [nothing -> string] {
 }
 
 # Add a prefix to each line of the content to be copied
-@deprecated "The clip module has been moved to std. Please use the std version instead of the std-rfc version." --since 0.105.0 --remove 0.107.0
+@deprecated "The clip module has been moved to std. Please use the std version instead of the std-rfc version." --since 0.106.0 --remove 0.108.0
 @example "Format output for Nushell doc" {
   [1 2 3] | clip prefix '# => '
 } --result "# => ╭───┬───╮


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Follow-up to #15877. That PR was created before 0.105, but merged after it was released. This PR adjusts the deprecation window from 0.105.0-0.107.0 to 0.106.0-0.108.0 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
* N/A, previous PR not part of a release yet

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
