### PR TITLE
update help to remove incorrect link

### DIFF
--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -19,7 +19,7 @@ bench = false
 nu-plugin = { path = "../nu-plugin", version = "0.107.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.107.1" }
 
-gjson = "0.8"
+gjson = "0.8.1"
 scraper = { default-features = false, version = "0.23" }
 sxd-document = "0.3"
 sxd-xpath = "0.4"

--- a/crates/nu_plugin_query/src/query_json.rs
+++ b/crates/nu_plugin_query/src/query_json.rs
@@ -19,7 +19,7 @@ impl SimplePluginCommand for QueryJson {
     }
 
     fn extra_description(&self) -> &str {
-        "query json uses the gjson crate https://github.com/tidwall/gjson.rs to query json data. The query syntax is available at https://github.com/tidwall/gjson/blob/master/SYNTAX.md."
+        "query json uses the gjson crate https://github.com/tidwall/gjson.rs to query json data."
     }
 
     fn signature(&self) -> Signature {


### PR DESCRIPTION
This PR updates the `query json` help to remove an incorrect link. The link is correct for the gjson syntax, but the problem is that the rust crate does not support the entire syntax.

closes #16583

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io) for `query json`
