### PR TITLE
Bump ureq, get redirect history.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1115,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceb37c5798821e37369cb546f430f19da2f585e0364c9615ae340a9f2e6067b"
 dependencies = [
  "supports-color",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -2953,6 +2969,28 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -6479,6 +6517,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.28",
+ "rustls-native-certs 0.8.1",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.3",
+ "security-framework 3.0.1",
+ "security-framework-sys",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7799,6 +7864,7 @@ dependencies = [
  "rustls 0.23.28",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "socks",
@@ -8589,6 +8655,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -8612,6 +8687,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8656,6 +8746,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -8668,6 +8764,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -8677,6 +8779,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8698,6 +8806,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -8707,6 +8821,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8722,6 +8842,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -8731,6 +8857,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "once_cell",
  "percent-encoding",
  "sha2",
@@ -578,7 +578,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -595,7 +595,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -2279,7 +2279,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -2421,9 +2421,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -2448,7 +2448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -2459,7 +2459,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -2529,7 +2529,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2 0.4.7",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2563,10 +2563,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "hyper 1.5.1",
  "hyper-util",
- "rustls 0.23.20",
+ "rustls 0.23.28",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -2600,7 +2600,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.5.1",
  "pin-project-lite",
@@ -3185,9 +3185,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
@@ -3437,7 +3437,7 @@ dependencies = [
  "assert-json-diff",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.5.1",
@@ -3779,6 +3779,7 @@ dependencies = [
  "filesize",
  "filetime",
  "getrandom 0.2.15",
+ "http 1.3.1",
  "human-date-parser",
  "indexmap",
  "indicatif",
@@ -3831,7 +3832,7 @@ dependencies = [
  "rstest",
  "rstest_reuse",
  "rusqlite",
- "rustls 0.23.20",
+ "rustls 0.23.28",
  "rustls-native-certs 0.8.1",
  "scopeguard",
  "serde",
@@ -3849,7 +3850,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width 0.2.0",
  "update-informer",
- "ureq 2.12.1",
+ "ureq",
  "url",
  "uu_cp",
  "uu_mkdir",
@@ -4590,7 +4591,7 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "futures",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body-util",
  "humantime",
  "hyper 1.5.1",
@@ -5819,7 +5820,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.0",
- "rustls 0.23.20",
+ "rustls 0.23.28",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -5837,7 +5838,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.1.0",
- "rustls 0.23.20",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -6137,7 +6138,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.7",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.5.1",
@@ -6153,7 +6154,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.20",
+ "rustls 0.23.28",
  "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -6412,15 +6413,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
 ]
@@ -6469,11 +6470,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -6488,9 +6490,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7468,7 +7470,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.20",
+ "rustls 0.23.28",
  "tokio",
 ]
 
@@ -7777,49 +7779,29 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "ureq 3.0.3",
+ "ureq",
 ]
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
+ "der",
  "encoding_rs",
  "flate2",
  "log",
  "native-tls",
- "once_cell",
- "rustls 0.23.20",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "socks",
- "url",
- "webpki-roots 0.26.8",
-]
-
-[[package]]
-name = "ureq"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217751151c53226090391713e533d9a5e904ba2570dabaaace29032687589c3e"
-dependencies = [
- "base64 0.22.1",
- "cc",
- "cookie_store",
- "der",
- "flate2",
- "log",
- "native-tls",
  "percent-encoding",
- "rustls 0.23.20",
+ "rustls 0.23.28",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
+ "socks",
  "ureq-proto",
  "utf-8",
  "webpki-root-certs 0.26.11",
@@ -7828,12 +7810,12 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.3.5"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae239d0a3341aebc94259414d1dc67cfce87d41cbebc816772c91b77902fafa4"
+checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
 dependencies = [
  "base64 0.22.1",
- "http 1.2.0",
+ "http 1.3.1",
  "httparse",
  "log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ fancy-regex = "0.14"
 filesize = "0.2"
 filetime = "0.2"
 heck = "0.5.0"
+http = "1.3.1"
 human-date-parser = "0.3.0"
 indexmap = "2.10"
 indicatif = "0.17"
@@ -172,7 +173,7 @@ update-informer = { version = "1.3.0", default-features = false, features = ["gi
 umask = "2.1"
 unicode-segmentation = "1.12"
 unicode-width = "0.2"
-ureq = { version = "2.12", default-features = false, features = ["socks-proxy"] }
+ureq = { version = "3.0.12", default-features = false, features = ["socks-proxy"] }
 url = "2.2"
 uu_cp = "0.0.30"
 uu_mkdir = "0.0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,10 @@ rstest = { version = "0.23", default-features = false }
 rstest_reuse = "0.7"
 rusqlite = "0.31"
 rust-embed = "8.7.0"
-rustls = { version = "0.23", default-features = false, features = ["std", "tls12"] }
+# We have to fix rustls and ureq versions
+# because we use unversioned api to allow users set up their own
+# crypto providers (grep for "unversioned")
+rustls = { version = "=0.23.28", default-features = false, features = ["std", "tls12"] }
 rustls-native-certs = "0.8"
 scopeguard = { version = "1.2.0" }
 serde = { version = "1.0" }
@@ -173,7 +176,7 @@ update-informer = { version = "1.3.0", default-features = false, features = ["gi
 umask = "2.1"
 unicode-segmentation = "1.12"
 unicode-width = "0.2"
-ureq = { version = "3.0.12", default-features = false, features = ["socks-proxy"] }
+ureq = { version = "=3.0.12", default-features = false, features = ["socks-proxy"] }
 url = "2.2"
 uu_cp = "0.0.30"
 uu_mkdir = "0.0.30"

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -753,7 +753,7 @@ impl NuCompleter {
             Ok(value) => {
                 log::error!(
                     "External completer returned invalid value of type {}",
-                    value.get_type().to_string()
+                    value.get_type()
                 );
                 Some(vec![])
             }

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -140,7 +140,7 @@ impl<T: Completer> Completer for CustomCompletion<T> {
                 _ => {
                     log::error!(
                         "Custom completer returned invalid value of type {}",
-                        value.get_type().to_string()
+                        value.get_type()
                     );
                     return vec![];
                 }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -60,6 +60,7 @@ encoding_rs = { workspace = true }
 fancy-regex = { workspace = true }
 filesize = { workspace = true }
 filetime = { workspace = true }
+http = {workspace = true}
 human-date-parser = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true }
@@ -219,7 +220,7 @@ rustls-tls = [
 	"dep:rustls-native-certs",
 	"dep:webpki-roots",
 	"update-informer/rustls-tls",
-	"ureq/tls", # ureq 3 will has the feature rustls instead
+	"ureq/rustls",
 ]
 
 plugin = ["nu-parser/plugin", "os"]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -192,6 +192,7 @@ os = [
 	"uu_uname",
 	"uu_whoami",
 	"which",
+	"ureq/platform-verifier"
 ]
 
 # The dependencies listed below need 'getrandom'.

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -273,6 +273,10 @@ pub fn send_request(
                 request
             };
 
+            if let Some(h) = extract_request_headers(&req) {
+                request_headers = h;
+            }
+
             match body_type {
                 BodyType::Json => send_json_request(
                     engine_state,

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -813,7 +813,7 @@ pub(crate) fn handle_response_status(
     if is_success {
         Ok(())
     } else {
-        return Err(handle_status_error(span, requested_url, resp.status()));
+        Err(handle_status_error(span, requested_url, resp.status()))
     }
 }
 

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -682,13 +682,17 @@ fn handle_response_error(span: Span, requested_url: &str, response_err: Error) -
             ),
             span,
         },
-        e => {
-            // FIXME(ureq): handle other errors
-            ShellError::NetworkFailure {
-                msg: e.to_string(),
-                span,
-            }
-        }
+        Error::ConnectionFailed => ShellError::NetworkFailure {
+            msg: format!(
+                "Cannot make request to {requested_url}, there was an error establishing a connection.",
+            ),
+            span,
+        },
+        Error::Io(error) => ShellError::Io(IoError::new(error, span, None)),
+        e => ShellError::NetworkFailure {
+            msg: e.to_string(),
+            span,
+        },
     }
 }
 

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -1,7 +1,8 @@
 use crate::network::http::client::{
-    HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request, send_request_no_body,
+    HttpBody, RequestFlags, RequestMetadata, check_response_redirection, http_client,
+    http_parse_redirect_mode, http_parse_url, request_add_authorization_header,
+    request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
+    send_request_no_body,
 };
 use nu_engine::command_prelude::*;
 
@@ -245,12 +246,14 @@ fn helper(
     request_handle_response(
         engine_state,
         stack,
-        span,
-        &requested_url,
-        request_flags,
+        RequestMetadata {
+            requested_url: &requested_url,
+            span,
+            headers: request_headers,
+            redirect_mode,
+            flags: request_flags,
+        },
         response,
-        request_headers,
-        redirect_mode,
     )
 }
 

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -1,7 +1,8 @@
 use crate::network::http::client::{
     HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
     http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request, send_request_no_body,
+    request_error_to_shell_error, request_handle_response, request_set_timeout, send_request,
+    send_request_no_body,
 };
 use nu_engine::command_prelude::*;
 
@@ -239,6 +240,7 @@ fn helper(
         full: args.full,
         allow_errors: args.allow_errors,
     };
+    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
 
     check_response_redirection(redirect_mode, span, &response)?;
     request_handle_response(
@@ -249,7 +251,7 @@ fn helper(
         request_flags,
         response,
         request_headers,
-        redirect_mode
+        redirect_mode,
     )
 }
 

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
-    HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request,
+    HttpBody, RequestFlags, check_response_redirection, extract_request_headers, http_client,
+    http_parse_redirect_mode, http_parse_url, request_add_authorization_header,
+    request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -217,10 +217,11 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
+    let request_headers = extract_request_headers(&request);
+
     let response = send_request(
         engine_state,
-        request.clone(),
-        args.data,
+        super::client::GenericRequestBuilder::WithoutBody(request),
         args.content_type,
         call.head,
         engine_state.signals(),
@@ -240,7 +241,7 @@ fn helper(
         &requested_url,
         request_flags,
         response,
-        request,
+        request_headers.unwrap_or_default(),
     )
 }
 

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -1,8 +1,7 @@
 use crate::network::http::client::{
     HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
     http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_error_to_shell_error, request_handle_response, request_set_timeout, send_request,
-    send_request_no_body,
+    request_handle_response, request_set_timeout, send_request, send_request_no_body,
 };
 use nu_engine::command_prelude::*;
 
@@ -240,7 +239,7 @@ fn helper(
         full: args.full,
         allow_errors: args.allow_errors,
     };
-    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
+    let response = response?;
 
     check_response_redirection(redirect_mode, span, &response)?;
     request_handle_response(

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -218,7 +218,7 @@ fn helper(
     request = request_add_custom_headers(args.headers, request)?;
     let (response, request_headers) = match args.data {
         None => send_request_no_body(request, call.head, engine_state.signals()),
-        
+
         Some(body) => send_request(
             engine_state,
             // Nushell allows sending body via delete method, but not via get.
@@ -230,7 +230,7 @@ fn helper(
             body,
             args.content_type,
             span,
-            engine_state.signals()
+            engine_state.signals(),
         ),
     };
 

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -249,6 +249,7 @@ fn helper(
         request_flags,
         response,
         request_headers,
+        redirect_mode
     )
 }
 

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
-    RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request_no_body,
+    RequestFlags, RequestMetadata, check_response_redirection, http_client,
+    http_parse_redirect_mode, http_parse_url, request_add_authorization_header,
+    request_add_custom_headers, request_handle_response, request_set_timeout, send_request_no_body,
 };
 use nu_engine::command_prelude::*;
 
@@ -193,12 +193,14 @@ fn helper(
     request_handle_response(
         engine_state,
         stack,
-        span,
-        &requested_url,
-        request_flags,
+        RequestMetadata {
+            requested_url: &requested_url,
+            span,
+            headers: request_headers,
+            redirect_mode,
+            flags: request_flags,
+        },
         response,
-        request_headers,
-        redirect_mode,
     )
 }
 

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -1,7 +1,6 @@
 use crate::network::http::client::{
     RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_error_to_shell_error, request_handle_response, request_set_timeout,
+    http_parse_url, request_add_authorization_header, request_add_custom_headers, request_handle_response, request_set_timeout,
     send_request_no_body,
 };
 use nu_engine::command_prelude::*;
@@ -188,7 +187,7 @@ fn helper(
         allow_errors: args.allow_errors,
     };
 
-    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
+    let response = response?;
 
     check_response_redirection(redirect_mode, span, &response)?;
     request_handle_response(

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -196,6 +196,7 @@ fn helper(
         request_flags,
         response,
         request_headers,
+        redirect_mode
     )
 }
 

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -1,7 +1,8 @@
 use crate::network::http::client::{
     RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
     http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request_no_body,
+    request_error_to_shell_error, request_handle_response, request_set_timeout,
+    send_request_no_body,
 };
 use nu_engine::command_prelude::*;
 
@@ -187,6 +188,8 @@ fn helper(
         allow_errors: args.allow_errors,
     };
 
+    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
+
     check_response_redirection(redirect_mode, span, &response)?;
     request_handle_response(
         engine_state,
@@ -196,7 +199,7 @@ fn helper(
         request_flags,
         response,
         request_headers,
-        redirect_mode
+        redirect_mode,
     )
 }
 

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
-    RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request,
+    GenericRequestBuilder, RequestFlags, check_response_redirection, extract_request_headers,
+    http_client, http_parse_redirect_mode, http_parse_url, request_add_authorization_header,
+    request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -180,11 +180,10 @@ fn helper(
     request = request_set_timeout(args.timeout, request)?;
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
-
+    let request_headers = extract_request_headers(&request);
     let response = send_request(
         engine_state,
-        request.clone(),
-        HttpBody::None,
+        GenericRequestBuilder::WithoutBody(request),
         None,
         call.head,
         engine_state.signals(),
@@ -204,7 +203,7 @@ fn helper(
         &requested_url,
         request_flags,
         response,
-        request,
+        request_headers.unwrap_or_default(),
     )
 }
 

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
     RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers, request_handle_response, request_set_timeout,
-    send_request_no_body,
+    http_parse_url, request_add_authorization_header, request_add_custom_headers,
+    request_handle_response, request_set_timeout, send_request_no_body,
 };
 use nu_engine::command_prelude::*;
 

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -161,8 +161,7 @@ fn helper(
 
     let response = send_request(
         engine_state,
-        request,
-        HttpBody::None,
+        super::client::GenericRequestBuilder::WithoutBody(request),
         None,
         call.head,
         signals,

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
     check_response_redirection, extract_response_headers, handle_response_status, headers_to_nu,
     http_client, http_parse_redirect_mode, http_parse_url, request_add_authorization_header,
-    request_add_custom_headers, request_error_to_shell_error, request_set_timeout,
+    request_add_custom_headers, request_set_timeout,
     send_request_no_body,
 };
 use nu_engine::command_prelude::*;
@@ -159,7 +159,7 @@ fn helper(
     request = request_add_custom_headers(args.headers, request)?;
 
     let (response, _request_headers) = send_request_no_body(request, call.head, signals);
-    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
+    let response = response?;
     check_response_redirection(redirect_mode, span, &response)?;
     handle_response_status(&response, redirect_mode, &requested_url, span, false)?;
     headers_to_nu(&extract_response_headers(&response), span)

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -1,8 +1,7 @@
-use super::client::HttpBody;
 use crate::network::http::client::{
     check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
     request_add_authorization_header, request_add_custom_headers, request_handle_response_headers,
-    request_set_timeout, send_request,
+    request_set_timeout, send_request_no_body,
 };
 use nu_engine::command_prelude::*;
 use nu_protocol::Signals;
@@ -140,7 +139,6 @@ fn run_head(
 }
 
 // Helper function that actually goes to retrieve the resource from the url given
-// The Option<String> return a possible file extension which can be used in AutoConvert commands
 fn helper(
     engine_state: &EngineState,
     stack: &mut Stack,
@@ -159,13 +157,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(
-        engine_state,
-        super::client::GenericRequestBuilder::WithoutBody(request),
-        None,
-        call.head,
-        signals,
-    );
+    let (response, _request_headers) = send_request_no_body(request, call.head, signals);
     check_response_redirection(redirect_mode, span, &response)?;
     request_handle_response_headers(span, response)
 }

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -1,8 +1,7 @@
 use crate::network::http::client::{
     check_response_redirection, extract_response_headers, handle_response_status, headers_to_nu,
     http_client, http_parse_redirect_mode, http_parse_url, request_add_authorization_header,
-    request_add_custom_headers, request_set_timeout,
-    send_request_no_body,
+    request_add_custom_headers, request_set_timeout, send_request_no_body,
 };
 use nu_engine::command_prelude::*;
 use nu_protocol::Signals;

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
-    check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
-    request_add_authorization_header, request_add_custom_headers, request_handle_response_headers,
-    request_set_timeout, send_request_no_body,
+    check_response_redirection, handle_response_status, http_client, http_parse_redirect_mode,
+    http_parse_url, request_add_authorization_header, request_add_custom_headers,
+    request_handle_response_headers, request_set_timeout, send_request_no_body,
 };
 use nu_engine::command_prelude::*;
 use nu_protocol::Signals;
@@ -159,6 +159,12 @@ fn helper(
 
     let (response, _request_headers) = send_request_no_body(request, call.head, signals);
     check_response_redirection(redirect_mode, span, &response)?;
+
+    // TODO(ureq): streamline this
+    if let Ok(resp) = &response {
+        handle_response_status(resp, redirect_mode, &requested_url, span, false)?;
+    }
+
     request_handle_response_headers(span, response)
 }
 

--- a/crates/nu-command/src/network/http/http_.rs
+++ b/crates/nu-command/src/network/http/http_.rs
@@ -69,7 +69,14 @@ impl Command for Http {
             )
             .switch(
                 "full",
-                "returns the full response instead of only the body",
+                r#"Returns the record, containing metainformation about the exchange in addition to the response.
+                Returning record fields:
+                - urls: list of url redirects this command had to make to get to the destination
+                - headers.request: list of headers passed when doing the request
+                - headers.response: list of received headers
+                - body: the http body of the response
+                - status: the http status of the response
+                "#,
                 Some('f'),
             )
             .switch(

--- a/crates/nu-command/src/network/http/mod.rs
+++ b/crates/nu-command/src/network/http/mod.rs
@@ -7,6 +7,7 @@ mod options;
 mod patch;
 mod post;
 mod put;
+mod timeout_extractor_reader;
 
 pub use delete::HttpDelete;
 pub use get::HttpGet;

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -1,10 +1,8 @@
 use crate::network::http::client::{
-    RedirectMode, RequestFlags, http_client, http_parse_url,
-    request_add_authorization_header, request_add_custom_headers, request_handle_response,
-    request_set_timeout, send_request_no_body,
+    RedirectMode, RequestFlags, http_client, http_parse_url, request_add_authorization_header,
+    request_add_custom_headers, request_handle_response, request_set_timeout, send_request_no_body,
 };
 use nu_engine::command_prelude::*;
-
 
 #[derive(Clone)]
 pub struct HttpOptions;

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -1,6 +1,6 @@
 use crate::network::http::client::{
     RedirectMode, RequestFlags, http_client, http_parse_url, request_add_authorization_header,
-    request_add_custom_headers, request_error_to_shell_error, request_handle_response,
+    request_add_custom_headers, request_handle_response,
     request_set_timeout, send_request_no_body,
 };
 use nu_engine::command_prelude::*;
@@ -162,7 +162,7 @@ fn helper(
     let (response, request_headers) =
         send_request_no_body(request, call.head, engine_state.signals());
 
-    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
+    let response = response?;
 
     // http options' response always showed in header, so we set full to true.
     // And `raw` is useless too because options method doesn't return body, here we set to true

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -150,8 +150,8 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
-
-    let client = http_client(args.insecure, RedirectMode::Follow, engine_state, stack)?;
+    let redirect_mode = RedirectMode::Follow;
+    let client = http_client(args.insecure, redirect_mode, engine_state, stack)?;
     let mut request = client.options(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;
@@ -178,6 +178,7 @@ fn helper(
         request_flags,
         response,
         request_headers,
+        redirect_mode
     )
 }
 

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -1,6 +1,7 @@
 use crate::network::http::client::{
-    RedirectMode, RequestFlags, http_client, http_parse_url, request_add_authorization_header,
-    request_add_custom_headers, request_handle_response, request_set_timeout, send_request_no_body,
+    RedirectMode, RequestFlags, RequestMetadata, http_client, http_parse_url,
+    request_add_authorization_header, request_add_custom_headers, request_handle_response,
+    request_set_timeout, send_request_no_body,
 };
 use nu_engine::command_prelude::*;
 
@@ -175,12 +176,14 @@ fn helper(
     request_handle_response(
         engine_state,
         stack,
-        span,
-        &requested_url,
-        request_flags,
+        RequestMetadata {
+            requested_url: &requested_url,
+            span,
+            headers: request_headers,
+            redirect_mode,
+            flags: request_flags,
+        },
         response,
-        request_headers,
-        redirect_mode,
     )
 }
 

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -1,7 +1,6 @@
 use crate::network::http::client::{
     RedirectMode, RequestFlags, http_client, http_parse_url, request_add_authorization_header,
-    request_add_custom_headers, request_handle_response,
-    request_set_timeout, send_request_no_body,
+    request_add_custom_headers, request_handle_response, request_set_timeout, send_request_no_body,
 };
 use nu_engine::command_prelude::*;
 

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -1,6 +1,7 @@
 use crate::network::http::client::{
     RedirectMode, RequestFlags, http_client, http_parse_url, request_add_authorization_header,
-    request_add_custom_headers, request_handle_response, request_set_timeout, send_request_no_body,
+    request_add_custom_headers, request_error_to_shell_error, request_handle_response,
+    request_set_timeout, send_request_no_body,
 };
 use nu_engine::command_prelude::*;
 
@@ -161,6 +162,8 @@ fn helper(
     let (response, request_headers) =
         send_request_no_body(request, call.head, engine_state.signals());
 
+    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
+
     // http options' response always showed in header, so we set full to true.
     // And `raw` is useless too because options method doesn't return body, here we set to true
     // too.
@@ -178,7 +181,7 @@ fn helper(
         request_flags,
         response,
         request_headers,
-        redirect_mode
+        redirect_mode,
     )
 }
 

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -242,6 +242,7 @@ fn helper(
         request_flags,
         response,
         request_headers,
+        redirect_mode
     )
 }
 

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
-    HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request,
+    HttpBody, RequestFlags, check_response_redirection, extract_request_headers, http_client,
+    http_parse_redirect_mode, http_parse_url, request_add_authorization_header,
+    request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -218,10 +218,13 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
+    // FIXME(ureq): this ignores the late-set headers,
+    //              request needs to be fully built before extracting the headers
+    let request_headers = extract_request_headers(&request);
+
     let response = send_request(
         engine_state,
-        request.clone(),
-        args.data,
+        super::client::GenericRequestBuilder::WithBody(request, args.data),
         args.content_type,
         call.head,
         engine_state.signals(),
@@ -241,7 +244,7 @@ fn helper(
         &requested_url,
         request_flags,
         response,
-        request,
+        request_headers.unwrap_or_default(),
     )
 }
 

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
-    HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request,
+    HttpBody, RequestFlags, RequestMetadata, check_response_redirection, http_client,
+    http_parse_redirect_mode, http_parse_url, request_add_authorization_header,
+    request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -239,12 +239,14 @@ fn helper(
     request_handle_response(
         engine_state,
         stack,
-        span,
-        &requested_url,
-        request_flags,
+        RequestMetadata {
+            requested_url: &requested_url,
+            span,
+            headers: request_headers,
+            redirect_mode,
+            flags: request_flags,
+        },
         response,
-        request_headers,
-        redirect_mode,
     )
 }
 

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
     HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
     http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request,
+    request_error_to_shell_error, request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -233,6 +233,8 @@ fn helper(
         allow_errors: args.allow_errors,
     };
 
+    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
+
     check_response_redirection(redirect_mode, span, &response)?;
     request_handle_response(
         engine_state,
@@ -242,7 +244,7 @@ fn helper(
         request_flags,
         response,
         request_headers,
-        redirect_mode
+        redirect_mode,
     )
 }
 

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -1,6 +1,7 @@
 use crate::network::http::client::{
     HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
+    http_parse_url, request_add_authorization_header, request_add_custom_headers,
+    request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -1,7 +1,6 @@
 use crate::network::http::client::{
     HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_error_to_shell_error, request_handle_response, request_set_timeout, send_request,
+    http_parse_url, request_add_authorization_header, request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -233,7 +232,7 @@ fn helper(
         allow_errors: args.allow_errors,
     };
 
-    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
+    let response = response?;
 
     check_response_redirection(redirect_mode, span, &response)?;
     request_handle_response(

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
     HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
     http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request,
+    request_error_to_shell_error, request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -243,6 +243,8 @@ fn helper(
         allow_errors: args.allow_errors,
     };
 
+    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
+
     check_response_redirection(redirect_mode, span, &response)?;
     request_handle_response(
         engine_state,
@@ -252,7 +254,7 @@ fn helper(
         request_flags,
         response,
         request_headers,
-        redirect_mode
+        redirect_mode,
     )
 }
 

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -252,6 +252,7 @@ fn helper(
         request_flags,
         response,
         request_headers,
+        redirect_mode
     )
 }
 

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -1,7 +1,6 @@
 use crate::network::http::client::{
     HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_error_to_shell_error, request_handle_response, request_set_timeout, send_request,
+    http_parse_url, request_add_authorization_header, request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -243,7 +242,7 @@ fn helper(
         allow_errors: args.allow_errors,
     };
 
-    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
+    let response = response?;
 
     check_response_redirection(redirect_mode, span, &response)?;
     request_handle_response(

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -1,6 +1,7 @@
 use crate::network::http::client::{
     HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
+    http_parse_url, request_add_authorization_header, request_add_custom_headers,
+    request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -1,10 +1,9 @@
 use crate::network::http::client::{
-    HttpBody, RequestFlags, check_response_redirection, extract_request_headers, http_client,
-    http_parse_redirect_mode, http_parse_url, request_add_authorization_header,
-    request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
+    HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
+    http_parse_url, request_add_authorization_header, request_add_custom_headers,
+    request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
-use ureq::typestate::WithBody;
 
 #[derive(Clone)]
 pub struct HttpPost;
@@ -170,19 +169,19 @@ pub fn run_post(
 ) -> Result<PipelineData, ShellError> {
     let (data, maybe_metadata) = call
         .opt::<Value>(engine_state, stack, 1)?
-        .map(|v| (HttpBody::Value(v), None))
+        .map(|v| (Some(HttpBody::Value(v)), None))
         .unwrap_or_else(|| match input {
-            PipelineData::Value(v, metadata) => (HttpBody::Value(v), metadata),
+            PipelineData::Value(v, metadata) => (Some(HttpBody::Value(v)), metadata),
             PipelineData::ByteStream(byte_stream, metadata) => {
-                (HttpBody::ByteStream(byte_stream), metadata)
+                (Some(HttpBody::ByteStream(byte_stream)), metadata)
             }
-            _ => (HttpBody::None, None),
+            _ => (None, None),
         });
     let content_type = call
         .get_flag(engine_state, stack, "content-type")?
         .or_else(|| maybe_metadata.and_then(|m| m.content_type));
 
-    if let HttpBody::None = data {
+    let Some(data) = data else {
         return Err(ShellError::GenericError {
             error: "Data must be provided either through pipeline or positional argument".into(),
             msg: "".into(),
@@ -190,7 +189,7 @@ pub fn run_post(
             help: None,
             inner: vec![],
         });
-    }
+    };
 
     let args = Arguments {
         url: call.req(engine_state, stack, 0)?,
@@ -229,11 +228,10 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let request_headers = extract_request_headers(&request);
-
-    let response = send_request(
+    let (response, request_headers) = send_request(
         engine_state,
-        super::client::GenericRequestBuilder::WithBody(request, args.data),
+        request,
+        args.data,
         args.content_type,
         call.head,
         engine_state.signals(),
@@ -253,7 +251,7 @@ fn helper(
         &requested_url,
         request_flags,
         response,
-        request_headers.unwrap_or_default(),
+        request_headers,
     )
 }
 

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
-    HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request,
+    HttpBody, RequestFlags, RequestMetadata, check_response_redirection, http_client,
+    http_parse_redirect_mode, http_parse_url, request_add_authorization_header,
+    request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -249,12 +249,14 @@ fn helper(
     request_handle_response(
         engine_state,
         stack,
-        span,
-        &requested_url,
-        request_flags,
+        RequestMetadata {
+            requested_url: &requested_url,
+            span,
+            headers: request_headers,
+            redirect_mode,
+            flags: request_flags,
+        },
         response,
-        request_headers,
-        redirect_mode,
     )
 }
 

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -1,7 +1,6 @@
 use crate::network::http::client::{
     HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_error_to_shell_error, request_handle_response, request_set_timeout, send_request,
+    http_parse_url, request_add_authorization_header, request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -233,7 +232,7 @@ fn helper(
         full: args.full,
         allow_errors: args.allow_errors,
     };
-    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
+    let response = response?;
 
     check_response_redirection(redirect_mode, span, &response)?;
     request_handle_response(

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
-    HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request,
+    HttpBody, RequestFlags, RequestMetadata, check_response_redirection, http_client,
+    http_parse_redirect_mode, http_parse_url, request_add_authorization_header,
+    request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -239,12 +239,14 @@ fn helper(
     request_handle_response(
         engine_state,
         stack,
-        span,
-        &requested_url,
-        request_flags,
+        RequestMetadata {
+            requested_url: &requested_url,
+            span,
+            headers: request_headers,
+            redirect_mode,
+            flags: request_flags,
+        },
         response,
-        request_headers,
-        redirect_mode,
     )
 }
 

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -243,6 +243,7 @@ fn helper(
         request_flags,
         response,
         request_headers,
+        redirect_mode
     )
 }
 

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
-    HttpBody, RequestFlags, check_response_redirection, extract_request_headers, http_client,
-    http_parse_redirect_mode, http_parse_url, request_add_authorization_header,
-    request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
+    HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
+    http_parse_url, request_add_authorization_header, request_add_custom_headers,
+    request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -159,16 +159,16 @@ fn run_put(
 ) -> Result<PipelineData, ShellError> {
     let (data, maybe_metadata) = call
         .opt::<Value>(engine_state, stack, 1)?
-        .map(|v| (HttpBody::Value(v), None))
+        .map(|v| (Some(HttpBody::Value(v)), None))
         .unwrap_or_else(|| match input {
-            PipelineData::Value(v, metadata) => (HttpBody::Value(v), metadata),
+            PipelineData::Value(v, metadata) => (Some(HttpBody::Value(v)), metadata),
             PipelineData::ByteStream(byte_stream, metadata) => {
-                (HttpBody::ByteStream(byte_stream), metadata)
+                (Some(HttpBody::ByteStream(byte_stream)), metadata)
             }
-            _ => (HttpBody::None, None),
+            _ => (None, None),
         });
 
-    if let HttpBody::None = data {
+    let Some(data) = data else {
         return Err(ShellError::GenericError {
             error: "Data must be provided either through pipeline or positional argument".into(),
             msg: "".into(),
@@ -176,7 +176,7 @@ fn run_put(
             help: None,
             inner: vec![],
         });
-    }
+    };
 
     let content_type = call
         .get_flag(engine_state, stack, "content-type")?
@@ -219,13 +219,10 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    // FIXME(ureq): this ignores the late-set headers,
-    //              request needs to be fully built before extracting the headers
-    let request_headers = extract_request_headers(&request);
-
-    let response = send_request(
+    let (response, request_headers) = send_request(
         engine_state,
-        super::client::GenericRequestBuilder::WithBody(request, args.data),
+        request,
+        args.data,
         args.content_type,
         call.head,
         engine_state.signals(),
@@ -245,7 +242,7 @@ fn helper(
         &requested_url,
         request_flags,
         response,
-        request_headers.unwrap_or_default(),
+        request_headers,
     )
 }
 

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
     HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
     http_parse_url, request_add_authorization_header, request_add_custom_headers,
-    request_handle_response, request_set_timeout, send_request,
+    request_error_to_shell_error, request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 
@@ -233,6 +233,7 @@ fn helper(
         full: args.full,
         allow_errors: args.allow_errors,
     };
+    let response = response.map_err(|e| request_error_to_shell_error(span, e))?;
 
     check_response_redirection(redirect_mode, span, &response)?;
     request_handle_response(
@@ -243,7 +244,7 @@ fn helper(
         request_flags,
         response,
         request_headers,
-        redirect_mode
+        redirect_mode,
     )
 }
 

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -1,6 +1,7 @@
 use crate::network::http::client::{
     HttpBody, RequestFlags, check_response_redirection, http_client, http_parse_redirect_mode,
-    http_parse_url, request_add_authorization_header, request_add_custom_headers, request_handle_response, request_set_timeout, send_request,
+    http_parse_url, request_add_authorization_header, request_add_custom_headers,
+    request_handle_response, request_set_timeout, send_request,
 };
 use nu_engine::command_prelude::*;
 

--- a/crates/nu-command/src/network/http/timeout_extractor_reader.rs
+++ b/crates/nu-command/src/network/http/timeout_extractor_reader.rs
@@ -1,0 +1,35 @@
+//! Ureq 3.0.12 converts timeout errors into std::io::ErrorKind::Other: <https://github.com/algesten/ureq/blob/3.0.12/src/error.rs#L193>
+//! But Nushell infrastructure expects std::io::ErrorKind::Timeout when an operation times out.
+//! This is an adapter that converts former into latter.
+
+use std::io::Read;
+
+/// Convert errors io errors with [std::io::ErrorKind::Other] and [ureq::Error::Timeout]
+/// into io errors with [std::io::ErrorKind::Timeout]
+pub struct UreqTimeoutExtractorReader<R> {
+    pub r: R,
+}
+
+impl<R: Read> Read for UreqTimeoutExtractorReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.r.read(buf).map_err(|e| {
+            // TODO: if-let chains when rust 1.88
+
+            // ureq packages time-outs into "other"
+            if e.kind() != std::io::ErrorKind::Other {
+                return e;
+            }
+            let ureq_err = match e.downcast::<ureq::Error>() {
+                Err(e) => return e,
+                Ok(e) => e,
+            };
+            match ureq_err {
+                ureq::Error::Timeout(..) => {
+                    std::io::Error::new(std::io::ErrorKind::TimedOut, ureq_err)
+                }
+                // package it back
+                e => std::io::Error::new(std::io::ErrorKind::Other, e),
+            }
+        })
+    }
+}

--- a/crates/nu-command/src/network/tls/impl_rustls.rs
+++ b/crates/nu-command/src/network/tls/impl_rustls.rs
@@ -106,8 +106,6 @@ pub fn tls(allow_insecure: bool) -> Result<TlsConfig, ShellError> {
             let certs = RootCerts::WebPki;
 
             TlsConfig::builder()
-                // FIXME(ureq): this call does not have semver guarantees
-                // should we set up crypto provider some other way?
                 .unversioned_rustls_crypto_provider(crypto_provider)
                 .root_certs(certs)
                 .build()

--- a/crates/nu-command/src/network/tls/impl_rustls.rs
+++ b/crates/nu-command/src/network/tls/impl_rustls.rs
@@ -1,17 +1,8 @@
-use std::{
-    ops::Deref,
-    sync::{Arc, LazyLock, OnceLock},
-};
+use std::sync::{Arc, OnceLock};
 
-use nu_engine::command_prelude::IoError;
 use nu_protocol::ShellError;
-use rustls::{
-    DigitallySignedStruct, RootCertStore, SignatureScheme,
-    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
-    crypto::CryptoProvider,
-    pki_types::{CertificateDer, ServerName, UnixTime},
-};
-use ureq::unversioned::transport::{Connector, RustlsConnector, TcpConnector};
+use rustls::crypto::CryptoProvider;
+use ureq::tls::{RootCerts, TlsConfig};
 
 // TODO: replace all these generic errors with proper errors
 
@@ -103,156 +94,26 @@ impl NuCryptoProvider {
     }
 }
 
-#[cfg(feature = "os")]
-static ROOT_CERT_STORE: LazyLock<Result<Arc<RootCertStore>, ShellError>> = LazyLock::new(|| {
-    let mut roots = RootCertStore::empty();
-
-    let native_certs = rustls_native_certs::load_native_certs();
-
-    let errors: Vec<_> = native_certs
-        .errors
-        .into_iter()
-        .map(|err| match err.kind {
-            rustls_native_certs::ErrorKind::Io { inner, path } => ShellError::Io(
-                IoError::new_internal_with_path(inner, err.context, nu_protocol::location!(), path),
-            ),
-            rustls_native_certs::ErrorKind::Os(error) => ShellError::GenericError {
-                error: error.to_string(),
-                msg: err.context.to_string(),
-                span: None,
-                help: None,
-                inner: vec![],
-            },
-            rustls_native_certs::ErrorKind::Pem(error) => ShellError::GenericError {
-                error: error.to_string(),
-                msg: err.context.to_string(),
-                span: None,
-                help: None,
-                inner: vec![],
-            },
-            _ => ShellError::GenericError {
-                error: String::from("unknown error loading native certs"),
-                msg: err.context.to_string(),
-                span: None,
-                help: None,
-                inner: vec![],
-            },
-        })
-        .collect();
-    if !errors.is_empty() {
-        return Err(ShellError::GenericError {
-            error: String::from("error loading native certs"),
-            msg: String::from("could not load native certs"),
-            span: None,
-            help: None,
-            inner: errors,
-        });
-    }
-
-    for cert in native_certs.certs {
-        roots.add(cert).map_err(|err| ShellError::GenericError {
-            error: err.to_string(),
-            msg: String::from("could not add root cert"),
-            span: None,
-            help: None,
-            inner: vec![],
-        })?;
-    }
-
-    Ok(Arc::new(roots))
-});
-
-#[cfg(not(feature = "os"))]
-static ROOT_CERT_STORE: LazyLock<Result<Arc<RootCertStore>, ShellError>> = LazyLock::new(|| {
-    Ok(Arc::new(rustls::RootCertStore {
-        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
-    }))
-});
-
 #[doc = include_str!("./tls.rustdoc.md")]
-pub fn tls(allow_insecure: bool) -> Result<impl Connector, ShellError> {
+pub fn tls(allow_insecure: bool) -> Result<TlsConfig, ShellError> {
     let crypto_provider = CRYPTO_PROVIDER.get()?;
+    let config = match allow_insecure {
+        false => {
+            #[cfg(feature = "os")]
+            let certs = RootCerts::PlatformVerifier;
 
-    let make_protocol_versions_error = |err: rustls::Error| ShellError::GenericError {
-        error: err.to_string(),
-        msg: "crypto provider is incompatible with protocol versions".to_string(),
-        span: None,
-        help: None,
-        inner: vec![],
+            #[cfg(not(feature = "os"))]
+            let certs = RootCerts::WebPki;
+
+            TlsConfig::builder()
+                // FIXME(ureq): this call does not have semver guarantees
+                // should we set up crypto provider some other way?
+                .unversioned_rustls_crypto_provider(crypto_provider)
+                .root_certs(certs)
+                .build()
+        }
+        true => TlsConfig::builder().disable_verification(true).build(),
     };
-    // FIXME(ureq)
-    let connector = match allow_insecure {
-        true => todo!("FIXME(ureq)"),
-        false => ().chain(TcpConnector::default()).chain(RustlsConnector::default()),
-    };
 
-    Ok(connector)
-
-    // let client_config = match allow_insecure {
-    //     false => rustls::ClientConfig::builder_with_provider(crypto_provider)
-    //         .with_safe_default_protocol_versions()
-    //         .map_err(make_protocol_versions_error)?
-    //         .with_root_certificates(ROOT_CERT_STORE.deref().clone()?)
-    //         .with_no_client_auth(),
-    //     true => rustls::ClientConfig::builder_with_provider(crypto_provider)
-    //         .with_safe_default_protocol_versions()
-    //         .map_err(make_protocol_versions_error)?
-    //         .dangerous()
-    //         .with_custom_certificate_verifier(Arc::new(UnsecureServerCertVerifier))
-    //         .with_no_client_auth(),
-    // };
-
-    // Ok(Arc::new(client_config))
-}
-
-#[derive(Debug)]
-struct UnsecureServerCertVerifier;
-
-impl ServerCertVerifier for UnsecureServerCertVerifier {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _server_name: &ServerName<'_>,
-        _ocsp_response: &[u8],
-        _now: UnixTime,
-    ) -> Result<ServerCertVerified, rustls::Error> {
-        Ok(ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        Ok(HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        Ok(HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        vec![
-            SignatureScheme::RSA_PKCS1_SHA1,
-            SignatureScheme::ECDSA_SHA1_Legacy,
-            SignatureScheme::RSA_PKCS1_SHA256,
-            SignatureScheme::ECDSA_NISTP256_SHA256,
-            SignatureScheme::RSA_PKCS1_SHA384,
-            SignatureScheme::ECDSA_NISTP384_SHA384,
-            SignatureScheme::RSA_PKCS1_SHA512,
-            SignatureScheme::ECDSA_NISTP521_SHA512,
-            SignatureScheme::RSA_PSS_SHA256,
-            SignatureScheme::RSA_PSS_SHA384,
-            SignatureScheme::RSA_PSS_SHA512,
-            SignatureScheme::ED25519,
-            SignatureScheme::ED448,
-        ]
-    }
+    Ok(config)
 }

--- a/crates/nu-command/tests/commands/network/http/delete.rs
+++ b/crates/nu-command/tests/commands/network/http/delete.rs
@@ -57,7 +57,7 @@ fn http_delete_failed_due_to_server_error() {
         .as_str()
     ));
 
-    assert!(actual.err.contains("Bad request (400)"))
+    assert!(actual.err.contains("Bad request (400)"), "unexpected error: {:?}", actual.err)
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/network/http/delete.rs
+++ b/crates/nu-command/tests/commands/network/http/delete.rs
@@ -57,7 +57,11 @@ fn http_delete_failed_due_to_server_error() {
         .as_str()
     ));
 
-    assert!(actual.err.contains("Bad request (400)"), "unexpected error: {:?}", actual.err)
+    assert!(
+        actual.err.contains("Bad request (400)"),
+        "unexpected error: {:?}",
+        actual.err
+    )
 }
 
 #[test]
@@ -140,6 +144,14 @@ fn http_delete_timeout() {
         format!("http delete --max-time 100ms {url}", url = server.url()).as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::io::timed_out"));
-    assert!(&actual.err.contains("Timed out"));
+    assert!(
+        &actual.err.contains("nu::shell::io::timed_out"),
+        "unexpected error : {:?}",
+        actual.err
+    );
+    assert!(
+        &actual.err.contains("Timed out"),
+        "unexpected error : {:?}",
+        actual.err
+    );
 }

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -334,6 +334,14 @@ fn http_get_timeout() {
         format!("http get --max-time 100ms {url}", url = server.url()).as_str()
     ));
 
-    assert!(&actual.err.contains("nu::shell::io::timed_out"));
-    assert!(&actual.err.contains("Timed out"));
+    assert!(
+        &actual.err.contains("nu::shell::io::timed_out"),
+        "unexpected error: {:?}",
+        actual.err
+    );
+    assert!(
+        &actual.err.contains("Timed out"),
+        "unexpected error: {:?}",
+        actual.err
+    );
 }

--- a/crates/nu-command/tests/commands/network/http/head.rs
+++ b/crates/nu-command/tests/commands/network/http/head.rs
@@ -36,8 +36,11 @@ fn http_head_failed_due_to_server_error() {
         )
         .as_str()
     ));
-
-    assert!(actual.err.contains("Bad request (400)"))
+    assert!(
+        actual.err.contains("Bad request (400)"),
+        "Unexpected error: {:?}",
+        actual.err
+    )
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/network/http/post.rs
+++ b/crates/nu-command/tests/commands/network/http/post.rs
@@ -101,14 +101,15 @@ fn http_post_failed_due_to_unexpected_body() {
     assert!(actual.err.contains("Cannot make request"))
 }
 
+const JSON: &str = r#"{
+  "foo": "bar"
+}"#;
+
 #[test]
 fn http_post_json_is_success() {
     let mut server = Server::new();
 
-    let mock = server
-        .mock("POST", "/")
-        .match_body(r#"{"foo":"bar"}"#)
-        .create();
+    let mock = server.mock("POST", "/").match_body(JSON).create();
 
     let actual = nu!(format!(
         r#"http post -t 'application/json' {url} {{foo: 'bar'}}"#,
@@ -116,17 +117,14 @@ fn http_post_json_is_success() {
     ));
 
     mock.assert();
-    assert!(actual.out.is_empty())
+    assert!(actual.out.is_empty(), "Unexpected output {:?}", actual.out)
 }
 
 #[test]
 fn http_post_json_string_is_success() {
     let mut server = Server::new();
 
-    let mock = server
-        .mock("POST", "/")
-        .match_body(r#"{"foo":"bar"}"#)
-        .create();
+    let mock = server.mock("POST", "/").match_body(JSON).create();
 
     let actual = nu!(format!(
         r#"http post -t 'application/json' {url} '{{"foo":"bar"}}'"#,
@@ -137,14 +135,17 @@ fn http_post_json_string_is_success() {
     assert!(actual.out.is_empty())
 }
 
+const JSON_LIST: &str = r#"[
+  {
+    "foo": "bar"
+  }
+]"#;
+
 #[test]
 fn http_post_json_list_is_success() {
     let mut server = Server::new();
 
-    let mock = server
-        .mock("POST", "/")
-        .match_body(r#"[{"foo":"bar"}]"#)
-        .create();
+    let mock = server.mock("POST", "/").match_body(JSON_LIST).create();
 
     let actual = nu!(format!(
         r#"http post -t 'application/json' {url} [{{foo: "bar"}}]"#,


### PR DESCRIPTION
Remake of #16076
closes https://github.com/nushell/nushell/issues/15986

# Remaining tasks
- [x] Fix TLS setup
- [x] `ureq` errors shape changed, need to re-write handling logic

# Description

- Updates to new version of `ureq`
- gathers full redirect history in the output of `http <verb> --full` command

![image](https://github.com/user-attachments/assets/719548b2-4f66-4451-af66-d5bd4c10bbef)


# User-Facing Changes
## http post now sends body serialized as pretty json.

This will increase the body size

<details><summary>Examples</summary>
<p>


before
```http
POST / HTTP/1.1
Host: localhost:1234
User-Agent: nushell
Accept: */*
Content-Type: application/json
accept-encoding: gzip
Content-Length: 13

{"foo":"bar"}
```
now 
```http
POST / HTTP/1.1
accept-encoding: gzip
content-length: 18
user-agent: nushell
accept: */*
host: localhost:1234
content-type: application/json; charset=utf-8

{
  "foo": "bar"
}
```


</p>
</details> 

## non-ascii and non-utf-8 header sometimes cause an error

These used to be silently ignored

<details><summary>now</summary>
<p>


```nu
# term1:
[("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nx-header: "| into binary) 0x[1F FF AA AA] ("\r\n\r\n" | into binary)] | bytes collect | nc -l 1234
# term2:
http get --full --allow-errors http://localhost:1234
Error: nu::shell::network_failure

  × Network failure
   ╭─[entry #5:1:32]
 1 │ http get --full --allow-errors http://localhost:1234
   ·                                ──────────┬──────────
   ·                                          ╰── protocol: http parse fail: invalid header value
   ╰────
```

</p>
</details> 


## New field `urls` in the returning record might break exotic cases
If users relied on the lack of field
e.g. `{urls: important} | merge (http get --full <...>)`

# Tests + Formatting
There seems to be extensive integration testing with mockito
- [x] fix tests

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
The documentation is auto-generated from the source code, so no need to edit nushell.github.io