### PR TITLE
Fix the `nu-path` fuzz-target

### DIFF
--- a/crates/nu-path/fuzz/README.md
+++ b/crates/nu-path/fuzz/README.md
@@ -5,4 +5,4 @@
 # Quick start guide
 - Install cargo-fuzz by `cargo install cargo-fuzz`
 - Make output directory `mkdir out`
-- Run the fuzzer with `cargo fuzz run parse out`
+- Run the fuzzer with `cargo fuzz run path out`

--- a/crates/nu-path/fuzz/fuzz_targets/path_fuzzer.rs
+++ b/crates/nu-path/fuzz/fuzz_targets/path_fuzzer.rs
@@ -17,6 +17,6 @@ fuzz_target!(|data: &[u8]| {
         // Here, we're assuming a second path for the "relative to" aspect.
         // For simplicity, we're just using the current directory.
         let current_dir = std::path::Path::new(".");
-        let _ = expand_path_with(path, &current_dir);
+        let _ = expand_path_with(path, &current_dir, true);
     }
 });


### PR DESCRIPTION
This code didn't compile, fixed provisionally by always running the
codepath with tilde expansion.

@IanManske worth discussing what we may want to fuzz here.
