### PR TITLE
fix: unwrap `ShellErrorBridge` in `ByteStream::into_bytes`

### DIFF
--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -598,7 +598,12 @@ impl ByteStream {
         match self.stream {
             ByteStreamSource::Read(mut read) => {
                 let mut buf = Vec::new();
-                read.read_to_end(&mut buf).map_err(&from_io_error)?;
+                read.read_to_end(&mut buf).map_err(|err| {
+                    match ShellErrorBridge::try_from(err) {
+                        Ok(ShellErrorBridge(err)) => err,
+                        Err(err) => ShellError::Io(from_io_error(err)),
+                    }
+                })?;
                 Ok(buf)
             }
             ByteStreamSource::File(mut file) => {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

- closes #16159 

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

The setup in #16159 produced a `ByteStream` that held the `ShellError` inside an `std::io::Error`. For exactly this setup is the `ShellErrorBridge` designed, while figuring out what happened I found out that inside `BytesStream::into_bytes` a sneaky `ShellErrorBridge` was hiding:
<img width="1034" height="580" alt="image" src="https://github.com/user-attachments/assets/a0d16ca6-1a60-4c3c-a4cb-5e4b0695f20c" />

To fix this, I try to unwrap the bridge and if that is possible, return the original `ShellError`. This is done at multiple occasions inside `byte_stream.rs` already.

With this fix, we get the original error that looks like this:
<img width="1439" height="733" alt="image" src="https://github.com/user-attachments/assets/73f4dee7-f986-4f68-9c2c-0140a6e9e2b2" />


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

None, just a better error.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

To have less situations with other I/O errors, I opened #16160 to find out faster what other error was passed around.