### PR TITLE
Upload artifact during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,13 @@ jobs:
       - name: Install Nushell
         run: cargo install --path . --locked --force
 
+      - name: Upload Nushell build
+        uses: actions/upload-artifact@v4
+        with:
+          name: "nu-${{ github.event.number }}-${{ matrix.platform }}"
+          path: "~/.cargo/bin/nu"
+          retention-days: 14
+
       - name: Standard library tests
         run: nu -c 'use crates/nu-std/testing.nu; testing run-tests --path crates/nu-std'
 


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

This PR uploads the compiled Nushell binary as an artifact during the `std-lib-and-python-virtualenv` test. This makes it possible for reviewers to download the existing compiled binary from the CI rather than manually compiling it. A zip file containing the nushell binary is uploaded per platform, with this naming format: `nu-<PR number or branch name>-platform.zip`

I put the retention policy to 14 days. I'm not sure how much this will impact our storage usage (cc @sholderbach) (I don't think I have permissions to see that?). I think ideally we would only keep the latest artifact per PR, but there isn't really any way to do that out of the box. If we need to implement due to storage space that then I can look into it.

As a bonus, here's a little script to run the latest artifact from a PR:
```nushell
def run-pr [number: int] {
  let platform = "ubuntu-22.04" # change as needed
  let url = (
    gh api /repos/132ikl/nushell/actions/artifacts
    | from json
    | get artifacts
    | where name == $"nu-($number)-($platform)"
    | first 
    | get archive_download_url
  )
  let tmp = (mktemp -t -d)
  let zip = $tmp | path join artifact.zip
  gh api $url | save -p $zip
  unzip -d $tmp $zip 
  ^($tmp | path join nu)
}
```

## Release notes summary - What our users need to know
N/A