### PR TITLE
Fix documentation of `--number-bytes` flag for several `bits` commands

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -46,7 +46,7 @@ impl Command for BitsRol {
             .named(
                 "number-bytes",
                 SyntaxShape::Int,
-                "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
+                "the word size in number of bytes. Must be `1`, `2`, `4`, or `8` (defaults to the smallest of those that fits the input number)",
                 Some('n'),
             )
             .category(Category::Bits)

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -46,7 +46,7 @@ impl Command for BitsRor {
             .named(
                 "number-bytes",
                 SyntaxShape::Int,
-                "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
+                "the word size in number of bytes. Must be `1`, `2`, `4`, or `8` (defaults to the smallest of those that fits the input number)",
                 Some('n'),
             )
             .category(Category::Bits)

--- a/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
@@ -49,7 +49,7 @@ impl Command for BitsShl {
             .named(
                 "number-bytes",
                 SyntaxShape::Int,
-                "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
+                "the word size in number of bytes. Must be `1`, `2`, `4`, or `8` (defaults to the smallest of those that fits the input number)",
                 Some('n'),
             )
             .category(Category::Bits)

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -46,7 +46,7 @@ impl Command for BitsShr {
             .named(
                 "number-bytes",
                 SyntaxShape::Int,
-                "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
+                "the word size in number of bytes. Must be `1`, `2`, `4`, or `8` (defaults to the smallest of those that fits the input number)",
                 Some('n'),
             )
             .category(Category::Bits)


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
Fixes incorrect documentation of the default behavior of the `bits rol`, `bits ror`, `bits shl`, and `bits shr` commands when the `--number-bytes` flag is not provided

## Further info

The `--number-bytes` flag defaults to `auto`, not 8 (look at this snippet in context):
https://github.com/nushell/nushell/blob/fc82eb5ebfdadcd7f142d21216eecbdb0cbdbfe1/crates/nu-cmd-extra/src/extra/bits/mod.rs#L69

Also, the `--number-bytes` flag does not accept a value of `auto`. I didn't mention that fix in the release notes, because unlike the other change where you could have written a program that seems to work, but assumes the wrong thing, you'll just get an error if you try to specify `auto`.
