### PR TITLE
Command-wide completions

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -12,6 +12,7 @@ use reedline::Suggestion;
 
 use super::{SemanticSuggestion, completion_options::NuMatcher};
 
+// TODO: Add a toggle for quoting multi word commands. Useful for: `which` and `attr complete`
 pub struct CommandCompletion {
     /// Whether to include internal commands
     pub internals: bool,

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -719,6 +719,15 @@ impl NuCompleter {
                 };
                 return self.process_completion(&mut completer, ctx);
             }
+            "attr complete" => {
+                *need_fallback = false;
+
+                let mut completer = CommandCompletion {
+                    internals: true,
+                    externals: false,
+                };
+                return self.process_completion(&mut completer, ctx);
+            }
             _ => (),
         }
 

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -461,9 +461,10 @@ impl NuCompleter {
                             let ctx = Context::new(working_set, span, b"", offset);
                             let results = self.process_completion(&mut completion, &ctx);
 
+                            // Prioritize external results over (sub)commands
+                            suggestions.splice(0..0, results);
+
                             if !completion.need_fallback {
-                                // Prioritize external results over (sub)commands
-                                suggestions.splice(0..0, results);
                                 return suggestions;
                             }
                         }
@@ -558,9 +559,10 @@ impl NuCompleter {
                             let ctx = Context::new(working_set, span, b"", offset);
                             let results = self.process_completion(&mut completion, &ctx);
 
+                            // Prioritize external results over (sub)commands
+                            suggestions.splice(0..0, results);
+
                             if !completion.need_fallback {
-                                // Prioritize external results over (sub)commands
-                                suggestions.splice(0..0, results);
                                 return suggestions;
                             }
                         }

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -7,7 +7,7 @@ use crate::completions::{
 use nu_color_config::{color_record_to_nustyle, lookup_ansi_color_style};
 use nu_parser::{parse, parse_module_file_or_dir};
 use nu_protocol::{
-    Completion, Span, Type, Value,
+    CommandWideCompleter, Completion, Span, Type, Value,
     ast::{Argument, Block, Expr, Expression, FindMapResult, ListItem, Traverse},
     engine::{EngineState, Stack, StateWorkingSet},
 };
@@ -461,13 +461,15 @@ impl NuCompleter {
                         };
 
                         let completion = match command_wide_completer {
-                            Some(decl_id) => CommandWideCompletion::command(
-                                working_set,
-                                decl_id,
-                                element_expression,
-                                strip,
-                            ),
-                            None => self
+                            CommandWideCompleter::Command(decl_id) => {
+                                CommandWideCompletion::command(
+                                    working_set,
+                                    decl_id,
+                                    element_expression,
+                                    strip,
+                                )
+                            }
+                            CommandWideCompleter::External => self
                                 .engine_state
                                 .get_config()
                                 .completions

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -268,17 +268,11 @@ impl<'a> Completer for CommandWideCompletion<'a> {
                 ),
             );
         }
-        let mut new_engine_state;
-        let engine_state = if self.block_id.get() < working_set.permanent_state.num_decls() {
-            working_set.permanent_state
-        } else {
-            new_engine_state = working_set.permanent_state.clone();
-            let _ = new_engine_state.merge_delta(working_set.delta.clone());
-            &new_engine_state
-        };
+        let mut engine_state = working_set.permanent_state.clone();
+        let _ = engine_state.merge_delta(working_set.delta.clone());
 
         let result = nu_engine::eval_block::<WithoutDebug>(
-            engine_state,
+            &engine_state,
             &mut callee_stack,
             block,
             PipelineData::empty(),

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -5,10 +5,10 @@ use crate::completions::{
 use nu_engine::eval_call;
 use nu_parser::{FlatShape, flatten_expression};
 use nu_protocol::{
-    DeclId, IntoSpanned, PipelineData, Span, Spanned, Type, Value,
+    DeclId, IntoSpanned, PipelineData, ShellError, Span, Spanned, Type, Value,
     ast::{Argument, Call, Expr, Expression},
     debugger::WithoutDebug,
-    engine::{EngineState, Stack, StateWorkingSet},
+    engine::{Closure, EngineState, Stack, StateWorkingSet},
 };
 use std::collections::HashMap;
 
@@ -168,6 +168,82 @@ impl<T: Completer> Completer for CustomCompletion<T> {
     }
 }
 
+pub struct ExternalCompletion<'a> {
+    closure: &'a Closure,
+    expression: &'a Expression,
+    strip: bool,
+    pub need_fallback: bool,
+}
+
+impl<'a> ExternalCompletion<'a> {
+    pub fn new(closure: &'a Closure, expression: &'a Expression, strip: bool) -> Self {
+        Self {
+            closure,
+            expression,
+            strip,
+            need_fallback: false,
+        }
+    }
+}
+
+impl<'e> Completer for ExternalCompletion<'e> {
+    fn fetch(
+        &mut self,
+        working_set: &StateWorkingSet,
+        stack: &Stack,
+        _prefix: impl AsRef<str>,
+        span: Span,
+        offset: usize,
+        _options: &CompletionOptions,
+    ) -> Vec<SemanticSuggestion> {
+        let Spanned {
+            item: mut args,
+            span: args_span,
+        } = get_command_arguments(working_set, self.expression);
+        let mut new_span = span;
+        // strip the placeholder
+        if self.strip
+            && let Some(last) = args.last_mut()
+        {
+            last.item.pop();
+            new_span = Span::new(span.start, span.end.saturating_sub(1));
+        }
+
+        let block = working_set.permanent_state.get_block(self.closure.block_id);
+        let mut callee_stack =
+            stack.captures_to_stack_preserve_out_dest(self.closure.captures.clone());
+
+        if let Some(pos_arg) = block.signature.required_positional.first()
+            && let Some(var_id) = pos_arg.var_id
+        {
+            callee_stack.add_var(
+                var_id,
+                Value::list(
+                    args.into_iter()
+                        .map(|Spanned { item, span }| Value::string(item, span))
+                        .collect(),
+                    args_span,
+                ),
+            );
+        }
+
+        let result = nu_engine::eval_block::<WithoutDebug>(
+            working_set.permanent_state,
+            &mut callee_stack,
+            block,
+            PipelineData::empty(),
+        )
+        .map(|p| p.body);
+
+        if let Some(results) = convert_whole_command_completion_results(offset, new_span, result) {
+            results
+        } else {
+            self.need_fallback = true;
+            vec![]
+        }
+    }
+}
+
 pub fn get_command_arguments(
     working_set: &StateWorkingSet<'_>,
     element_expression: &Expression,
@@ -187,4 +263,51 @@ pub fn get_command_arguments(
         })
         .collect::<Vec<_>>()
         .into_spanned(span)
+}
+
+/// Converts the output of the external completion closure and whole command custom completion
+/// commands'
+fn convert_whole_command_completion_results(
+    offset: usize,
+    span: Span,
+    result: Result<PipelineData, nu_protocol::ShellError>,
+) -> Option<Vec<SemanticSuggestion>> {
+    let value = match result.and_then(|pipeline_data| pipeline_data.into_value(span)) {
+        Ok(value) => value,
+        Err(err) => {
+            log::error!(
+                "{}",
+                ShellError::GenericError {
+                    error: "nu::shell::completion".into(),
+                    msg: "failed to eval completer block".into(),
+                    span: None,
+                    help: None,
+                    inner: vec![err],
+                }
+            );
+            return Some(vec![]);
+        }
+    };
+
+    match value {
+        Value::List { vals, .. } => Some(map_value_completions(
+            vals.iter(),
+            Span::new(span.start, span.end),
+            offset,
+        )),
+        Value::Nothing { .. } => None,
+        _ => {
+            log::error!(
+                "{}",
+                ShellError::GenericError {
+                    error: "nu::shell::completion".into(),
+                    msg: "completer returned invalid value of type".into(),
+                    span: None,
+                    help: None,
+                    inner: vec![],
+                },
+            );
+            Some(vec![])
+        }
+    }
 }

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -840,7 +840,9 @@ fn command_wide_completion_flag_completion() {
 
     let sample = /* lang=nu */ r#"
         def "nu-complete cmd" [spans: list] {
-            [command wide completion]
+            let last = $spans | last
+            [command wide --with --external]
+            | where $it starts-with $last
         }
 
         def "nu-complete cmd bar" [] {
@@ -848,7 +850,7 @@ fn command_wide_completion_flag_completion() {
         }
 
         @complete "nu-complete cmd"
-        def "cmd" [
+        def --wrapped "cmd" [
             --switch(-s)
             --flag(-f): string
             foo: string,
@@ -859,7 +861,7 @@ fn command_wide_completion_flag_completion() {
         cmd -"#;
 
     let suggestions = completer.complete(sample, sample.len());
-    let expected = vec!["--flag", "--help", "--switch", "-f", "-h", "-s"];
+    let expected = vec!["--flag", "--switch", "-f", "-s", "--with", "--external"];
     match_suggestions(&expected, &suggestions);
 }
 

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -835,6 +835,35 @@ fn parameter_completion_overrides_command_wide_completion() {
 }
 
 #[test]
+fn command_wide_completion_flag_completion() {
+    let mut completer = custom_completer();
+
+    let sample = /* lang=nu */ r#"
+        def "nu-complete cmd" [spans: list] {
+            [command wide completion]
+        }
+
+        def "nu-complete cmd bar" [] {
+            [bar specific]
+        }
+
+        @complete "nu-complete cmd"
+        def "cmd" [
+            --switch(-s)
+            --flag(-f): string
+            foo: string,
+            bar: string@"nu-complete cmd bar",
+            ...rest
+        ] {}
+
+        cmd -"#;
+
+    let suggestions = completer.complete(sample, sample.len());
+    let expected = vec!["--flag", "--help", "--switch", "-f", "-h", "-s"];
+    match_suggestions(&expected, &suggestions);
+}
+
+#[test]
 fn file_completions() {
     // Create a new engine
     let (dir, dir_str, engine, stack) = new_engine();

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -774,6 +774,50 @@ fn external_completer_invalid() {
 }
 
 #[test]
+fn command_wide_completion_external() {
+    let mut completer = custom_completer();
+
+    let sample = /* lang=nu */ r#"
+        @complete external
+        extern "gh" []
+
+        gh alias one two"#;
+
+    let suggestions = completer.complete(sample, sample.len());
+    let got = suggestions
+        .iter()
+        .map(|s| s.value.as_str())
+        .collect::<Vec<_>>();
+    let expacted = vec!["gh", "alias", "one", "two"];
+
+    assert_eq!(got, expacted);
+}
+
+#[test]
+fn command_wide_completion_custom() {
+    let mut completer = custom_completer();
+
+    let sample = /* lang=nu */ r#"
+        def "nu-complete foo" [spans: list] {
+            $spans ++ [some more]
+        }
+
+        @complete "nu-complete foo"
+        def --wrapped "foo" [...rest] {}
+
+        foo bar baz"#;
+
+    let suggestions = completer.complete(sample, sample.len());
+    let got = suggestions
+        .iter()
+        .map(|s| s.value.as_str())
+        .collect::<Vec<_>>();
+    let expacted = vec!["foo", "bar", "baz", "some", "more"];
+
+    assert_eq!(got, expacted);
+}
+
+#[test]
 fn file_completions() {
     // Create a new engine
     let (dir, dir_str, engine, stack) = new_engine();

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -784,13 +784,8 @@ fn command_wide_completion_external() {
         gh alias one two"#;
 
     let suggestions = completer.complete(sample, sample.len());
-    let got = suggestions
-        .iter()
-        .map(|s| s.value.as_str())
-        .collect::<Vec<_>>();
-    let expacted = vec!["gh", "alias", "one", "two"];
-
-    assert_eq!(got, expacted);
+    let expected = vec!["gh", "alias", "one", "two"];
+    match_suggestions(&expected, &suggestions);
 }
 
 #[test]
@@ -808,13 +803,8 @@ fn command_wide_completion_custom() {
         foo bar baz"#;
 
     let suggestions = completer.complete(sample, sample.len());
-    let got = suggestions
-        .iter()
-        .map(|s| s.value.as_str())
-        .collect::<Vec<_>>();
-    let expacted = vec!["foo", "bar", "baz", "some", "more"];
-
-    assert_eq!(got, expacted);
+    let expected = vec!["foo", "bar", "baz", "some", "more"];
+    match_suggestions(&expected, &suggestions);
 }
 
 #[test]

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -808,6 +808,33 @@ fn command_wide_completion_custom() {
 }
 
 #[test]
+fn parameter_completion_overrides_command_wide_completion() {
+    let mut completer = custom_completer();
+
+    let sample = /* lang=nu */ r#"
+        def "nu-complete cmd" [spans: list] {
+            [command wide completion]
+        }
+
+        def "nu-complete cmd bar" [] {
+            [bar specific]
+        }
+
+        @complete "nu-complete cmd"
+        def --wrapped "cmd" [
+            foo: string,
+            bar: string@"nu-complete cmd bar",
+            ...rest
+        ] {}
+
+        cmd one "#;
+
+    let suggestions = completer.complete(sample, sample.len());
+    let expected = vec!["bar", "specific"];
+    match_suggestions(&expected, &suggestions);
+}
+
+#[test]
 fn file_completions() {
     // Create a new engine
     let (dir, dir_str, engine, stack) = new_engine();

--- a/crates/nu-cmd-lang/src/core_commands/attr/complete.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/complete.rs
@@ -1,0 +1,65 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct AttrComplete;
+
+impl Command for AttrComplete {
+    fn name(&self) -> &str {
+        "attr complete"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("attr complete")
+            .input_output_types(vec![
+                (Type::Nothing, Type::Nothing),
+                (Type::Nothing, Type::String),
+            ])
+            .allow_variants_without_examples(true)
+            .optional(
+                "completer",
+                SyntaxShape::String,
+                "Name of the completion command command.",
+            )
+            .category(Category::Core)
+    }
+
+    fn description(&self) -> &str {
+        "Attribute for enabling use of the external completer, or addition of a custom one, to command."
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let arg: Option<Spanned<String>> = call.opt(engine_state, stack, 0)?;
+        run_impl(arg, call.span())
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let arg: Option<Spanned<String>> = call.opt_const(working_set, 0)?;
+        run_impl(arg, call.span())
+    }
+
+    fn is_const(&self) -> bool {
+        true
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![]
+    }
+}
+
+fn run_impl(arg: Option<Spanned<String>>, head: Span) -> Result<PipelineData, ShellError> {
+    Ok(arg
+        .map(|Spanned { item, span }| Value::string(item, span))
+        .unwrap_or(Value::nothing(head))
+        .into_pipeline_data())
+}

--- a/crates/nu-cmd-lang/src/core_commands/attr/complete.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/complete.rs
@@ -15,13 +15,13 @@ impl Command for AttrComplete {
             .required(
                 "completer",
                 SyntaxShape::String,
-                "Name of the completion command command.",
+                "Name of the completion command.",
             )
             .category(Category::Core)
     }
 
     fn description(&self) -> &str {
-        "Attribute for adding a custom completer that acts on the whole command."
+        "Attribute for using another command as a completion source for all arguments."
     }
 
     fn run(
@@ -50,7 +50,17 @@ impl Command for AttrComplete {
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![]
+        vec![Example {
+            description: "Use another command as completion source",
+            example: "\
+                def complete-foo [spans: list<string>] {\n    \
+                    [bar baz qux spam eggs] | where $it not-in $spans\n\
+                }\n\n\
+                @complete 'complete-foo'\n\
+                def foo [...args] { $args }\
+            ",
+            result: None,
+        }]
     }
 }
 
@@ -101,6 +111,15 @@ impl Command for AttrCompleteExternal {
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![]
+        vec![Example {
+            description: "Use the external completer for a wrapper command",
+            example: "\
+                @complete external\n\
+                def --wrapped jc [...args] {\n    \
+                    ^jc ...$args | from json\n\
+                }\
+            ",
+            result: None,
+        }]
     }
 }

--- a/crates/nu-cmd-lang/src/core_commands/attr/mod.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/mod.rs
@@ -1,11 +1,13 @@
 mod attr_;
 mod category;
+mod complete;
 mod deprecated;
 mod example;
 mod search_terms;
 
 pub use attr_::Attr;
 pub use category::AttrCategory;
+pub use complete::AttrComplete;
 pub use deprecated::AttrDeprecated;
 pub use example::AttrExample;
 pub use search_terms::AttrSearchTerms;

--- a/crates/nu-cmd-lang/src/core_commands/attr/mod.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/mod.rs
@@ -7,7 +7,7 @@ mod search_terms;
 
 pub use attr_::Attr;
 pub use category::AttrCategory;
-pub use complete::AttrComplete;
+pub use complete::{AttrComplete, AttrCompleteExternal};
 pub use deprecated::AttrDeprecated;
 pub use example::AttrExample;
 pub use search_terms::AttrSearchTerms;

--- a/crates/nu-cmd-lang/src/default_context.rs
+++ b/crates/nu-cmd-lang/src/default_context.rs
@@ -22,6 +22,7 @@ pub fn add_default_context(mut engine_state: EngineState) -> EngineState {
             Attr,
             AttrCategory,
             AttrComplete,
+            AttrCompleteExternal,
             AttrDeprecated,
             AttrExample,
             AttrSearchTerms,

--- a/crates/nu-cmd-lang/src/default_context.rs
+++ b/crates/nu-cmd-lang/src/default_context.rs
@@ -21,6 +21,7 @@ pub fn add_default_context(mut engine_state: EngineState) -> EngineState {
             Alias,
             Attr,
             AttrCategory,
+            AttrComplete,
             AttrDeprecated,
             AttrExample,
             AttrSearchTerms,

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -1,5 +1,5 @@
 use nu_protocol::{
-    DeclId, ModuleId, Signature, Span, Type, Value, VarId,
+    CommandWideCompleter, DeclId, ModuleId, Signature, Span, Type, Value, VarId,
     ast::Expr,
     engine::{Command, EngineState, Stack, Visibility},
     record,
@@ -135,8 +135,8 @@ impl<'e, 's> ScopeData<'e, 's> {
                     "extra_description" => Value::string(decl.extra_description(), span),
                     "search_terms" => Value::string(decl.search_terms().join(", "), span),
                     "complete" => match signature.complete {
-                        Some(Some(decl_id)) => Value::int(decl_id.get() as i64, span),
-                        Some(None) => Value::string("external", span),
+                        Some(CommandWideCompleter::Command(decl_id)) => Value::int(decl_id.get() as i64, span),
+                        Some(CommandWideCompleter::External) => Value::string("external", span),
                         None => Value::nothing(span),
                     },
                     "decl_id" => Value::int(decl_id.get() as i64, span),

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -134,6 +134,11 @@ impl<'e, 's> ScopeData<'e, 's> {
                     "creates_scope" => Value::bool(signature.creates_scope, span),
                     "extra_description" => Value::string(decl.extra_description(), span),
                     "search_terms" => Value::string(decl.search_terms().join(", "), span),
+                    "complete" => match signature.complete {
+                        Some(Some(decl_id)) => Value::int(decl_id.get() as i64, span),
+                        Some(None) => Value::string("external", span),
+                        None => Value::nothing(span),
+                    },
                     "decl_id" => Value::int(decl_id.get() as i64, span),
                 };
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -10,8 +10,9 @@ use crate::{
 use log::trace;
 use nu_path::canonicalize_with;
 use nu_protocol::{
-    Alias, BlockId, CustomExample, DeclId, FromValue, Module, ModuleId, ParseError, PositionalArg,
-    ResolvedImportPattern, ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value, VarId,
+    Alias, BlockId, CommandWideCompleter, CustomExample, DeclId, FromValue, Module, ModuleId,
+    ParseError, PositionalArg, ResolvedImportPattern, ShellError, Signature, Span, Spanned,
+    SyntaxShape, Type, Value, VarId,
     ast::{
         Argument, AttributeBlock, Block, Call, Expr, Expression, ImportPattern, ImportPatternHead,
         ImportPatternMember, Pipeline, PipelineElement,
@@ -1018,7 +1019,7 @@ fn handle_special_attributes(
                     if let Some(decl) = working_set.find_decl(item.as_bytes()) {
                         // TODO: Enforce command signature? Not before settling on a unified
                         // custom completion api
-                        signature.complete = Some(Some(decl));
+                        signature.complete = Some(CommandWideCompleter::Command(decl));
                     } else {
                         working_set.error(ParseError::UnknownCommand(span));
                     }
@@ -1036,7 +1037,7 @@ fn handle_special_attributes(
             },
             "complete external" => match value {
                 Value::Nothing { .. } => {
-                    signature.complete = Some(None);
+                    signature.complete = Some(CommandWideCompleter::External);
                 }
                 _ => {
                     let e = ShellError::GenericError {

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -155,6 +155,12 @@ impl PositionalArg {
     }
 }
 
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum CommandWideCompleter {
+    External,
+    Command(DeclId),
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Completion {
     Command(DeclId),
@@ -319,8 +325,7 @@ pub struct Signature {
     pub is_filter: bool,
     pub creates_scope: bool,
     pub allows_unknown_args: bool,
-    /// TODO: Use a proper type here
-    pub complete: Option<Option<DeclId>>,
+    pub complete: Option<CommandWideCompleter>,
     // Signature category used to classify commands stored in the list of declarations
     pub category: Category,
 }

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -319,6 +319,8 @@ pub struct Signature {
     pub is_filter: bool,
     pub creates_scope: bool,
     pub allows_unknown_args: bool,
+    /// TODO: Use a proper type here
+    pub complete: Option<Option<DeclId>>,
     // Signature category used to classify commands stored in the list of declarations
     pub category: Category,
 }
@@ -354,6 +356,7 @@ impl Signature {
             creates_scope: false,
             category: Category::Default,
             allows_unknown_args: false,
+            complete: None,
         }
     }
 


### PR DESCRIPTION
- closes #14504
- closes #14806
- partially addresses #5035

---

Added `attr complete external`, which enables using the external completer for `extern` and custom command `def`initions:

```nushell
@complete external
def --wrapped jc [...args] {
    ^jc ...$args | from json
}
```

Added `attr complete` which uses another command (similar to the `arg: string@"command"`) to provide completions for _all arguments_ of a command:

```nushell
def fish-completer [spans: list<string>] {
	^fish ...
}

def carapace-completer [spans: list<string>] {
    ^carapace ...
}

@complete fish-completer
extern git []

@complete carapace-completer
def --env get-env [name] { $env | get $name }

@complete carapace-completer
def --env set-env [name, value] { load-env { $name: $value } }

@complete carapace-completer
def --env unset-env [name] { hide-env $name }
```

<details>
    <summary>Full implementation of <code>fish-completer</code> from the cookbook.</summary>

```nushell
def fish-completer [spans: list<string>] {
	^fish --command $"complete '--do-complete=($spans | str replace --all "'" "\\'" | str join ' ')'"
	| from tsv --flexible --noheaders --no-infer
	| rename value description
	| update value {|row|
		let value = $row.value
		let need_quote = ['\' ',' '[' ']' '(' ')' ' ' '\t' "'" '"' "`"] | any { $in in $value }
		if ($need_quote and ($value | path exists)) {
			let expanded_path = if ($value starts-with ~) { $value | path expand --no-symlink } else { $value }
			$'"($expanded_path | str replace --all "\"" "\\\"")"'
		} else { $value }
	}
}
```

</details>

Also includes the following bugfix:

-   `spans: list<string>` argument provided to the external completer (and completer commands used with `attr complete` with this addition) previously had invalid spans (from `Span::unknown`).
    These values now have correct spans pointing to their location in the source code.

<details><summary>This change was moved out to another PR</summary>

Using a nonexistent command name as a parameter completer now throws a parse error:
```
Error: nu::parser::unknown_command

  × Unknown command.
   ╭─[source:1:17]
 1 │ def foo [p: any@bar] { }
   ·                 ─┬─
   ·                  ╰── unknown command
   ╰────
```

</details>

## Release notes summary - What our users need to know

TODO

## Tasks after submitting
- [ ] Update the [custom completion documentation](https://www.nushell.sh/book/custom_completions.html)
