### PR TITLE
Fully qualify the sqlite path for `into sqlite`

### DIFF
--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -414,21 +414,3 @@ fn get_columns_with_sqlite_types(
 
     Ok(columns)
 }
-
-#[cfg(test)]
-mod tests {
-    use nu_test_support::{nu, playground::Playground};
-
-    #[test]
-    fn test_auto_conversion() {
-        Playground::setup("sqlite json auto conversion", |_, playground| {
-            let raw = "{a_record:{foo:bar,baz:quux},a_list:[1,2,3],a_table:[[a,b];[0,1],[2,3]]}";
-            nu!(cwd: playground.cwd(), "{} | into sqlite filename.db -t my_table", raw);
-            let outcome = nu!(
-                cwd: playground.cwd(),
-                "open filename.db | get my_table.0 | to nuon --raw"
-            );
-            assert_eq!(outcome.out, raw);
-        });
-    }
-}

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -414,3 +414,21 @@ fn get_columns_with_sqlite_types(
 
     Ok(columns)
 }
+
+#[cfg(test)]
+mod tests {
+    use nu_test_support::{nu, playground::Playground};
+
+    #[test]
+    fn test_auto_conversion() {
+        Playground::setup("sqlite json auto conversion", |_, playground| {
+            let raw = "{a_record:{foo:bar,baz:quux},a_list:[1,2,3],a_table:[[a,b];[0,1],[2,3]]}";
+            nu!(cwd: playground.cwd(), "{} | into sqlite filename.db -t my_table", raw);
+            let outcome = nu!(
+                cwd: playground.cwd(),
+                "open filename.db | get my_table.0 | to nuon --raw"
+            );
+            assert_eq!(outcome.out, raw);
+        });
+    }
+}

--- a/crates/nu-command/tests/commands/database/into_sqlite.rs
+++ b/crates/nu-command/tests/commands/database/into_sqlite.rs
@@ -495,3 +495,16 @@ fn insert_test_rows(dirs: &Dirs, nu_table: &str, sql_query: Option<&str>, expect
 
     assert_eq!(expected, actual_rows);
 }
+
+#[test]
+fn test_auto_conversion() {
+    Playground::setup("sqlite json auto conversion", |_, playground| {
+        let raw = "{a_record:{foo:bar,baz:quux},a_list:[1,2,3],a_table:[[a,b];[0,1],[2,3]]}";
+        nu!(cwd: playground.cwd(), "{} | into sqlite filename.db -t my_table", raw);
+        let outcome = nu!(
+            cwd: playground.cwd(),
+            "open filename.db | get my_table.0 | to nuon --raw"
+        );
+        assert_eq!(outcome.out, raw);
+    });
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

- related #16258

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

In #16258 we had some trouble getting tests to work properly. After some investigation with @WindSoilder we figured out that `Table::new` inside `into_sqlite.rs` did not respect the `$env.PWD`. The underlying `open_sqlite_db` and in that `Connection::open` respects the current working directory. That one is updated via `cd` but not necessarily in tests (and we should not try that). In this PR I join the `$env.PWD` with the path passed to `into sqlite`.

This PR also adds a test for the auto conversion from #16258.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Should be none, some edge cases might be fixed now.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
