### PR TITLE
update reedline to the latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6426,7 +6426,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.42.0"
-source = "git+https://github.com/nushell/reedline?branch=main#77137e3611ff407fa6d567f91656b528e3506aaa"
+source = "git+https://github.com/nushell/reedline?branch=main#32e82c279df0282ab04d7a81baedf58a5db1a705"
 dependencies = [
  "arboard",
  "chrono",

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -13,8 +13,9 @@ use nu_protocol::{
 };
 use reedline::{
     ColumnarMenu, DescriptionMenu, DescriptionMode, EditCommand, IdeMenu, Keybindings, ListMenu,
-    MenuBuilder, Reedline, ReedlineEvent, ReedlineMenu, TraversalDirection,
-    default_emacs_keybindings, default_vi_insert_keybindings, default_vi_normal_keybindings,
+    MenuBuilder, Reedline, ReedlineEvent, ReedlineMenu, TextObject, TextObjectScope,
+    TextObjectType, TraversalDirection, default_emacs_keybindings, default_vi_insert_keybindings,
+    default_vi_normal_keybindings,
 };
 use std::sync::Arc;
 
@@ -1335,6 +1336,12 @@ fn edit_from_record(
             let right = extract_char(value)?;
             EditCommand::CopyAroundPair { left, right }
         }
+        "copytextobject" => EditCommand::CopyTextObject {
+            text_object: parse_text_object(record, config, span)?,
+        },
+        "cuttextobject" => EditCommand::CutTextObject {
+            text_object: parse_text_object(record, config, span)?,
+        },
         str => {
             return Err(ShellError::InvalidValue {
                 valid: "a reedline EditCommand".into(),
@@ -1365,6 +1372,48 @@ fn extract_char(value: &Value) -> Result<char, ShellError> {
             span: value.span(),
         })
     }
+}
+
+fn parse_text_object(
+    record: &Record,
+    config: &Config,
+    span: Span,
+) -> Result<TextObject, ShellError> {
+    let scope_value = extract_value("scope", record, span)?;
+    let scope_str = scope_value
+        .to_expanded_string("", config)
+        .to_ascii_lowercase();
+    let scope = match scope_str.as_str() {
+        "inner" => TextObjectScope::Inner,
+        "around" => TextObjectScope::Around,
+        str => {
+            return Err(ShellError::InvalidValue {
+                valid: "'inner' or 'around'".into(),
+                actual: format!("'{str}'"),
+                span: scope_value.span(),
+            });
+        }
+    };
+
+    let type_value = extract_value("object_type", record, span)?;
+    let type_str = type_value
+        .to_expanded_string("", config)
+        .to_ascii_lowercase();
+    let object_type = match type_str.as_str() {
+        "word" => TextObjectType::Word,
+        "bigword" => TextObjectType::BigWord,
+        "brackets" | "bracket" => TextObjectType::Brackets,
+        "quote" | "quotes" => TextObjectType::Quote,
+        str => {
+            return Err(ShellError::InvalidValue {
+                valid: "'word', 'bigword', 'brackets', or 'quote'".into(),
+                actual: format!("'{str}'"),
+                span: type_value.span(),
+            });
+        }
+    };
+
+    Ok(TextObject { scope, object_type })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR updates nushell to the latest nushell/reedline@32e82c27 which includes:

- nushell/reedline#939
- nushell/reedline#957

Notes from @JonLD (who authored these PRs, along with #16808) regarding `reedline`'s new `TextObject`:

Since `EditCommand` contains a `TextObject` and not a string it is not possible for the user to directly there needs to be a bit of work done to construct the relevant text object. Maintains the edit command names, seen under "keybindings list", of `CutTextObject` and `CopyTextObject` and using scope: <inner|around> and the object_type: mirrors the Reedline implementation and the informative error messages should help signal to users what are valid inputs. Ideally the `keybindings list` would be a bit mor informative as to how to set up specific keybindings but that's not currently possible, and perhaps not even necessary.
The alternative would be to set up edit commands for each text object, this would be a larger Reedline change and add unecessary complexity to Reedline but would expose the commands better to the use. You could just add them in this file and keep Reedline as is but that would not be exposed to the user via `keybindings list` as this command lists the actual enums and not commands set up in the `reedline_config.rs`.

## Release notes summary - What our users need to know

### Changes to `EditCommand`s:

- renamed `cutinside` to `cutinsidepair` 
- renamed `yankinside` to `copyinsidepair`
- added `cutaroundpair`
- added `copyaroundpair`
- added `cuttextobject`
- added `copytextobject`

### Vi Mode Text Objects

Vi mode now supports inner and around (`i` and `a`) text objects for:
- word, bound to `w` (a sequence of letters, digits and underscores, separated with white space)
- WORD, bound to `W` (a sequence of non-blank characters, separated with white space)
- brackets, bound to `b` (any of `( )`, `[ ]`, `{ }`)
- quotes, bound to `q` (any of `" "`, `' '`, ` `` `)

Existing "pair" motions for specific matching pairs (e.g. `di(` or `ci"`) are also extended to support "around" versions (e.g. `da(` or `ca"`) that cover the pair characters.

Additionally, the pair motions will now jump to the next pair if non are found within search range.

- For _symmetric pairs_ like quotes, searching is restricted to the current line.
- For _asymmetric pairs_ like brackets, search is multi-line across the whole buffer.

Symmetric pairs search does not do any parsing or matching of pairs based on language/groupings.
It simply searches for the previous and next matching characters.

---

## Tasks after submitting
N/A
