### PR TITLE
update to rust version 1.87.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://www.nushell.sh"
 license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
-rust-version = "1.86.0"
+rust-version = "1.87.0"
 version = "0.106.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -203,6 +203,7 @@ webpki-roots = "1.0"
 # todo = "warn"
 unchecked_duration_subtraction = "warn"
 used_underscore_binding = "warn"
+result_large_err = "allow"
 
 [lints]
 workspace = true

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -236,7 +236,7 @@ fn default(
 
 /// A wrapper around the default value to handle closures and caching values
 enum DefaultValue {
-    Uncalculated(Spanned<ClosureEval>),
+    Uncalculated(Box<Spanned<ClosureEval>>),
     Calculated(Value),
 }
 
@@ -258,7 +258,7 @@ impl DefaultValue {
         match value {
             Value::Closure { val, .. } => {
                 let closure_eval = ClosureEval::new(engine_state, stack, *val);
-                DefaultValue::Uncalculated(closure_eval.into_spanned(span))
+                DefaultValue::Uncalculated(Box::new(closure_eval.into_spanned(span)))
             }
             _ => DefaultValue::Calculated(value),
         }

--- a/crates/nu-command/src/network/http/timeout_extractor_reader.rs
+++ b/crates/nu-command/src/network/http/timeout_extractor_reader.rs
@@ -28,7 +28,7 @@ impl<R: Read> Read for UreqTimeoutExtractorReader<R> {
                     std::io::Error::new(std::io::ErrorKind::TimedOut, ureq_err)
                 }
                 // package it back
-                e => std::io::Error::new(std::io::ErrorKind::Other, e),
+                e => std::io::Error::other(e),
             }
         })
     }

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -210,7 +210,7 @@ impl Command for SubCommand {
 enum Matcher {
     Regex(Regex),
     Direct(Value),
-    Closure(ClosureEval),
+    Closure(Box<ClosureEval>),
 }
 
 enum Split {
@@ -257,7 +257,7 @@ impl Matcher {
     }
 
     pub fn from_closure(closure: ClosureEval) -> Self {
-        Self::Closure(closure)
+        Self::Closure(Box::new(closure))
     }
 
     pub fn compare(&mut self, rhs: &Value) -> Result<bool, ShellError> {

--- a/crates/nu-json/src/de.rs
+++ b/crates/nu-json/src/de.rs
@@ -2,16 +2,16 @@
 //!
 //! This module provides for Hjson deserialization with the type `Deserializer`.
 
-use std::char;
-use std::io;
-use std::marker::PhantomData;
-use std::str;
-
-use serde::de;
-
 use super::error::{Error, ErrorCode, Result};
 use super::util::StringReader;
 use super::util::{Number, ParseNumber};
+use serde::de;
+use std::{
+    char, io,
+    io::{BufReader, Read},
+    marker::PhantomData,
+    str,
+};
 
 enum State {
     Normal,
@@ -804,7 +804,10 @@ where
     R: io::Read,
     T: de::DeserializeOwned,
 {
-    from_iter(rdr.bytes())
+    // Use a buffered reader so that calling `.bytes()` is efficient and
+    // doesn't trigger clippy's `unbuffered_bytes` lint when the input
+    // comes from a non-memory source.
+    from_iter(BufReader::new(rdr).bytes())
 }
 
 /// Decodes a Hjson value from a byte slice `&[u8]`.

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -757,7 +757,7 @@ fn get_proc_env<T: RtlUserProcessParameters>(params: &T, handle: HANDLE) -> Vec<
             let mut begin = 0;
             while let Some(offset) = raw_env[begin..].iter().position(|&c| c == 0) {
                 let end = begin + offset;
-                if raw_env[begin..end].iter().any(|&c| c == equals) {
+                if raw_env[begin..end].contains(&equals) {
                     result.push(
                         OsString::from_wide(&raw_env[begin..end])
                             .to_string_lossy()

--- a/crates/nu_plugin_custom_values/src/cool_custom_value.rs
+++ b/crates/nu_plugin_custom_values/src/cool_custom_value.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 use nu_protocol::{
     CustomValue, ShellError, Span, Type, Value,
     ast::{self, Math, Operator},

--- a/crates/nu_plugin_custom_values/src/second_custom_value.rs
+++ b/crates/nu_plugin_custom_values/src/second_custom_value.rs
@@ -1,7 +1,7 @@
-use std::cmp::Ordering;
-
+#![allow(clippy::result_large_err)]
 use nu_protocol::{CustomValue, ShellError, Span, Value};
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SecondCustomValue {

--- a/crates/nu_plugin_polars/src/lib.rs
+++ b/crates/nu_plugin_polars/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 use std::{
     cmp::Ordering,
     panic::{AssertUnwindSafe, catch_unwind},

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -14,4 +14,4 @@ profile = "default"
 # so that we give repo maintainers and package managers a chance to update to a more
 # recent version of rust. However, if there is a "cool new feature" that we want to
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
-channel = "1.86.0"
+channel = "1.87.0"


### PR DESCRIPTION
The PR upgrades nushell to rust version 1.87.0.

## Dev overview from clippy
- I added `result_large_err` to clippy in the root Cargo.toml to avoid the warnings (and a few places in plugins). At some point a more proper fix, perhaps boxing these, will need to be performed. This PR is to just get us over the hump.
- I boxed a couple areas in some commands
- I changed `rdr.bytes()` to `BufReader::new(rdr).bytes()` in nu-json

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
If you're not confident about this, a core team member would be glad to help!
-->

## Tasks after submitting
