### PR TITLE
repect color_config.header color for record key

### DIFF
--- a/crates/nu-table/src/types/general.rs
+++ b/crates/nu-table/src/types/general.rs
@@ -46,7 +46,6 @@ fn get_key_style(topts: &TableOpts<'_>) -> TextStyle {
 
 fn kv_table(record: Record, opts: TableOpts<'_>) -> StringResult {
     let mut table = NuTable::new(record.len(), 2);
-    // table.set_index_style(TextStyle::default_field());
     table.set_index_style(get_key_style(&opts));
     table.set_indent(opts.config.table.padding);
 

--- a/crates/nu-table/src/types/general.rs
+++ b/crates/nu-table/src/types/general.rs
@@ -40,9 +40,14 @@ fn list_table(input: Vec<Value>, opts: TableOpts<'_>) -> Result<Option<String>, 
     Ok(table)
 }
 
+fn get_key_style(topts: &TableOpts<'_>) -> TextStyle {
+    get_header_style(&topts.style_computer).alignment(nu_color_config::Alignment::Left)
+}
+
 fn kv_table(record: Record, opts: TableOpts<'_>) -> StringResult {
     let mut table = NuTable::new(record.len(), 2);
-    table.set_index_style(TextStyle::default_field());
+    // table.set_index_style(TextStyle::default_field());
+    table.set_index_style(get_key_style(&opts));
     table.set_indent(opts.config.table.padding);
 
     for (i, (key, value)) in record.into_iter().enumerate() {


### PR DESCRIPTION
# Description

This PR fixes an oversight where the record key value was not being colored as the color_config.header color when used with the `table` command in some circumstances. It respected it with `table -e` but just not `table`.

### Before
![image](https://github.com/user-attachments/assets/a41e609f-9b3a-415b-af90-037e6ee47318)

### After
![image](https://github.com/user-attachments/assets/c3afb293-ebb3-4cb3-8ee6-4f7e2e96723b)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
