### PR TITLE
Quote strings containing `=`

### DIFF
--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -516,6 +516,17 @@ fn quotes_some_strings_necessarily() {
 }
 
 #[test]
+fn quotes_equal_sign_in_record_keys() {
+    let actual = nu!(pipeline(
+        r#"
+        {"=": 42} | to nuon | from nuon | columns | describe
+        "#
+    ));
+
+    assert_eq!(actual.out, "list<string>");
+}
+
+#[test]
 fn read_code_should_fail_rather_than_panic() {
     let actual = nu!(cwd: "tests/fixtures/formats", pipeline(
         r#"open code.nu | from nuon"#

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -516,10 +516,12 @@ fn quotes_some_strings_necessarily() {
 }
 
 #[test]
-fn quotes_equal_sign_in_record_keys() {
+fn quotes_some_strings_necessarily_in_record_keys() {
     let actual = nu!(pipeline(
         r#"
-        {"=": 42} | to nuon | from nuon | columns | describe
+        ['=', 'a=', '=a'] | each {
+           {$in : 42}
+        } | reduce {|elt, acc| $acc | merge $elt} | to nuon | from nuon | columns | describe
         "#
     ));
 

--- a/crates/nu-utils/src/quoting.rs
+++ b/crates/nu-utils/src/quoting.rs
@@ -2,13 +2,12 @@ use fancy_regex::Regex;
 use std::sync::LazyLock;
 
 // This hits, in order:
-// • Any character of []:`{}#'";()|$,.!?
+// • Any character of []:`{}#'";()|$,.!?=
 // • Any digit (\d)
 // • Any whitespace (\s)
 // • Case-insensitive sign-insensitive float "keywords" inf, infinity and nan.
-// • lone `=`
 static NEEDS_QUOTING_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"[\[\]:`\{\}#'";\(\)\|\$,\.\d\s!?]|(?i)^[+\-]?(inf(inity)?|nan)$|^=$"#)
+    Regex::new(r#"[\[\]:`\{\}#'";\(\)\|\$,\.\d\s!?=]|(?i)^[+\-]?(inf(inity)?|nan)$"#)
         .expect("internal error: NEEDS_QUOTING_REGEX didn't compile")
 });
 

--- a/crates/nu-utils/src/quoting.rs
+++ b/crates/nu-utils/src/quoting.rs
@@ -6,8 +6,9 @@ use std::sync::LazyLock;
 // • Any digit (\d)
 // • Any whitespace (\s)
 // • Case-insensitive sign-insensitive float "keywords" inf, infinity and nan.
+// • lone `=`
 static NEEDS_QUOTING_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"[\[\]:`\{\}#'";\(\)\|\$,\.\d\s!?]|(?i)^[+\-]?(inf(inity)?|nan)$"#)
+    Regex::new(r#"[\[\]:`\{\}#'";\(\)\|\$,\.\d\s!?]|(?i)^[+\-]?(inf(inity)?|nan)$|^=$"#)
         .expect("internal error: NEEDS_QUOTING_REGEX didn't compile")
 });
 


### PR DESCRIPTION
Fixes nushell/nushell#16438

## Release notes summary - What our users need to know

Previously, a record key `=` would not be quoted in `to nuon`, producing invalid nuon output. It wasn't quoted in other string values either, but it didn't cause problems there. Now any string containing `=` gets quoted.