### PR TITLE
Gate SQLite history behind existing `sqlite` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,7 @@ nu-protocol = { path = "./crates/nu-protocol", version = "0.107.1" }
 nu-std = { path = "./crates/nu-std", version = "0.107.1" }
 nu-system = { path = "./crates/nu-system", version = "0.107.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.107.1" }
-reedline = { workspace = true, features = ["bashisms", "sqlite"] }
+reedline = { workspace = true, features = ["bashisms"] }
 
 crossterm = { workspace = true }
 ctrlc = { workspace = true }
@@ -315,7 +315,13 @@ system-clipboard = [
 trash-support = ["nu-command/trash-support"]
 
 # SQLite commands for nushell
-sqlite = ["nu-command/sqlite", "nu-std/sqlite"]
+sqlite = [
+  "nu-cli/sqlite",
+  "nu-command/sqlite",
+  "nu-std/sqlite",
+  "nu-protocol/sqlite",
+  "reedline/sqlite"
+]
 
 [profile.release]
 opt-level = "s"     # Optimize for size

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -30,7 +30,7 @@ nu-utils = { path = "../nu-utils", version = "0.107.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.107.1" }
 nu-experimental = { path = "../nu-experimental", version = "0.107.1" }
 nu-ansi-term = { workspace = true }
-reedline = { workspace = true, features = ["bashisms", "sqlite"] }
+reedline = { workspace = true, features = ["bashisms"] }
 
 chrono = { default-features = false, features = ["std"], workspace = true }
 crossterm = { workspace = true }
@@ -50,6 +50,7 @@ which = { workspace = true }
 [features]
 plugin = ["nu-plugin-engine"]
 system-clipboard = ["reedline/system_clipboard"]
+sqlite = ["reedline/sqlite"]
 
 [lints]
 workspace = true

--- a/crates/nu-cli/src/commands/default_context.rs
+++ b/crates/nu-cli/src/commands/default_context.rs
@@ -17,12 +17,16 @@ pub fn add_cli_context(mut engine_state: EngineState) -> EngineState {
             CommandlineGetCursor,
             CommandlineSetCursor,
             History,
-            HistoryImport,
-            HistorySession,
             Keybindings,
             KeybindingsDefault,
             KeybindingsList,
             KeybindingsListen,
+        };
+
+        #[cfg(feature = "sqlite")]
+        bind_command! {
+            HistoryImport,
+            HistorySession
         };
 
         working_set.render()

--- a/crates/nu-cli/src/commands/history/fields.rs
+++ b/crates/nu-cli/src/commands/history/fields.rs
@@ -1,9 +1,15 @@
 // Each const is named after a HistoryItem field, and the value is the field name to be displayed to
 // the user (or accept during import).
 pub const COMMAND_LINE: &str = "command";
+#[cfg_attr(not(feature = "sqlite"), allow(dead_code))]
 pub const START_TIMESTAMP: &str = "start_timestamp";
+#[cfg_attr(not(feature = "sqlite"), allow(dead_code))]
 pub const HOSTNAME: &str = "hostname";
+#[cfg_attr(not(feature = "sqlite"), allow(dead_code))]
 pub const CWD: &str = "cwd";
+#[cfg_attr(not(feature = "sqlite"), allow(dead_code))]
 pub const EXIT_STATUS: &str = "exit_status";
+#[cfg_attr(not(feature = "sqlite"), allow(dead_code))]
 pub const DURATION: &str = "duration";
+#[cfg_attr(not(feature = "sqlite"), allow(dead_code))]
 pub const SESSION_ID: &str = "session_id";

--- a/crates/nu-cli/src/commands/history/history_.rs
+++ b/crates/nu-cli/src/commands/history/history_.rs
@@ -3,10 +3,9 @@ use nu_protocol::{
     HistoryFileFormat,
     shell_error::{self, io::IoError},
 };
-use reedline::{
-    FileBackedHistory, History as ReedlineHistory, HistoryItem, SearchDirection, SearchQuery,
-    SqliteBackedHistory,
-};
+use reedline::{FileBackedHistory, History as ReedlineHistory, SearchDirection, SearchQuery};
+#[cfg(feature = "sqlite")]
+use reedline::{HistoryItem, SqliteBackedHistory};
 
 use super::fields;
 
@@ -58,9 +57,12 @@ impl Command for History {
             return Ok(PipelineData::empty());
         }
 
+        #[cfg_attr(not(feature = "sqlite"), allow(unused_variables))]
         let long = call.has_flag(engine_state, stack, "long")?;
+
         let signals = engine_state.signals().clone();
         let history_reader: Option<Box<dyn ReedlineHistory>> = match history.file_format {
+            #[cfg(feature = "sqlite")]
             HistoryFileFormat::Sqlite => {
                 SqliteBackedHistory::with_file(history_path.clone(), None, None)
                     .map(|inner| {
@@ -102,6 +104,7 @@ impl Command for History {
                     history_path,
                 ))?
                 .into_pipeline_data(head, signals)),
+            #[cfg(feature = "sqlite")]
             HistoryFileFormat::Sqlite => Ok(history_reader
                 .and_then(|h| {
                     h.search(SearchQuery::everything(SearchDirection::Forward, None))
@@ -142,6 +145,7 @@ impl Command for History {
     }
 }
 
+#[cfg(feature = "sqlite")]
 fn create_sqlite_history_record(idx: usize, entry: HistoryItem, long: bool, head: Span) -> Value {
     //1. Format all the values
     //2. Create a record of either short or long columns and values

--- a/crates/nu-cli/src/commands/history/mod.rs
+++ b/crates/nu-cli/src/commands/history/mod.rs
@@ -1,8 +1,15 @@
 mod fields;
 mod history_;
-mod history_import;
-mod history_session;
 
 pub use history_::History;
+
+// if more history formats are added, will need to reconsider this
+#[cfg(feature = "sqlite")]
+mod history_import;
+#[cfg(feature = "sqlite")]
+mod history_session;
+
+#[cfg(feature = "sqlite")]
 pub use history_import::HistoryImport;
+#[cfg(feature = "sqlite")]
 pub use history_session::HistorySession;

--- a/crates/nu-cli/src/commands/mod.rs
+++ b/crates/nu-cli/src/commands/mod.rs
@@ -7,7 +7,7 @@ mod keybindings_list;
 mod keybindings_listen;
 
 pub use commandline::{Commandline, CommandlineEdit, CommandlineGetCursor, CommandlineSetCursor};
-pub use history::{History, HistoryImport, HistorySession};
+pub use history::*;
 pub use keybindings::Keybindings;
 pub use keybindings_default::KeybindingsDefault;
 pub use keybindings_list::KeybindingsList;

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -34,9 +34,11 @@ use nu_utils::{
     filesystem::{PermissionResult, have_permission},
     perf,
 };
+#[cfg(feature = "sqlite")]
+use reedline::SqliteBackedHistory;
 use reedline::{
     CursorConfig, CwdAwareHinter, DefaultCompleter, EditCommand, Emacs, FileBackedHistory,
-    HistorySessionId, Reedline, SqliteBackedHistory, Vi,
+    HistorySessionId, Reedline, Vi,
 };
 use std::sync::atomic::Ordering;
 use std::{
@@ -512,10 +514,11 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
     let line_editor_input_time = std::time::Instant::now();
     match input {
         Ok(Signal::Success(repl_cmd_line_text)) => {
-            let history_supports_meta = matches!(
-                engine_state.history_config().map(|h| h.file_format),
-                Some(HistoryFileFormat::Sqlite)
-            );
+            let history_supports_meta = match engine_state.history_config().map(|h| h.file_format) {
+                #[cfg(feature = "sqlite")]
+                Some(HistoryFileFormat::Sqlite) => true,
+                _ => false,
+            };
 
             if history_supports_meta {
                 prepare_history_metadata(
@@ -1232,6 +1235,7 @@ fn update_line_editor_history(
             FileBackedHistory::with_file(history.max_size as usize, history_path)
                 .into_diagnostic()?,
         ),
+        #[cfg(feature = "sqlite")]
         HistoryFileFormat::Sqlite => Box::new(
             SqliteBackedHistory::with_file(
                 history_path.to_path_buf(),

--- a/crates/nu-cli/tests/commands/mod.rs
+++ b/crates/nu-cli/tests/commands/mod.rs
@@ -1,3 +1,5 @@
-mod history_import;
 mod keybindings_list;
 mod nu_highlight;
+
+#[cfg(feature = "sqlite")]
+mod history_import;

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -66,6 +66,8 @@ plugin = [
   "os",
   "rmp-serde",
 ]
+# enables SQLite history
+sqlite = []
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/nu-protocol/src/config/history.rs
+++ b/crates/nu-protocol/src/config/history.rs
@@ -4,6 +4,7 @@ use crate::{self as nu_protocol, ConfigWarning};
 #[derive(Clone, Copy, Debug, IntoValue, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HistoryFileFormat {
     /// Store history as an SQLite database with additional context
+    #[cfg(feature = "sqlite")]
     Sqlite,
     /// store history as a plain text file where every line is one command (without any context such as timestamps)
     Plaintext,
@@ -13,6 +14,7 @@ impl HistoryFileFormat {
     pub fn default_file_name(self) -> std::path::PathBuf {
         match self {
             HistoryFileFormat::Plaintext => "history.txt",
+            #[cfg(feature = "sqlite")]
             HistoryFileFormat::Sqlite => "history.sqlite3",
         }
         .into()
@@ -24,9 +26,13 @@ impl FromStr for HistoryFileFormat {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_ascii_lowercase().as_str() {
+            #[cfg(feature = "sqlite")]
             "sqlite" => Ok(Self::Sqlite),
             "plaintext" => Ok(Self::Plaintext),
+            #[cfg(feature = "sqlite")]
             _ => Err("'sqlite' or 'plaintext'"),
+            #[cfg(not(feature = "sqlite"))]
+            _ => Err("'plaintext'"),
         }
     }
 }
@@ -104,6 +110,7 @@ impl UpdateFromValue for HistoryConfig {
                     help: r#"disable history isolation, or set $env.config.history.file_format = "sqlite""#,
                 });
             }
+            #[cfg(feature = "sqlite")]
             (true, HistoryFileFormat::Sqlite) => (),
             (false, _) => (),
         }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -89,6 +89,7 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
             |e| e,
             |mut path| {
                 match engine_state.config.history.file_format {
+                    #[cfg(feature = "sqlite")]
                     HistoryFileFormat::Sqlite => {
                         path.push("history.sqlite3");
                     }


### PR DESCRIPTION
This PR gates the reedline SQLite history behind the top-level crate's `sqlite` feature. Reedline already feature gates the SQLite history, but currently Nushell always pulls it in anyways. Gating the reedline `sqlite` feature behind Nushell's `sqlite` feature makes it possible to build Nushell without pulling in SQLite at all, which can shave off a couple seconds during compilation, especially for the test and release profiles.

Here's the commands I used for testing:
```
cargo clean --release
cargo build --release --no-default-features --features plugin,rustls-tls,system-clipboard,trash-support
```

Here's the time the `cargo build` command took on my system (using the default `.cargo/config.toml`)
* `main`: 2m 34s
* `sqlite-history-gate`: 2m 24s

Some of the `#[cfg(feature = "sqlite")]`s are pretty haphazard, @cptpiepmatz you might have some better ideas on how to make it a bit nicer and this may also conflict with your SQLite changes

## Release notes summary - What our users need to know
Nushell can now be built without pulling in SQLite as a dependency.
