### PR TITLE
Refactor: introduce 2 associated functions to `PipelineData`

### DIFF
--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -278,7 +278,7 @@ pub fn migrate_old_plugin_file(engine_state: &EngineState) -> bool {
         &mut stack,
         &old_contents,
         &old_plugin_file_path.to_string_lossy(),
-        PipelineData::Empty,
+        PipelineData::empty(),
         false,
     ) != 0
     {

--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -76,7 +76,7 @@ fn get_prompt_string(
                     })
                     .ok()
             }
-            Value::String { .. } => Some(PipelineData::Value(v.clone(), None)),
+            Value::String { .. } => Some(PipelineData::value(v.clone(), None)),
             _ => None,
         })
         .and_then(|pipeline_data| {

--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -61,7 +61,7 @@ fn get_prompt_string(
         .and_then(|v| match v {
             Value::Closure { val, .. } => {
                 let result = ClosureEvalOnce::new(engine_state, stack, val.as_ref().clone())
-                    .run_with_input(PipelineData::Empty);
+                    .run_with_input(PipelineData::empty());
 
                 trace!(
                     "get_prompt_string (block) {}:{}:{}",

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -159,7 +159,7 @@ pub(crate) fn add_menus(
             engine_state.merge_delta(delta)?;
 
             let mut temp_stack = Stack::new().collect_value();
-            let input = PipelineData::Empty;
+            let input = PipelineData::empty();
             menu_eval_results.push(eval_block::<WithoutDebug>(
                 &engine_state,
                 &mut temp_stack,

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -2140,7 +2140,8 @@ fn run_external_completion_within_pwd(
     assert!(engine_state.merge_delta(delta).is_ok());
 
     assert!(
-        eval_block::<WithoutDebug>(&engine_state, &mut stack, &block, PipelineData::Empty).is_ok()
+        eval_block::<WithoutDebug>(&engine_state, &mut stack, &block, PipelineData::empty())
+            .is_ok()
     );
 
     // Merge environment into the permanent state

--- a/crates/nu-cli/tests/completions/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/completions/support/completions_helpers.rs
@@ -199,7 +199,7 @@ pub fn merge_input(
             engine_state,
             stack,
             &block,
-            PipelineData::Value(Value::nothing(Span::unknown()), None),
+            PipelineData::value(Value::nothing(Span::unknown()), None),
         )
         .is_ok()
     );

--- a/crates/nu-cmd-base/src/wrap_call.rs
+++ b/crates/nu-cmd-base/src/wrap_call.rs
@@ -12,7 +12,7 @@ use nu_protocol::{
 /// ```rust
 /// # use nu_engine::command_prelude::*;
 /// # use nu_cmd_base::WrapCall;
-/// # fn do_command_logic(call: WrapCall) -> Result<PipelineData, ShellError> { Ok(PipelineData::Empty) }
+/// # fn do_command_logic(call: WrapCall) -> Result<PipelineData, ShellError> { Ok(PipelineData::empty()) }
 ///
 /// # struct Command {}
 /// # impl Command {

--- a/crates/nu-cmd-extra/src/extra/filters/each_while.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/each_while.rs
@@ -72,7 +72,7 @@ impl Command for EachWhile {
 
         let metadata = input.metadata();
         match input {
-            PipelineData::Empty => Ok(PipelineData::Empty),
+            PipelineData::Empty => Ok(PipelineData::empty()),
             PipelineData::Value(Value::Range { .. }, ..)
             | PipelineData::Value(Value::List { .. }, ..)
             | PipelineData::ListStream(..) => {
@@ -109,7 +109,7 @@ impl Command for EachWhile {
                         .fuse()
                         .into_pipeline_data(head, engine_state.signals().clone()))
                 } else {
-                    Ok(PipelineData::Empty)
+                    Ok(PipelineData::empty())
                 }
             }
             // This match allows non-iterables to be accepted,

--- a/crates/nu-cmd-extra/src/extra/formats/from/url.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/from/url.rs
@@ -55,7 +55,7 @@ fn from_url(input: PipelineData, head: Span) -> Result<PipelineData, ShellError>
                 .map(|(k, v)| (k, Value::string(v, head)))
                 .collect();
 
-            Ok(PipelineData::Value(Value::record(record, head), metadata))
+            Ok(PipelineData::value(Value::record(record, head), metadata))
         }
         _ => Err(ShellError::UnsupportedInput {
             msg: "String not compatible with URL encoding".to_string(),

--- a/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
@@ -113,7 +113,7 @@ fn format_bits(
     let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
 
     if let PipelineData::ByteStream(stream, metadata) = input {
-        Ok(PipelineData::ByteStream(
+        Ok(PipelineData::byte_stream(
             byte_stream_to_bits(stream, head),
             metadata,
         ))

--- a/crates/nu-cmd-extra/src/extra/strings/format/command.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/command.rs
@@ -191,7 +191,7 @@ fn format(
     //  We can only handle a Record or a List of Records
     match data_as_value {
         Value::Record { .. } => match format_record(format_operations, &data_as_value, config) {
-            Ok(value) => Ok(PipelineData::Value(Value::string(value, head_span), None)),
+            Ok(value) => Ok(PipelineData::value(Value::string(value, head_span), None)),
             Err(value) => Err(value),
         },
 

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -2,7 +2,7 @@ use nu_engine::{command_prelude::*, get_eval_block_with_early_return, redirect_e
 #[cfg(feature = "os")]
 use nu_protocol::process::{ChildPipe, ChildProcess};
 use nu_protocol::{
-    engine::Closure, shell_error::io::IoError, ByteStream, ByteStreamSource, OutDest,
+    ByteStream, ByteStreamSource, OutDest, engine::Closure, shell_error::io::IoError,
 };
 
 use std::{

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -189,7 +189,7 @@ impl Command for Do {
                         value
                     }
                 });
-                Ok(PipelineData::ListStream(stream, metadata))
+                Ok(PipelineData::list_stream(stream, metadata))
             }
             r => r,
         }

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -2,7 +2,7 @@ use nu_engine::{command_prelude::*, get_eval_block_with_early_return, redirect_e
 #[cfg(feature = "os")]
 use nu_protocol::process::{ChildPipe, ChildProcess};
 use nu_protocol::{
-    ByteStream, ByteStreamSource, OutDest, engine::Closure, shell_error::io::IoError,
+    engine::Closure, shell_error::io::IoError, ByteStream, ByteStreamSource, OutDest,
 };
 
 use std::{

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -157,12 +157,12 @@ impl Command for Do {
                         if !stderr_msg.is_empty() {
                             child.stderr = Some(ChildPipe::Tee(Box::new(Cursor::new(stderr_msg))));
                         }
-                        Ok(PipelineData::ByteStream(
+                        Ok(PipelineData::byte_stream(
                             ByteStream::child(child, span),
                             metadata,
                         ))
                     }
-                    Err(stream) => Ok(PipelineData::ByteStream(stream, metadata)),
+                    Err(stream) => Ok(PipelineData::byte_stream(stream, metadata)),
                 }
             }
             Ok(PipelineData::ByteStream(mut stream, metadata))
@@ -176,7 +176,7 @@ impl Command for Do {
                 if let ByteStreamSource::Child(child) = stream.source_mut() {
                     child.ignore_error(true);
                 }
-                Ok(PipelineData::ByteStream(stream, metadata))
+                Ok(PipelineData::byte_stream(stream, metadata))
             }
             Ok(PipelineData::Value(Value::Error { .. }, ..)) | Err(_) if ignore_all_errors => {
                 Ok(PipelineData::empty())

--- a/crates/nu-cmd-plugin/src/commands/plugin/stop.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/stop.rs
@@ -66,7 +66,7 @@ impl Command for PluginStop {
         }
 
         if found {
-            Ok(PipelineData::Empty)
+            Ok(PipelineData::empty())
         } else {
             Err(ShellError::GenericError {
                 error: format!("Failed to stop the `{}` plugin", name.item),

--- a/crates/nu-command/src/bytes/at.rs
+++ b/crates/nu-command/src/bytes/at.rs
@@ -76,7 +76,7 @@ impl Command for BytesAt {
 
         if let PipelineData::ByteStream(stream, metadata) = input {
             let stream = stream.slice(call.head, call.arguments_span(), range)?;
-            Ok(PipelineData::ByteStream(stream, metadata))
+            Ok(PipelineData::byte_stream(stream, metadata))
         } else {
             operate(
                 map_value,

--- a/crates/nu-command/src/bytes/collect.rs
+++ b/crates/nu-command/src/bytes/collect.rs
@@ -67,7 +67,7 @@ impl Command for BytesCollect {
             ByteStreamType::Binary,
         );
 
-        Ok(PipelineData::ByteStream(output, metadata))
+        Ok(PipelineData::byte_stream(output, metadata))
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -129,7 +129,7 @@ fn into_binary(
 
     if let PipelineData::ByteStream(stream, metadata) = input {
         // Just set the type - that should be good enough
-        Ok(PipelineData::ByteStream(
+        Ok(PipelineData::byte_stream(
             stream.with_type(ByteStreamType::Binary),
             metadata,
         ))

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -170,7 +170,7 @@ fn string_helper(
         // within a string stream is actually valid UTF-8. But refuse to do it if it was already set
         // to binary
         if stream.type_().is_string_coercible() {
-            Ok(PipelineData::ByteStream(
+            Ok(PipelineData::byte_stream(
                 stream.with_type(ByteStreamType::String),
                 metadata,
             ))

--- a/crates/nu-command/src/database/commands/schema.rs
+++ b/crates/nu-command/src/database/commands/schema.rs
@@ -79,7 +79,7 @@ impl Command for SchemaDb {
 
         // TODO: add views and triggers
 
-        Ok(PipelineData::Value(Value::record(record, span), None))
+        Ok(PipelineData::value(Value::record(record, span), None))
     }
 }
 

--- a/crates/nu-command/src/debug/debug_.rs
+++ b/crates/nu-command/src/debug/debug_.rs
@@ -42,7 +42,7 @@ impl Command for Debug {
         let raw = call.has_flag(engine_state, stack, "raw")?;
         let raw_value = call.has_flag(engine_state, stack, "raw-value")?;
 
-        // Should PipelineData::Empty result in an error here?
+        // Should PipelineData::empty() result in an error here?
 
         input.map(
             move |x| {

--- a/crates/nu-command/src/debug/env.rs
+++ b/crates/nu-command/src/debug/env.rs
@@ -25,7 +25,7 @@ impl Command for DebugEnv {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(PipelineData::Value(
+        Ok(PipelineData::value(
             env_to_strings(engine_state, stack)?.into_value(call.head),
             None,
         ))

--- a/crates/nu-command/src/debug/experimental_options.rs
+++ b/crates/nu-command/src/debug/experimental_options.rs
@@ -35,7 +35,7 @@ impl Command for DebugExperimentalOptions {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(PipelineData::Value(
+        Ok(PipelineData::value(
             Value::list(
                 nu_experimental::ALL
                     .iter()

--- a/crates/nu-command/src/env/config/config_.rs
+++ b/crates/nu-command/src/env/config/config_.rs
@@ -124,7 +124,7 @@ pub(super) fn start_editor(
 
     let post_wait_callback = PostWaitCallback::for_job_control(engine_state, None, None);
 
-    // Wrap the output into a `PipelineData::ByteStream`.
+    // Wrap the output into a `PipelineData::byte_stream`.
     let child = nu_protocol::process::ChildProcess::new(
         child,
         None,
@@ -133,7 +133,7 @@ pub(super) fn start_editor(
         Some(post_wait_callback),
     )?;
 
-    Ok(PipelineData::ByteStream(
+    Ok(PipelineData::byte_stream(
         ByteStream::child(child, call.head),
         None,
     ))

--- a/crates/nu-command/src/env/config/config_use_colors.rs
+++ b/crates/nu-command/src/env/config/config_use_colors.rs
@@ -33,7 +33,7 @@ impl Command for ConfigUseColors {
             .get_config()
             .use_ansi_coloring
             .get(engine_state);
-        Ok(PipelineData::Value(
+        Ok(PipelineData::value(
             Value::bool(use_ansi_coloring, call.head),
             None,
         ))

--- a/crates/nu-command/src/filesystem/mktemp.rs
+++ b/crates/nu-command/src/filesystem/mktemp.rs
@@ -120,6 +120,6 @@ impl Command for Mktemp {
                 });
             }
         };
-        Ok(PipelineData::Value(Value::string(res, span), None))
+        Ok(PipelineData::value(Value::string(res, span), None))
     }
 }

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -246,7 +246,7 @@ impl Command for Open {
         }
 
         if output.is_empty() {
-            Ok(PipelineData::Empty)
+            Ok(PipelineData::empty())
         } else if output.len() == 1 {
             Ok(output.remove(0))
         } else {

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -176,7 +176,7 @@ impl Command for Open {
                         .map_err(|err| IoError::new(err, arg_span, PathBuf::from(path)))?;
 
                     // No content_type by default - Is added later if no converter is found
-                    let stream = PipelineData::ByteStream(
+                    let stream = PipelineData::byte_stream(
                         ByteStream::file(file, call_span, engine_state.signals().clone()),
                         Some(PipelineMetadata {
                             data_source: DataSource::FilePath(path.to_path_buf()),

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -339,7 +339,7 @@ fn rm(
                 inner: vec![],
             });
         } else if !confirmed {
-            return Ok(PipelineData::Empty);
+            return Ok(PipelineData::empty());
         }
     }
 

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -191,7 +191,7 @@ impl Command for Save {
                     }
                 }
 
-                Ok(PipelineData::Empty)
+                Ok(PipelineData::empty())
             }
             PipelineData::ListStream(ls, pipeline_metadata)
                 if raw || prepare_path(&path, append, force)?.0.extension().is_none() =>

--- a/crates/nu-command/src/filesystem/start.rs
+++ b/crates/nu-command/src/filesystem/start.rs
@@ -45,7 +45,7 @@ impl Command for Start {
         // Attempt to parse the input as a URL
         if let Ok(url) = url::Url::parse(path_no_whitespace) {
             open_path(url.as_str(), engine_state, stack, path.span)?;
-            return Ok(PipelineData::Empty);
+            return Ok(PipelineData::empty());
         }
         // If it's not a URL, treat it as a file path
         let cwd = engine_state.cwd(Some(stack))?;
@@ -54,7 +54,7 @@ impl Command for Start {
         // Check if the path exists or if it's a valid file/directory
         if full_path.exists() {
             open_path(full_path, engine_state, stack, path.span)?;
-            return Ok(PipelineData::Empty);
+            return Ok(PipelineData::empty());
         }
         // If neither file nor URL, return an error
         Err(ShellError::GenericError {

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -196,7 +196,7 @@ impl Command for Watch {
                         new_path.unwrap_or_else(|| "".into()).to_string_lossy(),
                         head,
                     ))
-                    .run_with_input(PipelineData::Empty);
+                    .run_with_input(PipelineData::empty());
 
                 match result {
                     Ok(val) => val.print_table(engine_state, stack, false, false)?,

--- a/crates/nu-command/src/filters/chunk_by.rs
+++ b/crates/nu-command/src/filters/chunk_by.rs
@@ -199,7 +199,7 @@ pub fn chunk_by(
     let metadata = input.metadata();
 
     match input {
-        PipelineData::Empty => Ok(PipelineData::Empty),
+        PipelineData::Empty => Ok(PipelineData::empty()),
         PipelineData::Value(Value::Range { .. }, ..)
         | PipelineData::Value(Value::List { .. }, ..)
         | PipelineData::ListStream(..) => {

--- a/crates/nu-command/src/filters/chunks.rs
+++ b/crates/nu-command/src/filters/chunks.rs
@@ -124,11 +124,11 @@ pub fn chunks(
         PipelineData::Value(Value::List { vals, .. }, metadata) => {
             let chunks = ChunksIter::new(vals, chunk_size, span);
             let stream = ListStream::new(chunks, span, engine_state.signals().clone());
-            Ok(PipelineData::ListStream(stream, metadata))
+            Ok(PipelineData::list_stream(stream, metadata))
         }
         PipelineData::ListStream(stream, metadata) => {
             let stream = stream.modify(|iter| ChunksIter::new(iter, chunk_size, span));
-            Ok(PipelineData::ListStream(stream, metadata))
+            Ok(PipelineData::list_stream(stream, metadata))
         }
         PipelineData::Value(Value::Binary { val, .. }, metadata) => {
             let chunk_read = ChunkRead {

--- a/crates/nu-command/src/filters/chunks.rs
+++ b/crates/nu-command/src/filters/chunks.rs
@@ -148,7 +148,7 @@ pub fn chunks(
         }
         PipelineData::ByteStream(stream, metadata) => {
             let pipeline_data = match stream.reader() {
-                None => PipelineData::Empty,
+                None => PipelineData::empty(),
                 Some(reader) => {
                     let chunk_read = ChunkRead {
                         reader,

--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -74,7 +74,7 @@ impl Command for Columns {
 fn getcol(head: Span, input: PipelineData) -> Result<PipelineData, ShellError> {
     let metadata = input.metadata();
     match input {
-        PipelineData::Empty => Ok(PipelineData::Empty),
+        PipelineData::Empty => Ok(PipelineData::empty()),
         PipelineData::Value(v, ..) => {
             let span = v.span();
             let cols = match v {

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -269,7 +269,7 @@ impl DefaultValue {
             DefaultValue::Uncalculated(closure) => {
                 let value = closure
                     .item
-                    .run_with_input(PipelineData::Empty)?
+                    .run_with_input(PipelineData::empty())?
                     .into_value(closure.span)?;
                 *self = DefaultValue::Calculated(value.clone());
                 Ok(value)
@@ -282,7 +282,7 @@ impl DefaultValue {
     fn single_run_pipeline_data(self) -> Result<PipelineData, ShellError> {
         match self {
             DefaultValue::Uncalculated(mut closure) => {
-                closure.item.run_with_input(PipelineData::Empty)
+                closure.item.run_with_input(PipelineData::empty())
             }
             DefaultValue::Calculated(val) => Ok(val.into_pipeline_data()),
         }

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -227,7 +227,7 @@ fn default(
         // stream's internal state already preserves the original signals config, so if this
         // Signals::empty list stream gets interrupted it will be caught by the underlying iterator
         let ls = ListStream::new(stream, span, Signals::empty());
-        Ok(PipelineData::ListStream(ls, metadata))
+        Ok(PipelineData::list_stream(ls, metadata))
     // Otherwise, return the input as is
     } else {
         Ok(input)

--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -108,7 +108,7 @@ fn drop_cols(
                         metadata,
                     ))
             } else {
-                Ok(PipelineData::Empty)
+                Ok(PipelineData::empty())
             }
         }
         PipelineData::Value(mut v, ..) => {
@@ -136,7 +136,7 @@ fn drop_cols(
                 val => Err(unsupported_value_error(&val, head)),
             }
         }
-        PipelineData::Empty => Ok(PipelineData::Empty),
+        PipelineData::Empty => Ok(PipelineData::empty()),
         PipelineData::ByteStream(stream, ..) => Err(ShellError::OnlySupportsThisInputType {
             exp_input_type: "table or record".into(),
             wrong_type: stream.type_().describe().into(),

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -106,7 +106,7 @@ with 'transpose' first."#
 
         let metadata = input.metadata();
         match input {
-            PipelineData::Empty => Ok(PipelineData::Empty),
+            PipelineData::Empty => Ok(PipelineData::empty()),
             PipelineData::Value(Value::Range { .. }, ..)
             | PipelineData::Value(Value::List { .. }, ..)
             | PipelineData::ListStream(..) => {
@@ -164,7 +164,7 @@ with 'transpose' first."#
                         })
                         .into_pipeline_data(head, engine_state.signals().clone()))
                 } else {
-                    Ok(PipelineData::Empty)
+                    Ok(PipelineData::empty())
                 }
             }
             // This match allows non-iterables to be accepted,

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -28,7 +28,7 @@ pub fn empty(
         }
     } else {
         match input {
-            PipelineData::Empty => Ok(PipelineData::Empty),
+            PipelineData::Empty => Ok(PipelineData::empty()),
             PipelineData::ByteStream(stream, ..) => {
                 let span = stream.span();
                 match stream.reader() {

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -448,7 +448,7 @@ fn find_in_pipelinedata(
     let map_columns_to_search = columns_to_search.clone();
 
     match input {
-        PipelineData::Empty => Ok(PipelineData::Empty),
+        PipelineData::Empty => Ok(PipelineData::empty()),
         PipelineData::Value(_, _) => input
             .filter(
                 move |value| {
@@ -489,7 +489,7 @@ fn find_in_pipelinedata(
                 }
                 Ok(Value::list(output, span).into_pipeline_data())
             } else {
-                Ok(PipelineData::Empty)
+                Ok(PipelineData::empty())
             }
         }
     }

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -470,7 +470,7 @@ fn find_in_pipelinedata(
                 .map(move |x| highlight_matches_in_value(&map_pattern, x, &map_columns_to_search))
             });
 
-            Ok(PipelineData::ListStream(stream, metadata))
+            Ok(PipelineData::list_stream(stream, metadata))
         }
         PipelineData::ByteStream(stream, ..) => {
             let span = stream.span();

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -202,7 +202,7 @@ fn first_helper(
                         ))
                     }
                 } else {
-                    Ok(PipelineData::Empty)
+                    Ok(PipelineData::empty())
                 }
             } else {
                 Err(ShellError::OnlySupportsThisInputType {

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -167,7 +167,7 @@ fn first_helper(
                     Err(ShellError::AccessEmptyContent { span: head })
                 }
             } else {
-                Ok(PipelineData::ListStream(
+                Ok(PipelineData::list_stream(
                     stream.modify(|iter| iter.take(rows)),
                     metadata,
                 ))

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -191,7 +191,7 @@ fn first_helper(
                         }
                     } else {
                         // Just take 'rows' bytes off the stream, mimicking the binary behavior
-                        Ok(PipelineData::ByteStream(
+                        Ok(PipelineData::byte_stream(
                             ByteStream::read(
                                 reader.take(rows as u64),
                                 head,

--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -264,7 +264,7 @@ fn insert(
                         value
                     }
                 });
-                Ok(PipelineData::ListStream(stream, metadata))
+                Ok(PipelineData::list_stream(stream, metadata))
             } else {
                 let stream = stream.map(move |mut value| {
                     if let Err(e) = value.insert_data_at_cell_path(
@@ -278,7 +278,7 @@ fn insert(
                     }
                 });
 
-                Ok(PipelineData::ListStream(stream, metadata))
+                Ok(PipelineData::list_stream(stream, metadata))
             }
         }
         PipelineData::Empty => Err(ShellError::IncompatiblePathAccess {

--- a/crates/nu-command/src/filters/interleave.rs
+++ b/crates/nu-command/src/filters/interleave.rs
@@ -120,7 +120,7 @@ interleave
             .into_iter()
             .chain(closures.into_iter().map(|closure| {
                 ClosureEvalOnce::new(engine_state, stack, closure)
-                    .run_with_input(PipelineData::Empty)
+                    .run_with_input(PipelineData::empty())
             }))
             .try_for_each(|stream| {
                 stream.and_then(|stream| {

--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -42,7 +42,7 @@ impl Command for Items {
 
         let metadata = input.metadata();
         match input {
-            PipelineData::Empty => Ok(PipelineData::Empty),
+            PipelineData::Empty => Ok(PipelineData::empty()),
             PipelineData::Value(value, ..) => {
                 let span = value.span();
                 match value {
@@ -55,7 +55,7 @@ impl Command for Items {
                                 let result = closure
                                     .add_arg(Value::string(col, span))
                                     .add_arg(val)
-                                    .run_with_input(PipelineData::Empty)
+                                    .run_with_input(PipelineData::empty())
                                     .and_then(|data| data.into_value(head));
 
                                 match result {

--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -85,7 +85,7 @@ impl Command for Join {
                 Value::String { val: r_on, .. },
             ) => {
                 let result = join(rows_1, rows_2, l_on, r_on, join_type, span);
-                Ok(PipelineData::Value(result, metadata))
+                Ok(PipelineData::value(result, metadata))
             }
             _ => Err(ShellError::UnsupportedInput {
                 msg: "(PipelineData<table>, table, string, string)".into(),

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -186,7 +186,7 @@ impl Command for Last {
                             }
                         }
                     } else {
-                        Ok(PipelineData::Empty)
+                        Ok(PipelineData::empty())
                     }
                 } else {
                     Err(ShellError::OnlySupportsThisInputType {

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -57,7 +57,7 @@ impl Command for Lines {
                     src_span: value.span(),
                 }),
             },
-            PipelineData::Empty => Ok(PipelineData::Empty),
+            PipelineData::Empty => Ok(PipelineData::empty()),
             PipelineData::ListStream(stream, metadata) => {
                 let stream = stream.modify(|iter| {
                     iter.filter_map(move |value| {

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -81,7 +81,7 @@ impl Command for Lines {
                     .flatten()
                 });
 
-                Ok(PipelineData::ListStream(stream, metadata))
+                Ok(PipelineData::list_stream(stream, metadata))
             }
             PipelineData::ByteStream(stream, ..) => {
                 if let Some(lines) = stream.lines() {

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -130,7 +130,7 @@ impl Command for ParEach {
         };
 
         match input {
-            PipelineData::Empty => Ok(PipelineData::Empty),
+            PipelineData::Empty => Ok(PipelineData::empty()),
             PipelineData::Value(value, ..) => {
                 let span = value.span();
                 match value {

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -123,7 +123,7 @@ impl Command for Reduce {
             acc = closure
                 .add_arg(value)
                 .add_arg(acc.clone())
-                .run_with_input(PipelineData::Value(acc, None))?
+                .run_with_input(PipelineData::value(acc, None))?
                 .into_value(head)?;
         }
 

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -94,7 +94,7 @@ impl Command for Skip {
             PipelineData::ByteStream(stream, metadata) => {
                 if stream.type_().is_binary_coercible() {
                     let span = stream.span();
-                    Ok(PipelineData::ByteStream(
+                    Ok(PipelineData::byte_stream(
                         stream.skip(span, n as u64)?,
                         metadata,
                     ))

--- a/crates/nu-command/src/filters/slice.rs
+++ b/crates/nu-command/src/filters/slice.rs
@@ -81,7 +81,7 @@ impl Command for Slice {
             };
 
             if count == 0 {
-                Ok(PipelineData::Value(Value::list(vec![], head), None))
+                Ok(PipelineData::value(Value::list(vec![], head), None))
             } else {
                 let iter = v.into_iter().skip(from).take(count);
                 Ok(iter.into_pipeline_data(head, engine_state.signals().clone()))
@@ -102,7 +102,7 @@ impl Command for Slice {
             };
 
             if count == 0 {
-                Ok(PipelineData::Value(Value::list(vec![], head), None))
+                Ok(PipelineData::value(Value::list(vec![], head), None))
             } else {
                 let iter = input.into_iter().skip(from).take(count);
                 Ok(iter.into_pipeline_data(head, engine_state.signals().clone()))

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -62,7 +62,7 @@ impl Command for Take {
                         )),
                     Value::Binary { val, .. } => {
                         let slice: Vec<u8> = val.into_iter().take(rows_desired).collect();
-                        Ok(PipelineData::Value(Value::binary(slice, span), metadata))
+                        Ok(PipelineData::value(Value::binary(slice, span), metadata))
                     }
                     Value::Range { val, .. } => Ok(val
                         .into_range_iter(span, Signals::empty())

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -89,7 +89,7 @@ impl Command for Take {
             PipelineData::ByteStream(stream, metadata) => {
                 if stream.type_().is_binary_coercible() {
                     let span = stream.span();
-                    Ok(PipelineData::ByteStream(
+                    Ok(PipelineData::byte_stream(
                         stream.take(span, rows_desired as u64)?,
                         metadata,
                     ))

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -82,7 +82,7 @@ impl Command for Take {
                     }),
                 }
             }
-            PipelineData::ListStream(stream, metadata) => Ok(PipelineData::ListStream(
+            PipelineData::ListStream(stream, metadata) => Ok(PipelineData::list_stream(
                 stream.modify(|iter| iter.take(rows_desired)),
                 metadata,
             )),

--- a/crates/nu-command/src/filters/tee.rs
+++ b/crates/nu-command/src/filters/tee.rs
@@ -243,7 +243,7 @@ use it in your pipeline."#
                             thread.join().unwrap_or_else(|_| Err(panic_error()))?;
                         }
                         child.wait()?;
-                        Ok(PipelineData::Empty)
+                        Ok(PipelineData::empty())
                     }
                 }
             }

--- a/crates/nu-command/src/filters/tee.rs
+++ b/crates/nu-command/src/filters/tee.rs
@@ -138,7 +138,7 @@ use it in your pipeline."#
                     let tee_thread = spawn_tee(info, eval_block)?;
                     let tee = IoTee::new(read, tee_thread);
 
-                    Ok(PipelineData::ByteStream(
+                    Ok(PipelineData::byte_stream(
                         ByteStream::read(tee, span, engine_state.signals().clone(), type_),
                         metadata,
                     ))
@@ -151,7 +151,7 @@ use it in your pipeline."#
                     let tee_thread = spawn_tee(info, eval_block)?;
                     let tee = IoTee::new(file, tee_thread);
 
-                    Ok(PipelineData::ByteStream(
+                    Ok(PipelineData::byte_stream(
                         ByteStream::read(tee, span, engine_state.signals().clone(), type_),
                         metadata,
                     ))
@@ -234,7 +234,7 @@ use it in your pipeline."#
                     };
 
                     if child.stdout.is_some() || child.stderr.is_some() {
-                        Ok(PipelineData::ByteStream(
+                        Ok(PipelineData::byte_stream(
                             ByteStream::child(*child, span),
                             metadata,
                         ))
@@ -439,7 +439,7 @@ fn spawn_tee(
                 Signals::empty(),
                 info.type_,
             );
-            eval_block(PipelineData::ByteStream(stream, info.metadata))
+            eval_block(PipelineData::byte_stream(stream, info.metadata))
         })
         .map_err(|err| {
             IoError::new_with_additional_context(err, info.span, None, "Could not spawn tee")

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -293,7 +293,7 @@ pub fn transpose(
         })
         .collect::<Vec<Value>>();
     if result_data.len() == 1 && args.as_record {
-        Ok(PipelineData::Value(
+        Ok(PipelineData::value(
             result_data
                 .pop()
                 .expect("already check result only contains one item"),

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -210,7 +210,7 @@ fn update(
                     }
                 });
 
-                Ok(PipelineData::ListStream(stream, metadata))
+                Ok(PipelineData::list_stream(stream, metadata))
             } else {
                 let stream = stream.map(move |mut value| {
                     if let Err(e) =
@@ -222,7 +222,7 @@ fn update(
                     }
                 });
 
-                Ok(PipelineData::ListStream(stream, metadata))
+                Ok(PipelineData::list_stream(stream, metadata))
             }
         }
         PipelineData::Empty => Err(ShellError::IncompatiblePathAccess {

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -288,7 +288,7 @@ fn upsert(
                     }
                 });
 
-                Ok(PipelineData::ListStream(stream, metadata))
+                Ok(PipelineData::list_stream(stream, metadata))
             } else {
                 let stream = stream.map(move |mut value| {
                     if let Err(e) =
@@ -300,7 +300,7 @@ fn upsert(
                     }
                 });
 
-                Ok(PipelineData::ListStream(stream, metadata))
+                Ok(PipelineData::list_stream(stream, metadata))
             }
         }
         PipelineData::Empty => Err(ShellError::IncompatiblePathAccess {

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -335,7 +335,7 @@ fn upsert_value_by_closure(
     let input = value_at_path
         .map(Cow::into_owned)
         .map(IntoPipelineData::into_pipeline_data)
-        .unwrap_or(PipelineData::Empty);
+        .unwrap_or(PipelineData::empty());
 
     let new_value = closure
         .add_arg(arg)
@@ -366,7 +366,7 @@ fn upsert_single_value_by_closure(
     let input = value_at_path
         .map(Cow::into_owned)
         .map(IntoPipelineData::into_pipeline_data)
-        .unwrap_or(PipelineData::Empty);
+        .unwrap_or(PipelineData::empty());
 
     let new_value = closure
         .add_arg(arg)

--- a/crates/nu-command/src/filters/values.rs
+++ b/crates/nu-command/src/filters/values.rs
@@ -137,7 +137,7 @@ fn values(
     let signals = engine_state.signals().clone();
     let metadata = input.metadata();
     match input {
-        PipelineData::Empty => Ok(PipelineData::Empty),
+        PipelineData::Empty => Ok(PipelineData::empty()),
         PipelineData::Value(v, ..) => {
             let span = v.span();
             match v {

--- a/crates/nu-command/src/filters/window.rs
+++ b/crates/nu-command/src/filters/window.rs
@@ -120,12 +120,12 @@ impl Command for Window {
                 PipelineData::Value(Value::List { vals, .. }, metadata) => {
                     let chunks = WindowGapIter::new(vals, size, stride, remainder, head);
                     let stream = ListStream::new(chunks, head, engine_state.signals().clone());
-                    Ok(PipelineData::ListStream(stream, metadata))
+                    Ok(PipelineData::list_stream(stream, metadata))
                 }
                 PipelineData::ListStream(stream, metadata) => {
                     let stream = stream
                         .modify(|iter| WindowGapIter::new(iter, size, stride, remainder, head));
-                    Ok(PipelineData::ListStream(stream, metadata))
+                    Ok(PipelineData::list_stream(stream, metadata))
                 }
                 input => Err(input.unsupported_input_error("list", head)),
             }
@@ -134,12 +134,12 @@ impl Command for Window {
                 PipelineData::Value(Value::List { vals, .. }, metadata) => {
                     let chunks = WindowOverlapIter::new(vals, size, stride, remainder, head);
                     let stream = ListStream::new(chunks, head, engine_state.signals().clone());
-                    Ok(PipelineData::ListStream(stream, metadata))
+                    Ok(PipelineData::list_stream(stream, metadata))
                 }
                 PipelineData::ListStream(stream, metadata) => {
                     let stream = stream
                         .modify(|iter| WindowOverlapIter::new(iter, size, stride, remainder, head));
-                    Ok(PipelineData::ListStream(stream, metadata))
+                    Ok(PipelineData::list_stream(stream, metadata))
                 }
                 input => Err(input.unsupported_input_error("list", head)),
             }

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -36,7 +36,7 @@ impl Command for Wrap {
         let metadata = input.metadata();
 
         match input {
-            PipelineData::Empty => Ok(PipelineData::Empty),
+            PipelineData::Empty => Ok(PipelineData::empty()),
             PipelineData::Value(Value::Range { .. }, ..)
             | PipelineData::Value(Value::List { .. }, ..)
             | PipelineData::ListStream { .. } => Ok(input

--- a/crates/nu-command/src/filters/zip.rs
+++ b/crates/nu-command/src/filters/zip.rs
@@ -103,7 +103,7 @@ impl Command for Zip {
         let metadata = input.metadata();
         let other = if let Value::Closure { val, .. } = other {
             // If a closure was provided, evaluate it and consume its stream output
-            ClosureEvalOnce::new(engine_state, stack, *val).run_with_input(PipelineData::Empty)?
+            ClosureEvalOnce::new(engine_state, stack, *val).run_with_input(PipelineData::empty())?
         } else {
             other.into_pipeline_data()
         };

--- a/crates/nu-command/src/formats/from/delimited.rs
+++ b/crates/nu-command/src/formats/from/delimited.rs
@@ -95,7 +95,7 @@ pub(super) fn from_delimited_data(
 ) -> Result<PipelineData, ShellError> {
     let metadata = input.metadata().map(|md| md.with_content_type(None));
     match input {
-        PipelineData::Empty => Ok(PipelineData::Empty),
+        PipelineData::Empty => Ok(PipelineData::empty()),
         PipelineData::Value(value, ..) => {
             let string = value.into_string()?;
             let byte_stream = ByteStream::read_string(string, name, Signals::empty());

--- a/crates/nu-command/src/formats/from/delimited.rs
+++ b/crates/nu-command/src/formats/from/delimited.rs
@@ -99,7 +99,7 @@ pub(super) fn from_delimited_data(
         PipelineData::Value(value, ..) => {
             let string = value.into_string()?;
             let byte_stream = ByteStream::read_string(string, name, Signals::empty());
-            Ok(PipelineData::ListStream(
+            Ok(PipelineData::list_stream(
                 from_delimited_stream(config, byte_stream, name)?,
                 metadata,
             ))
@@ -110,7 +110,7 @@ pub(super) fn from_delimited_data(
             dst_span: name,
             src_span: list_stream.span(),
         }),
-        PipelineData::ByteStream(byte_stream, ..) => Ok(PipelineData::ListStream(
+        PipelineData::ByteStream(byte_stream, ..) => Ok(PipelineData::list_stream(
             from_delimited_stream(config, byte_stream, name)?,
             metadata,
         )),

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -94,7 +94,7 @@ impl Command for FromJson {
                             metadata,
                         ))
                     } else {
-                        Ok(PipelineData::Empty)
+                        Ok(PipelineData::empty())
                     }
                 }
                 _ => Err(ShellError::OnlySupportsThisInputType {

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -76,20 +76,22 @@ impl Command for FromJson {
         if call.has_flag(engine_state, stack, "objects")? {
             // Return a stream of JSON values, one for each non-empty line
             match input {
-                PipelineData::Value(Value::String { val, .. }, ..) => Ok(PipelineData::ListStream(
-                    read_json_lines(
-                        Cursor::new(val),
-                        span,
-                        strict,
-                        engine_state.signals().clone(),
-                    ),
-                    metadata,
-                )),
+                PipelineData::Value(Value::String { val, .. }, ..) => {
+                    Ok(PipelineData::list_stream(
+                        read_json_lines(
+                            Cursor::new(val),
+                            span,
+                            strict,
+                            engine_state.signals().clone(),
+                        ),
+                        metadata,
+                    ))
+                }
                 PipelineData::ByteStream(stream, ..)
                     if stream.type_() != ByteStreamType::Binary =>
                 {
                     if let Some(reader) = stream.reader() {
-                        Ok(PipelineData::ListStream(
+                        Ok(PipelineData::list_stream(
                             read_json_lines(reader, span, strict, Signals::empty()),
                             metadata,
                         ))

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -168,7 +168,7 @@ fn from_ods(
         }
     }
 
-    Ok(PipelineData::Value(
+    Ok(PipelineData::value(
         Value::record(dict.into_iter().collect(), head),
         None,
     ))

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -181,7 +181,7 @@ fn from_xlsx(
         }
     }
 
-    Ok(PipelineData::Value(
+    Ok(PipelineData::value(
         Value::record(dict.into_iter().collect(), head),
         None,
     ))

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -181,5 +181,5 @@ pub fn to_delimited_data(
         },
     );
 
-    Ok(PipelineData::ByteStream(stream, metadata))
+    Ok(PipelineData::byte_stream(stream, metadata))
 }

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -132,7 +132,7 @@ pub fn to_delimited_data(
                 Value::Record { val, .. } => val.columns().cloned().collect(),
                 _ => return Err(make_unsupported_input_error(value.get_type(), head, span)),
             };
-            input = PipelineData::Value(value, metadata.clone());
+            input = PipelineData::value(value, metadata.clone());
             columns
         }
     };

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -76,7 +76,7 @@ impl Command for ToJson {
                     data_source: nu_protocol::DataSource::None,
                     content_type: Some(mime::APPLICATION_JSON.to_string()),
                 };
-                Ok(PipelineData::Value(res, Some(metadata)))
+                Ok(PipelineData::value(res, Some(metadata)))
             }
             _ => Err(ShellError::CantConvert {
                 to_type: "JSON".into(),

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -121,10 +121,10 @@ impl Command for ToText {
                     )
                 };
 
-                Ok(PipelineData::ByteStream(stream, update_metadata(meta)))
+                Ok(PipelineData::byte_stream(stream, update_metadata(meta)))
             }
             PipelineData::ByteStream(stream, meta) => {
-                Ok(PipelineData::ByteStream(stream, update_metadata(meta)))
+                Ok(PipelineData::byte_stream(stream, update_metadata(meta)))
             }
         }
     }

--- a/crates/nu-command/src/generators/generate.rs
+++ b/crates/nu-command/src/generators/generate.rs
@@ -112,7 +112,7 @@ In this case, generation also stops when the input stream stops."#
 
                     let closure_result = closure
                         .add_arg(state_arg)
-                        .run_with_input(PipelineData::Empty);
+                        .run_with_input(PipelineData::empty());
                     let (output, next_input) = parse_closure_result(closure_result, head);
 
                     // We use `state` to control when to stop, not `output`. By wrapping
@@ -135,7 +135,7 @@ In this case, generation also stops when the input stream stops."#
                     let closure_result = closure
                         .add_arg(item)
                         .add_arg(state_arg)
-                        .run_with_input(PipelineData::Empty);
+                        .run_with_input(PipelineData::empty());
                     let (output, next_input) = parse_closure_result(closure_result, head);
                     state = next_input;
                     Some(output)

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -76,7 +76,7 @@ pub fn calculate(
         PipelineData::Value(Value::List { ref vals, .. }, ..) => match &vals[..] {
             [Value::Record { .. }, _end @ ..] => helper_for_tables(
                 vals,
-                values.span().expect("PipelineData::Value had no span"),
+                values.span().expect("PipelineData::value had no span"),
                 name,
                 mf,
             ),

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -143,7 +143,7 @@ pub fn response_to_buffer(
 
     let reader = response.into_reader();
 
-    PipelineData::ByteStream(
+    PipelineData::byte_stream(
         ByteStream::read(reader, span, engine_state.signals().clone(), response_type)
             .with_known_size(buffer_size),
         None,

--- a/crates/nu-command/src/network/url/parse.rs
+++ b/crates/nu-command/src/network/url/parse.rs
@@ -117,7 +117,7 @@ fn parse(value: Value, head: Span, config: &Config) -> Result<PipelineData, Shel
         "params" => params,
     };
 
-    Ok(PipelineData::Value(Value::record(record, head), None))
+    Ok(PipelineData::value(Value::record(record, head), None))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/network/url/split_query.rs
+++ b/crates/nu-command/src/network/url/split_query.rs
@@ -89,7 +89,7 @@ impl Command for UrlSplitQuery {
         let span = value.span();
         let query = value.to_expanded_string("", &stack.get_config(engine_state));
         let table = query_string_to_table(&query, call.head, span)?;
-        Ok(PipelineData::Value(table, None))
+        Ok(PipelineData::value(table, None))
     }
 }
 

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -168,12 +168,12 @@ fn run(call: &Call, args: &Arguments, input: PipelineData) -> Result<PipelineDat
     let metadata = input.metadata();
 
     match input {
-        PipelineData::Value(val, md) => Ok(PipelineData::Value(handle_value(val, args, head), md)),
-        PipelineData::ListStream(stream, ..) => Ok(PipelineData::Value(
+        PipelineData::Value(val, md) => Ok(PipelineData::value(handle_value(val, args, head), md)),
+        PipelineData::ListStream(stream, ..) => Ok(PipelineData::value(
             handle_value(stream.into_value(), args, head),
             metadata,
         )),
-        PipelineData::ByteStream(stream, ..) => Ok(PipelineData::Value(
+        PipelineData::ByteStream(stream, ..) => Ok(PipelineData::value(
             handle_value(stream.into_value()?, args, head),
             metadata,
         )),

--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -66,7 +66,7 @@ impl Command for Clear {
             }
         };
 
-        Ok(PipelineData::Empty)
+        Ok(PipelineData::empty())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/platform/is_terminal.rs
+++ b/crates/nu-command/src/platform/is_terminal.rs
@@ -63,7 +63,7 @@ impl Command for IsTerminal {
             }
         };
 
-        Ok(PipelineData::Value(
+        Ok(PipelineData::value(
             Value::bool(is_terminal, call.head),
             None,
         ))

--- a/crates/nu-command/src/platform/ulimit.rs
+++ b/crates/nu-command/src/platform/ulimit.rs
@@ -555,7 +555,7 @@ impl Command for ULimit {
                 set_limits(&limit_value, &res, hard, soft, call.head)?;
             }
 
-            Ok(PipelineData::Empty)
+            Ok(PipelineData::empty())
         } else {
             print_limits(call, engine_state, stack, all, soft, hard)
         }

--- a/crates/nu-command/src/random/bool.rs
+++ b/crates/nu-command/src/random/bool.rs
@@ -78,7 +78,7 @@ fn bool(
 
     let bool_result: bool = random_bool(probability);
 
-    Ok(PipelineData::Value(Value::bool(bool_result, span), None))
+    Ok(PipelineData::value(Value::bool(bool_result, span), None))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/random/byte_stream.rs
+++ b/crates/nu-command/src/random/byte_stream.rs
@@ -24,7 +24,7 @@ pub(super) fn random_byte_stream(
 
     const OUTPUT_CHUNK_SIZE: usize = 8192;
     let mut remaining_bytes = length;
-    PipelineData::ByteStream(
+    PipelineData::byte_stream(
         ByteStream::from_fn(span, signals.clone(), stream_type, move |out| {
             if remaining_bytes == 0 || signals.interrupted() {
                 return Ok(false);

--- a/crates/nu-command/src/random/float.rs
+++ b/crates/nu-command/src/random/float.rs
@@ -93,9 +93,9 @@ fn float(
                 Bound::Unbounded => random_range(range.start()..f64::MAX),
             };
 
-            Ok(PipelineData::Value(Value::float(value, span), None))
+            Ok(PipelineData::value(Value::float(value, span), None))
         }
-        None => Ok(PipelineData::Value(
+        None => Ok(PipelineData::value(
             Value::float(random_range(0.0..1.0), span),
             None,
         )),

--- a/crates/nu-command/src/random/int.rs
+++ b/crates/nu-command/src/random/int.rs
@@ -97,7 +97,7 @@ fn integer(
                         Bound::Unbounded => random_range(range.start()..=i64::MAX),
                     };
 
-                    Ok(PipelineData::Value(Value::int(value, span), None))
+                    Ok(PipelineData::value(Value::int(value, span), None))
                 }
                 Range::FloatRange(_) => Err(ShellError::UnsupportedInput {
                     msg: "float range".into(),
@@ -107,7 +107,7 @@ fn integer(
                 }),
             }
         }
-        None => Ok(PipelineData::Value(
+        None => Ok(PipelineData::value(
             Value::int(random_range(0..=i64::MAX), span),
             None,
         )),

--- a/crates/nu-command/src/random/uuid.rs
+++ b/crates/nu-command/src/random/uuid.rs
@@ -143,7 +143,7 @@ fn uuid(
         }
     };
 
-    Ok(PipelineData::Value(Value::string(uuid_str, span), None))
+    Ok(PipelineData::value(Value::string(uuid_str, span), None))
 }
 
 fn validate_flags(

--- a/crates/nu-command/src/sort_utils.rs
+++ b/crates/nu-command/src/sort_utils.rs
@@ -270,7 +270,7 @@ pub fn compare_custom_closure(
     closure_eval
         .add_arg(left.clone())
         .add_arg(right.clone())
-        .run_with_input(PipelineData::Value(
+        .run_with_input(PipelineData::value(
             Value::list(vec![left.clone(), right.clone()], span),
             None,
         ))

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -160,7 +160,7 @@ fn run(
 ) -> Result<PipelineData, ShellError> {
     let head = call.head;
     if list {
-        return Ok(PipelineData::Value(
+        return Ok(PipelineData::value(
             generate_strftime_list(head, false),
             None,
         ));

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -195,7 +195,7 @@ fn operate(
         .collect::<Vec<_>>();
 
     match input {
-        PipelineData::Empty => Ok(PipelineData::Empty),
+        PipelineData::Empty => Ok(PipelineData::empty()),
         PipelineData::Value(value, ..) => match value {
             Value::String { val, .. } => {
                 let captures = regex
@@ -270,7 +270,7 @@ fn operate(
 
                 Ok(ListStream::new(iter, head, Signals::empty()).into())
             } else {
-                Ok(PipelineData::Empty)
+                Ok(PipelineData::empty())
             }
         }
     }

--- a/crates/nu-command/src/strings/str_/join.rs
+++ b/crates/nu-command/src/strings/str_/join.rs
@@ -128,7 +128,7 @@ fn run(
         },
     );
 
-    Ok(PipelineData::ByteStream(output, metadata))
+    Ok(PipelineData::byte_stream(output, metadata))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -234,10 +234,10 @@ fn check_parse(
                 inner: vec![],
             })
         } else {
-            Ok(PipelineData::Value(Value::bool(false, call_head), None))
+            Ok(PipelineData::value(Value::bool(false, call_head), None))
         }
     } else {
-        Ok(PipelineData::Value(Value::bool(true, call_head), None))
+        Ok(PipelineData::value(Value::bool(true, call_head), None))
     }
 }
 
@@ -289,10 +289,10 @@ fn parse_file_or_dir_module(
                 inner: vec![],
             })
         } else {
-            Ok(PipelineData::Value(Value::bool(false, call_head), None))
+            Ok(PipelineData::value(Value::bool(false, call_head), None))
         }
     } else {
-        Ok(PipelineData::Value(Value::bool(true, call_head), None))
+        Ok(PipelineData::value(Value::bool(true, call_head), None))
     }
 }
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -793,12 +793,12 @@ mod test {
         assert_eq!(buf, b"");
 
         let mut buf = vec![];
-        let input = PipelineData::Value(Value::string("foo", Span::unknown()), None);
+        let input = PipelineData::value(Value::string("foo", Span::unknown()), None);
         write_pipeline_data(engine_state.clone(), stack.clone(), input, &mut buf).unwrap();
         assert_eq!(buf, b"foo");
 
         let mut buf = vec![];
-        let input = PipelineData::Value(Value::binary(b"foo", Span::unknown()), None);
+        let input = PipelineData::value(Value::binary(b"foo", Span::unknown()), None);
         write_pipeline_data(engine_state.clone(), stack.clone(), input, &mut buf).unwrap();
         assert_eq!(buf, b"foo");
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -788,7 +788,7 @@ mod test {
         engine_state.add_env_var("PWD".into(), Value::string(cwd, Span::test_data()));
 
         let mut buf = vec![];
-        let input = PipelineData::Empty;
+        let input = PipelineData::empty();
         write_pipeline_data(engine_state.clone(), stack.clone(), input, &mut buf).unwrap();
         assert_eq!(buf, b"");
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -246,7 +246,7 @@ impl Command for External {
                 }
                 Err(stream) => {
                     command.stdin(Stdio::piped());
-                    Some(PipelineData::ByteStream(stream, metadata))
+                    Some(PipelineData::byte_stream(stream, metadata))
                 }
             },
             PipelineData::Empty => {
@@ -313,7 +313,7 @@ impl Command for External {
 
         let child_pid = child.pid();
 
-        // Wrap the output into a `PipelineData::ByteStream`.
+        // Wrap the output into a `PipelineData::byte_stream`.
         let mut child = ChildProcess::new(
             child,
             merged_stream,
@@ -336,7 +336,7 @@ impl Command for External {
             child.ignore_error(true);
         }
 
-        Ok(PipelineData::ByteStream(
+        Ok(PipelineData::byte_stream(
             ByteStream::child(child, call.head),
             None,
         ))
@@ -478,7 +478,7 @@ fn resolve_globbed_path_to_cwd_relative(
 ///
 /// Note: Avoid using this function when piping data from an external command to
 /// another external command, because it copies data unnecessarily. Instead,
-/// extract the pipe from the `PipelineData::ByteStream` of the first command
+/// extract the pipe from the `PipelineData::byte_stream` of the first command
 /// and hand it to the second command directly.
 fn write_pipeline_data(
     mut engine_state: EngineState,
@@ -803,7 +803,7 @@ mod test {
         assert_eq!(buf, b"foo");
 
         let mut buf = vec![];
-        let input = PipelineData::ByteStream(
+        let input = PipelineData::byte_stream(
             ByteStream::read(
                 b"foo".as_slice(),
                 Span::unknown(),

--- a/crates/nu-command/src/system/uname.rs
+++ b/crates/nu-command/src/system/uname.rs
@@ -69,7 +69,7 @@ impl Command for UName {
                     .to_string())
             })
             .collect::<Result<Vec<String>, ShellError>>()?;
-        Ok(PipelineData::Value(
+        Ok(PipelineData::value(
             Value::record(
                 record! {
                     "kernel-name" => Value::string(outputs[0].clone(), span),

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -424,13 +424,13 @@ fn handle_table_command(mut input: CmdInput<'_>) -> ShellResult<PipelineData> {
     match input.data {
         // Binary streams should behave as if they really are `binary` data, and printed as hex
         PipelineData::ByteStream(stream, _) if stream.type_() == ByteStreamType::Binary => Ok(
-            PipelineData::ByteStream(pretty_hex_stream(stream, input.call.head), None),
+            PipelineData::byte_stream(pretty_hex_stream(stream, input.call.head), None),
         ),
         PipelineData::ByteStream(..) => Ok(input.data),
         PipelineData::Value(Value::Binary { val, .. }, ..) => {
             let signals = input.engine_state.signals().clone();
             let stream = ByteStream::read_binary(val, input.call.head, signals);
-            Ok(PipelineData::ByteStream(
+            Ok(PipelineData::byte_stream(
                 pretty_hex_stream(stream, input.call.head),
                 None,
             ))
@@ -761,7 +761,7 @@ fn handle_row_stream(
         Signals::empty(),
         ByteStreamType::String,
     );
-    Ok(PipelineData::ByteStream(stream, None))
+    Ok(PipelineData::byte_stream(stream, None))
 }
 
 fn make_clickable_link(

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -439,16 +439,16 @@ fn handle_table_command(mut input: CmdInput<'_>) -> ShellResult<PipelineData> {
         PipelineData::Value(Value::List { vals, .. }, metadata) => {
             let signals = input.engine_state.signals().clone();
             let stream = ListStream::new(vals.into_iter(), span, signals);
-            input.data = PipelineData::Empty;
+            input.data = PipelineData::empty();
 
             handle_row_stream(input, stream, metadata)
         }
         PipelineData::ListStream(stream, metadata) => {
-            input.data = PipelineData::Empty;
+            input.data = PipelineData::empty();
             handle_row_stream(input, stream, metadata)
         }
         PipelineData::Value(Value::Record { val, .. }, ..) => {
-            input.data = PipelineData::Empty;
+            input.data = PipelineData::empty();
             handle_record(input, val.into_owned())
         }
         PipelineData::Value(Value::Error { error, .. }, ..) => {
@@ -464,7 +464,7 @@ fn handle_table_command(mut input: CmdInput<'_>) -> ShellResult<PipelineData> {
             let signals = input.engine_state.signals().clone();
             let stream =
                 ListStream::new(val.into_range_iter(span, Signals::empty()), span, signals);
-            input.data = PipelineData::Empty;
+            input.data = PipelineData::empty();
             handle_row_stream(input, stream, metadata)
         }
         x => Ok(x),

--- a/crates/nu-command/tests/commands/start.rs
+++ b/crates/nu-command/tests/commands/start.rs
@@ -2,9 +2,9 @@ use super::*;
 use nu_engine::test_help::{convert_single_value_to_cmd_args, eval_block_with_input};
 use nu_engine::{current_dir, eval_expression};
 use nu_protocol::{
+    PipelineData, Span, Spanned, Type, Value,
     ast::Call,
     engine::{EngineState, Stack, StateWorkingSet},
-    PipelineData, Span, Spanned, Type, Value,
 };
 use std::path::PathBuf;
 
@@ -33,19 +33,14 @@ fn test_start_valid_url() {
 
     // Create call for: `start https://www.example.com`
     let path = "https://www.example.com".to_string();
-    let span = Span::test_data(); 
+    let span = Span::test_data();
     let call = Call::test(
         "start",
         // The arguments for `start` are just the path in this case
         vec![Value::string(path, span)],
     );
 
-    let result = Start.run(
-        &engine_state,
-        &mut stack,
-        &call,
-        PipelineData::Empty,
-    );
+    let result = Start.run(&engine_state, &mut stack, &call, PipelineData::empty);
 
     assert!(
         result.is_ok(),
@@ -61,17 +56,9 @@ fn test_start_valid_local_path() {
     // Here we'll simulate opening the current directory (`.`).
     let path = ".".to_string();
     let span = Span::test_data();
-    let call = Call::test(
-        "start",
-        vec![Value::string(path, span)],
-    );
+    let call = Call::test("start", vec![Value::string(path, span)]);
 
-    let result = Start.run(
-        &engine_state,
-        &mut stack,
-        &call,
-        PipelineData::Empty,
-    );
+    let result = Start.run(&engine_state, &mut stack, &call, PipelineData::empty);
 
     // If the environment is correctly set, it should succeed.
     // If you're running in a CI environment or restricted environment
@@ -90,17 +77,9 @@ fn test_start_nonexistent_local_path() {
     // Create an obviously invalid path
     let path = "this_file_does_not_exist_hopefully.txt".to_string();
     let span = Span::test_data();
-    let call = Call::test(
-        "start",
-        vec![Value::string(path, span)],
-    );
+    let call = Call::test("start", vec![Value::string(path, span)]);
 
-    let result = Start.run(
-        &engine_state,
-        &mut stack,
-        &call,
-        PipelineData::Empty,
-    );
+    let result = Start.run(&engine_state, &mut stack, &call, PipelineData::empty);
 
     // We expect an error since the file does not exist
     assert!(
@@ -118,3 +97,4 @@ fn test_start_nonexistent_local_path() {
         panic!("Unexpected error type, expected ShellError::GenericError");
     }
 }
+

--- a/crates/nu-engine/src/closure_eval.rs
+++ b/crates/nu-engine/src/closure_eval.rs
@@ -37,7 +37,7 @@ fn eval_fn(debug: bool) -> EvalBlockWithEarlyReturnFn {
 /// let mut closure = ClosureEval::new(engine_state, stack, closure);
 /// let iter = Vec::<Value>::new()
 ///     .into_iter()
-///     .map(move |value| closure.add_arg(value).run_with_input(PipelineData::Empty));
+///     .map(move |value| closure.add_arg(value).run_with_input(PipelineData::empty()));
 /// ```
 ///
 /// Many closures follow a simple, common scheme where the pipeline input and the first argument are the same value.
@@ -175,7 +175,7 @@ impl ClosureEval {
 /// # let value = unimplemented!();
 /// let result = ClosureEvalOnce::new(engine_state, stack, closure)
 ///     .add_arg(value)
-///     .run_with_input(PipelineData::Empty);
+///     .run_with_input(PipelineData::empty());
 /// ```
 ///
 /// Many closures follow a simple, common scheme where the pipeline input and the first argument are the same value.

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -532,7 +532,7 @@ fn update_ansi_from_config(
                         arguments: vec![argument],
                         parser_info: HashMap::new(),
                     },
-                    PipelineData::Empty,
+                    PipelineData::empty(),
                 ) {
                     if let Ok((str, ..)) = result.collect_string_strict(span) {
                         *ansi_code = str;

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -412,7 +412,7 @@ fn get_command_documentation(
                     ))],
                     parser_info: HashMap::new(),
                 },
-                PipelineData::Value(Value::list(vals, span), None),
+                PipelineData::value(Value::list(vals, span), None),
             ) {
                 if let Ok((str, ..)) = result.collect_string_strict(span) {
                     let _ = writeln!(long_desc, "\n{help_section_name}Input/output types{RESET}:");
@@ -487,7 +487,7 @@ fn get_command_documentation(
                             engine_state,
                             stack,
                             &(&table_call).into(),
-                            PipelineData::Value(result.clone(), None),
+                            PipelineData::value(result.clone(), None),
                         )
                         .ok()
                 });

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -294,7 +294,7 @@ pub fn eval_block_with_early_return<D: DebugContext>(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     match eval_block::<D>(engine_state, stack, block, input) {
-        Err(ShellError::Return { span: _, value }) => Ok(PipelineData::Value(*value, None)),
+        Err(ShellError::Return { span: _, value }) => Ok(PipelineData::value(*value, None)),
         x => x,
     }
 }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -141,7 +141,7 @@ impl<'a> EvalContext<'a> {
     fn clone_reg(&mut self, reg_id: RegId, error_span: Span) -> Result<PipelineData, ShellError> {
         match &self.registers[reg_id.get() as usize] {
             PipelineData::Empty => Ok(PipelineData::empty()),
-            PipelineData::Value(val, meta) => Ok(PipelineData::Value(val.clone(), meta.clone())),
+            PipelineData::Value(val, meta) => Ok(PipelineData::value(val.clone(), meta.clone())),
             _ => Err(ShellError::IrEvalError {
                 msg: "Must collect to value before using instruction that clones from a register"
                     .into(),
@@ -838,7 +838,7 @@ fn load_literal(
     span: Span,
 ) -> Result<InstructionResult, ShellError> {
     let value = literal_value(ctx, lit, span)?;
-    ctx.put_reg(dst, PipelineData::Value(value, None));
+    ctx.put_reg(dst, PipelineData::value(value, None));
     Ok(InstructionResult::Continue)
 }
 
@@ -993,7 +993,7 @@ fn binary_op(
         }
     };
 
-    ctx.put_reg(lhs_dst, PipelineData::Value(result, None));
+    ctx.put_reg(lhs_dst, PipelineData::value(result, None));
 
     Ok(InstructionResult::Continue)
 }
@@ -1466,7 +1466,7 @@ fn collect(data: PipelineData, fallback_span: Span) -> Result<PipelineData, Shel
         other => other,
     };
     let value = data.into_value(span)?;
-    Ok(PipelineData::Value(value, metadata))
+    Ok(PipelineData::value(value, metadata))
 }
 
 /// Helper for drain behavior.

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1594,7 +1594,7 @@ fn eval_iterate(
         let span = data.span().unwrap_or(Span::unknown());
         ctx.put_reg(
             stream,
-            PipelineData::ListStream(
+            PipelineData::list_stream(
                 ListStream::new(data.into_iter(), span, Signals::EMPTY),
                 metadata,
             ),

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -48,7 +48,7 @@ pub fn eval_ir_block<D: DebugContext>(
         // the heap allocation here by reusing buffers - our allocator is fast enough
         let mut registers = Vec::with_capacity(ir_block.register_count as usize);
         for _ in 0..ir_block.register_count {
-            registers.push(PipelineData::Empty);
+            registers.push(PipelineData::empty());
         }
 
         // Initialize file storage.
@@ -133,14 +133,14 @@ impl<'a> EvalContext<'a> {
         // log::trace!("<- {reg_id}");
         std::mem::replace(
             &mut self.registers[reg_id.get() as usize],
-            PipelineData::Empty,
+            PipelineData::empty(),
         )
     }
 
     /// Clone data from a register. Must be collected first.
     fn clone_reg(&mut self, reg_id: RegId, error_span: Span) -> Result<PipelineData, ShellError> {
         match &self.registers[reg_id.get() as usize] {
-            PipelineData::Empty => Ok(PipelineData::Empty),
+            PipelineData::Empty => Ok(PipelineData::empty()),
             PipelineData::Value(val, meta) => Ok(PipelineData::Value(val.clone(), meta.clone())),
             _ => Err(ShellError::IrEvalError {
                 msg: "Must collect to value before using instruction that clones from a register"
@@ -269,7 +269,7 @@ fn prepare_error_handler(
             );
         } else {
             // Set the register to empty
-            ctx.put_reg(reg_id, PipelineData::Empty);
+            ctx.put_reg(reg_id, PipelineData::empty());
         }
     }
 }
@@ -1584,7 +1584,7 @@ fn eval_iterate(
             ctx.put_reg(stream, data); // put the stream back so it can be iterated on again
             Ok(InstructionResult::Continue)
         } else {
-            ctx.put_reg(dst, PipelineData::Empty);
+            ctx.put_reg(dst, PipelineData::empty());
             Ok(InstructionResult::Branch(end_index))
         }
     } else {

--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -88,8 +88,8 @@ impl Command for Explore {
         let result = run_pager(engine_state, &mut stack.clone(), input, config);
 
         match result {
-            Ok(Some(value)) => Ok(PipelineData::Value(value, None)),
-            Ok(None) => Ok(PipelineData::Value(Value::default(), None)),
+            Ok(Some(value)) => Ok(PipelineData::value(value, None)),
+            Ok(None) => Ok(PipelineData::value(Value::default(), None)),
             Err(err) => {
                 let shell_error = match err.downcast::<ShellError>() {
                     Ok(e) => e,
@@ -102,7 +102,7 @@ impl Command for Explore {
                     },
                 };
 
-                Ok(PipelineData::Value(
+                Ok(PipelineData::value(
                     Value::error(shell_error, call.head),
                     None,
                 ))

--- a/crates/nu-explore/src/nu_common/command.rs
+++ b/crates/nu-explore/src/nu_common/command.rs
@@ -23,7 +23,7 @@ pub fn run_command_with_value(
         });
     }
 
-    let pipeline = PipelineData::Value(input.clone(), None);
+    let pipeline = PipelineData::value(input.clone(), None);
     let pipeline = run_nu_command(engine_state, stack, command, pipeline)?;
     if let PipelineData::Value(Value::Error { error, .. }, ..) = pipeline {
         Err(ShellError::GenericError {

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -531,7 +531,7 @@ mod tests {
                 engine_state,
                 stack,
                 &block,
-                PipelineData::Value(Value::nothing(Span::unknown()), None),
+                PipelineData::value(Value::nothing(Span::unknown()), None),
             )
             .is_ok()
         );

--- a/crates/nu-plugin-core/src/interface/mod.rs
+++ b/crates/nu-plugin-core/src/interface/mod.rs
@@ -185,7 +185,7 @@ pub trait InterfaceManager {
     ) -> Result<PipelineData, ShellError> {
         self.prepare_pipeline_data(match header {
             PipelineDataHeader::Empty => PipelineData::empty(),
-            PipelineDataHeader::Value(value, metadata) => PipelineData::Value(value, metadata),
+            PipelineDataHeader::Value(value, metadata) => PipelineData::value(value, metadata),
             PipelineDataHeader::ListStream(info) => {
                 let handle = self.stream_manager().get_handle();
                 let reader = handle.read_stream(info.id, self.get_interface())?;

--- a/crates/nu-plugin-core/src/interface/mod.rs
+++ b/crates/nu-plugin-core/src/interface/mod.rs
@@ -197,7 +197,7 @@ pub trait InterfaceManager {
                 let reader = handle.read_stream(info.id, self.get_interface())?;
                 let bs =
                     ByteStream::from_result_iter(reader, info.span, signals.clone(), info.type_);
-                PipelineData::ByteStream(bs, info.metadata)
+                PipelineData::byte_stream(bs, info.metadata)
             }
         })
     }

--- a/crates/nu-plugin-core/src/interface/mod.rs
+++ b/crates/nu-plugin-core/src/interface/mod.rs
@@ -190,7 +190,7 @@ pub trait InterfaceManager {
                 let handle = self.stream_manager().get_handle();
                 let reader = handle.read_stream(info.id, self.get_interface())?;
                 let ls = ListStream::new(reader, info.span, signals.clone());
-                PipelineData::ListStream(ls, info.metadata)
+                PipelineData::list_stream(ls, info.metadata)
             }
             PipelineDataHeader::ByteStream(info) => {
                 let handle = self.stream_manager().get_handle();

--- a/crates/nu-plugin-core/src/interface/mod.rs
+++ b/crates/nu-plugin-core/src/interface/mod.rs
@@ -184,7 +184,7 @@ pub trait InterfaceManager {
         signals: &Signals,
     ) -> Result<PipelineData, ShellError> {
         self.prepare_pipeline_data(match header {
-            PipelineDataHeader::Empty => PipelineData::Empty,
+            PipelineDataHeader::Empty => PipelineData::empty(),
             PipelineDataHeader::Value(value, metadata) => PipelineData::Value(value, metadata),
             PipelineDataHeader::ListStream(info) => {
                 let handle = self.stream_manager().get_handle();

--- a/crates/nu-plugin-core/src/interface/tests.rs
+++ b/crates/nu-plugin-core/src/interface/tests.rs
@@ -128,7 +128,7 @@ fn read_pipeline_data_empty() -> Result<(), ShellError> {
 
     assert!(matches!(
         manager.read_pipeline_data(header, &Signals::empty())?,
-        PipelineData::Empty
+        PipelineData::empty()
     ));
     Ok(())
 }
@@ -302,7 +302,7 @@ fn write_pipeline_data_empty() -> Result<(), ShellError> {
     let manager = TestInterfaceManager::new(&test);
     let interface = manager.get_interface();
 
-    let (header, writer) = interface.init_write_pipeline_data(PipelineData::Empty, &())?;
+    let (header, writer) = interface.init_write_pipeline_data(PipelineData::empty(), &())?;
 
     assert!(matches!(header, PipelineDataHeader::Empty));
 

--- a/crates/nu-plugin-core/src/interface/tests.rs
+++ b/crates/nu-plugin-core/src/interface/tests.rs
@@ -128,7 +128,7 @@ fn read_pipeline_data_empty() -> Result<(), ShellError> {
 
     assert!(matches!(
         manager.read_pipeline_data(header, &Signals::empty())?,
-        PipelineData::empty()
+        PipelineData::Empty
     ));
     Ok(())
 }
@@ -180,7 +180,7 @@ fn read_pipeline_data_list_stream() -> Result<(), ShellError> {
 
     let pipe = manager.read_pipeline_data(header, &Signals::empty())?;
     assert!(
-        matches!(pipe, PipelineData::list_stream(..)),
+        matches!(pipe, PipelineData::ListStream(..)),
         "unexpected PipelineData: {pipe:?}"
     );
 

--- a/crates/nu-plugin-core/src/interface/tests.rs
+++ b/crates/nu-plugin-core/src/interface/tests.rs
@@ -180,7 +180,7 @@ fn read_pipeline_data_list_stream() -> Result<(), ShellError> {
 
     let pipe = manager.read_pipeline_data(header, &Signals::empty())?;
     assert!(
-        matches!(pipe, PipelineData::ListStream(..)),
+        matches!(pipe, PipelineData::list_stream(..)),
         "unexpected PipelineData: {pipe:?}"
     );
 
@@ -376,7 +376,7 @@ fn write_pipeline_data_list_stream() -> Result<(), ShellError> {
     ];
 
     // Set up pipeline data for a list stream
-    let pipe = PipelineData::ListStream(
+    let pipe = PipelineData::list_stream(
         ListStream::new(
             values.clone().into_iter(),
             Span::test_data(),

--- a/crates/nu-plugin-core/src/interface/tests.rs
+++ b/crates/nu-plugin-core/src/interface/tests.rs
@@ -324,7 +324,7 @@ fn write_pipeline_data_value() -> Result<(), ShellError> {
     let value = Value::test_int(7);
 
     let (header, writer) =
-        interface.init_write_pipeline_data(PipelineData::Value(value.clone(), None), &())?;
+        interface.init_write_pipeline_data(PipelineData::value(value.clone(), None), &())?;
 
     match header {
         PipelineDataHeader::Value(read_value, _) => assert_eq!(value, read_value),
@@ -349,7 +349,7 @@ fn write_pipeline_data_prepared_properly() {
     // Sending a binary should be an error in our test scenario
     let value = Value::test_binary(vec![7, 8]);
 
-    match interface.init_write_pipeline_data(PipelineData::Value(value, None), &()) {
+    match interface.init_write_pipeline_data(PipelineData::value(value, None), &()) {
         Ok(_) => panic!("prepare_pipeline_data was not called"),
         Err(err) => {
             assert_eq!(

--- a/crates/nu-plugin-core/src/interface/tests.rs
+++ b/crates/nu-plugin-core/src/interface/tests.rs
@@ -430,7 +430,7 @@ fn write_pipeline_data_byte_stream() -> Result<(), ShellError> {
     let span = Span::new(400, 500);
 
     // Set up pipeline data for a byte stream
-    let data = PipelineData::ByteStream(
+    let data = PipelineData::byte_stream(
         ByteStream::read(
             std::io::Cursor::new(expected),
             span,

--- a/crates/nu-plugin-engine/src/context.rs
+++ b/crates/nu-plugin-engine/src/context.rs
@@ -117,7 +117,7 @@ impl PluginExecutionContext for PluginExecutionCommandContext<'_> {
                 match value {
                     Value::Closure { val, .. } => {
                         ClosureEvalOnce::new(&self.engine_state, &self.stack, *val)
-                            .run_with_input(PipelineData::Empty)
+                            .run_with_input(PipelineData::empty())
                             .and_then(|data| data.into_value(span))
                             .unwrap_or_else(|err| Value::error(err, self.call.head))
                     }

--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -1101,7 +1101,7 @@ impl Interface for PluginInterface {
         match data {
             PipelineData::Value(mut value, meta) => {
                 state.prepare_value(&mut value, &self.state.source)?;
-                Ok(PipelineData::Value(value, meta))
+                Ok(PipelineData::value(value, meta))
             }
             PipelineData::ListStream(stream, meta) => {
                 let source = self.state.source.clone();

--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -600,7 +600,7 @@ impl InterfaceManager for PluginInterfaceManager {
             }
             PipelineData::ListStream(stream, meta) => {
                 let source = self.state.source.clone();
-                Ok(PipelineData::ListStream(
+                Ok(PipelineData::list_stream(
                     stream.map(move |mut value| {
                         let _ = PluginCustomValueWithSource::add_source_in(&mut value, &source);
                         value
@@ -1106,7 +1106,7 @@ impl Interface for PluginInterface {
             PipelineData::ListStream(stream, meta) => {
                 let source = self.state.source.clone();
                 let state = state.clone();
-                Ok(PipelineData::ListStream(
+                Ok(PipelineData::list_stream(
                     stream.map(move |mut value| {
                         match state.prepare_value(&mut value, &source) {
                             Ok(()) => value,

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -1084,7 +1084,7 @@ fn interface_run() -> Result<(), ShellError> {
                 positional: vec![],
                 named: vec![],
             },
-            input: PipelineData::Empty,
+            input: PipelineData::empty(),
         },
         &mut PluginExecutionBogusContext,
     )?;
@@ -1361,7 +1361,7 @@ fn prepare_plugin_call_run() {
                     positional: vec![Value::test_int(4)],
                     named: vec![("x".to_owned().into_spanned(span), Some(Value::test_int(6)))],
                 },
-                input: PipelineData::Empty,
+                input: PipelineData::empty(),
             }),
         ),
         (
@@ -1373,7 +1373,7 @@ fn prepare_plugin_call_run() {
                     positional: vec![cv_ok.clone()],
                     named: vec![("ok".to_owned().into_spanned(span), Some(cv_ok.clone()))],
                 },
-                input: PipelineData::Empty,
+                input: PipelineData::empty(),
             }),
         ),
         (
@@ -1385,7 +1385,7 @@ fn prepare_plugin_call_run() {
                     positional: vec![cv_bad.clone()],
                     named: vec![],
                 },
-                input: PipelineData::Empty,
+                input: PipelineData::empty(),
             }),
         ),
         (
@@ -1397,7 +1397,7 @@ fn prepare_plugin_call_run() {
                     positional: vec![],
                     named: vec![("bad".to_owned().into_spanned(span), Some(cv_bad.clone()))],
                 },
-                input: PipelineData::Empty,
+                input: PipelineData::empty(),
             }),
         ),
         (

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -646,7 +646,7 @@ fn manager_consume_stream_end_removes_context_only_if_last_stream() -> Result<()
 fn manager_prepare_pipeline_data_adds_source_to_values() -> Result<(), ShellError> {
     let manager = TestCase::new().plugin("test");
 
-    let data = manager.prepare_pipeline_data(PipelineData::Value(
+    let data = manager.prepare_pipeline_data(PipelineData::value(
         Value::test_custom_value(Box::new(test_plugin_custom_value())),
         None,
     ))?;
@@ -815,7 +815,7 @@ fn interface_write_plugin_call_writes_run_with_value_input() -> Result<(), Shell
                 positional: vec![],
                 named: vec![],
             },
-            input: PipelineData::Value(Value::test_int(-1), Some(metadata0.clone())),
+            input: PipelineData::value(Value::test_int(-1), Some(metadata0.clone())),
         }),
         None,
     )?;
@@ -1072,7 +1072,7 @@ fn interface_run() -> Result<(), ShellError> {
 
     start_fake_plugin_call_responder(manager, 1, move |_| {
         vec![ReceivedPluginCallMessage::Response(
-            PluginCallResponse::PipelineData(PipelineData::Value(Value::test_int(number), None)),
+            PluginCallResponse::PipelineData(PipelineData::value(Value::test_int(number), None)),
         )]
     });
 
@@ -1106,7 +1106,7 @@ fn interface_custom_value_to_base_value() -> Result<(), ShellError> {
 
     start_fake_plugin_call_responder(manager, 1, move |_| {
         vec![ReceivedPluginCallMessage::Response(
-            PluginCallResponse::PipelineData(PipelineData::Value(Value::test_string(string), None)),
+            PluginCallResponse::PipelineData(PipelineData::value(Value::test_string(string), None)),
         )]
     });
 
@@ -1137,7 +1137,7 @@ fn interface_prepare_pipeline_data_accepts_normal_values() -> Result<(), ShellEr
     let interface = TestCase::new().plugin("test").get_interface();
     let state = CurrentCallState::default();
     for value in normal_values(&interface) {
-        match interface.prepare_pipeline_data(PipelineData::Value(value.clone(), None), &state) {
+        match interface.prepare_pipeline_data(PipelineData::value(value.clone(), None), &state) {
             Ok(data) => assert_eq!(
                 value.get_type(),
                 data.into_value(Span::test_data())?.get_type(),
@@ -1201,7 +1201,7 @@ fn interface_prepare_pipeline_data_rejects_bad_custom_value() -> Result<(), Shel
     let interface = TestCase::new().plugin("test").get_interface();
     let state = CurrentCallState::default();
     for value in bad_custom_values() {
-        match interface.prepare_pipeline_data(PipelineData::Value(value.clone(), None), &state) {
+        match interface.prepare_pipeline_data(PipelineData::value(value.clone(), None), &state) {
             Err(err) => match err {
                 ShellError::CustomValueIncorrectForPlugin { .. } => (),
                 _ => panic!("expected error type CustomValueIncorrectForPlugin, but got {err:?}"),
@@ -1410,7 +1410,7 @@ fn prepare_plugin_call_run() {
                     named: vec![],
                 },
                 // Shouldn't check input - that happens somewhere else
-                input: PipelineData::Value(cv_bad.clone(), None),
+                input: PipelineData::value(cv_bad.clone(), None),
             }),
         ),
     ];

--- a/crates/nu-plugin-protocol/src/lib.rs
+++ b/crates/nu-plugin-protocol/src/lib.rs
@@ -84,7 +84,7 @@ pub enum PipelineDataHeader {
     ///
     /// Items are sent via [`StreamData`]
     ListStream(ListStreamInfo),
-    /// Initiate [`nu_protocol::PipelineData::ByteStream`].
+    /// Initiate [`nu_protocol::PipelineData::byte_stream`].
     ///
     /// Items are sent via [`StreamData`]
     ByteStream(ByteStreamInfo),

--- a/crates/nu-plugin-protocol/src/lib.rs
+++ b/crates/nu-plugin-protocol/src/lib.rs
@@ -650,7 +650,7 @@ impl<D> EngineCallResponse<D> {
 impl EngineCallResponse<PipelineData> {
     /// Build an [`EngineCallResponse::PipelineData`] from a [`Value`]
     pub fn value(value: Value) -> EngineCallResponse<PipelineData> {
-        EngineCallResponse::PipelineData(PipelineData::Value(value, None))
+        EngineCallResponse::PipelineData(PipelineData::value(value, None))
     }
 
     /// An [`EngineCallResponse::PipelineData`] with [`PipelineData::empty()`]

--- a/crates/nu-plugin-protocol/src/lib.rs
+++ b/crates/nu-plugin-protocol/src/lib.rs
@@ -653,8 +653,8 @@ impl EngineCallResponse<PipelineData> {
         EngineCallResponse::PipelineData(PipelineData::Value(value, None))
     }
 
-    /// An [`EngineCallResponse::PipelineData`] with [`PipelineData::Empty`]
+    /// An [`EngineCallResponse::PipelineData`] with [`PipelineData::empty()`]
     pub const fn empty() -> EngineCallResponse<PipelineData> {
-        EngineCallResponse::PipelineData(PipelineData::Empty)
+        EngineCallResponse::PipelineData(PipelineData::empty())
     }
 }

--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -194,7 +194,7 @@ impl PluginTest {
     /// # }
     /// ```
     pub fn eval(&mut self, nu_source: &str) -> Result<PipelineData, ShellError> {
-        self.eval_with(nu_source, PipelineData::Empty)
+        self.eval_with(nu_source, PipelineData::empty())
     }
 
     /// Test a list of plugin examples. Prints an error for each failing example.

--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -137,7 +137,7 @@ impl PluginTest {
 
         // Serialize custom values in the input
         let source = self.source.clone();
-        let input = if matches!(input, PipelineData::byte_stream(..)) {
+        let input = if matches!(input, PipelineData::ByteStream(..)) {
             input
         } else {
             input.map(
@@ -159,7 +159,7 @@ impl PluginTest {
         // Eval the block with the input
         let mut stack = Stack::new().collect_value();
         let data = eval_block::<WithoutDebug>(&self.engine_state, &mut stack, &block, input)?;
-        if matches!(data, PipelineData::byte_stream(..)) {
+        if matches!(data, PipelineData::ByteStream(..)) {
             Ok(data)
         } else {
             data.map(

--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -137,7 +137,7 @@ impl PluginTest {
 
         // Serialize custom values in the input
         let source = self.source.clone();
-        let input = if matches!(input, PipelineData::ByteStream(..)) {
+        let input = if matches!(input, PipelineData::byte_stream(..)) {
             input
         } else {
             input.map(
@@ -159,7 +159,7 @@ impl PluginTest {
         // Eval the block with the input
         let mut stack = Stack::new().collect_value();
         let data = eval_block::<WithoutDebug>(&self.engine_state, &mut stack, &block, input)?;
-        if matches!(data, PipelineData::ByteStream(..)) {
+        if matches!(data, PipelineData::byte_stream(..)) {
             Ok(data)
         } else {
             data.map(

--- a/crates/nu-plugin-test-support/tests/custom_value/mod.rs
+++ b/crates/nu-plugin-test-support/tests/custom_value/mod.rs
@@ -145,7 +145,7 @@ fn test_into_int_from_u32() -> Result<(), ShellError> {
     let result = PluginTest::new("custom_u32", CustomU32Plugin.into())?
         .eval_with(
             "into int from u32",
-            PipelineData::Value(CustomU32(42).into_value(Span::test_data()), None),
+            PipelineData::value(CustomU32(42).into_value(Span::test_data()), None),
         )?
         .into_value(Span::test_data())?;
     assert_eq!(Value::test_int(42), result);

--- a/crates/nu-plugin/src/plugin/command.rs
+++ b/crates/nu-plugin/src/plugin/command.rs
@@ -322,7 +322,7 @@ where
         let input_value = input.into_value(span)?;
         // Wrap the output in PipelineData::value
         <Self as SimplePluginCommand>::run(self, plugin, engine, call, &input_value)
-            .map(|Value| PipelineData::value(value, None))
+            .map(|value| PipelineData::value(value, None))
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-plugin/src/plugin/command.rs
+++ b/crates/nu-plugin/src/plugin/command.rs
@@ -320,9 +320,9 @@ where
         // simpler signature in Plugin
         let span = input.span().unwrap_or(call.head);
         let input_value = input.into_value(span)?;
-        // Wrap the output in PipelineData::Value
+        // Wrap the output in PipelineData::value
         <Self as SimplePluginCommand>::run(self, plugin, engine, call, &input_value)
-            .map(|value| PipelineData::Value(value, None))
+            .map(|Value| PipelineData::value(value, None))
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -558,7 +558,7 @@ impl EngineInterface {
     }
 
     /// Do an engine call returning an `Option<Value>` as either `PipelineData::empty()` or
-    /// `PipelineData::Value`
+    /// `PipelineData::value`
     fn engine_call_option_value(
         &self,
         engine_call: EngineCall<PipelineData>,
@@ -721,7 +721,7 @@ impl EngineInterface {
     pub fn enter_foreground(&self) -> Result<ForegroundGuard, ShellError> {
         match self.engine_call(EngineCall::EnterForeground)? {
             EngineCallResponse::Error(error) => Err(error),
-            EngineCallResponse::PipelineData(PipelineData::Value(
+            EngineCallResponse::PipelineData(PipelineData::value(
                 Value::Int { val: pgrp, .. },
                 _,
             )) => {
@@ -786,7 +786,7 @@ impl EngineInterface {
     /// # use nu_plugin::{EngineInterface, EvaluatedCall};
     /// # fn example(engine: &EngineInterface, call: &EvaluatedCall) -> Result<(), ShellError> {
     /// let closure = call.req(0)?;
-    /// let input = PipelineData::Value(Value::int(4, call.head), None);
+    /// let input = PipelineData::value(Value::int(4, call.head), None);
     /// let output = engine.eval_closure_with_stream(
     ///     &closure,
     ///     vec![],
@@ -885,7 +885,7 @@ impl EngineInterface {
         positional: Vec<Value>,
         input: Option<Value>,
     ) -> Result<Value, ShellError> {
-        let input = input.map_or_else(|| PipelineData::empty(), |v| PipelineData::Value(v, None));
+        let input = input.map_or_else(|| PipelineData::empty(), |v| PipelineData::value(v, None));
         let output = self.eval_closure_with_stream(closure, positional, input, true, false)?;
         // Unwrap an error value
         match output.into_value(closure.span)? {

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -885,7 +885,7 @@ impl EngineInterface {
         positional: Vec<Value>,
         input: Option<Value>,
     ) -> Result<Value, ShellError> {
-        let input = input.map_or_else(|| PipelineData::empty(), |v| PipelineData::value(v, None));
+        let input = input.map_or_else(PipelineData::empty, |v| PipelineData::value(v, None));
         let output = self.eval_closure_with_stream(closure, positional, input, true, false)?;
         // Unwrap an error value
         match output.into_value(closure.span)? {

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -367,7 +367,7 @@ impl InterfaceManager for EngineInterfaceManager {
                         .map(|()| value)
                         .unwrap_or_else(|err| Value::error(err, span))
                 });
-                Ok(PipelineData::ListStream(stream, meta))
+                Ok(PipelineData::list_stream(stream, meta))
             }
             PipelineData::empty() | PipelineData::ByteStream(..) => Ok(data),
         }
@@ -1025,7 +1025,7 @@ impl Interface for EngineInterface {
                         .map(|_| value)
                         .unwrap_or_else(|err| Value::error(err, span))
                 });
-                Ok(PipelineData::ListStream(stream, meta))
+                Ok(PipelineData::list_stream(stream, meta))
             }
             PipelineData::Empty | PipelineData::ByteStream(..) => Ok(data),
         }

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -369,7 +369,7 @@ impl InterfaceManager for EngineInterfaceManager {
                 });
                 Ok(PipelineData::ListStream(stream, meta))
             }
-            PipelineData::Empty | PipelineData::ByteStream(..) => Ok(data),
+            PipelineData::empty() | PipelineData::ByteStream(..) => Ok(data),
         }
     }
 }
@@ -557,7 +557,7 @@ impl EngineInterface {
         }
     }
 
-    /// Do an engine call returning an `Option<Value>` as either `PipelineData::Empty` or
+    /// Do an engine call returning an `Option<Value>` as either `PipelineData::empty()` or
     /// `PipelineData::Value`
     fn engine_call_option_value(
         &self,
@@ -565,7 +565,7 @@ impl EngineInterface {
     ) -> Result<Option<Value>, ShellError> {
         let name = engine_call.name();
         match self.engine_call(engine_call)? {
-            EngineCallResponse::PipelineData(PipelineData::Empty) => Ok(None),
+            EngineCallResponse::PipelineData(PipelineData::empty()) => Ok(None),
             EngineCallResponse::PipelineData(PipelineData::Value(value, _)) => Ok(Some(value)),
             EngineCallResponse::Error(err) => Err(err),
             _ => Err(ShellError::PluginFailedToDecode {
@@ -728,7 +728,7 @@ impl EngineInterface {
                 set_pgrp_from_enter_foreground(pgrp)?;
                 Ok(ForegroundGuard(Some(self.clone())))
             }
-            EngineCallResponse::PipelineData(PipelineData::Empty) => {
+            EngineCallResponse::PipelineData(PipelineData::empty()) => {
                 Ok(ForegroundGuard(Some(self.clone())))
             }
             _ => Err(ShellError::PluginFailedToDecode {
@@ -741,7 +741,7 @@ impl EngineInterface {
     fn leave_foreground(&self) -> Result<(), ShellError> {
         match self.engine_call(EngineCall::LeaveForeground)? {
             EngineCallResponse::Error(error) => Err(error),
-            EngineCallResponse::PipelineData(PipelineData::Empty) => Ok(()),
+            EngineCallResponse::PipelineData(PipelineData::empty()) => Ok(()),
             _ => Err(ShellError::PluginFailedToDecode {
                 msg: "Received unexpected response type for EngineCall::LeaveForeground".into(),
             }),
@@ -885,7 +885,7 @@ impl EngineInterface {
         positional: Vec<Value>,
         input: Option<Value>,
     ) -> Result<Value, ShellError> {
-        let input = input.map_or_else(|| PipelineData::Empty, |v| PipelineData::Value(v, None));
+        let input = input.map_or_else(|| PipelineData::empty(), |v| PipelineData::Value(v, None));
         let output = self.eval_closure_with_stream(closure, positional, input, true, false)?;
         // Unwrap an error value
         match output.into_value(closure.span)? {
@@ -904,7 +904,7 @@ impl EngineInterface {
         match self.engine_call(call)? {
             EngineCallResponse::Error(err) => Err(err),
             EngineCallResponse::Identifier(id) => Ok(Some(id)),
-            EngineCallResponse::PipelineData(PipelineData::Empty) => Ok(None),
+            EngineCallResponse::PipelineData(PipelineData::empty()) => Ok(None),
             _ => Err(ShellError::PluginFailedToDecode {
                 msg: "Received unexpected response type for EngineCall::FindDecl".into(),
             }),
@@ -924,7 +924,7 @@ impl EngineInterface {
     ///     let commands = engine.call_decl(
     ///         decl_id,
     ///         EvaluatedCall::new(call.head),
-    ///         PipelineData::Empty,
+    ///         PipelineData::empty(),
     ///         true,
     ///         false,
     ///     )?;

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -369,7 +369,7 @@ impl InterfaceManager for EngineInterfaceManager {
                 });
                 Ok(PipelineData::list_stream(stream, meta))
             }
-            PipelineData::empty() | PipelineData::ByteStream(..) => Ok(data),
+            PipelineData::Empty | PipelineData::ByteStream(..) => Ok(data),
         }
     }
 }

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -565,7 +565,7 @@ impl EngineInterface {
     ) -> Result<Option<Value>, ShellError> {
         let name = engine_call.name();
         match self.engine_call(engine_call)? {
-            EngineCallResponse::PipelineData(PipelineData::empty()) => Ok(None),
+            EngineCallResponse::PipelineData(PipelineData::Empty) => Ok(None),
             EngineCallResponse::PipelineData(PipelineData::Value(value, _)) => Ok(Some(value)),
             EngineCallResponse::Error(err) => Err(err),
             _ => Err(ShellError::PluginFailedToDecode {
@@ -721,14 +721,14 @@ impl EngineInterface {
     pub fn enter_foreground(&self) -> Result<ForegroundGuard, ShellError> {
         match self.engine_call(EngineCall::EnterForeground)? {
             EngineCallResponse::Error(error) => Err(error),
-            EngineCallResponse::PipelineData(PipelineData::value(
+            EngineCallResponse::PipelineData(PipelineData::Value(
                 Value::Int { val: pgrp, .. },
                 _,
             )) => {
                 set_pgrp_from_enter_foreground(pgrp)?;
                 Ok(ForegroundGuard(Some(self.clone())))
             }
-            EngineCallResponse::PipelineData(PipelineData::empty()) => {
+            EngineCallResponse::PipelineData(PipelineData::Empty) => {
                 Ok(ForegroundGuard(Some(self.clone())))
             }
             _ => Err(ShellError::PluginFailedToDecode {
@@ -741,7 +741,7 @@ impl EngineInterface {
     fn leave_foreground(&self) -> Result<(), ShellError> {
         match self.engine_call(EngineCall::LeaveForeground)? {
             EngineCallResponse::Error(error) => Err(error),
-            EngineCallResponse::PipelineData(PipelineData::empty()) => Ok(()),
+            EngineCallResponse::PipelineData(PipelineData::Empty) => Ok(()),
             _ => Err(ShellError::PluginFailedToDecode {
                 msg: "Received unexpected response type for EngineCall::LeaveForeground".into(),
             }),
@@ -904,7 +904,7 @@ impl EngineInterface {
         match self.engine_call(call)? {
             EngineCallResponse::Error(err) => Err(err),
             EngineCallResponse::Identifier(id) => Ok(Some(id)),
-            EngineCallResponse::PipelineData(PipelineData::empty()) => Ok(None),
+            EngineCallResponse::PipelineData(PipelineData::Empty) => Ok(None),
             _ => Err(ShellError::PluginFailedToDecode {
                 msg: "Received unexpected response type for EngineCall::FindDecl".into(),
             }),

--- a/crates/nu-plugin/src/plugin/interface/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/tests.rs
@@ -901,7 +901,7 @@ fn interface_get_plugin_config() -> Result<(), ShellError> {
 
     start_fake_plugin_call_responder(manager, 2, |id| {
         if id == 0 {
-            EngineCallResponse::PipelineData(PipelineData::Empty)
+            EngineCallResponse::PipelineData(PipelineData::empty())
         } else {
             EngineCallResponse::PipelineData(PipelineData::Value(Value::test_int(2), None))
         }
@@ -1051,7 +1051,7 @@ fn interface_eval_closure_with_stream() -> Result<(), ShellError> {
                 span: Span::test_data(),
             },
             vec![Value::test_string("test")],
-            PipelineData::Empty,
+            PipelineData::empty(),
             true,
             false,
         )?

--- a/crates/nu-plugin/src/plugin/interface/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/tests.rs
@@ -583,7 +583,7 @@ fn manager_consume_engine_call_response_forwards_to_subscriber_with_pipeline_dat
 fn manager_prepare_pipeline_data_deserializes_custom_values() -> Result<(), ShellError> {
     let manager = TestCase::new().engine();
 
-    let data = manager.prepare_pipeline_data(PipelineData::Value(
+    let data = manager.prepare_pipeline_data(PipelineData::value(
         Value::test_custom_value(Box::new(test_plugin_custom_value())),
         None,
     ))?;
@@ -690,7 +690,7 @@ fn interface_write_response_with_value() -> Result<(), ShellError> {
     let test = TestCase::new();
     let interface = test.engine().interface_for_context(33);
     interface
-        .write_response(Ok::<_, ShellError>(PipelineData::Value(
+        .write_response(Ok::<_, ShellError>(PipelineData::value(
             Value::test_int(6),
             None,
         )))?
@@ -903,7 +903,7 @@ fn interface_get_plugin_config() -> Result<(), ShellError> {
         if id == 0 {
             EngineCallResponse::PipelineData(PipelineData::empty())
         } else {
-            EngineCallResponse::PipelineData(PipelineData::Value(Value::test_int(2), None))
+            EngineCallResponse::PipelineData(PipelineData::value(Value::test_int(2), None))
         }
     });
 
@@ -1038,7 +1038,7 @@ fn interface_eval_closure_with_stream() -> Result<(), ShellError> {
     let interface = manager.interface_for_context(0);
 
     start_fake_plugin_call_responder(manager, 1, |_| {
-        EngineCallResponse::PipelineData(PipelineData::Value(Value::test_int(2), None))
+        EngineCallResponse::PipelineData(PipelineData::value(Value::test_int(2), None))
     });
 
     let result = interface
@@ -1100,7 +1100,7 @@ fn interface_prepare_pipeline_data_serializes_custom_values() -> Result<(), Shel
     let interface = TestCase::new().engine().get_interface();
 
     let data = interface.prepare_pipeline_data(
-        PipelineData::Value(
+        PipelineData::value(
             Value::test_custom_value(Box::new(expected_test_custom_value())),
             None,
         ),

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -642,7 +642,7 @@ fn custom_value_op(
         CustomValueOp::Dropped => {
             let result = plugin
                 .custom_value_dropped(engine, local_value.item)
-                .map(|_| PipelineData::Empty);
+                .map(|_| PipelineData::empty());
             engine
                 .write_response(result)
                 .and_then(|writer| writer.write())

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -600,7 +600,7 @@ fn custom_value_op(
         CustomValueOp::ToBaseValue => {
             let result = plugin
                 .custom_value_to_base_value(engine, local_value)
-                .map(|value| PipelineData::Value(value, None));
+                .map(|value| PipelineData::value(value, None));
             engine
                 .write_response(result)
                 .and_then(|writer| writer.write())
@@ -608,7 +608,7 @@ fn custom_value_op(
         CustomValueOp::FollowPathInt(index) => {
             let result = plugin
                 .custom_value_follow_path_int(engine, local_value, index)
-                .map(|value| PipelineData::Value(value, None));
+                .map(|value| PipelineData::value(value, None));
             engine
                 .write_response(result)
                 .and_then(|writer| writer.write())
@@ -616,7 +616,7 @@ fn custom_value_op(
         CustomValueOp::FollowPathString(column_name) => {
             let result = plugin
                 .custom_value_follow_path_string(engine, local_value, column_name)
-                .map(|value| PipelineData::Value(value, None));
+                .map(|value| PipelineData::value(value, None));
             engine
                 .write_response(result)
                 .and_then(|writer| writer.write())
@@ -634,7 +634,7 @@ fn custom_value_op(
             PluginCustomValue::deserialize_custom_values_in(&mut right)?;
             let result = plugin
                 .custom_value_operation(engine, local_value, operator, right)
-                .map(|value| PipelineData::Value(value, None));
+                .map(|value| PipelineData::value(value, None));
             engine
                 .write_response(result)
                 .and_then(|writer| writer.write())

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -417,7 +417,7 @@ pub fn eval_constant_with_input(
             let block = working_set.get_block(*block_id);
             eval_const_subexpression(working_set, block, input, expr.span(&working_set))
         }
-        _ => eval_constant(working_set, expr).map(|v| PipelineData::Value(v, None)),
+        _ => eval_constant(working_set, expr).map(|v| PipelineData::value(v, None)),
     }
 }
 

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -737,7 +737,7 @@ impl ByteStream {
 
 impl From<ByteStream> for PipelineData {
     fn from(stream: ByteStream) -> Self {
-        Self::ByteStream(stream, None)
+        Self::byte_stream(stream, None)
     }
 }
 

--- a/crates/nu-protocol/src/pipeline/list_stream.rs
+++ b/crates/nu-protocol/src/pipeline/list_stream.rs
@@ -139,7 +139,7 @@ impl IntoIterator for ListStream {
 
 impl From<ListStream> for PipelineData {
     fn from(stream: ListStream) -> Self {
-        Self::ListStream(stream, None)
+        Self::list_stream(stream, None)
     }
 }
 

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -52,7 +52,7 @@ impl PipelineData {
         PipelineData::Empty
     }
 
-    pub fn value(val: Value, metadata: Option<PipelineMetadata>) -> Self {
+    pub const fn value(val: Value, metadata: Option<PipelineMetadata>) -> Self {
         PipelineData::Value(val, metadata)
     }
 
@@ -103,9 +103,9 @@ impl PipelineData {
     /// Returns `Value(Nothing)` with the given span if it was [`PipelineData::empty()`].
     pub fn with_span(self, span: Span) -> Self {
         match self {
-            PipelineData::Empty => PipelineData::Value(Value::nothing(span), None),
+            PipelineData::Empty => PipelineData::value(Value::nothing(span), None),
             PipelineData::Value(value, metadata) => {
-                PipelineData::Value(value.with_span(span), metadata)
+                PipelineData::value(value.with_span(span), metadata)
             }
             PipelineData::ListStream(stream, metadata) => {
                 PipelineData::list_stream(stream.with_span(span), metadata)
@@ -614,9 +614,9 @@ impl PipelineData {
                         }
                         let range_values: Vec<Value> =
                             val.into_range_iter(span, Signals::empty()).collect();
-                        Ok(PipelineData::Value(Value::list(range_values, span), None))
+                        Ok(PipelineData::value(Value::list(range_values, span), None))
                     }
-                    x => Ok(PipelineData::Value(x, metadata)),
+                    x => Ok(PipelineData::value(x, metadata)),
                 }
             }
             _ => Ok(self),
@@ -886,14 +886,14 @@ where
     V: Into<Value>,
 {
     fn into_pipeline_data(self) -> PipelineData {
-        PipelineData::Value(self.into(), None)
+        PipelineData::value(self.into(), None)
     }
 
     fn into_pipeline_data_with_metadata(
         self,
         metadata: impl Into<Option<PipelineMetadata>>,
     ) -> PipelineData {
-        PipelineData::Value(self.into(), metadata.into())
+        PipelineData::value(self.into(), metadata.into())
     }
 }
 

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -60,7 +60,7 @@ impl PipelineData {
         PipelineData::ListStream(stream, metadata)
     }
 
-    pub fn byte_stream(stream: ByteStream, metadata: Option<PipelineMetadata>) -> Self {
+    pub const fn byte_stream(stream: ByteStream, metadata: Option<PipelineMetadata>) -> Self {
         PipelineData::ByteStream(stream, metadata)
     }
 
@@ -111,7 +111,7 @@ impl PipelineData {
                 PipelineData::list_stream(stream.with_span(span), metadata)
             }
             PipelineData::ByteStream(stream, metadata) => {
-                PipelineData::ByteStream(stream.with_span(span), metadata)
+                PipelineData::byte_stream(stream.with_span(span), metadata)
             }
         }
     }
@@ -209,13 +209,13 @@ impl PipelineData {
                 ))
             }
             PipelineData::Value(Value::String { val, .. }, metadata) => {
-                Ok(PipelineData::ByteStream(
+                Ok(PipelineData::byte_stream(
                     ByteStream::read_string(val, span, engine_state.signals().clone()),
                     metadata,
                 ))
             }
             PipelineData::Value(Value::Binary { val, .. }, metadata) => {
-                Ok(PipelineData::ByteStream(
+                Ok(PipelineData::byte_stream(
                     ByteStream::read_binary(val, span, engine_state.signals().clone()),
                     metadata,
                 ))

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -503,7 +503,7 @@ impl PipelineData {
                 };
                 Ok(pipeline.set_metadata(metadata))
             }
-            PipelineData::ListStream(stream, metadata) => Ok(PipelineData::ListStream(
+            PipelineData::ListStream(stream, metadata) => Ok(PipelineData::list_stream(
                 stream.modify(|iter| iter.flat_map(f)),
                 metadata,
             )),
@@ -554,7 +554,7 @@ impl PipelineData {
                 };
                 Ok(pipeline.set_metadata(metadata))
             }
-            PipelineData::ListStream(stream, metadata) => Ok(PipelineData::ListStream(
+            PipelineData::ListStream(stream, metadata) => Ok(PipelineData::list_stream(
                 stream.modify(|iter| iter.filter(f)),
                 metadata,
             )),

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -56,7 +56,7 @@ impl PipelineData {
         PipelineData::Value(val, metadata)
     }
 
-    pub fn list_stream(stream: ListStream, metadata: Option<PipelineMetadata>) -> Self {
+    pub const fn list_stream(stream: ListStream, metadata: Option<PipelineMetadata>) -> Self {
         PipelineData::ListStream(stream, metadata)
     }
 
@@ -108,7 +108,7 @@ impl PipelineData {
                 PipelineData::Value(value.with_span(span), metadata)
             }
             PipelineData::ListStream(stream, metadata) => {
-                PipelineData::ListStream(stream.with_span(span), metadata)
+                PipelineData::list_stream(stream.with_span(span), metadata)
             }
             PipelineData::ByteStream(stream, metadata) => {
                 PipelineData::ByteStream(stream.with_span(span), metadata)
@@ -203,7 +203,7 @@ impl PipelineData {
             PipelineData::ListStream(..) | PipelineData::ByteStream(..) => Ok(self),
             PipelineData::Value(Value::List { .. } | Value::Range { .. }, ref metadata) => {
                 let metadata = metadata.clone();
-                Ok(PipelineData::ListStream(
+                Ok(PipelineData::list_stream(
                     ListStream::new(self.into_iter(), span, engine_state.signals().clone()),
                     metadata,
                 ))
@@ -468,7 +468,7 @@ impl PipelineData {
             }
             PipelineData::Empty => Ok(PipelineData::empty()),
             PipelineData::ListStream(stream, metadata) => {
-                Ok(PipelineData::ListStream(stream.map(f), metadata))
+                Ok(PipelineData::list_stream(stream.map(f), metadata))
             }
             PipelineData::ByteStream(stream, metadata) => {
                 Ok(f(stream.into_value()?).into_pipeline_data_with_metadata(metadata))
@@ -923,7 +923,7 @@ where
         signals: Signals,
         metadata: impl Into<Option<PipelineMetadata>>,
     ) -> PipelineData {
-        PipelineData::ListStream(
+        PipelineData::list_stream(
             ListStream::new(self.into_iter().map(Into::into), span, signals),
             metadata.into(),
         )

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -52,16 +52,16 @@ impl PipelineData {
         PipelineData::Empty
     }
 
-    pub const fn value(val: Value, metadata: Option<PipelineMetadata>) -> Self {
-        PipelineData::Value(val, metadata)
+    pub fn value(val: Value, metadata: impl Option<PipelineMetadata>) -> Self {
+        PipelineData::Value(val, metadata.into())
     }
 
-    pub const fn list_stream(stream: ListStream, metadata: Option<PipelineMetadata>) -> Self {
-        PipelineData::ListStream(stream, metadata)
+    pub fn list_stream(stream: ListStream, metadata: impl Option<PipelineMetadata>) -> Self {
+        PipelineData::ListStream(stream, metadata.into())
     }
 
-    pub const fn byte_stream(stream: ByteStream, metadata: Option<PipelineMetadata>) -> Self {
-        PipelineData::ByteStream(stream, metadata)
+    pub fn byte_stream(stream: ByteStream, metadata: impl Option<PipelineMetadata>) -> Self {
+        PipelineData::ByteStream(stream, metadata.into())
     }
 
     pub fn metadata(&self) -> Option<PipelineMetadata> {

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -52,15 +52,15 @@ impl PipelineData {
         PipelineData::Empty
     }
 
-    pub fn value(val: Value, metadata: impl Option<PipelineMetadata>) -> Self {
+    pub fn value(val: Value, metadata: impl Into<Option<PipelineMetadata>>) -> Self {
         PipelineData::Value(val, metadata.into())
     }
 
-    pub fn list_stream(stream: ListStream, metadata: impl Option<PipelineMetadata>) -> Self {
+    pub fn list_stream(stream: ListStream, metadata: impl Into<Option<PipelineMetadata>>) -> Self {
         PipelineData::ListStream(stream, metadata.into())
     }
 
-    pub fn byte_stream(stream: ByteStream, metadata: impl Option<PipelineMetadata>) -> Self {
+    pub fn byte_stream(stream: ByteStream, metadata: impl Into<Option<PipelineMetadata>>) -> Self {
         PipelineData::ByteStream(stream, metadata.into())
     }
 

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -48,8 +48,20 @@ pub enum PipelineData {
 }
 
 impl PipelineData {
-    pub fn empty() -> PipelineData {
+    pub const fn empty() -> PipelineData {
         PipelineData::Empty
+    }
+
+    pub fn value(val: Value, metadata: Option<PipelineMetadata>) -> Self {
+        PipelineData::Value(val, metadata)
+    }
+
+    pub fn list_stream(stream: ListStream, metadata: Option<PipelineMetadata>) -> Self {
+        PipelineData::ListStream(stream, metadata)
+    }
+
+    pub fn byte_stream(stream: ByteStream, metadata: Option<PipelineMetadata>) -> Self {
+        PipelineData::ByteStream(stream, metadata)
     }
 
     pub fn metadata(&self) -> Option<PipelineMetadata> {
@@ -88,7 +100,7 @@ impl PipelineData {
 
     /// Change the span of the [`PipelineData`].
     ///
-    /// Returns `Value(Nothing)` with the given span if it was [`PipelineData::Empty`].
+    /// Returns `Value(Nothing)` with the given span if it was [`PipelineData::empty()`].
     pub fn with_span(self, span: Span) -> Self {
         match self {
             PipelineData::Empty => PipelineData::Value(Value::nothing(span), None),
@@ -454,7 +466,7 @@ impl PipelineData {
                 };
                 Ok(pipeline.set_metadata(metadata))
             }
-            PipelineData::Empty => Ok(PipelineData::Empty),
+            PipelineData::Empty => Ok(PipelineData::empty()),
             PipelineData::ListStream(stream, metadata) => {
                 Ok(PipelineData::ListStream(stream.map(f), metadata))
             }
@@ -473,7 +485,7 @@ impl PipelineData {
         F: FnMut(Value) -> U + 'static + Send,
     {
         match self {
-            PipelineData::Empty => Ok(PipelineData::Empty),
+            PipelineData::Empty => Ok(PipelineData::empty()),
             PipelineData::Value(value, metadata) => {
                 let span = value.span();
                 let pipeline = match value {
@@ -520,7 +532,7 @@ impl PipelineData {
         F: FnMut(&Value) -> bool + 'static + Send,
     {
         match self {
-            PipelineData::Empty => Ok(PipelineData::Empty),
+            PipelineData::Empty => Ok(PipelineData::empty()),
             PipelineData::Value(value, metadata) => {
                 let span = value.span();
                 let pipeline = match value {

--- a/crates/nu_plugin_example/src/commands/collect_bytes.rs
+++ b/crates/nu_plugin_example/src/commands/collect_bytes.rs
@@ -48,7 +48,7 @@ impl PluginCommand for CollectBytes {
         call: &EvaluatedCall,
         input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
-        Ok(PipelineData::ByteStream(
+        Ok(PipelineData::byte_stream(
             ByteStream::from_result_iter(
                 input.into_iter().map(Value::coerce_into_binary),
                 call.head,

--- a/crates/nu_plugin_example/src/commands/ctrlc.rs
+++ b/crates/nu_plugin_example/src/commands/ctrlc.rs
@@ -45,6 +45,6 @@ impl PluginCommand for Ctrlc {
         eprintln!("interrupt status: {:?}", engine.signals().interrupted());
         eprintln!("peace.");
 
-        Ok(PipelineData::Empty)
+        Ok(PipelineData::empty())
     }
 }

--- a/crates/nu_plugin_example/src/commands/for_each.rs
+++ b/crates/nu_plugin_example/src/commands/for_each.rs
@@ -53,7 +53,7 @@ impl PluginCommand for ForEach {
             let result = engine.eval_closure(&closure, vec![value.clone()], Some(value))?;
             eprintln!("{}", result.to_expanded_string(", ", &config));
         }
-        Ok(PipelineData::Empty)
+        Ok(PipelineData::empty())
     }
 }
 

--- a/crates/nu_plugin_example/src/commands/sum.rs
+++ b/crates/nu_plugin_example/src/commands/sum.rs
@@ -57,7 +57,7 @@ impl PluginCommand for Sum {
                     .with_label("can't be used here", call.head));
             }
         }
-        Ok(PipelineData::Value(acc.to_value(call.head), None))
+        Ok(PipelineData::value(acc.to_value(call.head), None))
     }
 }
 

--- a/crates/nu_plugin_polars/src/cache/get.rs
+++ b/crates/nu_plugin_polars/src/cache/get.rs
@@ -72,7 +72,7 @@ impl PluginCommand for CacheGet {
             Value::nothing(call.head)
         };
 
-        Ok(PipelineData::Value(value, None))
+        Ok(PipelineData::value(value, None))
     }
 }
 

--- a/crates/nu_plugin_polars/src/cache/rm.rs
+++ b/crates/nu_plugin_polars/src/cache/rm.rs
@@ -50,7 +50,7 @@ impl PluginCommand for CacheRemove {
             .map(|ref key| remove_cache_entry(plugin, engine, key, call.head))
             .collect::<Result<Vec<Value>, ShellError>>()?;
 
-        Ok(PipelineData::Value(Value::list(msgs, call.head), None))
+        Ok(PipelineData::value(Value::list(msgs, call.head), None))
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/command/core/columns.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/columns.rs
@@ -67,7 +67,7 @@ fn command(
 
     let names = Value::list(names, call.head);
 
-    Ok(PipelineData::Value(names, None))
+    Ok(PipelineData::value(names, None))
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
@@ -205,7 +205,7 @@ fn command(
             "File without extension",
         ))),
     }
-    .map(|Value| PipelineData::value(value, Some(metadata)))
+    .map(|value| PipelineData::value(value, Some(metadata)))
 }
 
 fn from_parquet(

--- a/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
@@ -205,7 +205,7 @@ fn command(
             "File without extension",
         ))),
     }
-    .map(|value| PipelineData::Value(value, Some(metadata)))
+    .map(|Value| PipelineData::value(value, Some(metadata)))
 }
 
 fn from_parquet(

--- a/crates/nu_plugin_polars/src/dataframe/command/core/profile.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/profile.rs
@@ -107,5 +107,5 @@ fn command_lazy(
         call.head,
     );
 
-    Ok(PipelineData::Value(result, None))
+    Ok(PipelineData::value(result, None))
 }

--- a/crates/nu_plugin_polars/src/dataframe/command/core/schema.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/schema.rs
@@ -51,7 +51,7 @@ impl PluginCommand for SchemaCmd {
         input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         if call.has_flag("datatype-list")? {
-            Ok(PipelineData::Value(datatype_list(Span::unknown()), None))
+            Ok(PipelineData::value(datatype_list(Span::unknown()), None))
         } else {
             command(plugin, engine, call, input).map_err(LabeledError::from)
         }
@@ -68,12 +68,12 @@ fn command(
         PolarsPluginObject::NuDataFrame(df) => {
             let schema = df.schema();
             let value = schema.base_value(call.head)?;
-            Ok(PipelineData::Value(value, None))
+            Ok(PipelineData::value(value, None))
         }
         PolarsPluginObject::NuLazyFrame(mut lazy) => {
             let schema = lazy.schema()?;
             let value = schema.base_value(call.head)?;
-            Ok(PipelineData::Value(value, None))
+            Ok(PipelineData::value(value, None))
         }
         _ => Err(ShellError::GenericError {
             error: "Must be a dataframe or lazy dataframe".into(),

--- a/crates/nu_plugin_polars/src/dataframe/command/core/to_lazy.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/to_lazy.rs
@@ -85,7 +85,7 @@ impl PluginCommand for ToLazyFrame {
         let mut lazy = NuLazyFrame::from_dataframe(df);
         // We don't want this converted back to an eager dataframe at some point
         lazy.from_eager = false;
-        Ok(PipelineData::Value(
+        Ok(PipelineData::value(
             lazy.cache(plugin, engine, call.head)?.into_value(call.head),
             None,
         ))

--- a/crates/nu_plugin_polars/src/dataframe/command/core/to_nu.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/to_nu.rs
@@ -106,15 +106,15 @@ fn command(
         PolarsPluginObject::NuLazyFrame(lazy) => dataframe_command(call, lazy.collect(call.head)?),
         PolarsPluginObject::NuExpression(expr) => {
             let value = expr.to_value(call.head)?;
-            Ok(PipelineData::Value(value, None))
+            Ok(PipelineData::value(value, None))
         }
         PolarsPluginObject::NuDataType(dt) => {
             let value = dt.base_value(call.head)?;
-            Ok(PipelineData::Value(value, None))
+            Ok(PipelineData::value(value, None))
         }
         PolarsPluginObject::NuSchema(schema) => {
             let value = schema.base_value(call.head)?;
-            Ok(PipelineData::Value(value, None))
+            Ok(PipelineData::value(value, None))
         }
         _ => Err(cant_convert_err(
             &value,
@@ -147,7 +147,7 @@ fn dataframe_command(call: &EvaluatedCall, df: NuDataFrame) -> Result<PipelineDa
 
     let value = Value::list(values, call.head);
 
-    Ok(PipelineData::Value(value, None))
+    Ok(PipelineData::value(value, None))
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/command/core/to_repr.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/to_repr.rs
@@ -98,7 +98,7 @@ fn dataframe_command(
 ) -> Result<PipelineData, ShellError> {
     let df = NuDataFrame::try_from_value_coerce(plugin, &input, call.head)?;
     let value = Value::string(format!("{df}"), call.head);
-    Ok(PipelineData::Value(value, None))
+    Ok(PipelineData::value(value, None))
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/command/data/collect.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/collect.rs
@@ -69,7 +69,7 @@ impl PluginCommand for LazyCollect {
                 let mut eager = lazy.collect(call.head)?;
                 // We don't want this converted back to a lazy frame
                 eager.from_lazy = true;
-                Ok(PipelineData::Value(
+                Ok(PipelineData::value(
                     eager
                         .cache(plugin, engine, call.head)?
                         .into_value(call.head),
@@ -94,7 +94,7 @@ impl PluginCommand for LazyCollect {
                 let df = NuDataFrame::from_cache_value(cv.value.clone())?;
 
                 // just return the dataframe, add to cache again to be safe
-                Ok(PipelineData::Value(df.into_value(call.head), None))
+                Ok(PipelineData::value(df.into_value(call.head), None))
             }
             _ => Err(cant_convert_err(
                 &value,

--- a/crates/nu_plugin_polars/src/dataframe/command/stub.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/stub.rs
@@ -48,7 +48,7 @@ to the `polars agg` command with some column expressions for aggregation which t
         call: &EvaluatedCall,
         _input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
-        Ok(PipelineData::Value(
+        Ok(PipelineData::value(
             Value::string(engine.get_help()?, call.head),
             None,
         ))

--- a/crates/nu_plugin_polars/src/dataframe/values/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/mod.rs
@@ -406,7 +406,7 @@ pub trait CustomValueSupport: Cacheable {
         engine: &EngineInterface,
         span: Span,
     ) -> Result<PipelineData, ShellError> {
-        Ok(PipelineData::Value(
+        Ok(PipelineData::value(
             self.cache_and_to_value(plugin, engine, span)?,
             None,
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,7 +403,7 @@ fn main() -> Result<()> {
     start_time = std::time::Instant::now();
     let input = if let Some(redirect_stdin) = &parsed_nu_cli_args.redirect_stdin {
         trace!("redirecting stdin");
-        PipelineData::ByteStream(ByteStream::stdin(redirect_stdin.span)?, None)
+        PipelineData::byte_stream(ByteStream::stdin(redirect_stdin.span)?, None)
     } else {
         trace!("not redirecting stdin");
         PipelineData::empty()


### PR DESCRIPTION
# Description
As title: this pr is try to introduce 2 functions to `PipelineData`:
1. PipelineData::list_stream --> create a PipelineData::ListStream
2. PipelineData::byte_stream -> create a PipelineData::ByteStream
And use these functions everywhere.

### Reason behind this change
I tried to implement `pipefail` feature, but this would required to change `PipelineData` from enum to struct.  So use these functions can reduce diff if I finally change to struct.  [Discord message here](https://discord.com/channels/601130461678272522/615962413203718156/1396999539000479784) is my plan.

# User-Facing Changes
NaN

# Tests + Formatting
NaN

# After Submitting
NaN