### PR TITLE
Disallow `clippy::used_underscore_binding` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,6 +195,7 @@ webpki-roots = "1.0"
 # Warning: workspace lints affect library code as well as tests, so don't enable lints that would be too noisy in tests like that.
 # todo = "warn"
 unchecked_duration_subtraction = "warn"
+used_underscore_binding = "warn"
 
 [lints]
 workspace = true

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -17,7 +17,7 @@ pub struct NuHighlighter {
 }
 
 impl Highlighter for NuHighlighter {
-    fn highlight(&self, line: &str, _cursor: usize) -> StyledText {
+    fn highlight(&self, line: &str, cursor: usize) -> StyledText {
         trace!("highlighting: {}", line);
 
         let config = self.stack.get_config(&self.engine_state);
@@ -58,7 +58,7 @@ impl Highlighter for NuHighlighter {
         let mut output = StyledText::default();
         let mut last_seen_span = global_span_offset;
 
-        let global_cursor_offset = _cursor + global_span_offset;
+        let global_cursor_offset = cursor + global_span_offset;
         let matching_brackets_pos = find_matching_brackets(
             line,
             &working_set,

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -142,7 +142,7 @@ fn into_binary(
     }
 }
 
-fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
+fn action(input: &Value, args: &Arguments, span: Span) -> Value {
     let value = match input {
         Value::Binary { .. } => input.clone(),
         Value::Int { val, .. } => Value::binary(val.to_ne_bytes().to_vec(), span),
@@ -168,7 +168,7 @@ fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
         ),
     };
 
-    if _args.compact {
+    if args.compact {
         let val_span = value.span();
         if let Value::Binary { val, .. } = value {
             let val = if cfg!(target_endian = "little") {

--- a/crates/nu-command/tests/commands/move_/umv.rs
+++ b/crates/nu-command/tests/commands/move_/umv.rs
@@ -422,29 +422,31 @@ fn mv_change_case_of_directory() {
         let original_dir = String::from("somedir");
         let new_dir = String::from("SomeDir");
 
-        let _actual = nu!(
+        #[allow(unused)]
+        let actual = nu!(
             cwd: dirs.test(),
             format!("mv {original_dir} {new_dir}")
         );
 
-        // Doing this instead of `Path::exists()` because we need to check file existence in
-        // a case-sensitive way. `Path::exists()` is understandably case-insensitive on NTFS
-        let _files_in_test_directory: Vec<String> = std::fs::read_dir(dirs.test())
-            .unwrap()
-            .map(|de| de.unwrap().file_name().to_string_lossy().into_owned())
-            .collect();
-
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-        assert!(
-            !_files_in_test_directory.contains(&original_dir)
-                && _files_in_test_directory.contains(&new_dir)
-        );
+        {
+            // Doing this instead of `Path::exists()` because we need to check file existence in
+            // a case-sensitive way. `Path::exists()` is understandably case-insensitive on NTFS
+            let files_in_test_directory: Vec<String> = std::fs::read_dir(dirs.test())
+                .unwrap()
+                .map(|de| de.unwrap().file_name().to_string_lossy().into_owned())
+                .collect();
 
-        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-        assert!(files_exist_at(&["somefile.txt"], dirs.test().join(new_dir)));
+            assert!(
+                !files_in_test_directory.contains(&original_dir)
+                    && files_in_test_directory.contains(&new_dir)
+            );
+
+            assert!(files_exist_at(&["somefile.txt"], dirs.test().join(new_dir)));
+        }
 
         #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
-        _actual.err.contains("to a subdirectory of itself");
+        actual.err.contains("to a subdirectory of itself");
     })
 }
 
@@ -458,24 +460,27 @@ fn mv_change_case_of_file() {
         let original_file_name = String::from("somefile.txt");
         let new_file_name = String::from("SomeFile.txt");
 
-        let _actual = nu!(
+        #[allow(unused)]
+        let actual = nu!(
             cwd: dirs.test(),
             format!("mv {original_file_name} -f {new_file_name}")
         );
 
-        // Doing this instead of `Path::exists()` because we need to check file existence in
-        // a case-sensitive way. `Path::exists()` is understandably case-insensitive on NTFS
-        let _files_in_test_directory: Vec<String> = std::fs::read_dir(dirs.test())
-            .unwrap()
-            .map(|de| de.unwrap().file_name().to_string_lossy().into_owned())
-            .collect();
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-        assert!(
-            !_files_in_test_directory.contains(&original_file_name)
-                && _files_in_test_directory.contains(&new_file_name)
-        );
+        {
+            // Doing this instead of `Path::exists()` because we need to check file existence in
+            // a case-sensitive way. `Path::exists()` is understandably case-insensitive on NTFS
+            let files_in_test_directory: Vec<String> = std::fs::read_dir(dirs.test())
+                .unwrap()
+                .map(|de| de.unwrap().file_name().to_string_lossy().into_owned())
+                .collect();
+            assert!(
+                !files_in_test_directory.contains(&original_file_name)
+                    && files_in_test_directory.contains(&new_file_name)
+            );
+        }
         #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
-        _actual.err.contains("are the same file");
+        actual.err.contains("are the same file");
     })
 }
 


### PR DESCRIPTION

# Description
This can be a bad practice for actually used function params.

Somewhat more tedious handling of conditional compilation is necessary
with this lint enabled.

# User-Facing Changes
NA

# Tests + Formatting
Fixed tests in the minimal way (those for `uu_mv` look somewhat sus)

