### PR TITLE
fix uninlined_format_args clippy warnings

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -82,7 +82,7 @@ pub fn evaluate_file(
         .expect("internal error: missing filename");
 
     let mut working_set = StateWorkingSet::new(engine_state);
-    trace!("parsing file: {}", file_path_str);
+    trace!("parsing file: {file_path_str}");
     let block = parse(&mut working_set, Some(file_path_str), &file, false);
 
     if let Some(warning) = working_set.parse_warnings.first() {

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -450,7 +450,7 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
         start_time = std::time::Instant::now();
         if history.sync_on_enter {
             if let Err(e) = line_editor.sync_history() {
-                warn!("Failed to sync history: {}", e);
+                warn!("Failed to sync history: {e}");
             }
         }
 
@@ -934,7 +934,7 @@ fn do_run_cmd(
     entry_num: usize,
     use_color: bool,
 ) -> Reedline {
-    trace!("eval source: {}", s);
+    trace!("eval source: {s}");
 
     let mut cmds = s.split_whitespace();
 

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -38,7 +38,7 @@ pub(crate) fn highlight_syntax(
     line: &str,
     cursor: usize,
 ) -> HighlightResult {
-    trace!("highlighting: {}", line);
+    trace!("highlighting: {line}");
 
     let config = stack.get_config(engine_state);
     let highlight_resolved_externals = config.highlight_resolved_externals;

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -132,7 +132,7 @@ impl SQLiteDatabase {
     }
 
     fn sleeper(attempts: i32) -> bool {
-        log::warn!("SQLITE_BUSY, retrying after 250ms (attempt {})", attempts);
+        log::warn!("SQLITE_BUSY, retrying after 250ms (attempt {attempts})");
         std::thread::sleep(std::time::Duration::from_millis(250));
         true
     }
@@ -202,7 +202,7 @@ impl SQLiteDatabase {
                     (p.pagecount - p.remaining) * 100 / p.pagecount
                 };
                 if percent % 10 == 0 {
-                    log::trace!("Restoring: {} %", percent);
+                    log::trace!("Restoring: {percent} %");
                 }
             }),
         )?;

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -320,7 +320,7 @@ impl Theme for NuTheme {
             if indices.contains(&idx) {
                 write!(f, "{prefix}{c}{suffix}")?;
             } else {
-                write!(f, "{}", c)?;
+                write!(f, "{c}")?;
             }
         }
         write!(f, "{RESET}")

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -8,7 +8,7 @@ fn nu_path(prefix: &str) -> String {
     let binary = nu_test_support::fs::executable_path()
         .to_string_lossy()
         .to_string();
-    format!("{prefix}{}", binary)
+    format!("{prefix}{binary}")
 }
 
 // Template for run-external test to ensure tests work when calling

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1415,7 +1415,7 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
     } else {
         // We might be parsing left-unbounded range ("..10")
         let bytes = working_set.get_span_contents(spans[0]);
-        trace!("parsing: range {:?} ", bytes);
+        trace!("parsing: range {bytes:?}");
         if let (Some(b'.'), Some(b'.')) = (bytes.first(), bytes.get(1)) {
             trace!("-- found leading range indicator");
             let starting_error_count = working_set.parse_errors.len();
@@ -1906,7 +1906,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Option<Expr
         Some(parse_value(working_set, to_span, &SyntaxShape::Number))
     };
 
-    trace!("-- from: {:?} to: {:?}", from, to);
+    trace!("-- from: {from:?} to: {to:?}");
 
     if let (None, None) = (&from, &to) {
         working_set.error(ParseError::Expected("at least one range bound set", span));
@@ -2664,7 +2664,7 @@ pub fn parse_directory(working_set: &mut StateWorkingSet, span: Span) -> Express
     trace!("parsing: directory");
 
     if err.is_none() {
-        trace!("-- found {}", token);
+        trace!("-- found {token}");
 
         Expression::new(
             working_set,
@@ -2686,7 +2686,7 @@ pub fn parse_filepath(working_set: &mut StateWorkingSet, span: Span) -> Expressi
     trace!("parsing: filepath");
 
     if err.is_none() {
-        trace!("-- found {}", token);
+        trace!("-- found {token}");
 
         Expression::new(
             working_set,
@@ -2875,7 +2875,7 @@ pub fn parse_unit_value<'res>(
             None => num_float as i64,
         };
 
-        trace!("-- found {} {:?}", num, unit);
+        trace!("-- found {num} {unit:?}");
         let value = ValueWithUnit {
             expr: Expression::new_unknown(Expr::Int(num), lhs_span, Type::Number),
             unit: Spanned {
@@ -3056,7 +3056,7 @@ pub fn parse_glob_pattern(working_set: &mut StateWorkingSet, span: Span) -> Expr
     trace!("parsing: glob pattern");
 
     if err.is_none() {
-        trace!("-- found {}", token);
+        trace!("-- found {token}");
 
         Expression::new(
             working_set,
@@ -3363,7 +3363,7 @@ pub fn parse_string_strict(working_set: &mut StateWorkingSet, span: Span) -> Exp
     };
 
     if let Ok(token) = String::from_utf8(bytes.into()) {
-        trace!("-- found {}", token);
+        trace!("-- found {token}");
 
         if quoted {
             Expression::new(working_set, Expr::String(token), span, Type::String)
@@ -5192,7 +5192,7 @@ pub fn parse_value(
     span: Span,
     shape: &SyntaxShape,
 ) -> Expression {
-    trace!("parsing: value: {}", shape);
+    trace!("parsing: value: {shape}");
 
     let bytes = working_set.get_span_contents(span);
 
@@ -6563,7 +6563,7 @@ pub fn parse_block(
         working_set.error(err);
     }
 
-    trace!("parsing block: {:?}", lite_block);
+    trace!("parsing block: {lite_block:?}");
 
     if scoped {
         working_set.enter_scope();

--- a/crates/nu-plugin-core/src/interface/stream/mod.rs
+++ b/crates/nu-plugin-core/src/interface/stream/mod.rs
@@ -526,7 +526,7 @@ impl Default for StreamManager {
 impl Drop for StreamManager {
     fn drop(&mut self) {
         if let Err(err) = self.drop_all_writers() {
-            log::warn!("error during Drop for StreamManager: {}", err)
+            log::warn!("error during Drop for StreamManager: {err}")
         }
     }
 }

--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -126,7 +126,7 @@ impl Drop for PluginCallState {
     fn drop(&mut self) {
         // Clear the keep custom values channel, so drop notifications can be sent
         for value in self.keep_plugin_custom_values.1.try_iter() {
-            log::trace!("Dropping custom value that was kept: {:?}", value);
+            log::trace!("Dropping custom value that was kept: {value:?}");
             drop(value);
         }
     }
@@ -467,7 +467,7 @@ impl InterfaceManager for PluginInterfaceManager {
     }
 
     fn consume(&mut self, input: Self::Input) -> Result<(), ShellError> {
-        log::trace!("from plugin: {:?}", input);
+        log::trace!("from plugin: {input:?}");
 
         match input {
             PluginOutput::Hello(info) => {
@@ -1066,9 +1066,9 @@ impl Interface for PluginInterface {
     type DataContext = CurrentCallState;
 
     fn write(&self, input: PluginInput) -> Result<(), ShellError> {
-        log::trace!("to plugin: {:?}", input);
+        log::trace!("to plugin: {input:?}");
         self.state.writer.write(&input).map_err(|err| {
-            log::warn!("write() error: {}", err);
+            log::warn!("write() error: {err}");
             // If there's an error in the state, return that instead because it's likely more
             // descriptive
             self.state.error.get().cloned().unwrap_or(err)
@@ -1077,7 +1077,7 @@ impl Interface for PluginInterface {
 
     fn flush(&self) -> Result<(), ShellError> {
         self.state.writer.flush().map_err(|err| {
-            log::warn!("flush() error: {}", err);
+            log::warn!("flush() error: {err}");
             // If there's an error in the state, return that instead because it's likely more
             // descriptive
             self.state.error.get().cloned().unwrap_or(err)
@@ -1186,7 +1186,7 @@ impl CurrentCallState {
                 .downcast_ref::<PluginCustomValueWithSource>()
             {
                 if custom_value.notify_on_drop() {
-                    log::trace!("Keeping custom value for drop later: {:?}", custom_value);
+                    log::trace!("Keeping custom value for drop later: {custom_value:?}");
                     keep_tx
                         .send(custom_value.clone())
                         .map_err(|_| ShellError::NushellFailed {

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -242,7 +242,7 @@ impl InterfaceManager for EngineInterfaceManager {
     }
 
     fn consume(&mut self, input: Self::Input) -> Result<(), ShellError> {
-        log::trace!("from engine: {:?}", input);
+        log::trace!("from engine: {input:?}");
         match input {
             PluginInput::Hello(info) => {
                 let info = Arc::new(info);
@@ -991,7 +991,7 @@ impl Interface for EngineInterface {
     type DataContext = ();
 
     fn write(&self, output: PluginOutput) -> Result<(), ShellError> {
-        log::trace!("to engine: {:?}", output);
+        log::trace!("to engine: {output:?}");
         self.state.writer.write(&output)
     }
 

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -201,7 +201,7 @@ pub(crate) fn read_vendor_autoload_files(engine_state: &mut EngineState, stack: 
                             continue;
                         }
                         let path = autoload_dir.join(entry);
-                        warn!("AutoLoading: {:?}", path);
+                        warn!("AutoLoading: {path:?}");
                         eval_config_contents(path, engine_state, stack);
                     }
                 }
@@ -215,7 +215,7 @@ fn eval_default_config(
     config_file: &str,
     is_env_config: bool,
 ) {
-    warn!("eval_default_config() is_env_config: {}", is_env_config);
+    warn!("eval_default_config() is_env_config: {is_env_config}");
     eval_source(
         engine_state,
         stack,


### PR DESCRIPTION
I noticed some clippy errors while running clippy under 1.88.
```
error: variables can be used directly in the `format!` string
   --> src/config_files.rs:204:25
    |
204 |                         warn!("AutoLoading: {:?}", path);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::uninlined_format_args)]`
```
And this pr is going to fix this.

## Release notes summary - What our users need to know
NaN

## Tasks after submitting
NaN
