### PR TITLE
16507 feature right column split

### DIFF
--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -112,7 +112,66 @@ impl Command for SplitColumn {
                 ])),
             },
             Example {
-                description: "Split from the right using --right",
+                description: "Split from the right with a single delimiter",
+                example: r#""a-b-c" | split column --right -"#,
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                    "column1" => Value::test_string("a-b"),
+                    "column2" => Value::test_string("c"),
+                })])),
+            },
+              Example {
+                description: "Right Split a string into columns of char and remove the empty columns",
+                example: "'abc' | split column --right --collapse-empty ''",
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                        "column1" => Value::test_string("c"),
+                        "column2" => Value::test_string("b"),
+                        "column3" => Value::test_string("a"),
+                })])),
+            },
+            Example {
+                description: "Right Split a list of strings into a table",
+                example: "['a-b' 'c-d'] | split column --right -",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "column1" => Value::test_string("b"),
+                        "column2" => Value::test_string("a"),
+                    }),
+                    Value::test_record(record! {
+                        "column1" => Value::test_string("d"),
+                        "column2" => Value::test_string("c"),
+                    }),
+                ])),
+            },
+            Example {
+                description: "Right Split a list of strings into a table, ignoring padding",
+                example: r"['a -  b' 'c  -    d'] | split column --right --regex '\s*-\s*'",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "column1" => Value::test_string("b"),
+                        "column2" => Value::test_string("a"),
+                    }),
+                    Value::test_record(record! {
+                        "column1" => Value::test_string("d"),
+                        "column2" => Value::test_string("c"),
+                    }),
+                ])),
+            },
+            Example {
+                description: "Split into columns, last column may contain the delimiter",
+                example: r"['author: Shahid Afridi' r#'title: Where's Goober?: An Eleanor & Park book'#] | split column --right --number 2 ': ' key value",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "key" => Value::test_string("author"),
+                        "value" => Value::test_string("Shahid Afridi"),
+                    }),
+                    Value::test_record(record! {
+                        "key" => Value::test_string("title: Where's Goober?"),
+                        "value" => Value::test_string(" An Eleanor & Park book"),
+                    }),
+                ])),
+            },
+            Example {
+                description: "Split from the right using --right with a number",
                 example: r#""a-b-c" | split column --number 2 --right -"#,
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "column1" => Value::test_string("a-b"),

--- a/crates/nu-command/tests/commands/split_column.rs
+++ b/crates/nu-command/tests/commands/split_column.rs
@@ -60,3 +60,62 @@ fn to_column() {
         assert!(actual.out.contains("shipper"));
     })
 }
+
+#[test]
+fn to_column_right_split() {
+    Playground::setup("split_column_test_right", |dirs, sandbox| {
+        sandbox.with_files(&[
+            FileWithContentToBeTrimmed(
+                "sample.txt",
+                r#"
+                importer,shipper,tariff_item,name,origin
+            "#,
+            ),
+            FileWithContentToBeTrimmed(
+                "sample2.txt",
+                r#"
+                importer , shipper  , tariff_item  ,   name  ,  origin
+            "#,
+            ),
+        ]);
+        // right split with no number
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open sample.txt
+                | lines
+                | str trim
+                | split column --right ","
+                | get column2
+            "#
+        ));
+        assert!(actual.out.contains("name"));
+
+        // right split with number
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+        open sample.txt
+        | lines
+        | str trim
+        | split column --right -n 2 ","
+        | get column1
+    "#
+        ));
+        assert!(actual.out.contains("importer,shipper,tariff_item,name"));
+
+        // right split with regex
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r"
+                open sample2.txt
+                | lines
+                | str trim
+                | split column --right --regex '\s*,\s*'
+                | get column2
+            "
+        ));
+
+        assert!(actual.out.contains("name"));
+    });
+}


### PR DESCRIPTION
Adds a new feature for right column splitting in the Nushell command interface. See issue [#16507](https://github.com/nushell/nushell/issues/16507) for details.

It also includes a test case to ensure the feature works as expected.

## Release notes summary - What our users need to know
Added a new flag `--right`, now `split column` has the ability to split string to column from right.

## Tasks after submitting
None
