### PR TITLE
fix(parser): env shorthand false positive

### DIFF
--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -1027,3 +1027,9 @@ fn not_panic_with_recursive_call() {
     );
     assert!(result.status.success());
 }
+
+// https://github.com/nushell/nushell/issues/16332
+#[test]
+fn quote_escape_but_not_env_shorthand() -> TestResult {
+    run_test(r#""\"=foo""#, "\"=foo")
+}


### PR DESCRIPTION
Fixes #16332

# Description

More restrictions on env shorthand parsing to avoid false positives.

# User-Facing Changes

# Tests + Formatting

+1

# After Submitting
