### PR TITLE
fix `ansi --list` missing new items

### DIFF
--- a/crates/nu-command/src/strings/ansi/ansi_.rs
+++ b/crates/nu-command/src/strings/ansi/ansi_.rs
@@ -902,8 +902,8 @@ fn generate_ansi_code_list(
             let code = Value::string(ansi_code.code.replace('\u{1b}', "\\e"), call_span);
 
             let record = if use_ansi_coloring {
-                // The first 397 items in the ansi array are previewable
-                let preview = if i < 397 {
+                // The first 409 items in the ansi array are previewable
+                let preview = if i < 409 {
                     Value::string(
                         format!("\u{1b}[0m{}NUSHELL\u{1b}[0m", &ansi_code.code),
                         call_span,


### PR DESCRIPTION
# Description

This fixes an oversight where not all items show in `ansi --list`.

### Before
![image](https://github.com/user-attachments/assets/2fd60744-28e1-4769-b491-7ac92b8b96c6)

### After
![image](https://github.com/user-attachments/assets/422993a5-5f29-4c24-8d90-66b642d72fa4)



# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
