### PR TITLE
improve histogram output with unicode box characters for bars

### DIFF
--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -252,9 +252,9 @@ fn histogram_impl(
             max_cnt = new_cnt;
         }
     }
-
-    let mut result = vec![];
+    const PARTIAL_BOXES: [&str; 9]= ["", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"];
     const MAX_FREQ_COUNT: f64 = 100.0;
+    let mut result = vec![];
     for (val, count) in counter.into_iter().sorted() {
         let quantile = match calc_method {
             PercentageCalcMethod::Normalize => count as f64 / total_cnt as f64,
@@ -262,7 +262,9 @@ fn histogram_impl(
         };
 
         let percentage = format!("{:.2}%", quantile * 100_f64);
-        let freq = "*".repeat((MAX_FREQ_COUNT * quantile).floor() as usize);
+        let integral_part = (MAX_FREQ_COUNT * quantile).floor();
+        let fractional_part = (((MAX_FREQ_COUNT * quantile) - integral_part) * 8.0).round() as usize;
+        let freq = PARTIAL_BOXES[8].repeat(integral_part as usize) + PARTIAL_BOXES[fractional_part];
 
         result.push((
             count, // attach count first for easily sorting.


### PR DESCRIPTION
This patch changes the histogram filter to output bars using block-characters instead of “*” (also fixes a small rounding bug regarding the number of stars, but that’s also doable on its own). The Result would look like this:

```nushell
> [1 2 2 3 3 3] | histogram | table -t light
 #   value   count   quantile   percentage                       frequency                      
────────────────────────────────────────────────────────────────────────────────────────────────
 0       3       3       0.50   50.00%       ██████████████████████████████████████████████████ 
 1       2       2       0.33   33.33%       █████████████████████████████████▍                 
 2       1       1       0.17   16.67%       ████████████████▋                                  
```

Note that the last block is only a partial block, using partial blocks (U+2589 - U+258F).
This leads to a more precise, well defined length of the bar, but comes with one downside: Since these are full blocks, there is no obvious separation between neighbouring bars; An alternative could for example be to use the “🬃” and “🬋” (only the center third of the height), at the cost of reducing the horizontal resolution to a quarter (but still twice that of “*”.

I believe that this is more intuitive than stars and that since stars are not really a output that is going to be used a lot for pipelines, the primary concern here is how it looks in the terminal, making this what I believe to be a better solution. (Insofar as the bars shouldn’t be a separate filter to begin with… (Which is a discussion that might also be interesting, since putting the bars into the histogram is kinda really limiting the applicability and arguably mixing calculation and output in the same step, which may not be desirable…)

I also noticed that the current computation contains a minor bug in the length calculation, in that it uses `.floor()` instead of `.round()` to compute the display length of the bar; I do not believe that to be the desirable behavior, and have thus modified it in this PR. Even if this doesn’t get accepted, I believe it should be fixed.

(To verify the issue it might be useful to compile with a much lower `MAX_FREQ_COUNT` and compare the display length of bars whose fractional part of the length unit is greater than 0.5 with the expected length.)

I would also argue that there is a question to be had about the display-width. Right now this is hard-coded to be 100, which seems like a rather arbitrary value; it might make sense to add this as another parameter…



## Release notes summary - What our users need to know

* Use box-characters to draw histogram bars.
* Fix bug in length calculation of the histogram bars.

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
