### PR TITLE
fix(parser): external argument with subexpressions

### DIFF
--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -1027,3 +1027,12 @@ fn not_panic_with_recursive_call() {
     );
     assert!(result.status.success());
 }
+
+// https://github.com/nushell/nushell/issues/16040
+#[test]
+fn external_argument_with_subexpressions() -> TestResult {
+    run_test(r#"^echo foo( ('bar') | $in ++ 'baz' )"#, "foobarbaz")?;
+    run_test(r#"^echo foo( 'bar' )('baz')"#, "foobarbaz")?;
+    run_test(r#"^echo ")('foo')(""#, ")('foo')(")?;
+    fail_test(r#"^echo foo( 'bar'"#, "Unexpected end of code")
+}


### PR DESCRIPTION
Fixes #16040

# Description

TBH, I not a fan of this whole `parse_external_string` idea.
Maybe I lack some of the background knowledge here, but I don't see why we choose not to 
1. parse external arguments the same way as internal ones
2. treat them literally at runtime if necessary

# User-Facing Changes

# Tests + Formatting

+1

# After Submitting
