### PR TITLE
Fix for the confusing type mismatch error message in `bytes collect`

### DIFF
--- a/crates/nu-command/src/bytes/collect.rs
+++ b/crates/nu-command/src/bytes/collect.rs
@@ -11,7 +11,7 @@ impl Command for BytesCollect {
 
     fn signature(&self) -> Signature {
         Signature::build("bytes collect")
-            .input_output_types(vec![(Type::List(Box::new(Type::Binary)), Type::Binary)])
+            .input_output_types(vec![(Type::List(Box::new(Type::Binary)), Type::Binary), (Type::table(), Type::Binary)])
             .optional(
                 "separator",
                 SyntaxShape::Binary,


### PR DESCRIPTION
Fixes #16695 by updating the `input_output_types()` with `Type::table()`
## Release notes summary - What our users need to know

-->

## Tasks after submitting