### PR TITLE
Make pipeline buffer size configurable

### DIFF
--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -18,6 +18,7 @@ pub use history::{HistoryConfig, HistoryFileFormat};
 pub use hooks::Hooks;
 pub use ls::LsConfig;
 pub use output::{BannerKind, ErrorStyle};
+pub use pipeline::{DEFAULT_PIPELINE_BUFFER_SIZE, PipelineConfig};
 pub use plugin_gc::{PluginGcConfig, PluginGcConfigs};
 pub use reedline::{CursorShapeConfig, EditBindings, NuCursorShape, ParsedKeybinding, ParsedMenu};
 pub use rm::RmConfig;
@@ -35,6 +36,7 @@ mod history;
 mod hooks;
 mod ls;
 mod output;
+mod pipeline;
 mod plugin_gc;
 mod prelude;
 mod reedline;
@@ -71,6 +73,7 @@ pub struct Config {
     pub display_errors: DisplayErrors,
     pub use_kitty_protocol: bool,
     pub highlight_resolved_externals: bool,
+    pub pipeline: PipelineConfig,
     /// Configuration for plugins.
     ///
     /// Users can provide configuration for a plugin through this entry.  The entry name must
@@ -127,6 +130,8 @@ impl Default for Config {
 
             use_kitty_protocol: false,
             highlight_resolved_externals: false,
+
+            pipeline: PipelineConfig::default(),
 
             plugins: HashMap::new(),
             plugin_gc: PluginGcConfigs::default(),
@@ -188,6 +193,7 @@ impl UpdateFromValue for Config {
                 "highlight_resolved_externals" => {
                     self.highlight_resolved_externals.update(val, path, errors)
                 }
+                "pipeline" => self.pipeline.update(val, path, errors),
                 "plugins" => self.plugins.update(val, path, errors),
                 "plugin_gc" => self.plugin_gc.update(val, path, errors),
                 "menus" => match Vec::from_value(val.clone()) {

--- a/crates/nu-protocol/src/config/pipeline.rs
+++ b/crates/nu-protocol/src/config/pipeline.rs
@@ -1,0 +1,71 @@
+use super::prelude::*;
+
+pub const DEFAULT_PIPELINE_BUFFER_SIZE: usize = 8192;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PipelineConfig {
+    #[serde(default = "default_buffer_size")]
+    pub buffer_size: usize,
+}
+
+const fn default_buffer_size() -> usize {
+    DEFAULT_PIPELINE_BUFFER_SIZE
+}
+
+impl Default for PipelineConfig {
+    fn default() -> Self {
+        Self {
+            buffer_size: DEFAULT_PIPELINE_BUFFER_SIZE,
+        }
+    }
+}
+
+impl PipelineConfig {
+    pub fn buffer_size(&self) -> usize {
+        self.buffer_size
+    }
+}
+
+impl IntoValue for PipelineConfig {
+    fn into_value(self, span: Span) -> Value {
+        record! {
+            "buffer_size" => Value::int(
+                i64::try_from(self.buffer_size).unwrap_or(i64::MAX),
+                span
+            )
+        }
+        .into_value(span)
+    }
+}
+
+impl UpdateFromValue for PipelineConfig {
+    fn update<'a>(
+        &mut self,
+        value: &'a Value,
+        path: &mut ConfigPath<'a>,
+        errors: &mut ConfigErrors,
+    ) {
+        let Value::Record { val: record, .. } = value else {
+            errors.type_mismatch(path, Type::record(), value);
+            return;
+        };
+
+        for (col, val) in record.iter() {
+            let path = &mut path.push(col);
+            match col.as_str() {
+                "buffer_size" => match val.as_int() {
+                    Ok(v) if v > 0 => {
+                        if let Ok(v) = usize::try_from(v) {
+                            self.buffer_size = v;
+                        } else {
+                            errors.invalid_value(path, "a usize value", val);
+                        }
+                    }
+                    Ok(_) => errors.invalid_value(path, "an int greater than 0", val),
+                    Err(_) => errors.type_mismatch(path, Type::Int, val),
+                },
+                _ => errors.unknown_option(path, val),
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `pipeline` config section with a configurable pipeline buffer size and keep the default at 8 KiB
- expose an engine-state helper to resolve the effective buffer size, honoring config and NU_PIPE_BUFFER_SIZE overrides
- update pipeline output and byte-stream copying to use the configurable chunk size when writing to stdout/stderr

## Testing
- `cargo fmt`
- `cargo test -p nu-protocol` *(fails: integration tests expect target/debug/nu binary in this environment)*
- `cargo test -p nu-protocol --lib`

closes #4020