### PR TITLE
Add `-h/--help` flag to testbin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,8 @@ use nu_std::load_standard_library;
 use nu_utils::perf;
 use run::{run_commands, run_file, run_repl};
 use signals::ctrlc_protection;
-use std::{borrow::Cow, path::PathBuf, str::FromStr, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, path::PathBuf, str::FromStr, sync::Arc};
+use test_bins::TestBin;
 
 /// Get the directory where the Nushell executable is located.
 fn current_exe_directory() -> PathBuf {
@@ -371,6 +372,12 @@ fn main() -> Result<()> {
 
     start_time = std::time::Instant::now();
     if let Some(testbin) = &parsed_nu_cli_args.testbin {
+        let mut dispatcher: HashMap<String, Box<&dyn TestBin>> = HashMap::new();
+        dispatcher.insert("echo_env".to_string(), Box::new(&test_bins::EchoEnv));
+        dispatcher.insert(
+            "echo_env_stderr".to_string(),
+            Box::new(&test_bins::EchoEnvStderr),
+        );
         // Call out to the correct testbin
         match testbin.item.as_str() {
             "echo_env" => test_bins::echo_env(true),
@@ -389,6 +396,7 @@ fn main() -> Result<()> {
             "repeat_bytes" => test_bins::repeat_bytes(),
             "nu_repl" => test_bins::nu_repl(),
             "input_bytes_length" => test_bins::input_bytes_length(),
+            "-h" => test_bins::show_help(&dispatcher),
             _ => std::process::exit(1),
         }
         std::process::exit(0)

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,7 @@ use nu_std::load_standard_library;
 use nu_utils::perf;
 use run::{run_commands, run_file, run_repl};
 use signals::ctrlc_protection;
-use std::{borrow::Cow, collections::HashMap, path::PathBuf, str::FromStr, sync::Arc};
-use test_bins::TestBin;
+use std::{borrow::Cow, path::PathBuf, str::FromStr, sync::Arc};
 
 /// Get the directory where the Nushell executable is located.
 fn current_exe_directory() -> PathBuf {
@@ -372,38 +371,7 @@ fn main() -> Result<()> {
 
     start_time = std::time::Instant::now();
     if let Some(testbin) = &parsed_nu_cli_args.testbin {
-        let mut dispatcher: HashMap<String, Box<&dyn TestBin>> = HashMap::new();
-        dispatcher.insert("echo_env".to_string(), Box::new(&test_bins::EchoEnv));
-        dispatcher.insert(
-            "echo_env_stderr".to_string(),
-            Box::new(&test_bins::EchoEnvStderr),
-        );
-        dispatcher.insert(
-            "echo_env_stderr_fail".to_string(),
-            Box::new(&test_bins::EchoEnvStderrFail),
-        );
-        dispatcher.insert(
-            "echo_env_mixed".to_string(),
-            Box::new(&test_bins::EchoEnvMixed),
-        );
-        dispatcher.insert("cococo".to_string(), Box::new(&test_bins::Cococo));
-        dispatcher.insert("meow".to_string(), Box::new(&test_bins::Meow));
-        dispatcher.insert("meowb".to_string(), Box::new(&test_bins::Meowb));
-        dispatcher.insert("relay".to_string(), Box::new(&test_bins::Relay));
-        dispatcher.insert("iecho".to_string(), Box::new(&test_bins::Iecho));
-        dispatcher.insert("fail".to_string(), Box::new(&test_bins::Fail));
-        dispatcher.insert("nonu".to_string(), Box::new(&test_bins::Nonu));
-        dispatcher.insert("chop".to_string(), Box::new(&test_bins::Chop));
-        dispatcher.insert("repeater".to_string(), Box::new(&test_bins::Repeater));
-        dispatcher.insert(
-            "repeat_bytes".to_string(),
-            Box::new(&test_bins::RepeatBytes),
-        );
-        dispatcher.insert("nu_repl".to_string(), Box::new(&test_bins::NuRepl));
-        dispatcher.insert(
-            "input_bytes_length".to_string(),
-            Box::new(&test_bins::InputBytesLength),
-        );
+        let dispatcher = test_bins::new_testbin_dispatcher();
         let test_bin = testbin.item.as_str();
         match dispatcher.get(test_bin) {
             Some(test_bin) => test_bin.run(),
@@ -411,7 +379,7 @@ fn main() -> Result<()> {
                 if ["-h", "--help"].contains(&test_bin) {
                     test_bins::show_help(&dispatcher);
                 } else {
-                    eprintln!("ERROR: Unknown testbin '{}'", test_bin);
+                    eprintln!("ERROR: Unknown testbin '{test_bin}'");
                     std::process::exit(1);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,7 +390,7 @@ fn main() -> Result<()> {
         dispatcher.insert("meow".to_string(), Box::new(&test_bins::Meow));
         dispatcher.insert("meowb".to_string(), Box::new(&test_bins::Meowb));
         dispatcher.insert("relay".to_string(), Box::new(&test_bins::Relay));
-        dispatcher.insert("iecho".to_string(), Box::new(&test_bins::IEcho));
+        dispatcher.insert("iecho".to_string(), Box::new(&test_bins::Iecho));
         dispatcher.insert("fail".to_string(), Box::new(&test_bins::Fail));
         dispatcher.insert("nonu".to_string(), Box::new(&test_bins::Nonu));
         dispatcher.insert("chop".to_string(), Box::new(&test_bins::Chop));

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,26 +378,43 @@ fn main() -> Result<()> {
             "echo_env_stderr".to_string(),
             Box::new(&test_bins::EchoEnvStderr),
         );
-        // Call out to the correct testbin
-        match testbin.item.as_str() {
-            "echo_env" => test_bins::echo_env(true),
-            "echo_env_stderr" => test_bins::echo_env(false),
-            "echo_env_stderr_fail" => test_bins::echo_env_and_fail(false),
-            "echo_env_mixed" => test_bins::echo_env_mixed(),
-            "cococo" => test_bins::cococo(),
-            "meow" => test_bins::meow(),
-            "meowb" => test_bins::meowb(),
-            "relay" => test_bins::relay(),
-            "iecho" => test_bins::iecho(),
-            "fail" => test_bins::fail(),
-            "nonu" => test_bins::nonu(),
-            "chop" => test_bins::chop(),
-            "repeater" => test_bins::repeater(),
-            "repeat_bytes" => test_bins::repeat_bytes(),
-            "nu_repl" => test_bins::nu_repl(),
-            "input_bytes_length" => test_bins::input_bytes_length(),
-            "-h" => test_bins::show_help(&dispatcher),
-            _ => std::process::exit(1),
+        dispatcher.insert(
+            "echo_env_stderr_fail".to_string(),
+            Box::new(&test_bins::EchoEnvStderrFail),
+        );
+        dispatcher.insert(
+            "echo_env_mixed".to_string(),
+            Box::new(&test_bins::EchoEnvMixed),
+        );
+        dispatcher.insert("cococo".to_string(), Box::new(&test_bins::Cococo));
+        dispatcher.insert("meow".to_string(), Box::new(&test_bins::Meow));
+        dispatcher.insert("meowb".to_string(), Box::new(&test_bins::Meowb));
+        dispatcher.insert("relay".to_string(), Box::new(&test_bins::Relay));
+        dispatcher.insert("iecho".to_string(), Box::new(&test_bins::IEcho));
+        dispatcher.insert("fail".to_string(), Box::new(&test_bins::Fail));
+        dispatcher.insert("nonu".to_string(), Box::new(&test_bins::Nonu));
+        dispatcher.insert("chop".to_string(), Box::new(&test_bins::Chop));
+        dispatcher.insert("repeater".to_string(), Box::new(&test_bins::Repeater));
+        dispatcher.insert(
+            "repeat_bytes".to_string(),
+            Box::new(&test_bins::RepeatBytes),
+        );
+        dispatcher.insert("nu_repl".to_string(), Box::new(&test_bins::NuRepl));
+        dispatcher.insert(
+            "input_bytes_length".to_string(),
+            Box::new(&test_bins::InputBytesLength),
+        );
+        let test_bin = testbin.item.as_str();
+        match dispatcher.get(test_bin) {
+            Some(test_bin) => test_bin.run(),
+            None => {
+                if ["-h", "--help"].contains(&test_bin) {
+                    test_bins::show_help(&dispatcher);
+                } else {
+                    eprintln!("ERROR: Unknown testbin '{}'", test_bin);
+                    std::process::exit(1);
+                }
+            }
         }
         std::process::exit(0)
     } else {

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -539,7 +539,7 @@ pub fn show_help(dispatcher: &std::collections::HashMap<String, Box<&dyn TestBin
     let mut names = dispatcher.keys().collect::<Vec<_>>();
     names.sort();
     for n in names {
-        let test_bin = dispatcher.get(*k).expect("Test bin should exist");
+        let test_bin = dispatcher.get(n).expect("Test bin should exist");
         println!("{n} -> {}", test_bin.help())
     }
 }

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -299,6 +299,16 @@ impl TestBin for InputBytesLength {
     }
 }
 
+/// Echo's value of env keys from args
+/// Example: nu --testbin env_echo FOO BAR
+/// If it it's not present echo's nothing
+pub fn echo_env(to_stdout: bool) {
+    let args = args();
+    for arg in args {
+        echo_one_env(&arg, to_stdout)
+    }
+}
+
 fn echo_one_env(arg: &str, to_stdout: bool) {
     if let Ok(v) = std::env::var(arg) {
         if to_stdout {

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -288,7 +288,7 @@ impl TestBin for NuRepl {
 
 impl TestBin for InputBytesLength {
     fn help(&self) -> &'static str {
-        "Prints the number of bytes received on stdin(e.g: 0x[deadbeef] | nu `--testbin` input_bytes_length)"
+        "Prints the number of bytes received on stdin(e.g: 0x[deadbeef] | nu --testbin input_bytes_length)"
     }
 
     fn run(&self) {
@@ -296,16 +296,6 @@ impl TestBin for InputBytesLength {
         let count = stdin.lock().bytes().count();
 
         println!("{count}");
-    }
-}
-
-/// Echo's value of env keys from args
-/// Example: nu --testbin env_echo FOO BAR
-/// If it it's not present echo's nothing
-pub fn echo_env(to_stdout: bool) {
-    let args = args();
-    for arg in args {
-        echo_one_env(&arg, to_stdout)
     }
 }
 
@@ -319,54 +309,9 @@ fn echo_one_env(arg: &str, to_stdout: bool) {
     }
 }
 
-/// Mix echo of env keys from input
-/// Example:
-///     * nu --testbin echo_env_mixed out-err FOO BAR
-///     * nu --testbin echo_env_mixed err-out FOO BAR
-/// If it's not present, panic instead
-pub fn echo_env_mixed() {}
-
-/// Cross platform echo using println!()
-/// Example: nu --testbin cococo a b c
-/// a b c
-pub fn cococo() {}
-
-/// Cross platform cat (open a file, print the contents) using read_to_string and println!()
-pub fn meow() {}
-
-/// Cross platform cat (open a file, print the contents) using read() and write_all() / binary
-pub fn meowb() {}
-
-// Relays anything received on stdin to stdout
-pub fn relay() {
-    io::copy(&mut io::stdin().lock(), &mut io::stdout().lock())
-        .expect("failed to copy stdin to stdout");
-}
-
-/// Cross platform echo but concats arguments without space and NO newline
-/// nu --testbin nonu a b c
-/// abc
-pub fn nonu() {}
-
-/// Repeat a string or char N times
-/// nu --testbin repeater a 5
-/// aaaaa
-/// nu --testbin repeater test 5
-/// testtesttesttesttest
-pub fn repeater() {}
-
-/// A version of repeater that can output binary data, even null bytes
-pub fn repeat_bytes() {}
-
-/// Another type of echo that outputs a parameter per line, looping infinitely
-pub fn iecho() {}
-
 pub fn fail() {
     std::process::exit(1);
 }
-
-/// With no parameters, will chop a character off the end of each line
-pub fn chop() {}
 
 fn outcome_err(engine_state: &EngineState, error: &ShellError) -> ! {
     report_shell_error(engine_state, error);
@@ -514,8 +459,6 @@ fn did_chop_arguments() -> bool {
 
     false
 }
-
-pub fn input_bytes_length() {}
 
 fn args() -> Vec<String> {
     // skip `nu` path (first argument)

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -99,7 +99,7 @@ impl TestBin for EchoEnvMixed {
 
 impl TestBin for Cococo {
     fn help(&self) -> &'static str {
-        "Cross platform echo using println!()"
+        "Cross platform echo using println!()(e.g: nu --testbin cococo a b c)"
     }
 
     fn run(&self) {
@@ -118,7 +118,7 @@ impl TestBin for Cococo {
 
 impl TestBin for Meow {
     fn help(&self) -> &'static str {
-        "Cross platform cat (open a file, print the contents) using read_to_string and println!()"
+        "Cross platform cat (open a file, print the contents) using read_to_string and println!()(e.g: nu --testbin meow file.txt)"
     }
 
     fn run(&self) {
@@ -133,7 +133,7 @@ impl TestBin for Meow {
 
 impl TestBin for Meowb {
     fn help(&self) -> &'static str {
-        "Cross platform cat (open a file, print the contents) using read() and write_all() / binary"
+        "Cross platform cat (open a file, print the contents) using read() and write_all() / binary(e.g: nu --testbin meowb sample.db)"
     }
 
     fn run(&self) {
@@ -151,7 +151,7 @@ impl TestBin for Meowb {
 
 impl TestBin for Relay {
     fn help(&self) -> &'static str {
-        "Relays anything received on stdin to stdout"
+        "Relays anything received on stdin to stdout(e.g: 0x[beef] | nu --testbin relay)"
     }
 
     fn run(&self) {
@@ -177,7 +177,7 @@ impl TestBin for Iecho {
 
 impl TestBin for Fail {
     fn help(&self) -> &'static str {
-        "Exits with failure code 1"
+        "Exits with failure code 1(e.g: nu --testbin fail)"
     }
 
     fn run(&self) {
@@ -248,7 +248,7 @@ impl TestBin for Repeater {
 
 impl TestBin for RepeatBytes {
     fn help(&self) -> &'static str {
-        "A version of repeater that can output binary data, even null bytes"
+        "A version of repeater that can output binary data, even null bytes(e.g: nu --testbin repeat_bytes 003d9fbf 10)"
     }
 
     fn run(&self) {
@@ -288,7 +288,7 @@ impl TestBin for NuRepl {
 
 impl TestBin for InputBytesLength {
     fn help(&self) -> &'static str {
-        "Prints the number of bytes received on stdin"
+        "Prints the number of bytes received on stdin(e.g: 0x[deadbeef] | nu `--testbin` input_bytes_length)"
     }
 
     fn run(&self) {

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -9,6 +9,7 @@ use nu_protocol::{
 };
 use nu_std::load_standard_library;
 use std::{
+    collections::HashMap,
     io::{self, BufRead, Read, Write},
     sync::Arc,
 };
@@ -487,7 +488,7 @@ fn args() -> Vec<String> {
     })
 }
 
-pub fn show_help(dispatcher: &std::collections::HashMap<String, Box<&dyn TestBin>>) {
+pub fn show_help(dispatcher: &std::collections::HashMap<String, Box<dyn TestBin>>) {
     println!("Usage: nu --testbin <bin>\n<bin>:");
     let mut names = dispatcher.keys().collect::<Vec<_>>();
     names.sort();
@@ -495,4 +496,29 @@ pub fn show_help(dispatcher: &std::collections::HashMap<String, Box<&dyn TestBin
         let test_bin = dispatcher.get(n).expect("Test bin should exist");
         println!("{n} -> {}", test_bin.help())
     }
+}
+
+/// Create a new testbin dispatcher, which is useful to guide the testbin to run.
+pub fn new_testbin_dispatcher() -> HashMap<String, Box<dyn TestBin>> {
+    let mut dispatcher: HashMap<String, Box<dyn TestBin>> = HashMap::new();
+    dispatcher.insert("echo_env".to_string(), Box::new(EchoEnv));
+    dispatcher.insert("echo_env_stderr".to_string(), Box::new(EchoEnvStderr));
+    dispatcher.insert(
+        "echo_env_stderr_fail".to_string(),
+        Box::new(EchoEnvStderrFail),
+    );
+    dispatcher.insert("echo_env_mixed".to_string(), Box::new(EchoEnvMixed));
+    dispatcher.insert("cococo".to_string(), Box::new(Cococo));
+    dispatcher.insert("meow".to_string(), Box::new(Meow));
+    dispatcher.insert("meowb".to_string(), Box::new(Meowb));
+    dispatcher.insert("relay".to_string(), Box::new(Relay));
+    dispatcher.insert("iecho".to_string(), Box::new(Iecho));
+    dispatcher.insert("fail".to_string(), Box::new(Fail));
+    dispatcher.insert("nonu".to_string(), Box::new(Nonu));
+    dispatcher.insert("chop".to_string(), Box::new(Chop));
+    dispatcher.insert("repeater".to_string(), Box::new(Repeater));
+    dispatcher.insert("repeat_bytes".to_string(), Box::new(RepeatBytes));
+    dispatcher.insert("nu_repl".to_string(), Box::new(NuRepl));
+    dispatcher.insert("input_bytes_length".to_string(), Box::new(InputBytesLength));
+    dispatcher
 }

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -37,7 +37,7 @@ pub struct InputBytesLength;
 
 impl TestBin for EchoEnv {
     fn help(&self) -> &'static str {
-        "Echo's value of env keys from args(nu --testbin echo_env FOO BAR)"
+        "Echo's value of env keys from args(e.g: nu --testbin echo_env FOO BAR)"
     }
 
     fn run(&self) {
@@ -47,7 +47,7 @@ impl TestBin for EchoEnv {
 
 impl TestBin for EchoEnvStderr {
     fn help(&self) -> &'static str {
-        "Echo's value of env keys from args to stderr(nu --testbin echo_env_stderr FOO BAR)"
+        "Echo's value of env keys from args to stderr(e.g: nu --testbin echo_env_stderr FOO BAR)"
     }
 
     fn run(&self) {
@@ -57,7 +57,7 @@ impl TestBin for EchoEnvStderr {
 
 impl TestBin for EchoEnvStderrFail {
     fn help(&self) -> &'static str {
-        "Echo's value of env keys from args to stderr, and exit with failure(nu --testbin echo_env_stderr_fail FOO BAR)"
+        "Echo's value of env keys from args to stderr, and exit with failure(e.g: nu --testbin echo_env_stderr_fail FOO BAR)"
     }
 
     fn run(&self) {
@@ -68,7 +68,7 @@ impl TestBin for EchoEnvStderrFail {
 
 impl TestBin for EchoEnvMixed {
     fn help(&self) -> &'static str {
-        "Mix echo of env keys from input(nu --testbin echo_env_mixed out-err FOO BAR; nu --testbin echo_env_mixed err-out FOO BAR)"
+        "Mix echo of env keys from input(e.g: nu --testbin echo_env_mixed out-err FOO BAR; nu --testbin echo_env_mixed err-out FOO BAR)"
     }
 
     fn run(&self) {
@@ -162,7 +162,7 @@ impl TestBin for Relay {
 
 impl TestBin for Iecho {
     fn help(&self) -> &'static str {
-        "Another type of echo that outputs a parameter per line, looping infinitely(nu --testbin iecho 3)"
+        "Another type of echo that outputs a parameter per line, looping infinitely(e.g: nu --testbin iecho 3)"
     }
 
     fn run(&self) {
@@ -187,7 +187,7 @@ impl TestBin for Fail {
 
 impl TestBin for Nonu {
     fn help(&self) -> &'static str {
-        "Cross platform echo but concats arguments without space and NO newline(nu --testbin nonu a b c)"
+        "Cross platform echo but concats arguments without space and NO newline(e.g: nu --testbin nonu a b c)"
     }
 
     fn run(&self) {
@@ -228,7 +228,7 @@ impl TestBin for Chop {
 }
 impl TestBin for Repeater {
     fn help(&self) -> &'static str {
-        "Repeat a string or char N times(nu --testbin repeater a 5)"
+        "Repeat a string or char N times(e.g: nu --testbin repeater a 5)"
     }
 
     fn run(&self) {
@@ -536,7 +536,10 @@ fn args() -> Vec<String> {
 
 pub fn show_help(dispatcher: &std::collections::HashMap<String, Box<&dyn TestBin>>) {
     println!("Usage: nu --testbin <bin>\n<bin>:");
-    for (name, test_bin) in dispatcher.iter() {
-        println!("{name} -> {}", test_bin.help())
+    let mut names = dispatcher.keys().collect::<Vec<_>>();
+    names.sort();
+    for n in names {
+        let test_bin = dispatcher.get(*k).expect("Test bin should exist");
+        println!("{n} -> {}", test_bin.help())
     }
 }

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -13,6 +13,29 @@ use std::{
     sync::Arc,
 };
 
+pub trait TestBin {
+    fn run(&self);
+
+    fn help(&self) -> &'static str;
+}
+
+pub struct EchoEnv;
+pub struct EchoEnvStderr;
+pub struct EchoEnvStderrFail;
+pub struct EchoEnvMixed;
+pub struct Cococo;
+pub struct Meow;
+pub struct Meowb;
+pub struct Relay;
+pub struct Iecho;
+pub struct Fail;
+pub struct Nonu;
+pub struct Chop;
+pub struct Repeater;
+pub struct RepeatBytes;
+pub struct NuRepl;
+pub struct InputBytesLength;
+
 /// Echo's value of env keys from args
 /// Example: nu --testbin env_echo FOO BAR
 /// If it it's not present echo's nothing
@@ -374,4 +397,11 @@ fn args() -> Vec<String> {
         }
         acc
     })
+}
+
+pub fn show_help(dispatcher: &std::collections::HashMap<String, Box<&dyn TestBin>>) {
+    println!("Usage: nu --testbin <bin>\n<bin>:");
+    for (name, test_bin) in dispatcher.iter() {
+        println!("{name} -> {}", test_bin.help())
+    }
 }


### PR DESCRIPTION
# Description
As title, this pr introduce `-h` flag to testbin, so if I want to see which testbin I should use, I don't need to look into source code.

### About the change
I don't know if there is any way to get docstring of a function inside rust code.  So I created a trait, and put docstring into it's `help` method:
```rust
pub trait TestBin {
    // the docstring of original functions are moved here.
    fn help(&self) -> &'static str;
    fn run(&self);
}
```
Take `cococo` testbin as example, the changes are:
```
original cococo function --> Cococo struct, then
1. put the body of `cococo` function into `run` method
2. put the docstring of `cococo` function into `help` method
```

# User-Facing Changes

`-h/--help` flag in testbin is enabled.
```
> nu --testbin -h
Usage: nu --testbin <bin>
<bin>:
chop -> With no parameters, will chop a character off the end of each line
cococo -> Cross platform echo using println!()(e.g: nu --testbin cococo a b c)
echo_env -> Echo's value of env keys from args(e.g: nu --testbin echo_env FOO BAR)
echo_env_mixed -> Mix echo of env keys from input(e.g: nu --testbin echo_env_mixed out-err FOO BAR; nu --testbin echo_env_mixed err-out FOO BAR)
echo_env_stderr -> Echo's value of env keys from args to stderr(e.g: nu --testbin echo_env_stderr FOO BAR)
echo_env_stderr_fail -> Echo's value of env keys from args to stderr, and exit with failure(e.g: nu --testbin echo_env_stderr_fail FOO BAR)
fail -> Exits with failure code 1(e.g: nu --testbin fail)
iecho -> Another type of echo that outputs a parameter per line, looping infinitely(e.g: nu --testbin iecho 3)
input_bytes_length -> Prints the number of bytes received on stdin(e.g: 0x[deadbeef] | nu --testbin input_bytes_length)
meow -> Cross platform cat (open a file, print the contents) using read_to_string and println!()(e.g: nu --testbin meow file.txt)
meowb -> Cross platform cat (open a file, print the contents) using read() and write_all() / binary(e.g: nu --testbin meowb sample.db)
nonu -> Cross platform echo but concats arguments without space and NO newline(e.g: nu --testbin nonu a b c)
nu_repl -> Run a REPL with the given source lines
relay -> Relays anything received on stdin to stdout(e.g: 0x[beef] | nu --testbin relay)
repeat_bytes -> A version of repeater that can output binary data, even null bytes(e.g: nu --testbin repeat_bytes 003d9fbf 10)
repeater -> Repeat a string or char N times(e.g: nu --testbin repeater a 5)
```

# Tests + Formatting
None, all existed tests can guarantee the behavior of testbins doesn't change.

# After Submitting
NaN