### PR TITLE
Add `tango` folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ wix/nu/
 lcov.info
 tarpaulin-report.html
 
+# benchmarking
+/tango
+
 # Visual Studio
 .vs/*
 *.rsproj


### PR DESCRIPTION
This is the folder used by `toolkit.nu` when invoking the tango commands
