### PR TITLE
fix(overlay): `overlay use` and `overlay hide` now update config state

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
@@ -96,6 +96,7 @@ impl Command for OverlayHide {
         for (name, val) in env_vars_to_keep {
             stack.add_env_var(name, val);
         }
+        stack.update_config(engine_state)?;
         Ok(PipelineData::empty())
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -178,6 +178,7 @@ impl Command for OverlayUse {
             }
         } else {
             caller_stack.add_overlay(overlay_name);
+            caller_stack.update_config(engine_state)?;
         }
 
         Ok(PipelineData::empty())


### PR DESCRIPTION
- fixes #5986
- fixes #7760
- fixes #8856
- fixes #10592
- fixes #11082

# Description
Unconditionally update the config state after each `overlay use` and `overlay hide`.

The fix looks simple, but only because of the constant improvements and refactors to the codebase that have taken place over time made it possible.

Fixing these issue when they were initially filed would have been much harder.

# User-Facing Changes
Overlays can add hooks, change color_config, update the config in general.

# Tests + Formatting
No tests added as I still haven't figured out how to simulate the repl in tests.

# After Submitting
N/A
