### PR TITLE
Rename {MULTILINE_INDICATOR,INDICATOR_MULTILINE}

### DIFF
--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -14,7 +14,7 @@ pub(crate) const PROMPT_COMMAND_RIGHT: &str = "PROMPT_COMMAND_RIGHT";
 pub(crate) const PROMPT_INDICATOR: &str = "PROMPT_INDICATOR";
 pub(crate) const PROMPT_INDICATOR_VI_INSERT: &str = "PROMPT_INDICATOR_VI_INSERT";
 pub(crate) const PROMPT_INDICATOR_VI_NORMAL: &str = "PROMPT_INDICATOR_VI_NORMAL";
-pub(crate) const PROMPT_MULTILINE_INDICATOR: &str = "PROMPT_MULTILINE_INDICATOR";
+pub(crate) const PROMPT_INDICATOR_MULTILINE: &str = "PROMPT_INDICATOR_MULTILINE";
 pub(crate) const TRANSIENT_PROMPT_COMMAND: &str = "TRANSIENT_PROMPT_COMMAND";
 pub(crate) const TRANSIENT_PROMPT_COMMAND_RIGHT: &str = "TRANSIENT_PROMPT_COMMAND_RIGHT";
 pub(crate) const TRANSIENT_PROMPT_INDICATOR: &str = "TRANSIENT_PROMPT_INDICATOR";
@@ -22,8 +22,8 @@ pub(crate) const TRANSIENT_PROMPT_INDICATOR_VI_INSERT: &str =
     "TRANSIENT_PROMPT_INDICATOR_VI_INSERT";
 pub(crate) const TRANSIENT_PROMPT_INDICATOR_VI_NORMAL: &str =
     "TRANSIENT_PROMPT_INDICATOR_VI_NORMAL";
-pub(crate) const TRANSIENT_PROMPT_MULTILINE_INDICATOR: &str =
-    "TRANSIENT_PROMPT_MULTILINE_INDICATOR";
+pub(crate) const TRANSIENT_PROMPT_INDICATOR_MULTILINE: &str =
+    "TRANSIENT_PROMPT_INDICATOR_MULTILINE";
 
 // Store all these Ansi Escape Markers here so they can be reused easily
 // According to Daniel Imms @Tyriar, we need to do these this way:
@@ -142,7 +142,7 @@ pub(crate) fn update_prompt(
     let prompt_indicator_string = get_prompt_string(PROMPT_INDICATOR, config, engine_state, stack);
 
     let prompt_multiline_string =
-        get_prompt_string(PROMPT_MULTILINE_INDICATOR, config, engine_state, stack);
+        get_prompt_string(PROMPT_INDICATOR_MULTILINE, config, engine_state, stack);
 
     let prompt_vi_insert_string =
         get_prompt_string(PROMPT_INDICATOR_VI_INSERT, config, engine_state, stack);
@@ -201,7 +201,7 @@ pub(crate) fn make_transient_prompt(
     }
 
     if let Some(s) = get_prompt_string(
-        TRANSIENT_PROMPT_MULTILINE_INDICATOR,
+        TRANSIENT_PROMPT_INDICATOR_MULTILINE,
         config,
         engine_state,
         stack,

--- a/crates/nu-command/src/platform/input/reedline_prompt.rs
+++ b/crates/nu-command/src/platform/input/reedline_prompt.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 /// The default prompt indicator
 pub static DEFAULT_VI_INSERT_PROMPT_INDICATOR: &str = ": ";
 pub static DEFAULT_VI_NORMAL_PROMPT_INDICATOR: &str = "〉";
-pub static DEFAULT_MULTILINE_INDICATOR: &str = "::: ";
+pub static DEFAULT_INDICATOR_MULTILINE: &str = "::: ";
 
 /// Simple [`Prompt`] displaying a configurable left and a right prompt.
 /// For more fine-tuned configuration, implement the [`Prompt`] trait.
@@ -41,7 +41,7 @@ impl Prompt for ReedlinePrompt {
     }
 
     fn render_prompt_multiline_indicator(&self) -> Cow<'_, str> {
-        Cow::Borrowed(DEFAULT_MULTILINE_INDICATOR)
+        Cow::Borrowed(DEFAULT_INDICATOR_MULTILINE)
     }
 
     fn render_prompt_history_search_indicator(

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -875,7 +875,7 @@ $env.PROMPT_INDICATOR_VI_NORMAL = "> "
 $env.PROMPT_INDICATOR_VI_INSERT = ": "
 
 # When a commandline extends across multiple lines:
-$env.PROMPT_MULTILINE_INDICATOR = "::: "
+$env.PROMPT_INDICATOR_MULTILINE = "::: "
 
 # TRANSIENT_PROMPT_*
 # ------------------
@@ -890,7 +890,7 @@ $env.TRANSIENT_PROMPT_INDICATOR_VI_INSERT = ""
 $env.TRANSIENT_PROMPT_INDICATOR_VI_NORMAL = ""
 # Tip: Removing the transient multiline indicator and right-prompt can simplify
 #      copying from the terminal
-$env.TRANSIENT_PROMPT_MULTILINE_INDICATOR = ""
+$env.TRANSIENT_PROMPT_INDICATOR_MULTILINE = ""
 $env.TRANSIENT_PROMPT_COMMAND_RIGHT = ""
 
 # ENV_CONVERSIONS

--- a/src/main.rs
+++ b/src/main.rs
@@ -505,11 +505,11 @@ fn main() -> Result<()> {
             Value::test_string(": "),
         );
         engine_state.add_env_var(
-            "PROMPT_MULTILINE_INDICATOR".to_string(),
+            "PROMPT_INDICATOR_MULTILINE".to_string(),
             Value::test_string("::: "),
         );
         engine_state.add_env_var(
-            "TRANSIENT_PROMPT_MULTILINE_INDICATOR".to_string(),
+            "TRANSIENT_PROMPT_INDICATOR_MULTILINE".to_string(),
             Value::test_string(""),
         );
         engine_state.add_env_var(


### PR DESCRIPTION
Would this be a good change to make?

My reasoning is that I was trying to configure my nushell multiline indicator for 45+ minutes, and I was setting it to the wrong name 🤣 as I was assuming that the variable in the $env would be named in the same convention as the other INDICATOR values.

I had this in my config:

<img width="664" height="165" alt="image" src="https://github.com/user-attachments/assets/118ecbfe-5b4d-428d-b575-031455761c93" />
