### PR TITLE
Fix autocomplete on clueless input

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -176,6 +176,7 @@ pub fn surround_remove(partial: &str) -> String {
     partial.to_string()
 }
 
+#[derive(Debug)]
 pub struct FileSuggestion {
     pub span: nu_protocol::Span,
     pub path: String,

--- a/crates/nu-utils/src/lib.rs
+++ b/crates/nu-utils/src/lib.rs
@@ -29,7 +29,7 @@ pub use flatten_json::JsonFlattener;
 pub use float::ObviousFloat;
 pub use multilife::MultiLife;
 pub use nu_cow::NuCow;
-pub use quoting::{escape_quote_string, needs_quoting};
+pub use quoting::{escape_quote_string, needs_quoting, split_quote_groups};
 pub use shared_cow::SharedCow;
 pub use split_read::SplitRead;
 

--- a/crates/nu-utils/src/quoting.rs
+++ b/crates/nu-utils/src/quoting.rs
@@ -48,18 +48,18 @@ enum State {
 }
 
 /// Splits a string into groups separated by whitespace, but keeps text inside quotes together.
-/// 
+///
 /// Supports `'`, `"`, and `` ` `` as quotes. Backslashes escape quotes (except inside backticks),
 /// and escaped characters are treated as part of the group.
-/// 
+///
 /// Example:
 /// ```rust
 /// assert_eq!(
-///     split_quote_groups("foo 'bar baz' qux"),
+///     nu_utils::split_quote_groups("foo 'bar baz' qux"),
 ///     vec!["foo", "'bar baz'", "qux"]
 /// );
 /// ```
-/// 
+///
 /// This function does not remove the quotes. It just groups the input so the caller can
 /// decide what to do with them later.
 pub fn split_quote_groups(input: &str) -> Vec<&str> {

--- a/crates/nu-utils/src/quoting.rs
+++ b/crates/nu-utils/src/quoting.rs
@@ -41,3 +41,115 @@ pub fn escape_quote_string(string: &str) -> String {
     output.push('"');
     output
 }
+
+enum State {
+    Unquoted,
+    InQuote(char),
+}
+
+/// Splits a string into groups separated by whitespace, but keeps text inside quotes together.
+/// 
+/// Supports `'`, `"`, and `` ` `` as quotes. Backslashes escape quotes (except inside backticks),
+/// and escaped characters are treated as part of the group.
+/// 
+/// Example:
+/// ```rust
+/// assert_eq!(
+///     split_quote_groups("foo 'bar baz' qux"),
+///     vec!["foo", "'bar baz'", "qux"]
+/// );
+/// ```
+/// 
+/// This function does not remove the quotes. It just groups the input so the caller can
+/// decide what to do with them later.
+pub fn split_quote_groups(input: &str) -> Vec<&str> {
+    let mut out = Vec::with_capacity(4); // gut feeling start
+
+    let mut group_start = 0;
+    let mut state = State::Unquoted;
+    let mut escaped = false;
+
+    for (i, c) in input.char_indices() {
+        match state {
+            State::Unquoted => match c {
+                c if c.is_whitespace() => {
+                    out.push(&input[group_start..i]);
+                    group_start = i + 1;
+                }
+                '\'' | '"' | '`' if !escaped => state = State::InQuote(c),
+                '\\' => escaped = !escaped,
+                _ => escaped = false,
+            },
+            State::InQuote(q) => match c {
+                c if c == q && !escaped => state = State::Unquoted,
+                '\\' if q != '`' => escaped = !escaped,
+                _ => escaped = false,
+            },
+        }
+    }
+
+    out.push(&input[group_start..]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use split_quote_groups as sqg;
+
+    #[test]
+    fn split_quote_groups_works() {
+        assert_eq!(sqg("abc"), vec!["abc"]);
+        assert_eq!(sqg("abc def"), vec!["abc", "def"]);
+        assert_eq!(
+            sqg(r#""with space" without"#),
+            vec![r#""with space""#, "without"]
+        );
+        assert_eq!(sqg(r#""with 'quote'""#), vec![r#""with 'quote'""#]);
+        assert_eq!(
+            sqg(r#"`escaping\` doesn't\matter`"#),
+            vec![r#"`escaping\`"#, r#"doesn't\matter`"#]
+        );
+        assert_eq!(
+            sqg(r#""escaping \" does" matter"#),
+            vec![r#""escaping \" does""#, "matter"]
+        );
+    }
+
+    #[test]
+    fn empty_input_is_single_empty_group() {
+        assert_eq!(sqg(""), vec![""]);
+    }
+
+    #[test]
+    fn preserves_empty_groups_from_whitespace_runs() {
+        assert_eq!(sqg("  a   b  "), vec!["", "", "a", "", "", "b", "", ""]);
+        assert_eq!(sqg("a  b   c"), vec!["a", "", "b", "", "", "c"]);
+        assert_eq!(sqg("a \t  b"), vec!["a", "", "", "", "b"]);
+    }
+
+    #[test]
+    fn leading_and_trailing_whitespace_create_empty_edges() {
+        assert_eq!(sqg(" a"), vec!["", "a"]);
+        assert_eq!(sqg("a "), vec!["a", ""]);
+        assert_eq!(sqg(" a "), vec!["", "a", ""]);
+    }
+
+    #[test]
+    fn all_whitespace_is_all_empties_plus_final_empty() {
+        // three spaces -> 4 empty groups
+        assert_eq!(sqg("   "), vec!["", "", "", ""]);
+    }
+
+    #[test]
+    fn consecutive_whitespace_between_quotes_keeps_internal_empties() {
+        assert_eq!(sqg(r#""a"  "b""#), vec![r#""a""#, "", r#""b""#]);
+    }
+
+    #[test]
+    fn escaped_space_outside_quotes_is_still_a_split() {
+        assert_eq!(sqg(r"a\ b"), vec![r"a\", "b"]);
+        assert_eq!(sqg(r"one\ two  three"), vec![r"one\", "two", "", "three"]);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
- fixes #16712 

The autocomplete at the end of `nu-cli` when everything was tried and we fall back to file completion does not properly handle quoted strings which caues it to create too short prefixes. I tried to work around that issue by providing a function that groups quoted strings together and create a prefix from the last element of that list.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
N/A
