### PR TITLE
Add assertion that DeprecationEntry flag do not have dashes

### DIFF
--- a/crates/nu-protocol/src/deprecation.rs
+++ b/crates/nu-protocol/src/deprecation.rs
@@ -87,7 +87,16 @@ impl DeprecationEntry {
     fn check(&self, call: &Call) -> bool {
         match &self.ty {
             DeprecationType::Command => true,
-            DeprecationType::Flag(flag) => call.get_named_arg(flag).is_some(),
+            DeprecationType::Flag(flag) => {
+                // Make sure we don't accidentally have dashes in the flag
+                debug_assert!(
+                    !flag.starts_with("--"),
+                    "DeprecationEntry for {} should not include dashes in the flag name!",
+                    flag
+                );
+
+                call.get_named_arg(flag).is_some()
+            }
         }
     }
 


### PR DESCRIPTION
Added a `debug_assert` when using `DeprecationType::Flag` to ensure that the dashes aren't included as part of the flag name. This will hopefully catch something like the issue discovered in #16473 from occurring.

## Release notes summary - What our users need to know
N/A