### PR TITLE
Fix typo in glob example description ("files for folders" → "files or folders")

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -85,7 +85,7 @@ impl Command for Glob {
                 result: None,
             },
             Example {
-                description: "Search for files for folders that do not begin with c, C, b, M, or s",
+                description: "Search for files or folders that do not begin with c, C, b, M, or s",
                 example: r#"glob "[!cCbMs]*""#,
                 result: None,
             },


### PR DESCRIPTION
This pull request fixes a typo in the description of a `glob` example:

**Before:**
```
  Search for files for folders that do not begin with c, C, b, M, or s
  > glob "[!cCbMs]*"
```
**After:**
```
  Search for files or folders that do not begin with c, C, b, M, or s
  > glob "[!cCbMs]*"
```