### PR TITLE
fix(overlay use): report errors in export-env

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -158,7 +158,7 @@ impl Command for OverlayUse {
                 }
 
                 let eval_block = get_eval_block(engine_state);
-                let _ = eval_block(engine_state, &mut callee_stack, block, input);
+                let _ = eval_block(engine_state, &mut callee_stack, block, input)?;
 
                 // The export-env block should see the env vars *before* activating this overlay
                 caller_stack.add_overlay(overlay_name);

--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -354,3 +354,15 @@ fn test_use_with_printing_current_file() {
         assert_eq!(actual.out, dirs.test().join("mod.nu").to_string_lossy());
     });
 }
+
+#[test]
+fn report_errors_in_export_env() {
+    let actual = nu!(r#"
+        module spam {
+            export-env { error make -u {msg: "reported"} }
+        }
+        use spam
+    "#);
+
+    assert!(actual.err.contains("reported"));
+}

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -1606,3 +1606,17 @@ fn test_overlay_use_with_printing_current_file() {
         );
     });
 }
+
+#[test]
+fn report_errors_in_export_env() {
+    let inp = &[
+        r#"module spam { export-env { error make -u {msg: "reported"} } }"#,
+        "overlay use spam",
+    ];
+
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
+
+    assert!(actual.err.contains("reported"));
+    assert!(actual_repl.err.contains("reported"));
+}


### PR DESCRIPTION
- fixes #10242

# Tests + Formatting
Added 2 tests to confirm `use` and `overlay use` report errors in `export-env` blocks.