### PR TITLE
Expand alias when sending command to external completion

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -887,17 +887,10 @@ mod completer_tests {
         let mut engine_state =
             nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
 
-        let (completer_closure, define_alias_block, delta) = {
-            let mut working_set = nu_protocol::engine::StateWorkingSet::new(&engine_state);
-            let define_alias_block = parse(
-                &mut working_set,
-                None,
-                br#"cd; alias example_alias = example_cmd arg1 arg2"#,
-                false,
-            );
-            // Define an external completer that returns the arguments passed to it
-            let completer_closure = parse(&mut working_set, None, br#"{|s| $s }"#, false);
-            (completer_closure, define_alias_block, working_set.render())
+        // Custom additions
+        let delta = {
+            let working_set = nu_protocol::engine::StateWorkingSet::new(&engine_state);
+            working_set.render()
         };
 
         let result = engine_state.merge_delta(delta);
@@ -907,44 +900,8 @@ mod completer_tests {
             result.err().unwrap()
         );
 
-        let stack = &mut Stack::new();
-        let completer_block = eval_block::<WithoutDebug>(
-            &engine_state,
-            stack,
-            &completer_closure,
-            PipelineData::Empty,
-        )
-        .unwrap()
-        .body;
-
-        eval_block::<WithoutDebug>(
-            &engine_state,
-            stack,
-            &define_alias_block,
-            PipelineData::Empty,
-        )
-        .unwrap();
-
-        engine_state.merge_env(stack).unwrap();
-
-        if let Value::Closure {
-            val,
-            internal_span: _,
-        } = completer_block.into_value(Span::test_data()).unwrap()
-        {
-            let mut config = (*engine_state.config).clone();
-            config.completions.external.completer = Some(*val);
-            engine_state.config = Arc::new(config);
-        }
-
         let completer = NuCompleter::new(engine_state.into(), Arc::new(Stack::new()));
         let dataset = [
-            (
-                "example_alias extra_arg",
-                true,
-                "",
-                vec!["example_cmd", "arg1", "arg2", "extra_arg"], // The custom external completer returns the arguments passed to it
-            ),
             ("1 bit-sh", true, "b", vec!["bit-shl", "bit-shr"]),
             ("1.0 bit-sh", false, "b", vec![]),
             ("1 m", true, "m", vec!["mod"]),

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -2723,6 +2723,46 @@ fn cellpath_assignment_operator_completions() {
     match_suggestions(&expected, &suggestions);
 }
 
+#[test]
+fn alias_expansion_for_external_completions() {
+    let (_, _, mut engine, mut stack) = new_engine();
+    let command = r#"alias example_alias = example_cmd arg1 arg2"#;
+    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    // Define an external completer that returns the arguments passed to it
+    let command = r#"$env.config.completions.external.completer = {|s| $s }"#;
+    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let completion_str = "example_alias extra_arg";
+    let suggestions = completer.complete(completion_str, completion_str.len());
+    let expected: Vec<_> = vec!["example_cmd", "arg1", "arg2", "extra_arg"];
+    match_suggestions(&expected, &suggestions);
+}
+
+#[test]
+fn nested_alias_expansion_for_external_completions() {
+    let (_, _, mut engine, mut stack) = new_engine();
+    let command = r#"alias example_alias = example_cmd arg1 arg2; alias nested_alias = example_alias nested_alias_arg"#;
+    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    // Define an external completer that returns the arguments passed to it
+    let command = r#"$env.config.completions.external.completer = {|s| $s }"#;
+    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let completion_str = "nested_alias extra_arg";
+    let suggestions = completer.complete(completion_str, completion_str.len());
+    let expected: Vec<_> = vec![
+        "example_cmd",
+        "arg1",
+        "arg2",
+        "nested_alias_arg",
+        "extra_arg",
+    ];
+    match_suggestions(&expected, &suggestions);
+}
+
 // TODO: type inference
 #[ignore]
 #[rstest]


### PR DESCRIPTION
An attempt to fix #8483.

When an alias is used, `flatten_expression` returns a `FlatShape::External(span)` which contains the expanded alias. Use that to get the expanded alias and send it to external completion instead of the alias itself.

```
alias glo = git log --oneline

// Without patch
glo test<TAB>   =>   external completer called with ["glo" "log" "--oneline" "test"}

// With patch
glo test<TAB>   =>   external completer called with ["git" "log" "--oneline" "test"}
```

## Release notes summary - What our users need to know
### Aliases are now expanded before being sent to external completers

Before this change, when an external completer was invoked for an alias, the first argument sent to the completer would be the alias itself instead of the aliased command.

For example, with an alias defined as `alias gl = git log`, typing `gl branch_name` and pressing `TAB` would send the arguments `gl`, `log`, `branch_name` to the external completer.

After this change, the alias is expanded and the arguments sent to the external completer will be `git`, `log`, `branch_name`.


## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
