### PR TITLE
feat: add custom metadata support and HTTP response metadata

### DIFF
--- a/crates/nu-cmd-extra/src/extra/formats/to/html.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html.rs
@@ -360,6 +360,7 @@ fn to_html(
     let metadata = PipelineMetadata {
         data_source: nu_protocol::DataSource::None,
         content_type: Some(mime::TEXT_HTML_UTF_8.to_string()),
+        ..Default::default()
     };
 
     Ok(Value::string(output_string, head).into_pipeline_data_with_metadata(metadata))
@@ -401,6 +402,7 @@ fn theme_demo(span: Span) -> PipelineData {
     Value::list(result, span).into_pipeline_data_with_metadata(PipelineMetadata {
         data_source: DataSource::HtmlThemes,
         content_type: None,
+        ..Default::default()
     })
 }
 

--- a/crates/nu-cmd-extra/src/extra/formats/to/html.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html.rs
@@ -401,7 +401,6 @@ fn theme_demo(span: Span) -> PipelineData {
         .collect();
     Value::list(result, span).into_pipeline_data_with_metadata(PipelineMetadata {
         data_source: DataSource::HtmlThemes,
-        content_type: None,
         ..Default::default()
     })
 }

--- a/crates/nu-cmd-lang/src/core_commands/collect.rs
+++ b/crates/nu-cmd-lang/src/core_commands/collect.rs
@@ -51,6 +51,7 @@ is particularly large, this can cause high memory usage."#
             Some(PipelineMetadata {
                 data_source: DataSource::FilePath(_),
                 content_type: None,
+                ..
             }) => None,
             other => other,
         };

--- a/crates/nu-command/src/debug/metadata_set.rs
+++ b/crates/nu-command/src/debug/metadata_set.rs
@@ -108,9 +108,14 @@ impl Command for MetadataSet {
                 result: None,
             },
             Example {
-                description: "Set the metadata of a file path",
+                description: "Set the content type metadata",
                 example: "'crates' | metadata set --content-type text/plain | metadata | get content_type",
                 result: Some(Value::test_string("text/plain")),
+            },
+            Example {
+                description: "Set custom metadata with namespaced keys",
+                example: r#""response data" | metadata set --merge {"http.status": 200} | metadata | get "http.status""#,
+                result: Some(Value::test_int(200)),
             },
         ]
     }

--- a/crates/nu-command/src/debug/metadata_set.rs
+++ b/crates/nu-command/src/debug/metadata_set.rs
@@ -33,6 +33,12 @@ impl Command for MetadataSet {
                 "Assign content type metadata to the input",
                 Some('c'),
             )
+            .named(
+                "merge",
+                SyntaxShape::Record(vec![]),
+                "Merge arbitrary metadata fields",
+                Some('m'),
+            )
             .allow_variants_without_examples(true)
             .category(Category::Debug)
     }
@@ -48,6 +54,7 @@ impl Command for MetadataSet {
         let ds_fp: Option<String> = call.get_flag(engine_state, stack, "datasource-filepath")?;
         let ds_ls = call.has_flag(engine_state, stack, "datasource-ls")?;
         let content_type: Option<String> = call.get_flag(engine_state, stack, "content-type")?;
+        let merge: Option<Value> = call.get_flag(engine_state, stack, "merge")?;
 
         let mut metadata = match &mut input {
             PipelineData::Value(_, metadata)
@@ -58,6 +65,13 @@ impl Command for MetadataSet {
 
         if let Some(content_type) = content_type {
             metadata.content_type = Some(content_type);
+        }
+
+        if let Some(merge) = merge {
+            let custom_record = merge.as_record()?;
+            for (key, value) in custom_record {
+                metadata.custom.insert(key.clone(), value.clone());
+            }
         }
 
         match (ds_fp, ds_ls) {

--- a/crates/nu-command/src/debug/util.rs
+++ b/crates/nu-command/src/debug/util.rs
@@ -8,6 +8,7 @@ pub fn extend_record_with_metadata(
     if let Some(PipelineMetadata {
         data_source,
         content_type,
+        custom,
     }) = metadata
     {
         match data_source {
@@ -23,6 +24,9 @@ pub fn extend_record_with_metadata(
         }
         if let Some(content_type) = content_type {
             record.push("content_type", Value::string(content_type, head));
+        }
+        for (key, value) in custom {
+            record.push(key, value.clone());
         }
     };
 

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -224,7 +224,6 @@ impl Command for ViewSource {
         };
         source.map(|x| {
             x.set_metadata(Some(PipelineMetadata {
-                data_source: DataSource::None,
                 content_type: Some("application/x-nuscript".into()),
                 ..Default::default()
             }))

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -226,6 +226,7 @@ impl Command for ViewSource {
             x.set_metadata(Some(PipelineMetadata {
                 data_source: DataSource::None,
                 content_type: Some("application/x-nuscript".into()),
+                ..Default::default()
             }))
         })
     }

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::{Config, DataSource, PipelineMetadata};
+use nu_protocol::{Config, PipelineMetadata};
 
 use std::fmt::Write;
 

--- a/crates/nu-command/src/debug/view_span.rs
+++ b/crates/nu-command/src/debug/view_span.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::{DataSource, PipelineMetadata};
+use nu_protocol::PipelineMetadata;
 
 #[derive(Clone)]
 pub struct ViewSpan;

--- a/crates/nu-command/src/debug/view_span.rs
+++ b/crates/nu-command/src/debug/view_span.rs
@@ -54,7 +54,6 @@ impl Command for ViewSpan {
 
         source.map(|x| {
             x.set_metadata(Some(PipelineMetadata {
-                data_source: DataSource::None,
                 content_type: Some("application/x-nuscript".into()),
                 ..Default::default()
             }))

--- a/crates/nu-command/src/debug/view_span.rs
+++ b/crates/nu-command/src/debug/view_span.rs
@@ -56,6 +56,7 @@ impl Command for ViewSpan {
             x.set_metadata(Some(PipelineMetadata {
                 data_source: DataSource::None,
                 content_type: Some("application/x-nuscript".into()),
+                ..Default::default()
             }))
         })
     }

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -128,6 +128,7 @@ impl Command for Ls {
                         PipelineMetadata {
                             data_source: DataSource::Ls,
                             content_type: None,
+                            ..Default::default()
                         },
                     ),
             ),
@@ -153,6 +154,7 @@ impl Command for Ls {
                         PipelineMetadata {
                             data_source: DataSource::Ls,
                             content_type: None,
+                            ..Default::default()
                         },
                     ))
             }

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -127,7 +127,6 @@ impl Command for Ls {
                         engine_state.signals().clone(),
                         PipelineMetadata {
                             data_source: DataSource::Ls,
-                            content_type: None,
                             ..Default::default()
                         },
                     ),
@@ -153,7 +152,6 @@ impl Command for Ls {
                         engine_state.signals().clone(),
                         PipelineMetadata {
                             data_source: DataSource::Ls,
-                            content_type: None,
                             ..Default::default()
                         },
                     ))

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -192,6 +192,7 @@ impl Command for Open {
                         Some(PipelineMetadata {
                             data_source: DataSource::FilePath(path.to_path_buf()),
                             content_type: None,
+                            ..Default::default()
                         }),
                     );
 
@@ -248,6 +249,7 @@ impl Command for Open {
                                 stream.set_metadata(Some(PipelineMetadata {
                                     data_source: DataSource::FilePath(path.to_path_buf()),
                                     content_type,
+                                    ..Default::default()
                                 }));
                             output.push(stream_with_content_type);
                         }

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -191,7 +191,6 @@ impl Command for Open {
                         ByteStream::file(file, call_span, engine_state.signals().clone()),
                         Some(PipelineMetadata {
                             data_source: DataSource::FilePath(path.to_path_buf()),
-                            content_type: None,
                             ..Default::default()
                         }),
                     );

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -75,6 +75,7 @@ impl Command for ToJson {
                 let metadata = PipelineMetadata {
                     data_source: nu_protocol::DataSource::None,
                     content_type: Some(mime::APPLICATION_JSON.to_string()),
+                    ..Default::default()
                 };
                 Ok(PipelineData::value(res, Some(metadata)))
             }

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -10,7 +10,7 @@ use http::StatusCode;
 use log::error;
 use multipart_rs::MultipartWriter;
 use nu_engine::command_prelude::*;
-use nu_protocol::{ByteStream, LabeledError, Signals, shell_error::io::IoError};
+use nu_protocol::{ByteStream, LabeledError, PipelineMetadata, Signals, shell_error::io::IoError};
 use serde_json::Value as JsonValue;
 use std::{
     collections::HashMap,
@@ -171,6 +171,9 @@ pub fn response_to_buffer(
         _ => ByteStreamType::Unknown,
     };
 
+    // Extract response metadata before consuming the body
+    let metadata = extract_response_metadata(&response, span);
+
     let reader = UreqTimeoutExtractorReader {
         r: response.into_body().into_reader(),
     };
@@ -178,8 +181,41 @@ pub fn response_to_buffer(
     PipelineData::byte_stream(
         ByteStream::read(reader, span, engine_state.signals().clone(), response_type)
             .with_known_size(buffer_size),
-        None,
+        Some(metadata),
     )
+}
+
+fn extract_response_metadata(response: &Response, span: Span) -> PipelineMetadata {
+    let status = Value::int(response.status().as_u16().into(), span);
+
+    let headers_value = headers_to_nu(&extract_response_headers(response), span)
+        .and_then(|data| data.into_value(span))
+        .unwrap_or(Value::nothing(span));
+
+    let urls = Value::list(
+        response
+            .get_redirect_history()
+            .into_iter()
+            .flatten()
+            .map(|v| Value::string(v.to_string(), span))
+            .collect(),
+        span,
+    );
+
+    let http_response = Value::record(
+        record! {
+            "status" => status,
+            "headers" => headers_value,
+            "urls" => urls,
+        },
+        span,
+    );
+
+    let mut metadata = PipelineMetadata::default();
+    metadata
+        .custom
+        .insert("http.response".to_string(), http_response);
+    metadata
 }
 
 pub fn request_add_authorization_header<B>(

--- a/crates/nu-command/tests/commands/debug/metadata_set.rs
+++ b/crates/nu-command/tests/commands/debug/metadata_set.rs
@@ -41,3 +41,34 @@ fn works_with_datasource_ls() {
 
     assert!(actual.out.contains("ls"));
 }
+
+#[test]
+fn works_with_merge_arbitrary_metadata() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo "foo"
+        | metadata set --merge {custom_key: "custom_value", foo: 42}
+        | metadata
+        | get custom_key
+        "#
+    ));
+
+    assert_eq!(actual.out, "custom_value");
+}
+
+#[test]
+fn merge_preserves_existing_metadata() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        echo "foo"
+        | metadata set --content-type "text/plain"
+        | metadata set --merge {custom: "value"}
+        | metadata
+        | get content_type
+        "#
+    ));
+
+    assert_eq!(actual.out, "text/plain");
+}

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -345,3 +345,25 @@ fn http_get_timeout() {
         actual.err
     );
 }
+
+#[test]
+fn http_get_response_metadata() {
+    let mut server = Server::new();
+
+    let _mock = server
+        .mock("GET", "/")
+        .with_status(200)
+        .with_header("x-custom-header", "test-value")
+        .with_body("success")
+        .create();
+
+    let actual = nu!(pipeline(
+        format!(
+            r#"http get --raw {url} | metadata | get "http.response" | get status"#,
+            url = server.url()
+        )
+        .as_str()
+    ));
+
+    assert_eq!(actual.out, "200");
+}

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -331,6 +331,7 @@ pub fn eval_collect<D: DebugContext>(
         Some(PipelineMetadata {
             data_source: DataSource::FilePath(_),
             content_type: None,
+            ..
         }) => None,
         other => other,
     };

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1517,6 +1517,7 @@ fn collect(data: PipelineData, fallback_span: Span) -> Result<PipelineData, Shel
         Some(PipelineMetadata {
             data_source: DataSource::FilePath(_),
             content_type: None,
+            ..
         }) => None,
         other => other,
     };

--- a/crates/nu-plugin-core/src/interface/tests.rs
+++ b/crates/nu-plugin-core/src/interface/tests.rs
@@ -16,7 +16,6 @@ use std::{path::Path, sync::Arc};
 fn test_metadata() -> PipelineMetadata {
     PipelineMetadata {
         data_source: DataSource::FilePath("/test/path".into()),
-        content_type: None,
         ..Default::default()
     }
 }
@@ -140,7 +139,6 @@ fn read_pipeline_data_value() -> Result<(), ShellError> {
     let value = Value::test_int(4);
     let metadata = Some(PipelineMetadata {
         data_source: DataSource::FilePath("/test/path".into()),
-        content_type: None,
         ..Default::default()
     });
     let header = PipelineDataHeader::Value(value.clone(), metadata.clone());
@@ -170,7 +168,6 @@ fn read_pipeline_data_list_stream() -> Result<(), ShellError> {
     test.add(StreamMessage::End(7));
 
     let metadata = Some(PipelineMetadata {
-        data_source: DataSource::None,
         content_type: Some("foobar".into()),
         ..Default::default()
     });
@@ -221,7 +218,6 @@ fn read_pipeline_data_byte_stream() -> Result<(), ShellError> {
     let test_span = Span::new(10, 13);
 
     let metadata = Some(PipelineMetadata {
-        data_source: DataSource::None,
         content_type: Some("foobar".into()),
         ..Default::default()
     });
@@ -276,7 +272,6 @@ fn read_pipeline_data_byte_stream() -> Result<(), ShellError> {
 fn read_pipeline_data_prepared_properly() -> Result<(), ShellError> {
     let manager = TestInterfaceManager::new(&TestCase::new());
     let metadata = Some(PipelineMetadata {
-        data_source: DataSource::None,
         content_type: Some("foobar".into()),
         ..Default::default()
     });

--- a/crates/nu-plugin-core/src/interface/tests.rs
+++ b/crates/nu-plugin-core/src/interface/tests.rs
@@ -17,6 +17,7 @@ fn test_metadata() -> PipelineMetadata {
     PipelineMetadata {
         data_source: DataSource::FilePath("/test/path".into()),
         content_type: None,
+        ..Default::default()
     }
 }
 
@@ -140,6 +141,7 @@ fn read_pipeline_data_value() -> Result<(), ShellError> {
     let metadata = Some(PipelineMetadata {
         data_source: DataSource::FilePath("/test/path".into()),
         content_type: None,
+        ..Default::default()
     });
     let header = PipelineDataHeader::Value(value.clone(), metadata.clone());
     match manager.read_pipeline_data(header, &Signals::empty())? {
@@ -170,6 +172,7 @@ fn read_pipeline_data_list_stream() -> Result<(), ShellError> {
     let metadata = Some(PipelineMetadata {
         data_source: DataSource::None,
         content_type: Some("foobar".into()),
+        ..Default::default()
     });
 
     let header = PipelineDataHeader::ListStream(ListStreamInfo {
@@ -220,6 +223,7 @@ fn read_pipeline_data_byte_stream() -> Result<(), ShellError> {
     let metadata = Some(PipelineMetadata {
         data_source: DataSource::None,
         content_type: Some("foobar".into()),
+        ..Default::default()
     });
 
     let header = PipelineDataHeader::ByteStream(ByteStreamInfo {
@@ -274,6 +278,7 @@ fn read_pipeline_data_prepared_properly() -> Result<(), ShellError> {
     let metadata = Some(PipelineMetadata {
         data_source: DataSource::None,
         content_type: Some("foobar".into()),
+        ..Default::default()
     });
 
     let header = PipelineDataHeader::ListStream(ListStreamInfo {

--- a/crates/nu-plugin-core/src/serializers/tests.rs
+++ b/crates/nu-plugin-core/src/serializers/tests.rs
@@ -125,7 +125,6 @@ macro_rules! generate_tests {
             };
 
             let metadata = Some(PipelineMetadata {
-                data_source: DataSource::None,
                 content_type: Some("foobar".into()),
                 ..Default::default()
             });

--- a/crates/nu-plugin-core/src/serializers/tests.rs
+++ b/crates/nu-plugin-core/src/serializers/tests.rs
@@ -127,6 +127,7 @@ macro_rules! generate_tests {
             let metadata = Some(PipelineMetadata {
                 data_source: DataSource::None,
                 content_type: Some("foobar".into()),
+                ..Default::default()
             });
 
             let plugin_call = PluginCall::Run(CallInfo {

--- a/crates/nu-plugin-core/src/serializers/tests.rs
+++ b/crates/nu-plugin-core/src/serializers/tests.rs
@@ -6,8 +6,8 @@ macro_rules! generate_tests {
             StreamData,
         };
         use nu_protocol::{
-            DataSource, LabeledError, PipelineMetadata, PluginSignature, Signature, Span, Spanned,
-            SyntaxShape, Value,
+            LabeledError, PipelineMetadata, PluginSignature, Signature, Span, Spanned, SyntaxShape,
+            Value,
         };
 
         #[test]

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -803,7 +803,6 @@ fn interface_write_plugin_call_writes_run_with_value_input() -> Result<(), Shell
     let interface = manager.get_interface();
 
     let metadata0 = PipelineMetadata {
-        data_source: DataSource::None,
         content_type: Some("baz".into()),
         ..Default::default()
     };

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -805,6 +805,7 @@ fn interface_write_plugin_call_writes_run_with_value_input() -> Result<(), Shell
     let metadata0 = PipelineMetadata {
         data_source: DataSource::None,
         content_type: Some("baz".into()),
+        ..Default::default()
     };
 
     let result = interface.write_plugin_call(

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -15,9 +15,8 @@ use nu_plugin_protocol::{
     test_util::{expected_test_custom_value, test_plugin_custom_value},
 };
 use nu_protocol::{
-    BlockId, ByteStreamType, CustomValue, DataSource, IntoInterruptiblePipelineData, IntoSpanned,
-    PipelineData, PipelineMetadata, PluginMetadata, PluginSignature, ShellError, Signals, Span,
-    Spanned, Value,
+    BlockId, ByteStreamType, CustomValue, IntoInterruptiblePipelineData, IntoSpanned, PipelineData,
+    PipelineMetadata, PluginMetadata, PluginSignature, ShellError, Signals, Span, Spanned, Value,
     ast::{Math, Operator},
     engine::Closure,
     shell_error,

--- a/crates/nu-plugin-protocol/src/lib.rs
+++ b/crates/nu-plugin-protocol/src/lib.rs
@@ -115,7 +115,7 @@ impl PipelineDataHeader {
 }
 
 /// Additional information about list (value) streams
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct ListStreamInfo {
     pub id: StreamId,
     pub span: Span,
@@ -134,7 +134,7 @@ impl ListStreamInfo {
 }
 
 /// Additional information about byte streams
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct ByteStreamInfo {
     pub id: StreamId,
     pub span: Span,

--- a/crates/nu-protocol/src/pipeline/metadata.rs
+++ b/crates/nu-protocol/src/pipeline/metadata.rs
@@ -2,11 +2,15 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::Record;
+
 /// Metadata that is valid for the whole [`PipelineData`](crate::PipelineData)
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct PipelineMetadata {
     pub data_source: DataSource,
     pub content_type: Option<String>,
+    #[serde(default)]
+    pub custom: Record,
 }
 
 impl PipelineMetadata {
@@ -29,7 +33,7 @@ impl PipelineMetadata {
 ///
 /// This can either be a particular family of commands (useful so downstream commands can adjust
 /// the presentation e.g. `Ls`) or the opened file to protect against overwrite-attempts properly.
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub enum DataSource {
     Ls,
     HtmlThemes,

--- a/crates/nu-protocol/src/pipeline/metadata.rs
+++ b/crates/nu-protocol/src/pipeline/metadata.rs
@@ -5,6 +5,17 @@ use serde::{Deserialize, Serialize};
 use crate::Record;
 
 /// Metadata that is valid for the whole [`PipelineData`](crate::PipelineData)
+///
+/// ## Custom Metadata
+///
+/// The `custom` field allows commands and plugins to attach arbitrary metadata to pipeline data.
+/// To avoid key collisions, it is recommended to use namespaced keys with a dot separator:
+///
+/// - `"http.response"` - HTTP response metadata (status, headers, etc.)
+/// - `"polars.schema"` - DataFrame schema information
+/// - `"custom_plugin.field"` - Plugin-specific metadata
+///
+/// This convention helps ensure different commands and plugins don't overwrite each other's metadata.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct PipelineMetadata {
     pub data_source: DataSource,

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use serde::{Deserialize, Serialize, de::Visitor, ser::SerializeMap};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Record {
     inner: Vec<(String, Value)>,
 }


### PR DESCRIPTION
## Release notes summary - What our users need to know

This PR adds two related features:

1. Custom metadata via metadata set --merge: You can now attach arbitrary metadata to pipeline data using the --merge flag with a record: 

```nushell
"data" | metadata set --merge {custom_key: "value"} | metadata | get custom_key
```

2. Automatic HTTP response metadata: All HTTP commands (http get, post, put, patch, delete, head, options) now automatically attach response metadata to pipeline data under the "http.response" key, containing:

- status - HTTP status code
- headers - Response headers as a list of {name, value} records
- urls - Redirect history

This allows streaming response bodies while accessing metadata:

```nushell
http get https://stream.wikimedia.org/v2/stream/recentchange | metadata access {|meta|
    if $meta."http.response".status  != 200 { "ugh" }
    else { }
} | lines | each { print ("HI " + $in)  }
```

### Metadata namespacing convention

To avoid key collisions, custom metadata uses namespaced keys with dot separators:

- "http.response" - HTTP response metadata
- "polars.schema" - DataFrame schema information (for future use)
- "custom_plugin.field" - Plugin-specific metadata

This convention is recommended but not enforced.

## Tasks after submitting

- Update the https://github.com/nushell/nushell.github.io (PR is coming)
