### PR TITLE
Update the behaviour how paths are interpreted in `start`

### DIFF
--- a/crates/nu-command/src/filesystem/start.rs
+++ b/crates/nu-command/src/filesystem/start.rs
@@ -49,7 +49,8 @@ impl Command for Start {
         }
         // If it's not a URL, treat it as a file path
         let cwd = engine_state.cwd(Some(stack))?;
-        let full_path = cwd.join(path_no_whitespace);
+        let full_path = nu_path::expand_path_with(path_no_whitespace, &cwd, true);
+
         // Check if the path exists or if it's a valid file/directory
         if full_path.exists() {
             open_path(full_path, engine_state, stack, path.span)?;


### PR DESCRIPTION
Closes: https://github.com/nushell/nushell/issues/13127

# Description

This PR updates the behaviour of `start` in the following ways:
Instead of joining the path with CWD, we expand the path.

Behaviour on `origin/main`:
```
nushell> ls ~/nushell-test
test.txt

nushell> start ~/nushell-test/test.txt
Error:   × Cannot find file or URL: ~/nushell-test/test.txt
...
help: Ensure the path or URL is correct and try again.
```

Behaviour in this PR:
```
nushell> ls ~/nushell-test
test.txt

nushell> start ~/nushell-test/test.txt
<opens text editor>
```

# User-Facing Changes

`start` now treats the input path differently. This is a breaking change, I believe. Although I'm not sure how breaking it would be in the perspective of the user.

# Tests + Formatting

I've manually tested this. The test suite for `start` is broken. And even if I fix it, I'm not sure how to test it.
I'll need to override the default command list for `start` in the sandbox for testing.

# After Submitting

I don't think the documentation needs to be updated.
