### PR TITLE
fix(runtime): respect table and record structure form `any` coercion at runtime

### DIFF
--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -352,7 +352,10 @@ fn eval_instruction<D: DebugContext>(
         }
         Instruction::StoreVariable { var_id, src } => {
             let value = ctx.collect_reg(*src, *span)?;
-            ctx.stack.add_var(*var_id, value);
+            // Perform runtime type checking and conversion for variable assignment
+            let variable = ctx.engine_state.get_var(*var_id);
+            let converted_value = convert_value_for_assignment(value, &variable.ty)?;
+            ctx.stack.add_var(*var_id, converted_value);
             Ok(Continue)
         }
         Instruction::DropVariable { var_id } => {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -42,6 +42,7 @@ use crate::{
     unescape_unquote_string,
 };
 
+
 /// These parser keywords can be aliased
 pub const ALIASABLE_PARSER_KEYWORDS: &[&[u8]] = &[
     b"if",
@@ -3366,7 +3367,19 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                     let rhs_type = rvalue.ty.clone();
 
                     if let Some(explicit_type) = &explicit_type {
-                        if !type_compatible(explicit_type, &rhs_type) {
+                        // When RHS returns Type::Any, check if the explicit type is "generic enough"
+                        // to accept any value. Specific types with constraints (like table<a: string>)
+                        // should not accept Type::Any at parse time.
+                        let compatible = if matches!(rhs_type, Type::Any) {
+                            // For Type::Any, defer all type checking to runtime.
+                            // This allows the runtime to perform actual compatibility validation
+                            // when the real data is available.
+                            true
+                        } else {
+                            type_compatible(explicit_type, &rhs_type)
+                        };
+                        
+                        if !compatible {
                             working_set.error(ParseError::TypeMismatch(
                                 explicit_type.clone(),
                                 rhs_type.clone(),
@@ -3484,7 +3497,19 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeli
                     let rhs_type = rvalue.ty.clone();
 
                     if let Some(explicit_type) = &explicit_type {
-                        if !type_compatible(explicit_type, &rhs_type) {
+                        // When RHS returns Type::Any, check if the explicit type is "generic enough"
+                        // to accept any value. Specific types with constraints (like table<a: string>)
+                        // should not accept Type::Any at parse time.
+                        let compatible = if matches!(rhs_type, Type::Any) {
+                            // For Type::Any, defer all type checking to runtime.
+                            // This allows the runtime to perform actual compatibility validation
+                            // when the real data is available.
+                            true
+                        } else {
+                            type_compatible(explicit_type, &rhs_type)
+                        };
+                        
+                        if !compatible {
                             working_set.error(ParseError::TypeMismatch(
                                 explicit_type.clone(),
                                 rhs_type.clone(),
@@ -3649,7 +3674,19 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                     let rhs_type = rvalue.ty.clone();
 
                     if let Some(explicit_type) = &explicit_type {
-                        if !type_compatible(explicit_type, &rhs_type) {
+                        // When RHS returns Type::Any, check if the explicit type is "generic enough"
+                        // to accept any value. Specific types with constraints (like table<a: string>)
+                        // should not accept Type::Any at parse time.
+                        let compatible = if matches!(rhs_type, Type::Any) {
+                            // For Type::Any, defer all type checking to runtime.
+                            // This allows the runtime to perform actual compatibility validation
+                            // when the real data is available.
+                            true
+                        } else {
+                            type_compatible(explicit_type, &rhs_type)
+                        };
+                        
+                        if !compatible {
                             working_set.error(ParseError::TypeMismatch(
                                 explicit_type.clone(),
                                 rhs_type.clone(),

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -42,7 +42,6 @@ use crate::{
     unescape_unquote_string,
 };
 
-
 /// These parser keywords can be aliased
 pub const ALIASABLE_PARSER_KEYWORDS: &[&[u8]] = &[
     b"if",
@@ -3370,7 +3369,7 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         // When RHS returns Type::Any, check if the explicit type is "generic enough"
                         // to accept any value. Specific types with constraints (like table<a: string>)
                         // should not accept Type::Any at parse time.
-                        let compatible = if matches!(rhs_type, Type::Any) {
+                        let compatible = if let Type::Any = rhs_type {
                             // For Type::Any, defer all type checking to runtime.
                             // This allows the runtime to perform actual compatibility validation
                             // when the real data is available.
@@ -3378,7 +3377,7 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         } else {
                             type_compatible(explicit_type, &rhs_type)
                         };
-                        
+
                         if !compatible {
                             working_set.error(ParseError::TypeMismatch(
                                 explicit_type.clone(),
@@ -3497,18 +3496,13 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeli
                     let rhs_type = rvalue.ty.clone();
 
                     if let Some(explicit_type) = &explicit_type {
-                        // When RHS returns Type::Any, check if the explicit type is "generic enough"
-                        // to accept any value. Specific types with constraints (like table<a: string>)
-                        // should not accept Type::Any at parse time.
-                        let compatible = if matches!(rhs_type, Type::Any) {
-                            // For Type::Any, defer all type checking to runtime.
-                            // This allows the runtime to perform actual compatibility validation
-                            // when the real data is available.
+                        // see `parse_let`
+                        let compatible = if let Type::Any = rhs_type {
                             true
                         } else {
                             type_compatible(explicit_type, &rhs_type)
                         };
-                        
+
                         if !compatible {
                             working_set.error(ParseError::TypeMismatch(
                                 explicit_type.clone(),
@@ -3674,18 +3668,13 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                     let rhs_type = rvalue.ty.clone();
 
                     if let Some(explicit_type) = &explicit_type {
-                        // When RHS returns Type::Any, check if the explicit type is "generic enough"
-                        // to accept any value. Specific types with constraints (like table<a: string>)
-                        // should not accept Type::Any at parse time.
-                        let compatible = if matches!(rhs_type, Type::Any) {
-                            // For Type::Any, defer all type checking to runtime.
-                            // This allows the runtime to perform actual compatibility validation
-                            // when the real data is available.
+                        // see `parse_let`
+                        let compatible = if let Type::Any = rhs_type {
                             true
                         } else {
                             type_compatible(explicit_type, &rhs_type)
                         };
-                        
+
                         if !compatible {
                             working_set.error(ParseError::TypeMismatch(
                                 explicit_type.clone(),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -863,6 +863,7 @@ impl Value {
 
             // matching composite types
             (val @ Value::Record { .. }, Type::Record(inner)) => record_compatible(val, inner),
+            (val @ Value::Record { .. }, Type::Table(inner)) => record_compatible(val, inner),
             (Value::List { vals, .. }, Type::List(inner)) => {
                 vals.iter().all(|val| val.is_subtype_of(inner))
             }

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -829,7 +829,7 @@ fn let_variable_record_to_table_conversion() -> TestResult {
 #[test]
 fn let_variable_record_to_table_key_mismatch() -> TestResult {
     // This conversion should fail due to a key mismatch
-    fail_test(r#"let x: table<b: int> = ({a: 1} | to nuon | from nuon); $x | describe"#, "expected table<b: int>, found table<a: int")
+    fail_test(r#"let x: table<b: int> = ({a: 1} | to nuon | from nuon); $x | describe"#, "can't convert table<a: int> to table<b: int>")
 }
 
 #[test]

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -815,6 +815,24 @@ fn let_variable_type_mismatch() -> TestResult {
 }
 
 #[test]
+fn let_variable_type_any_accepts_compatible_types() -> TestResult {
+    // Type::Any should be accepted by compatible types (record can convert to table)
+    run_test(r#"let x: table = ({a: 1} | into record | to nuon | from nuon); $x | describe"#, "table<a: int>")
+}
+
+#[test]
+fn let_variable_record_to_table_conversion() -> TestResult {
+    // Records from Type::Any sources should be convertible to tables when field types match
+    run_test(r#"let x: table<a: int> = ({a: 1} | to nuon | from nuon); $x | describe"#, "table<a: int>")
+}
+
+#[test]
+fn let_variable_record_to_table_key_mismatch() -> TestResult {
+    // This conversion should fail due to a key mismatch
+    fail_test(r#"let x: table<b: int> = ({a: 1} | to nuon | from nuon); $x | describe"#, "expected table<b: int>, found table<a: int")
+}
+
+#[test]
 fn let_variable_disallows_completer() -> TestResult {
     fail_test(
         r#"let x: int@completer = 42"#,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
currently the example below results in a type mismatch when
  assigning `$table2` to the value of `$table1`:
```nushell
let table1: table<a: string> = [{a: "foo"}]
let table2: table<b: string> = $table1
```

```io
Error: nu::parser::type_mismatch

  × Type mismatch.
   ╭─[example1.nu:2:32]
 1 │ let table1: table<a: string> = [{a: "foo"}]
 2 │ let table2: table<b: string> = $table1
   ·                                ───┬───
   ·                                   ╰── expected table<b: string>, found table<a: string>
   ╰────
```



However fields populated from the `any` type do not follow such constraints:

```nushell
let table1: table  = ({a: 1} | into record | to nuon | from nuon);
let table2: table<b: string> = $table1
# * circkets *
```

...and leads to some unexpected results:

```
$ let x: table<a: int> = ({a: 1} | to nuon | from nuon); $x | describe
record<a: int>
```

This change/fix now correctly handles the runtime issue with a `cant_convert` error:

```nushell
Error: nu::shell::cant_convert

  × Can't convert to table<b: string>.
   ╭─[test2.nu:2:32]
 1 │ let table1: table = ({a: 1} | into record | to nuon | from nuon);
 2 │ let table2: table<b: string> = $table1
   ·                                ───┬───
   ·                                   ╰── can't convert table<a: int> to table<b: string>
   ╰────
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

This is a breaking change for scripts where coercion ignored field constraints for records and tables

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
