### PR TITLE
typo: `help format filesize` has a wrong example

### DIFF
--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -99,7 +99,7 @@ impl Command for FormatFilesize {
         vec![
             Example {
                 description: "Convert the size column to KB",
-                example: "ls | format filesize KB size",
+                example: "ls | format filesize kB size",
                 result: None,
             },
             Example {


### PR DESCRIPTION
Just a small one letter typo in the help command. It should be `kB`

<img width="943" height="688" alt="image" src="https://github.com/user-attachments/assets/fcca3978-cc0d-483f-b74e-465743213b76" />
