### PR TITLE
Add more infos to experimental options

### DIFF
--- a/crates/nu-command/src/debug/experimental_options.rs
+++ b/crates/nu-command/src/debug/experimental_options.rs
@@ -18,6 +18,8 @@ impl Command for DebugExperimentalOptions {
                     (String::from("enabled"), Type::Bool),
                     (String::from("status"), Type::String),
                     (String::from("description"), Type::String),
+                    (String::from("since"), Type::String),
+                    (String::from("pr"), Type::String),
                 ])),
             )
             .add_help()
@@ -51,6 +53,11 @@ impl Command for DebugExperimentalOptions {
                                     Status::DeprecatedDefault => "deprecated-default"
                                 }, call.head),
                                 "description" => Value::string(option.description(), call.head),
+                                "since" => Value::string({
+                                    let (major, minor, patch) = option.since();
+                                    format!("{major}.{minor}.{patch}")
+                                }, call.head),
+                                "pr" => Value::string(option.pr_url(), call.head)
                             },
                             call.head,
                         )

--- a/crates/nu-experimental/src/lib.rs
+++ b/crates/nu-experimental/src/lib.rs
@@ -125,6 +125,18 @@ impl ExperimentalOption {
         self.marker.status()
     }
 
+    pub fn since(&self) -> Version {
+        self.marker.since()
+    }
+
+    pub fn pr_id(&self) -> u32 {
+        self.marker.pr()
+    }
+
+    pub fn pr_url(&self) -> String {
+        format!("https://github.com/nushell/nushell/pull/{}", self.marker.pr())
+    }
+
     pub fn get(&self) -> bool {
         self.value
             .load(Ordering::Relaxed)
@@ -204,6 +216,8 @@ pub(crate) trait DynExperimentalOptionMarker {
     fn identifier(&self) -> &'static str;
     fn description(&self) -> &'static str;
     fn status(&self) -> Status;
+    fn since(&self) -> Version;
+    fn pr(&self) -> u32;
 }
 
 impl<M: options::ExperimentalOptionMarker> DynExperimentalOptionMarker for M {
@@ -217,5 +231,13 @@ impl<M: options::ExperimentalOptionMarker> DynExperimentalOptionMarker for M {
 
     fn status(&self) -> Status {
         M::STATUS
+    }
+
+    fn since(&self) -> Version {
+        M::SINCE
+    }
+
+    fn pr(&self) -> u32 {
+        M::PR
     }
 }

--- a/crates/nu-experimental/src/lib.rs
+++ b/crates/nu-experimental/src/lib.rs
@@ -134,7 +134,10 @@ impl ExperimentalOption {
     }
 
     pub fn pr_url(&self) -> String {
-        format!("https://github.com/nushell/nushell/pull/{}", self.marker.pr())
+        format!(
+            "https://github.com/nushell/nushell/pull/{}",
+            self.marker.pr()
+        )
     }
 
     pub fn get(&self) -> bool {

--- a/crates/nu-experimental/src/options/example.rs
+++ b/crates/nu-experimental/src/options/example.rs
@@ -17,4 +17,6 @@ impl ExperimentalOptionMarker for Example {
     const IDENTIFIER: &'static str = "example";
     const DESCRIPTION: &'static str = "This is an example of an experimental option.";
     const STATUS: Status = Status::DeprecatedDiscard;
+    const SINCE: Version = (0, 105, 2);
+    const PR: u32 = 16028;
 }

--- a/crates/nu-experimental/src/options/mod.rs
+++ b/crates/nu-experimental/src/options/mod.rs
@@ -40,15 +40,15 @@ pub(crate) trait ExperimentalOptionMarker {
     const STATUS: Status;
 
     /// Nushell version since this experimental option is available.
-    /// 
+    ///
     /// These three values represent major.minor.patch version.
-    /// Don't use some macro to generate this dynamically as this would defeat the purpose of having 
+    /// Don't use some macro to generate this dynamically as this would defeat the purpose of having
     /// a historic record.
     const SINCE: Version;
 
     /// PR number that introduced this experimental option.
-    /// 
-    /// To make this work, add a placeholder value here when developing and then, after opening the 
+    ///
+    /// To make this work, add a placeholder value here when developing and then, after opening the
     /// PR, update this value.
     const PR: u32;
 }

--- a/crates/nu-experimental/src/options/mod.rs
+++ b/crates/nu-experimental/src/options/mod.rs
@@ -8,6 +8,8 @@ use crate::*;
 mod example;
 mod reorder_cell_paths;
 
+pub(crate) type Version = (u16, u16, u16);
+
 /// Marker trait for defining experimental options.
 ///
 /// Implement this trait to mark a struct as metadata for an [`ExperimentalOption`].
@@ -36,6 +38,19 @@ pub(crate) trait ExperimentalOptionMarker {
     /// Experimental options that stabilize should be marked as [`Status::DeprecatedDefault`] while
     /// options that will be removed should be [`Status::DeprecatedDiscard`].
     const STATUS: Status;
+
+    /// Nushell version since this experimental option is available.
+    /// 
+    /// These three values represent major.minor.patch version.
+    /// Don't use some macro to generate this dynamically as this would defeat the purpose of having 
+    /// a historic record.
+    const SINCE: Version;
+
+    /// PR number that introduced this experimental option.
+    /// 
+    /// To make this work, add a placeholder value here when developing and then, after opening the 
+    /// PR, update this value.
+    const PR: u32;
 }
 
 // Export only the static values.

--- a/crates/nu-experimental/src/options/reorder_cell_paths.rs
+++ b/crates/nu-experimental/src/options/reorder_cell_paths.rs
@@ -27,4 +27,6 @@ impl ExperimentalOptionMarker for ReorderCellPaths {
 \
         Reorder the parts of cell-path when accessing a cell in a table, always select the row before selecting the column.";
     const STATUS: Status = Status::OptIn;
+    const SINCE: Version = (0, 105, 2);
+    const PR: u32 = 15682;
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR adds more info to experimental options. It requires the two new fields `SINCE` and `PR`.

`SINCE` should be the version that adds the experimental option and `PR` the PR number that adds the option.
These two fields are available via `debug experimental-options`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Only more fields, nothing breaking.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
