### PR TITLE
fix LS_COLORS fi=0 coloring

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -1056,15 +1056,16 @@ fn render_path_name(
         && has_metadata
         && config.shell_integration.osc8;
 
-    let ansi_style = style.map(Style::to_nu_ansi_term_style).unwrap_or_default();
-    let ansi_style = if ansi_style.is_plain() {
-        // If there is no style at all (that's what is_plain() is checking),
-        // set it to use 'default' foreground and background colors
-        // This prevents it being colored in tabled as string colors
-        // to test this, set $env.LS_COLORS = 'fi=0' and $env.config.color_config.string = 'red'
-        // if a regular file without an extension is the color 'default' then it's working
-        // if a regular file without an extension is the color 'red' then it's not working
-        nu_ansi_term::Style {
+    // If there is no style at all set it to use 'default' foreground and background
+    // colors. This prevents it being colored in tabled as string colors.
+    // To test this:
+    //   $env.LS_COLORS = 'fi=0'
+    //   $env.config.color_config.string = 'red'
+    // if a regular file without an extension is the color 'default' then it's working
+    // if a regular file without an extension is the color 'red' then it's not working
+    let ansi_style = style
+        .map(Style::to_nu_ansi_term_style)
+        .unwrap_or(nu_ansi_term::Style {
             foreground: Some(nu_ansi_term::Color::Default),
             background: Some(nu_ansi_term::Color::Default),
             is_bold: false,
@@ -1076,10 +1077,7 @@ fn render_path_name(
             is_hidden: false,
             is_strikethrough: false,
             prefix_with_reset: false,
-        }
-    } else {
-        ansi_style
-    };
+        });
 
     let full_path = PathBuf::from(stripped_path.as_ref())
         .canonicalize()

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -1057,6 +1057,29 @@ fn render_path_name(
         && config.shell_integration.osc8;
 
     let ansi_style = style.map(Style::to_nu_ansi_term_style).unwrap_or_default();
+    let ansi_style = if ansi_style.is_plain() {
+        // If there is no style at all (that's what is_plain() is checking),
+        // set it to use 'default' foreground and background colors
+        // This prevents it being colored in tabled as string colors
+        // to test this, set $env.LS_COLORS = 'fi=0' and $env.config.color_config.string = 'red'
+        // if a regular file without an extension is the color 'default' then it's working
+        // if a regular file without an extension is the color 'red' then it's not working
+        nu_ansi_term::Style {
+            foreground: Some(nu_ansi_term::Color::Default),
+            background: Some(nu_ansi_term::Color::Default),
+            is_bold: false,
+            is_dimmed: false,
+            is_italic: false,
+            is_underline: false,
+            is_blink: false,
+            is_reverse: false,
+            is_hidden: false,
+            is_strikethrough: false,
+            prefix_with_reset: false,
+        }
+    } else {
+        ansi_style
+    };
 
     let full_path = PathBuf::from(stripped_path.as_ref())
         .canonicalize()


### PR DESCRIPTION
# Description

fixes #16010

When `$env.LS_COLORS = 'fi=0' and `$env.config.color_config.string = 'red'` were set, regular files without file extensions would be colored red. Now they're colored based on the LS_COLORS definition which, in this case, means use default colors.

This is done by checking if a style was applied from ls_colors and if none was applied, create a default nu_ansi_term style with 'Color::Default' for foreground and background.

### Before
![image](https://github.com/user-attachments/assets/ff245ee9-3299-4362-9df7-95613e8972ed)

### After
![image](https://github.com/user-attachments/assets/7c3f1178-6e6b-446d-b88c-1a5b0747345d)



# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
