### PR TITLE
Update rstest from 0.23 to 0.26 (the current version)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -6278,19 +6278,18 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",
@@ -8450,7 +8449,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ reedline = "0.41.0"
 rmp = "0.8"
 rmp-serde = "1.3"
 roxmltree = "0.20"
-rstest = { version = "0.23", default-features = false }
+rstest = { version = "0.26", default-features = false }
 rstest_reuse = "0.7"
 rusqlite = "0.31"
 rust-embed = "8.7.0"

--- a/crates/nu-json/tests/main.rs
+++ b/crates/nu-json/tests/main.rs
@@ -21,7 +21,11 @@ fn txt(text: String) -> String {
 
 // This test will fail if/when `nu_test_support::fs::assets()`'s return value changes.
 #[rstest]
-fn assert_rstest_finds_assets(#[files("../../tests/assets/nu_json")] rstest_supplied: PathBuf) {
+fn assert_rstest_finds_assets(
+    #[files("../../tests/assets/nu_json")]
+    #[dirs]
+    rstest_supplied: PathBuf,
+) {
     // rstest::files runs paths through `fs::canonicalize`, which:
     // > On Windows, this converts the path to use extended length path syntax
     // So we make sure to canonicalize both paths.


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Nothing special here, just bumping the dependencies downstream in Fedora’s nushell packages and sending the corresponding change upstream.

I needed to add the new `#[dirs]` directive in one spot for compatibility with `rstest` 0.26; see https://github.com/la10736/rstest/blob/v0.26.1/CHANGELOG.md, https://github.com/la10736/rstest/issues/306, and https://github.com/Obito-git/rstest/commit/54389dac7d6c21ef634c5e879094f93adcb4568e for details.

Nothing else in https://github.com/la10736/rstest/blob/v0.26.1/CHANGELOG.md looks like it should affect this project, and `cargo test --workspace` and `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` still pass.

Furthermore, this doesn’t add multiple versions of any crates to the dependency tree in `Cargo.lock`, which has been a sticking point in some other dependency-update PR’s.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

N/A; this can only affect people who are running the tests, and there should be no observable changes there, either.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Tested with `cargo test --workspace` and `cargo run -- -c "use toolkit.nu; toolkit test stdlib"`.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

N/A