### PR TITLE
Regex support for which command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3896,6 +3896,7 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rayon",
  "reedline",
+ "regex",
  "rmp",
  "roxmltree",
  "rstest",
@@ -8443,6 +8444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
+ "regex",
  "rustix 1.0.7",
  "winsafe",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ uuid = "1.16.0"
 v_htmlescape = "0.15.0"
 wax = "0.6"
 web-time = "1.1.0"
-which = "8.0.0"
+which = { version = "8.0.0", features = ["regex"] }
 windows = "0.56"
 windows-sys = "0.48"
 winreg = "0.52"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -138,6 +138,7 @@ unicode-width = { workspace = true }
 data-encoding = { version = "2.9.0", features = ["alloc"] }
 web-time = { workspace = true }
 webpki-roots = { workspace = true, optional = true }
+regex = "1.11.1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = { workspace = true }

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -118,3 +118,33 @@ fn which_accepts_spread_list() {
 
     assert_eq!(actual.out, "ls");
 }
+
+#[test]
+fn which_regex_single_match() {
+    let actual = nu!("which -r '^ls$' | get command.0");
+    assert_eq!(actual.out, "ls");
+}
+
+#[test]
+fn which_regex_multiple_matches() {
+    let actual = nu!("which -a -r '^l' | length");
+
+    let length: i32 = actual.out.parse().unwrap();
+    assert!(length >= 1);
+}
+
+#[test]
+fn which_regex_no_match() {
+    let actual = nu!("which -r '^zzz_nonexistent_cmd$' | length");
+
+    let length: i32 = actual.out.parse().unwrap();
+    assert_eq!(length, 0);
+}
+
+#[test]
+fn which_regex_invalid_pattern() {
+    // Test that invalid regex patterns return an error
+    let actual = nu!("which -r '[invalid'");
+
+    assert!(actual.err.contains("regex") || actual.err.contains("pattern"));
+}

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -121,8 +121,8 @@ fn which_accepts_spread_list() {
 
 #[test]
 fn which_regex_single_match() {
-    let actual = nu!("which -r '^ls$' | get command.0");
-    assert_eq!(actual.out, "ls");
+    let actual = nu!("which -r '^cd$' | get command.0");
+    assert_eq!(actual.out, "cd");
 }
 
 #[test]
@@ -143,7 +143,6 @@ fn which_regex_no_match() {
 
 #[test]
 fn which_regex_invalid_pattern() {
-    // Test that invalid regex patterns return an error
     let actual = nu!("which -r '[invalid'");
 
     assert!(actual.err.contains("regex") || actual.err.contains("pattern"));


### PR DESCRIPTION
Fixes #16140 
Goals:
- [x] Removed thin obsolete wrapper `fn get_entries_in_nu()` over `fn get_entry_in_commands()`.
- [x]  Added support for Regex search in `which` command using `which --regex (-r) 'your_regex'`
- [x] Added use example for Regex
- [x] Added tests for Regex search
## Release notes summary - What our users need to know

## Tasks after submitting