### PR TITLE
Fixup pre-release checkup workflow

### DIFF
--- a/.github/workflows/pre-release-checkup.yml
+++ b/.github/workflows/pre-release-checkup.yml
@@ -1,5 +1,4 @@
-name: Checks to run before release to verify individual crates can be built independently
-
+name: Checks to perform pre-release (manual)
 on:
   - workflow_dispatch
 
@@ -30,7 +29,7 @@ jobs:
         run: |
           cargo hack --all --feature-powerset --at-least-one-of rustls-tls,native-tls --mutually-exclusive-features rustls-tls,native-tls --mutually-exclusive-features rustls-tls,static-link-openssl --skip default-no-clipboard,stable,mimalloc check
       - name: Build all crates
-        run: cargo hack --all build
+        run: cargo hack --all build --clean-per-run
 
       - name: Check for clean repo
         shell: bash


### PR DESCRIPTION
Avoid going out of disk by running cargo clean between each build: https://github.com/taiki-e/cargo-hack#--clean-per-run

Also rename to something shorter for the overview

