### PR TITLE
feat(std-rfc/xml xaccess): experimental rewrite of `std/xml xaccess`

### DIFF
--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -138,6 +138,11 @@ pub fn load_standard_library(
             "std-rfc/random",
             include_str!("../std-rfc/random/mod.nu"),
         ),
+        (
+            "mod.nu",
+            "std-rfc/xml",
+            include_str!("../std-rfc/xml/mod.nu"),
+        ),
     ];
 
     for (filename, std_rfc_subdir_name, content) in std_rfc_submodules.drain(..) {

--- a/crates/nu-std/std-rfc/mod.nu
+++ b/crates/nu-std/std-rfc/mod.nu
@@ -5,6 +5,7 @@ export module clip
 export module str
 export module iter
 export module random
+export module xml
 
 # kv module depends on sqlite feature, which may not be available in some builds
 const kv_module = if ("sqlite" in (version).features) { "std-rfc/kv" } else { null }

--- a/crates/nu-std/std-rfc/xml/mod.nu
+++ b/crates/nu-std/std-rfc/xml/mod.nu
@@ -1,0 +1,67 @@
+use std-rfc/iter recurse
+
+def children []: list<record> -> list<record> {
+	where ($it.content | describe --detailed).type == list
+	| get content
+	| flatten
+}
+
+def descendant-or-self []: list<record<content: list<record>>> -> list<record>  {
+	recurse {
+		where ($it.content | describe --detailed).type == list
+		| get content
+	}
+	| get item
+	| flatten
+}
+
+export def pipeline [meta: record]: list<oneof<cell-path, string, int, closure, list>> -> closure {
+	let steps = each {|e|
+		if ($e | describe) == "cell-path" {
+			$e | split cell-path | get value
+		} else {
+			$e | prepend null  # make sure it's a list so `flatten` behaves in a predictable manner
+		}
+	}
+	| flatten
+
+	if ($steps | is-empty) {
+		error make {
+			msg: 'Empty path provided'
+			label: {
+				text: 'Use a non-empty list of path steps'
+				span: $meta.span
+			}
+		}
+	}
+
+	$steps
+	| reduce --fold {|| } {|step, prev|
+		match ($step | describe) {
+			"string" => {
+				match $step {
+					"*" => {|| do $prev | children }
+					"**" => {|| do $prev | descendant-or-self }
+					$tag => {|| do $prev | children | where tag == $tag }
+				}
+			}
+			"int" => {|| do $prev | select $step }
+			"closure" => {|| do $prev | where $step }
+			$type => {
+				let step_span = (metadata $step).span
+				error make {
+					msg: $'Incorrect path step type ($type)'
+					label: {
+						text: 'Use a string or int as a step'
+						span: $step_span
+					}
+				}
+			}
+		}
+	}
+}
+
+export def xaccess [...rest: oneof<cell-path, closure, list>] {
+	[{content: ($in | prepend null)}]
+	| do ($rest | pipeline (metadata $rest))
+}


### PR DESCRIPTION
I wrote this a while back and just forgot to make a PR.

AFAIK reducing multiple closures into a single one is (at least in nushell) a novel approach. This is why it's "experimental".

- adds descendant `//` support using `**` syntax
- uses ...rest param rather than a single list
  - params can be cell-path, closure, or a list
  - lists are flattened into the rest param, making the api backwards compatible with the existing implementation
  - closures are for filtering, kind of like having a `where` command in a pipeline
- Rather than reducing data by repeatedly applying closures, it reduces multiple closures into a single closure, and runs the data through it. This makes multiple operations into a single pipeline without collecting between operations.

Usage example:

```nushell
http get 'https://www.nushell.sh/rss.xml'
| xml xaccess **.item.title.*
```

cc: @weirdan I remember you working with xml, so I would like your take on this.

## Release notes summary - What our users need to know
TODO

## Tasks after submitting
N/A
