### PR TITLE
Fix UTF-8 multibyte handling in `explore` inputs

### DIFF
--- a/crates/nu-explore/src/views/try.rs
+++ b/crates/nu-explore/src/views/try.rs
@@ -16,6 +16,7 @@ use ratatui::{
     widgets::{BorderType, Borders, Paragraph},
 };
 use std::cmp::min;
+use unicode_width::UnicodeWidthStr;
 
 pub struct TryView {
     input: Value,
@@ -87,8 +88,8 @@ impl View for TryView {
 
         let mut input = self.command.as_str();
 
-        let max_cmd_len = min(input.len() as u16, cmd_input_area.width);
-        if input.len() as u16 > max_cmd_len {
+        let max_cmd_len = min(input.width() as u16, cmd_input_area.width);
+        if input.width() as u16 > max_cmd_len {
             // in such case we take last max_cmd_len chars
             let take_bytes = input
                 .chars()


### PR DESCRIPTION
# Description
`explore` was reading the byte length for computing:
- `:` command input cursor positions
- `/`/`?` search mode cursor positions
- `:try` input box cursor positions
- search highlighting

Fixed this for the majority of cases by using `unicode_width`, this is
only best effort as terminals don't need to follow those expectations
but for the most cases (traditional language scripts etc.) this should
lead to better result. The only way around the uncertainty would be to
perform the highlighting/cursor marking as we go, but this may not be as
compatible with the `ratatui` framework.

Fixed cursor position and search highlighting for non-ASCII characters, with the caveat mentioned above.
Closes #16312

# User-Facing Changes
## Release notes summary
In `explore`, cursor position and search highlighting works better on non-ASCII characters.



# Tests + Formatting
Manually tested
