### PR TITLE
Rename `into sqlite` to `to sqlite`

### DIFF
--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -1,0 +1,52 @@
+use nu_engine::command_prelude::*;
+use nu_protocol::{DeprecationEntry, DeprecationType, ReportMode};
+
+#[derive(Clone)]
+pub struct IntoSqliteDb(pub(crate) super::ToSqliteDb);
+
+impl Command for IntoSqliteDb {
+    fn deprecation_info(&self) -> Vec<nu_protocol::DeprecationEntry> {
+        vec![DeprecationEntry {
+            ty: DeprecationType::Command,
+            report_mode: ReportMode::FirstUse,
+            since: Some("0.107.0".into()),
+            expected_removal: None,
+            help: Some(
+                "to align the behavior of this command, it is now called `to sqlite`".into(),
+            ),
+        }]
+    }
+
+    fn name(&self) -> &str {
+        "into sqlite"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature {
+            name: self.name().into(),
+            ..self.0.signature()
+        }
+    }
+
+    fn description(&self) -> &str {
+        self.0.description()
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> std::result::Result<PipelineData, ShellError> {
+        self.0.run(engine_state, stack, call, input)
+    }
+
+    fn extra_description(&self) -> &str {
+        self.0.extra_description()
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        self.0.examples()
+    }
+}

--- a/crates/nu-command/src/database/commands/mod.rs
+++ b/crates/nu-command/src/database/commands/mod.rs
@@ -1,7 +1,9 @@
+mod into_sqlite;
 mod query_db;
 mod schema;
 mod to_sqlite;
 
+use into_sqlite::IntoSqliteDb;
 use nu_protocol::engine::StateWorkingSet;
 use query_db::QueryDb;
 use schema::SchemaDb;
@@ -18,5 +20,11 @@ pub fn add_commands_decls(working_set: &mut StateWorkingSet) {
         }
 
     // Series commands
-    bind_command!(ToSqliteDb, QueryDb, SchemaDb);
+    bind_command!(
+        // deprecated, use ToSqliteDb instead
+        IntoSqliteDb(ToSqliteDb),
+        ToSqliteDb,
+        QueryDb,
+        SchemaDb
+    );
 }

--- a/crates/nu-command/src/database/commands/mod.rs
+++ b/crates/nu-command/src/database/commands/mod.rs
@@ -1,11 +1,11 @@
-mod into_sqlite;
 mod query_db;
 mod schema;
+mod to_sqlite;
 
-use into_sqlite::IntoSqliteDb;
 use nu_protocol::engine::StateWorkingSet;
 use query_db::QueryDb;
 use schema::SchemaDb;
+use to_sqlite::ToSqliteDb;
 
 pub fn add_commands_decls(working_set: &mut StateWorkingSet) {
     macro_rules! bind_command {
@@ -18,5 +18,5 @@ pub fn add_commands_decls(working_set: &mut StateWorkingSet) {
         }
 
     // Series commands
-    bind_command!(IntoSqliteDb, QueryDb, SchemaDb);
+    bind_command!(ToSqliteDb, QueryDb, SchemaDb);
 }

--- a/crates/nu-command/src/database/commands/to_sqlite.rs
+++ b/crates/nu-command/src/database/commands/to_sqlite.rs
@@ -11,15 +11,15 @@ use std::{borrow::Cow, path::Path};
 pub const DEFAULT_TABLE_NAME: &str = "main";
 
 #[derive(Clone)]
-pub struct IntoSqliteDb;
+pub struct ToSqliteDb;
 
-impl Command for IntoSqliteDb {
+impl Command for ToSqliteDb {
     fn name(&self) -> &str {
-        "into sqlite"
+        "to sqlite"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("into sqlite")
+        Signature::build(self.name())
             .category(Category::Conversions)
             .input_output_types(vec![
                 (Type::table(), Type::Nothing),
@@ -61,28 +61,28 @@ impl Command for IntoSqliteDb {
         vec![
             Example {
                 description: "Convert ls entries into a SQLite database with 'main' as the table name",
-                example: "ls | into sqlite my_ls.db",
+                example: "ls | to sqlite my_ls.db",
                 result: None,
             },
             Example {
                 description: "Convert ls entries into a SQLite database with 'my_table' as the table name",
-                example: "ls | into sqlite my_ls.db -t my_table",
+                example: "ls | to sqlite my_ls.db -t my_table",
                 result: None,
             },
             Example {
                 description: "Convert table literal into a SQLite database with 'main' as the table name",
-                example: "[[name]; [-----] [someone] [=====] [somename] ['(((((']] | into sqlite filename.db",
+                example: "[[name]; [-----] [someone] [=====] [somename] ['(((((']] | to sqlite filename.db",
                 result: None,
             },
             Example {
                 description: "Insert a single record into a SQLite database",
-                example: "{ foo: bar, baz: quux } | into sqlite filename.db",
+                example: "{ foo: bar, baz: quux } | to sqlite filename.db",
                 result: None,
             },
             Example {
                 description: "Insert data that contains records, lists or tables, that will be stored as JSONB columns
 These columns will be automatically turned back into nu objects when read directly via cell-path",
-                example: "{a_record: {foo: bar, baz: quux}, a_list: [1 2 3], a_table: [[a b]; [0 1] [2 3]]} | into sqlite filename.db -t my_table
+                example: "{a_record: {foo: bar, baz: quux}, a_list: [1 2 3], a_table: [[a b]; [0 1] [2 3]]} | to sqlite filename.db -t my_table
 (open filename.db).my_table.0.a_list",
                 result: Some(Value::test_list(vec![
                     Value::test_int(1),

--- a/crates/nu-command/tests/commands/database/mod.rs
+++ b/crates/nu-command/tests/commands/database/mod.rs
@@ -1,2 +1,2 @@
-mod into_sqlite;
 mod query_db;
+mod to_sqlite;

--- a/crates/nu-command/tests/commands/database/to_sqlite.rs
+++ b/crates/nu-command/tests/commands/database/to_sqlite.rs
@@ -16,7 +16,7 @@ use rand::{
 use std::io::Write;
 
 #[test]
-fn into_sqlite_schema() {
+fn to_sqlite_schema() {
     Playground::setup("schema", |dirs, _| {
         let testdb = make_sqlite_db(
             &dirs,
@@ -56,7 +56,7 @@ fn into_sqlite_schema() {
 }
 
 #[test]
-fn into_sqlite_values() {
+fn to_sqlite_values() {
     Playground::setup("values", |dirs, _| {
         insert_test_rows(
             &dirs,
@@ -98,7 +98,7 @@ fn into_sqlite_values() {
 /// table. In the event that a column is null, we can't know what type the row
 /// should be, so we just assume TEXT.
 #[test]
-fn into_sqlite_values_first_column_null() {
+fn to_sqlite_values_first_column_null() {
     Playground::setup("values", |dirs, _| {
         insert_test_rows(
             &dirs,
@@ -139,7 +139,7 @@ fn into_sqlite_values_first_column_null() {
 /// If the DB / table already exist, then the insert should end up with the
 /// right data types no matter if the first row is null or not.
 #[test]
-fn into_sqlite_values_first_column_null_preexisting_db() {
+fn to_sqlite_values_first_column_null_preexisting_db() {
     Playground::setup("values", |dirs, _| {
         insert_test_rows(
             &dirs,
@@ -235,7 +235,7 @@ fn into_sqlite_values_first_column_null_preexisting_db() {
 
 /// Opening a preexisting database should append to it
 #[test]
-fn into_sqlite_existing_db_append() {
+fn to_sqlite_existing_db_append() {
     Playground::setup("existing_db_append", |dirs, _| {
         // create a new DB with only one row
         insert_test_rows(
@@ -298,7 +298,7 @@ fn into_sqlite_existing_db_append() {
 /// Test inserting a good number of randomly generated rows to test an actual
 /// streaming pipeline instead of a simple value
 #[test]
-fn into_sqlite_big_insert() {
+fn to_sqlite_big_insert() {
     let engine_state = EngineState::new();
     // don't serialize closures
     let serialize_types = false;
@@ -363,7 +363,7 @@ fn into_sqlite_big_insert() {
 
 /// empty in, empty out
 #[test]
-fn into_sqlite_empty() {
+fn to_sqlite_empty() {
     Playground::setup("empty", |dirs, _| {
         insert_test_rows(&dirs, r#"[]"#, Some("SELECT * FROM sqlite_schema;"), vec![]);
     });
@@ -473,7 +473,7 @@ fn make_sqlite_db(dirs: &Dirs, nu_table: &str) -> AbsolutePathBuf {
 
     let nucmd = nu!(
         cwd: testdir,
-        pipeline(&format!("{nu_table} | into sqlite {testdb}"))
+        pipeline(&format!("{nu_table} | to sqlite {testdb}"))
     );
 
     assert!(nucmd.status.success());
@@ -500,7 +500,7 @@ fn insert_test_rows(dirs: &Dirs, nu_table: &str, sql_query: Option<&str>, expect
 fn test_auto_conversion() {
     Playground::setup("sqlite json auto conversion", |_, playground| {
         let raw = "{a_record:{foo:bar,baz:quux},a_list:[1,2,3],a_table:[[a,b];[0,1],[2,3]]}";
-        nu!(cwd: playground.cwd(), "{} | into sqlite filename.db -t my_table", raw);
+        nu!(cwd: playground.cwd(), "{} | to sqlite filename.db -t my_table", raw);
         let outcome = nu!(
             cwd: playground.cwd(),
             "open filename.db | get my_table.0 | to nuon --raw"

--- a/crates/nu-std/std-rfc/kv/mod.nu
+++ b/crates/nu-std/std-rfc/kv/mod.nu
@@ -67,7 +67,7 @@ export def "kv set" [
   }
 
   match $universal {
-    true  => { $kv_pair | into sqlite (universal_db_path) -t $table }
+    true  => { $kv_pair | to sqlite (universal_db_path) -t $table }
     false => { $kv_pair | stor insert -t $table }
   }
 
@@ -198,7 +198,7 @@ def db_setup [
           key: $uuid
           value: ''
         }
-        $dummy_record | into sqlite (universal_db_path) -t $table
+        $dummy_record | to sqlite (universal_db_path) -t $table
         open (universal_db_path) | query db $"DELETE FROM ($table) WHERE key = :key" --params { key: $uuid }
       }
       false => {


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
- closes #8930

Generally `into` commands convert a type into another type while `to` converts into a file format. The `into sqlite` converts imo into a file format. Therefore it should be `to sqlite` and not `into sqlite`. This PR renames `into sqlite` into `to sqlite` and marks the `into sqlite` as deprecated.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

`into sqlite` was renamed to `to sqlite`. This change aligns it more to other `to *` commands instead of `into *` commands.