### PR TITLE
Stop using `macos-13` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,7 @@ jobs:
         # Pinning to Ubuntu 22.04 because building on newer Ubuntu versions causes linux-gnu
         # builds to link against a too-new-for-many-Linux-installs glibc version. Consider
         # revisiting this when 22.04 is closer to EOL (June 2027)
-        #
-        # Using macOS 13 runner because 14 is based on the M1 and has half as much RAM (7 GB,
-        # instead of 14 GB) which is too little for us right now. Revisit when `dfr` commands are
-        # removed and we're only building the `polars` plugin instead
-        platform: [windows-latest, macos-13, ubuntu-22.04]
+        platform: [windows-latest, macos-latest, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}
 
@@ -149,11 +145,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # Using macOS 13 runner because 14 is based on the M1 and has half as much RAM (7 GB,
-        # instead of 14 GB) which is too little for us right now.
-        #
-        # Failure occurring with clippy for rust 1.77.2
-        platform: [windows-latest, macos-13, ubuntu-22.04]
+        platform: [windows-latest, macos-latest, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
The `macos-13` Github Action runner [is getting deprecated](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/). To fix this, I replaced in our CI `macos-13` with `macos-latest`. Previously this caused issues while building. Let's see if that works now.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
N/A
