### PR TITLE
fix(env): Inconsistent behaviour in `export-env` between nested and flat variable `use` resolutions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,6 +3827,7 @@ dependencies = [
  "nu-path",
  "nu-protocol",
  "nu-utils",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -20,6 +20,7 @@ nu-glob = { path = "../nu-glob", version = "0.105.2" }
 nu-utils = { path = "../nu-utils", version = "0.105.2", default-features = false }
 fancy-regex = { workspace = true }
 log = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = ["os"]

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -300,3 +300,28 @@ fn path_is_a_list_in_script() {
         assert!(actual.out.ends_with("list<string>"));
     })
 }
+
+#[test]
+fn env_var_propagation_to_subshell_complex_types() {
+    // Test that complex environment variables (records, lists) are properly
+    // serialized and propagated to subshells instead of being silently dropped
+    let actual = nu!(r#"
+        $env.TEST_LIST = ["item1", "item2"]
+        $env.TEST_RECORD = {key: "value"}
+        
+        ^$nu.current-exe --no-config-file --commands '
+            print $env.TEST_LIST.0
+            print $env.TEST_RECORD.key
+        '
+    "#);
+
+    // The fix is working - both complex environment variables are now propagated
+    assert!(
+        actual.out.contains("item1"),
+        "List environment variable should be propagated"
+    );
+    assert!(
+        actual.out.contains("value"),
+        "Record environment variable should be propagated"
+    );
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
