### PR TITLE
Clearer help section for command attributes

### DIFF
--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -568,41 +568,18 @@ def build-command-page [command: record] {
         ""
         "This command:"
     ] | append (
-        if ($command.creates_scope) {
-            $"- (ansi cyan)does create(ansi reset) a scope."
-        } else {
-            $"- (ansi cyan)does not create(ansi reset) a scope."
-        }
-    ) | append (
-        if ($command.type == "built-in") {
-            $"- (ansi cyan)is(ansi reset) a built-in command."
-        } else {
-            $"- (ansi cyan)is not(ansi reset) a built-in command."
-        }
-    ) | append (
-        if ($command.is_sub) {
-            $"- (ansi cyan)is(ansi reset) a subcommand."
-        } else {
-            $"- (ansi cyan)is not(ansi reset) a subcommand."
-        }
-    ) | append (
-        if ($command.type == "plugin") {
-            $"- (ansi cyan)is part(ansi reset) of a plugin."
-        } else {
-            $"- (ansi cyan)is not part(ansi reset) of a plugin."
-        }
-    ) | append (
-        if ($command.type == "custom") {
-            $"- (ansi cyan)is(ansi reset) a custom command."
-        } else {
-            $"- (ansi cyan)is not(ansi reset) a custom command."
-        }
-    ) | append (
-        if ($command.type == "keyword") {
-            $"- (ansi cyan)is(ansi reset) a keyword."
-        } else {
-            $"- (ansi cyan)is not(ansi reset) a keyword."
-        }
+      {
+        "Creates scope" : $command.creates_scope,
+        "Is built-in" : ($command.type == "built-in"),
+        "Is a subcommand" : $command.is_sub,
+        "Is a part of a plugin": ($command.type == "plugin"),
+        "Is a custom command": ($command.type == "custom"),
+        "Is a keyword": ($command.type == "keyword"),
+      }
+      | transpose name value
+      | update value { if $in { "2705" } else { "274c" } | char --unicode $in }
+      | transpose -dr
+      | table
     ))
 
     let signatures = ($command.signatures | transpose | get column1)


### PR DESCRIPTION
Refs https://discord.com/channels/601130461678272522/615329862395101194/1385021428314800148

# Description

Clearer command attribute section (`This command:`).

# User-Facing Changes

This is a cosmetic change to how `std/help` shows the command attributes.

# Tests + Formatting

Pass.
