### PR TITLE
Load experimental options before command context is loaded

### DIFF
--- a/crates/nu-cmd-lang/src/default_context.rs
+++ b/crates/nu-cmd-lang/src/default_context.rs
@@ -2,8 +2,11 @@ use crate::*;
 use nu_protocol::engine::{EngineState, StateWorkingSet};
 
 pub fn create_default_context() -> EngineState {
-    let mut engine_state = EngineState::new();
+    let engine_state = EngineState::new();
+    add_default_context(engine_state)
+}
 
+pub fn add_default_context(mut engine_state: EngineState) -> EngineState {
     let delta = {
         let mut working_set = StateWorkingSet::new(&engine_state);
 

--- a/src/command_context.rs
+++ b/src/command_context.rs
@@ -1,7 +1,7 @@
 use nu_protocol::engine::EngineState;
 
-pub(crate) fn get_engine_state() -> EngineState {
-    let engine_state = nu_cmd_lang::create_default_context();
+pub(crate) fn add_command_context(engine_state: EngineState) -> EngineState {
+    let engine_state = nu_cmd_lang::add_default_context(engine_state);
     #[cfg(feature = "plugin")]
     let engine_state = nu_cmd_plugin::add_plugin_command_context(engine_state);
     let engine_state = nu_command::add_shell_command_context(engine_state);
@@ -27,7 +27,7 @@ mod tests {
             }
         }
 
-        let ctx = get_engine_state();
+        let ctx = add_command_context(EngineState::new());
         let decls = ctx.get_decls_sorted(true);
         let mut failures = Vec::new();
 
@@ -77,7 +77,7 @@ mod tests {
             }
         }
 
-        let ctx = get_engine_state();
+        let ctx = add_command_context(EngineState::new());
         let decls = ctx.get_decls_sorted(true);
         let mut failures = Vec::new();
 
@@ -108,7 +108,7 @@ mod tests {
 
     #[test]
     fn signature_name_matches_command_name() {
-        let ctx = get_engine_state();
+        let ctx = add_command_context(EngineState::new());
         let decls = ctx.get_decls_sorted(true);
         let mut failures = Vec::new();
 
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn commands_declare_input_output_types() {
-        let ctx = get_engine_state();
+        let ctx = add_command_context(EngineState::new());
         let decls = ctx.get_decls_sorted(true);
         let mut failures = Vec::new();
 
@@ -164,7 +164,7 @@ mod tests {
 
     #[test]
     fn no_search_term_duplicates() {
-        let ctx = get_engine_state();
+        let ctx = add_command_context(EngineState::new());
         let decls = ctx.get_decls_sorted(true);
         let mut failures = Vec::new();
 
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn description_end_period() {
-        let ctx = get_engine_state();
+        let ctx = add_command_context(EngineState::new());
         let decls = ctx.get_decls_sorted(true);
         let mut failures = Vec::new();
 
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn description_start_uppercase() {
-        let ctx = get_engine_state();
+        let ctx = add_command_context(EngineState::new());
         let decls = ctx.get_decls_sorted(true);
         let mut failures = Vec::new();
 


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

Currently it's not possible to modify what commands are available easily using experimental options. This PR changes that by moving the nu args parsing above loading the command context. This way we can apply the experimental options changes before loading the commands and allow to load different commands based on experimental options.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
N/A