### PR TITLE
Rework type checking for assignment operators

### DIFF
--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -67,7 +67,7 @@ fn mut_multiply_assign() {
 
 #[test]
 fn mut_divide_assign() {
-    let actual = nu!("mut y = 8; $y /= 2; $y");
+    let actual = nu!("mut y: number = 8; $y /= 2; $y");
 
     assert_eq!(actual.out, "4.0");
 }

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -1,6 +1,6 @@
 use nu_protocol::{
     ParseError, Span, Type,
-    ast::{Block, Comparison, Expr, Expression, Math, Operator, Pipeline, Range},
+    ast::{Assignment, Block, Comparison, Expr, Expression, Math, Operator, Pipeline, Range},
     engine::StateWorkingSet,
 };
 
@@ -721,16 +721,27 @@ pub fn math_result_type(
                 type_error(operator, op.span, lhs, rhs, |ty| matches!(ty, Type::Int))
             }
         },
-        // TODO: fix this
-        Operator::Assignment(_) => match (&lhs.ty, &rhs.ty) {
-            (x, y) if x == y => (Type::Nothing, None),
-            (Type::Any, _) => (Type::Nothing, None),
-            (_, Type::Any) => (Type::Nothing, None),
-            (Type::List(_) | Type::Table(_), Type::List(_) | Type::Table(_)) => {
-                (Type::Nothing, None)
-            }
-            _ => {
-                let err = ParseError::OperatorIncompatibleTypes {
+        Operator::Assignment(Assignment::AddAssign) => {
+            compound_assignment_result_type(working_set, lhs, op, rhs, operator, Math::Add)
+        }
+        Operator::Assignment(Assignment::ConcatenateAssign) => {
+            compound_assignment_result_type(working_set, lhs, op, rhs, operator, Math::Concatenate)
+        }
+        Operator::Assignment(Assignment::DivideAssign) => {
+            compound_assignment_result_type(working_set, lhs, op, rhs, operator, Math::Divide)
+        }
+        Operator::Assignment(Assignment::MultiplyAssign) => {
+            compound_assignment_result_type(working_set, lhs, op, rhs, operator, Math::Multiply)
+        }
+        Operator::Assignment(Assignment::SubtractAssign) => {
+            compound_assignment_result_type(working_set, lhs, op, rhs, operator, Math::Subtract)
+        }
+        Operator::Assignment(Assignment::Assign) => {
+            let err = if type_compatible(&lhs.ty, &rhs.ty) {
+                None
+            } else {
+                *op = Expression::garbage(working_set, op.span);
+                Some(ParseError::OperatorIncompatibleTypes {
                     op: operator.as_str(),
                     lhs: lhs.ty.clone(),
                     rhs: rhs.ty.clone(),
@@ -738,10 +749,10 @@ pub fn math_result_type(
                     lhs_span: lhs.span,
                     rhs_span: rhs.span,
                     help: None,
-                };
-                (Type::Nothing, Some(err))
-            }
-        },
+                })
+            };
+            (Type::Nothing, err)
+        }
     }
 }
 
@@ -913,5 +924,40 @@ pub fn check_range_types(working_set: &mut StateWorkingSet, range: &mut Range) {
             *to = Expression::garbage(working_set, to.span);
         }
         _ => (),
+    }
+}
+
+/// Get the result type for a compound assignment operator
+fn compound_assignment_result_type(
+    working_set: &mut StateWorkingSet,
+    lhs: &mut Expression,
+    op: &mut Expression,
+    rhs: &mut Expression,
+    operator: Operator,
+    operation: Math,
+) -> (Type, Option<ParseError>) {
+    let math_expr = Expr::Operator(Operator::Math(operation));
+    let mut math_op = Expression::new(working_set, math_expr, op.span, Type::Any);
+    match math_result_type(working_set, lhs, &mut math_op, rhs) {
+        // There was a type error in the math expression, so propagate it
+        (_, Some(err)) => (Type::Any, Some(err)),
+        // Operation type check okay, check regular assignment
+        (ty, None) if type_compatible(&lhs.ty, &ty) => (Type::Nothing, None),
+        // The math expression is fine, but we can't store the result back into the variable due to type mismatch
+        (_, None) => {
+            *op = Expression::garbage(working_set, op.span);
+            let err = ParseError::OperatorIncompatibleTypes {
+                op: operator.as_str(),
+                lhs: lhs.ty.clone(),
+                rhs: rhs.ty.clone(),
+                op_span: op.span,
+                lhs_span: lhs.span,
+                rhs_span: rhs.span,
+                help: Some(
+                    "The result type of this operation is not compatible with the type of the variable.",
+                ),
+            };
+            (Type::Nothing, Some(err))
+        }
     }
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Rel: #14429, #16079

Finishes up a TODO in the assignment type checking. 

- For regular assignment operations (only applies to `mut`), type checking is now done using `type_compatible` (which is what `let` uses)
  - This allows some mutable assignments to work which weren't allowed before

Before:
```nushell
let x: glob = "" 
# => ok, no error
mut x: glob = ""; $x = ""
# => Error: nu::parser::operator_incompatible_types
# => 
# =>   × Types 'glob' and 'string' are not compatible for the '=' operator.
# =>    ╭─[entry #6:1:19]
# =>  1 │ mut x: glob = ""; $x = ""
# =>    ·                   ─┬ ┬ ─┬
# =>    ·                    │ │  ╰── string
# =>    ·                    │ ╰── does not operate between 'glob' and 'string'
# =>    ·                    ╰── glob
# =>    ╰────

let x: number = 1
# ok, no error
mut x: number = 1; $x = 2
# => Error: nu::parser::operator_incompatible_types
# => 
# =>   × Types 'number' and 'int' are not compatible for the '=' operator.
# =>    ╭─[source:1:20]
# =>  1 │ mut x: number = 1; $x = 2
# =>    ·                    ─┬ ┬ ┬
# =>    ·                     │ │ ╰── int
# =>    ·                     │ ╰── does not operate between 'number' and 'int'
# =>    ·                     ╰── number
# =>    ╰────
```

After:
```nushell
let x: glob = ""
# ok, no error (same as before)
mut x: glob = ""; $x = ""
# ok, no error

let x: number = 1
# ok, no error (same as before)
mut x: number = 1; $x = 2
# ok, no error
```

- Properly type check compound operations. First checks if the operation (eg. `+` for `+=`) type checks successfully, and then checks if the assignment type checks successfully (also using `type_compatible`)
  - This fixes some issues where the "long version" of a compound assignment operator would error, but the compound assignment operator itself would not

Before:
```nushell
mut x = 1; $x = $x / 2
# => Error: nu::parser::operator_incompatible_types
# => 
# =>   × Types 'int' and 'float' are not compatible for the '=' operator.
# =>    ╭─[entry #15:1:12]
# =>  1 │ mut x = 1; $x = $x / 2
# =>    ·            ─┬ ┬ ───┬──
# =>    ·             │ │    ╰── float
# =>    ·             │ ╰── does not operate between 'int' and 'float'
# =>    ·             ╰── int
# =>    ╰────

mut x = 1; $x /= 2
# uh oh, no error...

mut x = (date now); $x = $x - 2019-05-10
# => Error: nu::parser::operator_incompatible_types
# => 
# =>   × Types 'datetime' and 'duration' are not compatible for the '=' operator.
# =>    ╭─[entry #1:1:21]
# =>  1 │ mut x = (date now); $x = $x - 2019-05-10
# =>    ·                     ─┬ ┬ ───────┬───────
# =>    ·                      │ │        ╰── duration
# =>    ·                      │ ╰── does not operate between 'datetime' and 'duration'
# =>    ·                      ╰── datetime
# =>    ╰────

mut x = (date now); $x -= 2019-05-10
# uh oh, no error... (the result of this is a duration, not a datetime)
```

After:
```nushell
mut x = 1; $x = $x / 2
# => Error: nu::parser::operator_incompatible_types
# => 
# =>   × Types 'int' and 'float' are not compatible for the '=' operator.
# =>    ╭─[entry #5:1:12]
# =>  1 │ mut x = 1; $x = $x / 2
# =>    ·            ─┬ ┬ ───┬──
# =>    ·             │ │    ╰── float
# =>    ·             │ ╰── does not operate between 'int' and 'float'
# =>    ·             ╰── int
# =>    ╰────

mut x = (date now); $x -= 2019-05-10
# => Error: nu::parser::operator_incompatible_types
# => 
# =>   × Types 'datetime' and 'datetime' are not compatible for the '-=' operator.
# =>    ╭─[entry #11:1:21]
# =>  1 │ mut x = (date now); $x -= 2019-05-10
# =>    ·                     ─┬ ─┬ ─────┬────
# =>    ·                      │  │      ╰── datetime
# =>    ·                      │  ╰── does not operate between 'datetime' and 'datetime'
# =>    ·                      ╰── datetime
# =>    ╰────
# =>   help: The result type of this operation is not compatible with the type of the variable.
```

This is technically a breaking change if you relied on the old behavior (for example, there was a test that broke after this change because it relied on `/=` improperly type checking)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
* Mutable assignment operations now use the same type checking rules as normal assignments
  * For example, `$x = 123` now uses the same type checking rules as `let x = 123` or `mut x = 123` 
* Compound assignment operations now type check using the same rules as the operation they use
* Assignment errors will also now highlight the invalid assignment operator in red


# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
