### PR TITLE
Fix confusing double negation with empty `else if`

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1799,11 +1799,10 @@ pub fn parse_number(working_set: &mut StateWorkingSet, span: Span) -> Expression
     let result = parse_int(working_set, span);
     if starting_error_count == working_set.parse_errors.len() {
         return result;
-    } else if !matches!(
+    } else if matches!(
         working_set.parse_errors.last(),
         Some(ParseError::Expected(_, _))
     ) {
-    } else {
         working_set.parse_errors.truncate(starting_error_count);
     }
 


### PR DESCRIPTION
This `else if` branch being empty makes no sense if there is no comment.
Can be collapsed by removing the negation on the `matches!`

Stumbled over this while reading https://github.com/nushell/nushell/pull/16688#discussion_r2350203575

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
- [ ] Figure out an `ast-grep` rule for that, sadly [`clippy::needless_else`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_else) doesn't seem to catch it.
