### PR TITLE
Add multiline example for `input` command

### DIFF
--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -225,7 +225,7 @@ impl Command for Input {
             },
             Example {
                 description: "Get input from the user with history, and assign to a variable",
-                example: "let user_input = ([past,command,entries] | input)",
+                example: "let user_input = ([past,command,entries] | input --reedline)",
                 result: None,
             },
             Example {


### PR DESCRIPTION
# Description

Adds an example that documents how to use `input --reedline` to collect multiple lines of input from the user

I also removed an extraneous and inconsistent space in the following example.

# User-Facing Changes
## Release notes summary
`input` command has 1 more example on `--reedline` flag.

# Tests + Formatting

I did not run any tests or autoformatters because of the docs-only nature of the change, and the fact that I copy-pasted the format from an existing example. If the autoformatter is unhappy, I apologize.

# After Submitting

This PR should automatically update the docs site at the next release, so no need to do anything there.
