### PR TITLE
Aliases for `str upcase` and `str downcase`

### DIFF
--- a/crates/nu-std/std/prelude/mod.nu
+++ b/crates/nu-std/std/prelude/mod.nu
@@ -52,3 +52,6 @@ export def pwd [
         $env.PWD
     }
 }
+
+export alias "str upper-case" = str upcase
+export alias "str lower-case" = str downcase


### PR DESCRIPTION
## References

Fixes nushell/nushell#16525

## Release notes summary - What our users need to know

Added two new aliases:

  * `str upper-case` (alias for `str upcase`)
  * `str lower-case` (alias for `str downcase`)

'Upper' / 'lower' case terms are more common, so it should help new users to discover these commands.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
