### PR TITLE
Refactor `each`

### DIFF
--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -119,7 +119,7 @@ with 'transpose' first."#
                 let mut closure = ClosureEval::new(engine_state, stack, closure);
                 Ok(input
                     .into_iter()
-                    .map_while(move |value| {
+                    .map(move |value| {
                         let span = value.span();
                         let is_error = value.is_error();
                         match closure.run_with_value(value) {
@@ -127,19 +127,19 @@ with 'transpose' first."#
                                 let mut vals = vec![];
                                 for v in s {
                                     if let Value::Error { .. } = v {
-                                        return Some(v);
+                                        return v;
                                     } else {
                                         vals.push(v)
                                     }
                                 }
-                                Some(Value::list(vals, span))
+                                Value::list(vals, span)
                             }
-                            Ok(data) => Some(data.into_value(head).unwrap_or_else(|err| {
+                            Ok(data) => data.into_value(head).unwrap_or_else(|err| {
                                 Value::error(chain_error_with_input(err, is_error, span), span)
-                            })),
+                            }),
                             Err(error) => {
                                 let error = chain_error_with_input(error, is_error, span);
-                                Some(Value::error(error, span))
+                                Value::error(error, span)
                             }
                         }
                     })
@@ -149,10 +149,10 @@ with 'transpose' first."#
                 if let Some(chunks) = stream.chunks() {
                     let mut closure = ClosureEval::new(engine_state, stack, closure);
                     Ok(chunks
-                        .map_while(move |value| {
+                        .map(move |value| {
                             let value = match value {
                                 Ok(value) => value,
-                                Err(err) => return Some(Value::error(err, head)),
+                                Err(err) => return Value::error(err, head),
                             };
 
                             let span = value.span();
@@ -161,10 +161,10 @@ with 'transpose' first."#
                                 .run_with_value(value)
                                 .and_then(|data| data.into_value(head))
                             {
-                                Ok(value) => Some(value),
+                                Ok(value) => value,
                                 Err(error) => {
                                     let error = chain_error_with_input(error, is_error, span);
-                                    Some(Value::error(error, span))
+                                    Value::error(error, span)
                                 }
                             }
                         })

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1769,6 +1769,14 @@ impl Value {
         matches!(self, Value::Error { .. })
     }
 
+    /// Extract [ShellError] from [Value::Error]
+    pub fn unwrap_error(self) -> Result<Self, ShellError> {
+        match self {
+            Self::Error { error, .. } => Err(*error),
+            val => Ok(val),
+        }
+    }
+
     pub fn is_true(&self) -> bool {
         matches!(self, Value::Bool { val: true, .. })
     }


### PR DESCRIPTION
Mostly clean up. Non-insignificant changes:
-   If the closure returned a stream, errors in the stream were not properly chained and lost outer/caller context:
    Running the following code:
    ```nushell
    0..1 | each {
        0..1 | each {|e|
            error make {msg: boom}
        }
    }
    ```
    we get:

    | Before | After  |
    |--------|--------|
    | ![error-chain-before] | ![error-chain-after] | 

-   Previously, `each`'s behavior on `ByteStream` inputs differed from `ListStream` inputs with regards to error handling. Now they use the same implementation.

-   Possible performance increase due to lifting `--keep-empty` check out of the `filter` closure.

<details><summary>Error Chain ANSI Output</summary>

Before:
```ansi
Error: [31mnu::shell::eval_block_with_input[0m

  [31m×[0m Eval block failed with pipeline input
   ╭─[[36;1;4msource:2:2[0m]
 [2m1[0m │ 0..1 | each {
 [2m2[0m │     0..1 | each {|e|
   · [35;1m    ──┬─[0m
   ·       [35;1m╰── [35;1msource value[0m[0m
 [2m3[0m │         error make {msg: boom}
   ╰────

Error: 
  [31m×[0m boom
   ╭─[[36;1;4msource:3:3[0m]
 [2m2[0m │     0..1 | each {|e|
 [2m3[0m │         error make {msg: boom}
   · [35;1m        ─────┬────[0m
   ·              [35;1m╰── [35;1moriginates from here[0m[0m
 [2m4[0m │     }
   ╰────
```

After:
```ansi
Error: [31mnu::shell::eval_block_with_input[0m

  [31m×[0m Eval block failed with pipeline input
   ╭─[[36;1;4msource:1:1[0m]
 [2m1[0m │ 0..1 | each {
   · [35;1m──┬─[0m
   ·   [35;1m╰── [35;1msource value[0m[0m
 [2m2[0m │     0..1 | each {|e|
   ╰────

Error: [31mnu::shell::eval_block_with_input[0m

  [31m×[0m Eval block failed with pipeline input
   ╭─[[36;1;4msource:2:2[0m]
 [2m1[0m │ 0..1 | each {
 [2m2[0m │     0..1 | each {|e|
   · [35;1m    ──┬─[0m
   ·       [35;1m╰── [35;1msource value[0m[0m
 [2m3[0m │         error make {msg: boom}
   ╰────

Error: 
  [31m×[0m boom
   ╭─[[36;1;4msource:3:3[0m]
 [2m2[0m │     0..1 | each {|e|
 [2m3[0m │         error make {msg: boom}
   · [35;1m        ─────┬────[0m
   ·              [35;1m╰── [35;1moriginates from here[0m[0m
 [2m4[0m │     }
   ╰────
```

</details>

[error-chain-before]: https://raw.githubusercontent.com/gist/Bahex/8cb76a8c183856287b8b98bfdf02cffc/raw/bf78b87dd7fcdff769c81ad8921cdba0dd095239/error-chain-before.svg
[error-chain-after]: https://raw.githubusercontent.com/gist/Bahex/8cb76a8c183856287b8b98bfdf02cffc/raw/bf78b87dd7fcdff769c81ad8921cdba0dd095239/error-chain-after.svg

## Release notes summary - What our users need to know
Errors raised in nested `each` calls now preserve their context.

## Tasks after submitting
N/A