### PR TITLE
Use correct column name in `history import -h` example

### DIFF
--- a/crates/nu-cli/src/commands/history/history_import.rs
+++ b/crates/nu-cli/src/commands/history/history_import.rs
@@ -57,7 +57,7 @@ Note that history item IDs are ignored when importing from file."#
                 result: None,
             },
             Example {
-                example: "[[ command_line cwd ]; [ foo /home ]] | history import",
+                example: "[[ command cwd ]; [ foo /home ]] | history import",
                 description: "Append `foo` ran from `/home` to the current history",
                 result: None,
             },


### PR DESCRIPTION
Closes #16189

See that issue for details.