### PR TITLE
Revert "Add `extern` for `nu` command"

### DIFF
--- a/crates/nu-cmd-extra/tests/commands/bytes/ends_with.rs
+++ b/crates/nu-cmd-extra/tests/commands/bytes/ends_with.rs
@@ -22,7 +22,7 @@ fn basic_string_fails() {
 #[test]
 fn short_stream_binary() {
     let actual = nu!(r#"
-            ^nu --testbin repeater (0x[01]) 5 | bytes ends-with 0x[010101]
+            nu --testbin repeater (0x[01]) 5 | bytes ends-with 0x[010101]
         "#);
 
     assert_eq!(actual.out, "true");
@@ -31,7 +31,7 @@ fn short_stream_binary() {
 #[test]
 fn short_stream_mismatch() {
     let actual = nu!(r#"
-            ^nu --testbin repeater (0x[010203]) 5 | bytes ends-with 0x[010204]
+            nu --testbin repeater (0x[010203]) 5 | bytes ends-with 0x[010204]
         "#);
 
     assert_eq!(actual.out, "false");
@@ -40,7 +40,7 @@ fn short_stream_mismatch() {
 #[test]
 fn short_stream_binary_overflow() {
     let actual = nu!(r#"
-            ^nu --testbin repeater (0x[01]) 5 | bytes ends-with 0x[010101010101]
+            nu --testbin repeater (0x[01]) 5 | bytes ends-with 0x[010101010101]
         "#);
 
     assert_eq!(actual.out, "false");
@@ -49,7 +49,7 @@ fn short_stream_binary_overflow() {
 #[test]
 fn long_stream_binary() {
     let actual = nu!(r#"
-            ^nu --testbin repeater (0x[01]) 32768 | bytes ends-with 0x[010101]
+            nu --testbin repeater (0x[01]) 32768 | bytes ends-with 0x[010101]
         "#);
 
     assert_eq!(actual.out, "true");
@@ -59,7 +59,7 @@ fn long_stream_binary() {
 fn long_stream_binary_overflow() {
     // .. ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
     let actual = nu!(r#"
-            ^nu --testbin repeater (0x[01]) 32768 | bytes ends-with (0..32768 | each {|| 0x[01] } | bytes collect)
+            nu --testbin repeater (0x[01]) 32768 | bytes ends-with (0..32768 | each {|| 0x[01] } | bytes collect)
         "#);
 
     assert_eq!(actual.out, "false");
@@ -69,7 +69,7 @@ fn long_stream_binary_overflow() {
 fn long_stream_binary_exact() {
     // ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
     let actual = nu!(r#"
-            ^nu --testbin repeater (0x[01020304]) 8192 | bytes ends-with (0..<8192 | each {|| 0x[01020304] } | bytes collect)
+            nu --testbin repeater (0x[01020304]) 8192 | bytes ends-with (0..<8192 | each {|| 0x[01020304] } | bytes collect)
         "#);
 
     assert_eq!(actual.out, "true");
@@ -79,7 +79,7 @@ fn long_stream_binary_exact() {
 fn long_stream_string_exact() {
     // ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
     let actual = nu!(r#"
-            ^nu --testbin repeater hell 8192 | bytes ends-with (0..<8192 | each {|| "hell" | into binary } | bytes collect)
+            nu --testbin repeater hell 8192 | bytes ends-with (0..<8192 | each {|| "hell" | into binary } | bytes collect)
         "#);
 
     assert_eq!(actual.out, "true");
@@ -92,7 +92,7 @@ fn long_stream_mixed_exact() {
             let binseg = (0..<2048 | each {|| 0x[003d9fbf] } | bytes collect)
             let strseg = (0..<2048 | each {|| "hell" | into binary } | bytes collect)
 
-            ^nu --testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes ends-with (bytes build $binseg $strseg)
+            nu --testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes ends-with (bytes build $binseg $strseg)
         "#);
 
     assert_eq!(
@@ -109,7 +109,7 @@ fn long_stream_mixed_overflow() {
             let binseg = (0..<2048 | each {|| 0x[003d9fbf] } | bytes collect)
             let strseg = (0..<2048 | each {|| "hell" | into binary } | bytes collect)
 
-            ^nu --testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes ends-with (bytes build 0x[01] $binseg $strseg)
+            nu --testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes ends-with (bytes build 0x[01] $binseg $strseg)
         "#);
 
     assert_eq!(

--- a/crates/nu-cmd-extra/tests/commands/bytes/starts_with.rs
+++ b/crates/nu-cmd-extra/tests/commands/bytes/starts_with.rs
@@ -22,7 +22,7 @@ fn basic_string_fails() {
 #[test]
 fn short_stream_binary() {
     let actual = nu!(r#"
-            ^nu --testbin repeater (0x[01]) 5 | bytes starts-with 0x[010101]
+            nu --testbin repeater (0x[01]) 5 | bytes starts-with 0x[010101]
         "#);
 
     assert_eq!(actual.out, "true");
@@ -31,7 +31,7 @@ fn short_stream_binary() {
 #[test]
 fn short_stream_mismatch() {
     let actual = nu!(r#"
-            ^nu --testbin repeater (0x[010203]) 5 | bytes starts-with 0x[010204]
+            nu --testbin repeater (0x[010203]) 5 | bytes starts-with 0x[010204]
         "#);
 
     assert_eq!(actual.out, "false");
@@ -40,7 +40,7 @@ fn short_stream_mismatch() {
 #[test]
 fn short_stream_binary_overflow() {
     let actual = nu!(r#"
-            ^nu --testbin repeater (0x[01]) 5 | bytes starts-with 0x[010101010101]
+            nu --testbin repeater (0x[01]) 5 | bytes starts-with 0x[010101010101]
         "#);
 
     assert_eq!(actual.out, "false");
@@ -49,7 +49,7 @@ fn short_stream_binary_overflow() {
 #[test]
 fn long_stream_binary() {
     let actual = nu!(r#"
-            ^nu --testbin repeater (0x[01]) 32768 | bytes starts-with 0x[010101]
+            nu --testbin repeater (0x[01]) 32768 | bytes starts-with 0x[010101]
         "#);
 
     assert_eq!(actual.out, "true");
@@ -59,7 +59,7 @@ fn long_stream_binary() {
 fn long_stream_binary_overflow() {
     // .. ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
     let actual = nu!(r#"
-            ^nu --testbin repeater (0x[01]) 32768 | bytes starts-with (0..32768 | each {|| 0x[01] } | bytes collect)
+            nu --testbin repeater (0x[01]) 32768 | bytes starts-with (0..32768 | each {|| 0x[01] } | bytes collect)
         "#);
 
     assert_eq!(actual.out, "false");
@@ -69,7 +69,7 @@ fn long_stream_binary_overflow() {
 fn long_stream_binary_exact() {
     // ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
     let actual = nu!(r#"
-            ^nu --testbin repeater (0x[01020304]) 8192 | bytes starts-with (0..<8192 | each {|| 0x[01020304] } | bytes collect)
+            nu --testbin repeater (0x[01020304]) 8192 | bytes starts-with (0..<8192 | each {|| 0x[01020304] } | bytes collect)
         "#);
 
     assert_eq!(actual.out, "true");
@@ -79,7 +79,7 @@ fn long_stream_binary_exact() {
 fn long_stream_string_exact() {
     // ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
     let actual = nu!(r#"
-            ^nu --testbin repeater hell 8192 | bytes starts-with (0..<8192 | each {|| "hell" | into binary } | bytes collect)
+            nu --testbin repeater hell 8192 | bytes starts-with (0..<8192 | each {|| "hell" | into binary } | bytes collect)
         "#);
 
     assert_eq!(actual.out, "true");
@@ -92,7 +92,7 @@ fn long_stream_mixed_exact() {
             let binseg = (0..<2048 | each {|| 0x[003d9fbf] } | bytes collect)
             let strseg = (0..<2048 | each {|| "hell" | into binary } | bytes collect)
 
-            ^nu --testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes starts-with (bytes build $binseg $strseg)
+            nu --testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes starts-with (bytes build $binseg $strseg)
         "#);
 
     assert_eq!(
@@ -109,7 +109,7 @@ fn long_stream_mixed_overflow() {
             let binseg = (0..<2048 | each {|| 0x[003d9fbf] } | bytes collect)
             let strseg = (0..<2048 | each {|| "hell" | into binary } | bytes collect)
 
-            ^nu --testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes starts-with (bytes build $binseg $strseg 0x[01])
+            nu --testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes starts-with (bytes build $binseg $strseg 0x[01])
         "#);
 
     assert_eq!(

--- a/crates/nu-engine/src/compile/call.rs
+++ b/crates/nu-engine/src/compile/call.rs
@@ -19,8 +19,7 @@ pub(crate) fn compile_call(
     let decl = working_set.get_decl(call.decl_id);
 
     // Check if this call has --help - if so, just redirect to `help`
-    // Special case the `nu` extern: we want to forward --help to the script
-    if call.named_iter().any(|(name, _, _)| name.item == "help") && decl.name() != "nu" {
+    if call.named_iter().any(|(name, _, _)| name.item == "help") {
         let name = working_set
             .find_decl_name(call.decl_id) // check for name in scope
             .and_then(|name| std::str::from_utf8(name).ok())

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -715,14 +715,6 @@ impl CustomExample {
             result: self.result.clone(),
         }
     }
-
-    pub fn from_example(example: Example<'_>) -> Self {
-        Self {
-            example: example.example.to_string(),
-            description: example.description.to_string(),
-            result: example.result,
-        }
-    }
 }
 
 #[derive(Clone)]

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,10 +1,9 @@
 use nu_engine::{command_prelude::*, get_full_help};
-use nu_parser::{KnownExternal, escape_for_script_arg, parse};
+use nu_parser::{escape_for_script_arg, parse};
 use nu_protocol::{
-    CustomExample,
     ast::{Expr, Expression},
     engine::StateWorkingSet,
-    report_parse_error, report_shell_error,
+    report_parse_error,
 };
 use nu_utils::{escape_quote_string, stdout_write_all_and_flush};
 
@@ -517,26 +516,5 @@ impl Command for Nu {
                 result: None,
             },
         ]
-    }
-}
-
-/// Add the [`Nu`] command as an extern so we get help and flag completions
-pub(crate) fn add_nu_extern(engine_state: &mut EngineState) {
-    let nu_extern = KnownExternal {
-        signature: Box::new(Nu.signature()),
-        attributes: vec![],
-        examples: Nu
-            .examples()
-            .into_iter()
-            .map(CustomExample::from_example)
-            .collect(),
-    };
-
-    let mut working_set = nu_protocol::engine::StateWorkingSet::new(engine_state);
-    working_set.add_decl(Box::new(nu_extern));
-    let delta = working_set.render();
-
-    if let Err(err) = engine_state.merge_delta(delta) {
-        report_shell_error(engine_state, &err);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use crate::{
     config_files::set_config_path,
     logger::{configure, logger},
 };
-use command::{add_nu_extern, gather_commandline_args};
+use command::gather_commandline_args;
 use log::{Level, trace};
 use miette::Result;
 use nu_cli::gather_parent_env_vars;
@@ -79,7 +79,6 @@ fn main() -> Result<()> {
         let mut working_set = nu_protocol::engine::StateWorkingSet::new(&engine_state);
         working_set.add_decl(Box::new(nu_cli::NuHighlight));
         working_set.add_decl(Box::new(nu_cli::Print));
-
         working_set.render()
     };
 
@@ -202,9 +201,6 @@ fn main() -> Result<()> {
             report_shell_error(&engine_state, &err);
             std::process::exit(1)
         });
-
-    // this has to happen after `parse_command_args` since that hides the `Nu` decl
-    add_nu_extern(&mut engine_state);
 
     experimental_options::load(&engine_state, &parsed_nu_cli_args, !script_name.is_empty());
 
@@ -387,6 +383,9 @@ fn main() -> Result<()> {
             "chop" => test_bins::chop(),
             "repeater" => test_bins::repeater(),
             "repeat_bytes" => test_bins::repeat_bytes(),
+            // Important: nu_repl must be called with `--testbin=nu_repl`
+            // `--testbin nu_repl` will not work due to argument count logic
+            // in test_bins.rs
             "nu_repl" => test_bins::nu_repl(),
             "input_bytes_length" => test_bins::input_bytes_length(),
             _ => std::process::exit(1),

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -45,6 +45,7 @@ fn echo_one_env(arg: &str, to_stdout: bool) {
 /// If it's not present, panic instead
 pub fn echo_env_mixed() {
     let args = args();
+    let args = &args[1..];
 
     if args.len() != 3 {
         panic!(
@@ -74,11 +75,11 @@ pub fn echo_env_mixed() {
 pub fn cococo() {
     let args: Vec<String> = args();
 
-    if !args.is_empty() {
+    if args.len() > 1 {
         // Write back out all the arguments passed
         // if given at least 1 instead of chickens
         // speaking co co co.
-        println!("{}", args.join(" "));
+        println!("{}", &args[1..].join(" "));
     } else {
         println!("cococo");
     }
@@ -88,7 +89,7 @@ pub fn cococo() {
 pub fn meow() {
     let args: Vec<String> = args();
 
-    for arg in args.iter() {
+    for arg in args.iter().skip(1) {
         let contents = std::fs::read_to_string(arg).expect("Expected a filepath");
         println!("{contents}");
     }
@@ -101,7 +102,7 @@ pub fn meowb() {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
 
-    for arg in args.iter() {
+    for arg in args.iter().skip(1) {
         let buf = std::fs::read(arg).expect("Expected a filepath");
         handle.write_all(&buf).expect("failed to write to stdout");
     }
@@ -117,7 +118,7 @@ pub fn relay() {
 /// nu --testbin nonu a b c
 /// abc
 pub fn nonu() {
-    args().iter().for_each(|arg| print!("{arg}"));
+    args().iter().skip(1).for_each(|arg| print!("{arg}"));
 }
 
 /// Repeat a string or char N times
@@ -127,7 +128,8 @@ pub fn nonu() {
 /// testtesttesttesttest
 pub fn repeater() {
     let mut stdout = io::stdout();
-    let mut args = args().into_iter();
+    let args = args();
+    let mut args = args.iter().skip(1);
     let letter = args.next().expect("needs a character to iterate");
     let count = args.next().expect("need the number of times to iterate");
 
@@ -142,7 +144,8 @@ pub fn repeater() {
 /// A version of repeater that can output binary data, even null bytes
 pub fn repeat_bytes() {
     let mut stdout = io::stdout();
-    let mut args = args().into_iter();
+    let args = args();
+    let mut args = args.iter().skip(1);
 
     while let (Some(binary), Some(count)) = (args.next(), args.next()) {
         let bytes: Vec<u8> = (0..binary.len())
@@ -170,6 +173,7 @@ pub fn iecho() {
     let mut stdout = io::stdout();
     let _ = args()
         .iter()
+        .skip(1)
         .cycle()
         .try_for_each(|v| writeln!(stdout, "{v}"));
 }
@@ -360,18 +364,6 @@ pub fn input_bytes_length() {
 }
 
 fn args() -> Vec<String> {
-    // skip `nu` path (first argument)
-    // then skip --testbin=foo OR --testbin foo
-    std::env::args().skip(1).fold(vec![], |mut acc, it| {
-        // if we have --testbin foo, skip the previous argument (--testbin) and this argument (foo)
-        if acc.last().is_some_and(|last| last == "--testbin") {
-            acc.pop();
-            return acc;
-        }
-        // if we have --testbin=foo, skip it
-        if !it.starts_with("--testbin=") {
-            acc.push(it);
-        }
-        acc
-    })
+    // skip (--testbin bin_name args)
+    std::env::args().skip(2).collect()
 }

--- a/tests/repl/test_known_external.rs
+++ b/tests/repl/test_known_external.rs
@@ -173,9 +173,3 @@ fn known_external_arg_internally_quoted_options() -> TestResult {
         "--option=test",
     )
 }
-
-// Verify that the KnownExternal for the `nu` binary exists
-#[test]
-fn known_external_nu() -> TestResult {
-    run_test_contains("help nu", "Usage")
-}

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -422,27 +422,27 @@ fn append_assign_takes_pipeline() -> TestResult {
 
 #[test]
 fn assign_bare_external_fails() {
-    let result = nu!("$env.FOO = cargo --version");
+    let result = nu!("$env.FOO = nu --testbin cococo");
     assert!(!result.status.success());
     assert!(result.err.contains("must be explicit"));
 }
 
 #[test]
 fn assign_bare_external_with_caret() {
-    let result = nu!("$env.FOO = ^cargo --version");
+    let result = nu!("$env.FOO = ^nu --testbin cococo");
     assert!(result.status.success());
 }
 
 #[test]
 fn assign_backtick_quoted_external_fails() {
-    let result = nu!("$env.FOO = `cargo` --version");
+    let result = nu!("$env.FOO = `nu` --testbin cococo");
     assert!(!result.status.success());
     assert!(result.err.contains("must be explicit"));
 }
 
 #[test]
 fn assign_backtick_quoted_external_with_caret() {
-    let result = nu!("$env.FOO = ^`cargo` --version");
+    let result = nu!("$env.FOO = ^`nu` --testbin cococo");
     assert!(result.status.success());
 }
 

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -290,7 +290,7 @@ fn scope_externs_sorted() {
     ];
 
     let actual = nu!(&inp.join("; "));
-    assert!(actual.out.starts_with("abc"));
+    assert_eq!(actual.out, "abc");
 }
 
 #[test]

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -609,15 +609,15 @@ mod external_command_arguments {
 
     #[test]
     fn remove_quotes_in_shell_arguments() {
-        let actual = nu!("^nu --testbin cococo expression='-r -w'");
+        let actual = nu!("nu --testbin cococo expression='-r -w'");
         assert_eq!(actual.out, "expression=-r -w");
-        let actual = nu!(r#"^nu --testbin cococo expression="-r -w""#);
+        let actual = nu!(r#"nu --testbin cococo expression="-r -w""#);
         assert_eq!(actual.out, "expression=-r -w");
-        let actual = nu!("^nu --testbin cococo expression='-r -w'");
+        let actual = nu!("nu --testbin cococo expression='-r -w'");
         assert_eq!(actual.out, "expression=-r -w");
-        let actual = nu!(r#"^nu --testbin cococo expression="-r\" -w""#);
+        let actual = nu!(r#"nu --testbin cococo expression="-r\" -w""#);
         assert_eq!(actual.out, r#"expression=-r" -w"#);
-        let actual = nu!(r#"^nu --testbin cococo expression='-r\" -w'"#);
+        let actual = nu!(r#"nu --testbin cococo expression='-r\" -w'"#);
         assert_eq!(actual.out, r#"expression=-r\" -w"#);
     }
 }
@@ -722,7 +722,7 @@ fn external_error_with_backtrace() {
 
 #[test]
 fn sub_external_expression_with_and_op_should_raise_proper_error() {
-    let actual = nu!("(^nu --testbin cococo false) and true");
+    let actual = nu!("(nu --testbin cococo false) and true");
     assert!(
         actual
             .err


### PR DESCRIPTION
Reverts nushell/nushell#16119

Because it trips over these case:
```nushell
# unknown-arg.nu
def main [--hi: string = 'hi'] {
  print $hi
}
```
```
nu unknown-arg.nu --hi hello
Error: nu::parser::unknown_flag

  × The `nu` command doesn't have flag `hi`.
  ...
```

---

```nushell
# overlapping-arg.nu
def main [--threads: string] {
  print $threads
}
```
```
nu overlapping-arg.nu --threads always
Error: nu::parser::parse_mismatch

  × Parse mismatch during operation.
  ...
```

It will have to wait until #16074 is done