### PR TITLE
Align `query db` description with other database commands

### DIFF
--- a/crates/nu-command/src/database/commands/query_db.rs
+++ b/crates/nu-command/src/database/commands/query_db.rs
@@ -28,7 +28,11 @@ impl Command for QueryDb {
     }
 
     fn description(&self) -> &str {
-        "Query a database using SQL."
+        "Query a SQLite database with SQL statements."
+    }
+
+    fn extra_description(&self) -> &str {
+        "This command is only supported for local or in-memory SQLite databases."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
Closes #10243.
`query db` is the only command that doesn't state "SQLite" in the main description (aside from `stor reset`).

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
N/A

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io) (although I think this is auto-generated for commands)
