### PR TITLE
fix(get): run_const uses `--optional` flag

### DIFF
--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -114,13 +114,14 @@ If multiple cell paths are given, this will produce a list of values."#
     ) -> Result<PipelineData, ShellError> {
         let cell_path: CellPath = call.req_const(working_set, 0)?;
         let rest: Vec<CellPath> = call.rest_const(working_set, 1)?;
-        let ignore_errors = call.has_flag_const(working_set, "ignore-errors")?;
+        let optional = call.has_flag_const(working_set, "optional")?
+            || call.has_flag_const(working_set, "ignore-errors")?;
         let metadata = input.metadata();
         action(
             input,
             cell_path,
             rest,
-            ignore_errors,
+            optional,
             working_set.permanent().signals().clone(),
             call.head,
         )


### PR DESCRIPTION
# Description
`Get::run_const()` was not update along `Get::run()` in #16007.

# Tests + Formatting
No tests added.

This bug escaping notice points towards the need for a more structured approach for verifying commands' parse-time behavior matches their run-time behavior (except for deliberate differences like `path self`).
