### PR TITLE
`which` without application parameter now lists all internal and external executables

### DIFF
--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -1,6 +1,10 @@
+use itertools::Itertools;
 use nu_engine::{command_prelude::*, env};
 use nu_protocol::engine::CommandType;
+use std::fs;
 use std::{ffi::OsStr, path::Path};
+use which::sys;
+use which::sys::Sys;
 
 #[derive(Clone)]
 pub struct Which;
@@ -20,7 +24,7 @@ impl Command for Which {
     }
 
     fn description(&self) -> &str {
-        "Finds a program file, alias or custom command."
+        "Finds a program file, alias or custom command. If `application` is not provided, all deduplicated commands will be returned."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -45,11 +49,18 @@ impl Command for Which {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Find if the 'myapp' application is available",
-            example: "which myapp",
-            result: None,
-        }]
+        vec![
+            Example {
+                description: "Find if the 'myapp' application is available",
+                example: "which myapp",
+                result: None,
+            },
+            Example {
+                description: "Find all executables across all paths without deduplication",
+                example: "which -a",
+                result: None,
+            },
+        ]
     }
 }
 
@@ -79,25 +90,6 @@ fn get_entry_in_commands(engine_state: &EngineState, name: &str, span: Span) -> 
     }
 }
 
-fn get_entries_in_nu(
-    engine_state: &EngineState,
-    name: &str,
-    span: Span,
-    skip_after_first_found: bool,
-) -> Vec<Value> {
-    let mut all_entries = vec![];
-
-    if !all_entries.is_empty() && skip_after_first_found {
-        return all_entries;
-    }
-
-    if let Some(ent) = get_entry_in_commands(engine_state, name, span) {
-        all_entries.push(ent);
-    }
-
-    all_entries
-}
-
 fn get_first_entry_in_path(
     item: &str,
     span: Span,
@@ -121,6 +113,52 @@ fn get_all_entries_in_path(
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn list_all_executables(
+    engine_state: &EngineState,
+    paths: impl AsRef<OsStr>,
+    all: bool,
+) -> Vec<Value> {
+    let decls = engine_state.get_decls_sorted(false);
+    let commands = decls
+        .into_iter()
+        .map(|x| {
+            let decl = engine_state.get_decl(x.1);
+            (
+                String::from_utf8_lossy(&x.0).to_string(),
+                String::new(),
+                decl.command_type(),
+            )
+        })
+        .chain(
+            sys::RealSys
+                .env_split_paths(paths.as_ref())
+                .into_iter()
+                .filter_map(|dir| fs::read_dir(dir).ok())
+                .flat_map(|entries| entries.flatten())
+                .map(|entry| entry.path())
+                .filter(|path| path.is_file())
+                .filter_map(|path| {
+                    let filename = path.file_name()?.to_string_lossy().to_string();
+                    Some((
+                        filename,
+                        path.to_string_lossy().to_string(),
+                        CommandType::External,
+                    ))
+                }),
+        );
+
+    if all {
+        commands
+            .map(|(filename, path, cmd_type)| entry(filename, path, cmd_type, Span::new(0, 0)))
+            .collect()
+    } else {
+        commands
+            .unique_by(|x| x.0.clone())
+            .map(|(filename, path, cmd_type)| entry(filename, path, cmd_type, Span::new(0, 0)))
+            .collect()
+    }
 }
 
 #[derive(Debug)]
@@ -150,12 +188,9 @@ fn which_single(
         (true, true) => get_all_entries_in_path(&prog_name, application.span, cwd, paths),
         (true, false) => {
             let mut output: Vec<Value> = vec![];
-            output.extend(get_entries_in_nu(
-                engine_state,
-                &prog_name,
-                application.span,
-                false,
-            ));
+            if let Some(entry) = get_entry_in_commands(engine_state, &prog_name, application.span) {
+                output.push(entry);
+            }
             output.extend(get_all_entries_in_path(
                 &prog_name,
                 application.span,
@@ -164,23 +199,13 @@ fn which_single(
             ));
             output
         }
-        (false, true) => {
-            if let Some(entry) = get_first_entry_in_path(&prog_name, application.span, cwd, paths) {
-                return vec![entry];
-            }
-            vec![]
-        }
-        (false, false) => {
-            let nu_entries = get_entries_in_nu(engine_state, &prog_name, application.span, true);
-            if !nu_entries.is_empty() {
-                return vec![nu_entries[0].clone()];
-            } else if let Some(entry) =
-                get_first_entry_in_path(&prog_name, application.span, cwd, paths)
-            {
-                return vec![entry];
-            }
-            vec![]
-        }
+        (false, true) => get_first_entry_in_path(&prog_name, application.span, cwd, paths)
+            .into_iter()
+            .collect(),
+        (false, false) => get_entry_in_commands(engine_state, &prog_name, application.span)
+            .or_else(|| get_first_entry_in_path(&prog_name, application.span, cwd, paths))
+            .into_iter()
+            .collect(),
     }
 }
 
@@ -195,18 +220,17 @@ fn which(
         all: call.has_flag(engine_state, stack, "all")?,
     };
 
-    if which_args.applications.is_empty() {
-        return Err(ShellError::MissingParameter {
-            param_name: "application".into(),
-            span: head,
-        });
-    }
-
     let mut output = vec![];
 
     #[allow(deprecated)]
     let cwd = env::current_dir_str(engine_state, stack)?;
     let paths = env::path_str(engine_state, stack, head)?;
+
+    if which_args.applications.is_empty() {
+        return Ok(list_all_executables(engine_state, paths, which_args.all)
+            .into_iter()
+            .into_pipeline_data(head, engine_state.signals().clone()));
+    }
 
     for app in which_args.applications {
         let values = which_single(

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -118,3 +118,11 @@ fn which_accepts_spread_list() {
 
     assert_eq!(actual.out, "ls");
 }
+
+#[test]
+fn which_dedup_is_less_than_all() {
+    let all: i32 = nu!("which -a | length").out.parse().unwrap();
+    let dedup: i32 = nu!("which | length").out.parse().unwrap();
+
+    assert!(all >= dedup);
+}


### PR DESCRIPTION
Fixes #16140

- [x] Aded main logic
- [x] Removed obsolete `fn get_entries_in_nu()`
- [x] Added test to prove  '--all` param. 

<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
The `which` command now lists all commands (internal and external) when no application parameter is passed to it 