### PR TITLE
Add `KillLine` to the `EditCommand` parser

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -1172,6 +1172,7 @@ fn edit_from_record(
         "cutfromlinestart" => EditCommand::CutFromLineStart,
         "cuttoend" => EditCommand::CutToEnd,
         "cuttolineend" => EditCommand::CutToLineEnd,
+        "killline" => EditCommand::KillLine,
         "cutwordleft" => EditCommand::CutWordLeft,
         "cutbigwordleft" => EditCommand::CutBigWordLeft,
         "cutwordright" => EditCommand::CutWordRight,


### PR DESCRIPTION
# Description
Follow-up to https://github.com/nushell/reedline/pull/901
Closes https://github.com/nushell/reedline/issues/935

# User-Facing Changes
You can now use `{edit: KillLine}` to mimic emacs `Ctrl-K` behavior`

