### PR TITLE
fix rest parameter spans

### DIFF
--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1178,12 +1178,17 @@ fn gather_arguments(
                     }
                     callee_stack.add_var(var_id, val);
                 } else {
-                    rest.push(val);
+                    let span = val.span();
+                    rest.push(val.into_spanned(span));
                 }
             }
-            Argument::Spread { vals, .. } => {
+            Argument::Spread {
+                vals,
+                span: spread_span,
+                ..
+            } => {
                 if let Value::List { vals, .. } = vals {
-                    rest.extend(vals);
+                    rest.extend(vals.into_iter().map(|v| v.into_spanned(spread_span)));
                     // All further positional args should go to spread
                     always_spread = true;
                 } else if let Value::Error { error, .. } = vals {
@@ -1218,9 +1223,17 @@ fn gather_arguments(
 
     // Add the collected rest of the arguments if a spread argument exists
     if let Some(rest_arg) = &block.signature.rest_positional {
-        let rest_span = rest.first().map(|v| v.span()).unwrap_or(call_head);
+        let rest_span = rest
+            .first()
+            .zip(rest.last())
+            .map(|(first, last)| first.span.append(last.span))
+            .unwrap_or(call_head);
+
         let var_id = expect_positional_var_id(rest_arg, rest_span)?;
-        callee_stack.add_var(var_id, Value::list(rest, rest_span));
+        callee_stack.add_var(
+            var_id,
+            Value::list(rest.into_iter().map(|v| v.item).collect(), rest_span),
+        );
     }
 
     // Check for arguments that haven't yet been set and set them to their defaults

--- a/tests/repl/test_engine.rs
+++ b/tests/repl/test_engine.rs
@@ -440,6 +440,14 @@ fn better_operator_spans() -> TestResult {
 }
 
 #[test]
+fn call_rest_arg_span() -> TestResult {
+    run_test(
+        r#"let l = [2, 3]; def foo [...rest] { metadata $rest | view span $in.span.start $in.span.end }; foo 1 ...$l"#,
+        "1 ...$l",
+    )
+}
+
+#[test]
 fn range_right_exclusive() -> TestResult {
     run_test(r#"[1, 4, 5, 8, 9] | slice 1..<3 | math sum"#, "9")
 }


### PR DESCRIPTION
Closes #16071

# Description

Rest parameter variables are now fully spanned, instead of just the first value:

```diff
def foo [...rest] {
  metadata $rest | view span $in.span.start $in.span.end
}
foo 1 2

-1
+1 2
```