### PR TITLE
mark LSP sessions as non-interactive

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,8 @@ fn main() -> Result<()> {
     engine_state.is_interactive = parsed_nu_cli_args.interactive_shell.is_some()
         || (parsed_nu_cli_args.testbin.is_none()
             && parsed_nu_cli_args.commands.is_none()
-            && script_name.is_empty());
+            && script_name.is_empty()
+            && !parsed_nu_cli_args.lsp);
 
     engine_state.is_login = parsed_nu_cli_args.login_shell.is_some();
 


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

The code is not `WIP`, but i want to prevent a merge before it is discussed.

In my eyes the LSP is not a interactive session.  
But that is a point open to interpretation / discussion. You could argue that the user controls what is going on at runtime (by writing code / asking for `help` / ..).  
On the other hand: a LSP is primarily active during scripting, meaning that the code is probably intended for non-interactive use.  
Marking it as non-interactive also allows splitting the `config.nu` into always active sections (like `$env.NU_LIB_DIRS`, `$env.PATH`, etc) and interactive specific things (like my oversized prompt, keybindings, `alias ll = ls -l`, etc). This both improves suggestions (less clutter, commands are marked as missing when they are missing, etc) and speeds up startup-time for the LSP (especially for big configs).

If i missed this being discussed before or anything like that: just close it.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
The LSP session is no longer marked as interactive (`$nu.is-interactive`).

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
<!-- - [ ] Update the [documentation](https://github.com/nushell/nushell.github.io) -->
not sure - i think only release-notes?