### PR TITLE
Fix some broken doc links

### DIFF
--- a/crates/nu-protocol/src/deprecation.rs
+++ b/crates/nu-protocol/src/deprecation.rs
@@ -7,9 +7,10 @@ use crate::{self as nu_protocol, ReportMode, Span};
 
 /// A entry which indicates that some part of, or all of, a command is deprecated
 ///
-/// Commands can implement [`Command::deprecation_info`] to return deprecation entries,
-/// which will cause a parse-time warning. Additionally, custom commands can use the
-/// @deprecated attribute to add a `DeprecationEntry`.
+/// Commands can implement [`Command::deprecation_info`](crate::engine::Command::deprecation_info) 
+/// to return deprecation entries, which will cause a parse-time warning. 
+/// Additionally, custom commands can use the `@deprecated` attribute to add a 
+/// `DeprecationEntry`.
 #[derive(FromValue)]
 pub struct DeprecationEntry {
     /// The type of deprecation

--- a/crates/nu-protocol/src/deprecation.rs
+++ b/crates/nu-protocol/src/deprecation.rs
@@ -7,9 +7,9 @@ use crate::{self as nu_protocol, ReportMode, Span};
 
 /// A entry which indicates that some part of, or all of, a command is deprecated
 ///
-/// Commands can implement [`Command::deprecation_info`](crate::engine::Command::deprecation_info) 
-/// to return deprecation entries, which will cause a parse-time warning. 
-/// Additionally, custom commands can use the `@deprecated` attribute to add a 
+/// Commands can implement [`Command::deprecation_info`](crate::engine::Command::deprecation_info)
+/// to return deprecation entries, which will cause a parse-time warning.
+/// Additionally, custom commands can use the `@deprecated` attribute to add a
 /// `DeprecationEntry`.
 #[derive(FromValue)]
 pub struct DeprecationEntry {

--- a/crates/nu-protocol/src/errors/parse_warning.rs
+++ b/crates/nu-protocol/src/errors/parse_warning.rs
@@ -10,7 +10,8 @@ use crate::{ReportMode, Reportable};
 pub enum ParseWarning {
     /// A parse-time deprectaion. Indicates that something will be removed in a future release.
     ///
-    /// Use [`ShellWarning::Deprecated`] if this is a deprecation which is only detectable at run-time.
+    /// Use [`ShellWarning::Deprecated`](crate::ShellWarning::Deprecated) if this is a deprecation 
+    /// which is only detectable at run-time.
     #[error("{dep_type} deprecated.")]
     #[diagnostic(code(nu::parser::deprecated))]
     Deprecated {

--- a/crates/nu-protocol/src/errors/parse_warning.rs
+++ b/crates/nu-protocol/src/errors/parse_warning.rs
@@ -10,7 +10,7 @@ use crate::{ReportMode, Reportable};
 pub enum ParseWarning {
     /// A parse-time deprectaion. Indicates that something will be removed in a future release.
     ///
-    /// Use [`ShellWarning::Deprecated`](crate::ShellWarning::Deprecated) if this is a deprecation 
+    /// Use [`ShellWarning::Deprecated`](crate::ShellWarning::Deprecated) if this is a deprecation
     /// which is only detectable at run-time.
     #[error("{dep_type} deprecated.")]
     #[diagnostic(code(nu::parser::deprecated))]

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -5,6 +5,8 @@ use std::{
     path::{Path, PathBuf},
 };
 use thiserror::Error;
+#[cfg(doc)] // allow mentioning this in doc comments
+use super::ShellError;
 
 use crate::Span;
 
@@ -103,7 +105,7 @@ pub struct IoError {
     /// and is part of [`std::io::Error`].
     /// If a kind cannot be represented by it, consider adding a new variant to [`ErrorKind`].
     ///
-    /// Only in very rare cases should [`std::io::ErrorKind::other()`] be used, make sure you provide
+    /// Only in very rare cases should [`std::io::Error::other()`] be used, make sure you provide
     /// `additional_context` to get useful errors in these cases.
     pub kind: ErrorKind,
 
@@ -181,8 +183,9 @@ pub enum ErrorKind {
     /// The file or directory is in use by another program.
     ///
     /// On Windows, this maps to
-    /// [`ERROR_SHARING_VIOLATION`](windows::Win32::Foundation::ERROR_SHARING_VIOLATION) and
+    /// [`ERROR_SHARING_VIOLATION`](::windows::Win32::Foundation::ERROR_SHARING_VIOLATION) and
     /// prevents access like deletion or modification.
+    #[cfg_attr(not(windows), allow(rustdoc::broken_intra_doc_links))]
     AlreadyInUse,
 
     // use these variants in cases where we know precisely whether a file or directory was expected

--- a/crates/nu-protocol/src/errors/shell_error/io.rs
+++ b/crates/nu-protocol/src/errors/shell_error/io.rs
@@ -1,3 +1,5 @@
+#[cfg(doc)] // allow mentioning this in doc comments
+use super::ShellError;
 use miette::{Diagnostic, LabeledSpan, SourceSpan};
 use std::{
     error::Error as StdError,
@@ -5,8 +7,6 @@ use std::{
     path::{Path, PathBuf},
 };
 use thiserror::Error;
-#[cfg(doc)] // allow mentioning this in doc comments
-use super::ShellError;
 
 use crate::Span;
 

--- a/crates/nu-protocol/src/errors/shell_warning.rs
+++ b/crates/nu-protocol/src/errors/shell_warning.rs
@@ -10,7 +10,7 @@ use crate::{ConfigWarning, ReportMode, Reportable};
 pub enum ShellWarning {
     /// A parse-time deprectaion. Indicates that something will be removed in a future release.
     ///
-    /// Use [`ParseWarning::Deprecated`](crate::ParseWarning::Deprecated) if this is a deprecation 
+    /// Use [`ParseWarning::Deprecated`](crate::ParseWarning::Deprecated) if this is a deprecation
     /// which is detectable at parse-time.
     #[error("{dep_type} deprecated.")]
     #[diagnostic(code(nu::shell::deprecated))]

--- a/crates/nu-protocol/src/errors/shell_warning.rs
+++ b/crates/nu-protocol/src/errors/shell_warning.rs
@@ -10,7 +10,8 @@ use crate::{ConfigWarning, ReportMode, Reportable};
 pub enum ShellWarning {
     /// A parse-time deprectaion. Indicates that something will be removed in a future release.
     ///
-    /// Use [`ParseWarning::Deprecated`] if this is a deprecation which is detectable at parse-time.
+    /// Use [`ParseWarning::Deprecated`](crate::ParseWarning::Deprecated) if this is a deprecation 
+    /// which is detectable at parse-time.
     #[error("{dep_type} deprecated.")]
     #[diagnostic(code(nu::shell::deprecated))]
     Deprecated {

--- a/crates/nu-protocol/src/value/filesize.rs
+++ b/crates/nu-protocol/src/value/filesize.rs
@@ -546,7 +546,7 @@ impl FilesizeUnitFormat {
         }
     }
 
-    /// Returns `true` for [`DisplayFilesizeUnit::Metric`] or if the underlying [`FilesizeUnit`]
+    /// Returns `true` for [`FilesizeUnitFormat::Metric`] or if the underlying [`FilesizeUnit`]
     /// is metric according to [`FilesizeUnit::is_metric`].
     ///
     /// Note that this returns `true` for [`FilesizeUnit::B`] as well.
@@ -558,7 +558,7 @@ impl FilesizeUnitFormat {
         }
     }
 
-    /// Returns `true` for [`DisplayFilesizeUnit::Binary`] or if the underlying [`FilesizeUnit`]
+    /// Returns `true` for [`FilesizeUnitFormat::Binary`] or if the underlying [`FilesizeUnit`]
     /// is binary according to [`FilesizeUnit::is_binary`].
     ///
     /// Note that this returns `true` for [`FilesizeUnit::B`] as well.
@@ -583,7 +583,7 @@ impl fmt::Display for FilesizeUnitFormat {
     }
 }
 
-/// The error returned when failing to parse a [`DisplayFilesizeUnit`].
+/// The error returned when failing to parse a [`FilesizeUnitFormat`].
 ///
 /// This occurs when the string being parsed does not exactly match any of:
 /// - `metric`


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
Some doc links were broken, you could see them when running `cargo doc`. So I fixed that. The `TlsConnector` warning is handled via #16518.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
N/A
