### PR TITLE
Add ast-grep lint for constructing Value directly

### DIFF
--- a/ast-grep/rules/value-variant.yml
+++ b/ast-grep/rules/value-variant.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: value-variant-direct
+language: rust
+severity: error
+message: "Use one of the value variant helpers"
+
+ignores:
+  - "crates/nu-protocol/src/value/*.rs"
+
+rule:
+  kind: struct_expression
+  has:
+    kind: scoped_type_identifier
+    has:
+      kind: identifier
+      pattern: Value

--- a/crates/nu-cli/tests/completions/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/completions/support/completions_helpers.rs
@@ -76,16 +76,10 @@ pub fn new_external_engine() -> EngineState {
     let mut engine = create_default_context();
     let dir = fs::fixtures().join("external_completions").join("path");
     let dir_str = dir.to_string_lossy().to_string();
-    let internal_span = nu_protocol::Span::new(0, dir_str.len());
+    let span = nu_protocol::Span::new(0, dir_str.len());
     engine.add_env_var(
         "PATH".to_string(),
-        Value::List {
-            vals: vec![Value::String {
-                val: dir_str,
-                internal_span,
-            }],
-            internal_span,
-        },
+        Value::list(vec![Value::string(dir_str, span)], span),
     );
     engine
 }

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dtype/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dtype/mod.rs
@@ -38,10 +38,7 @@ impl NuDataType {
 
 impl From<NuDataType> for Value {
     fn from(nu_dtype: NuDataType) -> Self {
-        Value::String {
-            val: nu_dtype.dtype.to_string(),
-            internal_span: Span::unknown(),
-        }
+        Value::string(nu_dtype.dtype.to_string(), Span::unknown())
     }
 }
 


### PR DESCRIPTION
Adds an `ast-grep` lint for constructing `Value` variants directly (e.g., `Value::Int { ... }`) instead of using the helper methods (e.g. `Value::int`)

## Release notes summary - What our users need to know
N/A