### PR TITLE
Add loongarch64-unknown-linux-musl build target

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - nightly   # Just for test purpose only with the nightly repo
+      - feature/loong64-musl
   # This schedule will run only from the default branch
   schedule:
     - cron: '15 0 * * *' # run at 00:15 AM UTC

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -182,6 +182,7 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       # WARN: Keep the rustflags to prevent from the winget submission error: `CAQuietExec: Error 0xc0000135`
       with:
+        cache: false
         rustflags: ''
 
     - name: Setup Nushell

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - nightly   # Just for test purpose only with the nightly repo
-      - feature/loong64-musl
   # This schedule will run only from the default branch
   schedule:
     - cron: '15 0 * * *' # run at 00:15 AM UTC

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -127,6 +127,7 @@ jobs:
         - armv7-unknown-linux-musleabihf
         - riscv64gc-unknown-linux-gnu
         - loongarch64-unknown-linux-gnu
+        - loongarch64-unknown-linux-musl
         include:
         - target: aarch64-apple-darwin
           os: macos-latest
@@ -151,6 +152,8 @@ jobs:
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-22.04
         - target: loongarch64-unknown-linux-gnu
+          os: ubuntu-22.04
+        - target: loongarch64-unknown-linux-musl
           os: ubuntu-22.04
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -99,6 +99,14 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
             $env.CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER = 'loongarch64-unknown-linux-gnu-gcc'
             cargo-build-nu
         }
+        'loongarch64-unknown-linux-musl' => {
+            print $"(ansi g)Downloading LoongArch64 musl cross-compilation toolchain...(ansi reset)"
+            aria2c -q https://github.com/LoongsonLab/oscomp-toolchains-for-oskernel/releases/download/loongarch64-linux-musl-cross-gcc-13.2.0/loongarch64-linux-musl-cross.tgz
+            tar -xf loongarch64-linux-musl-cross.tgz
+            $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.PWD)/loongarch64-linux-musl-cross/bin')
+            $env.CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_MUSL_LINKER = "loongarch64-linux-musl-gcc"
+            cargo-build-nu
+        }
         _ => {
             # musl-tools to fix 'Failed to find tool. Is `musl-gcc` installed?'
             # Actually just for x86_64-unknown-linux-musl target

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -105,7 +105,7 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
             tar -xf loongarch64-linux-musl-cross.tgz
             $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.PWD)/loongarch64-linux-musl-cross/bin')
             $env.CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_MUSL_LINKER = "loongarch64-linux-musl-gcc"
-            cargo-build-nu
+            cargo build --release --all --target $target --features=plugin,trash-support,sqlite,rustls-tls,static-link-openssl
         }
         _ => {
             # musl-tools to fix 'Failed to find tool. Is `musl-gcc` installed?'

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -105,7 +105,7 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
             tar -xf loongarch64-linux-musl-cross.tgz
             $env.PATH = ($env.PATH | split row (char esep) | prepend $'($env.PWD)/loongarch64-linux-musl-cross/bin')
             $env.CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_MUSL_LINKER = "loongarch64-linux-musl-gcc"
-            cargo build --release --all --target $target --features=plugin,trash-support,sqlite,rustls-tls,static-link-openssl
+            cargo-build-nu
         }
         _ => {
             # musl-tools to fix 'Failed to find tool. Is `musl-gcc` installed?'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         - armv7-unknown-linux-musleabihf
         - riscv64gc-unknown-linux-gnu
         - loongarch64-unknown-linux-gnu
+        - loongarch64-unknown-linux-musl
         include:
         - target: aarch64-apple-darwin
           os: macos-latest
@@ -59,6 +60,8 @@ jobs:
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-22.04
         - target: loongarch64-unknown-linux-gnu
+          os: ubuntu-22.04
+        - target: loongarch64-unknown-linux-musl
           os: ubuntu-22.04
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ name: Create Release Draft
 on:
   workflow_dispatch:
   push:
-    branches:
-      - feature/loong64-musl
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
       - '!*nightly*'  # Don't trigger release for nightly tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ name: Create Release Draft
 on:
   workflow_dispatch:
   push:
+    branches:
+      - feature/loong64-musl
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
       - '!*nightly*'  # Don't trigger release for nightly tags


### PR DESCRIPTION

# Description

- Add `loongarch64-unknown-linux-musl` build target
- Fix GLIBC error for loong arch64 here: https://github.com/nushell/integrations/actions/runs/15506997265/job/43663088497#step:4:86
- Disable `cache` for nightly workflow to inline with the release workflow

# User-Facing Changes

Users who want to deploy nushell on loongarch 64 systems with outdated or incompatible glibc versions can use `loongarch64-unknown-linux-musl` build instead.

# Tests + Formatting

We have this target included in the nightly builds for quite a while: https://github.com/nushell/nightly/releases/tag/0.105.2-nightly.12%2B760c9ef
