### PR TITLE
'find --columns .. --regex ..' works. Change help message to match.

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -47,7 +47,7 @@ impl Command for Find {
             .named(
                 "columns",
                 SyntaxShape::List(Box::new(SyntaxShape::String)),
-                "column names to be searched (with rest parameter, not regex yet)",
+                "column names to be searched",
                 Some('c'),
             )
             .switch(


### PR DESCRIPTION
# Description
find's help message for '--columns' claims incompatibility with '--regex'. However, both a review of the code and a test shows that this is not true, and the two flags are compatible.
This commit removes the incompatibility claim.

# User-Facing Changes
  * Help message of '--columns' flag in 'find' command is changed

# Tests + Formatting
Tested using 'toolkit check pr'. The stdlib tests don't pass on my system, but they didn't before this commit either.

# After Submitting
This command isn't mentioned in the main text, but is mentioned in the command reference. Should I rerun the command reference generator for the website? or is that done automatically before releases?
