### PR TITLE
group by to table empty

### DIFF
--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -231,7 +231,12 @@ pub fn group_by(
 
     let values: Vec<Value> = input.into_iter().collect();
     if values.is_empty() {
-        return Ok(Value::record(Record::new(), head).into_pipeline_data());
+        let val = if to_table {
+            Value::list(Vec::new(), head)
+        } else {
+            Value::record(Record::new(), head)
+        };
+        return Ok(val.into_pipeline_data());
     }
 
     let grouped = match &groupers[..] {

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -68,16 +68,18 @@ fn errors_if_column_not_found() {
 
 #[test]
 fn group_by_on_empty_list_returns_empty_record() {
-    let actual = nu!("[[a b]; [1 2]] | where false | group-by a");
+    let actual = nu!("[[a b]; [1 2]] | where false | group-by a | to nuon --raw");
+    let expected = r#"{}"#;
     assert!(actual.err.is_empty());
-    assert!(actual.out.contains("empty record"));
+    assert_eq!(actual.out, expected);
 }
 
 #[test]
 fn group_by_to_table_on_empty_list_returns_empty_list() {
-    let actual = nu!("[[a b]; [1 2]] | where false | group-by --to-table a");
+    let actual = nu!("[[a b]; [1 2]] | where false | group-by --to-table a | to nuon --raw");
+    let expected = r#"[]"#;
     assert!(actual.err.is_empty());
-    assert!(actual.out.contains("empty list"));
+    assert_eq!(actual.out, expected);
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -74,6 +74,13 @@ fn group_by_on_empty_list_returns_empty_record() {
 }
 
 #[test]
+fn group_by_to_table_on_empty_list_returns_empty_list() {
+    let actual = nu!("[[a b]; [1 2]] | where false | group-by --to-table a");
+    assert!(actual.err.is_empty());
+    assert!(actual.out.contains("empty list"));
+}
+
+#[test]
 fn optional_cell_path_works() {
     let actual = nu!("[{foo: 123}, {foo: 234}, {bar: 345}] | group-by foo? | to nuon");
     let expected = r#"{"123": [[foo]; [123]], "234": [[foo]; [234]]}"#;


### PR DESCRIPTION
- fixes #16217

# Description

> `group-by --to-table` does not always return a table (a list)
> ```nushell
> [] | group-by --to-table something
> #=> ╭──────────────╮
> #=> │ empty record │
> #=> ╰──────────────╯
> ```

Fixed:
```nushell
[] | group-by --to-table something
#=> ╭────────────╮
#=> │ empty list │
#=> ╰────────────╯
```

# Tests + Formatting
+1 test