### PR TITLE
Add warning when using history isolation with non-SQLite history format

### DIFF
--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -1,7 +1,7 @@
 //! Module containing the internal representation of user configuration
 
-use crate as nu_protocol;
 use crate::FromValue;
+use crate::{self as nu_protocol};
 use helper::*;
 use prelude::*;
 use std::collections::HashMap;
@@ -219,7 +219,11 @@ impl UpdateFromValue for Config {
 }
 
 impl Config {
-    pub fn update_from_value(&mut self, old: &Config, value: &Value) -> Option<ShellError> {
+    pub fn update_from_value(
+        &mut self,
+        old: &Config,
+        value: &Value,
+    ) -> Result<Option<ShellWarning>, ShellError> {
         // Current behaviour is that config errors are displayed, but do not prevent the rest
         // of the config from being updated (fields with errors are skipped/not updated).
         // Errors are simply collected one-by-one and wrapped into a ShellError variant at the end.
@@ -228,6 +232,6 @@ impl Config {
 
         self.update(value, &mut path, &mut errors);
 
-        errors.into_shell_error()
+        errors.check()
     }
 }

--- a/crates/nu-protocol/src/config/plugin_gc.rs
+++ b/crates/nu-protocol/src/config/plugin_gc.rs
@@ -147,7 +147,7 @@ mod tests {
         let mut errors = ConfigErrors::new(&config);
         let mut result = PluginGcConfigs::default();
         result.update(&input, &mut ConfigPath::new(), &mut errors);
-        assert!(errors.is_empty(), "errors: {errors:#?}");
+        assert!(!errors.has_errors(), "errors: {errors:#?}");
         assert_eq!(expected, result);
     }
 

--- a/crates/nu-protocol/src/config/prelude.rs
+++ b/crates/nu-protocol/src/config/prelude.rs
@@ -1,4 +1,4 @@
 pub(super) use super::{ConfigPath, UpdateFromValue, error::ConfigErrors};
-pub use crate::{IntoValue, ShellError, Span, Type, Value, record};
+pub use crate::{IntoValue, ShellError, ShellWarning, Span, Type, Value, record};
 pub use serde::{Deserialize, Serialize};
 pub use std::str::FromStr;

--- a/crates/nu-protocol/src/errors/config.rs
+++ b/crates/nu-protocol/src/errors/config.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use crate::{ShellError, Span, Type};
 use miette::Diagnostic;
 use thiserror::Error;
@@ -67,4 +69,16 @@ pub enum ConfigWarning {
         span: Span,
         help: &'static str,
     },
+}
+
+// To keep track of reported warnings
+impl Hash for ConfigWarning {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            ConfigWarning::IncompatibleOptions { label, help, .. } => {
+                label.hash(state);
+                help.hash(state);
+            }
+        }
+    }
 }

--- a/crates/nu-protocol/src/errors/config.rs
+++ b/crates/nu-protocol/src/errors/config.rs
@@ -54,3 +54,17 @@ pub enum ConfigError {
     #[diagnostic(transparent)]
     ShellError(#[from] ShellError),
 }
+
+/// Warnings which don't prevent config from being loaded, but we should inform the user about
+#[derive(Clone, Debug, PartialEq, Error, Diagnostic)]
+#[diagnostic(severity(Warning))]
+pub enum ConfigWarning {
+    #[error("Incompatible options")]
+    #[diagnostic(code(nu::shell::incompatible_options), help("{help}"))]
+    IncompatibleOptions {
+        label: &'static str,
+        #[label = "{label}"]
+        span: Span,
+        help: &'static str,
+    },
+}

--- a/crates/nu-protocol/src/errors/mod.rs
+++ b/crates/nu-protocol/src/errors/mod.rs
@@ -1,6 +1,6 @@
 mod chained_error;
 mod compile_error;
-mod config_error;
+mod config;
 mod labeled_error;
 mod parse_error;
 mod parse_warning;
@@ -9,7 +9,7 @@ pub mod shell_error;
 pub mod shell_warning;
 
 pub use compile_error::CompileError;
-pub use config_error::ConfigError;
+pub use config::{ConfigError, ConfigWarning};
 pub use labeled_error::{ErrorLabel, LabeledError};
 pub use parse_error::{DidYouMean, ParseError};
 pub use parse_warning::ParseWarning;

--- a/crates/nu-protocol/src/errors/parse_warning.rs
+++ b/crates/nu-protocol/src/errors/parse_warning.rs
@@ -1,14 +1,16 @@
 use crate::Span;
 use miette::Diagnostic;
-use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 use thiserror::Error;
 
 use crate::{ReportMode, Reportable};
 
-#[derive(Clone, Debug, Error, Diagnostic, Serialize, Deserialize)]
+#[derive(Clone, Debug, Error, Diagnostic)]
 #[diagnostic(severity(Warning))]
 pub enum ParseWarning {
+    /// A parse-time deprectaion. Indicates that something will be removed in a future release.
+    ///
+    /// Use [`ShellWarning::Deprecated`] if this is a deprecation which is only detectable at run-time.
     #[error("{dep_type} deprecated.")]
     #[diagnostic(code(nu::parser::deprecated))]
     Deprecated {

--- a/crates/nu-protocol/src/errors/shell_warning.rs
+++ b/crates/nu-protocol/src/errors/shell_warning.rs
@@ -35,7 +35,7 @@ impl Reportable for ShellWarning {
     fn report_mode(&self) -> ReportMode {
         match self {
             ShellWarning::Deprecated { report_mode, .. } => *report_mode,
-            ShellWarning::InvalidConfig { .. } => ReportMode::EveryUse,
+            ShellWarning::InvalidConfig { .. } => ReportMode::FirstUse,
         }
     }
 }

--- a/tests/repl/test_config.rs
+++ b/tests/repl/test_config.rs
@@ -168,3 +168,11 @@ fn mutate_nu_config_plugin_gc_plugins() -> TestResult {
         "0sec",
     )
 }
+
+#[test]
+fn mutate_nu_config_history_warning() -> TestResult {
+    fail_test(
+        r#"$env.config.history.file_format = "plaintext"; $env.config.history.isolation = true"#,
+        "history isolation only compatible with SQLite format",
+    )
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR depends on #16147, use `git diff 132ikl/shell-warning 132ikl/isolation-warn` to see only changes from this PR

People seem to get tripped up by this a lot, and it's not exactly intuitive, so I added a warning if you try to set `$env.config.history.isolation = true` when using the plaintext file format:

<img width="798" height="300" alt="image" src="https://github.com/user-attachments/assets/1828b960-082e-40ff-b0dd-738348c5678e" />


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
* Added a warning when using history isolation without using SQLite history.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Added a test

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A
