### PR TITLE
Forgo full build in the `cargo hack` wf

### DIFF
--- a/.github/workflows/pre-release-checkup.yml
+++ b/.github/workflows/pre-release-checkup.yml
@@ -28,8 +28,9 @@ jobs:
       - name: Feature power set
         run: |
           cargo hack --all --feature-powerset --at-least-one-of rustls-tls,native-tls --mutually-exclusive-features rustls-tls,native-tls --mutually-exclusive-features rustls-tls,static-link-openssl --skip default-no-clipboard,stable,mimalloc check
-      - name: Build all crates
-        run: cargo hack --all build --clean-per-run
+      # Don't build fully for now as it will run out of disk space
+      # - name: Build all crates
+      #   run: cargo hack --all build --clean-per-run
 
       - name: Check for clean repo
         shell: bash


### PR DESCRIPTION
We ran out of disk space on Github actions with the build part of this
workflow. We hope that `check` should catch the worst offenders.
