### PR TITLE
Fix `watch` return type

### DIFF
--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -49,7 +49,8 @@ impl Command for Watch {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("watch")
-        .input_output_types(vec![(Type::Nothing, Type::table())])
+        // actually `watch` never returns normally, but we don't have `noreturn` / `never` type yet
+        .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .required("path", SyntaxShape::Filepath, "The path to watch. Can be a file or directory.")
             .required("closure",
             SyntaxShape::Closure(Some(vec![SyntaxShape::String, SyntaxShape::String, SyntaxShape::String])),


### PR DESCRIPTION
Refs https://discord.com/channels/601130461678272522/615329862395101194/1403760147985207487

# Description

Currently `watch` doesn't normally return, ever. The only way to stop it
is to abort with `Ctrl+C` (or some internal error happens), so it never
produces a usable pipeline output. Since nu doesn't have `never` type
yet, `nothing` is the closest thing we can use.

# User-Facing Changes

Users may start to get type errors if they used `watch .... | something` and the `something` did not accept `nothing`.

# Tests + Formatting

All pass.
