### PR TITLE
Reapply "refactor(completion, parser): move custom_completion info from Expression to Signature" (#16250)

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -348,8 +348,43 @@ impl NuCompleter {
                 for (arg_idx, arg) in call.arguments.iter().enumerate() {
                     let span = arg.span();
                     if span.contains(pos) {
-                        // if customized completion specified, it has highest priority
-                        if let Some(decl_id) = arg.expr().and_then(|e| e.custom_completion) {
+                        // Get custom completion from PositionalArg or Flag
+                        let custom_completion_decl_id = {
+                            // Check PositionalArg or Flag from Signature
+                            let signature = working_set.get_decl(call.decl_id).signature();
+
+                            match arg {
+                                // For named arguments, check Flag
+                                Argument::Named((name, short, value)) => {
+                                    if value.as_ref().is_none_or(|e| !e.span.contains(pos)) {
+                                        None
+                                    } else {
+                                        // If we're completing the value of the flag,
+                                        // search for the matching custom completion decl_id (long or short)
+                                        let flag =
+                                            signature.get_long_flag(&name.item).or_else(|| {
+                                                short.as_ref().and_then(|s| {
+                                                    signature.get_short_flag(
+                                                        s.item.chars().next().unwrap_or('_'),
+                                                    )
+                                                })
+                                            });
+                                        flag.and_then(|f| f.custom_completion)
+                                    }
+                                }
+                                // For positional arguments, check PositionalArg
+                                Argument::Positional(_) => {
+                                    // Find the right positional argument by index
+                                    let arg_pos = positional_arg_indices.len();
+                                    signature
+                                        .get_positional(arg_pos)
+                                        .and_then(|pos_arg| pos_arg.custom_completion)
+                                }
+                                _ => None,
+                            }
+                        };
+
+                        if let Some(decl_id) = custom_completion_decl_id {
                             // for `--foo <tab>` and `--foo=<tab>`, the arg span should be trimmed
                             let (new_span, prefix) = if matches!(arg, Argument::Named(_)) {
                                 strip_placeholder_with_rsplit(

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -97,8 +97,11 @@ fn extern_completer() -> NuCompleter {
     // Add record value as example
     let record = r#"
         def animals [] { [ "cat", "dog", "eel" ] }
+        def fruits [] { [ "apple", "banana" ] }
         extern spam [
             animal: string@animals
+            fruit?: string@fruits
+            ...rest: string@animals
             --foo (-f): string@animals
             -b: string@animals
         ]
@@ -2262,6 +2265,22 @@ fn extern_custom_completion_positional(mut extern_completer: NuCompleter) {
 }
 
 #[rstest]
+fn extern_custom_completion_optional(mut extern_completer: NuCompleter) {
+    let suggestions = extern_completer.complete("spam foo -f bar ", 16);
+    let expected: Vec<_> = vec!["apple", "banana"];
+    match_suggestions(&expected, &suggestions);
+}
+
+#[rstest]
+fn extern_custom_completion_rest(mut extern_completer: NuCompleter) {
+    let suggestions = extern_completer.complete("spam foo -f bar baz ", 20);
+    let expected: Vec<_> = vec!["cat", "dog", "eel"];
+    match_suggestions(&expected, &suggestions);
+    let suggestions = extern_completer.complete("spam foo -f bar baz qux ", 24);
+    match_suggestions(&expected, &suggestions);
+}
+
+#[rstest]
 fn extern_custom_completion_long_flag_1(mut extern_completer: NuCompleter) {
     let suggestions = extern_completer.complete("spam --foo=", 11);
     let expected: Vec<_> = vec!["cat", "dog", "eel"];
@@ -2287,6 +2306,17 @@ fn extern_custom_completion_short_flag(mut extern_completer: NuCompleter) {
     let suggestions = extern_completer.complete("spam -b ", 8);
     let expected: Vec<_> = vec!["cat", "dog", "eel"];
     match_suggestions(&expected, &suggestions);
+}
+
+/// When we're completing the flag name itself, not its value,
+/// custom completions should not be used
+#[rstest]
+fn custom_completion_flag_name_not_value(mut extern_completer: NuCompleter) {
+    let suggestions = extern_completer.complete("spam --f", 8);
+    match_suggestions(&vec!["--foo"], &suggestions);
+    // Also test with partial short flag
+    let suggestions = extern_completer.complete("spam -f", 7);
+    match_suggestions(&vec!["-f"], &suggestions);
 }
 
 #[rstest]

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -648,14 +648,6 @@ impl HelpStyle {
     }
 }
 
-/// Make syntax shape presentable by stripping custom completer info
-fn document_shape(shape: &SyntaxShape) -> &SyntaxShape {
-    match shape {
-        SyntaxShape::CompleterWrapper(inner_shape, _) => inner_shape,
-        _ => shape,
-    }
-}
-
 #[derive(PartialEq)]
 enum PositionalKind {
     Required,
@@ -686,15 +678,14 @@ fn write_positional(
                 long_desc,
                 "{help_subcolor_one}\"{}\" + {RESET}<{help_subcolor_two}{}{RESET}>",
                 String::from_utf8_lossy(kw),
-                document_shape(shape),
+                shape,
             );
         }
         _ => {
             let _ = write!(
                 long_desc,
                 "{help_subcolor_one}{}{RESET} <{help_subcolor_two}{}{RESET}>",
-                positional.name,
-                document_shape(&positional.shape),
+                positional.name, &positional.shape,
             );
         }
     };
@@ -767,11 +758,7 @@ where
         }
         // Type/Syntax shape info
         if let Some(arg) = &flag.arg {
-            let _ = write!(
-                long_desc,
-                " <{help_subcolor_two}{}{RESET}>",
-                document_shape(arg)
-            );
+            let _ = write!(long_desc, " <{help_subcolor_two}{arg}{RESET}>");
         }
         if !flag.desc.is_empty() {
             let _ = write!(

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -183,11 +183,6 @@ fn flatten_expression_into(
     expr: &Expression,
     output: &mut Vec<(Span, FlatShape)>,
 ) {
-    if let Some(custom_completion) = &expr.custom_completion {
-        output.push((expr.span, FlatShape::Custom(*custom_completion)));
-        return;
-    }
-
     match &expr.expr {
         Expr::AttributeBlock(ab) => {
             for attr in &ab.attributes {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -350,6 +350,7 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
                 shape: var_type.to_shape(),
                 var_id: Some(*var_id),
                 default_value: None,
+                custom_completion: None,
             },
         );
     }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6,7 +6,7 @@ use crate::{
     lite_parser::{LiteCommand, LitePipeline, LiteRedirection, LiteRedirectionTarget, lite_parse},
     parse_keywords::*,
     parse_patterns::parse_pattern,
-    parse_shape_specs::{ShapeDescriptorUse, parse_shape_name, parse_type},
+    parse_shape_specs::{parse_completer, parse_shape_name, parse_type},
     type_check::{self, check_range_types, math_result_type, type_compatible},
 };
 use itertools::Itertools;
@@ -1071,6 +1071,7 @@ pub fn parse_internal_call(
                     desc: "".to_string(),
                     var_id: None,
                     default_value: None,
+                    custom_completion: None,
                 })
             }
 
@@ -1324,7 +1325,6 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
                 span: _,
                 span_id: _,
                 ty,
-                custom_completion,
             } = &alias.clone().wrapped_call
             {
                 trace!("parsing: alias of external call");
@@ -1338,14 +1338,13 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
                     final_args.push(arg);
                 }
 
-                let mut expression = Expression::new(
+                let expression = Expression::new(
                     working_set,
                     Expr::ExternalCall(head, final_args.into()),
                     Span::concat(spans),
                     ty.clone(),
                 );
 
-                expression.custom_completion = *custom_completion;
                 return expression;
             } else {
                 trace!("parsing: alias of internal call");
@@ -3760,6 +3759,7 @@ pub fn parse_row_condition(working_set: &mut StateWorkingSet, spans: &[Span]) ->
                 shape: SyntaxShape::Any,
                 var_id: Some(var_id),
                 default_value: None,
+                custom_completion: None,
             });
 
             compile_block(working_set, &mut block);
@@ -3944,6 +3944,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                             required: false,
                                             var_id: Some(var_id),
                                             default_value: None,
+                                            custom_completion: None,
                                         },
                                         type_annotated: false,
                                     });
@@ -4005,6 +4006,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                                 required: false,
                                                 var_id: Some(var_id),
                                                 default_value: None,
+                                                custom_completion: None,
                                             },
                                             type_annotated: false,
                                         });
@@ -4047,6 +4049,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                         required: false,
                                         var_id: Some(var_id),
                                         default_value: None,
+                                        custom_completion: None,
                                     },
                                     type_annotated: false,
                                 });
@@ -4114,6 +4117,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                         shape: SyntaxShape::Any,
                                         var_id: Some(var_id),
                                         default_value: None,
+                                        custom_completion: None,
                                     },
                                     required: false,
                                     type_annotated: false,
@@ -4141,6 +4145,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                     shape: SyntaxShape::Any,
                                     var_id: Some(var_id),
                                     default_value: None,
+                                    custom_completion: None,
                                 }));
                                 parse_mode = ParseMode::Arg;
                             }
@@ -4167,6 +4172,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                         shape: SyntaxShape::Any,
                                         var_id: Some(var_id),
                                         default_value: None,
+                                        custom_completion: None,
                                     },
                                     required: true,
                                     type_annotated: false,
@@ -4176,31 +4182,62 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                         }
                         ParseMode::Type => {
                             if let Some(last) = args.last_mut() {
-                                let syntax_shape = parse_shape_name(
-                                    working_set,
-                                    &contents,
-                                    span,
-                                    ShapeDescriptorUse::Argument,
-                                );
+                                let (syntax_shape, completer) = if contents.contains(&b'@') {
+                                    let mut split = contents.splitn(2, |b| b == &b'@');
+
+                                    let shape_name = split
+                                        .next()
+                                        .expect("If `bytes` contains `@` splitn returns 2 slices");
+                                    let shape_span =
+                                        Span::new(span.start, span.start + shape_name.len());
+                                    let cmd_span =
+                                        Span::new(span.start + shape_name.len() + 1, span.end);
+                                    let cmd_name = split
+                                        .next()
+                                        .expect("If `bytes` contains `@` splitn returns 2 slices");
+                                    (
+                                        parse_shape_name(working_set, shape_name, shape_span),
+                                        parse_completer(working_set, cmd_name, cmd_span),
+                                    )
+                                } else {
+                                    (parse_shape_name(working_set, &contents, span), None)
+                                };
                                 //TODO check if we're replacing a custom parameter already
                                 match last {
                                     Arg::Positional {
-                                        arg: PositionalArg { shape, var_id, .. },
+                                        arg:
+                                            PositionalArg {
+                                                shape,
+                                                var_id,
+                                                custom_completion,
+                                                ..
+                                            },
                                         required: _,
                                         type_annotated,
                                     } => {
                                         working_set.set_variable_type(var_id.expect("internal error: all custom parameters must have var_ids"), syntax_shape.to_type());
+                                        *custom_completion = completer;
                                         *shape = syntax_shape;
                                         *type_annotated = true;
                                     }
                                     Arg::RestPositional(PositionalArg {
-                                        shape, var_id, ..
+                                        shape,
+                                        var_id,
+                                        custom_completion,
+                                        ..
                                     }) => {
                                         working_set.set_variable_type(var_id.expect("internal error: all custom parameters must have var_ids"), Type::List(Box::new(syntax_shape.to_type())));
+                                        *custom_completion = completer;
                                         *shape = syntax_shape;
                                     }
                                     Arg::Flag {
-                                        flag: Flag { arg, var_id, .. },
+                                        flag:
+                                            Flag {
+                                                arg,
+                                                var_id,
+                                                custom_completion,
+                                                ..
+                                            },
                                         type_annotated,
                                     } => {
                                         working_set.set_variable_type(var_id.expect("internal error: all custom parameters must have var_ids"), syntax_shape.to_type());
@@ -4211,6 +4248,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                                 span,
                                             ));
                                         }
+                                        *custom_completion = completer;
                                         *arg = Some(syntax_shape);
                                         *type_annotated = true;
                                     }
@@ -5167,11 +5205,6 @@ pub fn parse_value(
     }
 
     match shape {
-        SyntaxShape::CompleterWrapper(shape, custom_completion) => {
-            let mut expression = parse_value(working_set, span, shape);
-            expression.custom_completion = Some(*custom_completion);
-            expression
-        }
         SyntaxShape::Number => parse_number(working_set, span),
         SyntaxShape::Float => parse_float(working_set, span),
         SyntaxShape::Int => parse_int(working_set, span),

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BlockId, DeclId, GetSpan, IN_VARIABLE_ID, Signature, Span, SpanId, Type, VarId,
+    BlockId, GetSpan, IN_VARIABLE_ID, Signature, Span, SpanId, Type, VarId,
     ast::{Argument, Block, Expr, ExternalArgument, ImportPattern, MatchPattern, RecordItem},
     engine::StateWorkingSet,
 };
@@ -15,7 +15,6 @@ pub struct Expression {
     pub span: Span,
     pub span_id: SpanId,
     pub ty: Type,
-    pub custom_completion: Option<DeclId>,
 }
 
 impl Expression {
@@ -26,7 +25,6 @@ impl Expression {
             span,
             span_id,
             ty: Type::Any,
-            custom_completion: None,
         }
     }
 
@@ -572,7 +570,6 @@ impl Expression {
             span,
             span_id,
             ty,
-            custom_completion: None,
         }
     }
 
@@ -582,7 +579,6 @@ impl Expression {
             span,
             span_id,
             ty,
-            custom_completion: None,
         }
     }
 
@@ -592,7 +588,6 @@ impl Expression {
             span,
             span_id: SpanId::new(0),
             ty,
-            custom_completion: None,
         }
     }
 
@@ -602,7 +597,6 @@ impl Expression {
             span: self.span,
             span_id,
             ty: self.ty,
-            custom_completion: self.custom_completion,
         }
     }
 

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BlockId, DeprecationEntry, Example, FromValue, PipelineData, ShellError, SyntaxShape, Type,
-    Value, VarId,
+    BlockId, DeclId, DeprecationEntry, Example, FromValue, PipelineData, ShellError, SyntaxShape,
+    Type, Value, VarId,
     engine::{Call, Command, CommandType, EngineState, Stack},
 };
 use nu_derive_value::FromValue as DeriveFromValue;
@@ -24,6 +24,7 @@ pub struct Flag {
     // For custom commands
     pub var_id: Option<VarId>,
     pub default_value: Option<Value>,
+    pub custom_completion: Option<DeclId>,
 }
 
 /// The signature definition for a positional argument
@@ -36,6 +37,7 @@ pub struct PositionalArg {
     // For custom commands
     pub var_id: Option<VarId>,
     pub default_value: Option<Value>,
+    pub custom_completion: Option<DeclId>,
 }
 
 /// Command categories
@@ -255,6 +257,7 @@ impl Signature {
             required: false,
             var_id: None,
             default_value: None,
+            custom_completion: None,
         };
         self.named.push(flag);
         self
@@ -319,6 +322,7 @@ impl Signature {
             shape: shape.into(),
             var_id: None,
             default_value: None,
+            custom_completion: None,
         });
 
         self
@@ -337,6 +341,7 @@ impl Signature {
             shape: shape.into(),
             var_id: None,
             default_value: None,
+            custom_completion: None,
         });
 
         self
@@ -354,6 +359,7 @@ impl Signature {
             shape: shape.into(),
             var_id: None,
             default_value: None,
+            custom_completion: None,
         });
 
         self
@@ -393,6 +399,7 @@ impl Signature {
             desc: desc.into(),
             var_id: None,
             default_value: None,
+            custom_completion: None,
         });
 
         self
@@ -416,6 +423,7 @@ impl Signature {
             desc: desc.into(),
             var_id: None,
             default_value: None,
+            custom_completion: None,
         });
 
         self
@@ -438,6 +446,7 @@ impl Signature {
             desc: desc.into(),
             var_id: None,
             default_value: None,
+            custom_completion: None,
         });
 
         self

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -1,4 +1,4 @@
-use crate::{DeclId, Type};
+use crate::Type;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -28,9 +28,6 @@ pub enum SyntaxShape {
 
     /// A closure is allowed, eg `{|| start this thing}`
     Closure(Option<Vec<SyntaxShape>>),
-
-    /// A [`SyntaxShape`] with custom completion logic
-    CompleterWrapper(Box<SyntaxShape>, DeclId),
 
     /// A datetime value, eg `2022-02-02` or `2019-10-12T07:20:50.52+00:00`
     DateTime,
@@ -147,7 +144,6 @@ impl SyntaxShape {
             SyntaxShape::Closure(_) => Type::Closure,
             SyntaxShape::Binary => Type::Binary,
             SyntaxShape::CellPath => Type::Any,
-            SyntaxShape::CompleterWrapper(inner, _) => inner.to_type(),
             SyntaxShape::DateTime => Type::Date,
             SyntaxShape::Duration => Type::Duration,
             SyntaxShape::Expression => Type::Any,
@@ -252,7 +248,6 @@ impl Display for SyntaxShape {
             SyntaxShape::ExternalArgument => write!(f, "external-argument"),
             SyntaxShape::Boolean => write!(f, "bool"),
             SyntaxShape::Error => write!(f, "error"),
-            SyntaxShape::CompleterWrapper(x, _) => write!(f, "completable<{x}>"),
             SyntaxShape::OneOf(list) => {
                 write!(f, "oneof<")?;
                 if let Some((last, rest)) = list.split_last() {

--- a/crates/nu-protocol/tests/test_signature.rs
+++ b/crates/nu-protocol/tests/test_signature.rs
@@ -45,6 +45,7 @@ fn test_signature_chained() {
             shape: SyntaxShape::String,
             var_id: None,
             default_value: None,
+            custom_completion: None,
         })
     );
     assert_eq!(
@@ -55,6 +56,7 @@ fn test_signature_chained() {
             shape: SyntaxShape::String,
             var_id: None,
             default_value: None,
+            custom_completion: None,
         })
     );
     assert_eq!(
@@ -65,6 +67,7 @@ fn test_signature_chained() {
             shape: SyntaxShape::String,
             var_id: None,
             default_value: None,
+            custom_completion: None,
         })
     );
 
@@ -78,6 +81,7 @@ fn test_signature_chained() {
             desc: "required named description".to_string(),
             var_id: None,
             default_value: None,
+            custom_completion: None,
         })
     );
 
@@ -91,6 +95,7 @@ fn test_signature_chained() {
             desc: "required named description".to_string(),
             var_id: None,
             default_value: None,
+            custom_completion: None,
         })
     );
 }


### PR DESCRIPTION
This reverts commit aeb517867eb582761fdc5f44be3e01bc282af454. The Nushell version has bumped, so it's okay to reapply the changes from https://github.com/nushell/nushell/pull/15613.