### PR TITLE
Add `all` to enable all active experimental options

### DIFF
--- a/crates/nu-experimental/src/lib.rs
+++ b/crates/nu-experimental/src/lib.rs
@@ -182,6 +182,24 @@ impl PartialEq for ExperimentalOption {
 
 impl Eq for ExperimentalOption {}
 
+/// Sets the state of all experimental option that aren't deprecated.
+///
+/// # Safety
+/// This method is unsafe to emphasize that experimental options are not designed to change
+/// dynamically at runtime.
+/// Changing their state at arbitrary points can lead to inconsistent behavior.
+/// You should set experimental options only during initialization, before the application fully
+/// starts.
+pub unsafe fn set_all(value: bool) {
+    for option in ALL {
+        match option.status() {
+            // SAFETY: The safety bounds for `ExperimentalOption.set` are the same as this function.
+            Status::OptIn | Status::OptOut => unsafe { option.set(value) },
+            Status::DeprecatedDefault | Status::DeprecatedDiscard => {}
+        }
+    }
+}
+
 pub(crate) trait DynExperimentalOptionMarker {
     fn identifier(&self) -> &'static str;
     fn description(&self) -> &'static str;

--- a/crates/nu-experimental/src/parse.rs
+++ b/crates/nu-experimental/src/parse.rs
@@ -95,7 +95,7 @@ pub fn parse_iter<'i, Ctx: Clone>(
     warnings
 }
 
-fn parse_val<'v>(val: Option<&'v str>) -> Result<bool, &'v str> {
+fn parse_val(val: Option<&str>) -> Result<bool, &str> {
     match val.map(str::trim) {
         None => Ok(true),
         Some("true") => Ok(true),

--- a/crates/nu-experimental/src/parse.rs
+++ b/crates/nu-experimental/src/parse.rs
@@ -19,6 +19,10 @@ pub enum ParseWarning {
     #[error("Invalid assignment for `{identifier}`, expected `true` or `false`, got `{1}`", identifier = .0.identifier())]
     InvalidAssignment(&'static ExperimentalOption, String),
 
+    /// The assignment for "all" wasn't valid. Only `true` or `false` is accepted.
+    #[error("Invalid assignment for `all`, expected `true` or `false`, got `{0}`")]
+    InvalidAssignmentAll(String),
+
     /// This experimental option is deprecated as this is now the default behavior.
     #[error("The experimental option `{identifier}` is deprecated as this is now the default behavior.", identifier = .0.identifier())]
     DeprecatedDefault(&'static ExperimentalOption),
@@ -33,6 +37,11 @@ pub enum ParseWarning {
 /// This is the recommended way to activate options, as it handles [`ParseWarning`]s properly
 /// and is easy to hook into.
 ///
+/// When the key `"all"` is encountered, [`set_all`](super::set_all) is used to set all
+/// experimental options that aren't deprecated.
+/// This allows opting (or opting out of) all experimental options that are currently available for
+/// testing.
+///
 /// The `iter` argument should yield:
 /// - the identifier of the option
 /// - an optional assignment value (`true`/`false`)
@@ -44,6 +53,19 @@ pub fn parse_iter<'i, Ctx: Clone>(
 ) -> Vec<(ParseWarning, Ctx)> {
     let mut warnings = Vec::new();
     for (key, val, ctx) in iter {
+        if key == "all" {
+            let val = match parse_val(val.as_deref()) {
+                Ok(val) => val,
+                Err(s) => {
+                    warnings.push((ParseWarning::InvalidAssignmentAll(s.to_owned()), ctx));
+                    continue;
+                }
+            };
+            // SAFETY: This is part of the expected parse function to be called at initialization.
+            unsafe { super::set_all(val) };
+            continue;
+        }
+
         let Some(option) = ALL.iter().find(|option| option.identifier() == key.trim()) else {
             warnings.push((ParseWarning::Unknown(key.to_string()), ctx));
             continue;
@@ -59,11 +81,9 @@ pub fn parse_iter<'i, Ctx: Clone>(
             _ => {}
         }
 
-        let val = match val.as_deref().map(str::trim) {
-            None => true,
-            Some("true") => true,
-            Some("false") => false,
-            Some(s) => {
+        let val = match parse_val(val.as_deref()) {
+            Ok(val) => val,
+            Err(s) => {
                 warnings.push((ParseWarning::InvalidAssignment(option, s.to_owned()), ctx));
                 continue;
             }
@@ -73,6 +93,15 @@ pub fn parse_iter<'i, Ctx: Clone>(
     }
 
     warnings
+}
+
+fn parse_val<'v>(val: Option<&'v str>) -> Result<bool, &'v str> {
+    match val.map(str::trim) {
+        None => Ok(true),
+        Some("true") => Ok(true),
+        Some("false") => Ok(false),
+        Some(s) => Err(s),
+    }
 }
 
 /// Parse experimental options from the [`ENV`] environment variable.
@@ -110,6 +139,7 @@ impl ParseWarning {
         match self {
             Self::Unknown(_) => "nu::experimental_option::unknown",
             Self::InvalidAssignment(_, _) => "nu::experimental_option::invalid_assignment",
+            Self::InvalidAssignmentAll(_) => "nu::experimental_option::invalid_assignment_all",
             Self::DeprecatedDefault(_) => "nu::experimental_option::deprecated_default",
             Self::DeprecatedDiscard(_) => "nu::experimental_option::deprecated_discard",
         }
@@ -126,6 +156,7 @@ impl ParseWarning {
                 ALL.iter().map(|option| option.identifier()).join(", ")
             )),
             Self::InvalidAssignment(_, _) => None,
+            Self::InvalidAssignmentAll(_) => None,
             Self::DeprecatedDiscard(_) => None,
             Self::DeprecatedDefault(_) => {
                 Some(String::from("You can safely remove this option now."))

--- a/src/command.rs
+++ b/src/command.rs
@@ -471,7 +471,7 @@ impl Command for Nu {
             .named(
                 "experimental-options",
                 SyntaxShape::List(Box::new(SyntaxShape::String)),
-                "enable or disable experimental options",
+                r#"enable or disable experimental options, use `"all"` to set all active options"#,
                 None,
             )
             .optional(


### PR DESCRIPTION
- closes #16118 

<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR adds the option to pass `all` to the experimental options parser. This will enable all active (not deprecated) experimental options to ease with dogfooding.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

A new valid value for `--experimental-options` and `NU_EXPERIMENTAL_OPTIONS`.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
