### PR TITLE
refactor(nu-command/parse)!: Return `null` for unmatched capture groups, rather than empty string

### DIFF
--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -78,12 +78,12 @@ impl Command for Parse {
                 example: "\"foo! bar.\" | parse --regex '(\\w+)(?=\\.)|(\\w+)(?=!)'",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
-                        "capture0" => Value::test_string(""),
+                        "capture0" => Value::test_nothing(),
                         "capture1" => Value::test_string("foo"),
                     }),
                     Value::test_record(record! {
                         "capture0" => Value::test_string("bar"),
-                        "capture1" => Value::test_string(""),
+                        "capture1" => Value::test_nothing(),
                     }),
                 ])),
             },


### PR DESCRIPTION
- closes #16085

# Description

> [!NOTE]
> This change only affects **optional capture groups** e.g.
> - `(?<foo>\w+)?`
> - `(?:=(?<val>.*))?`

```nushell
let example = r#'
user=0 action="bar"
user=0 action=""
user=0
'#

'>'; $example | parse --regex '(?m)^user=(?<user>[0-9]+)(?: action="(?<action>[^"]*)")?$' | to nuon
'='; [[user, action]; ["0", bar], ["0", ""], ["0", ""]]
```
`user=0 action=""` and `user=0` are different, yet indistinguishable in `parse`'s output.

With this PR, unmatched optional groups return `null`.
```nushell
[[user, action]; ["0", bar], ["0", ""], ["0", null]]
```

# User-Facing Changes

Existing uses of `parse` might break if unmatched capture groups are checked by comparison to an empty string.
However I don't think that's likely, from what I've seen most users prefer using `is-empty` for such comparisons (probably because it makes the intent clearer).

# Tests + Formatting

- :green_circle: toolkit fmt
- :green_circle: toolkit clippy
- :green_circle: toolkit test
- :green_circle: toolkit test stdlib

# After Submitting
N/A