### PR TITLE
Add `ShellWarning`

### DIFF
--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -3,7 +3,7 @@ use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_protocol::{
     PipelineData, ShellError, Spanned, Value,
-    cli_error::report_compile_error,
+    report_error::report_compile_error,
     debugger::WithoutDebug,
     engine::{EngineState, Stack, StateWorkingSet},
     report_parse_error, report_parse_warning,

--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -3,9 +3,9 @@ use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_protocol::{
     PipelineData, ShellError, Spanned, Value,
-    report_error::report_compile_error,
     debugger::WithoutDebug,
     engine::{EngineState, Stack, StateWorkingSet},
+    report_error::report_compile_error,
     report_parse_error, report_parse_warning,
 };
 use std::sync::Arc;

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -5,9 +5,9 @@ use nu_parser::parse;
 use nu_path::canonicalize_with;
 use nu_protocol::{
     PipelineData, ShellError, Span, Value,
-    report_error::report_compile_error,
     debugger::WithoutDebug,
     engine::{EngineState, Stack, StateWorkingSet},
+    report_error::report_compile_error,
     report_parse_error, report_parse_warning,
     shell_error::io::*,
 };

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -5,7 +5,7 @@ use nu_parser::parse;
 use nu_path::canonicalize_with;
 use nu_protocol::{
     PipelineData, ShellError, Span, Value,
-    cli_error::report_compile_error,
+    report_error::report_compile_error,
     debugger::WithoutDebug,
     engine::{EngineState, Stack, StateWorkingSet},
     report_parse_error, report_parse_warning,

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -5,9 +5,9 @@ use nu_engine::{eval_block, eval_block_with_early_return};
 use nu_parser::{Token, TokenContents, lex, parse, unescape_unquote_string};
 use nu_protocol::{
     PipelineData, ShellError, Span, Value,
-    report_error::report_compile_error,
     debugger::WithoutDebug,
     engine::{EngineState, Stack, StateWorkingSet},
+    report_error::report_compile_error,
     report_parse_error, report_parse_warning, report_shell_error,
 };
 #[cfg(windows)]

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -5,7 +5,7 @@ use nu_engine::{eval_block, eval_block_with_early_return};
 use nu_parser::{Token, TokenContents, lex, parse, unescape_unquote_string};
 use nu_protocol::{
     PipelineData, ShellError, Span, Value,
-    cli_error::report_compile_error,
+    report_error::report_compile_error,
     debugger::WithoutDebug,
     engine::{EngineState, Stack, StateWorkingSet},
     report_parse_error, report_parse_warning, report_shell_error,

--- a/crates/nu-cmd-base/src/hook.rs
+++ b/crates/nu-cmd-base/src/hook.rs
@@ -3,7 +3,7 @@ use nu_engine::{eval_block, eval_block_with_early_return, redirect_env};
 use nu_parser::parse;
 use nu_protocol::{
     PipelineData, PositionalArg, ShellError, Span, Type, Value, VarId,
-    cli_error::{report_parse_error, report_shell_error},
+    report_error::{report_parse_error, report_shell_error},
     debugger::WithoutDebug,
     engine::{Closure, EngineState, Stack, StateWorkingSet},
 };

--- a/crates/nu-cmd-base/src/hook.rs
+++ b/crates/nu-cmd-base/src/hook.rs
@@ -3,9 +3,9 @@ use nu_engine::{eval_block, eval_block_with_early_return, redirect_env};
 use nu_parser::parse;
 use nu_protocol::{
     PipelineData, PositionalArg, ShellError, Span, Type, Value, VarId,
-    report_error::{report_parse_error, report_shell_error},
     debugger::WithoutDebug,
     engine::{Closure, EngineState, Stack, StateWorkingSet},
+    report_error::{report_parse_error, report_shell_error},
 };
 use std::{collections::HashMap, sync::Arc};
 

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, ops::Deref};
 
 use nu_engine::{ClosureEval, command_prelude::*};
 use nu_protocol::{
-    ListStream, Signals,
+    ListStream, ReportMode, ShellWarning, Signals,
     ast::{Expr, Expression},
     report_shell_warning,
 };
@@ -329,7 +329,7 @@ fn closure_variable_warning(
         (Value::Closure { .. }, true) => {
             let span_contents = String::from_utf8_lossy(engine_state.get_span_contents(span));
             let carapace_suggestion = "re-run carapace init with version v1.3.3 or later\nor, change this to `{ $carapace_completer }`";
-            let suggestion = match span_contents {
+            let label = match span_contents {
                 Cow::Borrowed("$carapace_completer") => carapace_suggestion.to_string(),
                 Cow::Owned(s) if s.deref() == "$carapace_completer" => {
                     carapace_suggestion.to_string()
@@ -339,14 +339,15 @@ fn closure_variable_warning(
 
             report_shell_warning(
                 engine_state,
-                &ShellError::DeprecationWarning {
-                    deprecation_type: "Behavior",
-                    suggestion,
+                &ShellWarning::Deprecation {
+                    dep_type: "Behavior".to_string(),
+                    label,
                     span,
                     help: Some(
                         r"Since 0.105.0, closure literals passed to default are lazily evaluated, rather than returned as a value.
-In a future release, closures passed by variable will also be lazily evaluated.",
+In a future release, closures passed by variable will also be lazily evaluated.".to_string(),
                     ),
+                    report_mode: ReportMode::FirstUse,
                 },
             );
 

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -339,7 +339,7 @@ fn closure_variable_warning(
 
             report_shell_warning(
                 engine_state,
-                &ShellWarning::Deprecation {
+                &ShellWarning::Deprecated {
                     dep_type: "Behavior".to_string(),
                     label,
                     span,

--- a/crates/nu-engine/src/command_prelude.rs
+++ b/crates/nu-engine/src/command_prelude.rs
@@ -1,8 +1,8 @@
 pub use crate::CallExt;
 pub use nu_protocol::{
     ByteStream, ByteStreamType, Category, ErrSpan, Example, IntoInterruptiblePipelineData,
-    IntoPipelineData, IntoSpanned, IntoValue, PipelineData, Record, ShellError, Signature, Span,
-    Spanned, SyntaxShape, Type, Value,
+    IntoPipelineData, IntoSpanned, IntoValue, PipelineData, Record, ShellError, ShellWarning,
+    Signature, Span, Spanned, SyntaxShape, Type, Value,
     ast::CellPath,
     engine::{Call, Command, EngineState, Stack, StateWorkingSet},
     record,

--- a/crates/nu-protocol/src/deprecation.rs
+++ b/crates/nu-protocol/src/deprecation.rs
@@ -133,7 +133,7 @@ impl DeprecationEntry {
         let label = self.label(command_name);
         let span = self.span(call);
         let report_mode = self.report_mode;
-        Some(ParseWarning::Deprecation {
+        Some(ParseWarning::Deprecated {
             dep_type,
             label,
             span,

--- a/crates/nu-protocol/src/deprecation.rs
+++ b/crates/nu-protocol/src/deprecation.rs
@@ -133,7 +133,7 @@ impl DeprecationEntry {
         let label = self.label(command_name);
         let span = self.span(call);
         let report_mode = self.report_mode;
-        Some(ParseWarning::DeprecationWarning {
+        Some(ParseWarning::Deprecation {
             dep_type,
             label,
             span,

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -3,7 +3,6 @@ use crate::{
     ModuleId, OverlayId, ShellError, SignalAction, Signals, Signature, Span, SpanId, Type, Value,
     VarId, VirtualPathId,
     ast::Block,
-    report_error::ReportLog,
     debugger::{Debugger, NoopDebugger},
     engine::{
         CachedFile, Command, CommandType, DEFAULT_OVERLAY_NAME, EnvVars, OverlayFrame, ScopeFrame,
@@ -11,6 +10,7 @@ use crate::{
         description::{Doccomments, build_desc},
     },
     eval_const::create_nu_constant,
+    report_error::ReportLog,
     shell_error::io::IoError,
 };
 use fancy_regex::Regex;

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -3,7 +3,7 @@ use crate::{
     ModuleId, OverlayId, ShellError, SignalAction, Signals, Signature, Span, SpanId, Type, Value,
     VarId, VirtualPathId,
     ast::Block,
-    cli_error::ReportLog,
+    report_error::ReportLog,
     debugger::{Debugger, NoopDebugger},
     engine::{
         CachedFile, Command, CommandType, DEFAULT_OVERLAY_NAME, EnvVars, OverlayFrame, ScopeFrame,

--- a/crates/nu-protocol/src/errors/mod.rs
+++ b/crates/nu-protocol/src/errors/mod.rs
@@ -1,19 +1,21 @@
 mod chained_error;
-pub mod cli_error;
 mod compile_error;
 mod config_error;
 mod labeled_error;
 mod parse_error;
 mod parse_warning;
+pub mod report_error;
 pub mod shell_error;
+pub mod shell_warning;
 
-pub use cli_error::{
-    ReportMode, format_cli_error, report_parse_error, report_parse_warning, report_shell_error,
-    report_shell_warning,
-};
 pub use compile_error::CompileError;
 pub use config_error::ConfigError;
 pub use labeled_error::{ErrorLabel, LabeledError};
 pub use parse_error::{DidYouMean, ParseError};
 pub use parse_warning::ParseWarning;
+pub use report_error::{
+    ReportMode, Reportable, format_cli_error, report_parse_error, report_parse_warning,
+    report_shell_error, report_shell_warning,
+};
 pub use shell_error::ShellError;
+pub use shell_warning::ShellWarning;

--- a/crates/nu-protocol/src/errors/parse_warning.rs
+++ b/crates/nu-protocol/src/errors/parse_warning.rs
@@ -11,7 +11,7 @@ use crate::{ReportMode, Reportable};
 pub enum ParseWarning {
     #[error("{dep_type} deprecated.")]
     #[diagnostic(code(nu::parser::deprecated))]
-    Deprecation {
+    Deprecated {
         dep_type: String,
         label: String,
         #[label("{label}")]
@@ -25,7 +25,7 @@ pub enum ParseWarning {
 impl ParseWarning {
     pub fn span(&self) -> Span {
         match self {
-            ParseWarning::Deprecation { span, .. } => *span,
+            ParseWarning::Deprecated { span, .. } => *span,
         }
     }
 }
@@ -33,7 +33,7 @@ impl ParseWarning {
 impl Reportable for ParseWarning {
     fn report_mode(&self) -> ReportMode {
         match self {
-            ParseWarning::Deprecation { report_mode, .. } => *report_mode,
+            ParseWarning::Deprecated { report_mode, .. } => *report_mode,
         }
     }
 }
@@ -42,7 +42,7 @@ impl Reportable for ParseWarning {
 impl Hash for ParseWarning {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
-            ParseWarning::Deprecation {
+            ParseWarning::Deprecated {
                 dep_type, label, ..
             } => {
                 dep_type.hash(state);

--- a/crates/nu-protocol/src/errors/parse_warning.rs
+++ b/crates/nu-protocol/src/errors/parse_warning.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use super::ReportMode;
 
 #[derive(Clone, Debug, Error, Diagnostic, Serialize, Deserialize)]
+#[diagnostic(severity(Warning))]
 pub enum ParseWarning {
     #[error("{dep_type} deprecated.")]
     #[diagnostic(code(nu::parser::deprecated))]

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1220,7 +1220,7 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
     },
 
     #[error("{deprecation_type} deprecated.")]
-    #[diagnostic(code(nu::shell::deprecated))]
+    #[diagnostic(code(nu::shell::deprecated), severity(Warning))]
     DeprecationWarning {
         deprecation_type: &'static str,
         suggestion: String,

--- a/crates/nu-protocol/src/errors/shell_warning.rs
+++ b/crates/nu-protocol/src/errors/shell_warning.rs
@@ -10,7 +10,7 @@ use crate::{ReportMode, Reportable};
 #[diagnostic(severity(Warning))]
 pub enum ShellWarning {
     #[error("{dep_type} deprecated.")]
-    #[diagnostic(code(nu::parser::deprecated))]
+    #[diagnostic(code(nu::shell::deprecated))]
     Deprecated {
         dep_type: String,
         label: String,

--- a/crates/nu-protocol/src/errors/shell_warning.rs
+++ b/crates/nu-protocol/src/errors/shell_warning.rs
@@ -11,7 +11,7 @@ use crate::{ReportMode, Reportable};
 pub enum ShellWarning {
     #[error("{dep_type} deprecated.")]
     #[diagnostic(code(nu::parser::deprecated))]
-    Deprecation {
+    Deprecated {
         dep_type: String,
         label: String,
         #[label("{label}")]
@@ -25,7 +25,7 @@ pub enum ShellWarning {
 impl ShellWarning {
     pub fn span(&self) -> Span {
         match self {
-            ShellWarning::Deprecation { span, .. } => *span,
+            ShellWarning::Deprecated { span, .. } => *span,
         }
     }
 }
@@ -33,7 +33,7 @@ impl ShellWarning {
 impl Reportable for ShellWarning {
     fn report_mode(&self) -> ReportMode {
         match self {
-            ShellWarning::Deprecation { report_mode, .. } => *report_mode,
+            ShellWarning::Deprecated { report_mode, .. } => *report_mode,
         }
     }
 }
@@ -42,7 +42,7 @@ impl Reportable for ShellWarning {
 impl Hash for ShellWarning {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
-            ShellWarning::Deprecation {
+            ShellWarning::Deprecated {
                 dep_type, label, ..
             } => {
                 dep_type.hash(state);

--- a/crates/nu-protocol/src/errors/shell_warning.rs
+++ b/crates/nu-protocol/src/errors/shell_warning.rs
@@ -8,7 +8,7 @@ use crate::{ReportMode, Reportable};
 
 #[derive(Clone, Debug, Error, Diagnostic, Serialize, Deserialize)]
 #[diagnostic(severity(Warning))]
-pub enum ParseWarning {
+pub enum ShellWarning {
     #[error("{dep_type} deprecated.")]
     #[diagnostic(code(nu::parser::deprecated))]
     Deprecation {
@@ -22,27 +22,27 @@ pub enum ParseWarning {
     },
 }
 
-impl ParseWarning {
+impl ShellWarning {
     pub fn span(&self) -> Span {
         match self {
-            ParseWarning::Deprecation { span, .. } => *span,
+            ShellWarning::Deprecation { span, .. } => *span,
         }
     }
 }
 
-impl Reportable for ParseWarning {
+impl Reportable for ShellWarning {
     fn report_mode(&self) -> ReportMode {
         match self {
-            ParseWarning::Deprecation { report_mode, .. } => *report_mode,
+            ShellWarning::Deprecation { report_mode, .. } => *report_mode,
         }
     }
 }
 
 // To keep track of reported warnings
-impl Hash for ParseWarning {
+impl Hash for ShellWarning {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
-            ParseWarning::Deprecation {
+            ShellWarning::Deprecation {
                 dep_type, label, ..
             } => {
                 dep_type.hash(state);

--- a/devdocs/FAQ.md
+++ b/devdocs/FAQ.md
@@ -29,7 +29,7 @@ Approximate flow:
     - `return Err(ShellError::...)` and you're done in a `Command::run`
 4. Do you want to report a warning but not stop execution?
     - **NEVER** `println!`, we can write to stderr if necessary but...
-    - good practice: `nu_protocol::cli_error::report_error` or `report_error_new`
+    - good practice: `nu_protocol::report_error::report_error` or `report_error_new`
         - depending on whether you have access to a `StateWorkingSet`
     - if only relevant to in the field debugging: `log`-crate macros.
 

--- a/src/experimental_options.rs
+++ b/src/experimental_options.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 
 use nu_protocol::{
-    cli_error::report_experimental_option_warning,
+    report_error::report_experimental_option_warning,
     engine::{EngineState, StateWorkingSet},
 };
 

--- a/src/experimental_options.rs
+++ b/src/experimental_options.rs
@@ -1,8 +1,8 @@
 use std::borrow::Borrow;
 
 use nu_protocol::{
-    report_error::report_experimental_option_warning,
     engine::{EngineState, StateWorkingSet},
+    report_error::report_experimental_option_warning,
 };
 
 use crate::command::NushellCliArgs;


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Depends on #16146, do `git diff 132ikl/warning-diagnostic 132ikl/shell-warning` to see changes only from this PR.

Adds a proper `ShellWarning` enum which has the same functionality as `ParseWarning`.

Also moves the deprecation from #15806 into `ShellWarning::Deprecated` with `ReportMode::FirstUse`, so that warning will only pop up once now.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Technically the deprecation warning from #15806 is user facing but it's really not worth listing in the changelog

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
N/A

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A