### PR TITLE
Fix associativity when parsing with power operator

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5817,7 +5817,12 @@ pub fn parse_math_expression(
         }
         not_start_spans.clear();
 
-        while op_prec <= last_prec && expr_stack.len() > 1 {
+        // Parsing power must be right-associative unlike most operations which are left
+        // Hence, we should not collapse if the last and current operations are both power
+        let is_left_associative =
+            op.expr != Expr::Operator(Operator::Math(Math::Pow)) && op_prec <= last_prec;
+
+        while is_left_associative && expr_stack.len() > 1 {
             // Collapse the right associated operations first
             // so that we can get back to a stack with a lower precedence
             let mut rhs = expr_stack


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
Fixes #16550.

Grouping `()` with power operator also works with this change.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
The `**` (power) operator now parses as right-associative instead of left-associative, matching standard mathematical behavior.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- Add unit test for parsing with power operator (if this is required, Im not sure where to place it under [test_parser.rs](https://github.com/nushell/nushell/blob/main/crates/nu-parser/tests/test_parser.rs))
