### PR TITLE
Discard `path add` input

### DIFF
--- a/crates/nu-std/std/util/mod.nu
+++ b/crates/nu-std/std/util/mod.nu
@@ -15,7 +15,7 @@ export def --env "path add" [
     --append (-a)  # append to $env.PATH instead of prepending to.
     ...paths: any  # the paths to add to $env.PATH.
 ]: [nothing -> nothing, nothing -> list<path>] {
-    ignore; # discard the input, otherwise the `metadata` call below would fail
+    ignore # discard the input, otherwise the `metadata` call below would fail
     let span = (metadata $paths).span
     let paths = $paths | flatten
 


### PR DESCRIPTION
## References

https://discord.com/channels/601130461678272522/601130461678272524/1414675784056180817

## Release notes summary - What our users need to know

Previously `std path add` could fail if it was fed `any` input. Example:

```console
❯ ls | each {} | path add
Error: nu::shell::incompatible_parameters

  × Incompatible parameters.
    ╭─[std/util/mod.nu:18:17]
 17 │ ]: [nothing -> nothing, nothing -> list<path>] {
 18 │     let span = (metadata $paths).span
    ·                 ────┬─── ───┬──
    ·                     │       ╰── but a positional metadata expression was also given
    ·                     ╰── pipeline input was provided
 19 │     let paths = $paths | flatten
    ╰────
```

Now any input to `std path add` will be discarded. It's still possible to pass it with `$in`:

```nushell
[a b c] | each {|p| $env.HOME | path join $p } | std path add $in
```
