### PR TITLE
Add `--endian` flag to `into binary`

### DIFF
--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -39,7 +39,7 @@ impl Command for IntoBinary {
             .named(
                 "endian",
                 SyntaxShape::String,
-                "byte encode endian, available options: native(default), little, big",
+                "byte encode endian. Does not affect string, date or binary. In containers, only individual elements are affected. Available options: native(default), little, big",
                 Some('e'),
             )
             .rest(


### PR DESCRIPTION
This flag brings `into binary` in line with other commands such as `into int`.

The motivation to do this now comes from #16435:
the change to `format bits` to show the output in big endian makes the output of `42 | format bits` and `42 | into binary | format bits` diverge in little endian platforms. By adding this flag, we give the user the option to make them equal: `42 | into binary --endian big | format bits` (well, equal minus the padding zeros).

The default behavior is kept the same, since the default value is using the platforms native endianness.

<details>
<summary>Results in a little endian platform (with the changes from both PRs) </summary>

```nushell
258 | format bits
# => 00000001 00000010
258 | into binary --compact | format bits
# => 00000010 00000001
258 | into binary --compact --endian big | format bits
# => 00000001 00000010
258 | into binary | format bits
# => 00000010 00000001 00000000 00000000 00000000 00000000 00000000 00000000
258 | into binary --endian big | format bits
# => 00000000 00000000 00000000 00000000 00000000 00000000 00000001 00000010
```
</details>

<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

### `--endian` flag for `into binary`

Previously, converting values to `binary` with `into binary` could only do so in the native endianness of your platform. Using native endianness is still the default, but with the `--endian` flag, you get to choose:
```nushell
258 | into binary --endian little
# => Length: 8 (0x8) bytes | printable whitespace ascii_other non_ascii
# => 00000000:   02 01 00 00  00 00 00 00
258 | into binary --endian big
# => Length: 8 (0x8) bytes | printable whitespace ascii_other non_ascii
# => 00000000:   00 00 00 00  00 00 01 02
```

Note that this only affects `int`, `float`, `filesize`, `bool` and `duration` (i.e. it does not affect `string`s, `date`s and `binary`). Likewise, only the individual elements in `table`s and `record`s are affected (not the `table` or `record` itself)

## Tasks after submitting
None
