### PR TITLE
Respect `$env.LC_ALL` and `$env.LANG` in `format date`

### DIFF
--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -100,11 +100,16 @@ impl Command for FormatDate {
         let list = call.has_flag(engine_state, stack, "list")?;
         let format = call.opt::<Spanned<String>>(engine_state, stack, 0)?;
 
+        // env var preference is documented at https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html
+        // LC_ALL ovverides LC_TIME, LC_TIME overrides LANG
+
         // get the locale first so we can use the proper get_env_var functions since this is a const command
         // we can override the locale by setting $env.NU_TEST_LOCALE_OVERRIDE or $env.LC_TIME
         let locale = if let Some(loc) = engine_state
             .get_env_var(LOCALE_OVERRIDE_ENV_VAR)
+            .or_else(|| engine_state.get_env_var("LC_ALL"))
             .or_else(|| engine_state.get_env_var("LC_TIME"))
+            .or_else(|| engine_state.get_env_var("LANG"))
         {
             let locale_str = loc.as_str()?.split('.').next().unwrap_or("en_US");
             locale_str.try_into().unwrap_or(Locale::en_US)
@@ -129,11 +134,16 @@ impl Command for FormatDate {
         let list = call.has_flag_const(working_set, "list")?;
         let format = call.opt_const::<Spanned<String>>(working_set, 0)?;
 
+        // env var preference is documented at https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html
+        // LC_ALL ovverides LC_TIME, LC_TIME overrides LANG
+
         // get the locale first so we can use the proper get_env_var functions since this is a const command
         // we can override the locale by setting $env.NU_TEST_LOCALE_OVERRIDE or $env.LC_TIME
         let locale = if let Some(loc) = working_set
             .get_env_var(LOCALE_OVERRIDE_ENV_VAR)
+            .or_else(|| working_set.get_env_var("LC_ALL"))
             .or_else(|| working_set.get_env_var("LC_TIME"))
+            .or_else(|| working_set.get_env_var("LANG"))
         {
             let locale_str = loc.as_str()?.split('.').next().unwrap_or("en_US");
             locale_str.try_into().unwrap_or(Locale::en_US)


### PR DESCRIPTION
Refs https://github.com/nushell/nushell/issues/16368#issuecomment-3160728758

# Description

Respect user preference for date/time formats, in a more compatible way. Environment variable order is taken from https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html. Previously, only `$env.LC_TIME` was consulted to select the locale.

# User-Facing Changes

Users will be able to specify the format preference via `$env.LANG` and override it with `$env.LC_ALL`.

# Tests + Formatting

All pass.
