### PR TITLE
`first` always returns a single element

### DIFF
--- a/crates/nu-command/tests/commands/cal.rs
+++ b/crates/nu-command/tests/commands/cal.rs
@@ -63,7 +63,7 @@ fn cal_week_day_start_mo() {
 fn cal_sees_pipeline_year() {
     let actual = nu!(pipeline(
         r#"
-        cal --as-table --full-year 1020 | get mo | first 4 | to json -r
+        cal --as-table --full-year 1020 | get mo | take 4 | to json -r
         "#
     ));
 

--- a/crates/nu-command/tests/commands/echo.rs
+++ b/crates/nu-command/tests/commands/echo.rs
@@ -2,7 +2,7 @@ use nu_test_support::nu;
 
 #[test]
 fn echo_range_is_lazy() {
-    let actual = nu!("echo 1..10000000000 | first 3 | to json --raw");
+    let actual = nu!("echo 1..10000000000 | take 3 | to json --raw");
 
     assert_eq!(actual.out, "[1,2,3]");
 }

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -3,39 +3,6 @@ use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 
 #[test]
-fn gets_first_rows_by_amount() {
-    Playground::setup("first_test_1", |dirs, sandbox| {
-        sandbox.with_files(&[
-            EmptyFile("los.txt"),
-            EmptyFile("tres.txt"),
-            EmptyFile("amigos.txt"),
-            EmptyFile("arepas.clu"),
-        ]);
-
-        let actual = nu!(cwd: dirs.test(), "ls | first 3 | length");
-
-        assert_eq!(actual.out, "3");
-    })
-}
-
-#[test]
-fn gets_all_rows_if_amount_higher_than_all_rows() {
-    Playground::setup("first_test_2", |dirs, sandbox| {
-        sandbox.with_files(&[
-            EmptyFile("los.txt"),
-            EmptyFile("tres.txt"),
-            EmptyFile("amigos.txt"),
-            EmptyFile("arepas.clu"),
-        ]);
-
-        let actual = nu!(
-            cwd: dirs.test(), "ls | first 99 | length");
-
-        assert_eq!(actual.out, "4");
-    })
-}
-
-#[test]
 fn gets_first_row_when_no_amount_given() {
     Playground::setup("first_test_3", |dirs, sandbox| {
         sandbox.with_files(&[EmptyFile("caballeros.txt"), EmptyFile("arepas.clu")]);
@@ -48,31 +15,10 @@ fn gets_first_row_when_no_amount_given() {
 }
 
 #[test]
-fn gets_first_row_as_list_when_amount_given() {
-    let actual = nu!("[1, 2, 3] | first 1 | describe");
-
-    assert_eq!(actual.out, "list<int>");
-}
-
-#[test]
-fn gets_first_bytes() {
-    let actual = nu!("(0x[aa bb cc] | first 2) == 0x[aa bb]");
-
-    assert_eq!(actual.out, "true");
-}
-
-#[test]
 fn gets_first_byte() {
     let actual = nu!("0x[aa bb cc] | first");
 
     assert_eq!(actual.out, "170");
-}
-
-#[test]
-fn gets_first_bytes_from_stream() {
-    let actual = nu!("(1.. | each { 0x[aa bb cc] } | bytes collect | first 2) == 0x[aa bb]");
-
-    assert_eq!(actual.out, "true");
 }
 
 #[test]
@@ -94,7 +40,11 @@ fn works_with_binary_list() {
 fn errors_on_negative_rows() {
     let actual = nu!("[1, 2, 3] | first -10");
 
-    assert!(actual.err.contains("use a positive value"));
+    assert!(
+        actual.err.contains("doesn't have flag `-1`"),
+        "Expected unknown flag error, got: {}",
+        actual.err
+    );
 }
 
 #[test]
@@ -102,4 +52,16 @@ fn errors_on_empty_list_when_no_rows_given() {
     let actual = nu!("[] | first");
 
     assert!(actual.err.contains("index too large"));
+}
+
+#[test]
+fn errors_on_extra_positional_argument() {
+    let actual = nu!("[1, 2, 3] | first 2");
+    assert!(actual.err.contains("extra positional argument"));
+}
+
+#[test]
+fn errors_on_extra_positional_argument_from_command() {
+    let actual = nu!("ls | first 1");
+    assert!(actual.err.contains("extra positional argument"));
 }

--- a/crates/nu-command/tests/commands/generate.rs
+++ b/crates/nu-command/tests/commands/generate.rs
@@ -162,7 +162,7 @@ fn generate_with_input_is_streaming() {
         1..10
         | each {|x| print -en $x; $x}
         | generate {|e, sum=0| let sum = $e + $sum; {out: $sum, next: $sum}}
-        | first 5
+        | take 5
         | to nuon
         "#
     ));

--- a/crates/nu-command/tests/commands/sort.rs
+++ b/crates/nu-command/tests/commands/sort.rs
@@ -24,7 +24,7 @@ fn sort_primitive_values() {
             open cargo_sample.toml --raw
             | lines
             | skip 1
-            | first 6
+            | take 6
             | sort
             | first
         "

--- a/crates/nu-command/tests/commands/sort_by.rs
+++ b/crates/nu-command/tests/commands/sort_by.rs
@@ -8,12 +8,15 @@ fn by_column() {
             open cargo_sample.toml --raw
             | lines
             | skip 1
-            | first 4
-            | split column "="
+            | take 4
+            | each { split column "=" }
+            | flatten
+            | where column1 != null
             | sort-by column1
             | skip 1
-            | first
+            | take 1
             | get column1
+            | get 0
             | str trim
         "#
     ));
@@ -29,11 +32,13 @@ fn by_invalid_column() {
             open cargo_sample.toml --raw
             | lines
             | skip 1
-            | first 4
-            | split column "="
+            | take 4
+            | each { split column "=" }
+            | flatten
+            | where column1 != null
             | sort-by ColumnThatDoesNotExist
             | skip 1
-            | first
+            | take 1 
             | get column1
             | str trim
         "#

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -27,7 +27,7 @@ fn sets_the_column_from_a_block_full_stream_output() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             {content: null}
-            | update content {|| open --raw cargo_sample.toml | lines | first 5 }
+            | update content {|| open --raw cargo_sample.toml | lines | take 5 }
             | get content.1
             | str contains "nu"
         "#
@@ -42,7 +42,7 @@ fn sets_the_column_from_a_subexpression() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             {content: null}
-            | update content (open --raw cargo_sample.toml | lines | first 5)
+            | update content (open --raw cargo_sample.toml | lines | take 5)
             | get content.1
             | str contains "nu"
         "#

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -26,7 +26,7 @@ fn sets_the_column_from_a_block_full_stream_output() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             {content: null}
-            | upsert content {|| open --raw cargo_sample.toml | lines | first 5 }
+            | upsert content {|| open --raw cargo_sample.toml | lines | take 5 }
             | get content.1
             | str contains "nu"
         "#
@@ -41,7 +41,7 @@ fn sets_the_column_from_a_subexpression() {
         cwd: "tests/fixtures/formats", pipeline(
         r#"
             {content: null}
-            | upsert content (open --raw cargo_sample.toml | lines | first 5)
+            | upsert content (open --raw cargo_sample.toml | lines | take 5)
             | get content.1
             | str contains "nu"
         "#

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -91,7 +91,7 @@ fn binary_operator_comparisons() {
         "
             open sample.db
             | get ints
-            | first 4
+            | take 4
             | where z > 4200
             | get z.0
         "
@@ -104,7 +104,7 @@ fn binary_operator_comparisons() {
         "
             open sample.db
             | get ints
-            | first 4
+            | take 4
             | where z >= 4253
             | get z.0
         "
@@ -117,7 +117,7 @@ fn binary_operator_comparisons() {
         "
             open sample.db
             | get ints
-            | first 4
+            | take 4
             | where z < 10
             | get z.0
         "
@@ -130,7 +130,7 @@ fn binary_operator_comparisons() {
         "
             open sample.db
             | get ints
-            | first 4
+            | take 4
             | where z <= 1
             | get z.0
         "
@@ -144,7 +144,7 @@ fn binary_operator_comparisons() {
             open sample.db
             | get ints
             | where z != 1
-            | first
+            | first 
             | get z
         "
     ));

--- a/crates/nu-std/std-rfc/tables/mod.nu
+++ b/crates/nu-std/std-rfc/tables/mod.nu
@@ -178,7 +178,7 @@ export def "reject slices" [ ...slices ] {
 
 # Select one or more columns by their indices
 @example "Select column [0, 10, 11, 12]" {
-    ls -l | select column-slices 0 10..12 | first 3
+    ls -l | select column-slices 0 10..12 | take 3
 } --result [
     [name, created, accessed, modified];
     ["CITATION.cff", 2024-11-09T21:58:12+03:00, 2025-02-09T17:58:12+03:00, 2024-11-09T21:58:12+03:00],
@@ -194,7 +194,7 @@ export def "select column-slices" [
 
 # Reject one or more columns by their indices
 @example "Reject columns [0, 4, 5]" {
-    ls | reject column-slices 0 4 5 | first 3
+    ls | reject column-slices 0 4 5 | take 3
 }
 export def "reject column-slices" [
     ...slices

--- a/tests/repl/test_engine.rs
+++ b/tests/repl/test_engine.rs
@@ -310,7 +310,7 @@ fn nonshortcircuiting_xor() -> TestResult {
 
 #[test]
 fn open_ended_range() -> TestResult {
-    run_test(r#"1.. | first 100000 | length"#, "100000")
+    run_test(r#"1.. | take 100000 | length"#, "100000")
 }
 
 #[test]

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -738,7 +738,7 @@ fn exclusive_range_with_open_left() {
 #[test]
 fn range_with_open_right() {
     let actual = nu!("
-        echo 5.. | first 10 | math sum
+        echo 5.. | take 10 | math sum
         ");
 
     assert_eq!(actual.out, "95");
@@ -747,7 +747,7 @@ fn range_with_open_right() {
 #[test]
 fn exclusive_range_with_open_right() {
     let actual = nu!("
-        echo 5..< | first 10 | math sum
+        echo 5..< | take 10 | math sum
         ");
 
     assert_eq!(actual.out, "95");


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR updates the behavior of the `first` command by removing support for positional arguments (e.g., `first 3`).

Previously:

```bash
echo [1 2 3 4 5] | first 2  # returned [1, 2]
```

Now:

```bash
echo [1 2 3 4 5] | first    # returns just the first item (1)
```

Using `first 2` now triggers a parser error for extra positional arguments.

# User-Facing Changes

* `first` no longer accepts a positional argument.
* `first` always returns a single value (not a list).
* Users needing multiple elements should now use `take`, e.g., `take 2`.
* Updated error handling for invalid usage, including negative numbers.
* Updated relevant tests to reflect the new behavior.

# Tests + Formatting

* [x] Tests updated and added for all major scenarios
* [x] Ran `cargo fmt --all -- --check`
* [x] Ran `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used`
* [x] Ran `cargo test --workspace`
* [x]  Verified standard library: cargo run -- -c "use toolkit.nu; toolkit test stdlib"



# After Submitting

Documentation should reflect these changes.
