### PR TITLE
Add `--endian` flag to `format bits`

### DIFF
--- a/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
@@ -196,7 +196,7 @@ fn byte_stream_to_bits(stream: ByteStream, head: Span) -> ByteStream {
 
 fn convert_to_smallest_number_type(num: i64, span: Span, little_endian: bool) -> Value {
     if let Some(v) = num.to_i8() {
-        let bytes = v.to_ne_bytes(); // Eendianness does not affect `i8`
+        let bytes = v.to_ne_bytes(); // Endianness does not affect `i8`
         let mut raw_string = "".to_string();
         for ch in bytes {
             raw_string.push_str(&format!("{ch:08b} "));

--- a/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
@@ -8,6 +8,7 @@ use num_traits::ToPrimitive;
 
 struct Arguments {
     cell_paths: Option<Vec<CellPath>>,
+    little_endian: bool,
 }
 
 impl CmdArgument for Arguments {
@@ -37,6 +38,12 @@ impl Command for FormatBits {
                 (Type::record(), Type::record()),
             ])
             .allow_variants_without_examples(true) // TODO: supply exhaustive examples
+            .named(
+                "endian",
+                SyntaxShape::String,
+                "Byte encode endian. Only applies to int, filesize, duration and bool, as well as tables and records of those. Available options: native, little, big(default)",
+                Some('e'),
+            )
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
@@ -81,6 +88,11 @@ impl Command for FormatBits {
                 result: Some(Value::string("00000001 00000010", Span::test_data())),
             },
             Example {
+                description: "convert an int into a string, padded to 8 places with 0s (little endian)",
+                example: "258 | format bits --endian little",
+                result: Some(Value::string("00000010 00000001", Span::test_data())),
+            },
+            Example {
                 description: "convert a filesize value into a string, padded to 8 places with 0s",
                 example: "1b | format bits",
                 result: Some(Value::string("00000001", Span::test_data())),
@@ -123,7 +135,28 @@ fn format_bits(
             metadata,
         ))
     } else {
-        let args = Arguments { cell_paths };
+        let endian = call.get_flag::<Spanned<String>>(engine_state, stack, "endian")?;
+
+        let little_endian = if let Some(endian) = endian {
+            match endian.item.as_str() {
+                "native" => cfg!(target_endian = "little"),
+                "little" => true,
+                "big" => false,
+                _ => {
+                    return Err(ShellError::TypeMismatch {
+                        err_message: "Endian must be one of native, little, big".to_string(),
+                        span: endian.span,
+                    });
+                }
+            }
+        } else {
+            false
+        };
+
+        let args = Arguments {
+            cell_paths,
+            little_endian,
+        };
         operate(action, args, input, call.head, engine_state.signals())
     }
 }
@@ -161,30 +194,42 @@ fn byte_stream_to_bits(stream: ByteStream, head: Span) -> ByteStream {
     }
 }
 
-fn convert_to_smallest_number_type(num: i64, span: Span) -> Value {
+fn convert_to_smallest_number_type(num: i64, span: Span, little_endian: bool) -> Value {
     if let Some(v) = num.to_i8() {
-        let bytes = v.to_be_bytes();
+        let bytes = v.to_ne_bytes(); // Eendianness does not affect `i8`
         let mut raw_string = "".to_string();
         for ch in bytes {
             raw_string.push_str(&format!("{ch:08b} "));
         }
         Value::string(raw_string.trim(), span)
     } else if let Some(v) = num.to_i16() {
-        let bytes = v.to_be_bytes();
+        let bytes = if little_endian {
+            v.to_le_bytes()
+        } else {
+            v.to_be_bytes()
+        };
         let mut raw_string = "".to_string();
         for ch in bytes {
             raw_string.push_str(&format!("{ch:08b} "));
         }
         Value::string(raw_string.trim(), span)
     } else if let Some(v) = num.to_i32() {
-        let bytes = v.to_be_bytes();
+        let bytes = if little_endian {
+            v.to_le_bytes()
+        } else {
+            v.to_be_bytes()
+        };
         let mut raw_string = "".to_string();
         for ch in bytes {
             raw_string.push_str(&format!("{ch:08b} "));
         }
         Value::string(raw_string.trim(), span)
     } else {
-        let bytes = num.to_be_bytes();
+        let bytes = if little_endian {
+            num.to_le_bytes()
+        } else {
+            num.to_be_bytes()
+        };
         let mut raw_string = "".to_string();
         for ch in bytes {
             raw_string.push_str(&format!("{ch:08b} "));
@@ -193,7 +238,7 @@ fn convert_to_smallest_number_type(num: i64, span: Span) -> Value {
     }
 }
 
-fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
+fn action(input: &Value, args: &Arguments, span: Span) -> Value {
     match input {
         Value::Binary { val, .. } => {
             let mut raw_string = "".to_string();
@@ -202,9 +247,13 @@ fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
             }
             Value::string(raw_string.trim(), span)
         }
-        Value::Int { val, .. } => convert_to_smallest_number_type(*val, span),
-        Value::Filesize { val, .. } => convert_to_smallest_number_type(val.get(), span),
-        Value::Duration { val, .. } => convert_to_smallest_number_type(*val, span),
+        Value::Int { val, .. } => convert_to_smallest_number_type(*val, span, args.little_endian),
+        Value::Filesize { val, .. } => {
+            convert_to_smallest_number_type(val.get(), span, args.little_endian)
+        }
+        Value::Duration { val, .. } => {
+            convert_to_smallest_number_type(*val, span, args.little_endian)
+        }
         Value::String { val, .. } => {
             let raw_bytes = val.as_bytes();
             let mut raw_string = "".to_string();
@@ -215,7 +264,7 @@ fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
         }
         Value::Bool { val, .. } => {
             let v = <i64 as From<bool>>::from(*val);
-            convert_to_smallest_number_type(v, span)
+            convert_to_smallest_number_type(v, span, args.little_endian)
         }
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

This flag allows choosing the endianness of the result of `format bits`. This allows getting the behavior from before #16435 with `format bits --endian native`.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

### `--endian` flag for `format bits`

`format bits` used to output in native endian, until Nu 0.107.0 (#16435) changed it to big endian. Now, you will be able to choose the behavior with `--endian` (use `format bits --endian native` to get the original behavior from before Nu 0.107.0).

```nushell
~> 258 | format bits
00000001 00000010
```

```nushell
~> 258 | format bits --endian little # (or `--endian native` in a little endian system)
00000010 00000001
```

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
None
