### PR TITLE
fix(metadata set): return error when both --datasource-filepath and -datasource-ls are used

### DIFF
--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -43,10 +43,8 @@ impl Command for Metadata {
         let arg = call.positional_nth(stack, 0);
         let head = call.head;
 
-        let has_input = !matches!(input, PipelineData::Empty);
-
-        if let Some(arg_expr) = arg {
-            if has_input {
+        if !matches!(input, PipelineData::Empty) {
+            if let Some(arg_expr) = arg {
                 return Err(ShellError::IncompatibleParameters {
                     left_message: "pipeline input was provided".into(),
                     left_span: head,
@@ -54,14 +52,6 @@ impl Command for Metadata {
                     right_span: arg_expr.span,
                 });
             }
-        }
-
-        if has_input {
-            return Ok(Value::record(
-                extend_record_with_metadata(Record::new(), input.metadata().as_ref(), call.head),
-                call.head,
-            )
-            .into_pipeline_data());
         }
 
         match arg {

--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -44,15 +44,16 @@ impl Command for Metadata {
         let head = call.head;
 
         let has_input = !matches!(input, PipelineData::Empty);
-        let has_argument = arg.is_some();
 
-        if has_input && has_argument {
-            return Err(ShellError::IncompatibleParameters {
-                left_message: "pipeline input was provided".into(),
-                left_span: head,
-                right_message: "but a positional metadata expression was also given".into(),
-                right_span: arg.unwrap().span,
-            });
+        if let Some(arg_expr) = arg {
+            if has_input {
+                return Err(ShellError::IncompatibleParameters {
+                    left_message: "pipeline input was provided".into(),
+                    left_span: head,
+                    right_message: "but a positional metadata expression was also given".into(),
+                    right_span: arg_expr.span,
+                });
+            }
         }
 
         if has_input {

--- a/crates/nu-command/src/debug/metadata_set.rs
+++ b/crates/nu-command/src/debug/metadata_set.rs
@@ -63,7 +63,17 @@ impl Command for MetadataSet {
         match (ds_fp, ds_ls) {
             (Some(path), false) => metadata.data_source = DataSource::FilePath(path.into()),
             (None, true) => metadata.data_source = DataSource::Ls,
-            (Some(_), true) => (), // TODO: error here
+            (Some(_), true) => {
+                return Err(ShellError::GenericError {
+                    error: "Conflicting flags".into(),
+                    msg:
+                        "Cannot use both --datasource-filepath and --datasource-ls at the same time"
+                            .into(),
+                    span: Some(head),
+                    help: Some("Use only one of the two flags".into()),
+                    inner: vec![],
+                });
+            }
             (None, false) => (),
         }
 

--- a/crates/nu-command/src/debug/metadata_set.rs
+++ b/crates/nu-command/src/debug/metadata_set.rs
@@ -64,14 +64,15 @@ impl Command for MetadataSet {
             (Some(path), false) => metadata.data_source = DataSource::FilePath(path.into()),
             (None, true) => metadata.data_source = DataSource::Ls,
             (Some(_), true) => {
-                return Err(ShellError::GenericError {
-                    error: "Conflicting flags".into(),
-                    msg:
-                        "Cannot use both --datasource-filepath and --datasource-ls at the same time"
-                            .into(),
-                    span: Some(head),
-                    help: Some("Use only one of the two flags".into()),
-                    inner: vec![],
+                return Err(ShellError::IncompatibleParameters {
+                    left_message: "cannot use `--datasource-filepath`".into(),
+                    left_span: call
+                        .get_flag_span(stack, "datasource-filepath")
+                        .expect("has flag"),
+                    right_message: "with `--datasource-ls`".into(),
+                    right_span: call
+                        .get_flag_span(stack, "datasource-ls")
+                        .expect("has flag"),
                 });
             }
             (None, false) => (),

--- a/crates/nu-command/tests/commands/debug/metadata_set.rs
+++ b/crates/nu-command/tests/commands/debug/metadata_set.rs
@@ -1,0 +1,30 @@
+use nu_test_support::nu;
+use nu_test_support::pipeline;
+
+#[test]
+fn errors_on_conflicting_metadata_flags() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo "foo" | metadata set --datasource-filepath foo.txt --datasource-ls
+        "#
+    ));
+
+    assert!(
+        actual
+            .err
+            .contains("Cannot use both --datasource-filepath and --datasource-ls")
+    );
+}
+
+#[test]
+fn works_with_datasource_filepath() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo "foo" | metadata set --datasource-filepath foo.txt
+        "#
+    ));
+
+    assert!(actual.out.contains("foo"));
+}

--- a/crates/nu-command/tests/commands/debug/metadata_set.rs
+++ b/crates/nu-command/tests/commands/debug/metadata_set.rs
@@ -10,11 +10,8 @@ fn errors_on_conflicting_metadata_flags() {
         "#
     ));
 
-    assert!(
-        actual
-            .err
-            .contains("Cannot use both --datasource-filepath and --datasource-ls")
-    );
+    assert!(actual.err.contains("cannot use `--datasource-filepath`"));
+    assert!(actual.err.contains("with `--datasource-ls`"));
 }
 
 #[test]
@@ -22,9 +19,25 @@ fn works_with_datasource_filepath() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo "foo" | metadata set --datasource-filepath foo.txt
+        echo "foo"
+        | metadata set --datasource-filepath foo.txt
+        | metadata get
         "#
     ));
 
-    assert!(actual.out.contains("foo"));
+    assert!(actual.out.contains("foo.txt"));
+}
+
+#[test]
+fn works_with_datasource_ls() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo "foo"
+        | metadata set --datasource-ls
+        | metadata get
+        "#
+    ));
+
+    assert!(actual.out.contains("ls"));
 }

--- a/crates/nu-command/tests/commands/debug/metadata_set.rs
+++ b/crates/nu-command/tests/commands/debug/metadata_set.rs
@@ -21,7 +21,7 @@ fn works_with_datasource_filepath() {
         r#"
         echo "foo"
         | metadata set --datasource-filepath foo.txt
-        | metadata get
+        | metadata
         "#
     ));
 
@@ -35,7 +35,7 @@ fn works_with_datasource_ls() {
         r#"
         echo "foo"
         | metadata set --datasource-ls
-        | metadata get
+        | metadata
         "#
     ));
 

--- a/crates/nu-command/tests/commands/debug/mod.rs
+++ b/crates/nu-command/tests/commands/debug/mod.rs
@@ -1,1 +1,2 @@
+mod metadata_set;
 mod timeit;


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR improves the `metadata set` command by returning a clear error when both `--datasource-filepath` and `--datasource-ls` flags are used together. These flags are meant to be mutually exclusive, and previously this conflicting usage was silently ignored.

# User-Facing Changes

* Users will now see an error message if they use both `--datasource-filepath` and `--datasource-ls` together in `metadata set`.

# Tests + Formatting

* [x] Added test at `crates/nu-command/tests/commands/debug/metadata_set.rs` to verify the error behavior.
* [x] Ran `cargo fmt --all -- --check`
* [x] Ran `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used`
* [x] Ran `cargo test --workspace`


# After Submitting

N/A 
