### PR TITLE
Update benchmarking README

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -1,7 +1,13 @@
-# Divan benchmarks
+# Tango benchmarks
 
-These are benchmarks using [Divan](https://github.com/nvzqz/divan), a microbenchmarking tool for Rust.
+These are benchmarks using [tango](https://github.com/bazhenov/tango), a benchmark tool which pairs the executions of two versions of the given benchmarks. This claims to reduce the noise from other factors on the system and allow a more reliable comparison of two different implementation.
 
-Run all benchmarks with `cargo bench`
+The easiest way to start is to run:
 
-Or run individual benchmarks like `cargo bench -- <regex>` e.g. `cargo bench -- parse`
+```nushell
+use toolkit.nu
+# To compare the current branch to main
+toolkit benchmark-compare
+# or to compare a target git-revision against a reference git-revision
+toolkit benchmark-compare <target> <reference>
+```


### PR DESCRIPTION
The `/benches/README.md` was still stuck in the past when we used `divan` as our benchmark runner. Update it to show how to use `tango`
