### PR TITLE
fix(std/help): trim example results and fix binary examples

### DIFF
--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -708,8 +708,9 @@ def build-command-page [command: record] {
             (if not ($example.result | is-empty) {
                 $example.result
                 | table -e
-                | to text
-                | if ($example.result | describe) == "binary" { str join } else { lines }
+                | str trim --right
+                | lines
+                | skip until { is-not-empty }
                 | each {|line|
                     $"  ($line)"
                 }


### PR DESCRIPTION
# Description
Added trimming to the example results like in the normal `help`, and also changed the logic for binary examples to remove the weird spacing.
- Before:
<img width="998" height="919" alt="image" src="https://github.com/user-attachments/assets/03f18f45-5b12-41bc-b495-232bcf899964" />

- After:
<img width="959" height="720" alt="image" src="https://github.com/user-attachments/assets/894dc622-c603-467c-8904-aef582a82b0a" />

# User-Facing Changes
## Release notes summary
`std help` displays better on binary exmaples.

# Tests + Formatting

# After Submitting
