### PR TITLE
fix: http / metadata access examples '--allow-errors' flag required

### DIFF
--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -135,7 +135,7 @@ impl Command for HttpGet {
             },
             Example {
                 description: "Check response status while streaming",
-                example: r#"http get https://example.com/file | metadata access {|m| if $m.http_response.status != 200 { error make {msg: "failed"} } else { } } | lines"#,
+                example: r#"http get --allow-errors https://example.com/file | metadata access {|m| if $m.http_response.status != 200 { error make {msg: "failed"} } else { } } | lines"#,
                 result: None,
             },
         ]

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -160,7 +160,7 @@ impl Command for HttpPost {
             },
             Example {
                 description: "Check response status while streaming",
-                example: r#"http post https://example.com/upload 'data' | metadata access {|m| if $m.http_response.status != 200 { error make {msg: "failed"} } else { } } | lines"#,
+                example: r#"http post --allow-errors https://example.com/upload 'data' | metadata access {|m| if $m.http_response.status != 200 { error make {msg: "failed"} } else { } } | lines"#,
                 result: None,
             },
         ]


### PR DESCRIPTION
fall touch up for: https://github.com/nushell/nushell/pull/16821