### PR TITLE
Panic when converting `other` I/O errors into our I/O errors

### DIFF
--- a/crates/nu-protocol/src/engine/jobs.rs
+++ b/crates/nu-protocol/src/engine/jobs.rs
@@ -236,7 +236,7 @@ impl FrozenJob {
     pub fn kill(&self) -> shell_error::io::Result<()> {
         #[cfg(unix)]
         {
-            kill_by_pid(self.unfreeze.pid() as i64).into()
+            Ok(kill_by_pid(self.unfreeze.pid() as i64)?)
         }
 
         // it doesn't happen outside unix.

--- a/crates/nu-protocol/src/engine/jobs.rs
+++ b/crates/nu-protocol/src/engine/jobs.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 
 use nu_system::{UnfreezeHandle, kill_by_pid};
 
-use crate::{PipelineData, Signals};
+use crate::{PipelineData, Signals, shell_error};
 
 use crate::JobId;
 
@@ -92,7 +92,7 @@ impl Jobs {
     /// This function tries to forcefully kill a job from this job table,
     /// removes it from the job table. It always succeeds in removing the job
     /// from the table, but may fail in killing the job's active processes.
-    pub fn kill_and_remove(&mut self, id: JobId) -> std::io::Result<()> {
+    pub fn kill_and_remove(&mut self, id: JobId) -> shell_error::io::Result<()> {
         if let Some(job) = self.jobs.get(&id) {
             let err = job.kill();
 
@@ -109,7 +109,7 @@ impl Jobs {
     ///
     /// It returns an error if any of the job killing attempts fails, but always
     /// succeeds in removing the jobs from the table.
-    pub fn kill_all(&mut self) -> std::io::Result<()> {
+    pub fn kill_all(&mut self) -> shell_error::io::Result<()> {
         self.last_frozen_job_id = None;
 
         let first_err = self
@@ -180,7 +180,7 @@ impl ThreadJob {
         lock.iter().copied().collect()
     }
 
-    pub fn kill(&self) -> std::io::Result<()> {
+    pub fn kill(&self) -> shell_error::io::Result<()> {
         // it's okay to make this interrupt outside of the mutex, since it has acquire-release
         // semantics.
 
@@ -205,7 +205,7 @@ impl ThreadJob {
 }
 
 impl Job {
-    pub fn kill(&self) -> std::io::Result<()> {
+    pub fn kill(&self) -> shell_error::io::Result<()> {
         match self {
             Job::Thread(thread_job) => thread_job.kill(),
             Job::Frozen(frozen_job) => frozen_job.kill(),
@@ -233,10 +233,10 @@ pub struct FrozenJob {
 }
 
 impl FrozenJob {
-    pub fn kill(&self) -> std::io::Result<()> {
+    pub fn kill(&self) -> shell_error::io::Result<()> {
         #[cfg(unix)]
         {
-            kill_by_pid(self.unfreeze.pid() as i64)
+            kill_by_pid(self.unfreeze.pid() as i64).into()
         }
 
         // it doesn't happen outside unix.

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -10,6 +10,16 @@ use crate::Span;
 
 use super::location::Location;
 
+/// Alias for a `Result` with the error type [`ErrorKind`] by default.
+///
+/// This may be used in all situations that would usually return an [`std::io::Error`] but are
+/// already part of the [`nu_protocol`](crate) crate and can therefore interact with
+/// [`shell_error::io`](self) directly.
+///
+/// To make programming inside this module easier, you can pass the `E` type with another error.
+/// This avoids the annoyance of having a shadowed `Result`.
+pub type Result<T, E = ErrorKind> = std::result::Result<T, E>;
+
 /// Represents an I/O error in the [`ShellError::Io`] variant.
 ///
 /// This is the central I/O error for the [`ShellError::Io`] variant.
@@ -157,6 +167,14 @@ pub enum ErrorKind {
     /// If you want to provide an [`std::io::ErrorKind`] manually, use [`ErrorKind::from_std`].
     #[allow(private_interfaces)]
     Std(std::io::ErrorKind, Sealed),
+
+    /// Killing a job process failed.
+    ///
+    /// This error is part [`ShellError::Io`](super::ShellError::Io) instead of
+    /// [`ShellError::Job`](super::ShellError::Job) as this error occurs because some I/O operation
+    /// failed on the OS side.
+    /// And not part of our logic.
+    KillJobProcess,
 
     NotAFile,
 
@@ -394,6 +412,15 @@ I/O errors should always be specific, provide more context
     }
 }
 
+impl From<nu_system::KillByPidError> for ErrorKind {
+    fn from(value: nu_system::KillByPidError) -> Self {
+        match value {
+            nu_system::KillByPidError::Output(error) => error.into(),
+            nu_system::KillByPidError::KillProcess => ErrorKind::KillJobProcess,
+        }
+    }
+}
+
 impl StdError for IoError {}
 impl Display for IoError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -415,6 +442,7 @@ impl Display for ErrorKind {
                 let (first, rest) = msg.split_at(1);
                 write!(f, "{}{}", first.to_uppercase(), rest)
             }
+            ErrorKind::KillJobProcess => write!(f, "Killing job process failed"),
             ErrorKind::NotAFile => write!(f, "Not a file"),
             ErrorKind::AlreadyInUse => write!(f, "Already in use"),
             ErrorKind::FileNotFound => write!(f, "File not found"),
@@ -452,6 +480,7 @@ impl Diagnostic for IoError {
                 std::io::ErrorKind::Other => code.push_str("other"),
                 kind => code.push_str(&kind.to_string().to_lowercase().replace(" ", "_")),
             },
+            ErrorKind::KillJobProcess => code.push_str("kill_job_process"),
             ErrorKind::NotAFile => code.push_str("not_a_file"),
             ErrorKind::AlreadyInUse => code.push_str("already_in_use"),
             ErrorKind::FileNotFound => code.push_str("file_not_found"),

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -375,6 +375,21 @@ impl From<&std::io::Error> for ErrorKind {
             }
         }
 
+        #[cfg(debug_assertions)]
+        if err.kind() == std::io::ErrorKind::Other {
+            panic!(
+                "\
+suspicious conversion:
+    tried to convert `std::io::Error` with `std::io::ErrorKind::Other`
+    into `nu_protocol::shell_error::io::ErrorKind`
+
+I/O errors should always be specific, provide more context
+
+{err:#?}\
+            "
+            )
+        }
+
         ErrorKind::Std(err.kind(), Sealed)
     }
 }

--- a/crates/nu-system/src/util.rs
+++ b/crates/nu-system/src/util.rs
@@ -2,16 +2,24 @@ use std::io;
 use std::process::Command as CommandSys;
 
 /// Tries to forcefully kill a process by its PID
-pub fn kill_by_pid(pid: i64) -> io::Result<()> {
+pub fn kill_by_pid(pid: i64) -> Result<(), KillByPidError> {
     let mut cmd = build_kill_command(true, std::iter::once(pid), None);
 
-    let output = cmd.output()?;
+    let output = cmd.output().map_err(KillByPidError::Output)?;
 
-    if !output.status.success() {
-        return Err(io::Error::other("failed to kill process"));
+    match output.status.success() {
+        true => Ok(()),
+        false => Err(KillByPidError::KillProcess),
     }
+}
 
-    Ok(())
+/// Error while killing a process forcefully by its PID.
+pub enum KillByPidError {
+    /// I/O error while capturing the output of the process.
+    Output(io::Error),
+
+    /// Killing the process failed.
+    KillProcess,
 }
 
 /// Create a `std::process::Command` for the current target platform, for killing


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

While investigating #16159 I found out that sometimes slip `std::io::Error`s with `std::io::ErrorKind::Other` through our I/O error handling causing unhelpful errors with the name "Other error".

I thought about making it possible to show the content of other I/O errors in our `ErrorKind`, but that makes them more expensive and harder to match, which is kind of the whole point of having them. So instead, I added a debug-only check that makes sure only non-other I/O errors get converted. Since tests run in debug mode, that should help us catch these errors early. I left the check out in release mode on purpose so we don't crash users who have nu as their main shell. It's similar to the debug assertions in the same file that check for unknown spans.

This is the panic output when it encounters an other I/O error:
<img width="1469" height="876" alt="image" src="https://github.com/user-attachments/assets/45ac49a8-3572-42e2-8722-b58422c3b821" />

(This PR doesn't fix the issue mentioned #16159, that will be done in another PR.)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

None for both users and developers.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
