### PR TITLE
set pipefail issue number

### DIFF
--- a/crates/nu-experimental/src/options/pipefail.rs
+++ b/crates/nu-experimental/src/options/pipefail.rs
@@ -18,5 +18,5 @@ impl ExperimentalOptionMarker for PipeFail {
         to the exit code of rightmost command which failed.";
     const STATUS: Status = Status::OptIn;
     const SINCE: Version = (0, 107, 1);
-    const ISSUE: u32 = 0;
+    const ISSUE: u32 = 16760;
 }


### PR DESCRIPTION
Setting up issue number for pipefail experimental option.

## Release notes summary - What our users need to know
NaN

## Tasks after submitting
NaN