### PR TITLE
Fix building `nu-command` by itself

### DIFF
--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -179,6 +179,7 @@ os = [
 	# include other features
 	"js",
 	"network",
+	"nu-engine/os",
 	"nu-protocol/os",
 	"nu-utils/os",
 


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
On `main` you currently cannot build `nu-command` by itself via `cargo build -p nu-command`. This PR fixes that.

The dependency for the `os` feature in `nu-engine` was missing for `nu-command`.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
Fixed building `nu-command` by itself.
