### PR TITLE
fix(gstat): make `state` entry lowercase

### DIFF
--- a/crates/nu_plugin_gstat/src/gstat.rs
+++ b/crates/nu_plugin_gstat/src/gstat.rs
@@ -220,7 +220,7 @@ impl Stats {
         let mut st: Stats = Default::default();
 
         st.read_branch(repo);
-        st.state = format!("{:?}", repo.state());
+        st.state = format!("{:?}", repo.state()).to_lowercase();
 
         let mut opts = git2::StatusOptions::new();
 


### PR DESCRIPTION
A follow up to #15965 based on [this comment](https://github.com/nushell/nushell/pull/15965#issuecomment-3058106114).

# Description

Make Git state values lowercase instead of title case (as in [upstream](https://docs.rs/git2/latest/git2/enum.RepositoryState.html)).

# User-Facing Changes

Different values.