### PR TITLE
Change the behavior of `--ignore-case` and `--multiline` options for `find`

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -31,12 +31,12 @@ impl Command for Find {
             )
             .switch(
                 "ignore-case",
-                "case-insensitive; for regex mode, equivalent to (?i)",
+                "case-insensitive; when in regex mode, this is equivalent to (?i)",
                 Some('i'),
             )
             .switch(
                 "multiline",
-                "don't split multi-line strings into lists of lines. warning: this is not the same thing as (?m) for regex search.",
+                "don't split multi-line strings into lists of lines. you should use this option when using the (?m) or (?s) flags in regex mode",
                 Some('m'),
             )
             .switch(
@@ -72,8 +72,8 @@ impl Command for Find {
                 result: None,
             },
             Example {
-                description: "Search and highlight text for a term in a string. Note that regular search is case insensitive",
-                example: r#"'Cargo.toml' | find cargo"#,
+                description: "Search and highlight text for a term in a string.",
+                example: r#"'Cargo.toml' | find Cargo"#,
                 result: Some(Value::test_string(
                     "\u{1b}[37m\u{1b}[0m\u{1b}[41;37mCargo\u{1b}[0m\u{1b}[37m.toml\u{1b}[0m"
                         .to_owned(),
@@ -81,7 +81,7 @@ impl Command for Find {
             },
             Example {
                 description: "Search a number or a file size in a list of numbers",
-                example: r#"[1 5 3kb 4 3Mb] | find 5 3kb"#,
+                example: r#"[1 5 3kb 4 35 3Mb] | find 5 3kb"#,
                 result: Some(Value::list(
                     vec![Value::test_int(5), Value::test_filesize(3000)],
                     Span::test_data(),
@@ -103,16 +103,16 @@ impl Command for Find {
                 )),
             },
             Example {
-                description: "Find using regex",
-                example: r#"[abc bde arc abf] | find --regex "ab""#,
+                description: "Search using regex",
+                example: r#"[abc odb arc abf] | find --regex "b.""#,
                 result: Some(Value::list(
                     vec![
                         Value::test_string(
-                            "\u{1b}[37m\u{1b}[0m\u{1b}[41;37mab\u{1b}[0m\u{1b}[37mc\u{1b}[0m"
+                            "\u{1b}[37ma\u{1b}[0m\u{1b}[41;37mbc\u{1b}[0m\u{1b}[37m\u{1b}[0m"
                                 .to_string(),
                         ),
                         Value::test_string(
-                            "\u{1b}[37m\u{1b}[0m\u{1b}[41;37mab\u{1b}[0m\u{1b}[37mf\u{1b}[0m"
+                            "\u{1b}[37ma\u{1b}[0m\u{1b}[41;37mbf\u{1b}[0m\u{1b}[37m\u{1b}[0m"
                                 .to_string(),
                         ),
                     ],
@@ -120,8 +120,8 @@ impl Command for Find {
                 )),
             },
             Example {
-                description: "Find using regex case insensitive",
-                example: r#"[aBc bde Arc abf] | find --regex "ab" -i"#,
+                description: "Case insensitive search",
+                example: r#"[aBc bde Arc abf] | find "ab" -i"#,
                 result: Some(Value::list(
                     vec![
                         Value::test_string(
@@ -209,6 +209,28 @@ impl Command for Find {
                             "col3" => Value::test_string("curly".to_string()),
                     })],
                     Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Find in a multi-line string",
+                example: r#""Violets are red\nAnd roses are blue\nWhen metamaterials\nAlter their hue" | find "ue""#,
+                result: Some(Value::list(
+                    vec![
+                        Value::test_string(
+                            "\u{1b}[37mAnd roses are bl\u{1b}[0m\u{1b}[41;37mue\u{1b}[0m\u{1b}[37m\u{1b}[0m",
+                        ),
+                        Value::test_string(
+                            "\u{1b}[37mAlter their h\u{1b}[0m\u{1b}[41;37mue\u{1b}[0m\u{1b}[37m\u{1b}[0m",
+                        ),
+                    ],
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Find in a multi-line string without splitting the input into a list of lines",
+                example: r#""Violets are red\nAnd roses are blue\nWhen metamaterials\nAlter their hue" | find --multiline "ue""#,
+                result: Some(Value::test_string(
+                    "\u{1b}[37mViolets are red\nAnd roses are bl\u{1b}[0m\u{1b}[41;37mue\u{1b}[0m\u{1b}[37m\nWhen metamaterials\nAlter their h\u{1b}[0m\u{1b}[41;37mue\u{1b}[0m\u{1b}[37m\u{1b}[0m",
                 )),
             },
         ]

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -237,7 +237,7 @@ impl Command for Find {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["filter", "regex", "search", "condition"]
+        vec!["filter", "regex", "search", "condition", "grep"]
     }
 
     fn run(

--- a/crates/nu-command/tests/commands/find.rs
+++ b/crates/nu-command/tests/commands/find.rs
@@ -26,10 +26,11 @@ fn find_with_list_search_with_char() {
 
 #[test]
 fn find_with_bytestream_search_with_char() {
-    let actual =
-        nu!("\"ABC\" | save foo.txt; let res = open foo.txt | find abc; rm foo.txt; $res | get 0");
+    let actual = nu!(
+        "\"ABC\" | save foo.txt; let res = open foo.txt | find -i abc; rm foo.txt; $res | get 0"
+    );
     let actual_no_highlight = nu!(
-        "\"ABC\" | save foo.txt; let res = open foo.txt | find --no-highlight abc; rm foo.txt; $res | get 0"
+        "\"ABC\" | save foo.txt; let res = open foo.txt | find -i --no-highlight abc; rm foo.txt; $res | get 0"
     );
 
     assert_eq!(

--- a/typos.toml
+++ b/typos.toml
@@ -19,6 +19,7 @@ extend-ignore-re = [
     "0x\\[ba be\\]",
     "\\)BaR'",
     "fo�.txt",
+    "ue",
 ]
 
 [type.rust.extend-words]


### PR DESCRIPTION
# Description

Changes the behavior of `--ignore-case` and `--multiline` options for `find`, to make them more consistent between regex mode and search term mode, and to enable more options for using find.

# User-Facing Changes

Search term mode is now case-sensitive by default.

`--ignore-case` will make the search case-insensitive in search term mode. In regex mode, the previous behavior of adding a (?i) flag to the regex is preserved.

`--multiline` will no longer add a (?m) flag in regex mode. Instead, it will make the search not split multi-line strings into lists of lines.

closes #16317
closes #16022