### PR TITLE
feat(docs): add to `run-external` and `help` command descriptions

### DIFF
--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -31,7 +31,9 @@ impl Command for Help {
     }
 
     fn extra_description(&self) -> &str {
-        r#"`help word` searches for "word" in commands, aliases and modules, in that order."#
+        r#"`help word` searches for "word" in commands, aliases and modules, in that order.
+If you want your own help implementation, create a custom command named `help` and it will also be used for `--help` invocations.
+There already is an alternative `help` command in the standard library you can try with `use std/help`."#
     }
 
     fn run(

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -34,7 +34,7 @@ impl Command for External {
     }
 
     fn extra_description(&self) -> &str {
-        r#"All externals are run with this command, wether you call it directly with `run-external external` or use `external` or `^external`.
+        r#"All externals are run with this command, whether you call it directly with `run-external external` or use `external` or `^external`.
 If you create a custom command with this name, that will be used instead."#
     }
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -33,6 +33,11 @@ impl Command for External {
         "Runs external command."
     }
 
+    fn extra_description(&self) -> &str {
+        r#"All externals are run with this command, wether you call it directly with `run-external external` or use `external` or `^external`.
+If you create a custom command with this name, that will be used instead."#
+    }
+
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build(self.name())
             .input_output_types(vec![(Type::Any, Type::Any)])


### PR DESCRIPTION
Added to the extra_description of `run-external` and `help` that if you create a command with that name it will be used instead for running externals and `--help` outputs, which is not obvious. Also added it to the website nushell/nushell.github.io#2015.

Let me know if there is another command like this to expand the documentation.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
Added information to the `run-external` and `help` descriptions that indicates these commands or any with the same names are automatically used for running externals and the `--help` flags respectively.

## Tasks after submitting