### PR TITLE
refactor(get,select,reject)!: deprecate --ignore-errors in favor of --optional

### DIFF
--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -82,7 +82,7 @@ impl Command for Default {
             },
             Example {
                 description: "Get the env value of `MY_ENV` with a default value 'abc' if not present",
-                example: "$env | get --ignore-errors MY_ENV | default 'abc'",
+                example: "$env | get --optional MY_ENV | default 'abc'",
                 result: Some(Value::test_string("abc")),
             },
             Example {

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -164,7 +164,7 @@ If multiple cell paths are given, this will produce a list of values."#
                 report_mode: ReportMode::FirstUse,
                 since: Some("0.106.0".into()),
                 expected_removal: None,
-                help: Some("This flag has been renamed to `--optional` to better reflect it's behavior.".into())
+                help: Some("This flag has been renamed to `--optional (-o)` to better reflect it's behavior.".into())
             }
         ]
     }

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -164,7 +164,7 @@ If multiple cell paths are given, this will produce a list of values."#
                 report_mode: ReportMode::FirstUse,
                 since: Some("0.106.0".into()),
                 expected_removal: None,
-                help: Some("This flag has been renamed to `--optional (-o)` to better reflect it's behavior.".into())
+                help: Some("This flag has been renamed to `--optional (-o)` to better reflect its behavior.".into())
             }
         ]
     }

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -187,7 +187,7 @@ fn action(
 
     match input {
         PipelineData::Empty => return Err(ShellError::PipelineEmpty { dst_span: span }),
-        // Allow chaining of get -i
+        // Allow chaining of get -o
         PipelineData::Value(val @ Value::Nothing { .. }, ..) if !optional => {
             return Err(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "table or record".into(),

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -41,8 +41,13 @@ If multiple cell paths are given, this will produce a list of values."#
             )
             .rest("rest", SyntaxShape::CellPath, "Additional cell paths.")
             .switch(
-                "ignore-errors",
+                "optional",
                 "ignore missing data (make all cell path members optional)",
+                Some('o'),
+            )
+            .switch(
+                "ignore-errors",
+                "ignore missing data (make all cell path members optional) (deprecated)",
                 Some('i'),
             )
             .switch(
@@ -131,13 +136,14 @@ If multiple cell paths are given, this will produce a list of values."#
     ) -> Result<PipelineData, ShellError> {
         let cell_path: CellPath = call.req(engine_state, stack, 0)?;
         let rest: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
-        let ignore_errors = call.has_flag(engine_state, stack, "ignore-errors")?;
+        let optional = call.has_flag(engine_state, stack, "optional")?
+            || call.has_flag(engine_state, stack, "ignore-errors")?;
         let metadata = input.metadata();
         action(
             input,
             cell_path,
             rest,
-            ignore_errors,
+            optional,
             engine_state.signals().clone(),
             call.head,
         )
@@ -152,6 +158,13 @@ If multiple cell paths are given, this will produce a list of values."#
                 since: Some("0.105.0".into()),
                 expected_removal: None,
                 help: Some("Cell-paths are now case-sensitive by default.\nTo access fields case-insensitively, add `!` after the relevant path member.".into())
+            },
+            DeprecationEntry {
+                ty: DeprecationType::Flag("ignore-errors".into()),
+                report_mode: ReportMode::FirstUse,
+                since: Some("0.106.0".into()),
+                expected_removal: None,
+                help: Some("This flag has been renamed to `--optional` to better reflect it's behavior.".into())
             }
         ]
     }
@@ -161,11 +174,11 @@ fn action(
     input: PipelineData,
     mut cell_path: CellPath,
     mut rest: Vec<CellPath>,
-    ignore_errors: bool,
+    optional: bool,
     signals: Signals,
     span: Span,
 ) -> Result<PipelineData, ShellError> {
-    if ignore_errors {
+    if optional {
         cell_path.make_optional();
         for path in &mut rest {
             path.make_optional();
@@ -175,7 +188,7 @@ fn action(
     match input {
         PipelineData::Empty => return Err(ShellError::PipelineEmpty { dst_span: span }),
         // Allow chaining of get -i
-        PipelineData::Value(val @ Value::Nothing { .. }, ..) if !ignore_errors => {
+        PipelineData::Value(val @ Value::Nothing { .. }, ..) if !optional => {
             return Err(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "table or record".into(),
                 wrong_type: "nothing".into(),

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -113,7 +113,7 @@ impl Command for Reject {
             since: Some("0.106.0".into()),
             expected_removal: None,
             help: Some(
-                "This flag has been renamed to `--optional (-o)` to better reflect it's behavior."
+                "This flag has been renamed to `--optional (-o)` to better reflect its behavior."
                     .into(),
             ),
         }]

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -113,7 +113,7 @@ impl Command for Reject {
             since: Some("0.106.0".into()),
             expected_removal: None,
             help: Some(
-                "This flag has been renamed to `--optional` to better reflect it's behavior."
+                "This flag has been renamed to `--optional (-o)` to better reflect it's behavior."
                     .into(),
             ),
         }]

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::{ast::PathMember, casing::Casing};
+use nu_protocol::{DeprecationEntry, DeprecationType, ReportMode, ast::PathMember, casing::Casing};
 use std::{cmp::Reverse, collections::HashSet};
 
 #[derive(Clone)]
@@ -18,8 +18,13 @@ impl Command for Reject {
                 (Type::list(Type::Any), Type::list(Type::Any)),
             ])
             .switch(
-                "ignore-errors",
+                "optional",
                 "ignore missing data (make all cell path members optional)",
+                Some('o'),
+            )
+            .switch(
+                "ignore-errors",
+                "ignore missing data (make all cell path members optional) (deprecated)",
                 Some('i'),
             )
             .rest(
@@ -90,14 +95,28 @@ impl Command for Reject {
         }
         let span = call.head;
 
-        let ignore_errors = call.has_flag(engine_state, stack, "ignore-errors")?;
-        if ignore_errors {
+        let optional = call.has_flag(engine_state, stack, "optional")?
+            || call.has_flag(engine_state, stack, "ignore-errors")?;
+        if optional {
             for cell_path in &mut new_columns {
                 cell_path.make_optional();
             }
         }
 
         reject(engine_state, span, input, new_columns)
+    }
+
+    fn deprecation_info(&self) -> Vec<DeprecationEntry> {
+        vec![DeprecationEntry {
+            ty: DeprecationType::Flag("ignore-errors".into()),
+            report_mode: ReportMode::FirstUse,
+            since: Some("0.106.0".into()),
+            expected_removal: None,
+            help: Some(
+                "This flag has been renamed to `--optional` to better reflect it's behavior."
+                    .into(),
+            ),
+        }]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -1,5 +1,8 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::{PipelineIterator, ast::PathMember, casing::Casing};
+use nu_protocol::{
+    DeprecationEntry, DeprecationType, PipelineIterator, ReportMode, ast::PathMember,
+    casing::Casing,
+};
 use std::collections::BTreeSet;
 
 #[derive(Clone)]
@@ -19,8 +22,13 @@ impl Command for Select {
                 (Type::List(Box::new(Type::Any)), Type::Any),
             ])
             .switch(
-                "ignore-errors",
+                "optional",
                 "ignore missing data (make all cell path members optional)",
+                Some('o'),
+            )
+            .switch(
+                "ignore-errors",
+                "ignore missing data (make all cell path members optional) (deprecated)",
                 Some('i'),
             )
             .rest(
@@ -100,16 +108,30 @@ produce a table, a list will produce a list, and a record will produce a record.
                 }
             }
         }
-        let ignore_errors = call.has_flag(engine_state, stack, "ignore-errors")?;
+        let optional = call.has_flag(engine_state, stack, "optional")?
+            || call.has_flag(engine_state, stack, "ignore-errors")?;
         let span = call.head;
 
-        if ignore_errors {
+        if optional {
             for cell_path in &mut new_columns {
                 cell_path.make_optional();
             }
         }
 
         select(engine_state, span, new_columns, input)
+    }
+
+    fn deprecation_info(&self) -> Vec<DeprecationEntry> {
+        vec![DeprecationEntry {
+            ty: DeprecationType::Flag("ignore-errors".into()),
+            report_mode: ReportMode::FirstUse,
+            since: Some("0.106.0".into()),
+            expected_removal: None,
+            help: Some(
+                "This flag has been renamed to `--optional` to better reflect it's behavior."
+                    .into(),
+            ),
+        }]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -128,7 +128,7 @@ produce a table, a list will produce a list, and a record will produce a record.
             since: Some("0.106.0".into()),
             expected_removal: None,
             help: Some(
-                "This flag has been renamed to `--optional` to better reflect it's behavior."
+                "This flag has been renamed to `--optional (-o)` to better reflect it's behavior."
                     .into(),
             ),
         }]

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -128,7 +128,7 @@ produce a table, a list will produce a list, and a record will produce a record.
             since: Some("0.106.0".into()),
             expected_removal: None,
             help: Some(
-                "This flag has been renamed to `--optional (-o)` to better reflect it's behavior."
+                "This flag has been renamed to `--optional (-o)` to better reflect its behavior."
                     .into(),
             ),
         }]

--- a/crates/nu-command/tests/commands/default.rs
+++ b/crates/nu-command/tests/commands/default.rs
@@ -31,7 +31,7 @@ fn adds_row_data_if_column_missing() {
 
 #[test]
 fn default_after_empty_filter() {
-    let actual = nu!("[a b] | where $it == 'c' | get -i 0 | default 'd'");
+    let actual = nu!("[a b] | where $it == 'c' | get -o 0 | default 'd'");
 
     assert_eq!(actual.out, "d");
 }

--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -196,14 +196,14 @@ fn get_does_not_delve_too_deep_in_nested_lists() {
 
 #[test]
 fn ignore_errors_works() {
-    let actual = nu!(r#" let path = "foo"; {} | get -i $path | to nuon "#);
+    let actual = nu!(r#" let path = "foo"; {} | get -o $path | to nuon "#);
 
     assert_eq!(actual.out, "null");
 }
 
 #[test]
 fn ignore_multiple() {
-    let actual = nu!(r#"[[a];[b]] | get -i c d | to nuon"#);
+    let actual = nu!(r#"[[a];[b]] | get -o c d | to nuon"#);
 
     assert_eq!(actual.out, "[[null], [null]]");
 }

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -236,7 +236,7 @@ fn select_repeated_column() {
 fn ignore_errors_works() {
     let actual = nu!(r#"
         let path = "foo";
-        [{}] | select -i $path | to nuon
+        [{}] | select -o $path | to nuon
         "#);
 
     assert_eq!(actual.out, "[[foo]; [null]]");

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -315,7 +315,7 @@ fn from_csv_text_with_missing_columns_to_table() {
             r#"
                 open los_tres_caballeros.txt
                 | from csv --flexible
-                | get -i rusty_luck
+                | get -o rusty_luck
                 | compact
                 | length
             "#

--- a/crates/nu-command/tests/format_conversions/tsv.rs
+++ b/crates/nu-command/tests/format_conversions/tsv.rs
@@ -234,7 +234,7 @@ fn from_tsv_text_with_missing_columns_to_table() {
             r#"
                 open los_tres_caballeros.txt
                 | from tsv --flexible
-                | get -i rusty_luck
+                | get -o rusty_luck
                 | compact
                 | length
             "#

--- a/crates/nu-std/testing.nu
+++ b/crates/nu-std/testing.nu
@@ -42,7 +42,7 @@ def get-annotated [
     | from nuon
     | each {|e|
         # filter commands with test attributes, and map attributes to annotation name
-        let test_attributes = $e.attributes.name | each {|x| $valid_annotations | get -i $x }
+        let test_attributes = $e.attributes.name | each {|x| $valid_annotations | get -o $x }
         if ($test_attributes | is-not-empty) {
           $e | update attributes $test_attributes.0
         }

--- a/crates/nu-std/tests/logger_tests/test_basic_commands.nu
+++ b/crates/nu-std/tests/logger_tests/test_basic_commands.nu
@@ -11,7 +11,7 @@ def run [
     } else {
         ^$nu.current-exe --no-config-file --commands $'use std; use std/log; NU_LOG_LEVEL=($system_level) log ($message_level) "test message"'
     }
-    | complete | get --ignore-errors stderr
+    | complete | get --optional stderr
 }
 
 def "assert no message" [

--- a/crates/nu-std/tests/logger_tests/test_log_custom.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_custom.nu
@@ -19,7 +19,7 @@ def run-command [
     } else {
         ^$nu.current-exe --no-config-file --commands $'use std/log; NU_LOG_LEVEL=($system_level) log custom "($message)" "($format)" ($log_level) --level-prefix "($level_prefix)" --ansi "($ansi)"'
     }
-    | complete | get --ignore-errors stderr
+    | complete | get --optional stderr
 }
 
 @test

--- a/crates/nu-std/tests/logger_tests/test_log_format_flag.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_format_flag.nu
@@ -16,7 +16,7 @@ def run-command [
     } else {
         ^$nu.current-exe --no-config-file --commands $'use std; use std/log; NU_LOG_LEVEL=($system_level) log ($message_level) --format "($format)" "($message)"'
     }
-    | complete | get --ignore-errors stderr
+    | complete | get --optional stderr
 }
 
 

--- a/tests/parsing/samples/recursive_func_with_alias.nu
+++ b/tests/parsing/samples/recursive_func_with_alias.nu
@@ -10,7 +10,7 @@ export def "update" [
     let input = $in
     match ($input | describe | str replace --regex '<.*' '') {
         record => {
-            if ($input | get -i $field) != null {
+            if ($input | get -o $field) != null {
                 $input | orig update $field $value
             } else { $input }
         }


### PR DESCRIPTION
# Description
As decided on the team meeting on 2025-06-19, rename `--ignore-errors (-i)` to `--optional (-o)` with a (currently) indefinite grace period.

After `--ignore-errors (-i)` is removed, the short flag `-i` can be used for `--ignore-case` (not implemented as of this PR)

# User-Facing Changes
`get`/`select`/`reject`: rename `--ignore-errors (-i)` to `--optional (-o)` to better reflect its behavior.

# Tests + Formatting
- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
Update docs and inform third parties that integrate with nushell.
