### PR TITLE
Add release notes section to PR template, and enhance readibility

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,32 @@
 <!--
-if this PR closes one or more issues, you can automatically link the PR with
-them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
+Thank you for improving Nushell!
+
+**Please, read our contributing guide [1] and talk to the core team before making major changes.**
+
+If this PR closes one or more issues, you can automatically link the PR with them by using one of the linking keywords [2], e.g.:
+
 - this PR should close #xxxx
 - fixes #xxxx
 
-you can also mention related issues, PRs or discussions!
+You can also mention related issues, PRs or discussions!
+
+[1]: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
+[2]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 -->
 
-# Description
+# Release notes summary
 <!--
-Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.
+This section will be included as part of our release notes.
+Please write a brief summary of your change. We encourage adding examples and screenshots in this section.
 
-Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
+If you're not confident about this, a core team member would be glad to help!
+
+If this is a work in progress PR, feel free to write "WIP"/"TODO"/etc.
+You can also write "N/A" if this is a technical change which doesn't impact the user experience.
 -->
 
-# User-Facing Changes
-<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
+# Additional details
+<!-- Provide any additional details, technical or otherwise, which you'd like to note but aren't relevant for the release notes.  -->
 
 # Tests + Formatting
 <!--
@@ -25,16 +36,19 @@ Make sure you've run and fixed any issues with these commands:
 
 - `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
 - `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
-- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
+- `cargo test --workspace` to check that all tests pass (on Windows make sure to enable developer mode [1])
 - `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library
 
-> **Note**
-> from `nushell` you can also use the `toolkit` as follows
-> ```bash
+From Nushell, you can also use the `toolkit` as follows
 > use toolkit.nu  # or use an `env_change` hook to activate it automatically
-> toolkit check pr
-> ```
+> toolkit check
+
+[1]: https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging
 -->
 
 # After Submitting
-<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
+<!--
+If your PR had any user-facing changes, update the documentation [1] after the PR is merged, if necessary. This will help us keep the docs up to date.
+
+[1]: https://github.com/nushell/nushell.github.io
+-->


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
We discussed in a recent meeting that we want to better automate our release notes, and that we could do this by keeping track of the release note entries within the PRs themselves. This PR replaces the "Description" and "User-Facing Changes" sections with two new sections, "Release notes summary" and "Additional details", with explanations of the purposes of these sections.

I also changed some of the formatting of the PR to make it more readable. We had used some markdown syntax within the HTML comments before. This is never actually displayed as markdown, so I changed some of the more complex syntax (links, code blocks, blockquotes) to be more readable as plaintext. This does unfortunately further increase the length of the PR template, but I think the result is much less visually noisy.

# User-Facing Changes
N/A

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
N/A

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A