### PR TITLE
fix panic when `..=` syntax is used in stepped ranges

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1761,7 +1761,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Option<Expr
     let starting_error_count = working_set.parse_errors.len();
 
     // Range follows the following syntax: [<from>][<next_operator><next>]<range_operator>[<to>]
-    //   where <next_operator> is ".." or "..="
+    //   where <next_operator> is ".."
     //   and  <range_operator> is "..", "..=" or "..<"
     //   and one of the <from> or <to> bounds must be present (just '..' is not allowed since it
     //     looks like parent directory)

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1874,12 +1874,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Option<Expr
     }
 
     let (next, next_op_span) = if let Some(pos) = next_op_pos {
-        let next_op_str = if token[pos..].starts_with("..=") {
-            "..="
-        } else {
-            ".."
-        };
-        let next_op_span = Span::new(span.start + pos, span.start + pos + next_op_str.len());
+        let next_op_span = Span::new(span.start + pos, span.start + pos + "..".len());
         let next_span = Span::new(next_op_span.end, range_op_span.start);
 
         (

--- a/tests/repl/test_ranges.rs
+++ b/tests/repl/test_ranges.rs
@@ -48,7 +48,8 @@ fn zip_ranges() -> TestResult {
 
 #[test]
 fn int_in_stepped_range() -> TestResult {
-    run_test(r#"7 in 1..3..15"#, "true")
+    run_test(r#"7 in 1..3..15"#, "true")?;
+    run_test(r#"7 in 1..3..=15"#, "true")
 }
 
 #[test]
@@ -77,17 +78,12 @@ fn float_not_in_unbounded_stepped_range() -> TestResult {
 }
 
 #[rstest]
-#[case("1..=3.. == 1..3..")]
-#[case("1..3..=15 == 1..3..15")]
-#[case("..=3..=15 == ..3..15")]
-fn alt_inclusive_range_syntax(#[case] input: &str) -> TestResult {
-    run_test(input, "true")
-}
-
+#[case("1..=3..", "expected number")]
+#[case("..=3..=15", "expected number")]
+#[case("..=(..", "expected closing )")]
+#[case("..=()..", "expected at least one range bound")]
+#[case("..=..", "expected at least one range bound")]
 #[test]
-fn missing_range_bound_error() -> TestResult {
-    fail_test(
-        r#"def foo [r: range] {}; foo ..=.."#,
-        "expected at least one range bound",
-    )
+fn bad_range_syntax(#[case] input: &str, #[case] expect: &str) -> TestResult {
+    fail_test(&format!("def foo [r: range] {{}}; foo {input}"), expect)
 }

--- a/tests/repl/test_ranges.rs
+++ b/tests/repl/test_ranges.rs
@@ -1,4 +1,5 @@
 use crate::repl::tests::{TestResult, fail_test, run_test};
+use rstest::rstest;
 
 #[test]
 fn int_in_inc_range() -> TestResult {
@@ -73,4 +74,20 @@ fn float_in_unbounded_stepped_range() -> TestResult {
 #[test]
 fn float_not_in_unbounded_stepped_range() -> TestResult {
     run_test(r#"2.1 in 1.2..3.."#, "false")
+}
+
+#[rstest]
+#[case("1..=3.. == 1..3..")]
+#[case("1..3..=15 == 1..3..15")]
+#[case("..=3..=15 == ..3..15")]
+fn alt_inclusive_range_syntax(#[case] input: &str) -> TestResult {
+    run_test(input, "true")
+}
+
+#[test]
+fn missing_range_bound_error() -> TestResult {
+    fail_test(
+        r#"def foo [r: range] {}; foo ..=.."#,
+        "expected at least one range bound",
+    )
 }


### PR DESCRIPTION
Fixes #16185

# Description

Stepped range literals where `..=` precedes the second value no longer
cause a parser panic:

```diff
random int 1..=3..5
-Error:   x Main thread panicked.
-  |-> at crates/nu-protocol/src/engine/state_working_set.rs:400:48
-  `-> slice index starts at 8 but ends at 7
+Error: nu::parser::parse_mismatch
+
+  × Parse mismatch during operation.
+   ╭─[entry #1:1:15]
+ 1 │ random int 1..=3..5
+   ·               ─┬
+   ·                ╰── expected number
```