### PR TITLE
Mark `Value` variants as `#[non_exhaustive]`

### DIFF
--- a/crates/nu-cli/tests/completions/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/completions/support/completions_helpers.rs
@@ -76,16 +76,10 @@ pub fn new_external_engine() -> EngineState {
     let mut engine = create_default_context();
     let dir = fs::fixtures().join("external_completions").join("path");
     let dir_str = dir.to_string_lossy().to_string();
-    let internal_span = nu_protocol::Span::new(0, dir_str.len());
+    let span = nu_protocol::Span::new(0, dir_str.len());
     engine.add_env_var(
         "PATH".to_string(),
-        Value::List {
-            vals: vec![Value::String {
-                val: dir_str,
-                internal_span,
-            }],
-            internal_span,
-        },
+        Value::list(vec![Value::string(dir_str, span)], span),
     );
     engine
 }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -46,6 +46,7 @@ use std::{
 // impact on the PartialOrd implementation and the global sort order
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Value {
+    #[non_exhaustive]
     Bool {
         val: bool,
         /// note: spans are being refactored out of Value
@@ -53,6 +54,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Int {
         val: i64,
         /// note: spans are being refactored out of Value
@@ -60,6 +62,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Float {
         val: f64,
         /// note: spans are being refactored out of Value
@@ -67,6 +70,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     String {
         val: String,
         /// note: spans are being refactored out of Value
@@ -74,6 +78,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Glob {
         val: String,
         no_expand: bool,
@@ -82,6 +87,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Filesize {
         val: Filesize,
         /// note: spans are being refactored out of Value
@@ -89,6 +95,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Duration {
         /// The duration in nanoseconds.
         val: i64,
@@ -97,6 +104,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Date {
         val: DateTime<FixedOffset>,
         /// note: spans are being refactored out of Value
@@ -104,6 +112,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Range {
         val: Box<Range>,
         /// note: spans are being refactored out of Value
@@ -111,6 +120,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Record {
         val: SharedCow<Record>,
         /// note: spans are being refactored out of Value
@@ -118,6 +128,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     List {
         vals: Vec<Value>,
         /// note: spans are being refactored out of Value
@@ -125,6 +136,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Closure {
         val: Box<Closure>,
         /// note: spans are being refactored out of Value
@@ -132,6 +144,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Error {
         error: Box<ShellError>,
         /// note: spans are being refactored out of Value
@@ -139,6 +152,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Binary {
         val: Vec<u8>,
         /// note: spans are being refactored out of Value
@@ -146,6 +160,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     CellPath {
         val: CellPath,
         /// note: spans are being refactored out of Value
@@ -153,6 +168,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Custom {
         val: Box<dyn CustomValue>,
         /// note: spans are being refactored out of Value
@@ -160,6 +176,7 @@ pub enum Value {
         #[serde(rename = "span")]
         internal_span: Span,
     },
+    #[non_exhaustive]
     Nothing {
         /// note: spans are being refactored out of Value
         /// please use .span() instead of matching this span value

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -44,6 +44,10 @@ use std::{
 /// Core structured values that pass through the pipeline in Nushell.
 // NOTE: Please do not reorder these enum cases without thinking through the
 // impact on the PartialOrd implementation and the global sort order
+// NOTE: All variants are marked as `non_exhaustive` to prevent them
+// from being constructed (outside of this crate) with the struct
+// expression syntax. This makes using the constructor methods the
+// only way to construct `Value`'s
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Value {
     #[non_exhaustive]

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dtype/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dtype/mod.rs
@@ -38,10 +38,7 @@ impl NuDataType {
 
 impl From<NuDataType> for Value {
     fn from(nu_dtype: NuDataType) -> Self {
-        Value::String {
-            val: nu_dtype.dtype.to_string(),
-            internal_span: Span::unknown(),
-        }
+        Value::string(nu_dtype.dtype.to_string(), Span::unknown())
     }
 }
 


### PR DESCRIPTION
`Value` can no longer be constructed directly using struct expression syntax outside of the defining crate (`nu-protocol`)

Now it can only be constructed using the constructor methods.

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A