### PR TITLE
update reedline to latest commit a274653

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6413,7 +6413,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.42.0"
-source = "git+https://github.com/nushell/reedline?branch=main#32e82c279df0282ab04d7a81baedf58a5db1a705"
+source = "git+https://github.com/nushell/reedline?branch=main#a2746536213cab110ed9c392772ef27e9ad57b13"
 dependencies = [
  "arboard",
  "chrono",


### PR DESCRIPTION
This PR updates reedline to the latest commit [a274653](https://github.com/nushell/reedline/commit/a2746536213cab110ed9c392772ef27e9ad57b13)

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A