### PR TITLE
Add pipeline span to `metadata`

### DIFF
--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -87,10 +87,9 @@ impl Command for Metadata {
                         .into_pipeline_data(),
                 )
             }
-            None => Ok(
-                Value::record(build_metadata_record(input.metadata().as_ref(), head), head)
-                    .into_pipeline_data(),
-            ),
+            None => {
+                Ok(Value::record(build_metadata_record(&input, head), head).into_pipeline_data())
+            }
         }
     }
 
@@ -116,19 +115,7 @@ fn build_metadata_record_value(
     head: Span,
 ) -> Value {
     let mut record = Record::new();
-
-    let span = arg.span();
-    record.push(
-        "span",
-        Value::record(
-            record! {
-                "start" => Value::int(span.start as i64,span),
-                "end" => Value::int(span.end as i64, span),
-            },
-            head,
-        ),
-    );
-
+    record.push("span", arg.span().into_value(head));
     Value::record(extend_record_with_metadata(record, metadata, head), head)
 }
 

--- a/crates/nu-command/src/debug/metadata_access.rs
+++ b/crates/nu-command/src/debug/metadata_access.rs
@@ -42,10 +42,7 @@ impl Command for MetadataAccess {
         // `ClosureEvalOnce` is not used as it uses `Stack::captures_to_stack` rather than
         // `Stack::captures_to_stack_preserve_out_dest`. This command shouldn't collect streams
         let mut callee_stack = caller_stack.captures_to_stack_preserve_out_dest(closure.captures);
-        let metadata_record = Value::record(
-            build_metadata_record(input.metadata().as_ref(), call.head),
-            call.head,
-        );
+        let metadata_record = Value::record(build_metadata_record(&input, call.head), call.head);
 
         if let Some(var_id) = block.signature.get_positional(0).and_then(|var| var.var_id) {
             callee_stack.add_var(var_id, metadata_record)

--- a/crates/nu-command/src/debug/metadata_access.rs
+++ b/crates/nu-command/src/debug/metadata_access.rs
@@ -58,7 +58,7 @@ impl Command for MetadataAccess {
             example: r#"{foo: bar} | to json --raw | metadata access {|meta| {in: $in, content: $meta.content_type}}"#,
             result: Some(Value::test_record(record! {
                 "in" => Value::test_string(r#"{"foo":"bar"}"#),
-                "content_type" => Value::test_string(r#"application/json"#)
+                "content" => Value::test_string(r#"application/json"#)
             })),
         }]
     }

--- a/crates/nu-command/src/debug/metadata_access.rs
+++ b/crates/nu-command/src/debug/metadata_access.rs
@@ -55,12 +55,10 @@ impl Command for MetadataAccess {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Access metadata and data from a stream together",
-            example: r#"{foo: bar} | to json --raw | metadata access {|meta| {in: $in, meta: $meta}}"#,
+            example: r#"{foo: bar} | to json --raw | metadata access {|meta| {in: $in, content: $meta.content_type}}"#,
             result: Some(Value::test_record(record! {
                 "in" => Value::test_string(r#"{"foo":"bar"}"#),
-                "meta" => Value::test_record(record! {
-                    "content_type" => Value::test_string(r#"application/json"#)
-                })
+                "content_type" => Value::test_string(r#"application/json"#)
             })),
         }]
     }

--- a/crates/nu-command/src/debug/metadata_set.rs
+++ b/crates/nu-command/src/debug/metadata_set.rs
@@ -79,15 +79,13 @@ impl Command for MetadataSet {
             },
             Example {
                 description: "Set the metadata of a file path",
-                example: "'crates' | metadata set --datasource-filepath $'(pwd)/crates' | metadata",
+                example: "'crates' | metadata set --datasource-filepath $'(pwd)/crates'",
                 result: None,
             },
             Example {
                 description: "Set the metadata of a file path",
-                example: "'crates' | metadata set --content-type text/plain | metadata",
-                result: Some(Value::test_record(record! {
-                    "content_type" => Value::test_string("text/plain"),
-                })),
+                example: "'crates' | metadata set --content-type text/plain | metadata | get content_type",
+                result: Some(Value::test_string("text/plain")),
             },
         ]
     }

--- a/crates/nu-command/src/debug/util.rs
+++ b/crates/nu-command/src/debug/util.rs
@@ -1,4 +1,4 @@
-use nu_protocol::{DataSource, PipelineMetadata, Record, Span, Value};
+use nu_protocol::{DataSource, IntoValue, PipelineData, PipelineMetadata, Record, Span, Value};
 
 pub fn extend_record_with_metadata(
     mut record: Record,
@@ -29,6 +29,10 @@ pub fn extend_record_with_metadata(
     record
 }
 
-pub fn build_metadata_record(metadata: Option<&PipelineMetadata>, head: Span) -> Record {
-    extend_record_with_metadata(Record::new(), metadata, head)
+pub fn build_metadata_record(pipeline: &PipelineData, head: Span) -> Record {
+    let mut record = Record::new();
+    if let Some(span) = pipeline.span() {
+        record.insert("span", span.into_value(head));
+    }
+    extend_record_with_metadata(record, pipeline.metadata().as_ref(), head)
 }

--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -231,7 +231,7 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#""a,b\n1,2" | metadata set --content-type 'text/csv' --datasource-ls | from csv | metadata | reject span"#;
+        let cmd = r#""a,b\n1,2" | metadata set --content-type 'text/csv' --datasource-ls | from csv | metadata | reject span | $in"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -203,6 +203,7 @@ mod test {
 
     use super::*;
 
+    use crate::Reject;
     use crate::{Metadata, MetadataSet};
 
     #[test]
@@ -221,6 +222,7 @@ mod test {
             working_set.add_decl(Box::new(FromCsv {}));
             working_set.add_decl(Box::new(Metadata {}));
             working_set.add_decl(Box::new(MetadataSet {}));
+            working_set.add_decl(Box::new(Reject {}));
 
             working_set.render()
         };
@@ -229,7 +231,7 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#""a,b\n1,2" | metadata set --content-type 'text/csv' --datasource-ls | from csv | metadata | $in"#;
+        let cmd = r#""a,b\n1,2" | metadata set --content-type 'text/csv' --datasource-ls | from csv | metadata | reject span"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -248,6 +248,7 @@ fn convert_string_to_value_strict(string_input: &str, span: Span) -> Result<Valu
 mod test {
     use nu_cmd_lang::eval_pipeline_without_terminal_expression;
 
+    use crate::Reject;
     use crate::{Metadata, MetadataSet};
 
     use super::*;
@@ -268,6 +269,7 @@ mod test {
             working_set.add_decl(Box::new(FromJson {}));
             working_set.add_decl(Box::new(Metadata {}));
             working_set.add_decl(Box::new(MetadataSet {}));
+            working_set.add_decl(Box::new(Reject {}));
 
             working_set.render()
         };
@@ -276,7 +278,7 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#"'{"a":1,"b":2}' | metadata set --content-type 'application/json' --datasource-ls | from json | metadata | $in"#;
+        let cmd = r#"'{"a":1,"b":2}' | metadata set --content-type 'application/json' --datasource-ls | from json | metadata | reject span"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -278,7 +278,7 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#"'{"a":1,"b":2}' | metadata set --content-type 'application/json' --datasource-ls | from json | metadata | reject span"#;
+        let cmd = r#"'{"a":1,"b":2}' | metadata set --content-type 'application/json' --datasource-ls | from json | metadata | reject span | $in"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/msgpack.rs
+++ b/crates/nu-command/src/formats/from/msgpack.rs
@@ -545,7 +545,7 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#"{a: 1 b: 2} | to msgpack | metadata set --datasource-ls | from msgpack | metadata | reject span"#;
+        let cmd = r#"{a: 1 b: 2} | to msgpack | metadata set --datasource-ls | from msgpack | metadata | reject span | $in"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/msgpack.rs
+++ b/crates/nu-command/src/formats/from/msgpack.rs
@@ -514,6 +514,7 @@ fn assert_eof(input: &mut impl io::Read, span: Span) -> Result<(), ShellError> {
 mod test {
     use nu_cmd_lang::eval_pipeline_without_terminal_expression;
 
+    use crate::Reject;
     use crate::{Metadata, MetadataSet, ToMsgpack};
 
     use super::*;
@@ -535,6 +536,7 @@ mod test {
             working_set.add_decl(Box::new(FromMsgpack {}));
             working_set.add_decl(Box::new(Metadata {}));
             working_set.add_decl(Box::new(MetadataSet {}));
+            working_set.add_decl(Box::new(Reject {}));
 
             working_set.render()
         };
@@ -543,7 +545,7 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#"{a: 1 b: 2} | to msgpack | metadata set --datasource-ls | from msgpack | metadata | $in"#;
+        let cmd = r#"{a: 1 b: 2} | to msgpack | metadata set --datasource-ls | from msgpack | metadata | reject span"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -74,6 +74,7 @@ impl Command for FromNuon {
 mod test {
     use nu_cmd_lang::eval_pipeline_without_terminal_expression;
 
+    use crate::Reject;
     use crate::{Metadata, MetadataSet};
 
     use super::*;
@@ -94,6 +95,7 @@ mod test {
             working_set.add_decl(Box::new(FromNuon {}));
             working_set.add_decl(Box::new(Metadata {}));
             working_set.add_decl(Box::new(MetadataSet {}));
+            working_set.add_decl(Box::new(Reject {}));
 
             working_set.render()
         };
@@ -102,7 +104,7 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#"'[[a, b]; [1, 2]]' | metadata set --content-type 'application/x-nuon' --datasource-ls | from nuon | metadata | $in"#;
+        let cmd = r#"'[[a, b]; [1, 2]]' | metadata set --content-type 'application/x-nuon' --datasource-ls | from nuon | metadata | reject span"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -104,7 +104,7 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#"'[[a, b]; [1, 2]]' | metadata set --content-type 'application/x-nuon' --datasource-ls | from nuon | metadata | reject span"#;
+        let cmd = r#"'[[a, b]; [1, 2]]' | metadata set --content-type 'application/x-nuon' --datasource-ls | from nuon | metadata | reject span | $in"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/toml.rs
+++ b/crates/nu-command/src/formats/from/toml.rs
@@ -145,6 +145,7 @@ pub fn convert_string_to_value(string_input: String, span: Span) -> Result<Value
 
 #[cfg(test)]
 mod tests {
+    use crate::Reject;
     use crate::{Metadata, MetadataSet};
 
     use super::*;
@@ -345,6 +346,7 @@ mod tests {
             working_set.add_decl(Box::new(FromToml {}));
             working_set.add_decl(Box::new(Metadata {}));
             working_set.add_decl(Box::new(MetadataSet {}));
+            working_set.add_decl(Box::new(Reject {}));
 
             working_set.render()
         };
@@ -353,7 +355,7 @@ mod tests {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#""[a]\nb = 1\nc = 1" | metadata set --content-type 'text/x-toml' --datasource-ls | from toml | metadata | $in"#;
+        let cmd = r#""[a]\nb = 1\nc = 1" | metadata set --content-type 'text/x-toml' --datasource-ls | from toml | metadata | reject span"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/toml.rs
+++ b/crates/nu-command/src/formats/from/toml.rs
@@ -355,7 +355,7 @@ mod tests {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#""[a]\nb = 1\nc = 1" | metadata set --content-type 'text/x-toml' --datasource-ls | from toml | metadata | reject span"#;
+        let cmd = r#""[a]\nb = 1\nc = 1" | metadata set --content-type 'text/x-toml' --datasource-ls | from toml | metadata | reject span | $in"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/tsv.rs
+++ b/crates/nu-command/src/formats/from/tsv.rs
@@ -160,6 +160,7 @@ fn from_tsv(
 mod test {
     use nu_cmd_lang::eval_pipeline_without_terminal_expression;
 
+    use crate::Reject;
     use crate::{Metadata, MetadataSet};
 
     use super::*;
@@ -180,6 +181,7 @@ mod test {
             working_set.add_decl(Box::new(FromTsv {}));
             working_set.add_decl(Box::new(Metadata {}));
             working_set.add_decl(Box::new(MetadataSet {}));
+            working_set.add_decl(Box::new(Reject {}));
 
             working_set.render()
         };
@@ -188,7 +190,7 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#""a\tb\n1\t2" | metadata set --content-type 'text/tab-separated-values' --datasource-ls | from tsv | metadata | $in"#;
+        let cmd = r#""a\tb\n1\t2" | metadata set --content-type 'text/tab-separated-values' --datasource-ls | from tsv | metadata | reject span"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/tsv.rs
+++ b/crates/nu-command/src/formats/from/tsv.rs
@@ -190,7 +190,7 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#""a\tb\n1\t2" | metadata set --content-type 'text/tab-separated-values' --datasource-ls | from tsv | metadata | reject span"#;
+        let cmd = r#""a\tb\n1\t2" | metadata set --content-type 'text/tab-separated-values' --datasource-ls | from tsv | metadata | reject span | $in"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -370,6 +370,7 @@ fn make_xml_error_spanned(msg: impl Into<String>, src: String, pos: TextPos) -> 
 mod tests {
     use crate::Metadata;
     use crate::MetadataSet;
+    use crate::Reject;
 
     use super::*;
 
@@ -541,6 +542,7 @@ mod tests {
             working_set.add_decl(Box::new(FromXml {}));
             working_set.add_decl(Box::new(Metadata {}));
             working_set.add_decl(Box::new(MetadataSet {}));
+            working_set.add_decl(Box::new(Reject {}));
 
             working_set.render()
         };
@@ -552,7 +554,7 @@ mod tests {
         let cmd = r#"'<?xml version="1.0" encoding="UTF-8"?>
 <note>
   <remember>Event</remember>
-</note>' | metadata set --content-type 'application/xml' --datasource-ls | from xml | metadata | $in"#;
+</note>' | metadata set --content-type 'application/xml' --datasource-ls | from xml | metadata | reject span"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -554,7 +554,7 @@ mod tests {
         let cmd = r#"'<?xml version="1.0" encoding="UTF-8"?>
 <note>
   <remember>Event</remember>
-</note>' | metadata set --content-type 'application/xml' --datasource-ls | from xml | metadata | reject span"#;
+</note>' | metadata set --content-type 'application/xml' --datasource-ls | from xml | metadata | reject span | $in"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/yaml.rs
+++ b/crates/nu-command/src/formats/from/yaml.rs
@@ -244,6 +244,7 @@ fn from_yaml(input: PipelineData, head: Span) -> Result<PipelineData, ShellError
 
 #[cfg(test)]
 mod test {
+    use crate::Reject;
     use crate::{Metadata, MetadataSet};
 
     use super::*;
@@ -410,6 +411,7 @@ mod test {
             working_set.add_decl(Box::new(FromYaml {}));
             working_set.add_decl(Box::new(Metadata {}));
             working_set.add_decl(Box::new(MetadataSet {}));
+            working_set.add_decl(Box::new(Reject {}));
 
             working_set.render()
         };
@@ -418,7 +420,7 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#""a: 1\nb: 2" | metadata set --content-type 'application/yaml' --datasource-ls | from yaml | metadata | $in"#;
+        let cmd = r#""a: 1\nb: 2" | metadata set --content-type 'application/yaml' --datasource-ls | from yaml | metadata | reject span"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/from/yaml.rs
+++ b/crates/nu-command/src/formats/from/yaml.rs
@@ -420,7 +420,7 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = r#""a: 1\nb: 2" | metadata set --content-type 'application/yaml' --datasource-ls | from yaml | metadata | reject span"#;
+        let cmd = r#""a: 1\nb: 2" | metadata set --content-type 'application/yaml' --datasource-ls | from yaml | metadata | reject span | $in"#;
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),

--- a/crates/nu-command/src/formats/to/csv.rs
+++ b/crates/nu-command/src/formats/to/csv.rs
@@ -166,14 +166,14 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = "{a: 1 b: 2} | to csv  | metadata | get content_type";
+        let cmd = "{a: 1 b: 2} | to csv  | metadata | get content_type | $in";
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),
             &mut engine_state,
         );
         assert_eq!(
-            Value::test_record(record!("content_type" => Value::test_string("text/csv"))),
+            Value::test_string("text/csv"),
             result.expect("There should be a result")
         );
     }

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -229,14 +229,14 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = "{a: 1 b: 2} | to json  | metadata | get content_type";
+        let cmd = "{a: 1 b: 2} | to json  | metadata | get content_type | $in";
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),
             &mut engine_state,
         );
         assert_eq!(
-            Value::test_record(record!("content_type" => Value::test_string("application/json"))),
+            Value::test_string("application/json"),
             result.expect("There should be a result")
         );
     }

--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -906,14 +906,14 @@ mod tests {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = "{a: 1 b: 2} | to md  | metadata | get content_type";
+        let cmd = "{a: 1 b: 2} | to md  | metadata | get content_type | $in";
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),
             &mut engine_state,
         );
         assert_eq!(
-            Value::test_record(record!("content_type" => Value::test_string("text/markdown"))),
+            Value::test_string("text/markdown"),
             result.expect("There should be a result")
         );
     }

--- a/crates/nu-command/src/formats/to/msgpack.rs
+++ b/crates/nu-command/src/formats/to/msgpack.rs
@@ -348,16 +348,14 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = "{a: 1 b: 2} | to msgpack | metadata | get content_type";
+        let cmd = "{a: 1 b: 2} | to msgpack | metadata | get content_type | $in";
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),
             &mut engine_state,
         );
         assert_eq!(
-            Value::test_record(
-                record!("content_type" => Value::test_string("application/x-msgpack"))
-            ),
+            Value::test_string("application/x-msgpack"),
             result.expect("There should be a result")
         );
     }

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -143,14 +143,14 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = "{a: 1 b: 2} | to nuon | metadata | get content_type";
+        let cmd = "{a: 1 b: 2} | to nuon | metadata | get content_type | $in";
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),
             &mut engine_state,
         );
         assert_eq!(
-            Value::test_record(record!("content_type" => Value::test_string("application/x-nuon"))),
+            Value::test_string("application/x-nuon"),
             result.expect("There should be a result")
         );
     }

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -272,14 +272,14 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = "{a: 1 b: 2} | to text  | metadata | get content_type";
+        let cmd = "{a: 1 b: 2} | to text  | metadata | get content_type | $in";
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),
             &mut engine_state,
         );
         assert_eq!(
-            Value::test_record(record!("content_type" => Value::test_string("text/plain"))),
+            Value::test_string("text/plain"),
             result.expect("There should be a result")
         );
     }

--- a/crates/nu-command/src/formats/to/tsv.rs
+++ b/crates/nu-command/src/formats/to/tsv.rs
@@ -132,16 +132,14 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = "{a: 1 b: 2} | to tsv | metadata | get content_type";
+        let cmd = "{a: 1 b: 2} | to tsv | metadata | get content_type | $in";
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),
             &mut engine_state,
         );
         assert_eq!(
-            Value::test_record(
-                record!("content_type" => Value::test_string("text/tab-separated-values"))
-            ),
+            Value::test_string("text/tab-separated-values"),
             result.expect("There should be a result")
         );
     }

--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -540,14 +540,14 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = "{tag: note attributes: {} content : [{tag: remember attributes: {} content : [{tag: null attributes: null content : Event}]}]} | to xml | metadata | get content_type";
+        let cmd = "{tag: note attributes: {} content : [{tag: remember attributes: {} content : [{tag: null attributes: null content : Event}]}]} | to xml | metadata | get content_type | $in";
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),
             &mut engine_state,
         );
         assert_eq!(
-            Value::test_record(record!("content_type" => Value::test_string("application/xml"))),
+            Value::test_string("application/xml"),
             result.expect("There should be a result")
         );
     }

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -233,14 +233,14 @@ mod test {
             .merge_delta(delta)
             .expect("Error merging delta");
 
-        let cmd = "{a: 1 b: 2} | to yaml  | metadata | get content_type";
+        let cmd = "{a: 1 b: 2} | to yaml  | metadata | get content_type | $in";
         let result = eval_pipeline_without_terminal_expression(
             cmd,
             std::env::temp_dir().as_ref(),
             &mut engine_state,
         );
         assert_eq!(
-            Value::test_record(record!("content_type" => Value::test_string("application/yaml"))),
+            Value::test_string("application/yaml"),
             result.expect("There should be a result")
         );
     }

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -1,5 +1,5 @@
 //! [`Span`] to point to sections of source code and the [`Spanned`] wrapper type
-use crate::SpanId;
+use crate::{IntoValue, SpanId, Value, record};
 use miette::SourceSpan;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
@@ -235,6 +235,16 @@ impl Span {
             .into_iter()
             .reduce(Self::merge)
             .unwrap_or(Self::unknown())
+    }
+}
+
+impl IntoValue for Span {
+    fn into_value(self, span: Span) -> Value {
+        let record = record! {
+            "start" => Value::int(self.start as i64, self),
+            "end" => Value::int(self.end as i64, self),
+        };
+        record.into_value(span)
     }
 }
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR makes the span of a pipeline accessible through `metadata`, meaning it's possible to get the span of a pipeline without collecting it.

Examples:
```nushell
ls | metadata
# => ╭────────┬────────────────────╮
# => │        │ ╭───────┬────────╮ │
# => │ span   │ │ start │ 170218 │ │
# => │        │ │ end   │ 170220 │ │
# => │        │ ╰───────┴────────╯ │
# => │ source │ ls                 │
# => ╰────────┴────────────────────╯
```

```nushell
ls | metadata access {|meta|
  error make {msg: "error", label: {text: "here", span: $meta.span}}
}
# => Error:   × error
# =>    ╭─[entry #7:1:1]
# =>  1 │ ls | metadata access {|meta|
# =>    · ─┬
# =>    ·  ╰── here
# =>  2 │   error make {msg: "error", label: {text: "here", span: $meta.span}}
# =>    ╰────
```

Here's an example that wouldn't be possible before, since you would have to use `metadata $in` to get the span, collecting the (infinite) stream

```nushell
generate {|x=0| {out: 0, next: 0} } | metadata access {|meta|
  # do whatever with stream
  error make {msg: "error", label: {text: "here", span: $meta.span}}
}
# => Error:   × error
# =>    ╭─[entry #16:1:1]
# =>  1 │ generate {|x=0| {out: 0, next: 0} } | metadata access {|meta|
# =>    · ────┬───
# =>    ·     ╰── here
# =>  2 │   # do whatever with stream
# =>    ╰────
```

I haven't done the tests or anything yet since I'm not sure how we feel about having this as part of the normal metadata, rather than a new command like `metadata span` or something. We could also have a `metadata access` like functionality for that with an optional closure argument potentially.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
* The span of a pipeline is now available through `metadata` and `metadata access` without collecting a stream.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
TODO

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A