### PR TITLE
Ddd `cargo hack check` to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,34 @@ jobs:
       - name: Clippy of benchmarks
         run: cargo clippy --benches --workspace --exclude nu_plugin_* -- -D warnings
 
+  hack-check:
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: true
+      matrix:
+        platform: 
+          - windows-latest
+          - macos-13
+          - ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install `cargo-binstall`
+        uses: cargo-bins/cargo-binstall@1
+
+      - name: Install `cargo-hack`
+        run: cargo binstall cargo-hack@^0.6
+
+      - name: Check all packages
+        run: cargo hack check \
+          --workspace \
+          --feature-powerset \
+          --mutually-exclusive-features rustls-tls,native-tls \
+          --at-least-one-of rustls-tls,native-tls \
+          --no-dev-deps
+
   tests:
     strategy:
       fail-fast: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,14 +64,9 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install `cargo-binstall`
-        uses: cargo-bins/cargo-binstall@1
-
-      - name: Install `cargo-hack`
-        run: cargo binstall cargo-hack@^0.6
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/install@cargo-hack
 
       - name: Check all packages
         run: cargo hack check \


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

At the time of writing does `cargo build -p nu-command --features sqlite` not work which should be an easy catch via our CI. So I set up a new job that runs a `cargo hack` job on every package to see if we can catch this issue in a timely manner without having to wait forever on the CI.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
N/A
