### PR TITLE
Fix ir eval error on branched block redirection (Fixes #16582)

### DIFF
--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -488,3 +488,47 @@ fn subexpression_redirection(#[case] redir: &str, #[case] stdout_file_body: &str
         assert!(file_contents(dirs.test().join("result.txt")).contains(stdout_file_body));
     })
 }
+
+#[rstest::rstest]
+#[case("o>", "bar")]
+#[case("e>", "")]
+#[case("o+e>", "bar\nbaz")]
+fn file_redirection_in_if_true(#[case] redir: &str, #[case] stdout_file_body: &str) {
+    Playground::setup("file redirection if true block", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(),
+          format!("$env.BAR = 'bar'; $env.BAZ = 'baz'; if true {{ nu --testbin echo_env_mixed out-err BAR BAZ }} {redir} result.txt")
+        );
+        assert!(actual.status.success());
+        assert!(file_contents(dirs.test().join("result.txt")).contains(stdout_file_body));
+    })
+}
+
+#[rstest::rstest]
+#[case(true, "hey")]
+#[case(false, "ho")]
+fn file_redirection_in_if_else(#[case] cond: bool, #[case] stdout_file_body: &str) {
+    Playground::setup("file redirection if-else block", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(),
+            format!("if {cond} {{ echo 'hey' }} else {{ echo 'ho' }} out> result.txt")
+        );
+        assert!(actual.status.success());
+        assert!(file_contents(dirs.test().join("result.txt")).contains(stdout_file_body));
+    })
+}
+
+#[rstest::rstest]
+#[case("o>", "bar")]
+#[case("e>", "")]
+#[case("o+e>", "bar\nbaz")]
+fn file_redirection_in_try_catch(#[case] redir: &str, #[case] stdout_file_body: &str) {
+    Playground::setup("file redirection try-catch block", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(),
+            format!("$env.BAR = 'bar'; $env.BAZ = 'baz'; try {{ 1/0 }} catch {{ nu --testbin echo_env_mixed out-err BAR BAZ }} {redir} result.txt")
+        );
+        assert!(actual.status.success());
+        assert!(file_contents(dirs.test().join("result.txt")).contains(stdout_file_body));
+    })
+}


### PR DESCRIPTION
### Description

Attempt to fix issue [#16582](https://github.com/nushell/nushell/issues/16582) by avoiding duplicated `write` and `close` calls for an `out>`/`err>` redirected file for `try-catch` and `if-else` blocks.

Similarly to [this PR](https://github.com/nushell/nushell/pull/15617) a function to identify if a code block is being handeled, and if so skip the invocation of `finish_redirection` so that no additional writes are added. (The blocks perform redirections on their own and this then avoids the duplication).

### User-Facing Changes

The following commands will no longer raise ir-eval errors:

 - `if true { echo "hey" } out> /dev/null`
 - `if false { echo "hey" } else { echo "ho" } out> /dev/null`
 - `try { 1/0 } catch { echo "hi" } out> /dev/null`

IR before changes: 
[before.txt](https://github.com/user-attachments/files/22308084/before.txt)

IR after changes: 
[after.txt](https://github.com/user-attachments/files/22308085/after.txt)

### Tests

Added 8 tests.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

## Release notes summary - What our users need to know
TODO

## Tasks after submitting
TODO
