### PR TITLE
fix: highlighting a where command with invalid arguments can duplicate text

### DIFF
--- a/crates/nu-cli/tests/commands/nu_highlight.rs
+++ b/crates/nu-cli/tests/commands/nu_highlight.rs
@@ -5,3 +5,9 @@ fn nu_highlight_not_expr() {
     let actual = nu!("'not false' | nu-highlight | ansi strip");
     assert_eq!(actual.out, "not false");
 }
+
+#[test]
+fn nu_highlight_where_row_condition() {
+    let actual = nu!("'ls | where a b 12345(' | nu-highlight | ansi strip");
+    assert_eq!(actual.out, "ls | where a b 12345(");
+}

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -43,10 +43,7 @@ Row conditions cannot be stored in a variable. To pass a condition with a variab
             ])
             .required(
                 "condition",
-                SyntaxShape::OneOf(vec![
-                    SyntaxShape::RowCondition,
-                    SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
-                ]),
+                SyntaxShape::RowCondition,
                 "Filter row condition or closure.",
             )
             .allow_variants_without_examples(true)

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -795,6 +795,9 @@ fn parse_oneof(
             true => parse_multispan_value(working_set, spans, spans_idx, shape),
             false => parse_value(working_set, spans[*spans_idx], shape),
         };
+        if let SyntaxShape::RowCondition = shape {
+            return value;
+        }
 
         let new_errors = working_set.parse_errors[starting_error_count..].to_vec();
         // no new errors found means success

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -795,9 +795,6 @@ fn parse_oneof(
             true => parse_multispan_value(working_set, spans, spans_idx, shape),
             false => parse_value(working_set, spans[*spans_idx], shape),
         };
-        if let SyntaxShape::RowCondition = shape {
-            return value;
-        }
 
         let new_errors = working_set.parse_errors[starting_error_count..].to_vec();
         // no new errors found means success

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -239,7 +239,11 @@ impl Display for SyntaxShape {
             SyntaxShape::Duration => write!(f, "duration"),
             SyntaxShape::DateTime => write!(f, "datetime"),
             SyntaxShape::Operator => write!(f, "operator"),
-            SyntaxShape::RowCondition => write!(f, "condition"),
+            SyntaxShape::RowCondition => write!(
+                f,
+                "oneof<condition, {}>",
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any]))
+            ),
             SyntaxShape::MathExpression => write!(f, "variable"),
             SyntaxShape::VarWithOptType => write!(f, "vardecl"),
             SyntaxShape::Signature => write!(f, "signature"),


### PR DESCRIPTION
- fixes #16129

# Description

## Problem
Parsing a multi span value as RowCondition always produces a RowCondition
expression that covers all the spans.

Which is problematic inside OneOf and can produce multiple expressions with overlapping spans.
Which results in funky highlighting that duplicates text:
<img width="278" height="49" alt="image" src="https://github.com/user-attachments/assets/55ecf8f4-c2ca-4304-96df-b6de48af41ca" />

## Solution
~~Short circuiting on RowCondition while parsing OneOf (OneOf expression that contains RowCondition will *always* be parsed as RowCondition), prevents that.~~

Only reason for including `SyntaxShape::Closure` in the signature (#15697) was for documentation purposes, making it clear `help` texts that a closure can be used as the argument.

As our current parser is shape directed, simplifying the command signature means simplifies the parsing, so using a RowCondition on its own, and instead making it always look like a union with `closure(any)` solves the issue without any changes in the parser.

Also, RowCondition always accepts closure values anyway, so its textual representation should indicate that without the need to wrap it in OneOf.

# Tests + Formatting
+1 test to catch it if it ever reoccurs
