### PR TITLE
Fix parsing for octal strings

### DIFF
--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -479,6 +479,22 @@ pub fn parse_binary_with_octal_format() {
 }
 
 #[test]
+pub fn parse_binary_with_overflow_octal_format() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let block = parse(&mut working_set, None, b"0o[777]", true);
+
+    assert!(working_set.parse_errors.is_empty());
+    assert_eq!(block.len(), 1);
+    let pipeline = &block.pipelines[0];
+    assert_eq!(pipeline.len(), 1);
+    let element = &pipeline.elements[0];
+    assert!(element.redirection.is_none());
+    assert_eq!(element.expr.expr, Expr::Binary(vec![0o1, 0o377]));
+}
+
+#[test]
 pub fn parse_binary_with_incomplete_octal_format() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
Fixes #9566.
Binary and hexadecimal strings have no issues in parsing because they are parsed at a chunk of 8 characters (max of `11111111` or 255 in decimal) and 2 characters (max of `FF` or 255 in decimal). However, for octals this is not the case, previously it was chunked by 3 characters (max of `777` which is 511 in decimal hence it exceeds `u8::MAX`). 

I solved this by not chunking at all and instead parse the entire octal string as `u128`. Chunking will never work for octals since there isn't an exact number of chars that will fit exactly up to 255.

To see if it works, you can try this and it should parse & return true:
```nushell
0o[71777342767] == 0b[111 001 111 111 111 011 100 010 111 110 111]
# => true
```

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
Fixed parsing for octal strings. Previously, only octal strings up to `0o[377]` was allowed. Now, any octal strings can be parsed properly. 

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
N/A
