### PR TITLE
Using `break`/`continue` outside loops raises a compile error

### DIFF
--- a/crates/nu-command/tests/commands/break_.rs
+++ b/crates/nu-command/tests/commands/break_.rs
@@ -15,3 +15,12 @@ fn break_while_loop() {
 
     assert_eq!(actual.out, "hello");
 }
+
+#[test]
+fn break_outside_loop() {
+    let actual = nu!(r#"break"#);
+    assert!(actual.err.contains("not_in_a_loop"));
+
+    let actual = nu!(r#"do { break }"#);
+    assert!(actual.err.contains("not_in_a_loop"));
+}

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -804,20 +804,15 @@ pub(crate) fn compile_break(
     _redirect_modes: RedirectModes,
     io_reg: RegId,
 ) -> Result<(), CompileError> {
-    if builder.is_in_loop() {
-        builder.load_empty(io_reg)?;
-        builder.push_break(call.head)?;
-        builder.add_comment("break");
-    } else {
-        // Fall back to calling the command if we can't find the loop target statically
-        builder.push(
-            Instruction::Call {
-                decl_id: call.decl_id,
-                src_dst: io_reg,
-            }
-            .into_spanned(call.head),
-        )?;
+    if !builder.is_in_loop() {
+        return Err(CompileError::NotInALoop {
+            msg: "'break' can only be used inside a loop".to_string(),
+            span: Some(call.head),
+        });
     }
+    builder.load_empty(io_reg)?;
+    builder.push_break(call.head)?;
+    builder.add_comment("break");
     Ok(())
 }
 
@@ -829,20 +824,15 @@ pub(crate) fn compile_continue(
     _redirect_modes: RedirectModes,
     io_reg: RegId,
 ) -> Result<(), CompileError> {
-    if builder.is_in_loop() {
-        builder.load_empty(io_reg)?;
-        builder.push_continue(call.head)?;
-        builder.add_comment("continue");
-    } else {
-        // Fall back to calling the command if we can't find the loop target statically
-        builder.push(
-            Instruction::Call {
-                decl_id: call.decl_id,
-                src_dst: io_reg,
-            }
-            .into_spanned(call.head),
-        )?;
+    if !builder.is_in_loop() {
+        return Err(CompileError::NotInALoop {
+            msg: "'continue' can only be used inside a loop".to_string(),
+            span: Some(call.head),
+        });
     }
+    builder.load_empty(io_reg)?;
+    builder.push_continue(call.head)?;
+    builder.add_comment("continue");
     Ok(())
 }
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2,7 +2,8 @@ use crate::{
     exportable::Exportable,
     parse_block,
     parser::{
-        CallKind, compile_block, parse_attribute, parse_redirection, redirecting_builtin_error,
+        CallKind, compile_block, compile_block_with_id, parse_attribute, parse_redirection,
+        redirecting_builtin_error,
     },
     type_check::{check_block_input_output, type_compatible},
 };
@@ -629,8 +630,8 @@ fn parse_def_inner(
                         expr: Expr::Closure(block_id),
                         ..
                     } => {
-                        let block = working_set.get_block_mut(*block_id);
-                        block.signature = Box::new(sig.clone());
+                        compile_block_with_id(working_set, *block_id);
+                        working_set.get_block_mut(*block_id).signature = Box::new(sig.clone());
                     }
                     _ => working_set.error(ParseError::Expected(
                         "definition body closure { ... }",
@@ -1744,6 +1745,8 @@ pub fn parse_export_env(
         Span::concat(spans),
         Type::Any,
     )]);
+
+    compile_block_with_id(working_set, block_id);
 
     (pipeline, Some(block_id))
 }


### PR DESCRIPTION
- Depends on #16634
- Closes #16271 

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A