### PR TITLE
Update winget default INSTALLDIR for per-machine install path

### DIFF
--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -41,17 +41,6 @@
     <!-- If set to WixPerMachineFolder will install for PerMachine by default -->
     <Property Id="WixAppFolder" Value="WixLocalAppDataFolder" />
 
-    <!--
-      Support for winget install `——scope machine`:
-        Winget doesn't directly pass ALLUSERS=1 to the MSI installer when using
-        ——scope machine. Instead, it passes a property called INSTALLSCOPEMACHINE=1
-        This converts the winget parameter to the standard MSI parameter.
-        FIXME: However, this doesn't seem to work...
-    -->
-    <SetProperty Id="ALLUSERS" Value="1" After="LaunchConditions" Condition="INSTALLSCOPEMACHINE=1" />
-    <!-- This ensures the per-user flag is turned off when installing for all users. -->
-    <SetProperty Id="MSIINSTALLPERUSER" Value="0" After="LaunchConditions" Condition="INSTALLSCOPEMACHINE=1" />
-
     <!-- Workaround Wix Bug: https://github.com/wixtoolset/issues/issues/2165 -->
     <!-- The suggested folder in the dest folder dialog should be C:\Program Files\nu -->
     <CustomAction Id="Overwrite_WixSetDefaultPerMachineFolder" Property="WixPerMachineFolder"
@@ -248,7 +237,7 @@
     <!-- If installing per-machine (ALLUSERS=1 AND NOT MSIINSTALLPERUSER=1), this sets INSTALLDIR and BINDIR to point to machine-wide (Program Files) paths -->
     <SetProperty Id="INSTALLDIR"
                  Action="SetINSTALLDIR_Machine"
-                 Value="[APPLICATIONFOLDER]"
+                 Value="[ProgramFiles64Folder]$(var.ApplicationFolderName)"
                  After="LaunchConditions"
                  Condition="ALLUSERS=1 AND NOT MSIINSTALLPERUSER=1"
                  Sequence="both" />


### PR DESCRIPTION
# Description

- Update `winget` default INSTALLDIR for per-machine install path to ` C:\Program Files\nu`

# User-Facing Changes

These changes, along with the manifest update PR (such as [this example](https://github.com/microsoft/winget-pkgs/pull/266009/files)), will resolve [issue #15949](https://github.com/nushell/nushell/issues/15949) and add `--scope` flag support for `winget install`.

After these changes are merged, the following should occur:

1.  When no `nu` is installed, `winget install --id Nushell.Nushell --scope machine` will install Nushell to `C:\Program Files\nu`.
2.  `winget update --id Nushell.Nushell` will upgrade Nushell to the latest version with machine scope.
3.  When no `nu` is installed, `winget install --id Nushell.Nushell` will install Nushell to `%LOCALAPPDATA%\Programs\nu`.
4.  Due to [winget-cli issue #3011](https://github.com/microsoft/winget-cli/issues/3011), `winget update --id Nushell.Nushell` will unexpectedly install the latest version to `C:\Program Files\nu`. The workaround is to run `winget install --id Nushell.Nushell` again to install the latest version for user scope.

# Tests + Formatting

1. Nushell install from MSI tests: https://github.com/nushell/integrations/actions/runs/16088967701
2. Nushell install by Winget tests: https://github.com/nushell/integrations/actions/runs/16088814557
3. Nushell Upgrade by Winget tests: https://github.com/nushell/integrations/actions/runs/16088967705 and test script: https://github.com/nushell/integrations/blob/main/tests/test-all.nu

# After Submitting

The manifest files need to be updated manually for the next release, and I will do that.
