### PR TITLE
feat(completion): enable nucleo's `prefer_prefix` option

### DIFF
--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -102,7 +102,11 @@ impl<T> NuMatcher<'_, T> {
                     options,
                     needle: needle.to_owned(),
                     state: State::Fuzzy {
-                        matcher: Matcher::new(Config::DEFAULT),
+                        matcher: Matcher::new({
+                            let mut cfg = Config::DEFAULT;
+                            cfg.prefer_prefix = true;
+                            cfg
+                        }),
                         atom,
                         items: Vec::new(),
                     },

--- a/crates/nu-lsp/src/symbols.rs
+++ b/crates/nu-lsp/src/symbols.rs
@@ -80,7 +80,11 @@ pub(crate) struct SymbolCache {
 impl SymbolCache {
     pub fn new() -> Self {
         SymbolCache {
-            matcher: Matcher::new(Config::DEFAULT),
+            matcher: Matcher::new({
+                let mut cfg = Config::DEFAULT;
+                cfg.prefer_prefix = true;
+                cfg
+            }),
             cache: BTreeMap::new(),
             dirty_flags: BTreeMap::new(),
         }


### PR DESCRIPTION
cc: @blindFS @ysthakur

# Description
Enable `nucleo`'s `prefer_prefix` configuration option.
Ranks suggestions with matches closer to the start higher than suggestions that have matches further from the start.

Example: suggestions based on `reverse`:
<table>
<tr>
<td width=200>Before</td>
<td width=200>After</td>
</tr>
<tr>
<td>

```
bytes reverse
polars reverse
reverse
str reverse
```

</td>
<td>


```
reverse
str reverse
polars reverse
bytes reverse
```

</td>
</tr>
</table>

# User-Facing Changes
More relevant suggestions with fuzzy matching algorithm. (`$env.config.completions.algorithm = "fuzzy"`)

# Tests + Formatting
We might want to add tests to make sure this option keeps working in the future.
