### PR TITLE
fix(help): don't trim example result beginning

### DIFF
--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -497,8 +497,9 @@ fn get_command_documentation(
                     long_desc,
                     "  {}",
                     item.to_expanded_string("", nu_config)
+                        .trim_end()
+                        .trim_start_matches(|c: char| c.is_whitespace() && c != ' ')
                         .replace('\n', "\n  ")
-                        .trim()
                 );
             }
         }


### PR DESCRIPTION
# Description
The `help` command, when printing the examples with results, trims the first line and it appears unindented compared to the following lines.

- Before:
<img width="1110" height="346" alt="image" src="https://github.com/user-attachments/assets/3487381d-3631-49c9-bb0e-f7ad958b7291" />

- After:
<img width="1123" height="339" alt="image" src="https://github.com/user-attachments/assets/acb45afd-0492-49d2-a5cb-5130bbb4cf94" />

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
