### PR TITLE
Set up ast-grep with some custom lints

### DIFF
--- a/ast-grep/rules/if-matches-chain.yml
+++ b/ast-grep/rules/if-matches-chain.yml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: if-matches-chain
+language: rust
+severity: error
+message: "This would have been better handled with a `match` expression"
+
+rule:
+  pattern: "$ROOT"
+  matches: if_matches
+
+  # We don't want the match each if-else branch separately, we only want to
+  # match the initial one.
+  # A chain of if-else branches are technically nested (at least in the
+  # tree-sitter AST) so it will contain the following branches too
+  not:
+    inside:
+      kind: else_clause
+
+  # This rule should only match if there are successive `if matches!` branches
+  # and not match the simple case which can be converted to a `if let` easily
+  has:
+    kind: else_clause
+    has:
+      matches: if_matches
+
+labels:
+  ROOT:
+    style: primary
+
+utils:
+  if_matches:
+    kind: if_expression
+    has:
+      field: condition
+      pattern: "matches!"

--- a/ast-grep/rules/if-matches.yml
+++ b/ast-grep/rules/if-matches.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: if-matches
+language: rust
+severity: warning
+message: "Used `matches!` macro as an `if` condition"
+note: "It can be replaced with an `if let` expression"
+
+rule:
+  pattern: "matches!($VAL, $$$PAT)"
+  inside:
+    field: condition
+    kind: if_expression
+    all:
+      - not:
+          has:
+            field: alternative
+            kind: else_clause
+            has:
+              kind: if_expression
+      - not:
+          inside:
+            kind: else_clause
+
+fix: "let $$$PAT = $VAL"

--- a/ast-grep/rules/internal_span.yml
+++ b/ast-grep/rules/internal_span.yml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: internal_span
+language: rust
+severity: warning
+message: "Using `internal_span` directly is deprecated."
+note: "You can get the span using the `Value::span()` method."
+
+rule:
+  regex: internal_span
+  any:
+    - kind: shorthand_field_identifier
+    - kind: field_identifier
+
+fix: ".."

--- a/ast-grep/rules/long-string.yml
+++ b/ast-grep/rules/long-string.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: long-string
+language: rust
+severity: off
+message: "String literal too wide"
+
+rule:
+  kind: string_literal
+  regex: '[^\n]{80,}'

--- a/ast-grep/rules/span-unknown.yml
+++ b/ast-grep/rules/span-unknown.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: span-unknown
+language: rust
+severity: warning
+message: "Eliminate unknown spans."
+
+rule:
+  kind: call_expression
+  pattern: "Span::unknown()"

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,4 @@
+ruleDirs:
+- ast-grep/rules
+utilDirs:
+- ast-grep/utils


### PR DESCRIPTION
What it says on the tin.

[ast-grep](https://ast-grep.github.io/) is a structural search and replace tool and linter based on tree-sitter.

Running `ast-grep scan` will give you a list of diagnostics based on the rules defined in `ast-grep/rules`.

For editor integration, `ast-grep` supports LSP and has a vscode plugin.

Because it works with tree-sitter, it's possible to define lints for nu scripts too.

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A