### PR TITLE
Add syntax for simple completions from const lists

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -10,7 +10,9 @@ use nu_cli::NuCompleter;
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_path::{AbsolutePathBuf, expand_tilde};
-use nu_protocol::{Config, PipelineData, debugger::WithoutDebug, engine::StateWorkingSet};
+use nu_protocol::{
+    Config, ParseError, PipelineData, debugger::WithoutDebug, engine::StateWorkingSet,
+};
 use nu_std::load_standard_library;
 use nu_test_support::fs;
 use reedline::{Completer, Suggestion};
@@ -387,6 +389,25 @@ fn list_completions_defined_inline() {
 }
 
 #[test]
+fn list_completions_extern() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+
+    let completion_str = /* lang=nu */ r#"
+        export extern say [
+          animal: string@[cat dog]
+        ]
+
+        say "#;
+    let suggestions = completer.complete(completion_str, completion_str.len());
+
+    // including only subcommand completions
+    let expected: Vec<_> = vec!["cat", "dog"];
+    match_suggestions(&expected, &suggestions);
+}
+
+#[test]
 fn list_completions_from_constant_and_allows_record() {
     let (_, _, engine, stack) = new_engine();
 
@@ -407,6 +428,28 @@ fn list_completions_from_constant_and_allows_record() {
     // including only subcommand completions
     let expected: Vec<_> = vec!["cat", "dog"];
     match_suggestions(&expected, &suggestions);
+}
+
+#[test]
+fn list_completions_invalid_type() {
+    let (_, _, engine, _) = new_engine();
+
+    let record = /* lang=nu */ r#"
+        const animals = {cat: "meow", dog: "woof!"}
+        export def say [
+          animal: string@$animals
+        ] { }
+    "#;
+
+    let mut working_set = StateWorkingSet::new(&engine);
+    let _ = parse(&mut working_set, None, record.as_bytes(), false);
+
+    assert!(
+        working_set
+            .parse_errors
+            .iter()
+            .any(|err| matches!(err, ParseError::OperatorUnsupportedType { .. }))
+    );
 }
 
 /// External command only if starts with `^`

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -367,6 +367,48 @@ export def say [
     match_suggestions(&expected, &suggestions);
 }
 
+#[test]
+fn list_completions_defined_inline() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+
+    let completion_str = /* lang=nu */ r#"
+        export def say [
+          animal: string@[cat dog]
+        ] { }
+
+        say "#;
+    let suggestions = completer.complete(completion_str, completion_str.len());
+
+    // including only subcommand completions
+    let expected: Vec<_> = vec!["cat", "dog"];
+    match_suggestions(&expected, &suggestions);
+}
+
+#[test]
+fn list_completions_from_constant_and_allows_record() {
+    let (_, _, engine, stack) = new_engine();
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+
+    let completion_str = /* lang=nu */ r#"
+        const animals = [
+            cat
+            {value: "dog"}
+        ]
+        export def say [
+          animal: string@$animals
+        ] { }
+
+        say "#;
+    let suggestions = completer.complete(completion_str, completion_str.len());
+
+    // including only subcommand completions
+    let expected: Vec<_> = vec!["cat", "dog"];
+    match_suggestions(&expected, &suggestions);
+}
+
 /// External command only if starts with `^`
 #[test]
 fn external_commands() {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -13,10 +13,9 @@ use itertools::Itertools;
 use log::trace;
 use nu_engine::DIR_VAR_PARSER_INFO;
 use nu_protocol::{
-    BlockId, Completion, DeclId, DidYouMean, ENV_VARIABLE_ID, FilesizeUnit, Flag, IN_VARIABLE_ID,
-    ParseError, PositionalArg, ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
-    VarId, ast::*, casing::Casing, did_you_mean, engine::StateWorkingSet,
-    eval_const::eval_constant,
+    BlockId, DeclId, DidYouMean, ENV_VARIABLE_ID, FilesizeUnit, Flag, IN_VARIABLE_ID, ParseError,
+    PositionalArg, ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value, VarId, ast::*,
+    casing::Casing, did_you_mean, engine::StateWorkingSet, eval_const::eval_constant,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -4280,8 +4279,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                         .expect("If `bytes` contains `@` splitn returns 2 slices");
                                     (
                                         parse_shape_name(working_set, shape_name, shape_span),
-                                        parse_completer(working_set, cmd_name, cmd_span)
-                                            .map(Completion::Command),
+                                        parse_completer(working_set, cmd_name, cmd_span),
                                     )
                                 } else {
                                     (parse_shape_name(working_set, &contents, span), None)


### PR DESCRIPTION

## Release notes summary - What our users need to know

### Simple syntax for simple completions

![][static-list-completion.svg]
![][static-list-completion-const.svg]

[static-list-completion.svg]: https://gist.githubusercontent.com/Bahex/a4863e190061f0c9f8f300438ac5ffd4/raw/12fc0d66946faecc4baf9047b5b0c01d2a819cd1/static-list-completion.svg

[static-list-completion-const.svg]: https://gist.githubusercontent.com/Bahex/a4863e190061f0c9f8f300438ac5ffd4/raw/12fc0d66946faecc4baf9047b5b0c01d2a819cd1/static-list-completion-const.svg

---

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
