### PR TITLE
print to a value should be a SIGPIPE

### DIFF
--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -100,7 +100,7 @@ impl Expr {
             | Expr::GlobInterpolation(_, _)
             | Expr::Nothing => {
                 // These expressions do not use the output of the pipeline in any meaningful way,
-                // but we still need to use the pipelien ouptut, so the previous command
+                // but we still need to use the pipeline output, so the previous command
                 // can be stopped with SIGPIPE(in unix).
                 (None, None)
             }

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -100,8 +100,9 @@ impl Expr {
             | Expr::GlobInterpolation(_, _)
             | Expr::Nothing => {
                 // These expressions do not use the output of the pipeline in any meaningful way,
-                // so we can discard the previous output by redirecting it to `Null`.
-                (Some(OutDest::Null), None)
+                // but we still need to use the pipelien ouptut, so the previous command
+                // can be stopped with SIGPIPE(in unix).
+                (None, None)
             }
             Expr::VarDecl(_)
             | Expr::Operator(_)

--- a/tests/shell/pipeline/mod.rs
+++ b/tests/shell/pipeline/mod.rs
@@ -17,3 +17,10 @@ fn non_zero_exit_code_in_middle_of_pipeline_ignored() {
     let actual = nu!("nu -c 'print a b; exit 42' | nu --stdin -c 'collect'");
     assert_eq!(actual.out, "ab");
 }
+
+#[test]
+fn infinite_output_piped_to_value() {
+    let actual = nu!("nu --testbin iecho x | 1");
+    assert_eq!(actual.out, "1");
+    assert_eq!(actual.err, "");
+}


### PR DESCRIPTION
# Description
Partially handles #14799 
It's difficult to fix all cases there, but I think it's good to improve one of this with a small step

# User-Facing Changes
Given the following code in c:
```C
// write.c
#include <stdio.h>

int main() {
  while (1) {
    printf("a\n");
  }
}
```
After this pr, `./write | 0` will exit immediately, in that case, `./write` will receive `SIGPIPE` in unix.  Before this pr, `./write | 0` runs indefinitely. 

-----------------------

Maybe it's easier to see what happened internally by the different output of  `view ir { ./write | 0 }` command.
### Before
```
# 2 registers, 6 instructions, 7 bytes of data
   0: load-literal           %1, glob-pattern("./write", no_expand = false)
   1: push-positional        %1
   2: redirect-out           null
   3: call                   decl 135 "run-external", %0
   4: load-literal           %0, int(0)
   5: return                 %0
```

### After
```
# 2 registers, 6 instructions, 7 bytes of data
   0: load-literal           %1, glob-pattern("./write", no_expand = false)
   1: push-positional        %1
   2: redirect-out           pipe      # changed, the command's output is a pipe rather than null
   3: call                   decl 136 "run-external", %0
   4: load-literal           %0, int(0)
   5: return                 %0
```
# Tests + Formatting
Added 1 test.

# After Submitting
NaN
