### PR TITLE
Add `send: vichangemode` to reedline config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -6084,8 +6084,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b627c435d0189363b15f885f1b07193d310ec9e4e39c5627951c6e0f4d02c93a"
+source = "git+https://github.com/nushell/reedline?branch=main#faee143a688846d98e260407b4e09f653eb31307"
 dependencies = [
  "arboard",
  "chrono",
@@ -6535,7 +6534,7 @@ dependencies = [
  "security-framework 3.0.1",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8451,7 +8450,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,7 +342,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Run all benchmarks with `cargo bench`

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -1047,6 +1047,10 @@ fn event_from_record(
             ReedlineEvent::ExecuteHostCommand(cmd.to_expanded_string("", config))
         }
         "openeditor" => ReedlineEvent::OpenEditor,
+        "vichangemode" => {
+            let mode = extract_value("mode", record, span)?;
+            ReedlineEvent::ViChangeMode(mode.as_str()?.to_owned())
+        }
         str => {
             return Err(ShellError::InvalidValue {
                 valid: "a reedline event".into(),


### PR DESCRIPTION
# Description
Allows custom bindings (non-chord) to send a `edit_mode: vi` mode change
via the new `ReedlineEvent::ViChangeMode`
Takes https://github.com/nushell/reedline/pull/932

# User-Facing Changes
You can now set bindings which change the Vi mode. (This still has the same rules for defining the key-combination: Only modifiers and single keys are supported)
To do so send a `vichangemode` event with the `mode` field to set `normal`, `insert`, or `visual`

```nushell
$env.config.keybindings ++=
	[{
	    name: modechangetest
	    modifier: control
	    keycode: "char_["
	    mode: [vi_normal, vi_insert]
	    event: {send: vichangemode, mode: normal}
	}]

```

