### PR TITLE
Reset content type for commands returning partial input

### DIFF
--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -74,16 +74,9 @@ impl Command for BytesRemove {
         };
 
         operate(remove, arg, input, call.head, engine_state.signals()).map(|pipeline| {
-            match pipeline {
-                // image/png with bytes removed is not a valid image/png anymore
-                PipelineData::ByteStream(stream, Some(metadata)) => {
-                    PipelineData::byte_stream(stream, metadata.with_content_type(None))
-                }
-                PipelineData::Value(val, Some(metadata)) => {
-                    PipelineData::Value(val, Some(metadata.with_content_type(None)))
-                }
-                _ => pipeline,
-            }
+            // image/png with some bytes removed is likely not a valid image/png anymore
+            let metadata = pipeline.metadata().map(|m| m.with_content_type(None));
+            pipeline.set_metadata(metadata)
         })
     }
 

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -98,7 +98,8 @@ fn first_helper(
         1
     };
 
-    let metadata = input.metadata();
+    // first 5 bytes of an image/png are not image/png themselves
+    let metadata = input.metadata().map(|m| m.with_content_type(None));
 
     // early exit for `first 0`
     if rows == 0 {
@@ -176,6 +177,7 @@ fn first_helper(
         PipelineData::ByteStream(stream, metadata) => {
             if stream.type_().is_binary_coercible() {
                 let span = stream.span();
+                let metadata = metadata.map(|m| m.with_content_type(None));
                 if let Some(mut reader) = stream.reader() {
                     if return_single_element {
                         // Take a single byte

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -46,7 +46,7 @@ impl Command for Take {
         let head = call.head;
         let rows_desired: usize = call.req(engine_state, stack, 0)?;
 
-        let metadata = input.metadata();
+        let metadata = input.metadata().map(|m| m.with_content_type(None));
 
         match input {
             PipelineData::Value(val, _) => {
@@ -91,7 +91,8 @@ impl Command for Take {
                     let span = stream.span();
                     Ok(PipelineData::byte_stream(
                         stream.take(span, rows_desired as u64)?,
-                        metadata,
+                        // first 5 bytes of an image/png stream are not image/png themselves
+                        metadata.map(|m| m.with_content_type(None)),
                     ))
                 } else {
                     Err(ShellError::OnlySupportsThisInputType {

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -87,16 +87,9 @@ impl Command for StrSubstring {
             graphemes: grapheme_flags(engine_state, stack, call)?,
         };
         operate(action, args, input, call.head, engine_state.signals()).map(|pipeline| {
-            match pipeline {
-                // a substring of text/json is not necessarily text/json
-                PipelineData::ByteStream(stream, Some(metadata)) => {
-                    PipelineData::byte_stream(stream, metadata.with_content_type(None))
-                }
-                PipelineData::Value(val, Some(metadata)) => {
-                    PipelineData::Value(val, Some(metadata.with_content_type(None)))
-                }
-                _ => pipeline,
-            }
+            // a substring of text/json is not necessarily text/json itself
+            let metadata = pipeline.metadata().map(|m| m.with_content_type(None));
+            pipeline.set_metadata(metadata)
         })
     }
 
@@ -123,16 +116,9 @@ impl Command for StrSubstring {
             working_set.permanent().signals(),
         )
         .map(|pipeline| {
-            match pipeline {
-                // a substring of text/json is not necessarily text/json
-                PipelineData::ByteStream(stream, Some(metadata)) => {
-                    PipelineData::byte_stream(stream, metadata.with_content_type(None))
-                }
-                PipelineData::Value(val, Some(metadata)) => {
-                    PipelineData::Value(val, Some(metadata.with_content_type(None)))
-                }
-                _ => pipeline,
-            }
+            // a substring of text/json is not necessarily text/json itself
+            let metadata = pipeline.metadata().map(|m| m.with_content_type(None));
+            pipeline.set_metadata(metadata)
         })
     }
 

--- a/crates/nu-command/tests/commands/bytes/at.rs
+++ b/crates/nu-command/tests/commands/bytes/at.rs
@@ -75,3 +75,12 @@ pub fn test_string_returns_correct_slice_for_max_end() {
     let actual = nu!("\"Hello World\" | encode utf8 | bytes at 6..<11 | decode");
     assert_eq!(actual.out, "World");
 }
+
+#[test]
+pub fn test_drops_content_type() {
+    let actual = nu!(format!(
+        "open {} | bytes at 3..5 | metadata | get content_type? | describe",
+        file!(),
+    ));
+    assert_eq!(actual.out, "nothing", "Expected content_type to be dropped");
+}

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -103,3 +103,12 @@ fn errors_on_empty_list_when_no_rows_given() {
 
     assert!(actual.err.contains("index too large"));
 }
+
+#[test]
+fn gets_first_bytes_and_drops_content_type() {
+    let actual = nu!(format!(
+        "open {} | first 3 | metadata | get content_type? | describe",
+        file!(),
+    ));
+    assert_eq!(actual.out, "nothing");
+}

--- a/crates/nu-command/tests/commands/skip/skip_.rs
+++ b/crates/nu-command/tests/commands/skip/skip_.rs
@@ -20,3 +20,12 @@ fn fail_on_non_iterator() {
 
     assert!(actual.err.contains("command doesn't support"));
 }
+
+#[test]
+fn skips_bytes_and_drops_content_type() {
+    let actual = nu!(format!(
+        "open {} | skip 3 | metadata | get content_type? | describe",
+        file!(),
+    ));
+    assert_eq!(actual.out, "nothing");
+}

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -396,6 +396,15 @@ fn substring_of_empty_string() {
 }
 
 #[test]
+fn substring_drops_content_type() {
+    let actual = nu!(format!(
+        "open {} | str substring 0..2 | metadata | get content_type? | describe",
+        file!(),
+    ));
+    assert_eq!(actual.out, "nothing");
+}
+
+#[test]
 fn str_reverse() {
     let actual = nu!(r#"
         echo "nushell" | str reverse

--- a/crates/nu-command/tests/commands/take/rows.rs
+++ b/crates/nu-command/tests/commands/take/rows.rs
@@ -58,3 +58,13 @@ fn works_with_binary_list() {
 
     assert_eq!(actual.out, "true");
 }
+
+#[test]
+fn takes_bytes_and_drops_content_type() {
+    let actual = nu!(format!(
+        "open {} | take 3 | metadata | get content_type? | describe",
+        file!(),
+    ));
+
+    assert_eq!(actual.out, "nothing");
+}


### PR DESCRIPTION
Refs https://discord.com/channels/601130461678272522/615329862395101194/1408860803326808316

## Release notes summary - What our users need to know

The following commands no longer preserve `content_type` element of the input metadata:

* `bytes at` - bytes 3..5 of an `image/png` stream are not valid `image/png` stream themselves
* `bytes remove` - when you remove some bytes, the content type likely becomes invalid
* `first` - first 5 bytes of an `image/png` stream are not valid `image/png` stream themselves
* `skip` - bytes after 5th of an `image/png` stream are not valid `image/png` stream
* `take` - see `first`
* `str substring` - a random string slice of `application/json` isn't likely to be a valid `application/json` value

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
