### PR TITLE
Forbid bare word strings in match patterns

### DIFF
--- a/crates/nu-std/std-rfc/conversions/mod.nu
+++ b/crates/nu-std/std-rfc/conversions/mod.nu
@@ -8,9 +8,9 @@ export def "into list" []: any -> list {
   let input = $in
   let type = ($input | describe --detailed | get type)
   match $type {
-    range => {$input | each {||}}
-    list => $input
-    table => $input
+    "range" => {$input | each {||}}
+    "list" => $input
+    "table" => $input
     _ => [ $input ]
   }
 }

--- a/crates/nu-std/std-rfc/kv/mod.nu
+++ b/crates/nu-std/std-rfc/kv/mod.nu
@@ -49,7 +49,7 @@ export def "kv set" [
   # If passed a closure, execute it
   let arg_type = ($value_or_closure | describe)
   let value = match $arg_type {
-    closure => { $input | do $value_or_closure }
+    'closure' => { $input | do $value_or_closure }
     _ => ($value_or_closure | default $input)
   }
 

--- a/crates/nu-std/std/input/mod.nu
+++ b/crates/nu-std/std/input/mod.nu
@@ -51,7 +51,7 @@ export def display [
     }
 
     match $next_key {
-      {type: key key_type: other code: esc modifiers: []} => {
+      {type: "key" key_type: "other" code: "esc" modifiers: []} => {
         return
       }
       _ => {

--- a/tests/parsing/samples/recursive_func_with_alias.nu
+++ b/tests/parsing/samples/recursive_func_with_alias.nu
@@ -9,12 +9,12 @@ export def "update" [
 ]: [record -> record, table -> table, list<any> -> list<any>] {
     let input = $in
     match ($input | describe | str replace --regex '<.*' '') {
-        record => {
+        "record" => {
             if ($input | get -o $field) != null {
                 $input | orig update $field $value
             } else { $input }
         }
-        table|list => {
+        "table"|"list" => {
             $input | each {|| update $field $value }
         }
         _ => { $input | orig update $field $value }

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -197,8 +197,7 @@ fn respect_shape() -> TestResult {
     )
     .unwrap();
     fail_test("module foo { ...$bar }", "expected_keyword").unwrap();
-    run_test(r#"def "...$foo" [] {2}; do { ...$foo }"#, "2").unwrap();
-    run_test(r#"match "...$foo" { ...$foo => 5 }"#, "5")
+    run_test(r#"def "...$foo" [] {2}; do { ...$foo }"#, "2")
 }
 
 #[test]


### PR DESCRIPTION
As a shell, nu needs bare strings to avoid becoming bothersome for day to day use.

However, I think there are some places where being strict and requiring strings to be written explicitly with quotes makes more sense. I think match patterns are one of those places.

I used to (and still do from time to time) forget to add `$` before the variable names in match patterns, and end up with bare strings instead.

This might not be the "common pitfall" I expect it to be and just a skill issue on my part :shrug:

## Release notes summary - What our users need to know


## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
