### PR TITLE
Generalize `nu_protocol::format_shell_error`

### DIFF
--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -8,7 +8,7 @@ use notify_debouncer_full::{
 use nu_engine::{ClosureEval, command_prelude::*};
 use nu_protocol::{
     engine::{Closure, StateWorkingSet},
-    format_shell_error,
+    format_cli_error,
     shell_error::io::IoError,
 };
 use std::{
@@ -208,7 +208,7 @@ impl Command for Watch {
                     }
                     Err(err) => {
                         let working_set = StateWorkingSet::new(engine_state);
-                        eprintln!("{}", format_shell_error(&working_set, &err));
+                        eprintln!("{}", format_cli_error(&working_set, &err));
                     }
                 }
             }

--- a/crates/nu-protocol/src/errors/cli_error.rs
+++ b/crates/nu-protocol/src/errors/cli_error.rs
@@ -63,7 +63,7 @@ fn should_show_warning(engine_state: &EngineState, warning: &ParseWarning) -> bo
     }
 }
 
-pub fn format_shell_error(working_set: &StateWorkingSet, error: &ShellError) -> String {
+pub fn format_cli_error(working_set: &StateWorkingSet, error: &dyn miette::Diagnostic) -> String {
     format!("Error: {:?}", CliError(error, working_set))
 }
 

--- a/crates/nu-protocol/src/errors/mod.rs
+++ b/crates/nu-protocol/src/errors/mod.rs
@@ -8,7 +8,7 @@ mod parse_warning;
 pub mod shell_error;
 
 pub use cli_error::{
-    ReportMode, format_shell_error, report_parse_error, report_parse_warning, report_shell_error,
+    ReportMode, format_cli_error, report_parse_error, report_parse_warning, report_shell_error,
     report_shell_warning,
 };
 pub use compile_error::CompileError;

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1,7 +1,7 @@
 use super::chained_error::ChainedError;
 use crate::{
     ConfigError, LabeledError, ParseError, Span, Spanned, Type, Value, ast::Operator,
-    engine::StateWorkingSet, format_shell_error, record,
+    engine::StateWorkingSet, format_cli_error, record,
 };
 use job::JobError;
 use miette::Diagnostic;
@@ -1418,7 +1418,7 @@ impl ShellError {
             "msg" => Value::string(self.to_string(), span),
             "debug" => Value::string(format!("{self:?}"), span),
             "raw" => Value::error(self.clone(), span),
-            "rendered" => Value::string(format_shell_error(working_set, &self), span),
+            "rendered" => Value::string(format_cli_error(working_set, &self), span),
             "json" => Value::string(serde_json::to_string(&self).expect("Could not serialize error"), span),
         };
 
@@ -1431,7 +1431,7 @@ impl ShellError {
 
     // TODO: Implement as From trait
     pub fn wrap(self, working_set: &StateWorkingSet, span: Span) -> ParseError {
-        let msg = format_shell_error(working_set, &self);
+        let msg = format_cli_error(working_set, &self);
         ParseError::LabeledError(
             msg,
             "Encountered error during parse-time evaluation".into(),


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Nushell uses the `CliError` to format and report errors. The `nu_protocol::format_shell_error` function is public but only allows passing in `ShellError` while internally it is used for `ParseError` and `CompileError` too. This makes it hard to use when embedding nushell somewhere. 

So, in this PR, I made that function more general by allowing to pass in `&dyn miette::Diagnostic` instead. And since the name doesn't fit anymore, I renamed that function to `format_cli_error`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Embedders might need to update this function call if used. But plugin authors shouldn't be affected.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
