### PR TITLE
Fix commit ID hex formatting in gstat

### DIFF
--- a/crates/nu_plugin_gstat/src/gstat.rs
+++ b/crates/nu_plugin_gstat/src/gstat.rs
@@ -294,7 +294,7 @@ impl Stats {
                         if let Ok(commit) = head.peel_to_commit() {
                             let mut id = String::new();
                             for byte in &commit.id().as_bytes()[..4] {
-                                write!(&mut id, "{byte:x}").unwrap();
+                                write!(&mut id, "{byte:02x}").unwrap();
                             }
                             id
                         } else {


### PR DESCRIPTION
Fix commit ID hex formatting in gstat, closes #16307 

Leading zeros are preserved, maintaining the correct hex representation

This issue is relatively easy to fix, but it's not very easy to verify. However, I have already tested several scenarios, it works for commit sha like `000baeef`, `000003c7` and `00000002` etc.