### PR TITLE
fix(lsp): panic on goto std files

### DIFF
--- a/crates/nu-lsp/src/goto.rs
+++ b/crates/nu-lsp/src/goto.rs
@@ -200,18 +200,15 @@ mod tests {
         if let Some(name) = expected_file {
             target_uri = target_uri.replace(filename, name);
         }
-        assert_json_eq!(
-            result.pointer("/uri").unwrap(),
-            serde_json::json!(target_uri)
-        );
+        assert_json_eq!(result["uri"], serde_json::json!(target_uri));
         let (line, character) = expected_start;
         assert_json_eq!(
-            result.pointer("/range/start").unwrap(),
+            result["range"]["start"],
             serde_json::json!({ "line": line, "character": character })
         );
         if let Some((line, character)) = expected_end {
             assert_json_eq!(
-                result.pointer("/range/end").unwrap(),
+                result["range"]["end"],
                 serde_json::json!({ "line": line, "character": character })
             );
         }
@@ -265,9 +262,7 @@ mod tests {
         match resp {
             Message::Notification(Notification { params, .. }) => {
                 assert!(
-                    params
-                        .pointer("/message")
-                        .unwrap()
+                    params["message"]
                         .to_string()
                         .contains("absolute path is expected")
                 );

--- a/crates/nu-lsp/src/goto.rs
+++ b/crates/nu-lsp/src/goto.rs
@@ -15,6 +15,11 @@ impl LanguageServer {
         for cached_file in files.into_iter() {
             if cached_file.covered_span.contains(span.start) {
                 let path = Path::new(&*cached_file.name);
+                // skip nu-std files
+                // TODO: maybe find it in vendor directories?
+                if path.is_relative() {
+                    continue;
+                }
                 let target_uri = path_to_uri(path);
                 if let Some(file) = self.docs.lock().ok()?.get_document(&target_uri) {
                     return Some(Location {

--- a/crates/nu-lsp/src/hover.rs
+++ b/crates/nu-lsp/src/hover.rs
@@ -263,9 +263,7 @@ mod hover_tests {
         let resp = send_hover_request(&client_connection, script, line, character);
 
         assert_json_eq!(
-            result_from_message(resp)
-                .pointer("/contents/value")
-                .unwrap(),
+            result_from_message(resp)["contents"]["value"],
             serde_json::json!(expected)
         );
     }
@@ -281,12 +279,7 @@ mod hover_tests {
         open_unchecked(&client_connection, script.clone());
         let resp = send_hover_request(&client_connection, script, 6, 2);
 
-        let hover_text = result_from_message(resp)
-            .pointer("/contents/value")
-            .unwrap()
-            .as_str()
-            .unwrap()
-            .to_string();
+        let hover_text = result_from_message(resp)["contents"]["value"].to_string();
 
         #[cfg(not(windows))]
         assert!(hover_text.contains("SLEEP"));
@@ -321,11 +314,7 @@ mod hover_tests {
         let resp = send_hover_request(&client_connection, script_uri, line, character);
         let result = result_from_message(resp);
 
-        let actual = result
-            .pointer("/contents/value")
-            .unwrap()
-            .to_string()
-            .replace("\\r", "");
+        let actual = result["contents"]["value"].to_string().replace("\\r", "");
 
         assert!(actual.starts_with(expected_prefix));
     }

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -2,8 +2,8 @@
 use lsp_server::{Connection, IoThreads, Message, Response, ResponseError};
 use lsp_textdocument::{FullTextDocument, TextDocuments};
 use lsp_types::{
-    InlayHint, OneOf, Position, Range, ReferencesOptions, RenameOptions, SemanticToken,
-    SemanticTokenType, SemanticTokensLegend, SemanticTokensOptions,
+    InlayHint, MessageType, OneOf, Position, Range, ReferencesOptions, RenameOptions,
+    SemanticToken, SemanticTokenType, SemanticTokensLegend, SemanticTokensOptions,
     SemanticTokensServerCapabilities, ServerCapabilities, SignatureHelpOptions,
     TextDocumentSyncKind, Uri, WorkDoneProgressOptions, WorkspaceFolder,
     WorkspaceFoldersServerCapabilities, WorkspaceServerCapabilities,
@@ -291,6 +291,10 @@ impl LanguageServer {
     pub(crate) fn cancel_background_thread(&mut self) {
         if let Some((sender, _)) = &self.channels {
             sender.send(true).ok();
+            let _ = self.send_log_message(
+                MessageType::WARNING,
+                "Workspace-wide search took too long!".into(),
+            );
         }
     }
 

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -514,7 +514,7 @@ mod tests {
 
         let _initialize_response = client_connection
             .receiver
-            .recv_timeout(Duration::from_secs(2))
+            .recv_timeout(Duration::from_secs(5))
             .unwrap();
 
         (client_connection, recv)

--- a/crates/nu-lsp/src/notification.rs
+++ b/crates/nu-lsp/src/notification.rs
@@ -1,8 +1,9 @@
 use crate::LanguageServer;
 use lsp_types::{
     DidChangeTextDocumentParams, DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, ProgressParams, ProgressParamsValue, ProgressToken, Uri,
-    WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressReport,
+    DidOpenTextDocumentParams, LogMessageParams, MessageType, ProgressParams, ProgressParamsValue,
+    ProgressToken, Uri, WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressEnd,
+    WorkDoneProgressReport,
     notification::{
         DidChangeTextDocument, DidChangeWorkspaceFolders, DidCloseTextDocument,
         DidOpenTextDocument, Notification, Progress,
@@ -65,6 +66,18 @@ impl LanguageServer {
         };
         let notification =
             lsp_server::Notification::new(Progress::METHOD.to_string(), progress_params);
+        self.connection
+            .sender
+            .send(lsp_server::Message::Notification(notification))
+            .into_diagnostic()
+    }
+
+    pub(crate) fn send_log_message(&self, typ: MessageType, message: String) -> Result<()> {
+        let log_params = LogMessageParams { typ, message };
+        let notification = lsp_server::Notification::new(
+            lsp_types::notification::LogMessage::METHOD.to_string(),
+            log_params,
+        );
         self.connection
             .sender
             .send(lsp_server::Message::Notification(notification))

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -1003,10 +1003,7 @@ mod tests {
             match message {
                 Message::Notification(n) => {
                     if n.method == LogMessage::METHOD {
-                        assert_eq!(
-                            n.params.pointer("/message").unwrap().to_string(),
-                            "\"Workspace-wide search took too long!\""
-                        )
+                        assert_json_eq!(n.params["message"], "Workspace-wide search took too long!")
                     } else {
                         assert_eq!(n.method, Progress::METHOD)
                     };

--- a/tests/fixtures/lsp/goto/use_module.nu
+++ b/tests/fixtures/lsp/goto/use_module.nu
@@ -2,3 +2,7 @@ use module.nu "module name"
 overlay use module.nu as new_name
 overlay hide --keep-env [PWD] new_name
 hide "module name"
+
+# stdlib files are loaded virtually
+# goto_def on them should just fail without panic
+use std/log log-level


### PR DESCRIPTION
Fixes a new issue introduced by #16568 

```nushell
use std/assert
```

Goto def on `assert` will cause panic, since std files are cached with relative paths as names.

This PR simply skips those files.
Perhaps a better way would be to find them in the vendor std-lib directory, which I'm not sure how to get correctly.

## Release notes summary - What our users need to know

## Tasks after submitting
