### PR TITLE
Mitigate `watch -d` breaking change

### DIFF
--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -45,7 +45,7 @@ impl Command for Watch {
 
     fn deprecation_info(&self) -> Vec<DeprecationEntry> {
         vec![DeprecationEntry {
-            ty: DeprecationType::Flag("--debounce-ms".into()),
+            ty: DeprecationType::Flag("debounce-ms".into()),
             report_mode: ReportMode::FirstUse,
             since: Some("0.107.0".into()),
             expected_removal: Some("0.109.0".into()),


### PR DESCRIPTION
This PR reverts the breaking change of short flag change of `watch -d` to `--debounce` instead of `--debounce-ms`. This fully prevents #16187 from being a breaking change.

Before #16187:
```nushell
watch -d 1000 foo {}
# => Now watching files at "/home/rose/foo". Press ctrl+c to abort.
```

Before this PR (after #16187):
```nushell
watch -d 1000 foo {}
# => Error: nu::parser::parse_mismatch
# => 
# =>   × Parse mismatch during operation.
# =>    ╭─[entry #15:1:10]
# =>  1 │ watch -d 1000 foo {}
# =>    ·          ──┬─
# =>    ·            ╰── expected duration with valid units
# =>    ╰────
```

After this PR (after #16187):
```nushell
watch -d 1000 foo {}
# => Warning: nu::parser::deprecated
# => 
# =>   ⚠ Flag deprecated.
# =>    ╭─[entry #3:1:7]
# =>  1 │ watch -d 1000 foo {}
# =>    ·       ─┬
# =>    ·        ╰── watch --debounce-ms was deprecated in 0.107.0 and will be removed in 0.109.0.
# =>    ╰────
# =>   help: `--debounce-ms` will be removed in favour of  `--debounce`
# => 
# => Now watching files at "/home/rose/foo". Press ctrl+c to abort.
```

This PR also fixes the `DeprecationEntry` which incorrectly had a `--` in it, which I failed to realize when reviewing #16187. We should add a `debug_assert` or something for this.

Rel: #16187

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
- [X] Add `debug_assert` for `DeprecationType::Flag`s with `--`
