### PR TITLE
feat: `commandline edit --accept` to instantly execute command

### DIFF
--- a/crates/nu-cli/src/commands/commandline/edit.rs
+++ b/crates/nu-cli/src/commands/commandline/edit.rs
@@ -26,6 +26,11 @@ impl Command for CommandlineEdit {
                 "replaces the current contents of the buffer (default)",
                 Some('r'),
             )
+            .switch(
+                "accept",
+                "immediately executes the result after edit",
+                Some('A'),
+            )
             .required(
                 "str",
                 SyntaxShape::String,
@@ -61,6 +66,9 @@ impl Command for CommandlineEdit {
             repl.buffer = str;
             repl.cursor_pos = repl.buffer.len();
         }
+
+        repl.accept = call.has_flag(engine_state, stack, "accept")?;
+
         Ok(Value::nothing(call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -102,7 +102,6 @@ pub struct EngineState {
     pub config: Arc<Config>,
     pub pipeline_externals_state: Arc<(AtomicU32, AtomicU32)>,
     pub repl_state: Arc<Mutex<ReplState>>,
-    pub immediately_accept: bool,
     pub table_decl_id: Option<DeclId>,
     #[cfg(feature = "plugin")]
     pub plugin_path: Option<PathBuf>,
@@ -190,7 +189,6 @@ impl EngineState {
                 cursor_pos: 0,
                 accept: false,
             })),
-            immediately_accept: Default::default(),
             table_decl_id: None,
             #[cfg(feature = "plugin")]
             plugin_path: None,

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -46,6 +46,8 @@ pub struct ReplState {
     pub buffer: String,
     // A byte position, as `EditCommand::MoveToPosition` is also a byte position
     pub cursor_pos: usize,
+    /// Immediately accept the buffer on the next loop.
+    pub accept: bool,
 }
 
 pub struct IsDebugging(AtomicBool);
@@ -100,6 +102,7 @@ pub struct EngineState {
     pub config: Arc<Config>,
     pub pipeline_externals_state: Arc<(AtomicU32, AtomicU32)>,
     pub repl_state: Arc<Mutex<ReplState>>,
+    pub immediately_accept: bool,
     pub table_decl_id: Option<DeclId>,
     #[cfg(feature = "plugin")]
     pub plugin_path: Option<PathBuf>,
@@ -185,7 +188,9 @@ impl EngineState {
             repl_state: Arc::new(Mutex::new(ReplState {
                 buffer: "".to_string(),
                 cursor_pos: 0,
+                accept: false,
             })),
+            immediately_accept: Default::default(),
             table_decl_id: None,
             #[cfg(feature = "plugin")]
             plugin_path: None,
@@ -1078,6 +1083,7 @@ impl EngineState {
             self.repl_state = Arc::new(Mutex::new(ReplState {
                 buffer: "".to_string(),
                 cursor_pos: 0,
+                accept: false,
             }));
         }
         if Mutex::is_poisoned(&self.jobs) {

--- a/tests/repl/test_commandline.rs
+++ b/tests/repl/test_commandline.rs
@@ -140,3 +140,11 @@ fn commandline_test_cursor_end() -> TestResult {
 fn commandline_test_cursor_type() -> TestResult {
     run_test("commandline get-cursor | describe", "int")
 }
+
+#[test]
+fn commandline_test_accepted_command() -> TestResult {
+    run_test(
+        "commandline edit --accept \"print accepted\"\n | commandline",
+        "print accepted",
+    )
+}


### PR DESCRIPTION
# Description

Fixes 
- #11065

Revised 
- #15092

Depends on

- https://github.com/nushell/reedline/pull/933

Adds the `--accept` flag to the `commandline` command, to immediately accept the input.

Example use case: atuin

# User-facing changes

Users get the ability to pass `--accept` or `-A` to `commandline edit` in order to immediately execute the resulting commandline.

# Tests + Formatting

I added two test cases that execute `commandline edit -A`.
There is also some documentation about their unintuitive expectations output.

# After Submitting

The [docs](https://www.nushell.sh/commands/docs/commandline_edit.html) can be updated to the new flag:

--accept, -A: immediately execute the command (no additional return required)

> [!NOTE]
>
> This PR will be revised if / when https://github.com/nushell/reedline/pull/933 is accepted

# Demo

[![asciicast](https://asciinema.org/a/Ql4r1oWu8J0C4MecmIZjxw5Pg.svg)](https://asciinema.org/a/Ql4r1oWu8J0C4MecmIZjxw5Pg)