### PR TITLE
fix typo on documentation about pipes

### DIFF
--- a/crates/nu-command/src/help/help_pipe_and_redirect.rs
+++ b/crates/nu-command/src/help/help_pipe_and_redirect.rs
@@ -73,19 +73,19 @@ https://www.nushell.sh/lang-guide/chapters/pipelines.html"#
                 "o>>",
                 "redirection append",
                 "redirect stdout of a command, appending to a file",
-                "^cmd1 o> file.txt",
+                "^cmd1 o>> file.txt",
             ),
             HelpExamples::new(
                 "e>>",
                 "stderr redirection append",
                 "redirect stderr of a command, appending to a file",
-                "^cmd1 e> file.txt",
+                "^cmd1 e>> file.txt",
             ),
             HelpExamples::new(
                 "o+e>>",
                 "stdout and stderr redirection append",
                 "redirect stdout and stderr of a command, appending to a file",
-                "^cmd1 o+e> file.txt",
+                "^cmd1 o+e>> file.txt",
             ),
             HelpExamples::new(
                 "o>|",


### PR DESCRIPTION
these documentations say ">" when what they mean is ">>"

# Description

this documentation is about the use of ">>", but the documentation wrongly says ">". it has been updated to say ">>" instead.

# User-Facing Changes

the user will see ">>" in the documentation instead of ">".

# Tests + Formatting

there is nothing to test. this is a documentation change.

# After Submitting
