### PR TITLE
feat: `watch` returns a stream of events as a table when called without a closure

### DIFF
--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -201,15 +201,15 @@ impl Command for Watch {
 
                     if matches_glob {
                         let result = closure
-                            .add_arg(Value::string(event.operation, head))
-                            .add_arg(Value::string(event.path.to_string_lossy(), head))
-                            .add_arg(Value::string(
+                            .add_arg(event.operation.into_value(head))
+                            .add_arg(event.path.to_string_lossy().into_value(head))
+                            .add_arg(
                                 event
                                     .new_path
-                                    .unwrap_or_else(|| "".into())
-                                    .to_string_lossy(),
-                                head,
-                            ))
+                                    .as_deref()
+                                    .map(Path::to_string_lossy)
+                                    .into_value(head),
+                            )
                             .run_with_input(PipelineData::empty());
 
                         match result {

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -35,6 +35,10 @@ impl Command for Watch {
         "Watch for file changes and execute Nu code when they happen."
     }
 
+    fn extra_description(&self) -> &str {
+        "When run without a closure, `watch` returns a stream of events instead."
+    }
+
     fn search_terms(&self) -> Vec<&str> {
         vec!["watcher", "reload", "filesystem"]
     }
@@ -256,8 +260,13 @@ impl Command for Watch {
                 result: None,
             },
             Example {
-                description: "Log all changes in a directory",
-                example: r#"watch /foo/bar { |op, path| $"($op) - ($path)(char nl)" | save --append changes_in_bar.log }"#,
+                description: "`watch` (when run without a closure) can also emit a stream of events it detects.",
+                example: r#"watch /foo/bar
+    | where operation == Create
+    | first 5
+    | each {|e| $"New file!: ($e.path)" }
+    | to text
+    | save --append changes_in_bar.log"#,
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -115,15 +115,10 @@ impl Command for Watch {
         let verbose = call.has_flag(engine_state, stack, "verbose")?;
 
         let quiet = call.has_flag(engine_state, stack, "quiet")?;
-
-        let debounce_duration_flag_ms: Option<Spanned<i64>> =
-            call.get_flag(engine_state, stack, "debounce-ms")?;
-
-        let debounce_duration_flag: Option<Spanned<Duration>> =
-            call.get_flag(engine_state, stack, "debounce")?;
-
-        let debounce_duration: Duration =
-            resolve_duration_arguments(debounce_duration_flag_ms, debounce_duration_flag)?;
+        let debounce_duration: Duration = resolve_duration_arguments(
+            call.get_flag(engine_state, stack, "debounce-ms")?,
+            call.get_flag(engine_state, stack, "debounce")?,
+        )?;
 
         let glob_flag: Option<Spanned<String>> = call.get_flag(engine_state, stack, "glob")?;
         let glob_pattern = match glob_flag {

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -13,7 +13,8 @@ use nu_protocol::{
 };
 
 use std::{
-    path::PathBuf,
+    borrow::Cow,
+    path::{Path, PathBuf},
     sync::mpsc::{Receiver, RecvTimeoutError, channel},
     time::Duration,
 };
@@ -284,6 +285,23 @@ struct WatchEvent {
     operation: &'static str,
     path: PathBuf,
     new_path: Option<PathBuf>,
+}
+
+#[derive(IntoValue)]
+struct WatchEventRecord<'a> {
+    operation: &'static str,
+    path: Cow<'a, str>,
+    new_path: Option<Cow<'a, str>>,
+}
+
+impl<'a> From<&'a WatchEvent> for WatchEventRecord<'a> {
+    fn from(value: &'a WatchEvent) -> Self {
+        Self {
+            operation: value.operation,
+            path: value.path.to_string_lossy(),
+            new_path: value.new_path.as_deref().map(Path::to_string_lossy),
+        }
+    }
 }
 
 impl TryFrom<DebouncedEvent> for WatchEvent {


### PR DESCRIPTION
> @weirdan — 09/08/2025, 18:21 | _nushell discord, `#design-discussion`_
> - Does watch really return a table?
> - I suppose it would be great if it really did, and then it wouldn't need the closure parameter at all
> - IMO something like this would feel way more nu
>   ```nushell
>   watch .
>   | where op == Write and path like '.*md'
>   | each { md-lint $in.path }
>   ```

Which I thought was a great idea and would allow `watch` to compose with other commands, primarily with stream manipulating commands.

Returning a stream rather than running a closure enables:
- `skip`, `every`, `window`, and a lot of similar tools. These can't be emulated with the closure since it can't use mutable variables.
- terminating `watch` using commands like `first/take`, `take until` and `each while`. The closure version could only be terminated with <kbd>Ctrl + C</kbd>
- and probably a lot more

This PR is backwards compatible<sup>mostly</sup> and the closure parameter is not removed, just made optional. When it's provided `watch` works as before.

> [!TIP]
> This PR refactors `watch` command _heavily_.
> Reviewing this PR commit by commit will be much easier as the commit history was specifically prepared for that.

> [!WARNING]
> The only ***possibly* breaking change** in this PR is that the `new_path` parameter of the closure is now `null` on operations other than `Rename`, where previously it would be an empty string.
> Since accessing its value for any operation other than `Rename` *and* depending on it to be an empty string is very unlikely.

## Release notes summary

`watch` command can now be used to _return a stream_ of detected events instead of calling a closure with it's information, though using a closure is still possible and existing uses won't break.

In addition to this:
```nushell
watch . {|operation, path, new_path|
    if $operation == "Write" and $path like "*.md" {
        md-lint $path
    }
}
```

Now this is also possible:
```nushell
watch .
| where operation == Write and path like "*.md"
| each { md-lint $in.path }
```

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)