### PR TITLE
fix `attr *` command signatures

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/attr/attr_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/attr_.rs
@@ -19,7 +19,10 @@ impl Command for Attr {
     }
 
     fn extra_description(&self) -> &str {
-        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+        "\
+            You must use one of the following subcommands. \
+            Using this command as-is will only produce this help message.\
+        "
     }
 
     fn run(

--- a/crates/nu-cmd-lang/src/core_commands/attr/category.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/category.rs
@@ -10,7 +10,7 @@ impl Command for AttrCategory {
 
     fn signature(&self) -> Signature {
         Signature::build("attr category")
-            .input_output_type(Type::Nothing, Type::list(Type::String))
+            .input_output_type(Type::Nothing, Type::String)
             .allow_variants_without_examples(true)
             .required(
                 "category",

--- a/crates/nu-cmd-lang/src/core_commands/attr/deprecated.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/deprecated.rs
@@ -11,10 +11,7 @@ impl Command for AttrDeprecated {
 
     fn signature(&self) -> Signature {
         Signature::build("attr deprecated")
-            .input_output_types(vec![
-                (Type::Nothing, Type::Nothing),
-                (Type::Nothing, Type::String),
-            ])
+            .input_output_type(Type::Nothing, Type::record())
             .optional(
                 "message",
                 SyntaxShape::String,
@@ -52,11 +49,15 @@ impl Command for AttrDeprecated {
     }
 
     fn extra_description(&self) -> &str {
-        "Mark a command (default) or flag/switch (--flag) as deprecated. By default, only the first usage will trigger a deprecation warning.
-
-A help message can be included to provide more context for the deprecation, such as what to use as a replacement.
-
-Also consider setting the category to deprecated with @category deprecated"
+        "\
+            Mark a command (default) or flag/switch (--flag) as deprecated. \
+            By default, only the first usage will trigger a deprecation warning.\n\
+            \n\
+            A help message can be included to provide more context for the deprecation, \
+            such as what to use as a replacement.\n\
+            \n\
+            Also consider setting the category to deprecated with @category deprecated\
+        "
     }
 
     fn run(


### PR DESCRIPTION
## Release notes summary - What our users need to know

Some `attr` subcommands had incorrect output signatures, which are now fixed.

## Tasks after submitting
N/A