### PR TITLE
Allow enabling deprecated experimental options

### DIFF
--- a/crates/nu-experimental/src/parse.rs
+++ b/crates/nu-experimental/src/parse.rs
@@ -39,7 +39,7 @@ pub enum ParseWarning {
 /// - a context value, which is returned with any warning
 ///
 /// This way you don't need to manually track which input caused which warning.
-pub fn parse_iter<'i, Ctx>(
+pub fn parse_iter<'i, Ctx: Clone>(
     iter: impl Iterator<Item = (Cow<'i, str>, Option<Cow<'i, str>>, Ctx)>,
 ) -> Vec<(ParseWarning, Ctx)> {
     let mut warnings = Vec::new();
@@ -51,12 +51,10 @@ pub fn parse_iter<'i, Ctx>(
 
         match option.status() {
             Status::DeprecatedDiscard => {
-                warnings.push((ParseWarning::DeprecatedDiscard(option), ctx));
-                continue;
+                warnings.push((ParseWarning::DeprecatedDiscard(option), ctx.clone()));
             }
             Status::DeprecatedDefault => {
-                warnings.push((ParseWarning::DeprecatedDefault(option), ctx));
-                continue;
+                warnings.push((ParseWarning::DeprecatedDefault(option), ctx.clone()));
             }
             _ => {}
         }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR changes the behavior of #16028 to allow enabling experimental options even if they are marked as deprecated.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`