### PR TITLE
Add default error codes

### DIFF
--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -8,7 +8,7 @@ use notify_debouncer_full::{
 use nu_engine::{ClosureEval, command_prelude::*};
 use nu_protocol::{
     engine::{Closure, StateWorkingSet},
-    format_cli_error,
+    format_cli_error, report_shell_error,
     shell_error::io::IoError,
 };
 use std::{
@@ -203,14 +203,9 @@ impl Command for Watch {
                     .run_with_input(PipelineData::Empty);
 
                 match result {
-                    Ok(val) => {
-                        val.print_table(engine_state, stack, false, false)?;
-                    }
-                    Err(err) => {
-                        let working_set = StateWorkingSet::new(engine_state);
-                        eprintln!("{}", format_cli_error(&working_set, &err));
-                    }
-                }
+                    Ok(val) => val.print_table(engine_state, stack, false, false)?,
+                    Err(err) => report_shell_error(engine_state, &err),
+                };
             }
 
             Ok(())

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -7,8 +7,7 @@ use notify_debouncer_full::{
 };
 use nu_engine::{ClosureEval, command_prelude::*};
 use nu_protocol::{
-    engine::{Closure, StateWorkingSet},
-    format_cli_error, report_shell_error,
+    engine::Closure, report_shell_error,
     shell_error::io::IoError,
 };
 use std::{

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -6,10 +6,7 @@ use notify_debouncer_full::{
     },
 };
 use nu_engine::{ClosureEval, command_prelude::*};
-use nu_protocol::{
-    engine::Closure, report_shell_error,
-    shell_error::io::IoError,
-};
+use nu_protocol::{engine::Closure, report_shell_error, shell_error::io::IoError};
 use std::{
     path::PathBuf,
     sync::mpsc::{RecvTimeoutError, channel},

--- a/crates/nu-protocol/src/errors/cli_error.rs
+++ b/crates/nu-protocol/src/errors/cli_error.rs
@@ -79,8 +79,15 @@ fn should_show_warning(engine_state: &EngineState, warning: &ParseWarning) -> bo
     }
 }
 
-pub fn format_cli_error(working_set: &StateWorkingSet, error: &dyn miette::Diagnostic) -> String {
-    format!("Error: {:?}", CliError::new(error, working_set, None))
+pub fn format_cli_error(
+    working_set: &StateWorkingSet,
+    error: &dyn miette::Diagnostic,
+    default_code: Option<&'static str>,
+) -> String {
+    format!(
+        "Error: {:?}",
+        CliError::new(error, working_set, default_code)
+    )
 }
 
 pub fn report_shell_error(engine_state: &EngineState, error: &ShellError) {

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1418,7 +1418,7 @@ impl ShellError {
             "msg" => Value::string(self.to_string(), span),
             "debug" => Value::string(format!("{self:?}"), span),
             "raw" => Value::error(self.clone(), span),
-            "rendered" => Value::string(format_cli_error(working_set, &self), span),
+            "rendered" => Value::string(format_cli_error(working_set, &self, Some("nu::shell::error")), span),
             "json" => Value::string(serde_json::to_string(&self).expect("Could not serialize error"), span),
         };
 
@@ -1431,7 +1431,7 @@ impl ShellError {
 
     // TODO: Implement as From trait
     pub fn wrap(self, working_set: &StateWorkingSet, span: Span) -> ParseError {
-        let msg = format_cli_error(working_set, &self);
+        let msg = format_cli_error(working_set, &self, None);
         ParseError::LabeledError(
             msg,
             "Encountered error during parse-time evaluation".into(),

--- a/crates/nu-protocol/tests/test_config.rs
+++ b/crates/nu-protocol/tests/test_config.rs
@@ -60,7 +60,7 @@ fn fancy_default_errors() {
 
     assert_eq!(
         actual.err,
-        "Error:   \u{1b}[31m×\u{1b}[0m oh no!\n   ╭─[\u{1b}[36;1;4mline2:1:13\u{1b}[0m]\n \u{1b}[2m1\u{1b}[0m │ force_error \"My error\"\n   · \u{1b}[35;1m            ─────┬────\u{1b}[0m\n   ·                  \u{1b}[35;1m╰── \u{1b}[35;1mhere's the error\u{1b}[0m\u{1b}[0m\n   ╰────\n\n"
+        "Error: \u{1b}[31mnu::shell::error\u{1b}[0m\n\n  \u{1b}[31m×\u{1b}[0m oh no!\n   ╭─[\u{1b}[36;1;4mline2:1:13\u{1b}[0m]\n \u{1b}[2m1\u{1b}[0m │ force_error \"My error\"\n   · \u{1b}[35;1m            ─────┬────\u{1b}[0m\n   ·                  \u{1b}[35;1m╰── \u{1b}[35;1mhere's the error\u{1b}[0m\u{1b}[0m\n   ╰────\n\n"
     );
 }
 
@@ -90,6 +90,7 @@ Begin snippet for line2 starting at line 1, column 1
 
 snippet line 1: force_error "my error"
     label at line 1, columns 13 to 22: here's the error
+diagnostic code: nu::shell::error
 
 
 "#,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Before this PR, errors without error codes are printed somewhat strangely, with the `×` and the description being printed on the same line as the `Error:` text:
<img width="488" height="148" alt="image" src="https://github.com/user-attachments/assets/1b21fee0-36e9-47a5-be05-07b923704430" />

This PR adds a default error code for the different error types:
<img width="493" height="187" alt="image" src="https://github.com/user-attachments/assets/c06aebc3-650d-49ad-84a7-53e05a4a96ad" />

While maybe not as informative as a proper error code, it makes `GenericError`s and other things which don't have error codes look a lot nicer.

It would be nicer if we could just set `diagnostic(code: "nu::shell::error")` at the top of `ShellError`, but unfortunately you can't set a "default" at the `enum` level and then override it in the variants. @cptpiepmatz mentioned he might change miette's derive macro to accommodate this, in that case we can switch the approach here.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
* Errors without error codes now have a default error code corresponding to from which part of Nushell the error occurred (shell, parser, compile, etc)

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
N/A

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A