### PR TITLE
feat(std/help): add `is_const` information

### DIFF
--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -571,6 +571,7 @@ def build-command-page [command: record] {
       {
         "Creates scope" : $command.creates_scope,
         "Is built-in" : ($command.type == "built-in"),
+        "Is const" : $command.is_const,
         "Is a subcommand" : $command.is_sub,
         "Is a part of a plugin": ($command.type == "plugin"),
         "Is a custom command": ($command.type == "custom"),


### PR DESCRIPTION
# Description

I wanted to know if `version` is a const command and thought that it would be in the "This command" section but it wasn't, so I added it.
```
→ help version
Display Nu version, and its build configuration.

Category: core

This command:
 Creates scope         | ❌
 Is built-in           | ✅
 Is const              | ✅
 Is a subcommand       | ❌
 Is a part of a plugin | ❌
 Is a custom command   | ❌
 Is a keyword          | ❌
```

# User-Facing Changes

# Tests + Formatting

# After Submitting
