### PR TITLE
Change ListStream iterator item from `Value` to `Result<Value, ShellError>`

### DIFF
--- a/crates/nu-command/src/filters/drop/drop_.rs
+++ b/crates/nu-command/src/filters/drop/drop_.rs
@@ -79,7 +79,9 @@ impl Command for Drop {
         let head = call.head;
         let metadata = input.metadata();
         let rows: Option<Spanned<i64>> = call.opt(engine_state, stack, 0)?;
-        let mut values = input.into_iter_strict(head)?.collect::<Vec<_>>();
+        let mut values = input
+            .into_iter_strict(head)?
+            .collect::<Result<Vec<_>, ShellError>>()?;
 
         let rows_to_drop = if let Some(rows) = rows {
             if rows.item < 0 {

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -492,7 +492,11 @@ fn get_command_documentation(
                         .ok()
                 });
 
-            for item in table.into_iter().flatten() {
+            for item in table
+                .map(|pipe| pipe.into_value(Span::unknown()))
+                .into_iter()
+                .flatten()
+            {
                 let _ = writeln!(
                     long_desc,
                     "  {}",

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1649,7 +1649,7 @@ fn eval_iterate(
     if let PipelineData::ListStream(list_stream, _) = &mut data.body {
         // Modify the stream, taking one value off, and branching if it's empty
         if let Some(val) = list_stream.next_value() {
-            ctx.put_reg(dst, PipelineExecutionData::from(val.into_pipeline_data()));
+            ctx.put_reg(dst, PipelineExecutionData::from(val?.into_pipeline_data()));
             ctx.put_reg(stream, data); // put the stream back so it can be iterated on again
             Ok(InstructionResult::Continue)
         } else {

--- a/crates/nu-explore/src/nu_common/value.rs
+++ b/crates/nu-explore/src/nu_common/value.rs
@@ -1,22 +1,24 @@
 use super::NuSpan;
 use anyhow::Result;
 use nu_engine::get_columns;
-use nu_protocol::{ByteStream, ListStream, PipelineData, PipelineMetadata, Value, record};
+use nu_protocol::{
+    ByteStream, ListStream, PipelineData, PipelineMetadata, ShellError, Value, record,
+};
 use std::collections::HashMap;
 
 pub fn collect_pipeline(input: PipelineData) -> Result<(Vec<String>, Vec<Vec<Value>>)> {
     match input {
         PipelineData::Empty => Ok((vec![], vec![])),
         PipelineData::Value(value, ..) => collect_input(value),
-        PipelineData::ListStream(stream, ..) => Ok(collect_list_stream(stream)),
+        PipelineData::ListStream(stream, ..) => collect_list_stream(stream),
         PipelineData::ByteStream(stream, metadata) => Ok(collect_byte_stream(stream, metadata)),
     }
 }
 
-fn collect_list_stream(stream: ListStream) -> (Vec<String>, Vec<Vec<Value>>) {
+fn collect_list_stream(stream: ListStream) -> Result<(Vec<String>, Vec<Vec<Value>>), ShellError> {
     let mut records = vec![];
     for item in stream {
-        records.push(item);
+        records.push(item?);
     }
 
     let mut cols = get_columns(&records);

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -1002,6 +1002,12 @@ pub trait IntoInterruptiblePipelineData {
     ) -> PipelineData;
 }
 
+impl Into<Result<Value, ShellError>> for Value {
+    fn into(self) -> Result<Value, ShellError> {
+        Ok(self)
+    }
+}
+
 impl<I> IntoInterruptiblePipelineData for I
 where
     I: IntoIterator + Send + 'static,


### PR DESCRIPTION
This PR changes the iteration type of `ListStream` from `Value` to `Result<Value, ShellError>`. Currently, the only way to express errors within a `ListStream` is to put them into a `Value::Error`, which causes errors to get stuck inside of streams, resulting in lots of confusing situations. #16738 improved this situation by making it an error to collect streams with errors, but this PR takes this a step further by making it possible to return actual `ShellError`s in the `ListStream` iterator. These can then be properly handled by the consumer of the `ListStream` iterator.

This PR also opens up a path towards removing `Value::Error` altogether, if that is a direction we are interested in going.

This is a currently a draft PR, the core implementation of the `ListStream` and related functions has already been changed, but almost every place where `ListStream` is iterated over directly needs to be modified to unwrap the `Result`s. 

The `PipelineData::map` function still retains the same signature (`Value -> Value`), but we can also add a `PipelineData::try_map` function (`Value -> Result<Value, ShellError>`) which will enable us to replace any `PipelineData::map` invocation which constructs a `Value::Error`, and replace it with a `PipelineData::try_map` invocation which can return proper `ShellError`s.

## Release notes summary - What our users need to know
TODO
