### PR TITLE
Prevent `detect columns` from creating invalid records with duplicate keys

### DIFF
--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -237,6 +237,7 @@ fn detect_columns(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let name_span = call.head;
+    let input_span = input.span().unwrap_or(Span::unknown());
     let input = input.collect_string("", &args.config)?;
 
     let input: Vec<_> = input
@@ -311,11 +312,20 @@ fn detect_columns(
                     }
                 }
 
-                match &args.range {
+                let has_column_duplicates = record.columns().duplicates().count() > 0;
+                if has_column_duplicates {
+                    return Err(ShellError::ColumnDetectionFailure {
+                        bad_value: input_span,
+                        failure_site: name_span,
+                    });
+                }
+
+                Ok(match &args.range {
                     Some(range) => merge_record(record, range, name_span),
                     None => Value::record(record, name_span),
-                }
+                })
             })
+            .collect::<Result<Vec<_>, _>>()?
             .into_pipeline_data(call.head, engine_state.signals().clone()))
     } else {
         Ok(PipelineData::empty())

--- a/crates/nu-command/tests/commands/detect_columns.rs
+++ b/crates/nu-command/tests/commands/detect_columns.rs
@@ -94,3 +94,10 @@ drwxr-xr-x  4 root root 4.0K Mar 20 08:18 ~(char nl)
         assert_eq!(out.out, "true");
     })
 }
+
+#[test]
+fn detect_columns_may_fail() {
+    let out =
+        nu!(r#""meooooow cat\nkitty kitty woof" | try { detect columns } catch { "failed" }"#);
+    assert_eq!(out.out, "failed");
+}

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -667,6 +667,20 @@ pub enum ShellError {
         creation_site: Span,
     },
 
+    /// Failed to detect columns
+    ///
+    /// ## Resolution
+    ///
+    /// Use `detect columns --guess` or `parse` instead
+    #[error("Failed to detect columns")]
+    #[diagnostic(code(nu::shell::failed_to_detect_columns))]
+    ColumnDetectionFailure {
+        #[label = "value coming from here"]
+        bad_value: Span,
+        #[label = "tried to detect columns here"]
+        failure_site: Span,
+    },
+
     /// Attempted to us a relative range on an infinite stream
     ///
     /// ## Resolution


### PR DESCRIPTION
## References

Fixes nushell/nushell#11791

## Release notes summary - What our users need to know

Previously `detect columns` created records (rows) with duplicate key names under some circumstances. The resulting table behaved inconsistently with different commands.

Example:

```nushell
let data = "meooooow cat\nkitty kitty woof"

$data | detect columns

# => ╭───┬──────────┬───────╮
# => │ # │ meooooow │  cat  │
# => ├───┼──────────┼───────┤
# => │ 0 │ kitty    │ kitty │
# => ╰───┴──────────┴───────╯

$data | detect columns | get 0.cat
# => woof
```

Now it will result in an error suggesting using `detect columns --guess` or `parse`

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
