### PR TITLE
improve collection type inference

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4591,13 +4591,10 @@ pub fn parse_list_expression(
                     (ListItem::Item(arg), ty)
                 };
 
-                if let Some(ref ctype) = contained_type {
-                    if *ctype != ty {
-                        contained_type = Some(Type::Any);
-                    }
-                } else {
-                    contained_type = Some(ty);
-                }
+                contained_type = match contained_type {
+                    Some(ctype) => Some(ctype.widen(ty)),
+                    None => Some(ty),
+                };
 
                 args.push(arg);
 
@@ -4774,13 +4771,7 @@ fn table_type(head: &[Expression], rows: &[Vec<Expression>]) -> (Type, Vec<Parse
     let mut mk_ty = || -> Type {
         rows.iter_mut()
             .map(|row| row.pop().map(|x| x.ty).unwrap_or_default())
-            .reduce(|acc, ty| -> Type {
-                if type_compatible(&acc, &ty) {
-                    ty
-                } else {
-                    Type::Any
-                }
-            })
+            .reduce(|acc, ty| -> Type { acc.widen(ty) })
             .unwrap_or_default()
     };
 


### PR DESCRIPTION
Closes #16421

## Release notes summary - What our users need to know

Fixes order-dependent table type inference bugs and introduces similar type widening for lists:

```nushell
def get_type [] { scope variables | where name == "$foo" | first | get type }

let foo = [ [bar]; [ { baz: 1 } ], [ { baz: 1, extra: true } ] ]
get_type # table<bar: record<baz: int, extra: bool>> -> table<bar: record<baz: int>>

let foo = [ [bar]; [ { baz: 1, extra: true } ], [ { baz: 1 } ] ]
get_type # table<bar: any> -> table<bar: record<baz: int>>

let foo = [ { baz: 1 }, { baz: 1, extra: true } ]
get_type # list<any> -> list<record<baz: int>>
```