### PR TITLE
Windows device path fixes

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -2,7 +2,7 @@ use crate::progress_bar;
 use nu_engine::get_eval_block;
 #[allow(deprecated)]
 use nu_engine::{command_prelude::*, current_dir};
-use nu_path::expand_path_with;
+use nu_path::{expand_path_with, is_windows_device_path};
 use nu_protocol::{
     ByteStreamSource, DataSource, OutDest, PipelineMetadata, Signals, ast,
     byte_stream::copy_with_signals, process::ChildPipe, shell_error::io::IoError,
@@ -432,7 +432,8 @@ fn open_file(
     span: Span,
     append: bool,
 ) -> Result<File, ShellError> {
-    let file: std::io::Result<File> = match (append, path.exists()) {
+    let file: std::io::Result<File> = match (append, path.exists() || is_windows_device_path(path))
+    {
         (true, true) => std::fs::OpenOptions::new().append(true).open(path),
         _ => {
             // This is a temporary solution until `std::fs::File::create` is fixed on Windows (rust-lang/rust#134893)

--- a/crates/nu-command/src/misc/source.rs
+++ b/crates/nu-command/src/misc/source.rs
@@ -1,5 +1,5 @@
 use nu_engine::{command_prelude::*, get_eval_block_with_early_return};
-use nu_path::canonicalize_with;
+use nu_path::{canonicalize_with, is_windows_device_path};
 use nu_protocol::{BlockId, engine::CommandType, shell_error::io::IoError};
 
 /// Source a file for environment variables.
@@ -55,8 +55,13 @@ impl Command for Source {
         let cwd = engine_state.cwd_as_string(Some(stack))?;
         let pb = std::path::PathBuf::from(block_id_name);
         let parent = pb.parent().unwrap_or(std::path::Path::new(""));
-        let file_path = canonicalize_with(pb.as_path(), cwd)
-            .map_err(|err| IoError::new(err.not_found_as(NotFound::File), call.head, pb.clone()))?;
+        let file_path = if is_windows_device_path(pb.as_path()) {
+            pb.clone()
+        } else {
+            canonicalize_with(pb.as_path(), cwd).map_err(|err| {
+                IoError::new(err.not_found_as(NotFound::File), call.head, pb.clone())
+            })?
+        };
 
         // Note: We intentionally left out PROCESS_PATH since it's supposed to
         // to work like argv[0] in C, which is the name of the program being executed.

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -10,6 +10,7 @@ use crate::{
 
 use log::trace;
 use nu_path::canonicalize_with;
+use nu_path::is_windows_device_path;
 use nu_protocol::{
     Alias, BlockId, CustomExample, DeclId, FromValue, Module, ModuleId, ParseError, PositionalArg,
     ResolvedImportPattern, ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value, VarId,
@@ -3913,6 +3914,10 @@ pub fn find_in_dirs(
     cwd: &str,
     dirs_var_name: Option<&str>,
 ) -> Option<ParserPath> {
+    if is_windows_device_path(Path::new(&filename)) {
+        return Some(ParserPath::RealPath(filename.into()));
+    }
+
     pub fn find_in_dirs_with_id(
         filename: &str,
         working_set: &StateWorkingSet,

--- a/crates/nu-path/src/helpers.rs
+++ b/crates/nu-path/src/helpers.rs
@@ -1,4 +1,6 @@
-use std::path::PathBuf;
+#[cfg(windows)]
+use std::path::{Component, Prefix};
+use std::path::{Path, PathBuf};
 
 use crate::AbsolutePathBuf;
 
@@ -33,4 +35,103 @@ fn configurable_dir_path(
         .and_then(|path| AbsolutePathBuf::try_from(path).ok())
         .or_else(|| dir().and_then(|path| AbsolutePathBuf::try_from(path).ok()))
         .map(|path| path.canonicalize().map(Into::into).unwrap_or(path))
+}
+
+// List of special paths that can be written to and/or read from, even though they
+// don't appear as directory entries.
+// See https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+// In rare circumstances, reserved paths _can_ exist as regular files in a
+// directory which shadow their special counterpart, so the safe way of referring
+// to these paths is by prefixing them with '\\.\' (this instructs the Windows APIs
+// to access the Win32 device namespace instead of the Win32 file namespace)
+// https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+#[cfg(windows)]
+pub fn is_windows_device_path(path: &Path) -> bool {
+    match path.components().next() {
+        Some(Component::Prefix(prefix)) if matches!(prefix.kind(), Prefix::DeviceNS(_)) => {
+            return true;
+        }
+        _ => {}
+    }
+    let special_paths: [&Path; 28] = [
+        Path::new("CON"),
+        Path::new("PRN"),
+        Path::new("AUX"),
+        Path::new("NUL"),
+        Path::new("COM1"),
+        Path::new("COM2"),
+        Path::new("COM3"),
+        Path::new("COM4"),
+        Path::new("COM5"),
+        Path::new("COM6"),
+        Path::new("COM7"),
+        Path::new("COM8"),
+        Path::new("COM9"),
+        Path::new("COM¹"),
+        Path::new("COM²"),
+        Path::new("COM³"),
+        Path::new("LPT1"),
+        Path::new("LPT2"),
+        Path::new("LPT3"),
+        Path::new("LPT4"),
+        Path::new("LPT5"),
+        Path::new("LPT6"),
+        Path::new("LPT7"),
+        Path::new("LPT8"),
+        Path::new("LPT9"),
+        Path::new("LPT¹"),
+        Path::new("LPT²"),
+        Path::new("LPT³"),
+    ];
+    if special_paths.contains(&path) {
+        return true;
+    }
+    false
+}
+
+#[cfg(not(windows))]
+pub fn is_windows_device_path(_path: &Path) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod test_is_windows_device_path {
+    use crate::is_windows_device_path;
+    use std::path::Path;
+
+    #[cfg_attr(not(windows), ignore = "only for Windows")]
+    #[test]
+    fn device_namespace() {
+        assert!(is_windows_device_path(Path::new(r"\\.\CON")))
+    }
+
+    #[cfg_attr(not(windows), ignore = "only for Windows")]
+    #[test]
+    fn reserved_device_name() {
+        assert!(is_windows_device_path(Path::new(r"NUL")))
+    }
+
+    #[cfg_attr(not(windows), ignore = "only for Windows")]
+    #[test]
+    fn normal_path() {
+        assert!(!is_windows_device_path(Path::new(r"dir\file")))
+    }
+
+    #[cfg_attr(not(windows), ignore = "only for Windows")]
+    #[test]
+    fn absolute_path() {
+        assert!(!is_windows_device_path(Path::new(r"\dir\file")))
+    }
+
+    #[cfg_attr(not(windows), ignore = "only for Windows")]
+    #[test]
+    fn unc_path() {
+        assert!(!is_windows_device_path(Path::new(r"\\server\share")))
+    }
+
+    #[cfg_attr(not(windows), ignore = "only for Windows")]
+    #[test]
+    fn verbatim_path() {
+        assert!(!is_windows_device_path(Path::new(r"\\?\dir\file")))
+    }
 }

--- a/crates/nu-path/src/lib.rs
+++ b/crates/nu-path/src/lib.rs
@@ -13,7 +13,7 @@ pub use components::components;
 pub use expansions::{
     canonicalize_with, expand_path, expand_path_with, expand_to_real_path, locate_in_dirs,
 };
-pub use helpers::{cache_dir, data_dir, home_dir, nu_config_dir};
+pub use helpers::{cache_dir, data_dir, home_dir, is_windows_device_path, nu_config_dir};
 pub use path::*;
 pub use tilde::expand_tilde;
 pub use trailing_slash::{has_trailing_slash, strip_trailing_slash};

--- a/crates/nu-path/src/trailing_slash.rs
+++ b/crates/nu-path/src/trailing_slash.rs
@@ -112,4 +112,13 @@ mod tests {
             strip_trailing_slash(Path::new(r"\\foo\bar\"))
         );
     }
+
+    #[cfg_attr(not(windows), ignore = "only for Windows")]
+    #[test]
+    fn strip_trailing_windows_device() {
+        assert_eq!(
+            Path::new(r"\\.\foo"),
+            strip_trailing_slash(Path::new(r"\\.\foo\"))
+        );
+    }
 }


### PR DESCRIPTION
## Release notes summary - What our users need to know
* On Windows, UNC and device paths no longer get a trailing `\` appended when being cast to `path`
* On Windows, open, save and source now work with device paths like `\\.\NUL` or `\\.\CON`, as well as reserved device names like `NUL` and `CON`. Using full device paths is recommended.

## Tasks after submitting
