### PR TITLE
feat!: Special double dash (`--`) handling.

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1050,8 +1050,8 @@ pub fn parse_internal_call(
 
         if !flags_ended {
             if parse_flag_terminator(working_set, spans, spans_idx) {
-                // Pass it along for `extern` commands
-                if is_known_external {
+                // Pass it along for `extern` and `def --wrapped` commands
+                if is_known_external || signature.allows_unknown_args {
                     call.add_positional(Expression::new(
                         working_set,
                         Expr::String("--".into()),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1064,15 +1064,18 @@ pub fn parse_internal_call(
 
                 // skip over remainin positional parameters straight to ...rest
                 // fill optional positional parameters with null
-                let args_to_fill = (req_pos + opt_pos) as isize - call_pos as isize;
-                for _ in 0..args_to_fill {
-                    call.add_positional(Expression::new(
-                        working_set,
-                        Expr::Nothing,
-                        Span::unknown(),
-                        Type::Nothing,
-                    ));
-                    positional_idx += 1;
+                // skip this for `extern` commands
+                if !is_known_external {
+                    let args_to_fill = (req_pos + opt_pos) as isize - call_pos as isize;
+                    for _ in 0..args_to_fill {
+                        call.add_positional(Expression::new(
+                            working_set,
+                            Expr::Nothing,
+                            Span::unknown(),
+                            Type::Nothing,
+                        ));
+                        positional_idx += 1;
+                    }
                 }
 
                 // Pass it along for `extern` and `def --wrapped` commands

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -711,13 +711,7 @@ fn parse_short_flags(
     }
 }
 
-fn parse_flag_terminator(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    spans_idx: usize,
-) -> bool {
-    let arg_span = spans[spans_idx];
-
+fn parse_flag_terminator(working_set: &mut StateWorkingSet, arg_span: Span) -> bool {
     let arg_contents = working_set.get_span_contents(arg_span);
 
     let Ok(arg_contents_uft8_ref) = str::from_utf8(arg_contents) else {
@@ -1049,7 +1043,7 @@ pub fn parse_internal_call(
         let starting_error_count = working_set.parse_errors.len();
 
         if !flags_ended {
-            if parse_flag_terminator(working_set, spans, spans_idx) {
+            if parse_flag_terminator(working_set, arg_span) {
                 let call_pos = call.positional_len();
                 let req_pos = signature.required_positional.len();
                 let opt_pos = signature.optional_positional.len();
@@ -1057,7 +1051,7 @@ pub fn parse_internal_call(
                 if call_pos < req_pos {
                     working_set.error(ParseError::MissingPositional(
                         signature.required_positional[positional_idx].name.clone(),
-                        Span::new(spans[spans_idx].start, spans[spans_idx].start),
+                        arg_span.before(),
                         signature.call_signature(),
                     ));
                 }
@@ -1067,11 +1061,12 @@ pub fn parse_internal_call(
                 // skip this for `extern` commands
                 if !is_known_external {
                     let args_to_fill = (req_pos + opt_pos) as isize - call_pos as isize;
+                    let span = arg_span.before();
                     for _ in 0..args_to_fill {
                         call.add_positional(Expression::new(
                             working_set,
                             Expr::Nothing,
-                            Span::unknown(),
+                            span,
                             Type::Nothing,
                         ));
                         positional_idx += 1;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1050,6 +1050,23 @@ pub fn parse_internal_call(
 
         if !flags_ended {
             if parse_flag_terminator(working_set, spans, spans_idx) {
+                let call_pos = call.positional_len();
+                let req_pos = signature.required_positional.len();
+                let opt_pos = signature.optional_positional.len();
+
+                // skip over remainin positional parameters straight to ...rest
+                // fill optional positional parameters with null
+                let args_to_fill = (req_pos + opt_pos) as isize - call_pos as isize;
+                for _ in 0..args_to_fill {
+                    call.add_positional(Expression::new(
+                        working_set,
+                        Expr::Nothing,
+                        Span::unknown(),
+                        Type::Nothing,
+                    ));
+                    positional_idx += 1;
+                }
+
                 // Pass it along for `extern` and `def --wrapped` commands
                 if is_known_external || signature.allows_unknown_args {
                     call.add_positional(Expression::new(
@@ -1059,8 +1076,10 @@ pub fn parse_internal_call(
                         Type::String,
                     ));
                 }
+
                 flags_ended = true;
                 spans_idx += 1;
+
                 continue;
             }
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1054,6 +1054,14 @@ pub fn parse_internal_call(
                 let req_pos = signature.required_positional.len();
                 let opt_pos = signature.optional_positional.len();
 
+                if call_pos < req_pos {
+                    working_set.error(ParseError::MissingPositional(
+                        signature.required_positional[positional_idx].name.clone(),
+                        Span::new(spans[spans_idx].start, spans[spans_idx].start),
+                        signature.call_signature(),
+                    ));
+                }
+
                 // skip over remainin positional parameters straight to ...rest
                 // fill optional positional parameters with null
                 let args_to_fill = (req_pos + opt_pos) as isize - call_pos as isize;

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -140,6 +140,15 @@ impl Span {
         self.start <= span.start && span.end <= self.end && span.end != 0
     }
 
+    /// Point to the space just before this span, useful for missing values
+    pub fn before(&self) -> Self {
+        let pos = self.start.saturating_sub(1);
+        Self {
+            start: pos,
+            end: pos,
+        }
+    }
+
     /// Point to the space just past this span, useful for missing values
     pub fn past(&self) -> Self {
         Self {


### PR DESCRIPTION

# Description

Explicitly handle `--` (double dash) arguments:

-   raw external command: `^cargo run -- -e`

	Unaffected. As all parameters are passed as strings without modification,
	it already works as expected.

-   internal commands (that don't allow unknown flags): (most of) built-ins,
	`def name [] {}`

	-	After `--`, no parameter is parsed as a flag
	- 	`--` is not passed as an argument to the command
	-	`--` makes the parser skip directly to the `...rest` parameter.
		-	If required parameters were not passed before `--`,
			MissingPositional error is thrown.
		-	If optional parameters were not passed before, they are passed as
			`null` values

-   internal commands that allow unknown flags: some built-ins (e.g. `exec`),
	`def --wrapped name [] {}`
	-	Same as commands that don't allow unknown flags.
	- 	`--` **is passed** as a string argument to the command.
		It will always be passed as an item in the rest parameter.

-   known externals, `extern`:
	-	Same as `def --wrapped`
	-	Skipped optional parameters **are not** passed as `null`, there is no
		argument injection.

- [ ] Should we really skip optional parameters?

	Consider the following `demo.nu` file:
	```nushell
	#!/usr/bin/env nu
	def main [--foo, --bar, script?: file, ...args] { ... }
	```
	And we need to pass a file named `--bar` as the `script` paramater.

	This is not a problem when the command is _imported_ and not run as a
	script.

	```nushell
	demo --foo "--bar" a b c
	```

	But as a script, nu receives all arguments as strings from the caller's cmdline.
	```sh
	# these are passed to nu identically
	./demo --foo --bar a b c
	./demo --foo "--bar" a b c

	# Naturally, we would try something like this:
	./demo --foo -- --bar a b c
	```
	Should `$script` be `null` or `"--bar"`? And even if this is alright because the first element of `$args` can be manually extracted to be `$script`

	It's even more uncertain for required parameters: 
	```nushell
	#!/usr/bin/env nu
	def main [--foo, --bar, script: file, ...args] { ... }
	./demo --foo -- --bar a b c
	```

# User-Facing Changes

More things work as users expect 🎉

# Tests + Formatting

- [x] Existing tests pass without modification.
- [ ] Implement tests for the new feature.

-	:green_circle: toolkit fmt
- 	:green_circle: toolkit clippy
- 	:green_circle: toolkit test
- 	:green_circle: toolkit test stdlib

# After Submitting
-	Update [the documentation](https://github.com/nushell/nushell.github.io)