### PR TITLE
fix(get): to be consistent with regular cell-path access on `null` values

### DIFF
--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -172,18 +172,8 @@ fn action(
         }
     }
 
-    match input {
-        PipelineData::Empty => return Err(ShellError::PipelineEmpty { dst_span: span }),
-        // Allow chaining of get -i
-        PipelineData::Value(val @ Value::Nothing { .. }, ..) if !ignore_errors => {
-            return Err(ShellError::OnlySupportsThisInputType {
-                exp_input_type: "table or record".into(),
-                wrong_type: "nothing".into(),
-                dst_span: span,
-                src_span: val.span(),
-            });
-        }
-        _ => (),
+    if let PipelineData::Empty = input {
+        return Err(ShellError::PipelineEmpty { dst_span: span });
     }
 
     if rest.is_empty() {


### PR DESCRIPTION
# Description
Cell-path accesses on `null` values throw an error, unless the initial cell-path member is optional:
```nushell
">"; (null).a
# => Error: nu::shell::incompatible_path_access
# => 
# =>   x Data cannot be accessed with a cell path
# =>    ,-[source:1:8]
# =>  1 | (null).a
# =>    :        |
# =>    :        `-- nothing doesn't support cell paths
# =>    `----

">"; (null).a? | describe
# => nothing
```

`get` throws an error on `null` even when the cell-path is optional, and only returns `null` quietly with the `--ignore-errors` flag
```nushell
">"; null | get a?
# => Error: nu::shell::only_supports_this_input_type
# => 
# =>   x Input type not supported.
# =>    ,-[source:1:1]
# =>  1 | null | get a?
# =>    : ^^|^   ^|^
# =>    :   |     `-- only table or record input data is supported
# =>    :   `-- input type: nothing
# =>    `----

">"; null | get -i a? | describe
# => nothing
```

# Tests + Formatting
No breakage.

# After Submitting
N/A
