### PR TITLE
Add "did my homework" checkboxes to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,19 +1,25 @@
 name: Bug Report
-description: Create a report to help us improve
+description: Create a report of behavior that doesn't seem to be intended and help us improve
 labels: ["needs-triage"]
 body: 
+  - type: checkboxes
+    label: Bug report form
+    description: Thank you for your bug report.
+    options:
+      - label: I have done a basic search of the issue tracker to find any existing issues that are similar.
+      - label: I have checked that my version is at least the latest stable release available via my installation method.
   - type: textarea
     id: description
     attributes:
       label: Describe the bug
-      description: Thank you for your bug report.
+      description: Try to make it easy for us to understand what problem you are encountering.
     validations:
       required: true
   - type: textarea
     id: repro
     attributes:
       label: How to reproduce
-      description: Steps to reproduce the behavior (including succinct code examples or screenshots of the observed behavior)
+      description: Steps to reproduce the behavior (including succinct code examples or screenshots of the observed behavior).
       placeholder: |
         1.
         2.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,14 +1,19 @@
 name: Feature Request
-description: "When you want a new feature for something that doesn't already exist"
+description: "When you want to propose new feature for something that doesn't already exist"
 labels: ["needs-triage", "enhancement"]
 body:
+  - type: checkboxes
+    label: Basics
+    description: Thank you for your feature request.
+    options:
+      - label: I have done a basic search through the issue tracker to find similar or related issues.
+      - label: I have made myself familiar with the available features of Nushell for the particular area this enhancement request touches.
   - type: textarea
     id: problem
     attributes:
       label: Related problem
-      description: Thank you for your feature request.
+      description: A clear and concise description of what the thing is, that Nushell could do better.
       placeholder: |
-        A clear and concise description of what the problem is.
         Example: I am trying to do [...] but [...]
     validations:
       required: false
@@ -30,6 +35,6 @@ body:
     id: context
     attributes:
       label: Additional context and details
-      description: Add any other context or screenshots about the feature request here.
+      description: Add any other context or reference material about the feature request here.
     validations:
       required: false


### PR DESCRIPTION
Remind people to search the issue tracker before filing.
Also additional reminder on the bug report if they are using the latest version.
For the feature request another checkbox to make sure folks know what we have before they wish for more.
