### PR TITLE
Add `--raw` flag to `to html`

### DIFF
--- a/crates/nu-cmd-extra/src/extra/formats/to/html.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html.rs
@@ -109,16 +109,24 @@ impl Command for ToHtml {
                 "produce a color table of all available themes",
                 Some('l'),
             )
+            .switch("raw", "do not escape html tags", Some('r'))
             .category(Category::Formats)
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Outputs an  HTML string representing the contents of this table",
+                description: "Outputs an HTML string representing the contents of this table",
                 example: "[[foo bar]; [1 2]] | to html",
                 result: Some(Value::test_string(
                     r#"<html><style>body { background-color:white;color:black; }</style><body><table><thead><tr><th>foo</th><th>bar</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table></body></html>"#,
+                )),
+            },
+            Example {
+                description: "Outputs an HTML string using a record of xml data",
+                example: r#"{tag: a attributes: { style: "color: red" } content: ["hello!"] } | to xml | to html --raw"#,
+                result: Some(Value::test_string(
+                    r#"<html><style>body { background-color:white;color:black; }</style><body><a style="color: red">hello!</a></body></html>"#,
                 )),
             },
             Example {
@@ -254,6 +262,7 @@ fn to_html(
     let dark = call.has_flag(engine_state, stack, "dark")?;
     let partial = call.has_flag(engine_state, stack, "partial")?;
     let list = call.has_flag(engine_state, stack, "list")?;
+    let raw = call.has_flag(engine_state, stack, "raw")?;
     let theme: Option<Spanned<String>> = call.get_flag(engine_state, stack, "theme")?;
     let config = &stack.get_config(engine_state);
 
@@ -319,15 +328,15 @@ fn to_html(
     let inner_value = match vec_of_values.len() {
         0 => String::default(),
         1 => match headers {
-            Some(headers) => html_table(vec_of_values, headers, config),
+            Some(headers) => html_table(vec_of_values, headers, raw, config),
             None => {
                 let value = &vec_of_values[0];
-                html_value(value.clone(), config)
+                html_value(value.clone(), raw, config)
             }
         },
         _ => match headers {
-            Some(headers) => html_table(vec_of_values, headers, config),
-            None => html_list(vec_of_values, config),
+            Some(headers) => html_table(vec_of_values, headers, raw, config),
+            None => html_list(vec_of_values, raw, config),
         },
     };
 
@@ -395,19 +404,19 @@ fn theme_demo(span: Span) -> PipelineData {
     })
 }
 
-fn html_list(list: Vec<Value>, config: &Config) -> String {
+fn html_list(list: Vec<Value>, raw: bool, config: &Config) -> String {
     let mut output_string = String::new();
     output_string.push_str("<ol>");
     for value in list {
         output_string.push_str("<li>");
-        output_string.push_str(&html_value(value, config));
+        output_string.push_str(&html_value(value, raw, config));
         output_string.push_str("</li>");
     }
     output_string.push_str("</ol>");
     output_string
 }
 
-fn html_table(table: Vec<Value>, headers: Vec<String>, config: &Config) -> String {
+fn html_table(table: Vec<Value>, headers: Vec<String>, raw: bool, config: &Config) -> String {
     let mut output_string = String::new();
 
     output_string.push_str("<table>");
@@ -430,7 +439,7 @@ fn html_table(table: Vec<Value>, headers: Vec<String>, config: &Config) -> Strin
                     .cloned()
                     .unwrap_or_else(|| Value::nothing(span));
                 output_string.push_str("<td>");
-                output_string.push_str(&html_value(data, config));
+                output_string.push_str(&html_value(data, raw, config));
                 output_string.push_str("</td>");
             }
             output_string.push_str("</tr>");
@@ -441,7 +450,7 @@ fn html_table(table: Vec<Value>, headers: Vec<String>, config: &Config) -> Strin
     output_string
 }
 
-fn html_value(value: Value, config: &Config) -> String {
+fn html_value(value: Value, raw: bool, config: &Config) -> String {
     let mut output_string = String::new();
     match value {
         Value::Binary { val, .. } => {
@@ -450,11 +459,22 @@ fn html_value(value: Value, config: &Config) -> String {
             output_string.push_str(&output);
             output_string.push_str("</pre>");
         }
-        other => output_string.push_str(
-            &v_htmlescape::escape(&other.to_abbreviated_string(config))
-                .to_string()
-                .replace('\n', "<br>"),
-        ),
+        other => {
+            if raw {
+                output_string.push_str(
+                    &other
+                        .to_abbreviated_string(config)
+                        .to_string()
+                        .replace('\n', "<br>"),
+                )
+            } else {
+                output_string.push_str(
+                    &v_htmlescape::escape(&other.to_abbreviated_string(config))
+                        .to_string()
+                        .replace('\n', "<br>"),
+                )
+            }
+        }
     }
     output_string
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->
Potentially closes #16347 however more work may be required first

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Adds a `--raw` flag to `to html`. This stops the resulting html content being escaped
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
