### PR TITLE
feat(std-rfc/str): add `str align`

### DIFF
--- a/crates/nu-std/tests/test_std-rfc_str.nu
+++ b/crates/nu-std/tests/test_std-rfc_str.nu
@@ -291,3 +291,120 @@ def str-unindent_whitespace_works_with_tabs [] {
 
     assert equal $actual $expected
 }
+
+@test
+def str-align_simple [] {
+    let actual = [
+        "let a = 1"
+        "let max = 2"
+        "let very_long_variable_name = 3"
+    ] | str align '='
+
+    let expected = [
+        "let a                       = 1"
+        "let max                     = 2"
+        "let very_long_variable_name = 3"
+    ] | str join "\n"
+
+    assert equal $actual $expected
+}
+
+@test
+def str-align_with_range [] {
+    let actual = r#'match 5 {
+    1.. => { print "More than zero" }
+    0 => { print "Zero" }
+    -1 => { print "Negative one" }
+    -119283 => { print "Very negative" }
+}'# | str align '=>' --range 2..
+
+    let expected = r#'match 5 {
+    1.. => { print "More than zero" }
+    0       => { print "Zero" }
+    -1      => { print "Negative one" }
+    -119283 => { print "Very negative" }
+}'# | lines | str join "\n"
+
+    assert equal $actual $expected
+}
+
+@test
+def str-align_ignore_lines_with_no_target [] {
+    let actual = [
+        "let a = 1"
+        "let max = 2"
+        "# comment"
+    ] | str align '='
+
+    let expected = [
+        "let a   = 1"
+        "let max = 2"
+        "# comment"
+    ] | str join "\n"
+
+    assert equal $actual $expected
+}
+
+@test
+def str-align_use_different_char [] {
+    let actual = [
+        "=>"
+        "=====>"
+    ] | str align '>' -c '='
+
+    let expected = [
+        "=====>"
+        "=====>"
+    ] | str join "\n"
+
+    assert equal $actual $expected
+}
+
+@test
+def str-align_multiple_target_in_line [] {
+    let actual = [
+        "print test # Hello # World"
+        "print hello there # test"
+    ] | str align '#'
+
+    let expected = [
+        "print test        # Hello # World"
+        "print hello there # test"
+    ] | str join "\n"
+
+    assert equal $actual $expected
+}
+
+@test
+def str-align_no_target [] {
+
+    let expected = [
+        "print test # Hello # World"
+        "print hello there # test"
+    ] | str join "\n"
+
+    let actual = $expected | str align '='
+
+    assert equal $actual $expected
+}
+
+@test
+def str-align_empty_target_noop [] {
+
+    let expected = [
+        "print test # Hello # World"
+        "print hello there # test"
+    ] | str join "\n"
+
+    let actual = $expected | str align ''
+
+    assert equal $actual $expected
+}
+
+@test
+def str-align_error_empty [] {
+
+    assert error {||
+        "" | str align '='
+    }
+}


### PR DESCRIPTION
# Description
Added to the `std-rfc/str` module a new `str align` command that will look for a substring and add padding so that it is in the same column in all lines. It can also take a range to only align any number of lines.

I don't know how useful other people will find this.
```nu
→ help str align
Aligns each line in the input string to have the target in the same column through padding

Usage:
  > align {flags} <target>

Flags:
  -c, --char <string>: character to use for padding (default: ' ')
  -r, --range <range>: the range of lines to align
  -h, --help: Display the help message for this command

Parameters:
  target <string>: substring to align

Input/output types:
   # |    input     | output
  ---+--------------+--------
   0 | string       | string
   1 | list<string> | string

Examples:
  Create alias for each subcommand and align them
  > scope commands | where name starts-with split | get name | each {|x| $'export alias "($x | str replace split sp)" = ($x)'} | str align '='
  export alias "sp"           = split
  export alias "sp cell-path" = split cell-path
  export alias "sp chars"     = split chars
  export alias "sp column"    = split column
  export alias "sp list"      = split list
  export alias "sp row"       = split row
  export alias "sp words"     = split words
  export alias "sp-files"     = split-files
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
Added tests to `nu-std/tests/test_std-rfc_str.nu`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
