### PR TITLE
Fix CI artifact upload on Windows runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,11 +99,20 @@ jobs:
       - name: Install Nushell
         run: cargo install --path . --locked --force
 
-      - name: Upload Nushell build
+      - name: Upload Nushell build (Ubuntu and macOS)
         uses: actions/upload-artifact@v4
+        if: runner.os != 'Windows'
         with:
           name: "nu-${{ github.event.number || github.ref_name }}-${{ matrix.platform }}"
           path: "~/.cargo/bin/nu"
+          retention-days: 14
+
+      - name: Upload Nushell build (Windows)
+        uses: actions/upload-artifact@v4
+        if: runner.os == 'Windows'
+        with:
+          name: "nu-${{ github.event.number || github.ref_name }}-${{ matrix.platform }}"
+          path: 'C:\Users\runneradmin\.cargo\bin\nu.exe'
           retention-days: 14
 
       - name: Standard library tests


### PR DESCRIPTION
I realized that the Windows runners weren't uploading Nushell binaries. This PR fixes that.

~~There might be a better solution but I cannot be bothered to find it. The tilde expansion works on CI for Linux and macOS, but not Windows. On the other hand, `$HOME` works on Windows but not on Linux and macOS. Wonderful.~~

## Release notes summary - What our users need to know
N/A