### PR TITLE
Update PLATFORM_SUPPORT to mention loongarch limitations

### DIFF
--- a/devdocs/PLATFORM_SUPPORT.md
+++ b/devdocs/PLATFORM_SUPPORT.md
@@ -23,7 +23,7 @@ As an additional layer of validation we perform [nightly builds](https://github.
 
 Those target **additional build targets**:
 - **aarch64 for all platforms**
-- musl as an alternative to libc on linux
+- musl as an alternative to Glibc on linux
 - riscv only for linux
 - armv7 only for linux
 - loongarch64 only for linux (with limitations [^1])

--- a/devdocs/PLATFORM_SUPPORT.md
+++ b/devdocs/PLATFORM_SUPPORT.md
@@ -23,11 +23,14 @@ As an additional layer of validation we perform [nightly builds](https://github.
 
 Those target **additional build targets**:
 - **aarch64 for all platforms**
-- musl as an alternative to Glibc on linux
+- musl as an alternative to libc on linux
 - riscv only for linux
 - armv7 only for linux
+- loongarch64 only for linux (with limitations [^1])
 
 We will try to provide builds for all of them but a standard configuration for x86-64 or aarch64 will take priority for us should we face technical challenges in a release cycle.
+
+[^1]: The build for loongarch64 currently lacks support for the Nushell internal error recovery, thus bugs raising panics will abort your shell, while our other platforms have a limited capability to recover from non-fatal panics to provide a stable login shell.
 
 ### Supported feature flags
 

--- a/devdocs/PLATFORM_SUPPORT.md
+++ b/devdocs/PLATFORM_SUPPORT.md
@@ -30,7 +30,7 @@ Those target **additional build targets**:
 
 We will try to provide builds for all of them but a standard configuration for x86-64 or aarch64 will take priority for us should we face technical challenges in a release cycle.
 
-[^1]: The build for loongarch64 currently lacks support for the Nushell internal error recovery, thus bugs raising panics will abort your shell, while our other platforms have a limited capability to recover from non-fatal panics to provide a stable login shell.
+[^1]: The build for loongarch64 currently lacks support for the Nushell internal error recovery, as it doesn't compile with `rustc -C panic=unwind`. It has to use `panic=abort` thus bugs raising panics will abort your shell. Our other platforms by default have a limited capability to recover from non-fatal panics to provide a stable login shell.
 
 ### Supported feature flags
 


### PR DESCRIPTION
#16455 had to restrict to `panic=abort` which breaks the error recovery (and terminal raw mode disabling) on panic.

Mention this and the fact that loongarch64 are build by https://github.com/nushell/nightly/releases

