### PR TITLE
fix(std/help): add `debug -v` to string default parameters

### DIFF
--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -639,7 +639,7 @@ def build-command-page [command: record] {
                         $" - ($flag.description)"
                     }),
                     (if ($flag.parameter_default | is-empty) { "" } else {
-                        $" \(default: ($flag.parameter_default)\)"
+                        $" \(default: ($flag.parameter_default | if ($in | describe -d).type == string { debug -v } else {})\)"
                     }),
                 ] | str join ""
             } | str join "\n")


### PR DESCRIPTION
# Description
Added `debug -v` in case the default parameter is a string so that it will be not be printed literally:
- Before
```nu
  --char: <string> (default:  )
```
```nu
  --char: <string> (default:
)
```
```nu
  --char: <string> (default: abc)
```
- After
```nu
  --char: <string> (default: " ")
```
```nu
  --char: <string> (default: "\n")
```
```nu
  --char: <string> (default: "abc")
```
Other types like `int` remain unaffected.
# User-Facing Changes

# Tests + Formatting

# After Submitting
