### PR TITLE
feat: `each` can flatten streams from the closure without collecting

### DIFF
--- a/crates/nu-cli/src/menus/help_completions.rs
+++ b/crates/nu-cli/src/menus/help_completions.rs
@@ -140,7 +140,7 @@ mod test {
     use rstest::rstest;
 
     #[rstest]
-    #[case("who", 5, 8, &["whoami"])]
+    #[case("who", 5, 8, &["whoami", "each"])]
     #[case("hash", 1, 5, &["hash", "hash md5", "hash sha256"])]
     #[case("into f", 0, 6, &["into float", "into filesize"])]
     #[case("into nonexistent", 0, 16, &[])]

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -21,7 +21,20 @@ iterate over each record, not necessarily each cell within it.
 Avoid passing single records to this command. Since a record is a
 one-row structure, 'each' will only run once, behaving similar to 'do'.
 To iterate over a record's values, use 'items' or try converting it to a table
-with 'transpose' first."#
+with 'transpose' first.
+
+
+By default, for each input there is a single output value.
+If the closure returns a stream rather than value, the stream is collected
+completely, and the resulting value becomes one of the items in `each`'s output.
+
+To receive items from those streams without waiting for the whole stream to be
+collected, `each --flatten` can be used.
+Instead of waiting for the stream to be collected before returning the result as
+a single item, `each --flatten` will return each item as soon as they are received.
+
+This "flattens" the output, turning an output that would otherwise be a
+list of lists like `list<list<string>>` into a flat list like `list<string>`."#
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -99,6 +112,16 @@ with 'transpose' first."#
             Example {
                 example: r#"$env.name? | each { $"hello ($in)" } | default "bye""#,
                 description: "Update value if not null, otherwise do nothing",
+                result: None,
+            },
+            Example {
+                description: "Scan through multiple files without pause",
+                example: "\
+                    ls *.txt \
+                    | each --flatten {|f| open $f.name | lines } \
+                    | find -i 'note: ' \
+                    | str join \"\\n\"\
+                    ",
                 result: None,
             },
         ]

--- a/crates/nu-command/tests/commands/each.rs
+++ b/crates/nu-command/tests/commands/each.rs
@@ -78,3 +78,22 @@ fn each_noop_on_single_null() {
 
     assert_eq!(actual.out, "nothing");
 }
+
+#[test]
+fn each_flatten_dont_collect() {
+    let collected = nu!(r##"
+        def round  [] { each {|e| print -n $"\(($e)\)"; $e } }
+        def square [] { each {|e| print -n  $"[($e)]";  $e } }
+        [0 3] | each {|e| $e..<($e + 3) | round } | flatten | square | ignore
+    "##);
+
+    assert_eq!(collected.out, r#"(0)(1)(2)[0][1][2](3)(4)(5)[3][4][5]"#);
+
+    let streamed = nu!(r##"
+        def round  [] { each {|e| print -n $"\(($e)\)"; $e } }
+        def square [] { each {|e| print -n  $"[($e)]";  $e } }
+        [0 3] | each --flatten {|e| $e..<($e + 3) | round } | square | ignore
+    "##);
+
+    assert_eq!(streamed.out, r#"(0)[0](1)[1](2)[2](3)[3](4)[4](5)[5]"#);
+}


### PR DESCRIPTION
We don't have an actual flat_map for generated streams.

It feels like
```nushell
each {..} | flatten
```
would work, but unfortunately `each` has to collect the output of the closure due to the fact it returns a list, where each item is a **value** corresponding to an iteration of the closure.

We need either:
- a `--flat`/`--flatten` flag on `each`
- a separate `each` variant :bike::hut::
  - `each flat`
  - `each stream`
  - `each lazy`
  - `each concat`

<table>
<tr>
<th>

`each | flatten`

<th>

`each --flatten`

<tr>
<td>

```nushell
#
#
def slow-source [range: range] {
    $range | each {|e| sleep 0.1sec; $e }
}

0..10..<50
| each {|e| slow-source ($e)..<($e + 10) }
| flatten
| each {|e| print $e; $e}
| ignore
```

<td>

```nushell
#
#
def slow-source [range: range] {
    $range | each {|e| sleep 0.1sec; $e }
}

0..10..<50
| each --flatten {|e| slow-source ($e)..<($e + 10) }
# | flatten
| each {|e| print $e; $e}
| ignore
```

<tr>
<td>

[each-then-flatten-sad.webm](https://github.com/user-attachments/assets/7e8c7da7-2793-4176-a56c-4bffee8256dc)

<td>

[flat-each-yay.webm](https://github.com/user-attachments/assets/a3f9e3b0-f299-46cb-adaa-868211c69437)

</table>

## Release notes summary - What our users need to know
TODO

## Tasks after submitting
