### PR TITLE
FromValue return a custom FromValueError instead of ShellError

### DIFF
--- a/crates/nu-protocol/src/errors/mod.rs
+++ b/crates/nu-protocol/src/errors/mod.rs
@@ -16,4 +16,5 @@ pub use config_error::ConfigError;
 pub use labeled_error::{ErrorLabel, LabeledError};
 pub use parse_error::{DidYouMean, ParseError};
 pub use parse_warning::ParseWarning;
+pub use shell_error::FromValueError;
 pub use shell_error::ShellError;

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -124,7 +124,7 @@ pub trait FromValue: Sized {
     ///
     /// This method retrieves a value similarly to how strings are parsed using [`FromStr`].
     /// The operation might fail if the `Value` contains unexpected types or structures.
-    fn from_value(v: Value) -> Result<Self, FromValueError>;
+    fn from_value(v: Value) -> Result<Self, ShellError>;
 
     /// Expected `Value` type.
     ///
@@ -260,12 +260,11 @@ impl FromValue for i64 {
         match v {
             Value::Int { val, .. } => Ok(val),
             Value::Duration { val, .. } => Ok(val),
-            v => Err(ShellError::CantConvert {
-                to_type: Self::expected_type().to_string(),
-                from_type: v.get_type().to_string(),
-                span: v.span(),
-                help: None,
-            }),
+            v => Err(FromValueError::TypeMismatch {
+                expected: Self::expected_type(),
+                actual: v.get_type(),
+            }
+            .to_shell_error(v.span())),
         }
     }
 

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -1,5 +1,5 @@
 use crate::{
-    NuGlob, Range, Record, ShellError, Span, Spanned, Type, Value,
+    FromValueError, NuGlob, Range, Record, ShellError, Span, Spanned, Type, Value,
     ast::{CellPath, PathMember},
     casing::Casing,
     engine::Closure,
@@ -124,7 +124,7 @@ pub trait FromValue: Sized {
     ///
     /// This method retrieves a value similarly to how strings are parsed using [`FromStr`].
     /// The operation might fail if the `Value` contains unexpected types or structures.
-    fn from_value(v: Value) -> Result<Self, ShellError>;
+    fn from_value(v: Value) -> Result<Self, FromValueError>;
 
     /// Expected `Value` type.
     ///


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR introduces a `FromValueError` enum  for `FromValue` trait implementations. It fulfills the intent of this TODO
https://github.com/nushell/nushell/blob/ae0cf8780dc82acbd1051dc9acba20a59a2d2be9/crates/nu-protocol/src/value/from_value.rs#L122-L123

### Key changes:

* Introduced a new `FromValueError` enum with variants like `TypeMismatch`, `MissingField`, and `Custom`
* Implemented `From<FromValueError> for ShellError` for compatibility
* Updated the `FromValue` impl for `i64` to use `FromValueError` internally, while still returning `ShellError`
* Preserved the `FromValue` trait signature to avoid breaking changes

### Note

If this was not the intent of the TODO I will reiterate based on feedback.

# User-Facing Changes

<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

N/A

# Tests + Formatting

<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

* [x] Ran `cargo fmt --all`
* [x] Ran `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used`
* [x] Ran `cargo test --workspace`

# After Submitting

<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

N/A
