### PR TITLE
Ability to specify a table name for kv commands

### DIFF
--- a/crates/nu-std/tests/test_std-rfc_kv.nu
+++ b/crates/nu-std/tests/test_std-rfc_kv.nu
@@ -302,3 +302,17 @@ def universal-return_value_only [] {
     kv drop --universal $key
     rm $env.NU_UNIVERSAL_KV_PATH
 }
+
+@test
+def simple-local-set-table [] {
+    if ('sqlite' not-in (version).features) { return }
+
+    let key = (random uuid)
+
+    kv set -t foo $key 42
+    let actual = (kv get -t foo $key)
+    let expected = 42
+    assert equal $actual $expected
+
+    kv drop -t foo $key | ignore
+}


### PR DESCRIPTION
## Release notes summary - What our users need to know

`std-rfc/kv` commands now take an optional `--table (-t)` argument which allows a custom table name to be used. If not specified, the current `std-kv-store` table will be used.

## Tasks after submitting

- [ ] Add example

## Additional details

To protect against injection attacks, table names can only include alphanumeric characters with `_` and `-`.