### PR TITLE
Respecting $env.NO_PROXY

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -1295,11 +1295,10 @@ fn proxy_builder_from_env(
     if let Some(val) = stack
         .get_env_var(engine_state, "no_proxy")
         .or(stack.get_env_var(engine_state, "NO_PROXY"))
+        && let Ok(no_proxy) = val.as_str()
     {
-        if let Ok(no_proxy) = val.as_str() {
-            for proxy in no_proxy.split(',') {
-                builder = builder.no_proxy(proxy.trim());
-            }
+        for proxy in no_proxy.split(',') {
+            builder = builder.no_proxy(proxy.trim());
         }
     }
 

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -38,9 +38,11 @@ use std::{
 };
 use ureq::{
     Agent, Body, Error, RequestBuilder, ResponseExt, SendBody,
+    Proxy, ProxyBuilder, ProxyProtocol,
     typestate::{WithBody, WithoutBody},
     unversioned::transport::{ConnectProxyConnector, Connector, SocksConnector},
 };
+use std::convert::TryInto;
 use url::Url;
 
 #[cfg(feature = "native-tls")]
@@ -208,7 +210,8 @@ pub fn http_client(
     }
 
     if let Some(http_proxy) = retrieve_http_proxy_from_env(engine_state, stack)
-        && let Ok(proxy) = ureq::Proxy::new(&http_proxy)
+        && let Some(proxy) = proxy_builder_from_env(http_proxy, engine_state, stack)
+            .and_then(|builder| builder.build().ok())
     {
         config_builder = config_builder.proxy(Some(proxy));
     };
@@ -1266,9 +1269,81 @@ fn retrieve_http_proxy_from_env(engine_state: &EngineState, stack: &mut Stack) -
         .and_then(|proxy| proxy.coerce_into_string().ok())
 }
 
+fn proxy_builder_from_env(http_proxy: String, engine_state: &EngineState, stack: &mut Stack) -> Option<ProxyBuilder> {
+
+    let uri  = http_proxy.parse::<http::Uri>().ok()?;
+    let authority = uri.authority()?;
+    let scheme = uri.scheme_str().unwrap_or("http");
+    let proto: ProxyProtocol= scheme.try_into().ok()?;
+
+    let mut builder = Proxy::builder(proto)
+                        .host(authority.host());
+
+    if let Some(port) = uri.port() {
+        builder = builder.port(port.as_u16());
+    }
+
+    let (username, password) = retrieve_credential_from_authority(authority);
+    if let Some(username) = username {
+        builder = builder.username(username);
+        if let Some(password) = password {
+            builder = builder.password(password);
+        }
+    }
+
+    if let Some(val) = stack
+        .get_env_var(engine_state, "no_proxy")
+        .or(stack.get_env_var(engine_state, "NO_PROXY"))
+    {
+        if let Ok(no_proxy) = val.as_str() {
+            for proxy in no_proxy.split(',') {
+                builder = builder.no_proxy(proxy.trim());
+            }
+        }
+    }
+
+    Some(builder)
+}
+
+fn retrieve_credential_from_authority(authority: &http::uri::Authority) -> (Option<&str>, Option<&str>) {
+    let s = authority.as_str();
+    let user_info = s.rfind('@').map(|i| &s[..i]);
+    let username = user_info.map(|a| a.rfind(':').map(|i| &a[..i]).unwrap_or(a));
+    let password =  user_info.and_then(|a| a.rfind(':').map(|i| &a[i + 1..]));
+    (username, password)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
+
+
+    #[test]
+    fn test_retrieving_credentials_from_authority() {
+        // user and password
+        let uri = "http://user:pass@host/path".parse::<http::Uri>().unwrap();
+        let authority = uri.authority().unwrap();
+        let (user, pass) = retrieve_credential_from_authority(authority);
+        assert_eq!((user, pass), (Some("user"), Some("pass")));
+
+        // user and empty password
+        let uri = "http://user:@host/path".parse::<http::Uri>().unwrap();
+        let authority = uri.authority().unwrap();
+        let (user, pass) = retrieve_credential_from_authority(authority);
+        assert_eq!((user, pass), (Some("user"), Some("")));
+
+        // user only, no password
+        let uri = "http://user@host/path".parse::<http::Uri>().unwrap();
+        let authority = uri.authority().unwrap();
+        let (user, pass) = retrieve_credential_from_authority(authority);
+        assert_eq!((user, pass), (Some("user"), None));
+
+        // no user, no password
+        let uri = "http://host/path".parse::<http::Uri>().unwrap();
+        let authority = uri.authority().unwrap();
+        let (user, pass) = retrieve_credential_from_authority(authority);
+        assert_eq!((user, pass), (None, None));
+    }
 
     #[test]
     fn test_body_type_from_content_type() {

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -27,6 +27,7 @@ use nu_protocol::{
     },
 };
 use serde_json::Value as JsonValue;
+use std::convert::TryInto;
 use std::{
     collections::HashMap,
     io::{self, Cursor, Read},
@@ -37,12 +38,10 @@ use std::{
     time::Duration,
 };
 use ureq::{
-    Agent, Body, Error, RequestBuilder, ResponseExt, SendBody,
-    Proxy, ProxyBuilder, ProxyProtocol,
+    Agent, Body, Error, Proxy, ProxyBuilder, ProxyProtocol, RequestBuilder, ResponseExt, SendBody,
     typestate::{WithBody, WithoutBody},
     unversioned::transport::{ConnectProxyConnector, Connector, SocksConnector},
 };
-use std::convert::TryInto;
 use url::Url;
 
 #[cfg(feature = "native-tls")]
@@ -1269,15 +1268,17 @@ fn retrieve_http_proxy_from_env(engine_state: &EngineState, stack: &mut Stack) -
         .and_then(|proxy| proxy.coerce_into_string().ok())
 }
 
-fn proxy_builder_from_env(http_proxy: String, engine_state: &EngineState, stack: &mut Stack) -> Option<ProxyBuilder> {
-
-    let uri  = http_proxy.parse::<http::Uri>().ok()?;
+fn proxy_builder_from_env(
+    http_proxy: String,
+    engine_state: &EngineState,
+    stack: &mut Stack,
+) -> Option<ProxyBuilder> {
+    let uri = http_proxy.parse::<http::Uri>().ok()?;
     let authority = uri.authority()?;
     let scheme = uri.scheme_str().unwrap_or("http");
-    let proto: ProxyProtocol= scheme.try_into().ok()?;
+    let proto: ProxyProtocol = scheme.try_into().ok()?;
 
-    let mut builder = Proxy::builder(proto)
-                        .host(authority.host());
+    let mut builder = Proxy::builder(proto).host(authority.host());
 
     if let Some(port) = uri.port() {
         builder = builder.port(port.as_u16());
@@ -1305,18 +1306,19 @@ fn proxy_builder_from_env(http_proxy: String, engine_state: &EngineState, stack:
     Some(builder)
 }
 
-fn retrieve_credential_from_authority(authority: &http::uri::Authority) -> (Option<&str>, Option<&str>) {
+fn retrieve_credential_from_authority(
+    authority: &http::uri::Authority,
+) -> (Option<&str>, Option<&str>) {
     let s = authority.as_str();
     let user_info = s.rfind('@').map(|i| &s[..i]);
     let username = user_info.map(|a| a.rfind(':').map(|i| &a[..i]).unwrap_or(a));
-    let password =  user_info.and_then(|a| a.rfind(':').map(|i| &a[i + 1..]));
+    let password = user_info.and_then(|a| a.rfind(':').map(|i| &a[i + 1..]));
     (username, password)
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-
 
     #[test]
     fn test_retrieving_credentials_from_authority() {


### PR DESCRIPTION
https://github.com/algesten/ureq/commit/1ce334d329d5bdcc8f36126f34c7f61ba851c409 now reads the `NO_PROXY` variable automatically and handles proxy filter. As of writing this, the commit just got merged into main, `ureq` needs to be bumped to `3.1.x` for this work, the hard-coded git revision will be removed as soon as we have a release in ureq.

This implementation makes use of `ProxyBuilder` as the environment variables are scoped and ureq won't be able to read the value. The proxy builder is abstracted into `proxy_builder_from_env(2)` so that in the future we can also add a `--proxy-user` and `--proxy-pass` or `--no-proxy-list` to the `http` command.

## Release notes summary - What our users need to know
### `http` commands now respect the `$env.NO_PROXY` variable
`http` command now reads the environment variable `NO_PROXY` and supports the following patterns.
| Pattern         | Behavior |
------------------|-----------
| `example.com`   | Literally match `example.com`, but not `sub.example.com` |
| `.example.com`  | Match `sub.example.com` and `foo.sub.example.com`, but not `example.com`. |
| `*.example.com` | Exactly like `.example.com` |
| `*`             | Match everything |

> [!NOTE]
> Multiple patterns can be used by seperating them via comma and expressions that are not on the above form are ignored silently.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
