### PR TITLE
bump nushell to latest nu-ansi-term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,11 +3697,10 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+version = "0.50.2"
+source = "git+https://github.com/nushell/nu-ansi-term.git?branch=main#654c373775e1d8b70eacd1358b30dd876225483a"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,7 +346,7 @@ bench = false
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
 # reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
-# nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
+nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Run all benchmarks with `cargo bench`
 # Run individual benchmarks like `cargo bench -- <regex>` e.g. `cargo bench -- parse`


### PR DESCRIPTION
Bump to the latest commit of nu-ansi-term 654c373 to dog food before a release.

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A