### PR TITLE
feat: add text wrapping to nu-explore Expand ("e" key) view

### DIFF
--- a/crates/nu-explore/src/commands/expand.rs
+++ b/crates/nu-explore/src/commands/expand.rs
@@ -1,10 +1,6 @@
 use super::ViewCommand;
-use crate::{
-    nu_common::{self, collect_input},
-    views::{Preview, ViewConfig},
-};
+use crate::views::{Preview, ViewConfig};
 use anyhow::Result;
-use nu_color_config::StyleComputer;
 use nu_protocol::{
     Value,
     engine::{EngineState, Stack},
@@ -40,38 +36,15 @@ impl ViewCommand for ExpandCmd {
 
     fn spawn(
         &mut self,
-        engine_state: &EngineState,
-        stack: &mut Stack,
+        _: &EngineState,
+        _: &mut Stack,
         value: Option<Value>,
         _: &ViewConfig,
     ) -> Result<Self::View> {
         if let Some(value) = value {
-            let value_as_string = convert_value_to_string(value, engine_state, stack)?;
-            Ok(Preview::new(&value_as_string))
+            Ok(Preview::new(value))
         } else {
-            Ok(Preview::new(""))
+            Ok(Preview::empty())
         }
-    }
-}
-
-fn convert_value_to_string(
-    value: Value,
-    engine_state: &EngineState,
-    stack: &mut Stack,
-) -> Result<String> {
-    let (cols, vals) = collect_input(value.clone())?;
-
-    let has_no_head = cols.is_empty() || (cols.len() == 1 && cols[0].is_empty());
-    let has_single_value = vals.len() == 1 && vals[0].len() == 1;
-    if !has_no_head && has_single_value {
-        let config = stack.get_config(engine_state);
-        Ok(vals[0][0].to_abbreviated_string(&config))
-    } else {
-        let config = engine_state.get_config();
-        let style_computer = StyleComputer::from_config(engine_state, stack);
-        let table =
-            nu_common::try_build_table(value, engine_state.signals(), config, style_computer);
-
-        Ok(table)
     }
 }

--- a/crates/nu-explore/src/commands/help.rs
+++ b/crates/nu-explore/src/commands/help.rs
@@ -3,7 +3,7 @@ use crate::views::{Preview, ViewConfig};
 use anyhow::Result;
 use nu_ansi_term::Color;
 use nu_protocol::{
-    Value,
+    Span, Value,
     engine::{EngineState, Stack},
 };
 
@@ -15,7 +15,7 @@ pub struct HelpCmd {}
 impl HelpCmd {
     pub const NAME: &'static str = "help";
     pub fn view() -> Preview {
-        Preview::new(&HELP_MESSAGE)
+        Preview::new(Value::string(&*HELP_MESSAGE, Span::unknown()))
     }
 }
 
@@ -36,7 +36,8 @@ Drill down into records+tables:  Press <Enter> to select a cell, move around wit
             Go back/up a level:  Press <Esc> or "q"
  Transpose (flip rows+columns):  Press "t"
  Expand (show all nested data):  Press "e"
-          Open this help page :  Type ":help" then <Enter>
+          Toggle text wrapping:  Press "w" (in Expand view)
+           Open this help page:  Type ":help" then <Enter>
       Open an interactive REPL:  Type ":try" then <Enter>
          Run a Nushell command:  Type ":nu <command>" then <Enter>. The data currently being explored is piped into it.
                      Scroll up:  Press "Page Up", Ctrl+B, or Alt+V

--- a/crates/nu-explore/src/commands/nu.rs
+++ b/crates/nu-explore/src/commands/nu.rs
@@ -59,8 +59,7 @@ impl ViewCommand for NuCmd {
         let (columns, values) = collect_pipeline(pipeline)?;
 
         if let Some(value) = has_simple_value(&values) {
-            let text = value.to_abbreviated_string(&engine_state.config);
-            return Ok(NuView::Preview(Preview::new(&text)));
+            return Ok(NuView::Preview(Preview::new(value.clone())));
         }
 
         let mut view = RecordView::new(columns, values, config.explore_config.clone());

--- a/crates/nu-explore/src/lib.rs
+++ b/crates/nu-explore/src/lib.rs
@@ -58,8 +58,7 @@ fn run_pager(
     p.show_message("For help type :help");
 
     if let Some(value) = has_simple_value(&data) {
-        let text = value.to_abbreviated_string(config.nu_config);
-        let view = Some(Page::new(Preview::new(&text), false));
+        let view = Some(Page::new(Preview::new(value.clone()), false));
         return p.run(engine_state, stack, view, commands);
     }
 

--- a/crates/nu-explore/src/nu_common/mod.rs
+++ b/crates/nu-explore/src/nu_common/mod.rs
@@ -15,7 +15,6 @@ pub type NuText = (String, TextStyle);
 pub use command::run_command_with_value;
 pub use lscolor::{create_lscolors, lscolorize};
 pub use string::{string_width, truncate_str};
-pub use table::try_build_table;
 pub use value::{collect_input, collect_pipeline, create_map};
 
 pub fn has_simple_value(data: &[Vec<Value>]) -> Option<&Value> {

--- a/crates/nu-explore/src/nu_common/table.rs
+++ b/crates/nu-explore/src/nu_common/table.rs
@@ -6,6 +6,7 @@ use nu_table::{
     common::{nu_value_to_string, nu_value_to_string_clean},
 };
 
+#[allow(dead_code)]
 pub fn try_build_table(
     value: Value,
     signals: &Signals,
@@ -33,6 +34,7 @@ pub fn try_build_table(
     }
 }
 
+#[allow(dead_code)]
 fn try_build_map(record: &Record, opts: TableOpts<'_>) -> String {
     let result = ExpandedTable::new(None, false, String::new()).build_map(record, opts.clone());
     match result {
@@ -44,6 +46,7 @@ fn try_build_map(record: &Record, opts: TableOpts<'_>) -> String {
     }
 }
 
+#[allow(dead_code)]
 fn try_build_list(vals: Vec<Value>, opts: TableOpts<'_>) -> String {
     let result = ExpandedTable::new(None, false, String::new()).build_list(&vals, opts.clone());
     match result {

--- a/crates/nu-explore/src/views/preview.rs
+++ b/crates/nu-explore/src/views/preview.rs
@@ -3,7 +3,7 @@ use super::{
     cursor::WindowCursor2D,
 };
 use crate::{
-    nu_common::{NuSpan, NuText},
+    nu_common::NuText,
     pager::{Frame, StatusTopOrEnd, Transition, ViewInfo, report::Report},
 };
 use crossterm::event::KeyEvent;
@@ -14,40 +14,82 @@ use nu_protocol::{
 };
 use ratatui::layout::Rect;
 use std::cmp::max;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-// todo: Add wrap option
 #[derive(Debug)]
 pub struct Preview {
-    underlying_value: Option<Value>,
-    lines: Vec<String>,
+    value: Option<Value>,
     cursor: WindowCursor2D,
+    wrap_enabled: bool,
 }
 
 impl Preview {
-    pub fn new(value: &str) -> Self {
-        let lines: Vec<String> = value
-            .lines()
-            .map(|line| line.replace('\t', "    ")) // tui: doesn't support TAB
-            .collect();
-
-        // TODO: refactor so this is fallible and returns a Result instead of panicking
-        let cursor = WindowCursor2D::new(lines.len(), usize::MAX).expect("Failed to create cursor");
+    pub fn new(value: Value) -> Self {
+        let cursor = WindowCursor2D::new(1, usize::MAX).expect("Failed to create cursor");
         Self {
-            lines,
+            value: Some(value),
             cursor,
-            underlying_value: None,
+            wrap_enabled: true, // Enable wrapping by default
         }
+    }
+
+    pub fn empty() -> Self {
+        let cursor = WindowCursor2D::new(1, usize::MAX).expect("Failed to create cursor");
+        Self {
+            value: None,
+            cursor,
+            wrap_enabled: false,
+        }
+    }
+
+    pub fn toggle_wrap(&mut self) {
+        self.wrap_enabled = !self.wrap_enabled;
     }
 }
 
 impl View for Preview {
-    fn draw(&mut self, f: &mut Frame, area: Rect, _: ViewConfig<'_>, layout: &mut Layout) {
+    fn draw(&mut self, f: &mut Frame, area: Rect, cfg: ViewConfig<'_>, layout: &mut Layout) {
+        // Generate lines on-demand from value
+        // We regenerate text each draw to handle:
+        // 1. Wrapping state changes (toggle with 'w' key)
+        // 2. Terminal width changes (resize)
+        // Draw is called ~4 times per second continuously (250ms tick_rate in pager/events.rs:19),
+        // but Preview handles simple values, so performance is acceptable
+        let lines = if let Some(ref value) = self.value {
+            let config = &cfg.nu_config;
+            let text = value.to_expanded_string(", ", config);
+            let processed_lines = text
+                .lines()
+                .map(|line| line.replace('\t', "    "))
+                .collect::<Vec<_>>();
+
+            if self.wrap_enabled && area.width > 10 {
+                wrap_lines(&processed_lines, area.width as usize)
+            } else {
+                processed_lines
+            }
+        } else {
+            vec![String::new()]
+        };
+
+        // Update cursor with new line count, preserving position where possible
+        let current_row = self.cursor.row();
+        let current_col = self.cursor.column();
+
+        self.cursor =
+            WindowCursor2D::new(lines.len().max(1), usize::MAX).expect("Failed to create cursor");
         let _ = self
             .cursor
             .set_window_size(area.height as usize, area.width as usize);
 
-        let lines = &self.lines[self.cursor.window_origin().row..];
-        for (i, line) in lines.iter().enumerate().take(area.height as usize) {
+        // Try to restore position, clamping to new bounds
+        if current_row < lines.len() {
+            self.cursor
+                .set_window_start_position(current_row, current_col);
+        }
+
+        let visible_lines = &lines[self.cursor.window_origin().row..];
+        for (i, line) in visible_lines.iter().enumerate().take(area.height as usize) {
             let text_widget = ColoredTextWidget::new(line, self.cursor.column());
             let plain_text = text_widget.get_plain_text(area.width as usize);
 
@@ -67,6 +109,14 @@ impl View for Preview {
         info: &mut ViewInfo, // add this arg to draw too?
         key: KeyEvent,
     ) -> Transition {
+        // Handle wrap toggle first
+        if let crossterm::event::KeyCode::Char('w') = key.code {
+            self.toggle_wrap();
+            let wrap_status = if self.wrap_enabled { "ON" } else { "OFF" };
+            info.status = Some(Report::info(format!("Text wrapping: {wrap_status}")));
+            return Transition::Ok;
+        }
+
         match self.handle_input_key(&key) {
             Ok((transition, status_top_or_end)) => {
                 match status_top_or_end {
@@ -81,10 +131,15 @@ impl View for Preview {
     }
 
     fn collect_data(&self) -> Vec<NuText> {
-        self.lines
-            .iter()
-            .map(|line| (line.to_owned(), TextStyle::default()))
-            .collect::<Vec<_>>()
+        if let Some(ref value) = self.value {
+            let config = nu_protocol::Config::default();
+            let text = value.to_expanded_string(", ", &config);
+            text.lines()
+                .map(|line| (line.replace('\t', "    "), TextStyle::default()))
+                .collect::<Vec<_>>()
+        } else {
+            vec![(String::new(), TextStyle::default())]
+        }
     }
 
     fn show_data(&mut self, row: usize) -> bool {
@@ -97,13 +152,7 @@ impl View for Preview {
     }
 
     fn exit(&mut self) -> Option<Value> {
-        match &self.underlying_value {
-            Some(value) => Some(value.clone()),
-            None => {
-                let text = self.lines.join("\n");
-                Some(Value::string(text, NuSpan::unknown()))
-            }
-        }
+        self.value.clone()
     }
 }
 
@@ -135,4 +184,65 @@ fn set_status_top(view: &Preview, info: &mut ViewInfo) {
     } else {
         info.status = Some(Report::default());
     }
+}
+
+fn wrap_lines(lines: &[String], wrap_width: usize) -> Vec<String> {
+    let mut wrapped_lines = Vec::new();
+
+    for line in lines {
+        if line.width() <= wrap_width {
+            wrapped_lines.push(line.clone());
+        } else {
+            // Split long lines into multiple wrapped lines
+            let mut remaining = line.as_str();
+
+            while !remaining.is_empty() {
+                let mut split_pos = 0;
+                let mut current_width = 0;
+                let mut last_space = None;
+
+                // Find the best place to break the line
+                for (byte_pos, ch) in remaining.char_indices() {
+                    let char_width = ch.width().unwrap_or(0);
+
+                    if current_width + char_width > wrap_width {
+                        break;
+                    }
+
+                    current_width += char_width;
+                    split_pos = byte_pos + ch.len_utf8();
+
+                    // Remember the last space for word wrapping
+                    if ch.is_whitespace() {
+                        last_space = Some(split_pos);
+                    }
+                }
+
+                // If we found a space and we're not at the beginning, break at the space
+                let break_pos = if split_pos < remaining.len()
+                    && let Some(space_pos) = last_space
+                    && space_pos > wrap_width / 3
+                {
+                    space_pos
+                } else {
+                    split_pos
+                };
+
+                if break_pos == 0 {
+                    // Single character wider than wrap_width, just take it
+                    if let Some(ch) = remaining.chars().next() {
+                        wrapped_lines.push(ch.to_string());
+                        remaining = &remaining[ch.len_utf8()..];
+                    } else {
+                        break;
+                    }
+                } else {
+                    wrapped_lines.push(remaining[..break_pos].trim_end().to_string());
+                    remaining = remaining[break_pos..].trim_start();
+                }
+            }
+        }
+    }
+
+    wrapped_lines
 }


### PR DESCRIPTION
Add  text wrapping in nu-explore Expand (Preview) view.

## Changes in nu-explore

- Refactored/simplified Preview View to store Value and compute text representation on demand
- Added wrap text toggle with 'w' key and status feedback
- Added Unicode-aware text wrapping with word boundaries
- Updated help text to document the 'w' key functionality
- Text wrapping enabled by default for better readability

## Usage

<!-- I edited the code block to make it more readable, hope you don't mind -->
```nushell
use std/util repeat

1..5
| each { |i|
    {
        id: $i
        short: $"Item ($i)"
        long: (
            (
                "This is a very long string that contains lots of text to"
                ++ "test text wrapping functionality in the explore view"
            )
            | repeat 30
            | str join " "
        )
    }
}
| explore -i
```

   1. In explore navigate to a text cell with ... trim in the end and press 'e' to expand
   2. Press 'w' to toggle text wrapping on/off
   3. Text automatically adapts to terminal width when wrapping is enabled 

## Release notes summary - What our users need to know

The expand ("e" key) view in explore (-i) now handles text wrapping by pressing "w". It is used for a scrollable, expanded string view of a cell value, whereas Enter is used for drilling down into the field with the usual structured table view.

## Tasks after submitting

- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
