### PR TITLE
feat: `null` values can be spread as if they are empty lists or records.

### DIFF
--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -316,6 +316,7 @@ impl Call {
             if spread {
                 match result {
                     Value::List { mut vals, .. } => output.append(&mut vals),
+                    Value::Nothing { .. } => (),
                     _ => return Err(ShellError::CannotSpreadAsList { span: expr.span }),
                 }
             } else {

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -78,6 +78,7 @@ pub trait Eval {
                         ListItem::Item(expr) => output.push(Self::eval::<D>(state, mut_state, expr)?),
                         ListItem::Spread(_, expr) => match Self::eval::<D>(state, mut_state, expr)? {
                             Value::List { vals, .. } => output.extend(vals),
+                            Value::Nothing { .. } => (),
                             _ => return Err(ShellError::CannotSpreadAsList { span: expr_span }),
                         },
                     }

--- a/crates/nu-protocol/src/ir/call.rs
+++ b/crates/nu-protocol/src/ir/call.rs
@@ -187,6 +187,7 @@ impl Call {
             if spread {
                 match rest_val {
                     Value::List { vals, .. } => acc.extend(vals.iter().cloned()),
+                    Value::Nothing { .. } => (),
                     Value::Error { error, .. } => return Err(ShellError::clone(error)),
                     _ => {
                         return Err(ShellError::CannotSpreadAsList {

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -200,3 +200,9 @@ fn respect_shape() -> TestResult {
     run_test(r#"def "...$foo" [] {2}; do { ...$foo }"#, "2").unwrap();
     run_test(r#"match "...$foo" { ...$foo => 5 }"#, "5")
 }
+
+#[test]
+fn spread_null() -> TestResult {
+    run_test(r#"[1, 2, ...(null)] | to nuon --raw"#, r#"[1,2]"#)?;
+    run_test(r#"{a: 1, b: 2, ...(null)} | to nuon --raw"#, r#"{a:1,b:2}"#)
+}

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -203,6 +203,26 @@ fn respect_shape() -> TestResult {
 
 #[test]
 fn spread_null() -> TestResult {
+    // Spread in list
     run_test(r#"[1, 2, ...(null)] | to nuon --raw"#, r#"[1,2]"#)?;
-    run_test(r#"{a: 1, b: 2, ...(null)} | to nuon --raw"#, r#"{a:1,b:2}"#)
+
+    // Spread in record
+    run_test(r#"{a: 1, b: 2, ...(null)} | to nuon --raw"#, r#"{a:1,b:2}"#)?;
+
+    // Spread to built-in command's ...rest
+    run_test(r#"echo 1 2 ...(null) | to nuon --raw"#, r#"[1,2]"#)?;
+
+    // Spread to custom command's ...rest
+    run_test(
+        r#"
+            def foo [...rest] { $rest }
+            foo ...(null) 1 2 ...(null) 3 | to nuon --raw
+        "#,
+        r#"[1,2,3]"#,
+    )?;
+
+    // Spread to external command's arguments
+    assert_eq!(nu!(r#"nu --testbin cococo 1 ...(null) 2"#).out, "1 2");
+
+    Ok(())
 }


### PR DESCRIPTION
- closes #16283

# Description
With this PR, spread operator `...` treats `null` values as empty collections (whichever of list or record is appropriate)

## Context

A pattern that's common with wrappers for external commands is using a switch parameter in the wrapper and adding a flag to the wrapped command if it's `true`. This is usually accomplished with the following two methods:
- Spreading the result of an if expression (with `else` branch returning an empty list)
  ```nushell
  ^some-extern ...[
    ...(if $json    { [ --output-format=json ] } else { [] })
    ...(if $verbose { [ --verbose ]            } else { [] })
  ]
  ```
- Using a mutable list which is then added the elements imperatively:
  ```nushell
  mut args = []
  if $json    { $args ++= [ --output-format=json ] }
  if $verbose { $args ++= [ --verbose ]            }
  ^some-extern ...$args
  ```

This feature is meant to make the first method more ergonomic and legible.

```nushell
^some-extern ...[
  ...(if $json    { [ --output-format=json ] })
  ...(if $verbose { [ --verbose ]            })
]
```

# User-Facing Changes

`null` values can be used with the spread operator (`...`)

# Tests + Formatting
+1

# After Submitting
Update https://www.nushell.sh/book/operators.html