### PR TITLE
Fix: Ensure `job unfreeze` skips killed jobs and resumes the latest surviving frozen job

### DIFF
--- a/crates/nu-command/src/experimental/job_unfreeze.rs
+++ b/crates/nu-command/src/experimental/job_unfreeze.rs
@@ -15,13 +15,17 @@ impl Command for JobUnfreeze {
     }
 
     fn description(&self) -> &str {
-        "Unfreeze a frozen process job in foreground."
+        "Unfreeze the latest existing frozen job in the foreground."
     }
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("job unfreeze")
             .category(Category::Experimental)
-            .optional("id", SyntaxShape::Int, "The process id to unfreeze.")
+            .optional(
+                "id",
+                SyntaxShape::Int,
+                "The process id to unfreeze. Without an id, resumes the most recently frozen existing job.",
+            )
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
     }
@@ -68,12 +72,12 @@ impl Command for JobUnfreeze {
         vec![
             Example {
                 example: "job unfreeze",
-                description: "Unfreeze the latest frozen job",
+                description: "Unfreeze the most recently frozen existing job",
                 result: None,
             },
             Example {
                 example: "job unfreeze 4",
-                description: "Unfreeze a specific frozen job by its PID",
+                description: "Unfreeze a specific frozen job by its id",
                 result: None,
             },
         ]
@@ -81,7 +85,8 @@ impl Command for JobUnfreeze {
 
     fn extra_description(&self) -> &str {
         r#"When a running process is frozen (with the SIGTSTP signal or with the Ctrl-Z key on unix),
-a background job gets registered for this process, which can then be resumed using this command."#
+a background job gets registered for this process, which can then be resumed using this command.
+When called without an id, this command resumes the most recently frozen existing job."#
     }
 }
 

--- a/crates/nu-protocol/src/engine/jobs.rs
+++ b/crates/nu-protocol/src/engine/jobs.rs
@@ -74,6 +74,19 @@ impl Jobs {
     }
 
     pub fn most_recent_frozen_job_id(&mut self) -> Option<JobId> {
+        let cached_is_valid = matches!(
+            self.last_frozen_job_id,
+            Some(id) if matches!(self.jobs.get(&id), Some(Job::Frozen(_)))
+        );
+
+        if !cached_is_valid {
+            self.last_frozen_job_id = self
+                .jobs
+                .iter()
+                .filter_map(|(id, job)| matches!(job, Job::Frozen(_)).then_some(*id))
+                .max();
+        }
+
         self.last_frozen_job_id
     }
 


### PR DESCRIPTION
**Summary**

* Recomputed `Jobs::most_recent_frozen_job_id` so the cached identifier is verified and, if stale, replaced with the most recent surviving frozen job entry.
* Updated `job unfreeze` to rely on this validated fallback when no ID is supplied.
* Refreshed the help text, examples, and extra description to highlight that the command resumes the latest *existing* frozen job.
* Added a Unix-only regression test that freezes two jobs, kills the newest, and ensures `job unfreeze` resumes the remaining job via a new `freeze_self` test bin wired into the dispatcher.

**Testing**

* ✅ `cargo clippy --all-targets -- -D warnings`
* ✅ `cargo test -p nu-command job_unfreeze_ignores_killed_most_recent_job -- --nocapture`

**Files Changed**

* `crates/nu-command/src/experimental/job_unfreeze.rs` (+10/−5)
* `crates/nu-command/tests/commands/job.rs` (+48/−1)
* `crates/nu-protocol/src/engine/jobs.rs` (+13/−0)
* `src/test_bins.rs` (+24/−0)

**Closes**

* Closes #16561
