### PR TITLE
Parser clean up.

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -394,15 +394,14 @@ impl NuCompleter {
                             //   - "--foo ..a" => ["--foo", "..a"] => "..a"
                             //   - "--foo=..a" => ["--foo", "..a"] => "..a"
                             // - strip placeholder (`a`) if present
-                            let (new_span, prefix) = if matches!(arg, Argument::Named(_)) {
-                                strip_placeholder_with_rsplit(
+                            let (new_span, prefix) = match arg {
+                                Argument::Named(_) => strip_placeholder_with_rsplit(
                                     working_set,
                                     &span,
                                     |b| *b == b'=' || *b == b' ',
                                     strip,
-                                )
-                            } else {
-                                strip_placeholder_if_any(working_set, &span, strip)
+                                ),
+                                _ => strip_placeholder_if_any(working_set, &span, strip),
                             };
                             let ctx = Context::new(working_set, new_span, prefix, offset);
 

--- a/crates/nu-cli/src/completions/operator_completions.rs
+++ b/crates/nu-cli/src/completions/operator_completions.rs
@@ -229,7 +229,7 @@ impl Completer for OperatorCompletion<'_> {
             Type::Any => match &self.left_hand_side.expr {
                 Expr::FullCellPath(path) => {
                     // for `$ <tab>`
-                    if matches!(path.head.expr, Expr::Garbage) {
+                    if let Expr::Garbage = path.head.expr {
                         return vec![];
                     }
                     let value =

--- a/crates/nu-cmd-extra/src/extra/bits/and.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/and.rs
@@ -73,7 +73,7 @@ impl Command for BitsAnd {
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
 

--- a/crates/nu-cmd-extra/src/extra/bits/not.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/not.rs
@@ -73,7 +73,7 @@ impl Command for BitsNot {
         let number_size = get_number_bytes(number_bytes, head)?;
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
 

--- a/crates/nu-cmd-extra/src/extra/bits/or.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/or.rs
@@ -74,7 +74,7 @@ impl Command for BitsOr {
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
 

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -75,7 +75,7 @@ impl Command for BitsRol {
         let number_size = get_number_bytes(number_bytes, head)?;
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
 

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -75,7 +75,7 @@ impl Command for BitsRor {
         let number_size = get_number_bytes(number_bytes, head)?;
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
 

--- a/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
@@ -80,7 +80,7 @@ impl Command for BitsShl {
         let number_size = get_number_bytes(number_bytes, head)?;
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
 

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -77,7 +77,7 @@ impl Command for BitsShr {
         let number_size = get_number_bytes(number_bytes, head)?;
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
 

--- a/crates/nu-cmd-extra/src/extra/bits/xor.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/xor.rs
@@ -74,7 +74,7 @@ impl Command for BitsXor {
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
 

--- a/crates/nu-cmd-extra/src/extra/math/arccos.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccos.rs
@@ -40,7 +40,7 @@ impl Command for MathArcCos {
         let head = call.head;
         let use_degrees = call.has_flag(engine_state, stack, "degrees")?;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-cmd-extra/src/extra/math/arccosh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccosh.rs
@@ -38,7 +38,7 @@ impl Command for MathArcCosH {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| operate(value, head), engine_state.signals())

--- a/crates/nu-cmd-extra/src/extra/math/arcsin.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arcsin.rs
@@ -40,7 +40,7 @@ impl Command for MathArcSin {
         let head = call.head;
         let use_degrees = call.has_flag(engine_state, stack, "degrees")?;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-cmd-extra/src/extra/math/arcsinh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arcsinh.rs
@@ -38,7 +38,7 @@ impl Command for MathArcSinH {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| operate(value, head), engine_state.signals())

--- a/crates/nu-cmd-extra/src/extra/math/arctan.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arctan.rs
@@ -40,7 +40,7 @@ impl Command for MathArcTan {
         let head = call.head;
         let use_degrees = call.has_flag(engine_state, stack, "degrees")?;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-cmd-extra/src/extra/math/arctanh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arctanh.rs
@@ -38,7 +38,7 @@ impl Command for MathArcTanH {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| operate(value, head), engine_state.signals())

--- a/crates/nu-cmd-extra/src/extra/math/cos.rs
+++ b/crates/nu-cmd-extra/src/extra/math/cos.rs
@@ -39,7 +39,7 @@ impl Command for MathCos {
         let head = call.head;
         let use_degrees = call.has_flag(engine_state, stack, "degrees")?;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-cmd-extra/src/extra/math/cosh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/cosh.rs
@@ -38,7 +38,7 @@ impl Command for MathCosH {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| operate(value, head), engine_state.signals())

--- a/crates/nu-cmd-extra/src/extra/math/exp.rs
+++ b/crates/nu-cmd-extra/src/extra/math/exp.rs
@@ -38,7 +38,7 @@ impl Command for MathExp {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| operate(value, head), engine_state.signals())

--- a/crates/nu-cmd-extra/src/extra/math/ln.rs
+++ b/crates/nu-cmd-extra/src/extra/math/ln.rs
@@ -38,7 +38,7 @@ impl Command for MathLn {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| operate(value, head), engine_state.signals())

--- a/crates/nu-cmd-extra/src/extra/math/sin.rs
+++ b/crates/nu-cmd-extra/src/extra/math/sin.rs
@@ -39,7 +39,7 @@ impl Command for MathSin {
         let head = call.head;
         let use_degrees = call.has_flag(engine_state, stack, "degrees")?;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-cmd-extra/src/extra/math/sinh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/sinh.rs
@@ -38,7 +38,7 @@ impl Command for MathSinH {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| operate(value, head), engine_state.signals())

--- a/crates/nu-cmd-extra/src/extra/math/tan.rs
+++ b/crates/nu-cmd-extra/src/extra/math/tan.rs
@@ -39,7 +39,7 @@ impl Command for MathTan {
         let head = call.head;
         let use_degrees = call.has_flag(engine_state, stack, "degrees")?;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-cmd-extra/src/extra/math/tanh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/tanh.rs
@@ -38,7 +38,7 @@ impl Command for MathTanH {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| operate(value, head), engine_state.signals())

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -300,7 +300,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
     let dateformat = &args.format_options;
 
     // noop if the input is already a datetime
-    if matches!(input, Value::Date { .. }) {
+    if let Value::Date { .. } = input {
         return input.clone();
     }
 

--- a/crates/nu-command/src/date/from_human.rs
+++ b/crates/nu-command/src/date/from_human.rs
@@ -54,7 +54,7 @@ impl Command for DateFromHuman {
         }
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| helper(value, head), engine_state.signals())

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -46,7 +46,7 @@ impl Command for DateHumanize {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| helper(value, head), engine_state.signals())

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -60,7 +60,7 @@ impl Command for DateToTimezone {
         let timezone: Spanned<String> = call.req(engine_state, stack, 0)?;
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -163,7 +163,7 @@ fn default(
     // If user supplies columns, check if input is a record or list of records
     // and set the default value for the specified record columns
     if !columns.is_empty() {
-        if matches!(input, PipelineData::Value(Value::Record { .. }, _)) {
+        if let PipelineData::Value(Value::Record { .. }, _) = input {
             let record = input.into_value(input_span)?.into_record()?;
             fill_record(
                 record,

--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -272,7 +272,7 @@ fn join_rows(
         {
             if let Some(this_valkey) = this_record.get(this_join_key) {
                 if let Some(other_rows) = other.get(&this_valkey.to_expanded_string(sep, config)) {
-                    if matches!(include_inner, IncludeInner::Yes) {
+                    if let IncludeInner::Yes = include_inner {
                         for other_record in other_rows {
                             // `other` table contains rows matching `this` row on the join column
                             let record = match join_type {

--- a/crates/nu-command/src/filters/move_.rs
+++ b/crates/nu-command/src/filters/move_.rs
@@ -229,13 +229,13 @@ fn move_record_columns(
                         });
                     }
 
-                    if matches!(location, Location::After(..)) {
+                    if let Location::After(..) = location {
                         out.push(inp_col.clone(), inp_val.clone());
                     }
 
                     insert_moved(record, span, &column_idx, &mut out)?;
 
-                    if matches!(location, Location::Before(..)) {
+                    if let Location::Before(..) = location {
                         out.push(inp_col.clone(), inp_val.clone());
                     }
                 } else if !column_idx.contains(&i) {

--- a/crates/nu-command/src/filters/tee.rs
+++ b/crates/nu-command/src/filters/tee.rs
@@ -256,7 +256,7 @@ use it in your pipeline."#
             let metadata = input.metadata();
             let metadata_clone = metadata.clone();
 
-            if matches!(input, PipelineData::ListStream(..)) {
+            if let PipelineData::ListStream(..) = input {
                 // Only use the iterator implementation on lists / list streams. We want to be able
                 // to preserve errors as much as possible, and only the stream implementations can
                 // really do that

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -44,7 +44,7 @@ impl Command for MathCeil {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         if let PipelineData::Value(
@@ -68,7 +68,7 @@ impl Command for MathCeil {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         if let PipelineData::Value(

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -68,7 +68,7 @@ impl Command for MathFloor {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         if let PipelineData::Value(

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -43,19 +43,13 @@ impl Command for MathFloor {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty { dst_span: head });
-        }
-        if let PipelineData::Value(
-            Value::Range {
-                ref val,
-                internal_span,
-            },
-            ..,
-        ) = input
-        {
-            ensure_bounded(val.as_ref(), internal_span, head)?;
+        match input {
+            // This doesn't match explicit nulls
+            PipelineData::Empty => return Err(ShellError::PipelineEmpty { dst_span: head }),
+            PipelineData::Value(ref value @ Value::Range { val: ref range, .. }, ..) => {
+                ensure_bounded(range, value.span(), head)?
+            }
+            _ => (),
         }
         input.map(move |value| operate(value, head), engine_state.signals())
     }

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -122,7 +122,7 @@ fn log(
         });
     }
     // This doesn't match explicit nulls
-    if matches!(input, PipelineData::Empty) {
+    if let PipelineData::Empty = input {
         return Err(ShellError::PipelineEmpty { dst_span: head });
     }
     let base = base.item;

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -51,7 +51,7 @@ impl Command for MathRound {
         let precision_param: Option<i64> = call.get_flag(engine_state, stack, "precision")?;
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         if let PipelineData::Value(
@@ -79,7 +79,7 @@ impl Command for MathRound {
         let precision_param: Option<i64> = call.get_flag_const(working_set, "precision")?;
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         if let PipelineData::Value(

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -44,7 +44,7 @@ impl Command for MathSqrt {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         if let PipelineData::Value(
@@ -68,7 +68,7 @@ impl Command for MathSqrt {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         if let PipelineData::Value(

--- a/crates/nu-command/src/path/basename.rs
+++ b/crates/nu-command/src/path/basename.rs
@@ -56,7 +56,7 @@ impl Command for PathBasename {
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
@@ -77,7 +77,7 @@ impl Command for PathBasename {
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-command/src/path/dirname.rs
+++ b/crates/nu-command/src/path/dirname.rs
@@ -64,7 +64,7 @@ impl Command for PathDirname {
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
@@ -86,7 +86,7 @@ impl Command for PathDirname {
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -61,7 +61,7 @@ Also note that if you don't have a permission to a directory of a path, false wi
             not_follow_symlink: call.has_flag(engine_state, stack, "no-symlink")?,
         };
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
@@ -83,7 +83,7 @@ Also note that if you don't have a permission to a directory of a path, false wi
             not_follow_symlink: call.has_flag_const(working_set, "no-symlink")?,
         };
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -65,7 +65,7 @@ impl Command for PathExpand {
             not_follow_symlink: call.has_flag(engine_state, stack, "no-symlink")?,
         };
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
@@ -88,7 +88,7 @@ impl Command for PathExpand {
             not_follow_symlink: call.has_flag_const(working_set, "no-symlink")?,
         };
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-command/src/path/parse.rs
+++ b/crates/nu-command/src/path/parse.rs
@@ -58,7 +58,7 @@ On Windows, an extra 'prefix' column is added."#
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
@@ -79,7 +79,7 @@ On Windows, an extra 'prefix' column is added."#
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -62,7 +62,7 @@ path."#
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
@@ -83,7 +83,7 @@ path."#
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-command/src/path/split.rs
+++ b/crates/nu-command/src/path/split.rs
@@ -46,7 +46,7 @@ impl Command for PathSplit {
         let args = Arguments;
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
@@ -65,7 +65,7 @@ impl Command for PathSplit {
         let args = Arguments;
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-command/src/path/type.rs
+++ b/crates/nu-command/src/path/type.rs
@@ -57,7 +57,7 @@ If the path does not exist, null will be returned."#
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
@@ -78,7 +78,7 @@ If the path does not exist, null will be returned."#
         };
 
         // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
+        if let PipelineData::Empty = input {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -177,7 +177,7 @@ fn run(
     }
 
     // This doesn't match explicit nulls
-    if matches!(input, PipelineData::Empty) {
+    if let PipelineData::Empty = input {
         return Err(ShellError::PipelineEmpty { dst_span: head });
     }
     input.map(

--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -214,7 +214,7 @@ fn run(
     engine_state: &EngineState,
 ) -> Result<PipelineData, ShellError> {
     let span = call.head;
-    if matches!(input, PipelineData::Empty) {
+    if let PipelineData::Empty = input {
         return Err(ShellError::PipelineEmpty { dst_span: span });
     }
     input.map(

--- a/crates/nu-command/src/strings/str_/stats.rs
+++ b/crates/nu-command/src/strings/str_/stats.rs
@@ -102,7 +102,7 @@ fn stats(
 ) -> Result<PipelineData, ShellError> {
     let span = call.head;
     // This doesn't match explicit nulls
-    if matches!(input, PipelineData::Empty) {
+    if let PipelineData::Empty = input {
         return Err(ShellError::PipelineEmpty { dst_span: span });
     }
     input.map(

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -625,7 +625,7 @@ fn eval_instruction<D: DebugContext>(
         }
         Instruction::GlobFrom { src_dst, no_expand } => {
             let string_value = ctx.collect_reg(*src_dst, *span)?;
-            let glob_value = if matches!(string_value, Value::Glob { .. }) {
+            let glob_value = if let Value::Glob { .. } = string_value {
                 // It already is a glob, so don't touch it.
                 string_value
             } else {

--- a/crates/nu-explore/src/nu_common/table.rs
+++ b/crates/nu-explore/src/nu_common/table.rs
@@ -26,7 +26,7 @@ pub fn try_build_table(
     match value {
         Value::List { vals, .. } => try_build_list(vals, opts),
         Value::Record { val, .. } => try_build_map(&val, opts),
-        val if matches!(val, Value::String { .. }) => {
+        val @ Value::String { .. } => {
             nu_value_to_string_clean(&val, config, &opts.style_computer).0
         }
         val => nu_value_to_string(&val, config, &opts.style_computer).0,

--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -488,10 +488,9 @@ fn create_status_bar(report: Report) -> StatusBar {
 }
 
 fn report_msg_style(report: &Report, config: &ExploreConfig, style: NuStyle) -> NuStyle {
-    if matches!(report.level, Severity::Info) {
-        style
-    } else {
-        report_level_style(report.level, config)
+    match report.level {
+        Severity::Info => style,
+        _ => report_level_style(report.level, config),
     }
 }
 

--- a/crates/nu-explore/src/views/try.rs
+++ b/crates/nu-explore/src/views/try.rs
@@ -164,7 +164,7 @@ impl View for TryView {
                 return Transition::Ok;
             }
 
-            if matches!(key.code, KeyCode::Tab) {
+            if let KeyCode::Tab = key.code {
                 self.view_mode = false;
                 return Transition::Ok;
             }

--- a/crates/nu-lsp/src/signature.rs
+++ b/crates/nu-lsp/src/signature.rs
@@ -169,18 +169,12 @@ impl LanguageServer {
         let active_signature = working_set.get_decl(active_call.decl_id).signature();
         let label = get_signature_label(&active_signature, false);
 
-        let mut param_num_before_pos = 0;
-        for arg in active_call.arguments.iter() {
-            // skip flags
-            if matches!(arg, Argument::Named(_)) {
-                continue;
-            }
-            if arg.span().end <= pos_to_search {
-                param_num_before_pos += 1;
-            } else {
-                break;
-            }
-        }
+        let param_num_before_pos = active_call
+            .arguments
+            .iter()
+            .filter(|&arg| !matches!(arg, Argument::Named(..)))
+            .take_while(|&arg| arg.span().end <= pos_to_search)
+            .count() as u32;
 
         let str_to_doc = |s: String| {
             Some(Documentation::MarkupContent(MarkupContent {

--- a/crates/nu-parser/src/lite_parser.rs
+++ b/crates/nu-parser/src/lite_parser.rs
@@ -242,7 +242,7 @@ pub fn lite_parse(
                     TokenContents::Eol | TokenContents::Semicolon => {
                         command.attribute_idx.push(command.parts.len());
                         mode = Mode::Normal;
-                        if matches!(last_token, TokenContents::Eol | TokenContents::Semicolon) {
+                        if let TokenContents::Eol | TokenContents::Semicolon = last_token {
                             // Clear out the comment as we're entering a new comment
                             curr_comment = None;
                             pipeline.push(&mut command);
@@ -377,10 +377,7 @@ pub fn lite_parse(
                             // For example, this is currently allowed: ^echo thing o> out.txt extra_arg
 
                             if working_set.get_span_contents(token.span).starts_with(b"@") {
-                                if matches!(
-                                    last_token,
-                                    TokenContents::Eol | TokenContents::Semicolon
-                                ) {
+                                if let TokenContents::Eol | TokenContents::Semicolon = last_token {
                                     mode = Mode::Attribute;
                                 }
                                 command.push(token.span);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2057,7 +2057,7 @@ pub fn parse_paren_expr(
 
     working_set.parse_errors.truncate(starting_error_count);
 
-    if matches!(shape, SyntaxShape::Signature) {
+    if let SyntaxShape::Signature = shape {
         return parse_signature(working_set, span);
     }
 
@@ -4112,7 +4112,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                             // Short flag alias for long flag, e.g. --b (-a)
                             // This is the same as the short flag in --b(-a)
                             else if let Some(short_flag) = contents.strip_prefix(b"(-") {
-                                if matches!(parse_mode, ParseMode::AfterCommaArg) {
+                                if let ParseMode::AfterCommaArg = parse_mode {
                                     working_set
                                         .error(ParseError::Expected("parameter or flag", span));
                                 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2106,56 +2106,52 @@ pub fn parse_brace_expr(
     let bytes = working_set.get_span_contents(Span::new(span.start + 1, span.end - 1));
     let (tokens, _) = lex(bytes, span.start + 1, &[b'\r', b'\n', b'\t'], &[b':'], true);
 
-    let second_token = tokens
-        .first()
-        .map(|token| working_set.get_span_contents(token.span));
-
-    let second_token_contents = tokens.first().map(|token| token.contents);
-
-    let third_token = tokens
-        .get(1)
-        .map(|token| working_set.get_span_contents(token.span));
-
-    if second_token.is_none() {
+    match tokens.as_slice() {
         // If we're empty, that means an empty record or closure
-        if matches!(shape, SyntaxShape::Closure(_)) {
+        [] => match shape {
+            SyntaxShape::Closure(_) => parse_closure_expression(working_set, shape, span),
+            SyntaxShape::Block => parse_block_expression(working_set, span),
+            SyntaxShape::MatchBlock => parse_match_block_expression(working_set, span),
+            _ => parse_record(working_set, span),
+        },
+        [
+            Token {
+                contents: TokenContents::Pipe | TokenContents::PipePipe,
+                ..
+            },
+            ..,
+        ] => {
+            if let SyntaxShape::Block = shape {
+                working_set.error(ParseError::Mismatch("block".into(), "closure".into(), span));
+                return Expression::garbage(working_set, span);
+            }
             parse_closure_expression(working_set, shape, span)
-        } else if matches!(shape, SyntaxShape::Block) {
-            parse_block_expression(working_set, span)
-        } else if matches!(shape, SyntaxShape::MatchBlock) {
-            parse_match_block_expression(working_set, span)
-        } else {
-            parse_record(working_set, span)
         }
-    } else if matches!(second_token_contents, Some(TokenContents::Pipe))
-        || matches!(second_token_contents, Some(TokenContents::PipePipe))
-    {
-        if matches!(shape, SyntaxShape::Block) {
-            working_set.error(ParseError::Mismatch("block".into(), "closure".into(), span));
-            return Expression::garbage(working_set, span);
+        [_, third, ..] if working_set.get_span_contents(third.span) == b":" => {
+            parse_full_cell_path(working_set, None, span)
         }
-        parse_closure_expression(working_set, shape, span)
-    } else if matches!(third_token, Some(b":")) {
-        parse_full_cell_path(working_set, None, span)
-    } else if matches!(shape, SyntaxShape::Closure(_)) {
-        parse_closure_expression(working_set, shape, span)
-    } else if matches!(shape, SyntaxShape::Block) {
-        parse_block_expression(working_set, span)
-    } else if matches!(shape, SyntaxShape::MatchBlock) {
-        parse_match_block_expression(working_set, span)
-    } else if second_token.is_some_and(|c| {
-        c.len() > 3 && c.starts_with(b"...") && (c[3] == b'$' || c[3] == b'{' || c[3] == b'(')
-    }) {
-        parse_record(working_set, span)
-    } else if matches!(shape, SyntaxShape::Any) {
-        parse_closure_expression(working_set, shape, span)
-    } else {
-        working_set.error(ParseError::ExpectedWithStringMsg(
-            format!("non-block value: {shape}"),
-            span,
-        ));
+        [second, ..] => {
+            let second_bytes = working_set.get_span_contents(second.span);
+            match shape {
+                SyntaxShape::Closure(_) => parse_closure_expression(working_set, shape, span),
+                SyntaxShape::Block => parse_block_expression(working_set, span),
+                SyntaxShape::MatchBlock => parse_match_block_expression(working_set, span),
+                _ if second_bytes.starts_with(b"...")
+                    && second_bytes.get(3).is_some_and(|c| b"${(".contains(c)) =>
+                {
+                    parse_record(working_set, span)
+                }
+                SyntaxShape::Any => parse_closure_expression(working_set, shape, span),
+                _ => {
+                    working_set.error(ParseError::ExpectedWithStringMsg(
+                        format!("non-block value: {shape}"),
+                        span,
+                    ));
 
-        Expression::garbage(working_set, span)
+                    Expression::garbage(working_set, span)
+                }
+            }
+        }
     }
 }
 

--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -137,10 +137,9 @@ impl PluginTest {
 
         // Serialize custom values in the input
         let source = self.source.clone();
-        let input = if matches!(input, PipelineData::ByteStream(..)) {
-            input
-        } else {
-            input.map(
+        let input = match input {
+            input @ PipelineData::ByteStream(..) => input,
+            input => input.map(
                 move |mut value| {
                     let result = PluginCustomValue::serialize_custom_values_in(&mut value)
                         // Make sure to mark them with the source so they pass correctly, too.
@@ -153,17 +152,16 @@ impl PluginTest {
                     }
                 },
                 &Signals::empty(),
-            )?
+            )?,
         };
 
         // Eval the block with the input
         let mut stack = Stack::new().collect_value();
         let data = eval_block::<WithoutDebug>(&self.engine_state, &mut stack, &block, input)
             .map(|p| p.body)?;
-        if matches!(data, PipelineData::ByteStream(..)) {
-            Ok(data)
-        } else {
-            data.map(
+        match data {
+            data @ PipelineData::ByteStream(..) => Ok(data),
+            data => data.map(
                 |mut value| {
                     // Make sure to deserialize custom values
                     let result = PluginCustomValueWithSource::remove_source_in(&mut value)
@@ -174,7 +172,7 @@ impl PluginTest {
                     }
                 },
                 &Signals::empty(),
-            )
+            ),
         }
     }
 

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -787,7 +787,7 @@ impl Stack {
         let path = path.as_ref();
 
         if !path.is_absolute() {
-            if matches!(path.components().next(), Some(Component::Prefix(_))) {
+            if let Some(Component::Prefix(_)) = path.components().next() {
                 return Err(ShellError::GenericError {
                     error: "Cannot set $env.PWD to a prefix-only path".to_string(),
                     msg: "".into(),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3670,14 +3670,12 @@ impl Value {
                 lhs.operation(self.span(), Operator::Comparison(Comparison::In), op, rhs)
             }
             (lhs, rhs) => Err(
-                if matches!(
-                    rhs,
-                    Value::List { .. }
-                        | Value::Range { .. }
-                        | Value::String { .. }
-                        | Value::Record { .. }
-                        | Value::Custom { .. }
-                ) {
+                if let Value::List { .. }
+                | Value::Range { .. }
+                | Value::String { .. }
+                | Value::Record { .. }
+                | Value::Custom { .. } = rhs
+                {
                     ShellError::OperatorIncompatibleTypes {
                         op: Operator::Comparison(Comparison::In),
                         lhs: lhs.get_type(),
@@ -3742,14 +3740,12 @@ impl Value {
                 rhs,
             ),
             (lhs, rhs) => Err(
-                if matches!(
-                    rhs,
-                    Value::List { .. }
-                        | Value::Range { .. }
-                        | Value::String { .. }
-                        | Value::Record { .. }
-                        | Value::Custom { .. }
-                ) {
+                if let Value::List { .. }
+                | Value::Range { .. }
+                | Value::String { .. }
+                | Value::Record { .. }
+                | Value::Custom { .. } = rhs
+                {
                     ShellError::OperatorIncompatibleTypes {
                         op: Operator::Comparison(Comparison::NotIn),
                         lhs: lhs.get_type(),

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/aggregate.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/aggregate.rs
@@ -138,7 +138,7 @@ impl PluginCommand for LazyAggregate {
             if let Some(name) = get_col_name(expr) {
                 let dtype = group_by.schema.schema.get(name.as_str());
 
-                if matches!(dtype, Some(DataType::Object(..))) {
+                if let Some(DataType::Object(..)) = dtype {
                     return Err(ShellError::GenericError {
                             error: "Object type column not supported for aggregation".into(),
                             msg: format!("Column '{name}' is type Object"),

--- a/src/command_context.rs
+++ b/src/command_context.rs
@@ -143,7 +143,7 @@ mod tests {
             let sig_name = cmd.signature().name;
             let category = cmd.signature().category;
 
-            if matches!(category, Category::Removed) {
+            if let Category::Removed = category {
                 // Deprecated/Removed commands don't have to conform
                 continue;
             }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -115,10 +115,7 @@ pub fn configure(
     let log_target = LogTarget::from(target);
 
     // Only TermLogger supports color output
-    if matches!(
-        log_target,
-        LogTarget::Stdout | LogTarget::Stderr | LogTarget::Mixed
-    ) {
+    if let LogTarget::Stdout | LogTarget::Stderr | LogTarget::Mixed = log_target {
         Level::iter().for_each(|level| set_colored_level(builder, level));
     }
 


### PR DESCRIPTION
- Rewrite `if matches!(val, pat) { .. }` expressions as `if let pat = val { .. }`
- Replace `if matches!(..) {..}` with `match` expressions where it makes code easier to understand
- Use combinator methods instead of imperative code in a few places.
- Slay the [beast](https://github.com/nushell/nushell/compare/69857c108ca4070bc95e3618c8bd4a475a2ecf9d...c430bcde6f0f5941f9f2c8fff71ffdfe061ae073)

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A