### PR TITLE
Promote experimental option `reorder-cell-paths` to opt out

### DIFF
--- a/crates/nu-experimental/src/options/reorder_cell_paths.rs
+++ b/crates/nu-experimental/src/options/reorder_cell_paths.rs
@@ -26,7 +26,7 @@ impl ExperimentalOptionMarker for ReorderCellPaths {
 
 \
         Reorder the parts of cell-path when accessing a cell in a table, always select the row before selecting the column.";
-    const STATUS: Status = Status::OptIn;
+    const STATUS: Status = Status::OptOut;
     const SINCE: Version = (0, 105, 2);
     const ISSUE: u32 = 16766;
 }


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
As talked in our last meeting. We want to promote reordering cell paths to opt out instead of opt in.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

### Promoted `reorder-cell-paths` to opt-out
The [experimental option](https://www.nushell.sh/blog/2025-07-23-nushell_0_106_0.html#experimental-options-toc) [`reorder-cell-paths`](#16766) was promoted to being opt-out, meaning that by default this experimental option is enabled now.

This option improves cell-path accesses by reordering how the cell-path should be evaluated. This doesn't modify the output in any way.

If you have trouble with this, you can disable it via `nu --experimental-options '[reorder-cell-paths=false]'` or via `NU_EXPERIMENTAL_OPTIONS=reorder-cell-paths=false nu`.
