### PR TITLE
Add `network` feature to top-level crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,7 +271,7 @@ tempfile = { workspace = true }
 [features]
 # Enable all features while still avoiding mutually exclusive features.
 # Use this if `--all-features` fails.
-full = ["plugin", "rustls-tls", "system-clipboard", "trash-support", "sqlite"]
+full = ["plugin", "rustls-tls", "system-clipboard", "trash-support", "sqlite", "network"]
 
 plugin = [
   # crates
@@ -288,6 +288,7 @@ plugin = [
   "nu-protocol/plugin",
 ]
 
+network = ["nu-command/network"]
 native-tls = ["nu-command/native-tls"]
 rustls-tls = ["nu-command/rustls-tls"]
 
@@ -295,6 +296,7 @@ default = [
   "plugin",
   "trash-support",
   "sqlite",
+  "network",
   "rustls-tls"
 ]
 stable = ["default"]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -174,11 +174,10 @@ features = [
 workspace = true
 
 [features]
-default = ["os", "rustls-tls"]
+default = ["os", "network", "rustls-tls"]
 os = [
 	# include other features
 	"js",
-	"network",
 	"nu-engine/os",
 	"nu-protocol/os",
 	"nu-utils/os",

--- a/crates/nu-command/src/formats/to/mod.rs
+++ b/crates/nu-command/src/formats/to/mod.rs
@@ -25,4 +25,5 @@ pub use tsv::ToTsv;
 pub use xml::ToXml;
 pub use yaml::{ToYaml, ToYml};
 
+#[cfg(any(feature = "network", feature = "sqlite"))]
 pub(crate) use json::value_to_json_value;


### PR DESCRIPTION
This PR promotes `nu-command`'s `network` feature into a top-level crate feature. This makes it possible to compile without the network commands. This also in turn makes it possible to compile Nushell without either `native-tls` or `rustls-tls`, as previously exactly one of these was required. Now, if you also disable the `network` feature, you can disable both `native-tls` and `rustls-tls`. This helps shave a few seconds off compile time.

I tested `main` with `rustls-tls` enabled, versus this branch with `network` and `rustls-tls` disabled. I wrote down the results and then accidentally closed that window so I don't have the numbers anymore, but it was more than 10 seconds faster and less than 20 seconds faster. (source: dude trust me) 

## Release notes summary - What our users need to know
Nushell can now be compiled without network related commands.

## Tasks after submitting
- [ ] It seems like `ureq` is still in the dependency tree even with `network` disabled, so not sure what's up with that