### PR TITLE
Enable Dependabot updates for Rust toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"


### PR DESCRIPTION

<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
This change allows Dependabot to update the Rust toolchain version defined in `rust-toolchain.toml`. See [Dependabot now supports Rust toolchain updates - GitHub Changelog](https://github.blog/changelog/2025-08-19-dependabot-now-supports-rust-toolchain-updates/) for more details.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
