### PR TITLE
Add a benchmark `use`ing the whole `std`

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -139,6 +139,30 @@ fn bench_load_standard_lib() -> impl IntoBenchmarks {
     })]
 }
 
+/// Load all modules of standard library into the engine through a general `use`.
+fn bench_load_use_standard_lib() -> impl IntoBenchmarks {
+    [benchmark_fn("load_use_standard_lib", move |b| {
+        // We need additional commands like `format number` for the standard library
+        let engine = nu_cmd_extra::add_extra_command_context(setup_engine());
+        let commands = Spanned {
+            item: "use std".into(),
+            span: Span::unknown(),
+        };
+        b.iter(move || {
+            let mut engine = engine.clone();
+            let mut stack = Stack::new();
+            let _ = load_standard_library(&mut engine);
+            evaluate_commands(
+                &commands,
+                &mut engine,
+                &mut stack,
+                PipelineData::empty(),
+                Default::default(),
+            )
+        })
+    })]
+}
+
 fn create_flat_record_string(n: usize) -> String {
     let mut s = String::from("let record = { ");
     for i in 0..n {
@@ -437,6 +461,7 @@ fn decode_msgpack(row_cnt: usize, col_cnt: usize) -> impl IntoBenchmarks {
 
 tango_benchmarks!(
     bench_load_standard_lib(),
+    bench_load_use_standard_lib(),
     // Data types
     // Record
     bench_record_create(1),


### PR DESCRIPTION
In our benchmark suite for a while (#12025) we had a benchmark that invoked the `nu-std::load_standard_library` function. 
But as we prioritized the startup speed the default behavior is to just import the prelude and make the modules available for later parsing.

With this added benchmarks the entire library is loaded via `use std`.  
This gives us a parsing benchmark with a somewhat diverse set of constructs that get used. This should be helpful to inspect general trends when we make changes to the parser or the parts of the engines relevant during parse time.


## Release notes summary - What our users need to know
N/A
