### PR TITLE
fix(completion): put argument completion results before commands

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -469,7 +469,8 @@ impl NuCompleter {
                             if let Some(external_result) =
                                 self.external_completion(closure, &text_spans, offset, new_span)
                             {
-                                suggestions.extend(external_result);
+                                // Prioritize external results over (sub)commands
+                                suggestions.splice(0..0, external_result);
                                 return suggestions;
                             }
                         }
@@ -478,8 +479,7 @@ impl NuCompleter {
                             let (new_span, prefix) =
                                 strip_placeholder_if_any(working_set, &span, strip);
                             let ctx = Context::new(working_set, new_span, prefix, offset);
-                            suggestions.extend(self.process_completion(&mut FileCompletion, &ctx));
-                            return suggestions;
+                            return self.process_completion(&mut FileCompletion, &ctx);
                         }
                         break;
                     }

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1480,11 +1480,12 @@ fn command_watch_with_filecompletion() {
     match_suggestions(&expected_paths, &suggestions)
 }
 
-#[rstest]
-fn subcommand_completions() {
+#[test]
+fn subcommand_vs_external_completer() {
     let (_, _, mut engine, mut stack) = new_engine();
     let commands = r#"
             $env.config.completions.algorithm = "fuzzy"
+            $env.config.completions.external.completer = {|spans| ["external"]}
             def foo-test-command [] {}
             def "foo-test-command bar" [] {}
             def "foo-test-command aagap bcr" [] {}
@@ -1497,6 +1498,7 @@ fn subcommand_completions() {
     let suggestions = subcommand_completer.complete(prefix, prefix.len());
     match_suggestions(
         &vec![
+            "external",
             "food bar",
             "foo-test-command bar",
             "foo-test-command aagap bcr",
@@ -1506,7 +1508,7 @@ fn subcommand_completions() {
 
     let prefix = "foot bar";
     let suggestions = subcommand_completer.complete(prefix, prefix.len());
-    match_suggestions(&vec!["foo-test-command bar"], &suggestions);
+    match_suggestions(&vec!["external", "foo-test-command bar"], &suggestions);
 }
 
 #[test]

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -309,10 +309,10 @@ fn custom_arguments_and_subcommands() {
     let suggestions = completer.complete(completion_str, completion_str.len());
     // including both subcommand and directory completions
     let expected = [
-        "foo test bar".into(),
         folder("test_a"),
         file("test_a_symlink"),
         folder("test_b"),
+        "foo test bar".into(),
     ];
     match_suggestions_by_string(&expected, &suggestions);
 }
@@ -330,7 +330,7 @@ fn custom_flags_and_subcommands() {
     let completion_str = "foo --test";
     let suggestions = completer.complete(completion_str, completion_str.len());
     // including both flag and directory completions
-    let expected: Vec<_> = vec!["foo --test bar", "--test"];
+    let expected: Vec<_> = vec!["--test", "foo --test bar"];
     match_suggestions(&expected, &suggestions);
 }
 


### PR DESCRIPTION
#16075

# Description

# User-Facing Changes

Improved experience: more meaningful items on top of the completion menu.
Mostly for the fuzzy/substring matcher.

# Tests + Formatting

Adjusted

# After Submitting
