### PR TITLE
Add http url

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -811,7 +811,7 @@ fn request_handle_response_content(
         if resulting_url != requested_url {
             urls.push(Value::string(resulting_url.to_string(), span));
         }
-        
+
         let body = consume_response_body(resp)?.into_value(span)?;
 
         let full_response = Value::record(

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -804,6 +804,14 @@ fn request_handle_response_content(
             "response" => response_headers_value,
         };
 
+        let mut urls = Vec::with_capacity(2);
+        // FIXME: this distinguishes between `http://example.com` and `http://example.com/`
+        urls.push(Value::string(requested_url.to_string(), span));
+        let resulting_url = resp.get_url();
+        if resulting_url != requested_url {
+            urls.push(Value::string(resulting_url.to_string(), span));
+        }
+        
         let body = consume_response_body(resp)?.into_value(span)?;
 
         let full_response = Value::record(
@@ -811,7 +819,7 @@ fn request_handle_response_content(
                 "headers" => Value::record(headers, span),
                 "body" => body,
                 "status" => Value::int(response_status as i64, span),
-                "urls" => Value::list(vec![Value::string(requested_url.to_string(), span)], span)
+                "urls" => Value::list(urls, span)
             },
             span,
         );

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -811,6 +811,7 @@ fn request_handle_response_content(
                 "headers" => Value::record(headers, span),
                 "body" => body,
                 "status" => Value::int(response_status as i64, span),
+                "urls" => Value::list(vec![Value::string(requested_url.to_string(), span)], span)
             },
             span,
         );


### PR DESCRIPTION
closes #15986
# Description
http verbs with `--full` flag now return requested and resulting urls as a list

![image](https://github.com/user-attachments/assets/4c164185-a778-4399-bea4-6746fa9da17b)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

New field in a returning record might break exotic cases where the lack of field was relied upon,
e.g. `{urls: important} | merge (http get --full <...>)`


# Tests + Formatting

I would be interested in setting up mocking `ureq` and increase http command's test coverage,
but realistically I don't think I'll ever have the time.

<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting

- [ ] Update docs
- [ ] Maybe fix the duplicated url issue
