### PR TITLE
Also type-check optional arguments

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -264,7 +264,7 @@ fn bind_args_to(
             .expect("internal error: all custom parameters must have var_ids");
         if let Some(result) = val_iter.next() {
             let param_type = param.shape.to_type();
-            if required && !result.is_subtype_of(&param_type) {
+            if !result.is_subtype_of(&param_type) {
                 return Err(ShellError::CantConvert {
                     to_type: param.shape.to_type().to_string(),
                     from_type: result.get_type().to_string(),

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -60,3 +60,17 @@ fn run_closure_with_it_using() {
     assert!(actual.err.is_empty());
     assert_eq!(actual.out, "3");
 }
+
+#[test]
+fn required_argument_type_checked() {
+    let actual = nu!(r#"do {|x: string| $x} 4"#);
+    assert!(actual.out.is_empty());
+    assert!(actual.err.contains("nu::shell::cant_convert"));
+}
+
+#[test]
+fn optional_argument_type_checked() {
+    let actual = nu!(r#"do {|x?: string| $x} 4"#);
+    assert_eq!(actual.out, "");
+    assert!(actual.err.contains("nu::shell::cant_convert"));
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
Type-check all closure arguments, not just required arguments.

Not doing so looks like an oversight.

<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes

<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Previously, passing an argument of the wrong type to a closure would fail if the argument is required, but be accepted (ignoring the type annotation) if the argument is optional:

```
> do {|x: string| $x} 4
Error: nu::shell::cant_convert

  × Can't convert to string.
   ╭─[entry #13:1:21]
 1 │ do {|x: string| $x} 4
   ·                     ┬
   ·                     ╰── can't convert int to string
   ╰────
> do {|x?: string| $x} 4
4
> do {|x?: string| $x} 4 | describe
int
```

It now fails the same way in both cases.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Added tests, the existing tests still pass.

Please let me know if I added the wrong type of test or added them in the wrong place (I didn't spot similar tests in the nu-cmd-lang crate, so I put them next to the most-related existing tests I could find...

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

I think this is minor enough it doesn't need a doc update, but please point me in the right direction if not.
