### PR TITLE
fix: panic on large duration number

### DIFF
--- a/crates/nu-protocol/src/ast/unit.rs
+++ b/crates/nu-protocol/src/ast/unit.rs
@@ -35,7 +35,7 @@ pub enum Unit {
     Week,
 }
 
-/// TODO: something like `Filesize::from_unit` in the future?
+// TODO: something like `Filesize::from_unit` in the future?
 fn duration_mul_and_check(size: i64, factor: i64, span: Span) -> Result<Value, ShellError> {
     match size.checked_mul(factor) {
         Some(val) => Ok(Value::duration(val, span)),


### PR DESCRIPTION
Fixes #16592

Maybe a more organized version of type Duration (like those of #14369) is better, but that's beyond this naive fix.

## Release notes summary - What our users need to know

Fixed a panic when `duration`s were created with a value outside of the supported value range with certain unit suffixes.

## Tasks after submitting

None