### PR TITLE
Fix `native-tls` feature

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -1,6 +1,6 @@
 use crate::{
     formats::value_to_json_value,
-    network::{http::timeout_extractor_reader::UreqTimeoutExtractorReader, tls::tls},
+    network::{http::timeout_extractor_reader::UreqTimeoutExtractorReader, tls::tls_config},
 };
 use base64::{
     Engine, alphabet,
@@ -95,7 +95,7 @@ pub fn http_client(
         }
     };
 
-    config_builder = config_builder.tls_config(tls(allow_insecure)?);
+    config_builder = config_builder.tls_config(tls_config(allow_insecure)?);
     Ok(ureq::Agent::new_with_config(config_builder.build()))
 }
 

--- a/crates/nu-command/src/network/tls/impl_native_tls.rs
+++ b/crates/nu-command/src/network/tls/impl_native_tls.rs
@@ -2,7 +2,7 @@ use nu_protocol::ShellError;
 use ureq::tls::{TlsConfig, TlsProvider};
 
 #[doc = include_str!("./tls.rustdoc.md")]
-pub fn tls(allow_insecure: bool) -> Result<TlsConfig, ShellError> {
+pub fn tls_config(allow_insecure: bool) -> Result<TlsConfig, ShellError> {
     // The impl for rustls has the option to use other root certificates.
     // This is kind ob unnecessary for the native tls, as we expect to run with an OS.
     Ok(TlsConfig::builder()

--- a/crates/nu-command/src/network/tls/impl_native_tls.rs
+++ b/crates/nu-command/src/network/tls/impl_native_tls.rs
@@ -1,16 +1,12 @@
 use nu_protocol::ShellError;
-use ureq::TlsConnector;
+use ureq::tls::{TlsConfig, TlsProvider};
 
 #[doc = include_str!("./tls.rustdoc.md")]
-pub fn tls(allow_insecure: bool) -> Result<impl TlsConnector, ShellError> {
-    native_tls::TlsConnector::builder()
-        .danger_accept_invalid_certs(allow_insecure)
-        .build()
-        .map_err(|e| ShellError::GenericError {
-            error: format!("Failed to build network tls: {}", e),
-            msg: String::new(),
-            span: None,
-            help: None,
-            inner: vec![],
-        })
+pub fn tls(allow_insecure: bool) -> Result<TlsConfig, ShellError> {
+    // The impl for rustls has the option to use other root certificates.
+    // This is kind ob unnecessary for the native tls, as we expect to run with an OS.
+    Ok(TlsConfig::builder()
+        .provider(TlsProvider::NativeTls)
+        .disable_verification(allow_insecure)
+        .build())
 }

--- a/crates/nu-command/src/network/tls/impl_native_tls.rs
+++ b/crates/nu-command/src/network/tls/impl_native_tls.rs
@@ -1,7 +1,7 @@
 use nu_protocol::ShellError;
 use ureq::tls::{TlsConfig, TlsProvider};
 
-#[doc = include_str!("./tls.rustdoc.md")]
+#[doc = include_str!("./tls_config.rustdoc.md")]
 pub fn tls_config(allow_insecure: bool) -> Result<TlsConfig, ShellError> {
     // The impl for rustls has the option to use other root certificates.
     // This is kind ob unnecessary for the native tls, as we expect to run with an OS.

--- a/crates/nu-command/src/network/tls/impl_rustls.rs
+++ b/crates/nu-command/src/network/tls/impl_rustls.rs
@@ -95,7 +95,7 @@ impl NuCryptoProvider {
 }
 
 #[doc = include_str!("./tls.rustdoc.md")]
-pub fn tls(allow_insecure: bool) -> Result<TlsConfig, ShellError> {
+pub fn tls_config(allow_insecure: bool) -> Result<TlsConfig, ShellError> {
     let crypto_provider = CRYPTO_PROVIDER.get()?;
     let config = match allow_insecure {
         false => {

--- a/crates/nu-command/src/network/tls/impl_rustls.rs
+++ b/crates/nu-command/src/network/tls/impl_rustls.rs
@@ -94,7 +94,7 @@ impl NuCryptoProvider {
     }
 }
 
-#[doc = include_str!("./tls.rustdoc.md")]
+#[doc = include_str!("./tls_config.rustdoc.md")]
 pub fn tls_config(allow_insecure: bool) -> Result<TlsConfig, ShellError> {
     let crypto_provider = CRYPTO_PROVIDER.get()?;
     let config = match allow_insecure {

--- a/crates/nu-command/src/network/tls/tls_config.rustdoc.md
+++ b/crates/nu-command/src/network/tls/tls_config.rustdoc.md
@@ -1,4 +1,4 @@
-Provide a [`TlsConnector`] for [`ureq`].
+Provide a [`TlsConfig`] for [`ureq`].
 
 This is used by Nushell's networking commands (`http`) to handle secure 
 (or optionally insecure) HTTP connections.


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

While building the docs I realized that `nu-command` complained that it could not find `ureq::TlsConnector`. I investigated a bit and found out that #16078 broke it (I merged that, lol). It also broke the `native-tls` feature we have, but it did not come up in our CI as this would massively increase the CI time. This PR fixes the `native-tls` feature.

So `cargo build --no-default-features --features native-tls` works again.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
N/A
