### PR TITLE
fix(random dice): gracefully handle --sides 0 using NonZeroUsize

### DIFF
--- a/crates/nu-command/src/random/dice.rs
+++ b/crates/nu-command/src/random/dice.rs
@@ -1,6 +1,7 @@
 use nu_engine::command_prelude::*;
 use nu_protocol::ListStream;
 use rand::random_range;
+use std::num::NonZeroUsize;
 
 #[derive(Clone)]
 pub struct RandomDice;
@@ -70,8 +71,16 @@ fn dice(
 ) -> Result<PipelineData, ShellError> {
     let span = call.head;
 
-    let dice: usize = call.get_flag(engine_state, stack, "dice")?.unwrap_or(1);
-    let sides: usize = call.get_flag(engine_state, stack, "sides")?.unwrap_or(6);
+    let sides: NonZeroUsize = call
+        .get_flag(engine_state, stack, "sides")?
+        .unwrap_or_else(|| NonZeroUsize::new(6).expect("default sides must be non-zero"));
+
+    let dice: NonZeroUsize = call
+        .get_flag(engine_state, stack, "dice")?
+        .unwrap_or_else(|| NonZeroUsize::new(1).expect("default dice count must be non-zero"));
+
+    let sides = sides.get();
+    let dice = dice.get();
 
     let iter = (0..dice).map(move |_| Value::int(random_range(1..sides + 1) as i64, span));
 

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -10,6 +10,7 @@ use std::{
     cmp::Ordering,
     collections::{HashMap, VecDeque},
     fmt,
+    num::NonZeroUsize,
     path::PathBuf,
     str::FromStr,
 };
@@ -261,6 +262,33 @@ impl FromValue for i64 {
                 from_type: v.get_type().to_string(),
                 span: v.span(),
                 help: None,
+            }),
+        }
+    }
+
+    fn expected_type() -> Type {
+        Type::Int
+    }
+}
+
+impl FromValue for NonZeroUsize {
+    fn from_value(v: Value) -> Result<Self, ShellError> {
+        let span = v.span();
+        let v_ty = v.get_type();
+
+        match v {
+            Value::Int { val, .. } => {
+                NonZeroUsize::new(val as usize).ok_or_else(|| ShellError::IncorrectValue {
+                    msg: "use a value other than 0".into(),
+                    val_span: span,
+                    call_span: span,
+                })
+            }
+            _ => Err(ShellError::CantConvert {
+                to_type: Self::expected_type().to_string(),
+                from_type: v_ty.to_string(),
+                span,
+                help: Some("expected a non-zero positive integer".into()),
             }),
         }
     }


### PR DESCRIPTION
###  Fix `random dice` panic for `--sides 0`

#### Summary

This PR fixes a bug where running:

```sh
random dice --sides 0
```

would panic due to an empty range being passed to `random_range`. Instead of panicking, the command now returns a clear error message.

#### 🔧 Changes

* Introduced `FromValue` implementation for `NonZeroUsize`.
* Updated `random dice` command to use `NonZeroUsize` for `--sides` and `--dice` flags.
* Emits `ShellError::IncorrectValue` when a zero value is passed, with spans highlighting the offending input.

#### 🧪 Example Error

```
random dice --sides 0
Error: nu::shell::incorrect_value

  × Incorrect value.
   ╝─[entry #1:1:13]
 1 │ random dice --sides 0
   ·             ───┌──┌
   ·                 │    └── encountered here
   ·                 └── use a value other than 0
```

#### Related Issues

Fixes #15983
