### PR TITLE
[parser] Improve type errors for boolean literals

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5204,7 +5204,7 @@ pub fn parse_value(
             if matches!(shape, SyntaxShape::Boolean) || matches!(shape, SyntaxShape::Any) {
                 return Expression::new(working_set, Expr::Bool(true), span, Type::Bool);
             } else {
-                working_set.error(ParseError::Expected("non-boolean value", span));
+                working_set.error(ParseError::ExpectedWithStringMsg(shape.to_string(), span));
                 return Expression::garbage(working_set, span);
             }
         }
@@ -5212,7 +5212,7 @@ pub fn parse_value(
             if matches!(shape, SyntaxShape::Boolean) || matches!(shape, SyntaxShape::Any) {
                 return Expression::new(working_set, Expr::Bool(false), span, Type::Bool);
             } else {
-                working_set.error(ParseError::Expected("non-boolean value", span));
+                working_set.error(ParseError::ExpectedWithStringMsg(shape.to_string(), span));
                 return Expression::garbage(working_set, span);
             }
         }


### PR DESCRIPTION
Currently, strings `true` and `false` are intercepted early in parsing.  Previously, if they didn't match the expected shape, the parse error said "expected non-boolean value".  This PR changes the message to say "expected <shape>".

Because the parsing error requires a `&'static str` I had to add a `to_str(&self) -> &'static str` method on `SyntaxShape`.  It's a bit crude for more complex shapes: it simply says `keyword`, `list`, `table`, and so on for them, without exposing the underlying structure.

Fixes #16406

## Release notes summary
Type errors involving boolean literals are now more precise.