### PR TITLE
Theming fix

### DIFF
--- a/crates/nu-color-config/src/nu_style.rs
+++ b/crates/nu-color-config/src/nu_style.rs
@@ -561,7 +561,7 @@ pub fn lookup_style(s: &str) -> Style {
         "grey85" | "xterm_grey85" => Color::Fixed(253).normal(),
         "grey89" | "xterm_grey89" => Color::Fixed(254).normal(),
         "grey93" | "xterm_grey93" => Color::Fixed(255).normal(),
-        _ => Color::White.normal(),
+        _ => Color::Default.normal(),
     }
 }
 

--- a/crates/nu-std/std/config/mod.nu
+++ b/crates/nu-std/std/config/mod.nu
@@ -76,8 +76,8 @@ export def light-theme [] {
         empty: blue
         # Closures can be used to choose colors for specific values.
         # The value (in this case, a bool) is piped into the closure.
-        # eg) {|| if $in { 'dark_cyan' } else { 'dark_gray' } }
-        bool: dark_cyan
+        # eg) {|| if $in { 'darkcyan' } else { 'dark_gray' } }
+        bool: darkcyan
         int: dark_gray
         filesize: cyan_bold
         duration: dark_gray


### PR DESCRIPTION
## Release notes summary - What our users need to know
### boolean coloring in light theme
When using `std/config light-theme`, booleans inside structures are now colored in dark cyan instead of white, which was very hard to read in combination with a light terminal background.

### changed fallback for unknown color names
If some named color in `$env.config.color_config` is misspelled or otherwise unknown to nu, the corresponding element is now colored using the terminal's default (as in `ansi reset`) instead of white.
