### PR TITLE
Use symmetric float comparison for large floats

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -2234,11 +2234,14 @@ impl Default for Value {
 impl PartialOrd for Value {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         // Compare two floating point numbers. The decision interval for equality is dynamically
-        // scaled as the value being compared increases in magnitude.
+        // scaled as the value being compared increases in magnitude (using relative epsilon-based
+        // tolerance). Implementation is similar to python's `math.isclose()` function:
+        // https://docs.python.org/3/library/math.html#math.isclose. Fallback to the default strict
+        // float comparison if the difference exceeds the error epsilon.
         fn compare_floats(val: f64, other: f64) -> Option<Ordering> {
-            let prec = f64::EPSILON.max(val.abs() * f64::EPSILON);
+            let prec = f64::EPSILON.max(val.abs().max(other.abs()) * f64::EPSILON);
 
-            if (other - val).abs() < prec {
+            if (other - val).abs() <= prec {
                 return Some(Ordering::Equal);
             }
 

--- a/crates/nu-protocol/tests/test_value.rs
+++ b/crates/nu-protocol/tests/test_value.rs
@@ -46,6 +46,7 @@ fn test_float_equality_comparison() {
         ),
         (
             Value::test_float(0.1),
+            #[allow(clippy::excessive_precision)]
             Value::test_float(0.10000000000000001),
         ),
         (
@@ -82,6 +83,7 @@ fn test_float_equality_comparison() {
             Value::test_float(0.9999999999999999),
         ),
         (
+            #[allow(clippy::approx_constant)]
             Value::test_float(3.141592653589793),
             Value::test_float(3.1415926535897927),
         ),

--- a/crates/nu-protocol/tests/test_value.rs
+++ b/crates/nu-protocol/tests/test_value.rs
@@ -37,6 +37,69 @@ fn test_comparison_nothing() {
     }
 }
 
+#[test]
+fn test_float_equality_comparison() {
+    let values = vec![
+        (
+            Value::test_float(0.30000000000000004),
+            Value::test_float(0.3),
+        ),
+        (
+            Value::test_float(0.1),
+            Value::test_float(0.10000000000000001),
+        ),
+        (
+            Value::test_float(1.0000000000000002),
+            Value::test_float(1.0),
+        ),
+        (
+            Value::test_float(2.220446049250313e-16),
+            Value::test_float(0.0),
+        ),
+        (Value::test_float(1e-16), Value::test_float(0.0)),
+        (
+            Value::test_float((1e16 + 1.0) - 1e16),
+            Value::test_float(0.0),
+        ),
+        (
+            Value::test_float(10000000000000000.0),
+            Value::test_float(10000000000000002.0),
+        ),
+        (
+            Value::test_float(9007199254740992.0),
+            Value::test_float(9007199254740993.0),
+        ),
+        (
+            Value::test_float(4503599627370496.0),
+            Value::test_float(4503599627370497.0),
+        ),
+        (
+            Value::test_float(1.7976931348623157e308),
+            Value::test_float(1.7976931348623155e308),
+        ),
+        (
+            Value::test_float(1.0),
+            Value::test_float(0.9999999999999999),
+        ),
+        (
+            Value::test_float(3.141592653589793),
+            Value::test_float(3.1415926535897927),
+        ),
+    ];
+
+    for value in values {
+        assert!(matches!(
+            value.0.eq(Span::test_data(), &value.1, Span::test_data()),
+            Ok(Value::Bool { val: true, .. })
+        ));
+
+        assert!(matches!(
+            value.1.eq(Span::test_data(), &value.0, Span::test_data()),
+            Ok(Value::Bool { val: true, .. })
+        ));
+    }
+}
+
 #[rstest]
 #[case(365 * 24 * 3600 * 1_000_000_000, "52wk 1day")]
 #[case( (((((((7 + 2) * 24 + 3) * 60 + 4) * 60) + 5) * 1000 + 6) * 1000 + 7) * 1000 + 8,


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
Fixes #15622 

Sorry in advanced if this PR is somewhat math-heavy.

Rust doesn't really have any built-in functions for "approximate" float equality comparisons hence we have been using this formula for imprecise float comparisons `|a - b| < max(ε, |a| * ε)`. Note that `ε = 2.2204460492503131e-16` which is the error value allowed when comparing.

Since imprecise float comparisons rely on `a` or the left-hand side of comparisons (ie. `4503599627370496.0 == 4503599627370497.0 ⇒ true`). It would follow `4503599627370496.0` which would result in some rare instances where the result of `a == b` is not equivalent to `b == a`. In this example, the result must be true due to imprecise float comparison and not false.

The proposed formula to use is from python's [`math.isclose()` function](https://docs.python.org/3/library/math.html#math.isclose) which is symmetric but also allows `ε == 0.0`. The formula implemented in this PR is the following: `|a - b| ≤ max(ε, max(|a|, |b|) * ε)`.

Another alternative to consider is from numpy's [`isclose()` function](https://github.com/numpy/numpy/blob/583993f2f9f7cafe265b3a5505505fb8d2d376e7/numpy/_core/numeric.py#L2372-L2500) which is asymmetric but does not use `max()` for comparisons.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
Fix associative equality comparison for floats.


## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- Add unit test for float comparisons (not sure if this is required).
