### PR TITLE
feat(into string): add cell-path input to `into string`

### DIFF
--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -38,6 +38,7 @@ impl Command for IntoString {
                 (Type::Filesize, Type::String),
                 (Type::Date, Type::String),
                 (Type::Duration, Type::String),
+                (Type::CellPath, Type::String),
                 (Type::Range, Type::String),
                 (
                     Type::List(Box::new(Type::Any)),
@@ -141,6 +142,11 @@ impl Command for IntoString {
                 example: "9day | into string",
                 result: Some(Value::test_string("1wk 2day")),
             },
+            Example {
+                description: "convert cell-path to string",
+                example: "$.name | into string",
+                result: Some(Value::test_string("$.name")),
+            },
         ]
     }
 }
@@ -217,6 +223,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         Value::Date { val, .. } => Value::string(val.format("%c").to_string(), span),
         Value::String { val, .. } => Value::string(val, span),
         Value::Glob { val, .. } => Value::string(val, span),
+        Value::CellPath { val, .. } => Value::string(val.to_string(), span),
         Value::Filesize { val, .. } => {
             if group_digits {
                 let decimal_value = digits.unwrap_or(0) as usize;

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -39,6 +39,15 @@ fn from_boolean() {
 }
 
 #[test]
+fn from_cell_path() {
+    let actual = nu!(r#"
+        $.test | into string
+        "#);
+
+    assert_eq!(actual.out, "$.test");
+}
+
+#[test]
 fn from_string() {
     let actual = nu!(r#"
         echo "one" | into string


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
Now `into string` accepts a `cell-path` as input.

## Tasks after submitting

