### PR TITLE
Fix example result span

### DIFF
--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -100,7 +100,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                             record! {
                                 "description" => Value::string(x.description, span),
                                 "example" => Value::string(x.example, span),
-                                "result" => x.result.unwrap_or(Value::nothing(span)),
+                                "result" => x.result.unwrap_or(Value::nothing(span)).with_span(span),
                             },
                             span,
                         )

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -330,3 +330,19 @@ fn correct_scope_variables_fields() {
     let actual = nu!(&inp.join("; "));
     assert_eq!(actual.out, "false");
 }
+
+#[test]
+fn example_results_have_valid_span() {
+    let inp = &[
+        "scope commands",
+        "| where name == 'do'",
+        "| first",
+        "| get examples",
+        "| where result == 177",
+        "| get 0.result",
+        "| metadata",
+        "| view span $in.span.start $in.span.end",
+    ];
+    let actual = nu!(&inp.join(" "));
+    assert_eq!(actual.out, "scope commands");
+}


### PR DESCRIPTION
Refs https://discord.com/channels/601130461678272522/614593951969574961/1403435414416654427

# Description

Previously Example result values would have a test span, which would
cause hard to understand errors for the code that uses `scope commands`.

Now they will have the span that points to `scope commands` invocation.

# User-Facing Changes

Errors referencing example results will get slightly better.

# Tests + Formatting

All pass.
