### PR TITLE
feat: `for` loops are lazy, don't collect their source

### DIFF
--- a/crates/nu-command/tests/commands/for_.rs
+++ b/crates/nu-command/tests/commands/for_.rs
@@ -40,3 +40,14 @@ fn failed_for_should_break_running() {
         print 3");
     assert!(!actual.out.contains('3'));
 }
+
+#[test]
+fn for_loops_dont_collect_source() {
+    let actual = nu!("
+        for i in (seq 1 10 | each { print -n $in; $in}) {
+            print -n $i
+            if $i >= 5 { break }
+        }
+    ");
+    assert_eq!(actual.out, "1122334455");
+}

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -737,7 +737,7 @@ pub(crate) fn compile_for(
         working_set,
         builder,
         in_expr,
-        RedirectModes::value(in_expr.span),
+        RedirectModes::caller(in_expr.span),
         None,
         stream_reg,
     )?;


### PR DESCRIPTION
Using a sub-expression as the iterator/source of `for` loops no longer causes the inner expression to be collected.

This makes it possible to use `for` loops with slow or infinite streams.
Previously, `each` was used for such cases, which limited its used:
- no mutable vars
- external commands' could have trouble interacting properly with the terminal
- probably some other issues I can't recall
 
## Release notes summary - What our users need to know
### `for` loops no longer collect their source
Previously, `for` loops only worked with values (ranges, lists, etc), so using them with streaming commands would collect the whole stream before iteration could start. Now it also works with streams too! 

This makes it possible to use it with slow or unbounded streams:

```nushell
for event in (watch . --glob=**/*.rs) {
	cargo test
}
```

## Tasks after submitting
