### PR TITLE
Refactor `Record` api. Reduce code duplication and make future refactors easier.

### DIFF
--- a/crates/nu-protocol/src/casing.rs
+++ b/crates/nu-protocol/src/casing.rs
@@ -14,7 +14,7 @@ pub(crate) mod private {
     pub trait Seal {}
 }
 
-pub trait CasingCmp: private::Seal + 'static {
+pub trait CaseSensitivity: private::Seal + 'static {
     fn eq(lhs: &str, rhs: &str) -> bool;
 
     fn cmp(lhs: &str, rhs: &str) -> Ordering;
@@ -26,7 +26,7 @@ pub struct CaseInsensitive;
 impl private::Seal for CaseSensitive {}
 impl private::Seal for CaseInsensitive {}
 
-impl CasingCmp for CaseSensitive {
+impl CaseSensitivity for CaseSensitive {
     #[inline]
     fn eq(lhs: &str, rhs: &str) -> bool {
         lhs == rhs
@@ -38,7 +38,7 @@ impl CasingCmp for CaseSensitive {
     }
 }
 
-impl CasingCmp for CaseInsensitive {
+impl CaseSensitivity for CaseInsensitive {
     #[inline]
     fn eq(lhs: &str, rhs: &str) -> bool {
         lhs.eq_ignore_case(rhs)
@@ -48,4 +48,16 @@ impl CasingCmp for CaseInsensitive {
     fn cmp(lhs: &str, rhs: &str) -> Ordering {
         lhs.cmp_ignore_case(rhs)
     }
+}
+
+/// Wraps `Self` in a type that affects the case sensitivity of operations
+///
+/// Using methods of [`CaseSensitivity`] in `Wrapper` implementations are not mandotary.
+/// They are provided mostly for convenience and to have a common implementation for comparisons
+pub trait WrapCased {
+    /// Wrapper type generic over case sensitivity.
+    type Wrapper<S: CaseSensitivity>;
+
+    fn case_sensitive(self) -> Self::Wrapper<CaseSensitive>;
+    fn case_insensitive(self) -> Self::Wrapper<CaseInsensitive>;
 }

--- a/crates/nu-protocol/src/casing.rs
+++ b/crates/nu-protocol/src/casing.rs
@@ -1,3 +1,6 @@
+use std::cmp::Ordering;
+
+use nu_utils::IgnoreCaseExt;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
@@ -5,4 +8,44 @@ pub enum Casing {
     #[default]
     Sensitive,
     Insensitive,
+}
+
+pub(crate) mod private {
+    pub trait Seal {}
+}
+
+pub trait CasingCmp: private::Seal + 'static {
+    fn eq(lhs: &str, rhs: &str) -> bool;
+
+    fn cmp(lhs: &str, rhs: &str) -> Ordering;
+}
+
+pub struct CaseSensitive;
+pub struct CaseInsensitive;
+
+impl private::Seal for CaseSensitive {}
+impl private::Seal for CaseInsensitive {}
+
+impl CasingCmp for CaseSensitive {
+    #[inline]
+    fn eq(lhs: &str, rhs: &str) -> bool {
+        lhs == rhs
+    }
+
+    #[inline]
+    fn cmp(lhs: &str, rhs: &str) -> Ordering {
+        lhs.cmp(rhs)
+    }
+}
+
+impl CasingCmp for CaseInsensitive {
+    #[inline]
+    fn eq(lhs: &str, rhs: &str) -> bool {
+        lhs.eq_ignore_case(rhs)
+    }
+
+    #[inline]
+    fn cmp(lhs: &str, rhs: &str) -> Ordering {
+        lhs.cmp_ignore_case(rhs)
+    }
 }

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -283,60 +283,12 @@ impl Record {
         self.inner.push((col.into(), val));
     }
 
-    /// Insert into the record, replacing preexisting value if found.
-    ///
-    /// Returns `Some(previous_value)` if found. Else `None`
-    pub fn insert<K>(&mut self, col: K, val: Value) -> Option<Value>
-    where
-        K: AsRef<str> + Into<String>,
-    {
-        if let Some(curr_val) = self.get_mut(&col) {
-            Some(std::mem::replace(curr_val, val))
-        } else {
-            self.push(col, val);
-            None
-        }
-    }
-
-    pub fn contains(&self, col: impl AsRef<str>) -> bool {
-        self.columns().any(|k| k == col.as_ref())
-    }
-
-    pub fn index_of(&self, col: impl AsRef<str>) -> Option<usize> {
-        self.columns().position(|k| k == col.as_ref())
-    }
-
-    pub fn get(&self, col: impl AsRef<str>) -> Option<&Value> {
-        self.inner
-            .iter()
-            .find_map(|(k, v)| if k == col.as_ref() { Some(v) } else { None })
-    }
-
-    pub fn get_mut(&mut self, col: impl AsRef<str>) -> Option<&mut Value> {
-        self.inner
-            .iter_mut()
-            .find_map(|(k, v)| if k == col.as_ref() { Some(v) } else { None })
-    }
-
     pub fn get_index(&self, idx: usize) -> Option<(&String, &Value)> {
         self.inner.get(idx).map(|(col, val): &(_, _)| (col, val))
     }
 
     pub fn get_index_mut(&mut self, idx: usize) -> Option<(&mut String, &mut Value)> {
-        self.inner
-            .get_mut(idx)
-            .map(|(col, val): &mut (_, _)| (col, val))
-    }
-
-    /// Remove single value by key
-    ///
-    /// Returns `None` if key not found
-    ///
-    /// Note: makes strong assumption that keys are unique
-    pub fn remove(&mut self, col: impl AsRef<str>) -> Option<Value> {
-        let idx = self.index_of(col)?;
-        let (_, val) = self.inner.remove(idx);
-        Some(val)
+        self.inner.get_mut(idx).map(|(col, val)| (col, val))
     }
 
     /// Remove single value by index

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -276,9 +276,11 @@ impl Record {
 
     /// Naive push to the end of the datastructure.
     ///
+    /// <div class="warning">
     /// May duplicate data!
     ///
-    /// Consider to use [`Record::insert`] instead
+    /// Consider using [`CaseTypedRecord::insert`] or [`CasedRecord::insert`] instead.
+    /// </div>
     pub fn push(&mut self, col: impl Into<String>, val: Value) {
         self.inner.push((col.into(), val));
     }

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -1,5 +1,9 @@
 //! Our insertion ordered map-type [`Record`]
-use std::{iter::FusedIterator, ops::RangeBounds};
+use std::{
+    iter::FusedIterator,
+    ops::RangeBounds,
+    ops::{Deref, DerefMut},
+};
 
 use crate::{ShellError, Span, Value, casing::Casing};
 
@@ -125,6 +129,20 @@ impl AsRef<Record> for Record {
 impl AsMut<Record> for Record {
     fn as_mut(&mut self) -> &mut Record {
         self
+    }
+}
+
+impl Deref for Record {
+    type Target = CaseTypedRecord<true>;
+
+    fn deref(&self) -> &Self::Target {
+        self.case_sensitive()
+    }
+}
+
+impl DerefMut for Record {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.case_sensitive()
     }
 }
 

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -81,6 +81,53 @@ impl<const SENSITIVE: bool> CaseTypedRecord<SENSITIVE> {
     }
 }
 
+/// Extension trait for [`Record`]. Enables separate implementations for `&Record` and `&mut Record`
+pub trait RecordExt {
+    type Ref<const S: bool>;
+    fn case_sensitive(self) -> Self::Ref<true>;
+    fn case_insensitive(self) -> Self::Ref<false>;
+}
+
+impl<'a> RecordExt for &'a Record {
+    type Ref<const S: bool> = &'a CaseTypedRecord<S>;
+
+    #[inline]
+    fn case_sensitive(self) -> Self::Ref<true> {
+        CaseTypedRecord::<true>::from_record(self)
+    }
+
+    #[inline]
+    fn case_insensitive(self) -> Self::Ref<false> {
+        CaseTypedRecord::<false>::from_record(self)
+    }
+}
+
+impl<'a> RecordExt for &'a mut Record {
+    type Ref<const S: bool> = &'a mut CaseTypedRecord<S>;
+
+    #[inline]
+    fn case_sensitive(self) -> Self::Ref<true> {
+        CaseTypedRecord::<true>::from_record_mut(self)
+    }
+
+    #[inline]
+    fn case_insensitive(self) -> Self::Ref<false> {
+        CaseTypedRecord::<false>::from_record_mut(self)
+    }
+}
+
+impl AsRef<Record> for Record {
+    fn as_ref(&self) -> &Record {
+        self
+    }
+}
+
+impl AsMut<Record> for Record {
+    fn as_mut(&mut self) -> &mut Record {
+        self
+    }
+}
+
 /// A wrapper around [`Record`] that affects whether key comparisons are case sensitive or not.
 ///
 /// Implements commonly used methods of [`Record`].


### PR DESCRIPTION
Part of my efforts refactor `Record`. Aims of the this PR:
- Reduce ambiguity regarding case sensitivity when working with `Record`.
- Provide a new wrapper/proxy[^proxy] for cases where case sensitivity is known statically: `CasedRecord`.
- Reduce code duplication and the possibility of behaviors diverging.
- And as a bonus, introduce code patterns that might be applicable in other places as well.

[^proxy]: There is probably a better name for this pattern.

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A