### PR TITLE
Rework signature flag parsing

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3988,8 +3988,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                             if contents.starts_with(b"--") && contents.len() > 2 {
                                 // Split the long flag from the short flag with the ( character as delimiter.
                                 // The trailing ) is removed further down.
-                                let flags: Vec<_> =
-                                    contents.split(|x| x == &b'(').map(|x| x.to_vec()).collect();
+                                let flags: Vec<_> = contents.split(|x| x == &b'(').collect();
 
                                 let long = String::from_utf8_lossy(&flags[0][2..]).to_string();
                                 let mut variable_name = flags[0][2..].to_vec();

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4159,8 +4159,12 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                     ))
                                 }
 
-                                let var_id =
-                                    working_set.add_variable(optional_param.to_vec(), span, Type::Any, false);
+                                let var_id = working_set.add_variable(
+                                    optional_param.to_vec(),
+                                    span,
+                                    Type::Any,
+                                    false,
+                                );
 
                                 args.push(Arg::Positional {
                                     arg: PositionalArg {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4050,28 +4050,6 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                     let short_flag =
                                         String::from_utf8_lossy(short_flag).to_string();
                                     let chars: Vec<char> = short_flag.chars().collect();
-                                    let long = String::from_utf8_lossy(&flags[0][2..]).to_string();
-                                    let mut variable_name = flags[0][2..].to_vec();
-
-                                    (0..variable_name.len()).for_each(|idx| {
-                                        if variable_name[idx] == b'-' {
-                                            variable_name[idx] = b'_';
-                                        }
-                                    });
-
-                                    if !is_variable(&variable_name) {
-                                        working_set.error(ParseError::Expected(
-                                            "valid variable name for this short flag",
-                                            span,
-                                        ))
-                                    }
-
-                                    let var_id = working_set.add_variable(
-                                        variable_name,
-                                        span,
-                                        Type::Any,
-                                        false,
-                                    );
 
                                     if chars.len() == 1 {
                                         args.push(Arg::Flag {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3223,7 +3223,7 @@ pub fn unescape_string(bytes: &[u8], span: Span) -> (Vec<u8>, Option<ParseError>
                                 let result = char::from_u32(int);
 
                                 if let Some(result) = result {
-                                    let mut buffer = vec![0; 4];
+                                    let mut buffer = [0; 4];
                                     let result = result.encode_utf8(&mut buffer);
 
                                     for elem in result.bytes() {
@@ -4081,7 +4081,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                     working_set.error(ParseError::Expected("short flag", span));
                                 }
 
-                                let mut encoded_var_name = vec![0u8; 4];
+                                let mut encoded_var_name = [0u8; 4];
                                 let len = chars[0].encode_utf8(&mut encoded_var_name).len();
                                 let variable_name = encoded_var_name[0..len].to_vec();
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3993,11 +3993,11 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                 let long = String::from_utf8_lossy(&flags[0][2..]).to_string();
                                 let mut variable_name = flags[0][2..].to_vec();
                                 // Replace the '-' in a variable name with '_'
-                                (0..variable_name.len()).for_each(|idx| {
-                                    if variable_name[idx] == b'-' {
-                                        variable_name[idx] = b'_';
+                                for byte in variable_name.iter_mut() {
+                                    if *byte == b'-' {
+                                        *byte = b'_';
                                     }
-                                });
+                                }
 
                                 if !is_variable(&variable_name) {
                                     working_set.error(ParseError::Expected(


### PR DESCRIPTION
Simplify the code and try to avoid unnecessary temporary allocations when that is reasonable.

- **Remove redundant alloc of flag (variable) name**
- **Use arrays for fixed buffers**
- **Remove unnecessary intermediate allocation.**
- **Replace weird indexing loop with `.iter_mut`**
- **Use `.strip_{pre/suf}fix` instead of manual index**

There is more work to do:
- disallow illegal chars
- avoid `String::from_utf8_lossy`

Open questions to me:
- what is necessary for graceful error tolerance (otherwise I would skip some work.)

## Release notes summary - What our users need to know
N/A
