### PR TITLE
Fix: missing `installed_plugins` in `version`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,6 +269,7 @@ plugin = [
 
   # features
   "nu-cli/plugin",
+  "nu-cmd-lang/plugin",
   "nu-command/plugin",
   "nu-engine/plugin",
   "nu-engine/plugin",


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

- related #15972

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

In #15972 I was very eager removing fowarded features from `nu` to `nu-cmd-lang`. By accident I also removed `nu-cmd-lang/plugin` too. This removed `installed_plugins` from `version`. By adding the feature again, it works again.
