### PR TITLE
Fix memory leaks in REPL

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -208,7 +208,7 @@ pub fn evaluate_repl(
             )
         }));
         match iteration_panic_state {
-            Ok((continue_loop, es, s, le)) => {
+            Ok((continue_loop, mut es, s, le)) => {
                 // We apply the changes from the updated stack back onto our previous stack
                 let mut merged_stack = Stack::with_changes_from_child(previous_stack_arc, s);
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -275,7 +275,7 @@ impl EngineState {
                     existing_overlay.decls.insert(item.0, item.1);
                 }
                 for item in delta_overlay.vars.into_iter() {
-                    existing_overlay.vars.insert(item.0, item.1);
+                    existing_overlay.insert_variable(item.0, item.1);
                 }
                 for item in delta_overlay.modules.into_iter() {
                     existing_overlay.modules.insert(item.0, item.1);
@@ -378,24 +378,19 @@ impl EngineState {
 
     /// Clean up unused variables from a Stack to prevent memory leaks.
     /// This removes variables that are no longer referenced by any overlay.
-    pub fn cleanup_stack_variables(&self, stack: &mut Stack) {
+    pub fn cleanup_stack_variables(&mut self, stack: &mut Stack) {
         use std::collections::HashSet;
 
-        // Collect all VarIds that are still referenced by overlays
-        let referenced_vars: HashSet<_> = self
-            .scope
-            .overlays
-            .iter()
-            .flat_map(|(_, overlay)| overlay.vars.values())
-            .copied()
-            // Always preserve critical system variables
-            .chain([NU_VARIABLE_ID, IN_VARIABLE_ID, ENV_VARIABLE_ID])
-            .collect();
+        let mut shadowed_vars = HashSet::new();
+        for (_, frame) in self.scope.overlays.iter_mut() {
+            shadowed_vars.extend(frame.shadowed_vars.to_owned());
+            frame.shadowed_vars.clear();
+        }
 
         // Remove variables from stack that are no longer referenced
         stack
             .vars
-            .retain(|(var_id, _)| referenced_vars.contains(var_id));
+            .retain(|(var_id, _)| !shadowed_vars.contains(var_id));
     }
 
     pub fn active_overlay_ids<'a, 'b>(

--- a/crates/nu-protocol/src/engine/overlay.rs
+++ b/crates/nu-protocol/src/engine/overlay.rs
@@ -182,6 +182,7 @@ pub struct OverlayFrame {
     pub predecls: HashMap<Vec<u8>, DeclId>, // temporary storage for predeclarations
     pub decls: HashMap<Vec<u8>, DeclId>,
     pub modules: HashMap<Vec<u8>, ModuleId>,
+    pub shadowed_vars: Vec<VarId>,
     pub visibility: Visibility,
     pub origin: ModuleId, // The original module the overlay was created from
     pub prefixed: bool,   // Whether the overlay has definitions prefixed with its name
@@ -194,6 +195,7 @@ impl OverlayFrame {
             predecls: HashMap::new(),
             decls: HashMap::new(),
             modules: HashMap::new(),
+            shadowed_vars: Vec::new(),
             visibility: Visibility::new(),
             origin,
             prefixed,
@@ -209,7 +211,11 @@ impl OverlayFrame {
     }
 
     pub fn insert_variable(&mut self, name: Vec<u8>, variable_id: VarId) -> Option<VarId> {
-        self.vars.insert(name, variable_id)
+        let res = self.vars.insert(name, variable_id);
+        if let Some(old_id) = res {
+            self.shadowed_vars.push(old_id);
+        }
+        res
     }
 
     pub fn get_decl(&self, name: &[u8]) -> Option<DeclId> {

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -626,7 +626,7 @@ impl<'a> StateWorkingSet<'a> {
             name.insert(0, b'$');
         }
 
-        self.last_overlay_mut().vars.insert(name, next_id);
+        self.last_overlay_mut().insert_variable(name, next_id);
 
         self.delta.vars.push(Variable::new(span, ty, mutable));
 


### PR DESCRIPTION
This PR should close #16340 

# Description

After this change on Windows:
```nu
~ $> ps | where name == 'nu.exe' | select name mem
 #    name      mem
──────────────────────
 0   nu.exe   47.7 MB
 1   nu.exe   67.6 MB

~ $> let x = random binary 100mb
~ $> ps | where name == 'nu.exe' | select name mem
 #    name      mem
───────────────────────
 0   nu.exe    47.7 MB
 1   nu.exe   166.6 MB

~ $> let x = random binary 100mb
~ $> ps | where name == 'nu.exe' | select name mem
 #    name      mem
───────────────────────
 0   nu.exe    47.7 MB
 1   nu.exe   165.8 MB

~ $> let x = random binary 100mb
~ $> ps | where name == 'nu.exe' | select name mem
 #    name      mem
───────────────────────
 0   nu.exe    47.7 MB
 1   nu.exe   167.3 MB

~ $> let x = random binary 100mb
~ $> ps | where name == 'nu.exe' | select name mem
 #    name      mem
───────────────────────
 0   nu.exe    47.7 MB
 1   nu.exe   166.5 MB

~ $> let x = random binary 10mb
~ $> ps | where name == 'nu.exe' | select name mem
 #    name      mem
──────────────────────
 0   nu.exe   47.7 MB
 1   nu.exe   76.3 MB

~ $> let x = random binary 1mb
~ $> ps | where name == 'nu.exe' | select name mem
 #    name      mem
──────────────────────
 0   nu.exe   47.7 MB
 1   nu.exe   68.4 MB

~ $> ps | where name == 'nu.exe' | select name mem
 #    name      mem
──────────────────────
 0   nu.exe   47.7 MB
 1   nu.exe   67.7 MB

# After a while
~ $> ps | where name == 'nu.exe' | select name mem
 #    name      mem
──────────────────────
 0   nu.exe   38.6 MB
 1   nu.exe   55.7 MB
```

# User-Facing Changes

Hopefully none, and this https://github.com/nushell/nushell/issues/16340#issuecomment-3149930258 just work as before.

