### PR TITLE
Add backtrack named flag to parse (issue #15997)

### DIFF
--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -102,6 +102,14 @@ impl Command for Parse {
                     "capture0" => Value::test_string("b"),
                 })])),
             },
+            Example {
+                description: "Parse a string with a manually set fancy-regex backtrack limit",
+                example: "\"hi there\" | parse --backtrack 1500000 \"{foo} {bar}\"",
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                    "foo" => Value::test_string("hi"),
+                    "bar" => Value::test_string("there"),
+                })])),
+            },
         ]
     }
 

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -165,13 +165,16 @@ fn operate(
         build_regex(&pattern_item, pattern_span)?
     };
 
-    let regex = Regex::new(&item_to_parse).map_err(|e| ShellError::GenericError {
-        error: "Error with regular expression".into(),
-        msg: e.to_string(),
-        span: Some(pattern_span),
-        help: None,
-        inner: vec![],
-    })?;
+    let regex = RegexBuilder::new(&item_to_parse)
+        .backtrack_limit(backtrack_limit)
+        .build()
+        .map_err(|e| ShellError::GenericError {
+            error: "Error with regular expression".into(),
+            msg: e.to_string(),
+            span: Some(pattern_span),
+            help: None,
+            inner: vec![],
+        })?;
 
     let columns = regex
         .capture_names()

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -34,7 +34,7 @@ impl Command for Parse {
             .named(
                 "backtrack",
                 SyntaxShape::Int,
-                "set max backtrack limit for regex",
+                "set the max backtrack limit for regex",
                 Some('b'),
             )
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -31,6 +31,7 @@ impl Command for Parse {
                 (Type::List(Box::new(Type::Any)), Type::table()),
             ])
             .switch("regex", "use full regex syntax for patterns", Some('r'))
+            .named("backtrack", SyntaxShape::Int, "set max backtrack limit for regex", Some('b'))
             .allow_variants_without_examples(true)
             .category(Category::Strings)
     }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Adds a `--backtrack` or `-b` named flag to the `parse` command. Allows a user to specify a max backtrack limit for fancy-regex other than the default 1,000,000 limit.

Uses a RegexBuilder to add the manual config.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Adds a new named flag `backtrack` to the `parse` command. The flag is optional and defaults to 1,000,000.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Added an example test to the parse command using `--backtrack 1500000`.