### PR TITLE
feat: move random dice to std

### DIFF
--- a/crates/nu-command/src/random/dice.rs
+++ b/crates/nu-command/src/random/dice.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::{ListStream, ReportMode, ShellWarning, report_shell_warning};
+use nu_protocol::{DeprecationEntry, DeprecationType, ListStream, ReportMode};
 use rand::random_range;
 use std::num::NonZeroUsize;
 
@@ -38,6 +38,16 @@ impl Command for RandomDice {
         vec!["generate", "die", "1-6"]
     }
 
+    fn deprecation_info(&self) -> Vec<DeprecationEntry> {
+        vec![DeprecationEntry {
+            ty: DeprecationType::Command,
+            report_mode: ReportMode::FirstUse,
+            since: Some("0.107.0".to_owned()),
+            expected_removal: Some("0.108.0".to_owned()),
+            help: Some("Use `random dice` from std/random instead.".to_owned()),
+        }]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -45,19 +55,6 @@ impl Command for RandomDice {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        report_shell_warning(
-            engine_state,
-            &ShellWarning::Deprecated {
-                dep_type: "Command".to_owned(),
-                label: "deprecated".to_owned(),
-                span: call.span(),
-                help: Some(
-                    r"Deprecated since 0.107.0.  Use std/random/random-dice instead.".to_string(),
-                ),
-                report_mode: ReportMode::FirstUse,
-            },
-        );
-
         dice(engine_state, stack, call)
     }
 

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -65,6 +65,7 @@ pub fn load_standard_library(
             include_str!("../std/testing/mod.nu"),
         ),
         ("mod.nu", "std/clip", include_str!("../std/clip/mod.nu")),
+        ("mod.nu", "std/random", include_str!("../std/random/mod.nu")),
     ];
 
     for (filename, std_subdir_name, content) in std_submodules.drain(..) {

--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -16,6 +16,7 @@ export module std/math
 export module std/xml
 export module std/config
 export module std/testing
+export module std/random
 
 # Load main dirs command and all subcommands
 export use std/dirs main

--- a/crates/nu-std/std/random/mod.nu
+++ b/crates/nu-std/std/random/mod.nu
@@ -1,0 +1,19 @@
+# for examples
+alias "random dice" = dice
+
+# Generate a random dice roll
+@search-terms "generate" "die" "1-6"
+@example "Roll 1 dice with 6 sides each" { random dice }
+@example "Roll 10 dice with 12 sides each" {
+    random dice --dice 10 --sides 12
+}
+export def dice [
+    --dice = 1  # The amount of dice being rolled
+    --sides = 6  # The amount of sides a die has
+]: nothing -> list<int> {
+    mut out = []
+    for _ in 1..$dice {
+    	$out ++= [(random int 1..$sides)]
+    }
+    $out
+}


### PR DESCRIPTION
# Description

As per the suggestion in #16350, this PR moves `random dice` to std.  It's basically a thin wrapper over `random int` already.

# User-Facing Changes (deprecations)
## Release notes summary
### `random dice` moved to `std`

The `random dice` command has been rewritten in Nushell and moved to the standard library.  The `random dice` built-in is still available with a deprecation error, but will be removed in 0.108.  The new command can be used as follows:

```nushell
use std/random

random dice
```

It's behavior, parameters, and defaults are the same.


# After Submitting

Update documentation to reflect the change.

Closes #16350