### PR TITLE
Change the output of `format bits` to big endian instead of native endian

### DIFF
--- a/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
@@ -76,6 +76,11 @@ impl Command for FormatBits {
                 result: Some(Value::string("00000001", Span::test_data())),
             },
             Example {
+                description: "convert an int into a string, padded to 8 places with 0s (big endian)",
+                example: "258 | format bits",
+                result: Some(Value::string("00000001 00000010", Span::test_data())),
+            },
+            Example {
                 description: "convert a filesize value into a string, padded to 8 places with 0s",
                 example: "1b | format bits",
                 result: Some(Value::string("00000001", Span::test_data())),


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

Use the following space to include the motivation and any technical details behind this PR.
-->

Currently the command ouputs in native endian. That is unlike any other tool that I've used that shows bits (windows calculator comes to mind). Moreover, if you paste the output of `format bits` as a number you won't get the same output:

```nushell
~> 258 | format bits
00000010 00000001
~> 0b00000010_00000001
513
```

In order to get a roundtrip, you need to reverse the bytes:

```nushell
~> 0b00000001_00000010
258
~> 258 | format bits | split words | str join | $"0b($in)" | into int
513
~> 258 | format bits | split words | reverse | str join | $"0b($in)" | into int # Added `reverse`
258
```

The goal of this PR is to get rid of this weirdness (and as a bonus get a platform-independent behavior, without depending on what the native endianness is).

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
If you're not confident about this, a core team member would be glad to help!
-->

### Change the output of `format bits` to big endian instead of native endian

While the most popular architectures use little endian, many people are used to reading binary numbers as little endian. However, until now, if you were in a little endian system, you would get:
```nushell
~> 258 | format bits
00000010 00000001
```
If you copied and pasted that as a number, you would get a surprising result:
```nushell
~> 0b00000010_00000001
513
```
Now, `format bits` always formats in big endian:
```nushell
~> 258 | format bits
00000001 00000010
```

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
None
