### PR TITLE
feat(watch): implement --debounce flag with duration

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-As a shell and programming language Nushell provides you with great powers and the potential to do dangerous things to your computer and data. Whenever there is a risk that a malicious actor can abuse a bug or a violation of documented behavior/assumptions in Nushell to harm you this is a *security* risk. 
+As a shell and programming language Nushell provides you with great powers and the potential to do dangerous things to your computer and data. Whenever there is a risk that a malicious actor can abuse a bug or a violation of documented behavior/assumptions in Nushell to harm you this is a *security* risk.
 We want to fix those issues without exposing our users to unnecessary risk. Thus we want to explain our security policy.
 Additional issues may be part of *safety* where the behavior of Nushell as designed and implemented can cause unintended harm or a bug causes damage without the involvement of a third party.
 
@@ -11,7 +11,7 @@ Only if you provide a strong reasoning and the necessary resources, will we cons
 
 ## Reporting a Vulnerability
 
-If you suspect that a bug or behavior of Nushell can affect security or may be potentially exploitable, please report the issue to us in private. 
+If you suspect that a bug or behavior of Nushell can affect security or may be potentially exploitable, please report the issue to us in private.
 Either reach out to the core team on [our Discord server](https://discord.gg/NtAbbGn) to arrange a private channel or use the [GitHub vulnerability reporting form](https://github.com/nushell/nushell/security/advisories/new).
 Please try to answer the following questions:
 - How can we reach you for further questions?

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -41,8 +41,8 @@ impl Command for Watch {
         vec![DeprecationEntry {
             ty: DeprecationType::Flag("--debounce-ms".into()),
             report_mode: ReportMode::FirstUse,
-            since: Some("0.106.0".into()),
-            expected_removal: Some("0.108.0".into()),
+            since: Some("0.107.0".into()),
+            expected_removal: Some("0.109.0".into()),
             help: Some("`--debounce-ms` will be removed in favour of  `--debounce`".into()),
         }]
     }

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -6,11 +6,7 @@ use notify_debouncer_full::{
     },
 };
 use nu_engine::{ClosureEval, command_prelude::*};
-use nu_protocol::{
-    engine::{Closure, StateWorkingSet},
-    format_cli_error, report_shell_error,
-    shell_error::io::IoError,
-};
+use nu_protocol::{engine::Closure, report_shell_error, shell_error::io::IoError};
 
 use std::{
     path::PathBuf,

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -6,7 +6,10 @@ use notify_debouncer_full::{
     },
 };
 use nu_engine::{ClosureEval, command_prelude::*};
-use nu_protocol::{engine::Closure, report_shell_error, shell_error::io::IoError};
+use nu_protocol::{
+    DeprecationEntry, DeprecationType, ReportMode, engine::Closure, report_shell_error,
+    shell_error::io::IoError,
+};
 
 use std::{
     path::PathBuf,
@@ -32,6 +35,16 @@ impl Command for Watch {
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["watcher", "reload", "filesystem"]
+    }
+
+    fn deprecation_info(&self) -> Vec<DeprecationEntry> {
+        vec![DeprecationEntry {
+            ty: DeprecationType::Flag("--debounce-ms".into()),
+            report_mode: ReportMode::FirstUse,
+            since: Some("0.106.0".into()),
+            expected_removal: Some("0.108.0".into()),
+            help: Some("`--debounce-ms` will be removed in favour of  `--debounce`".into()),
+        }]
     }
 
     fn signature(&self) -> nu_protocol::Signature {
@@ -125,7 +138,7 @@ impl Command for Watch {
                         report_shell_error(
                             &engine_state,
                             &ShellError::DeprecationWarning {
-                                deprecation_type: "Something",
+                                deprecation_type: "--debounce-ms",
                                 suggestion: "Use the --debounce flag instead".into(),
                                 span: val.span,
                                 help: Some("--debounce uses a duration instead of an int"),

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -8,7 +8,7 @@ use notify_debouncer_full::{
 use nu_engine::{ClosureEval, command_prelude::*};
 use nu_protocol::{
     engine::{Closure, StateWorkingSet},
-    format_cli_error,
+    format_cli_error, report_shell_error,
     shell_error::io::IoError,
 };
 use std::{
@@ -124,7 +124,18 @@ impl Command for Watch {
             }
             (None, Some(val)) => {
                 debounce_duration = match u64::try_from(val.item) {
-                    Ok(val) => Duration::from_millis(val),
+                    Ok(v) => {
+                        report_shell_error(
+                            &engine_state,
+                            &ShellError::DeprecationWarning {
+                                deprecation_type: "Something",
+                                suggestion: "Use the --debounce flag instead".into(),
+                                span: val.span,
+                                help: Some("--debounce uses a duration instead of an int"),
+                            },
+                        );
+                        Duration::from_millis(v)
+                    }
                     Err(_) => {
                         return Err(ShellError::TypeMismatch {
                             err_message: "Debounce duration is invalid".to_string(),

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -134,18 +134,7 @@ impl Command for Watch {
             }
             (None, Some(val)) => {
                 debounce_duration = match u64::try_from(val.item) {
-                    Ok(v) => {
-                        report_shell_error(
-                            &engine_state,
-                            &ShellError::DeprecationWarning {
-                                deprecation_type: "--debounce-ms",
-                                suggestion: "Use the --debounce flag instead".into(),
-                                span: val.span,
-                                help: Some("--debounce uses a duration instead of an int"),
-                            },
-                        );
-                        Duration::from_millis(v)
-                    }
+                    Ok(v) => Duration::from_millis(v),
                     Err(_) => {
                         return Err(ShellError::TypeMismatch {
                             err_message: "Debounce duration is invalid".to_string(),

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -135,8 +135,8 @@ impl Command for Watch {
             }
             (Some(v), None) => match v.item {
                 dur @ Value::Duration { val, .. } => {
-                    debounce_duration = match u64::try_from(val / 1_000_000) {
-                        Ok(d) => Duration::from_millis(d),
+                    debounce_duration = match u64::try_from(val) {
+                        Ok(d) => Duration::from_nanos(d),
                         Err(_) => {
                             return Err(ShellError::TypeMismatch {
                                 err_message: "Debounce duration is invalid".to_string(),

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -121,9 +121,9 @@ impl Command for Watch {
         let debounce_duration_flag: Option<Spanned<Value>> =
             call.get_flag(engine_state, stack, "debounce")?;
 
-        let debounce_duration: Duration;
-        match (debounce_duration_flag, debounce_duration_flag_ms) {
-            (None, None) => debounce_duration = DEFAULT_WATCH_DEBOUNCE_DURATION,
+        let debounce_duration: Duration = match (debounce_duration_flag, debounce_duration_flag_ms)
+        {
+            (None, None) => DEFAULT_WATCH_DEBOUNCE_DURATION,
             (Some(l), Some(r)) => {
                 return Err(ShellError::IncompatibleParameters {
                     left_message: "Here".to_string(),
@@ -132,17 +132,15 @@ impl Command for Watch {
                     right_span: r.span,
                 });
             }
-            (None, Some(val)) => {
-                debounce_duration = match u64::try_from(val.item) {
-                    Ok(v) => Duration::from_millis(v),
-                    Err(_) => {
-                        return Err(ShellError::TypeMismatch {
-                            err_message: "Debounce duration is invalid".to_string(),
-                            span: val.span,
-                        });
-                    }
+            (None, Some(val)) => match u64::try_from(val.item) {
+                Ok(v) => Duration::from_millis(v),
+                Err(_) => {
+                    return Err(ShellError::TypeMismatch {
+                        err_message: "Debounce duration is invalid".to_string(),
+                        span: val.span,
+                    });
                 }
-            }
+            },
             (Some(v), None) => {
                 let Value::Duration { val, .. } = v.item else {
                     return Err(ShellError::TypeMismatch {
@@ -150,14 +148,12 @@ impl Command for Watch {
                         span: v.item.span(),
                     });
                 };
-                debounce_duration = Duration::from_nanos(u64::try_from(val).map_err(|_| {
-                    ShellError::TypeMismatch {
-                        err_message: "Debounce duration is invalid".to_string(),
-                        span: v.item.span(),
-                    }
+                Duration::from_nanos(u64::try_from(val).map_err(|_| ShellError::TypeMismatch {
+                    err_message: "Debounce duration is invalid".to_string(),
+                    span: v.item.span(),
                 })?)
             }
-        }
+        };
 
         let glob_flag: Option<Spanned<String>> = call.get_flag(engine_state, stack, "glob")?;
         let glob_pattern = match glob_flag {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -89,6 +89,7 @@ pub enum Value {
         internal_span: Span,
     },
     Duration {
+        /// The duration in nanoseconds.
         val: i64,
         /// note: spans are being refactored out of Value
         /// please use .span() instead of matching this span value

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -307,13 +307,13 @@ export def "check pr" [
 export def run [
     --experimental-options: oneof<list<string>, string> # enable or disable experimental options
 ] {
-    let experimental_options_arg = $experimental_options 
-        | default [] 
-        | [$in] 
-        | flatten 
-        | str join "," 
+    let experimental_options_arg = $experimental_options
+        | default []
+        | [$in]
+        | flatten
+        | str join ","
         | $"[($in)]"
- 
+
     ^cargo run -- ...[
         --experimental-options $experimental_options_arg
         -e "$env.PROMPT_COMMAND_RIGHT = $'(ansi magenta_reverse)trying Nushell inside Cargo(ansi reset)'"


### PR DESCRIPTION
Fixes #16178 

# Description
This PR implement --debounce flag with duration for `watch`.

This new flag has a weird issue with calculating the durations.

When I timed it with a debounce time of 1min, it registered the write at 1m11s...

# User-Facing Changes
It overwrites the shorthand `-d` flag that would previously map to `--debounce-ms`.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
Update the online docs for `watch`:
- new flag `--debounce: duration`
- `-d` is now the shorthand of `--debounce`
- `--debounce-ms` will be deprecated 