### PR TITLE
Implement `--before` and `--after` flags for `parse`

### DIFF
--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -122,6 +122,38 @@ impl Command for Parse {
                     "bar" => Value::test_string("there"),
                 })])),
             },
+            Example {
+                description: "Parse a string and collect the text after each match",
+                example: r#""1) first entry 2) second entry \n(multiline) 3) final entry" | parse -r '(?P<number>\d)\) ' --after "content""#,
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "number" => Value::test_string("1"),
+                        "content" => Value::test_string("first entry "),
+                    }),
+                    Value::test_record(record! {
+                        "number" => Value::test_string("2"),
+                        "content" => Value::test_string("second entry \n(multiline) "),
+                    }),
+                    Value::test_record(record! {
+                        "number" => Value::test_string("3"),
+                        "content" => Value::test_string("final entry"),
+                    }),
+                ])),
+            },
+            Example {
+                description: "Parse a string and collect the text before each match",
+                example: r#"'some text (page 7) some more text (page 12)' | parse -r ' \(page (?P<page>.+?)\);? ?' --before "text""#,
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "text" => Value::test_string("some text"),
+                        "page" => Value::test_string("7"),
+                    }),
+                    Value::test_record(record! {
+                        "text" => Value::test_string("some more text"),
+                        "page" => Value::test_string("12"),
+                    }),
+                ])),
+            },
         ]
     }
 


### PR DESCRIPTION
These flags will capture the text that is between regexes and put it in
an additional column. The `--before` flag adds the text that came before each match to the table, and the `--after` adds the text that came after the match instead.

# User-Facing Changes

`parse` now has `--before` and `--after` flags available. The  behavior of parse should otherwise remain unchanged.

# Example

Here's how this could be used to parse a log file

```
> 'Jun 28 19:34:27 Reading arguments from command line.
Jun 28 19:34:36 WARNING could not find config file. Using default config.
Jun 28 19:35:19 App successfully started.'
| parse -r '(?P<time>... \d{2} \d{2}:\d{2}:\d{2}) ' --after "log"
```
output:
```
| # |      time       |                            log                            |
|---|-----------------|-----------------------------------------------------------|
| 0 | Jun 28 19:34:27 | Reading arguments from command line.                      |
| 1 | Jun 28 19:34:36 | WARNING could not find config file. Using default config. |
| 2 | Jun 28 19:35:19 | App successfully started.                                  |

```