### PR TITLE
fix: raise compile error when `break` and `continue` used outside loop

### DIFF
--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -808,17 +808,13 @@ pub(crate) fn compile_break(
         builder.load_empty(io_reg)?;
         builder.push_break(call.head)?;
         builder.add_comment("break");
+        Ok(())
     } else {
-        // Fall back to calling the command if we can't find the loop target statically
-        builder.push(
-            Instruction::Call {
-                decl_id: call.decl_id,
-                src_dst: io_reg,
-            }
-            .into_spanned(call.head),
-        )?;
+        return Err(CompileError::NotInALoop {
+            msg: "'break' can only be used inside a loop".to_string(),
+            span: Some(call.head),
+        });
     }
-    Ok(())
 }
 
 /// Compile a call to `continue`.
@@ -833,17 +829,13 @@ pub(crate) fn compile_continue(
         builder.load_empty(io_reg)?;
         builder.push_continue(call.head)?;
         builder.add_comment("continue");
+        Ok(())
     } else {
-        // Fall back to calling the command if we can't find the loop target statically
-        builder.push(
-            Instruction::Call {
-                decl_id: call.decl_id,
-                src_dst: io_reg,
-            }
-            .into_spanned(call.head),
-        )?;
+        return Err(CompileError::NotInALoop {
+            msg: "'continue' can only be used inside a loop".to_string(),
+            span: Some(call.head),
+        });
     }
-    Ok(())
 }
 
 /// Compile a call to `return` as a `return-early` instruction.

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -810,10 +810,10 @@ pub(crate) fn compile_break(
         builder.add_comment("break");
         Ok(())
     } else {
-        return Err(CompileError::NotInALoop {
+        Err(CompileError::NotInALoop {
             msg: "'break' can only be used inside a loop".to_string(),
             span: Some(call.head),
-        });
+        })
     }
 }
 
@@ -831,10 +831,10 @@ pub(crate) fn compile_continue(
         builder.add_comment("continue");
         Ok(())
     } else {
-        return Err(CompileError::NotInALoop {
+        Err(CompileError::NotInALoop {
             msg: "'continue' can only be used inside a loop".to_string(),
             span: Some(call.head),
-        });
+        })
     }
 }
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
I tried to fix the issue https://github.com/nushell/nushell/issues/16271, I added compile error in both compile_break and compile_continue, while it does throw error one of the test is failing now.

<img width="898" height="391" alt="Screenshot 2025-07-27 at 11 00 37 PM" src="https://github.com/user-attachments/assets/6e64aebf-fbe0-4cd9-bee8-a6ce8ac57901" />


This is the test which is failing:
<img width="1650" height="378" alt="image" src="https://github.com/user-attachments/assets/b2b41c5e-37bb-4787-bfcd-391f7e8cff1c" />

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Shows actual error rather than internal implementation.
# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
