### PR TITLE
Fix `std help externs`

### DIFF
--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -398,7 +398,7 @@ export def externs [
     let externs = (
         scope commands
         | where type == "external"
-        | select name module_name description
+        | select name description
         | sort-by name
         | str trim
     )
@@ -552,11 +552,6 @@ def build-command-page [command: record] {
     let search_terms = (if ($command.search_terms? | is-not-empty) {[
         ""
         $"(build-help-header -n 'Search terms') ($command.search_terms)"
-    ]} else { [] })
-
-    let module = (if ($command.module_name? | is-not-empty) {[
-        ""
-        $"(build-help-header -n 'Module') ($command.module_name)"
     ]} else { [] })
 
     let category = (if ($command.category? | is-not-empty) {[
@@ -725,7 +720,6 @@ def build-command-page [command: record] {
         $description
         $extra_description
         $search_terms
-        $module
         $category
         $this
         $cli_usage


### PR DESCRIPTION
## Motivation

* `is_extern` column was removed in nushell/nushell#12832
* `module_name` appears to have been nushell/nushell#10023

It was throwing the following error:

```console
❯ use std/help
❯ help externs 
Error: nu::shell::column_not_found

  × Cannot find column 'is_extern'
     ╭─[std/help/mod.nu:400:17]
 399 │         scope commands
 400 │         | where is_extern == true
     ·                 ────┬────┬
     ·                     │    ╰── value originates here
     ·                     ╰── cannot find column 'is_extern'
 401 │         | select name module_name description
     ╰────
```

## Release notes summary - What our users need to know

Fixes an issue in `std help externs` - it was using a column that is no longer present.
