### PR TITLE
Improve error messages for invalid binary strings

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -106,6 +106,9 @@ pub fn is_math_expression_like(working_set: &mut StateWorkingSet, span: Span) ->
     working_set.parse_errors.truncate(starting_error_count);
 
     parse_binary(working_set, span);
+    // We need an additional negate match to check if the last error was unexpected
+    // or more specifically, if it was `ParseError::InvalidBinaryString`.
+    // If so, we supress the error and stop parsing to the next (which is `parse_range()`).
     if working_set.parse_errors.len() == starting_error_count {
         return true;
     } else if !matches!(
@@ -1723,7 +1726,7 @@ fn decode_with_base(s: &str, base: u32, digits_per_byte: usize) -> Result<Vec<u8
                 2 => "binary strings may contain only 0 or 1.",
                 8 => "octal strings must have a length that is a multiple of three and contain values between 0o000 and 0o377.",
                 16 => "hexadecimal strings may contain only the characters 0–9 and A–F.",
-                _ => "", // radix other than 2, 8, or 16 is an invalid radix
+                _ => "internal error: radix other than 2, 8, or 16 is not allowed."
             })
         })
         .collect()

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -108,7 +108,7 @@ pub fn is_math_expression_like(working_set: &mut StateWorkingSet, span: Span) ->
     parse_binary(working_set, span);
     // We need an additional negate match to check if the last error was unexpected
     // or more specifically, if it was `ParseError::InvalidBinaryString`.
-    // If so, we supress the error and stop parsing to the next (which is `parse_range()`).
+    // If so, we suppress the error and stop parsing to the next (which is `parse_range()`).
     if working_set.parse_errors.len() == starting_error_count {
         return true;
     } else if !matches!(

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -106,12 +106,13 @@ pub fn is_math_expression_like(working_set: &mut StateWorkingSet, span: Span) ->
     working_set.parse_errors.truncate(starting_error_count);
 
     parse_binary(working_set, span);
-    if working_set.parse_errors.len() == starting_error_count
-        || !matches!(
-            working_set.parse_errors.last(),
-            Some(ParseError::Expected(_, _))
-        )
-    {
+    if working_set.parse_errors.len() == starting_error_count {
+        return true;
+    } else if !matches!(
+        working_set.parse_errors.last(),
+        Some(ParseError::Expected(_, _))
+    ) {
+        working_set.parse_errors.truncate(starting_error_count);
         return true;
     }
     working_set.parse_errors.truncate(starting_error_count);

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -499,9 +499,13 @@ pub fn parse_binary_with_invalid_octal_format() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, b"0b[90]", true);
+    let block = parse(&mut working_set, None, b"0o[90]", true);
 
-    assert!(working_set.parse_errors.is_empty());
+    assert_eq!(working_set.parse_errors.len(), 1);
+    assert!(matches!(
+        working_set.parse_errors.first(),
+        Some(ParseError::InvalidBinaryString(_, _))
+    ));
     assert_eq!(block.len(), 1);
     let pipeline = &block.pipelines[0];
     assert_eq!(pipeline.len(), 1);
@@ -519,7 +523,11 @@ pub fn parse_binary_with_multi_byte_char() {
     let contents = b"0x[\xEF\xBF\xBD]";
     let block = parse(&mut working_set, None, contents, true);
 
-    assert!(working_set.parse_errors.is_empty());
+    assert_eq!(working_set.parse_errors.len(), 1);
+    assert!(matches!(
+        working_set.parse_errors.first(),
+        Some(ParseError::InvalidBinaryString(_, _))
+    ));
     assert_eq!(block.len(), 1);
     let pipeline = &block.pipelines[0];
     assert_eq!(pipeline.len(), 1);

--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -213,6 +213,10 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::incorrect_value), help("{2}"))]
     IncorrectValue(String, #[label("unexpected {0}")] Span, String),
 
+    #[error("Invalid binary string.")]
+    #[diagnostic(code(nu::parser::invalid_binary_string), help("{1}"))]
+    InvalidBinaryString(#[label("invalid binary string")] Span, String),
+
     #[error("Multiple rest params.")]
     #[diagnostic(code(nu::parser::multiple_rest_params))]
     MultipleRestParams(#[label = "multiple rest params"] Span),
@@ -588,6 +592,7 @@ impl ParseError {
             ParseError::NameIsBuiltinVar(_, s) => *s,
             ParseError::CaptureOfMutableVar(s) => *s,
             ParseError::IncorrectValue(_, s, _) => *s,
+            ParseError::InvalidBinaryString(s, _) => *s,
             ParseError::MultipleRestParams(s) => *s,
             ParseError::VariableNotFound(_, s) => *s,
             ParseError::EnvVarNotVar(_, s) => *s,


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
Fixes #9566. Based on the decision from this PR #16678, instead of dealing with out-of-range octal strings, throwing a specific error is better.

Let me know if these error messages are too detailed and prefer just having  a single "out-of-range error".

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
Previously, a generic shell error is thrown for invalid binary strings. Now, an improve error message is thrown for invalid binary, hexadecimal, and octal strings.
```nushell
> 0b[121]
# => Error: nu::parser::invalid_binary_string
# => 
# => × Invalid binary string.
# =>   ╭─[entry #1:1:1]
# => 1 │ 0b[121]
# =>   · ───┬───
# =>   ·    ╰── invalid binary string
# =>   ╰────
# =>  help: binary strings may contain only 0 or 1.
```
## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- N/A