### PR TITLE
feat(table): add 'double' table mode

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -1185,6 +1185,7 @@ fn supported_table_modes() -> Vec<Value> {
         Value::test_string("ascii_rounded"),
         Value::test_string("basic_compact"),
         Value::test_string("single"),
+        Value::test_string("double"),
     ]
 }
 

--- a/crates/nu-command/tests/commands/table.rs
+++ b/crates/nu-command/tests/commands/table.rs
@@ -3634,19 +3634,19 @@ fn table_list() {
     let actual = nu!("table --list");
     assert_eq!(
         actual.out,
-        "╭────┬────────────────╮│  0 │ basic          ││  1 │ compact        ││  2 │ compact_double ││  3 │ default        ││  4 │ heavy          ││  5 │ light          ││  6 │ none           ││  7 │ reinforced     ││  8 │ rounded        ││  9 │ thin           ││ 10 │ with_love      ││ 11 │ psql           ││ 12 │ markdown       ││ 13 │ dots           ││ 14 │ restructured   ││ 15 │ ascii_rounded  ││ 16 │ basic_compact  ││ 17 │ single         │╰────┴────────────────╯"
+        "╭────┬────────────────╮│  0 │ basic          ││  1 │ compact        ││  2 │ compact_double ││  3 │ default        ││  4 │ heavy          ││  5 │ light          ││  6 │ none           ││  7 │ reinforced     ││  8 │ rounded        ││  9 │ thin           ││ 10 │ with_love      ││ 11 │ psql           ││ 12 │ markdown       ││ 13 │ dots           ││ 14 │ restructured   ││ 15 │ ascii_rounded  ││ 16 │ basic_compact  ││ 17 │ single         ││ 18 │ double         │╰────┴────────────────╯"
     );
 
     let actual = nu!("ls | table --list");
     assert_eq!(
         actual.out,
-        "╭────┬────────────────╮│  0 │ basic          ││  1 │ compact        ││  2 │ compact_double ││  3 │ default        ││  4 │ heavy          ││  5 │ light          ││  6 │ none           ││  7 │ reinforced     ││  8 │ rounded        ││  9 │ thin           ││ 10 │ with_love      ││ 11 │ psql           ││ 12 │ markdown       ││ 13 │ dots           ││ 14 │ restructured   ││ 15 │ ascii_rounded  ││ 16 │ basic_compact  ││ 17 │ single         │╰────┴────────────────╯"
+        "╭────┬────────────────╮│  0 │ basic          ││  1 │ compact        ││  2 │ compact_double ││  3 │ default        ││  4 │ heavy          ││  5 │ light          ││  6 │ none           ││  7 │ reinforced     ││  8 │ rounded        ││  9 │ thin           ││ 10 │ with_love      ││ 11 │ psql           ││ 12 │ markdown       ││ 13 │ dots           ││ 14 │ restructured   ││ 15 │ ascii_rounded  ││ 16 │ basic_compact  ││ 17 │ single         ││ 18 │ double         │╰────┴────────────────╯"
     );
 
     let actual = nu!("table --list --theme basic");
     assert_eq!(
         actual.out,
-        "╭────┬────────────────╮│  0 │ basic          ││  1 │ compact        ││  2 │ compact_double ││  3 │ default        ││  4 │ heavy          ││  5 │ light          ││  6 │ none           ││  7 │ reinforced     ││  8 │ rounded        ││  9 │ thin           ││ 10 │ with_love      ││ 11 │ psql           ││ 12 │ markdown       ││ 13 │ dots           ││ 14 │ restructured   ││ 15 │ ascii_rounded  ││ 16 │ basic_compact  ││ 17 │ single         │╰────┴────────────────╯"
+        "╭────┬────────────────╮│  0 │ basic          ││  1 │ compact        ││  2 │ compact_double ││  3 │ default        ││  4 │ heavy          ││  5 │ light          ││  6 │ none           ││  7 │ reinforced     ││  8 │ rounded        ││  9 │ thin           ││ 10 │ with_love      ││ 11 │ psql           ││ 12 │ markdown       ││ 13 │ dots           ││ 14 │ restructured   ││ 15 │ ascii_rounded  ││ 16 │ basic_compact  ││ 17 │ single         ││ 18 │ double         │╰────┴────────────────╯"
     );
 }
 

--- a/crates/nu-protocol/src/config/table.rs
+++ b/crates/nu-protocol/src/config/table.rs
@@ -21,6 +21,7 @@ pub enum TableMode {
     AsciiRounded,
     BasicCompact,
     Single,
+    Double,
 }
 
 impl FromStr for TableMode {
@@ -46,8 +47,9 @@ impl FromStr for TableMode {
             "ascii_rounded" => Ok(Self::AsciiRounded),
             "basic_compact" => Ok(Self::BasicCompact),
             "single" => Ok(Self::Single),
+            "double" => Ok(Self::Double),
             _ => Err(
-                "'basic', 'thin', 'light', 'compact', 'with_love', 'compact_double', 'rounded', 'reinforced', 'heavy', 'none', 'psql', 'markdown', 'dots', 'restructured', 'ascii_rounded', 'basic_compact' or 'single'",
+                "'basic', 'thin', 'light', 'compact', 'with_love', 'compact_double', 'rounded', 'reinforced', 'heavy', 'none', 'psql', 'markdown', 'dots', 'restructured', 'ascii_rounded', 'basic_compact', 'single', or 'double'",
             ),
         }
     }

--- a/crates/nu-table/src/common.rs
+++ b/crates/nu-table/src/common.rs
@@ -187,6 +187,7 @@ pub fn load_theme(mode: TableMode) -> TableTheme {
         TableMode::AsciiRounded => TableTheme::ascii_rounded(),
         TableMode::BasicCompact => TableTheme::basic_compact(),
         TableMode::Single => TableTheme::single(),
+        TableMode::Double => TableTheme::double(),
     }
 }
 

--- a/crates/nu-table/src/table_theme.rs
+++ b/crates/nu-table/src/table_theme.rs
@@ -166,6 +166,15 @@ impl TableTheme {
         Self::new(Style::sharp(), full)
     }
 
+    pub fn double() -> TableTheme {
+        let hline = HorizontalLine::inherit(Style::extended());
+        let theme = Style::extended()
+            .remove_horizontal()
+            .horizontals([(1, hline)]);
+
+        Self::new(theme, Style::extended())
+    }
+
     pub fn none() -> TableTheme {
         Self::new(Style::blank(), Style::blank())
     }

--- a/crates/nu-table/tests/style.rs
+++ b/crates/nu-table/tests/style.rs
@@ -497,6 +497,52 @@ fn test_single() {
     assert_eq!(create_table_with_size(vec![], true, theme::single()), "");
 }
 
+#[test]
+fn test_double() {
+    assert_eq!(
+        create_table(vec![row(4); 3], true, theme::double()),
+        "╔═══╦═══╦═══╦═══╗\n\
+         ║ 0 ║ 1 ║ 2 ║ 3 ║\n\
+         ╠═══╬═══╬═══╬═══╣\n\
+         ║ 0 ║ 1 ║ 2 ║ 3 ║\n\
+         ║ 0 ║ 1 ║ 2 ║ 3 ║\n\
+         ╚═══╩═══╩═══╩═══╝"
+    );
+
+    assert_eq!(
+        create_table(vec![row(4); 2], true, theme::double()),
+        "╔═══╦═══╦═══╦═══╗\n\
+         ║ 0 ║ 1 ║ 2 ║ 3 ║\n\
+         ╠═══╬═══╬═══╬═══╣\n\
+         ║ 0 ║ 1 ║ 2 ║ 3 ║\n\
+         ╚═══╩═══╩═══╩═══╝"
+    );
+
+    assert_eq!(
+        create_table(vec![row(4); 1], true, theme::double()),
+        "╔═══╦═══╦═══╦═══╗\n\
+         ║ 0 ║ 1 ║ 2 ║ 3 ║\n\
+         ╚═══╩═══╩═══╩═══╝"
+    );
+
+    assert_eq!(
+        create_table(vec![row(4); 1], false, theme::double()),
+        "╔═══╦═══╦═══╦═══╗\n\
+         ║ 0 ║ 1 ║ 2 ║ 3 ║\n\
+         ╚═══╩═══╩═══╩═══╝"
+    );
+
+    assert_eq!(
+        create_table(vec![row(4); 2], false, theme::double()),
+        "╔═══╦═══╦═══╦═══╗\n\
+         ║ 0 ║ 1 ║ 2 ║ 3 ║\n\
+         ║ 0 ║ 1 ║ 2 ║ 3 ║\n\
+         ╚═══╩═══╩═══╩═══╝"
+    );
+
+    assert_eq!(create_table_with_size(vec![], true, theme::double()), "");
+}
+
 fn create_table(data: Vec<Vec<Text<String>>>, with_header: bool, theme: theme) -> String {
     let mut case = TestCase::new(usize::MAX).theme(theme);
     if with_header {

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -303,7 +303,7 @@ $env.config.footer_mode = 25
 # Specifies the visual display style of a table
 # One of: "default", "basic", "compact", "compact_double", "heavy", "light", "none", "reinforced",
 # "rounded", "thin", "with_love", "psql", "markdown", "dots", "restructured", "ascii_rounded",
-# "basic_compact" or "single"
+# "basic_compact", "single", or "double"
 # Can be overridden by passing a table to `| table --theme/-t`
 $env.config.table.mode = "default"
 


### PR DESCRIPTION
# Description

Add 'double' table mode, that is similar to `compact_double` but with left and right border lines. This is similar to how there exist both `single` and `compact`, but there is no `double` to compliment `compact_double`. Printing `[ { a: 1, b: 11 }, { a: 2, b:12 } ]` looks like this:

```
╔═══╦═══╦════╗
║ # ║ a ║ b  ║
╠═══╬═══╬════╣
║ 0 ║ 1 ║ 11 ║
║ 1 ║ 2 ║ 12 ║
╚═══╩═══╩════╝
```

The implementation is mostly a one-to-one of #15672 and #15681.

# User-Facing Changes

New value `double` to set as `$env.config.table.mode`.

# Tests + Formatting

Tests are added following the example of adding 'single' mode.

# After Submitting
