### PR TITLE
fix(std/help): `collect` windows `--help` output for gui programs

### DIFF
--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -762,7 +762,7 @@ def external-commands [
     let target_command = $command | str join " " | str replace "^" ""
     print $"(ansi default_italic)Help pages from external command ($target_command | pretty-cmd):(ansi reset)"
     if $env.NU_HELPER? == "--help" {
-        run-external ($target_command | split row " ") "--help"
+        run-external ($target_command | split row " ") "--help" | if $nu.os-info.name == "windows" { collect } else {}
     } else {
         ^($env.NU_HELPER? | default "man") $target_command
     }


### PR DESCRIPTION
# Description
Adding to #15962, I have realized that there are windows gui programs like `prismlauncher` or `firefox` that do accept the `--help` flag but won't output on the terminal unless `collect`ed, so now it collects the output on windows.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
