### PR TITLE
Manual GH workflow for `cargo hack` before release

### DIFF
--- a/.github/workflows/before-release-hack-check.yml
+++ b/.github/workflows/before-release-hack-check.yml
@@ -1,0 +1,44 @@
+name: Checks to run before release to verify individual crates can be built independently
+
+on:
+  - workflow_dispatch
+
+
+env:
+  NUSHELL_CARGO_PROFILE: ci
+  NU_LOG_LEVEL: DEBUG
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+
+    strategy:
+      fail-fast: true
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-22.04]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-hack
+
+      - name: Feature power set
+        run: |
+          cargo hack --all --feature-powerset --at-least-one-of rustls-tls,native-tls --mutually-exclusive-features rustls-tls,native-tls --mutually-exclusive-features rustls-tls,static-link-openssl --skip default-no-clipboard,stable,mimalloc check
+      - name: Build all crates
+        run: cargo hack --all build
+
+      - name: Check for clean repo
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "there are changes";
+            git status --porcelain
+            exit 1
+          else
+            echo "no changes in working directory";
+          fi


### PR DESCRIPTION
Currently we run this locally on whatever machine the person doing it is
using. With this we have all three major platforms covered and don't
block a personal machine before the release. Also any failures are
visible to everyone if we need to fix something.
