### PR TITLE
fix(parser): repeated `(` / parenthesis / opened sub-expressions causes memory leak

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2246,8 +2246,10 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
             if token_start < end {
                 let span = Span::new(token_start, end);
 
-                let expr = parse_full_cell_path(working_set, None, span);
-                output.push(expr);
+                if delimiter_stack.is_empty() {
+                    let expr = parse_full_cell_path(working_set, None, span);
+                    output.push(expr);
+                }
             }
         }
     }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2003,15 +2003,11 @@ pub fn parse_paren_expr(
     let fcp_error_count = working_set.parse_errors.len();
     if fcp_error_count > starting_error_count {
         let malformed_subexpr = working_set.parse_errors[starting_error_count..]
-            .iter()
-            .any(|e| match e {
-                ParseError::Unclosed(right, _) if right == ")" => true,
-                ParseError::Unbalanced(left, right, _) if left == "(" && right == ")" => true,
-                _ => false,
-            });
+            .first()
+            .is_some_and(|e| matches!(e, ParseError::Unclosed(right, _) if right == ")" ));
         if malformed_subexpr {
             working_set.parse_errors.truncate(starting_error_count);
-            parse_string(working_set, span)
+            parse_string_interpolation(working_set, span)
         } else {
             fcp_expr
         }


### PR DESCRIPTION
- fixes #16186

# Description

Don't attempt further parsing when there is no complete sub-expression.
