### PR TITLE
Clarify that `input`'s history feature uses reedline

### DIFF
--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -55,13 +55,13 @@ impl Command for Input {
             .named(
                 "history-file",
                 SyntaxShape::Filepath,
-                "Path to a file to read and write command history. This is a text file and will be created if it doesn't exist. Will be used as the selection list. History requires `--reedline`.",
+                "Path to a file to read and write command history. This is a text file and will be created if it doesn't exist. Will be used as the selection list. Implies `--reedline`.",
                 None,
             )
             .named(
                 "max-history",
                 SyntaxShape::Int,
-                "The maximum number of entries to keep in the history, defaults to $env.config.history.max_size. History requires `--reedline`.",
+                "The maximum number of entries to keep in the history, defaults to $env.config.history.max_size. Implies `--reedline`.",
                 None,
             )
             .switch("suppress-output", "don't print keystroke values", Some('s'))


### PR DESCRIPTION
Follow up to this commit @sholderbach made on my PR #16329: https://github.com/nushell/nushell/pull/16329/commits/f21350ec88a2f538f9ddc55bf464b5132c9634d6#diff-5cab4dac5ced236548db9fbf6cd0e9d250ba12317bb916ec26603054ce9144a7
