### PR TITLE
Add configuration for columnar menu traversal direction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6206,7 +6206,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.42.0"
-source = "git+https://github.com/nushell/reedline?rev=68084cde80e366fa5787079064bb65b710f23a97#68084cde80e366fa5787079064bb65b710f23a97"
+source = "git+https://github.com/nushell/reedline?branch=main#68084cde80e366fa5787079064bb65b710f23a97#68084cde80e366fa5787079064bb65b710f23a97"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6206,7 +6206,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.42.0"
-source = "git+https://github.com/nushell/reedline?branch=main#526b189d65a5533640ed3965ef64883aa785b808"
+source = "git+https://github.com/nushell/reedline?rev=68084cde80e366fa5787079064bb65b710f23a97#68084cde80e366fa5787079064bb65b710f23a97"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6206,7 +6206,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.42.0"
-source = "git+https://github.com/nushell/reedline?branch=main#68084cde80e366fa5787079064bb65b710f23a97#68084cde80e366fa5787079064bb65b710f23a97"
+source = "git+https://github.com/nushell/reedline?branch=main#68084cde80e366fa5787079064bb65b710f23a97"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -359,7 +359,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline", rev = "68084cde80e366fa5787079064bb65b710f23a97" }
 nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Run all benchmarks with `cargo bench`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -359,7 +359,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline", rev = "68084cde80e366fa5787079064bb65b710f23a97" }
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Run all benchmarks with `cargo bench`

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -13,8 +13,8 @@ use nu_protocol::{
 };
 use reedline::{
     ColumnarMenu, DescriptionMenu, DescriptionMode, EditCommand, IdeMenu, Keybindings, ListMenu,
-    MenuBuilder, Reedline, ReedlineEvent, ReedlineMenu, default_emacs_keybindings,
-    default_vi_insert_keybindings, default_vi_normal_keybindings,
+    MenuBuilder, Reedline, ReedlineEvent, ReedlineMenu, TraversalDirection,
+    default_emacs_keybindings, default_vi_insert_keybindings, default_vi_normal_keybindings,
 };
 use std::sync::Arc;
 
@@ -28,6 +28,7 @@ const DEFAULT_COMPLETION_MENU: &str = r#"
       columns: 4
       col_width: 20
       col_padding: 2
+      tab_traversal: "horizontal"
   }
   style: {
       text: green,
@@ -284,6 +285,23 @@ pub(crate) fn add_columnar_menu(
                 let col_padding = col_padding.as_int()?;
                 columnar_menu.with_column_padding(col_padding as usize)
             }
+            Err(_) => columnar_menu,
+        };
+
+        columnar_menu = match extract_value("tab_traversal", val, span) {
+            Ok(tab_traversal) => match tab_traversal.coerce_str()?.as_ref() {
+                "vertical" => columnar_menu.with_traversal_direction(TraversalDirection::Vertical),
+                "horizontal" => {
+                    columnar_menu.with_traversal_direction(TraversalDirection::Horizontal)
+                }
+                str => {
+                    return Err(ShellError::InvalidValue {
+                        valid: "'horizontal' or 'vertical'".into(),
+                        actual: format!("'{str}'"),
+                        span: tab_traversal.span(),
+                    });
+                }
+            },
             Err(_) => columnar_menu,
         };
     }

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -525,6 +525,25 @@ $env.config.menus ++= [
     }
 ]
 
+# Example - Completion menu configuration
+$env.config.menus ++= [{
+    name: completion_menu
+    only_buffer_difference: false     # Search is done on the text written after activating the menu
+    marker: "| "                      # Indicator that appears with the menu is active
+    type: {
+        layout: columnar              # Type of menu
+        columns: 4                    # Number of columns where the options are displayed
+        col_width: 20                 # Optional value. If missing all the screen width is used to calculate column width
+        col_padding: 2                # Padding between columns
+        tab_traversal: "horizontal"   # Direction in which pressing <Tab> will cycle through options, "horizontal" or "vertical"
+    }
+    style: {
+        text: green                   # Text style
+        selected_text: green_reverse  # Text style for selected option
+        description_text: yellow      # Text style for description
+    }
+}]
+
 # ---------------
 # Plugin behavior
 # ---------------


### PR DESCRIPTION
Make columnar menu tab traversal direction configurable. The configurable traversal direction feature was added to `reedline` with https://github.com/nushell/reedline/pull/951. This PR makes that configuration option available in `nushell`.

## Release notes summary - What our users need to know

The feature makes it possible to choose the direction that items are placed in the columnar menu. With the default value of `"horizontal"`, items are ordered left-to-right in each row, with later items appearing in rows below earlier items.
```
1   2   3   4
5   6   7   8
9   10
```
With the value set to `"vertical"`, items are ordered top-to-bottom in each column, with later items appearing in columns to the right of earlier items.
```
1   4   7   10
2   5   8
3   6   9
```

The configuration option is currently called "tab_traversal" with a default value of "horizontal".
A specific revision of reedline is pointed to in cargo.toml since the required changes are not available in any released version of reedline.



## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
