### PR TITLE
Fix error message: custom commands cannot be `const`

### DIFF
--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1186,7 +1186,7 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         span: Span,
     },
 
-    /// TODO: Update help text once custom const commands are supported
+    // TODO: Update help text once custom const commands are supported
     /// Tried running a command that is not const-compatible
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1190,13 +1190,12 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
     ///
     /// ## Resolution
     ///
-    /// Only a subset of builtin commands, and custom commands built only from those commands, can
-    /// run at parse time.
+    /// Only a subset of builtin commands can run at parse time.
     #[error("Not a const command.")]
     #[diagnostic(
         code(nu::shell::not_a_const_command),
         help(
-            "Only a subset of builtin commands, and custom commands built only from those commands, can run at parse time."
+            "Only a subset of builtin commands can run at parse time."
         )
     )]
     NotAConstCommand {

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1186,6 +1186,7 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         span: Span,
     },
 
+    /// TODO: Update help text once custom const commands are supported
     /// Tried running a command that is not const-compatible
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1194,9 +1194,7 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
     #[error("Not a const command.")]
     #[diagnostic(
         code(nu::shell::not_a_const_command),
-        help(
-            "Only a subset of builtin commands can run at parse time."
-        )
+        help("Only a subset of builtin commands can run at parse time.")
     )]
     NotAConstCommand {
         #[label("This command cannot run at parse time.")]


### PR DESCRIPTION
# Description

Fixes the error you get when you parse something like `const c = random int` to no longer imply that custom commands can be `const`. My understanding is that they currently cannot (though that feature is being tracked at #15074).

# User-Facing Changes

* Improved error message