### PR TITLE
Consolidate and fix closure parameter handling

### DIFF
--- a/crates/nu-cli/src/hints/external_hinter.rs
+++ b/crates/nu-cli/src/hints/external_hinter.rs
@@ -71,7 +71,7 @@ impl ExternalHinter {
         let stack = Stack::with_parent(self.stack.clone());
         let result = ClosureEvalOnce::new(self.engine_state.as_ref(), &stack, self.closure.clone())
             .add_arg(Value::record(context, span))
-            .run_with_input(PipelineData::empty())
+            .and_then(|closure| closure.run_with_input(PipelineData::empty()))
             .and_then(|data| data.into_value(span));
 
         match result {

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -1,4 +1,4 @@
-use nu_engine::{command_prelude::*, get_eval_block_with_early_return, redirect_env};
+use nu_engine::{ClosureEvalOnce, command_prelude::*};
 #[cfg(feature = "os")]
 use nu_protocol::process::{ChildPipe, ChildProcess};
 use nu_protocol::{
@@ -57,26 +57,20 @@ impl Command for Do {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let block: Closure = call.req(engine_state, caller_stack, 0)?;
+        let closure: Closure = call.req(engine_state, caller_stack, 0)?;
         let rest: Vec<Value> = call.rest(engine_state, caller_stack, 1)?;
         let ignore_all_errors = call.has_flag(engine_state, caller_stack, "ignore-errors")?;
 
         let capture_errors = call.has_flag(engine_state, caller_stack, "capture-errors")?;
         let has_env = call.has_flag(engine_state, caller_stack, "env")?;
 
-        let mut callee_stack = caller_stack.captures_to_stack_preserve_out_dest(block.captures);
-        let block = engine_state.get_block(block.block_id);
-
-        bind_args_to(&mut callee_stack, &block.signature, rest, head)?;
-        let eval_block_with_early_return = get_eval_block_with_early_return(engine_state);
-
-        let result = eval_block_with_early_return(engine_state, &mut callee_stack, block, input)
-            .map(|p| p.body);
-
-        if has_env {
-            // Merge the block's environment to the current stack
-            redirect_env(engine_state, caller_stack, &callee_stack);
+        let result = if has_env {
+            ClosureEvalOnce::new_env_preserve_out_dest(engine_state, caller_stack, closure)
+        } else {
+            ClosureEvalOnce::new_preserve_out_dest(engine_state, caller_stack, closure)
         }
+        .add_args(rest)?
+        .run_with_input(input);
 
         match result {
             Ok(PipelineData::ByteStream(stream, metadata)) if capture_errors => {
@@ -244,68 +238,6 @@ impl Command for Do {
             },
         ]
     }
-}
-
-fn bind_args_to(
-    stack: &mut Stack,
-    signature: &Signature,
-    args: Vec<Value>,
-    head_span: Span,
-) -> Result<(), ShellError> {
-    let mut val_iter = args.into_iter();
-    for (param, required) in signature
-        .required_positional
-        .iter()
-        .map(|p| (p, true))
-        .chain(signature.optional_positional.iter().map(|p| (p, false)))
-    {
-        let var_id = param
-            .var_id
-            .expect("internal error: all custom parameters must have var_ids");
-        if let Some(result) = val_iter.next() {
-            let param_type = param.shape.to_type();
-            if !result.is_subtype_of(&param_type) {
-                return Err(ShellError::CantConvert {
-                    to_type: param.shape.to_type().to_string(),
-                    from_type: result.get_type().to_string(),
-                    span: result.span(),
-                    help: None,
-                });
-            }
-            stack.add_var(var_id, result);
-        } else if let Some(value) = &param.default_value {
-            stack.add_var(var_id, value.to_owned())
-        } else if !required {
-            stack.add_var(var_id, Value::nothing(head_span))
-        } else {
-            return Err(ShellError::MissingParameter {
-                param_name: param.name.to_string(),
-                span: head_span,
-            });
-        }
-    }
-
-    if let Some(rest_positional) = &signature.rest_positional {
-        let mut rest_items = vec![];
-
-        for result in val_iter {
-            rest_items.push(result);
-        }
-
-        let span = if let Some(rest_item) = rest_items.first() {
-            rest_item.span()
-        } else {
-            head_span
-        };
-
-        stack.add_var(
-            rest_positional
-                .var_id
-                .expect("Internal error: rest positional parameter lacks var_id"),
-            Value::list(rest_items, span),
-        )
-    }
-    Ok(())
 }
 
 mod test {

--- a/crates/nu-command/src/debug/metadata_access.rs
+++ b/crates/nu-command/src/debug/metadata_access.rs
@@ -1,4 +1,4 @@
-use nu_engine::{command_prelude::*, get_eval_block_with_early_return, redirect_env};
+use nu_engine::{ClosureEvalOnce, command_prelude::*};
 use nu_protocol::{
     PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
     engine::{Call, Closure, Command, EngineState, Stack},
@@ -37,24 +37,11 @@ impl Command for MetadataAccess {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let closure: Closure = call.req(engine_state, caller_stack, 0)?;
-        let block = engine_state.get_block(closure.block_id);
-
-        // `ClosureEvalOnce` is not used as it uses `Stack::captures_to_stack` rather than
-        // `Stack::captures_to_stack_preserve_out_dest`. This command shouldn't collect streams
-        let mut callee_stack = caller_stack.captures_to_stack_preserve_out_dest(closure.captures);
         let metadata_record = Value::record(build_metadata_record(&input, call.head), call.head);
 
-        if let Some(var_id) = block.signature.get_positional(0).and_then(|var| var.var_id) {
-            callee_stack.add_var(var_id, metadata_record)
-        }
-
-        let eval = get_eval_block_with_early_return(engine_state);
-        let result = eval(engine_state, &mut callee_stack, block, input).map(|p| p.body);
-
-        // Merge the block's environment to the current stack
-        redirect_env(engine_state, caller_stack, &callee_stack);
-
-        result
+        ClosureEvalOnce::new_env_preserve_out_dest(engine_state, caller_stack, closure)
+            .add_arg(metadata_record)?
+            .run_with_input(input)
     }
 
     fn examples(&self) -> Vec<Example<'_>> {

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -186,15 +186,15 @@ impl Command for Watch {
 
                     if matches_glob {
                         let result = closure
-                            .add_arg(event.operation.into_value(head))
-                            .add_arg(event.path.to_string_lossy().into_value(head))
+                            .add_arg(event.operation.into_value(head))?
+                            .add_arg(event.path.to_string_lossy().into_value(head))?
                             .add_arg(
                                 event
                                     .new_path
                                     .as_deref()
                                     .map(Path::to_string_lossy)
                                     .into_value(head),
-                            )
+                            )?
                             .run_with_input(PipelineData::empty());
 
                         match result {

--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -54,8 +54,10 @@ impl Command for Items {
                             .map_while(move |(col, val)| {
                                 let result = closure
                                     .add_arg(Value::string(col, span))
-                                    .add_arg(val)
-                                    .run_with_input(PipelineData::empty())
+                                    .and_then(|closure| closure.add_arg(val))
+                                    .and_then(|closure| {
+                                        closure.run_with_input(PipelineData::empty())
+                                    })
                                     .and_then(|data| data.into_value(head));
 
                                 match result {

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -116,8 +116,8 @@ impl Command for Reduce {
         for value in iter {
             engine_state.signals().check(&head)?;
             acc = closure
-                .add_arg(value)
-                .add_arg(acc.clone())
+                .add_arg(value)?
+                .add_arg(acc.clone())?
                 .run_with_input(PipelineData::value(acc, None))?
                 .into_value(head)?;
         }

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -270,7 +270,7 @@ fn update_value_by_closure(
     }
 
     let new_value = closure
-        .add_arg(value.clone())
+        .add_arg(value.clone())?
         .run_with_input(value_at_path.into_owned().into_pipeline_data())?
         .into_value(span)?;
 
@@ -305,7 +305,7 @@ fn update_single_value_by_closure(
     };
 
     let new_value = closure
-        .add_arg(arg.clone())
+        .add_arg(arg.clone())?
         .run_with_input(value_at_path.into_owned().into_pipeline_data())?
         .into_value(span)?;
 

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -335,7 +335,7 @@ fn upsert_value_by_closure(
         .unwrap_or(PipelineData::empty());
 
     let new_value = closure
-        .add_arg(value.clone())
+        .add_arg(value.clone())?
         .run_with_input(input)?
         .into_value(span)?;
 
@@ -369,7 +369,7 @@ fn upsert_single_value_by_closure(
         .unwrap_or(PipelineData::empty());
 
     let new_value = closure
-        .add_arg(arg)
+        .add_arg(arg)?
         .run_with_input(input)?
         .into_value(span)?;
 

--- a/crates/nu-command/src/generators/generate.rs
+++ b/crates/nu-command/src/generators/generate.rs
@@ -113,7 +113,7 @@ In this case, generation also stops when the input stream stops."
 
                     let closure_result = closure
                         .add_arg(state_arg)
-                        .run_with_input(PipelineData::empty());
+                        .and_then(|closure| closure.run_with_input(PipelineData::empty()));
                     let (output, next_input) = parse_closure_result(closure_result, head);
 
                     // We use `state` to control when to stop, not `output`. By wrapping
@@ -135,8 +135,8 @@ In this case, generation also stops when the input stream stops."
                     let state_arg = state.take()?;
                     let closure_result = closure
                         .add_arg(item)
-                        .add_arg(state_arg)
-                        .run_with_input(PipelineData::empty());
+                        .and_then(|closure| closure.add_arg(state_arg))
+                        .and_then(|closure| closure.run_with_input(PipelineData::empty()));
                     let (output, next_input) = parse_closure_result(closure_result, head);
                     state = next_input;
                     Some(output)

--- a/crates/nu-command/src/sort_utils.rs
+++ b/crates/nu-command/src/sort_utils.rs
@@ -278,8 +278,8 @@ pub fn compare_custom_closure(
     span: Span,
 ) -> Result<Ordering, ShellError> {
     closure_eval
-        .add_arg(left.clone())
-        .add_arg(right.clone())
+        .add_arg(left.clone())?
+        .add_arg(right.clone())?
         .run_with_input(PipelineData::value(
             Value::list(vec![left.clone(), right.clone()], span),
             None,

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -355,7 +355,10 @@ fn action(
                                     Some(m) => Value::string(m.as_str().to_string(), head),
                                     None => Value::nothing(head),
                                 };
-                                closure_eval.add_arg(arg);
+                                if let Err(error) = closure_eval.add_arg(arg) {
+                                    first_error = Some(error);
+                                    return "".to_string();
+                                }
                             }
                             let value = match caps.get(0) {
                                 Some(m) => Value::string(m.as_str().to_string(), head),

--- a/crates/nu-engine/src/closure_eval.rs
+++ b/crates/nu-engine/src/closure_eval.rs
@@ -57,6 +57,11 @@ fn eval_fn(debug: bool) -> EvalBlockWithEarlyReturnFn {
 ///
 /// Environment isolation and other cleanup is handled by [`ClosureEval`],
 /// so nothing needs to be done following [`ClosureEval::run_with_input`] or [`ClosureEval::run_with_value`].
+///
+/// In contrast to [`ClosureEvalOnce`], [`ClosureEval`] holds an owned copy of the
+/// [`EngineState`] supplied. This makes it possible to return it from a function that
+/// only has a borrowed [`EngineState`] reference, such as the `run` function of a
+/// [`nu_engine::command_prelude::Command`] implementation.
 #[derive(Clone)]
 pub struct ClosureEval {
     engine_state: EngineState,
@@ -191,6 +196,9 @@ impl ClosureEval {
 /// # let value = unimplemented!();
 /// let result = ClosureEvalOnce::new(engine_state, stack, closure).run_with_value(value);
 /// ```
+///
+/// In contrast to [`ClosureEval`], the lifetime of [`ClosureEvalOnce`] is bound
+/// to that of the supplied [`EngineState`] reference, which makes it more light-weight.
 pub struct ClosureEvalOnce<'a> {
     engine_state: &'a EngineState,
     stack: Stack,

--- a/crates/nu-engine/src/closure_eval.rs
+++ b/crates/nu-engine/src/closure_eval.rs
@@ -143,9 +143,8 @@ impl ClosureEval {
     /// This function is equivalent to `self.add_arg(value)` followed by `self.run_with_input(value.into_pipeline_data())`.
     pub fn run_with_value(&mut self, value: Value) -> Result<PipelineData, ShellError> {
         self.call_eval
-            .add_positional(&self.block.signature, Cow::Borrowed(&value))?
-            .with_env(&self.env_vars, &self.env_hidden)
-            .run(&self.engine_state, &self.block, value.into_pipeline_data())
+            .add_positional(&self.block.signature, Cow::Borrowed(&value))?;
+        self.run_with_input(value.into_pipeline_data())
     }
 }
 

--- a/crates/nu-engine/src/closure_eval.rs
+++ b/crates/nu-engine/src/closure_eval.rs
@@ -1,11 +1,7 @@
-use crate::{
-    EvalBlockWithEarlyReturnFn, eval_block_with_early_return, get_eval_block_with_early_return,
-    redirect_env,
-};
+use crate::{eval::CallEval, get_eval_block_with_early_return};
 use nu_protocol::{
-    IntoPipelineData, PipelineData, ShellError, Signature, Span, Value,
+    IntoPipelineData, PipelineData, ShellError, Span, Value,
     ast::Block,
-    debugger::{WithDebug, WithoutDebug},
     engine::{Closure, EngineState, EnvName, EnvVars, Stack},
 };
 use std::{
@@ -61,7 +57,7 @@ pub struct ClosureEval {
     block: Arc<Block>,
     env_vars: Vec<Arc<EnvVars>>,
     env_hidden: Arc<HashMap<String, HashSet<EnvName>>>,
-    call_eval: ClosureEvalCommon,
+    call_eval: CallEval,
 }
 
 impl ClosureEval {
@@ -72,8 +68,9 @@ impl ClosureEval {
         let block = engine_state.get_block(closure.block_id).clone();
         let env_vars = stack.env_vars.clone();
         let env_hidden = stack.env_hidden.clone();
-        let call_eval = ClosureEvalCommon::new(
+        let call_eval = CallEval::new(
             callee_stack,
+            Span::unknown(),
             block.span.unwrap_or(Span::unknown()),
             get_eval_block_with_early_return(&engine_state),
         );
@@ -97,8 +94,9 @@ impl ClosureEval {
         let block = engine_state.get_block(closure.block_id).clone();
         let env_vars = stack.env_vars.clone();
         let env_hidden = stack.env_hidden.clone();
-        let call_eval = ClosureEvalCommon::new(
+        let call_eval = CallEval::new(
             callee_stack,
+            Span::unknown(),
             block.span.unwrap_or(Span::unknown()),
             get_eval_block_with_early_return(&engine_state),
         );
@@ -189,7 +187,7 @@ impl ClosureEval {
 pub struct ClosureEvalOnce<'a> {
     engine_state: &'a EngineState,
     block: &'a Block,
-    call_eval: ClosureEvalCommon,
+    call_eval: CallEval,
     caller_stack: Option<&'a mut Stack>,
 }
 
@@ -198,8 +196,9 @@ impl<'a> ClosureEvalOnce<'a> {
     pub fn new(engine_state: &'a EngineState, stack: &Stack, closure: Closure) -> Self {
         let block = engine_state.get_block(closure.block_id);
         let callee_stack = stack.captures_to_stack(closure.captures);
-        let call_eval = ClosureEvalCommon::new(
+        let call_eval = CallEval::new(
             callee_stack,
+            Span::unknown(),
             block.span.unwrap_or(Span::unknown()),
             get_eval_block_with_early_return(engine_state),
         );
@@ -218,8 +217,9 @@ impl<'a> ClosureEvalOnce<'a> {
     ) -> Self {
         let block = engine_state.get_block(closure.block_id);
         let callee_stack = stack.captures_to_stack_preserve_out_dest(closure.captures);
-        let call_eval = ClosureEvalCommon::new(
+        let call_eval = CallEval::new(
             callee_stack,
+            Span::unknown(),
             block.span.unwrap_or(Span::unknown()),
             get_eval_block_with_early_return(engine_state),
         );
@@ -238,8 +238,9 @@ impl<'a> ClosureEvalOnce<'a> {
     ) -> Self {
         let block = engine_state.get_block(closure.block_id);
         let callee_stack = stack.captures_to_stack_preserve_out_dest(closure.captures);
-        let call_eval = ClosureEvalCommon::new(
+        let call_eval = CallEval::new(
             callee_stack,
+            Span::unknown(),
             block.span.unwrap_or(Span::unknown()),
             get_eval_block_with_early_return(engine_state),
         );
@@ -297,170 +298,5 @@ impl<'a> ClosureEvalOnce<'a> {
         self.call_eval
             .add_positional(&self.block.signature, Cow::Borrowed(&value))?;
         self.run_with_input(value.into_pipeline_data())
-    }
-}
-
-/// Code shared between [`ClosureEval`] and [`ClosureEvalOnce`]
-#[derive(Clone)]
-struct ClosureEvalCommon {
-    callee_stack: Stack,
-    callee_span: Span,
-    arg_index: usize,
-    rest_args: Vec<Value>,
-    eval: EvalBlockWithEarlyReturnFn,
-}
-
-impl ClosureEvalCommon {
-    /// Create a new [`CallEval`] context
-    pub fn new(callee_stack: Stack, callee_span: Span, eval: EvalBlockWithEarlyReturnFn) -> Self {
-        Self {
-            callee_stack,
-            callee_span,
-            arg_index: 0,
-            rest_args: Vec::new(),
-            eval,
-        }
-    }
-
-    /// Add a positional argument to the call stack.
-    ///
-    /// Returns an error if the given `value` does not match the type of
-    /// the argument according to the signature (see [`CallEval::new`]).
-    pub fn add_positional(
-        &mut self,
-        signature: &Signature,
-        value: Cow<Value>,
-    ) -> Result<&mut Self, ShellError> {
-        let maybe_param = if self.arg_index < signature.required_positional.len() {
-            signature.required_positional.get(self.arg_index)
-        } else if self.arg_index
-            < (signature.required_positional.len() + signature.optional_positional.len())
-        {
-            signature
-                .optional_positional
-                .get(self.arg_index - signature.required_positional.len())
-        } else {
-            None
-        };
-        if let Some(param) = maybe_param {
-            let param_type = param.shape.to_type();
-            if value.is_subtype_of(&param_type) {
-                let var_id = param
-                    .var_id
-                    .expect("internal error: all custom parameters must have var_ids");
-                self.callee_stack.add_var(var_id, value.into_owned());
-                self.arg_index += 1;
-                Ok(self)
-            } else {
-                Err(ShellError::CantConvert {
-                    to_type: param_type.to_string(),
-                    from_type: value.get_type().to_string(),
-                    span: value.span(),
-                    help: None,
-                })
-            }
-        } else {
-            // assign arg to rest params
-            if let Some(rest_positional) = &signature.rest_positional {
-                let param_type = rest_positional.shape.to_type();
-                if value.is_subtype_of(&param_type) {
-                    self.rest_args.push(value.into_owned());
-                    Ok(self)
-                } else {
-                    Err(ShellError::CantConvert {
-                        to_type: param_type.to_string(),
-                        from_type: value.get_type().to_string(),
-                        span: value.span(),
-                        help: None,
-                    })
-                }
-            } else {
-                // We do not consider it an error if more arguments
-                // are added than the closure takes. This makes it possible
-                // to omit any unused arguments in the closure definition.
-                Ok(self)
-            }
-        }
-    }
-
-    /// Sets the environment variables for the call.
-    pub fn with_env(
-        &mut self,
-        env_vars: &[Arc<EnvVars>],
-        env_hidden: &Arc<HashMap<String, HashSet<String>>>,
-    ) -> &mut Self {
-        self.callee_stack.with_env(env_vars, env_hidden);
-        self
-    }
-
-    /// Sets whether to enable debugging when evaluating the closure.
-    pub fn debug(&mut self, debug: bool) -> &mut Self {
-        if debug {
-            self.eval = eval_block_with_early_return::<WithDebug>
-        } else {
-            self.eval = eval_block_with_early_return::<WithoutDebug>
-        };
-        self
-    }
-
-    /// Run the given block.
-    pub fn run(
-        &mut self,
-        engine_state: &EngineState,
-        block: &Block,
-        input: PipelineData,
-    ) -> Result<PipelineData, ShellError> {
-        self.finalize_arguments(&block.signature)?;
-        self.arg_index = 0;
-        self.rest_args.clear();
-        (self.eval)(engine_state, &mut self.callee_stack, block, input).map(|p| p.body)
-    }
-
-    /// Export the modified environment from callee to the caller.
-    pub fn redirect_env(&self, engine_state: &EngineState, stack: &mut Stack) {
-        redirect_env(engine_state, stack, &self.callee_stack);
-    }
-
-    /// Add default and rest values to the stack, raise error on
-    /// missing parameters.
-    fn finalize_arguments(&mut self, signature: &Signature) -> Result<(), ShellError> {
-        for (num, (param, required)) in signature
-            .required_positional
-            .iter()
-            .map(|p| (p, true))
-            .chain(signature.optional_positional.iter().map(|p| (p, false)))
-            .enumerate()
-        {
-            let var_id = param
-                .var_id
-                .expect("internal error: all custom parameters must have var_ids");
-            if num < self.arg_index {
-                // parameter has been added by add_positional
-            } else if let Some(value) = &param.default_value {
-                self.callee_stack.add_var(var_id, value.to_owned());
-            } else if !required {
-                self.callee_stack
-                    .add_var(var_id, Value::nothing(self.callee_span.to_owned()));
-            } else {
-                return Err(ShellError::MissingParameter {
-                    param_name: param.name.to_string(),
-                    span: self.callee_span.to_owned(),
-                });
-            }
-        }
-        if let Some(rest_positional) = &signature.rest_positional {
-            let span = if let Some(rest_item) = self.rest_args.first() {
-                rest_item.span()
-            } else {
-                self.callee_span.to_owned()
-            };
-            self.callee_stack.add_var(
-                rest_positional
-                    .var_id
-                    .expect("Internal error: rest positional parameter lackes var_id"),
-                Value::list(self.rest_args.to_owned(), span),
-            );
-        }
-        Ok(())
     }
 }

--- a/crates/nu-engine/src/closure_eval.rs
+++ b/crates/nu-engine/src/closure_eval.rs
@@ -1,8 +1,9 @@
 use crate::{
     EvalBlockWithEarlyReturnFn, eval_block_with_early_return, get_eval_block_with_early_return,
+    redirect_env,
 };
 use nu_protocol::{
-    IntoPipelineData, PipelineData, ShellError, Value,
+    IntoPipelineData, PipelineData, ShellError, Signature, Span, Value,
     ast::Block,
     debugger::{WithDebug, WithoutDebug},
     engine::{Closure, EngineState, EnvName, EnvVars, Stack},
@@ -12,14 +13,6 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-
-fn eval_fn(debug: bool) -> EvalBlockWithEarlyReturnFn {
-    if debug {
-        eval_block_with_early_return::<WithDebug>
-    } else {
-        eval_block_with_early_return::<WithoutDebug>
-    }
-}
 
 /// [`ClosureEval`] is used to repeatedly evaluate a closure with different values/inputs.
 ///
@@ -37,7 +30,7 @@ fn eval_fn(debug: bool) -> EvalBlockWithEarlyReturnFn {
 /// let mut closure = ClosureEval::new(engine_state, stack, closure);
 /// let iter = Vec::<Value>::new()
 ///     .into_iter()
-///     .map(move |value| closure.add_arg(value).run_with_input(PipelineData::empty()));
+///     .map(move |value| closure.add_arg(value).unwrap().run_with_input(PipelineData::empty()));
 /// ```
 ///
 /// Many closures follow a simple, common scheme where the pipeline input and the first argument are the same value.
@@ -65,32 +58,32 @@ fn eval_fn(debug: bool) -> EvalBlockWithEarlyReturnFn {
 #[derive(Clone)]
 pub struct ClosureEval {
     engine_state: EngineState,
-    stack: Stack,
     block: Arc<Block>,
-    arg_index: usize,
     env_vars: Vec<Arc<EnvVars>>,
     env_hidden: Arc<HashMap<String, HashSet<EnvName>>>,
-    eval: EvalBlockWithEarlyReturnFn,
+    call_eval: ClosureEvalCommon,
 }
 
 impl ClosureEval {
     /// Create a new [`ClosureEval`].
     pub fn new(engine_state: &EngineState, stack: &Stack, closure: Closure) -> Self {
         let engine_state = engine_state.clone();
-        let stack = stack.captures_to_stack(closure.captures);
+        let callee_stack = stack.captures_to_stack(closure.captures);
         let block = engine_state.get_block(closure.block_id).clone();
         let env_vars = stack.env_vars.clone();
         let env_hidden = stack.env_hidden.clone();
-        let eval = get_eval_block_with_early_return(&engine_state);
+        let call_eval = ClosureEvalCommon::new(
+            callee_stack,
+            block.span.unwrap_or(Span::unknown()),
+            get_eval_block_with_early_return(&engine_state),
+        );
 
         Self {
             engine_state,
-            stack,
             block,
-            arg_index: 0,
             env_vars,
             env_hidden,
-            eval,
+            call_eval,
         }
     }
 
@@ -100,20 +93,22 @@ impl ClosureEval {
         closure: Closure,
     ) -> Self {
         let engine_state = engine_state.clone();
-        let stack = stack.captures_to_stack_preserve_out_dest(closure.captures);
+        let callee_stack = stack.captures_to_stack_preserve_out_dest(closure.captures);
         let block = engine_state.get_block(closure.block_id).clone();
         let env_vars = stack.env_vars.clone();
         let env_hidden = stack.env_hidden.clone();
-        let eval = get_eval_block_with_early_return(&engine_state);
+        let call_eval = ClosureEvalCommon::new(
+            callee_stack,
+            block.span.unwrap_or(Span::unknown()),
+            get_eval_block_with_early_return(&engine_state),
+        );
 
         Self {
             engine_state,
-            stack,
             block,
-            arg_index: 0,
             env_vars,
             env_hidden,
-            eval,
+            call_eval,
         }
     }
 
@@ -121,38 +116,27 @@ impl ClosureEval {
     ///
     /// By default, this is controlled by the [`EngineState`] used to create this [`ClosureEval`].
     pub fn debug(&mut self, debug: bool) -> &mut Self {
-        self.eval = eval_fn(debug);
+        self.call_eval.debug(debug);
         self
-    }
-
-    fn try_add_arg(&mut self, value: Cow<Value>) {
-        if let Some(var_id) = self
-            .block
-            .signature
-            .get_positional(self.arg_index)
-            .and_then(|var| var.var_id)
-        {
-            self.stack.add_var(var_id, value.into_owned());
-            self.arg_index += 1;
-        }
     }
 
     /// Add an argument [`Value`] to the closure.
     ///
     /// Multiple [`add_arg`](Self::add_arg) calls can be chained together,
     /// but make sure that arguments are added based on their positional order.
-    pub fn add_arg(&mut self, value: Value) -> &mut Self {
-        self.try_add_arg(Cow::Owned(value));
-        self
+    pub fn add_arg(&mut self, value: Value) -> Result<&mut Self, ShellError> {
+        self.call_eval
+            .add_positional(&self.block.signature, Cow::Owned(value))?;
+        Ok(self)
     }
 
     /// Run the closure, passing the given [`PipelineData`] as input.
     ///
     /// Any arguments should be added beforehand via [`add_arg`](Self::add_arg).
     pub fn run_with_input(&mut self, input: PipelineData) -> Result<PipelineData, ShellError> {
-        self.arg_index = 0;
-        self.stack.with_env(&self.env_vars, &self.env_hidden);
-        (self.eval)(&self.engine_state, &mut self.stack, &self.block, input).map(|p| p.body)
+        self.call_eval
+            .with_env(&self.env_vars, &self.env_hidden)
+            .run(&self.engine_state, &self.block, input)
     }
 
     /// Run the closure using the given [`Value`] as both the pipeline input and the first argument.
@@ -160,8 +144,10 @@ impl ClosureEval {
     /// Using this function after or in combination with [`add_arg`](Self::add_arg) is most likely an error.
     /// This function is equivalent to `self.add_arg(value)` followed by `self.run_with_input(value.into_pipeline_data())`.
     pub fn run_with_value(&mut self, value: Value) -> Result<PipelineData, ShellError> {
-        self.try_add_arg(Cow::Borrowed(&value));
-        self.run_with_input(value.into_pipeline_data())
+        self.call_eval
+            .add_positional(&self.block.signature, Cow::Borrowed(&value))?
+            .with_env(&self.env_vars, &self.env_hidden)
+            .run(&self.engine_state, &self.block, value.into_pipeline_data())
     }
 }
 
@@ -181,6 +167,7 @@ impl ClosureEval {
 /// # let value = unimplemented!();
 /// let result = ClosureEvalOnce::new(engine_state, stack, closure)
 ///     .add_arg(value)
+///     .unwrap()
 ///     .run_with_input(PipelineData::empty());
 /// ```
 ///
@@ -201,23 +188,26 @@ impl ClosureEval {
 /// to that of the supplied [`EngineState`] reference, which makes it more light-weight.
 pub struct ClosureEvalOnce<'a> {
     engine_state: &'a EngineState,
-    stack: Stack,
     block: &'a Block,
-    arg_index: usize,
-    eval: EvalBlockWithEarlyReturnFn,
+    call_eval: ClosureEvalCommon,
+    caller_stack: Option<&'a mut Stack>,
 }
 
 impl<'a> ClosureEvalOnce<'a> {
     /// Create a new [`ClosureEvalOnce`].
     pub fn new(engine_state: &'a EngineState, stack: &Stack, closure: Closure) -> Self {
         let block = engine_state.get_block(closure.block_id);
-        let eval = get_eval_block_with_early_return(engine_state);
+        let callee_stack = stack.captures_to_stack(closure.captures);
+        let call_eval = ClosureEvalCommon::new(
+            callee_stack,
+            block.span.unwrap_or(Span::unknown()),
+            get_eval_block_with_early_return(engine_state),
+        );
         Self {
             engine_state,
-            stack: stack.captures_to_stack(closure.captures),
             block,
-            arg_index: 0,
-            eval,
+            call_eval,
+            caller_stack: None,
         }
     }
 
@@ -227,13 +217,37 @@ impl<'a> ClosureEvalOnce<'a> {
         closure: Closure,
     ) -> Self {
         let block = engine_state.get_block(closure.block_id);
-        let eval = get_eval_block_with_early_return(engine_state);
+        let callee_stack = stack.captures_to_stack_preserve_out_dest(closure.captures);
+        let call_eval = ClosureEvalCommon::new(
+            callee_stack,
+            block.span.unwrap_or(Span::unknown()),
+            get_eval_block_with_early_return(engine_state),
+        );
         Self {
             engine_state,
-            stack: stack.captures_to_stack_preserve_out_dest(closure.captures),
             block,
-            arg_index: 0,
-            eval,
+            call_eval,
+            caller_stack: None,
+        }
+    }
+
+    pub fn new_env_preserve_out_dest(
+        engine_state: &'a EngineState,
+        stack: &'a mut Stack,
+        closure: Closure,
+    ) -> Self {
+        let block = engine_state.get_block(closure.block_id);
+        let callee_stack = stack.captures_to_stack_preserve_out_dest(closure.captures);
+        let call_eval = ClosureEvalCommon::new(
+            callee_stack,
+            block.span.unwrap_or(Span::unknown()),
+            get_eval_block_with_early_return(engine_state),
+        );
+        Self {
+            engine_state,
+            block,
+            call_eval,
+            caller_stack: Some(stack),
         }
     }
 
@@ -241,36 +255,38 @@ impl<'a> ClosureEvalOnce<'a> {
     ///
     /// By default, this is controlled by the [`EngineState`] used to create this [`ClosureEvalOnce`].
     pub fn debug(mut self, debug: bool) -> Self {
-        self.eval = eval_fn(debug);
+        self.call_eval.debug(debug);
         self
-    }
-
-    fn try_add_arg(&mut self, value: Cow<Value>) {
-        if let Some(var_id) = self
-            .block
-            .signature
-            .get_positional(self.arg_index)
-            .and_then(|var| var.var_id)
-        {
-            self.stack.add_var(var_id, value.into_owned());
-            self.arg_index += 1;
-        }
     }
 
     /// Add an argument [`Value`] to the closure.
     ///
     /// Multiple [`add_arg`](Self::add_arg) calls can be chained together,
     /// but make sure that arguments are added based on their positional order.
-    pub fn add_arg(mut self, value: Value) -> Self {
-        self.try_add_arg(Cow::Owned(value));
-        self
+    pub fn add_arg(mut self, value: Value) -> Result<Self, ShellError> {
+        self.call_eval
+            .add_positional(&self.block.signature, Cow::Owned(value))?;
+        Ok(self)
+    }
+
+    /// Add a list of argument [`Value`]s to the closure.
+    pub fn add_args(mut self, values: Vec<Value>) -> Result<Self, ShellError> {
+        for value in values {
+            self.call_eval
+                .add_positional(&self.block.signature, Cow::Owned(value))?;
+        }
+        Ok(self)
     }
 
     /// Run the closure, passing the given [`PipelineData`] as input.
     ///
     /// Any arguments should be added beforehand via [`add_arg`](Self::add_arg).
     pub fn run_with_input(mut self, input: PipelineData) -> Result<PipelineData, ShellError> {
-        (self.eval)(self.engine_state, &mut self.stack, self.block, input).map(|p| p.body)
+        let result = self.call_eval.run(self.engine_state, self.block, input);
+        if let Some(caller) = self.caller_stack {
+            self.call_eval.redirect_env(self.engine_state, caller);
+        }
+        result
     }
 
     /// Run the closure using the given [`Value`] as both the pipeline input and the first argument.
@@ -278,7 +294,173 @@ impl<'a> ClosureEvalOnce<'a> {
     /// Using this function after or in combination with [`add_arg`](Self::add_arg) is most likely an error.
     /// This function is equivalent to `self.add_arg(value)` followed by `self.run_with_input(value.into_pipeline_data())`.
     pub fn run_with_value(mut self, value: Value) -> Result<PipelineData, ShellError> {
-        self.try_add_arg(Cow::Borrowed(&value));
+        self.call_eval
+            .add_positional(&self.block.signature, Cow::Borrowed(&value))?;
         self.run_with_input(value.into_pipeline_data())
+    }
+}
+
+/// Code shared between [`ClosureEval`] and [`ClosureEvalOnce`]
+#[derive(Clone)]
+struct ClosureEvalCommon {
+    callee_stack: Stack,
+    callee_span: Span,
+    arg_index: usize,
+    rest_args: Vec<Value>,
+    eval: EvalBlockWithEarlyReturnFn,
+}
+
+impl ClosureEvalCommon {
+    /// Create a new [`CallEval`] context
+    pub fn new(callee_stack: Stack, callee_span: Span, eval: EvalBlockWithEarlyReturnFn) -> Self {
+        Self {
+            callee_stack,
+            callee_span,
+            arg_index: 0,
+            rest_args: Vec::new(),
+            eval,
+        }
+    }
+
+    /// Add a positional argument to the call stack.
+    ///
+    /// Returns an error if the given `value` does not match the type of
+    /// the argument according to the signature (see [`CallEval::new`]).
+    pub fn add_positional(
+        &mut self,
+        signature: &Signature,
+        value: Cow<Value>,
+    ) -> Result<&mut Self, ShellError> {
+        let maybe_param = if self.arg_index < signature.required_positional.len() {
+            signature.required_positional.get(self.arg_index)
+        } else if self.arg_index
+            < (signature.required_positional.len() + signature.optional_positional.len())
+        {
+            signature
+                .optional_positional
+                .get(self.arg_index - signature.required_positional.len())
+        } else {
+            None
+        };
+        if let Some(param) = maybe_param {
+            let param_type = param.shape.to_type();
+            if value.is_subtype_of(&param_type) {
+                let var_id = param
+                    .var_id
+                    .expect("internal error: all custom parameters must have var_ids");
+                self.callee_stack.add_var(var_id, value.into_owned());
+                self.arg_index += 1;
+                Ok(self)
+            } else {
+                Err(ShellError::CantConvert {
+                    to_type: param_type.to_string(),
+                    from_type: value.get_type().to_string(),
+                    span: value.span(),
+                    help: None,
+                })
+            }
+        } else {
+            // assign arg to rest params
+            if let Some(rest_positional) = &signature.rest_positional {
+                let param_type = rest_positional.shape.to_type();
+                if value.is_subtype_of(&param_type) {
+                    self.rest_args.push(value.into_owned());
+                    Ok(self)
+                } else {
+                    Err(ShellError::CantConvert {
+                        to_type: param_type.to_string(),
+                        from_type: value.get_type().to_string(),
+                        span: value.span(),
+                        help: None,
+                    })
+                }
+            } else {
+                // We do not consider it an error if more arguments
+                // are added than the closure takes. This makes it possible
+                // to omit any unused arguments in the closure definition.
+                Ok(self)
+            }
+        }
+    }
+
+    /// Sets the environment variables for the call.
+    pub fn with_env(
+        &mut self,
+        env_vars: &[Arc<EnvVars>],
+        env_hidden: &Arc<HashMap<String, HashSet<String>>>,
+    ) -> &mut Self {
+        self.callee_stack.with_env(env_vars, env_hidden);
+        self
+    }
+
+    /// Sets whether to enable debugging when evaluating the closure.
+    pub fn debug(&mut self, debug: bool) -> &mut Self {
+        if debug {
+            self.eval = eval_block_with_early_return::<WithDebug>
+        } else {
+            self.eval = eval_block_with_early_return::<WithoutDebug>
+        };
+        self
+    }
+
+    /// Run the given block.
+    pub fn run(
+        &mut self,
+        engine_state: &EngineState,
+        block: &Block,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        self.finalize_arguments(&block.signature)?;
+        self.arg_index = 0;
+        self.rest_args.clear();
+        (self.eval)(engine_state, &mut self.callee_stack, block, input).map(|p| p.body)
+    }
+
+    /// Export the modified environment from callee to the caller.
+    pub fn redirect_env(&self, engine_state: &EngineState, stack: &mut Stack) {
+        redirect_env(engine_state, stack, &self.callee_stack);
+    }
+
+    /// Add default and rest values to the stack, raise error on
+    /// missing parameters.
+    fn finalize_arguments(&mut self, signature: &Signature) -> Result<(), ShellError> {
+        for (num, (param, required)) in signature
+            .required_positional
+            .iter()
+            .map(|p| (p, true))
+            .chain(signature.optional_positional.iter().map(|p| (p, false)))
+            .enumerate()
+        {
+            let var_id = param
+                .var_id
+                .expect("internal error: all custom parameters must have var_ids");
+            if num < self.arg_index {
+                // parameter has been added by add_positional
+            } else if let Some(value) = &param.default_value {
+                self.callee_stack.add_var(var_id, value.to_owned());
+            } else if !required {
+                self.callee_stack
+                    .add_var(var_id, Value::nothing(self.callee_span.to_owned()));
+            } else {
+                return Err(ShellError::MissingParameter {
+                    param_name: param.name.to_string(),
+                    span: self.callee_span.to_owned(),
+                });
+            }
+        }
+        if let Some(rest_positional) = &signature.rest_positional {
+            let span = if let Some(rest_item) = self.rest_args.first() {
+                rest_item.span()
+            } else {
+                self.callee_span.to_owned()
+            };
+            self.callee_stack.add_var(
+                rest_positional
+                    .var_id
+                    .expect("Internal error: rest positional parameter lackes var_id"),
+                Value::list(self.rest_args.to_owned(), span),
+            );
+        }
+        Ok(())
     }
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -185,23 +185,25 @@ impl CallEval {
     /// Add default and rest values to the stack, raise error on
     /// missing parameters.
     fn finalize_arguments(&mut self, signature: &Signature) -> Result<(), ShellError> {
-        for (num, (param, required)) in signature
+        for (param, required) in signature
             .required_positional
             .iter()
             .map(|p| (p, true))
             .chain(signature.optional_positional.iter().map(|p| (p, false)))
-            .enumerate()
+            // skip positional args added with add_positional
+            .skip(self.arg_index)
         {
             let var_id = param
                 .var_id
                 .expect("internal error: all custom parameters must have var_ids");
-            if num < self.arg_index {
-                // parameter has been added by add_positional
-            } else if let Some(value) = &param.default_value {
-                self.callee_stack.add_var(var_id, value.to_owned());
-            } else if !required {
-                self.callee_stack
-                    .add_var(var_id, Value::nothing(self.callee_span.to_owned()));
+
+            let maybe_value = param
+                .default_value
+                .clone()
+                .or((!required).then_some(Value::nothing(self.callee_span)));
+
+            if let Some(value) = maybe_value {
+                self.callee_stack.add_var(var_id, value);
             } else {
                 return Err(ShellError::MissingParameter {
                     param_name: param.name.to_string(),

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -211,6 +211,7 @@ impl CallEval {
                 });
             }
         }
+
         if let Some(rest_positional) = &signature.rest_positional {
             let span = if let Some(rest_item) = self.rest_args.first() {
                 rest_item.span()
@@ -224,21 +225,26 @@ impl CallEval {
                 Value::list(self.rest_args.to_owned(), span),
             );
         }
-        for named in signature.named.iter() {
+
+        let remaining_flags = signature
+            .named
+            .iter()
+            // Skip provided flags
+            .filter(|flag| !self.named_args.contains(&flag.long))
             // Ignore named arguments without var_id.
             // There is some code in nu_cli::completions that relies on this behavior of `eval_call`.
-            if let Some(var_id) = named.var_id {
-                if !self.named_args.contains(&named.long) {
-                    if named.arg.is_none() {
-                        self.callee_stack
-                            .add_var(var_id, Value::bool(false, self.head_span));
-                    } else if let Some(value) = named.default_value.clone() {
-                        self.callee_stack.add_var(var_id, value);
-                    } else {
-                        self.callee_stack
-                            .add_var(var_id, Value::nothing(self.head_span))
-                    }
-                }
+            .filter_map(|flag| Some((flag.var_id?, flag)));
+
+        for (var_id, flag) in remaining_flags {
+            if flag.arg.is_none() {
+                self.callee_stack
+                    .add_var(var_id, Value::bool(false, self.head_span));
+            } else {
+                let value = flag
+                    .default_value
+                    .clone()
+                    .unwrap_or(Value::nothing(self.head_span));
+                self.callee_stack.add_var(var_id, value);
             }
         }
         Ok(())

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -195,14 +195,15 @@ impl CallEval {
     /// Add default and rest values to the stack, raise error on
     /// missing parameters.
     fn finalize_arguments(&mut self, signature: &Signature) -> Result<(), ShellError> {
-        for (param, required) in signature
+        let remaining_positionals = signature
             .required_positional
             .iter()
             .map(|p| (p, true))
             .chain(signature.optional_positional.iter().map(|p| (p, false)))
             // skip positional args added with add_positional
-            .skip(self.arg_index)
-        {
+            .skip(self.arg_index);
+
+        for (param, required) in remaining_positionals {
             let var_id = param
                 .var_id
                 .expect("internal error: all custom parameters must have var_ids");
@@ -223,11 +224,12 @@ impl CallEval {
         }
 
         if let Some(rest_positional) = &signature.rest_positional {
-            let span = if let Some(rest_item) = self.rest_args.first() {
-                rest_item.span()
-            } else {
-                self.callee_span
-            };
+            let span = self
+                .rest_args
+                .first()
+                .map(|x| x.span())
+                .unwrap_or(self.callee_span);
+
             self.callee_stack.add_var(
                 rest_positional
                     .var_id
@@ -257,6 +259,7 @@ impl CallEval {
                 self.callee_stack.add_var(var_id, value);
             }
         }
+
         Ok(())
     }
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1,17 +1,249 @@
-use crate::eval_ir::eval_ir_block;
 #[allow(deprecated)]
 use crate::get_full_help;
+use crate::{EvalBlockWithEarlyReturnFn, eval_ir::eval_ir_block};
 use nu_protocol::{
     BlockId, Config, ENV_VARIABLE_ID, IntoPipelineData, PipelineData, PipelineExecutionData,
-    ShellError, Span, Value, VarId,
+    ShellError, Signature, Span, Value, VarId,
     ast::{Assignment, Block, Call, Expr, Expression, ExternalArgument, PathMember},
-    debugger::DebugContext,
-    engine::{Closure, EngineState, Stack},
+    debugger::{DebugContext, WithDebug, WithoutDebug},
+    engine::{Closure, EngineState, EnvName, EnvVars, Stack},
     eval_base::Eval,
 };
 use nu_utils::IgnoreCaseExt;
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+/// [`CallEval`] is used to evaluate a command or closure call.
+///
+/// It is intended as an internal interface in the engine, to make sure
+/// command and closure calls behave the same.
+/// If you want to evaluate a closure in a command, use [`ClosureEval`] or
+/// [`ClosureEvalOnce`]. If you want to call a command, use [`eval_call`].
+///
+/// [`CallEval`] has a builder API.
+/// It is first created vial [`CallEval::new`],
+/// then has arguments added via [`CallEval::add_positional`] and [`CallEval::add_named`],
+/// and then can be run using [`CallEval::run`].
+#[derive(Clone)]
+pub struct CallEval {
+    callee_stack: Stack,
+    head_span: Span,
+    callee_span: Span,
+    arg_index: usize,
+    named_args: Vec<String>,
+    rest_args: Vec<Value>,
+    eval: EvalBlockWithEarlyReturnFn,
+}
+
+impl CallEval {
+    /// Create a new [`CallEval`] context
+    pub fn new(
+        callee_stack: Stack,
+        call_head: Span,
+        callee_span: Span,
+        eval: EvalBlockWithEarlyReturnFn,
+    ) -> Self {
+        Self {
+            callee_stack,
+            head_span: call_head,
+            callee_span,
+            arg_index: 0,
+            named_args: Vec::new(),
+            rest_args: Vec::new(),
+            eval,
+        }
+    }
+
+    /// Add a positional argument to the call stack.
+    ///
+    /// Returns an error if the given `value` does not match the type of
+    /// the argument according to the signature (see [`CallEval::new`]).
+    pub fn add_positional(
+        &mut self,
+        signature: &Signature,
+        value: Cow<Value>,
+    ) -> Result<&mut Self, ShellError> {
+        let maybe_param = if self.arg_index < signature.required_positional.len() {
+            signature.required_positional.get(self.arg_index)
+        } else if self.arg_index
+            < (signature.required_positional.len() + signature.optional_positional.len())
+        {
+            signature
+                .optional_positional
+                .get(self.arg_index - signature.required_positional.len())
+        } else {
+            None
+        };
+        if let Some(param) = maybe_param {
+            let param_type = param.shape.to_type();
+            if value.is_subtype_of(&param_type) {
+                let var_id = param
+                    .var_id
+                    .expect("internal error: all custom parameters must have var_ids");
+                self.callee_stack.add_var(var_id, value.into_owned());
+                self.arg_index += 1;
+                Ok(self)
+            } else {
+                Err(ShellError::CantConvert {
+                    to_type: param_type.to_string(),
+                    from_type: value.get_type().to_string(),
+                    span: value.span(),
+                    help: None,
+                })
+            }
+        } else {
+            // assign arg to rest params
+            if let Some(rest_positional) = &signature.rest_positional {
+                let param_type = rest_positional.shape.to_type();
+                if value.is_subtype_of(&param_type) {
+                    self.rest_args.push(value.into_owned());
+                    Ok(self)
+                } else {
+                    Err(ShellError::CantConvert {
+                        to_type: param_type.to_string(),
+                        from_type: value.get_type().to_string(),
+                        span: value.span(),
+                        help: None,
+                    })
+                }
+            } else {
+                // We do not consider it an error if more arguments
+                // are added than the closure takes. This makes it possible
+                // to omit any unused arguments in the closure definition.
+                Ok(self)
+            }
+        }
+    }
+
+    /// Add a named parameter to the call stack.
+    pub fn add_named(
+        &mut self,
+        signature: &Signature,
+        long: &str,
+        short: Option<String>,
+        value: Option<Cow<Value>>,
+    ) -> Result<&mut Self, ShellError> {
+        let named = signature.named.iter().find(|named| {
+            (short.is_some() && short == named.short.map(|x| x.to_string())) || long == named.long
+        });
+        if let Some(named) = named {
+            let var_id = named
+                .var_id
+                .expect("internal error: all custom parameters must have var_ids");
+            if let Some(val) = value {
+                self.callee_stack.add_var(var_id, val.into_owned());
+            } else if let Some(val) = &named.default_value {
+                self.callee_stack.add_var(var_id, val.to_owned());
+            } else {
+                self.callee_stack
+                    .add_var(var_id, Value::bool(true, self.head_span));
+            }
+            self.named_args.push(long.to_string());
+        }
+        Ok(self)
+    }
+
+    /// Sets the environment variables for the call.
+    pub fn with_env(
+        &mut self,
+        env_vars: &[Arc<EnvVars>],
+        env_hidden: &Arc<HashMap<String, HashSet<EnvName>>>,
+    ) -> &mut Self {
+        self.callee_stack.with_env(env_vars, env_hidden);
+        self
+    }
+
+    /// Sets whether to enable debugging when evaluating the closure.
+    pub fn debug(&mut self, debug: bool) -> &mut Self {
+        if debug {
+            self.eval = eval_block_with_early_return::<WithDebug>
+        } else {
+            self.eval = eval_block_with_early_return::<WithoutDebug>
+        };
+        self
+    }
+
+    /// Run the given block.
+    pub fn run(
+        &mut self,
+        engine_state: &EngineState,
+        block: &Block,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        self.finalize_arguments(&block.signature)?;
+        self.arg_index = 0;
+        self.rest_args.clear();
+        (self.eval)(engine_state, &mut self.callee_stack, block, input).map(|p| p.body)
+    }
+
+    /// Export the modified environment from callee to the caller.
+    pub fn redirect_env(&self, engine_state: &EngineState, stack: &mut Stack) {
+        redirect_env(engine_state, stack, &self.callee_stack);
+    }
+
+    /// Add default and rest values to the stack, raise error on
+    /// missing parameters.
+    fn finalize_arguments(&mut self, signature: &Signature) -> Result<(), ShellError> {
+        for (num, (param, required)) in signature
+            .required_positional
+            .iter()
+            .map(|p| (p, true))
+            .chain(signature.optional_positional.iter().map(|p| (p, false)))
+            .enumerate()
+        {
+            let var_id = param
+                .var_id
+                .expect("internal error: all custom parameters must have var_ids");
+            if num < self.arg_index {
+                // parameter has been added by add_positional
+            } else if let Some(value) = &param.default_value {
+                self.callee_stack.add_var(var_id, value.to_owned());
+            } else if !required {
+                self.callee_stack
+                    .add_var(var_id, Value::nothing(self.callee_span.to_owned()));
+            } else {
+                return Err(ShellError::MissingParameter {
+                    param_name: param.name.to_string(),
+                    span: self.callee_span.to_owned(),
+                });
+            }
+        }
+        if let Some(rest_positional) = &signature.rest_positional {
+            let span = if let Some(rest_item) = self.rest_args.first() {
+                rest_item.span()
+            } else {
+                self.callee_span.to_owned()
+            };
+            self.callee_stack.add_var(
+                rest_positional
+                    .var_id
+                    .expect("Internal error: rest positional parameter lackes var_id"),
+                Value::list(self.rest_args.to_owned(), span),
+            );
+        }
+        for named in signature.named.iter() {
+            // Ignore named arguments without var_id.
+            // There is some code in nu_cli::completions that relies on this behavior of `eval_call`.
+            if let Some(var_id) = named.var_id {
+                if !self.named_args.contains(&named.long) {
+                    if named.arg.is_none() {
+                        self.callee_stack
+                            .add_var(var_id, Value::bool(false, self.head_span));
+                    } else if let Some(value) = named.default_value.clone() {
+                        self.callee_stack.add_var(var_id, value);
+                    } else {
+                        self.callee_stack
+                            .add_var(var_id, Value::nothing(self.head_span))
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Evaluate a call to a command (builtin, custom or external)
 pub fn eval_call<D: DebugContext>(
     engine_state: &EngineState,
     caller_stack: &mut Stack,
@@ -25,8 +257,8 @@ pub fn eval_call<D: DebugContext>(
         let help = get_full_help(decl, engine_state, caller_stack, call.head);
         Ok(Value::string(help, call.head).into_pipeline_data())
     } else if let Some(block_id) = decl.block_id() {
+        // call is a custom command
         let block = engine_state.get_block(block_id);
-
         let mut callee_stack = caller_stack.gather_captures(engine_state, &block.captures);
 
         // Rust does not check recursion limits outside of const evaluation.
@@ -44,120 +276,43 @@ pub fn eval_call<D: DebugContext>(
             });
         }
 
-        for (param_idx, (param, required)) in decl
-            .signature()
-            .required_positional
-            .iter()
-            .map(|p| (p, true))
-            .chain(
-                decl.signature()
-                    .optional_positional
-                    .iter()
-                    .map(|p| (p, false)),
-            )
-            .enumerate()
-        {
-            let var_id = param
-                .var_id
-                .expect("internal error: all custom parameters must have var_ids");
-
-            if let Some(arg) = call.positional_nth(param_idx) {
-                let result = eval_expression::<D>(engine_state, caller_stack, arg)?;
-                let param_type = param.shape.to_type();
-                if required && !result.is_subtype_of(&param_type) {
-                    return Err(ShellError::CantConvert {
-                        to_type: param.shape.to_type().to_string(),
-                        from_type: result.get_type().to_string(),
-                        span: result.span(),
-                        help: None,
-                    });
-                }
-                callee_stack.add_var(var_id, result);
-            } else if let Some(value) = &param.default_value {
-                callee_stack.add_var(var_id, value.to_owned());
-            } else {
-                callee_stack.add_var(var_id, Value::nothing(call.head));
-            }
+        let mut call_eval = CallEval::new(
+            callee_stack,
+            call.head,
+            block.span.unwrap_or(Span::unknown()),
+            eval_block_with_early_return::<D>,
+        );
+        for arg in call.positional_iter() {
+            let result = eval_expression::<D>(engine_state, caller_stack, arg)?;
+            call_eval.add_positional(&decl.signature(), Cow::Owned(result))?;
         }
-
-        if let Some(rest_positional) = decl.signature().rest_positional {
-            let mut rest_items = vec![];
-
-            for result in call.rest_iter_flattened(
-                decl.signature().required_positional.len()
-                    + decl.signature().optional_positional.len(),
-                |expr| eval_expression::<D>(engine_state, caller_stack, expr),
-            )? {
-                rest_items.push(result);
-            }
-
-            let span = if let Some(rest_item) = rest_items.first() {
-                rest_item.span()
+        for call_named in call.named_iter() {
+            let result: Option<Cow<Value>> = if let Some(arg) = &call_named.2 {
+                Some(Cow::Owned(eval_expression::<D>(
+                    engine_state,
+                    caller_stack,
+                    arg,
+                )?))
             } else {
-                call.head
+                None
             };
-
-            callee_stack.add_var(
-                rest_positional
-                    .var_id
-                    .expect("Internal error: rest positional parameter lacks var_id"),
-                Value::list(rest_items, span),
-            )
+            call_eval.add_named(
+                &decl.signature(),
+                &call_named.0.item,
+                call_named.1.clone().map(|x| x.item),
+                result,
+            )?;
         }
 
-        for named in decl.signature().named {
-            if let Some(var_id) = named.var_id {
-                let mut found = false;
-                for call_named in call.named_iter() {
-                    if let (Some(spanned), Some(short)) = (&call_named.1, named.short) {
-                        if spanned.item == short.to_string() {
-                            if let Some(arg) = &call_named.2 {
-                                let result = eval_expression::<D>(engine_state, caller_stack, arg)?;
-
-                                callee_stack.add_var(var_id, result);
-                            } else if let Some(value) = &named.default_value {
-                                callee_stack.add_var(var_id, value.to_owned());
-                            } else {
-                                callee_stack.add_var(var_id, Value::bool(true, call.head))
-                            }
-                            found = true;
-                        }
-                    } else if call_named.0.item == named.long {
-                        if let Some(arg) = &call_named.2 {
-                            let result = eval_expression::<D>(engine_state, caller_stack, arg)?;
-
-                            callee_stack.add_var(var_id, result);
-                        } else if let Some(value) = &named.default_value {
-                            callee_stack.add_var(var_id, value.to_owned());
-                        } else {
-                            callee_stack.add_var(var_id, Value::bool(true, call.head))
-                        }
-                        found = true;
-                    }
-                }
-
-                if !found {
-                    if named.arg.is_none() {
-                        callee_stack.add_var(var_id, Value::bool(false, call.head))
-                    } else if let Some(value) = named.default_value {
-                        callee_stack.add_var(var_id, value);
-                    } else {
-                        callee_stack.add_var(var_id, Value::nothing(call.head))
-                    }
-                }
-            }
-        }
-
-        let result =
-            eval_block_with_early_return::<D>(engine_state, &mut callee_stack, block, input)
-                .map(|p| p.body);
+        let result = call_eval.run(engine_state, block, input);
 
         if block.redirect_env {
-            redirect_env(engine_state, caller_stack, &callee_stack);
+            call_eval.redirect_env(engine_state, caller_stack);
         }
 
         result
     } else {
+        // call is a builtin or external command
         // We pass caller_stack here with the knowledge that internal commands
         // are going to be specifically looking for global state in the stack
         // rather than any local state.

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -64,55 +64,58 @@ impl CallEval {
         signature: &Signature,
         value: Cow<Value>,
     ) -> Result<&mut Self, ShellError> {
-        let maybe_param = if self.arg_index < signature.required_positional.len() {
-            signature.required_positional.get(self.arg_index)
-        } else if self.arg_index
-            < (signature.required_positional.len() + signature.optional_positional.len())
+        let maybe_param = match self
+            .arg_index
+            .checked_sub(signature.required_positional.len())
         {
-            signature
-                .optional_positional
-                .get(self.arg_index - signature.required_positional.len())
-        } else {
-            None
+            // arg_index < required_len
+            None => signature.required_positional.get(self.arg_index),
+            // required_len <= arg_index < (required_len + optional_len)
+            Some(opt_idx) if opt_idx < signature.optional_positional.len() => {
+                signature.optional_positional.get(opt_idx)
+            }
+            // (required_len + optional_len) <= arg_index
+            _ => None,
         };
+
         if let Some(param) = maybe_param {
             let param_type = param.shape.to_type();
-            if value.is_subtype_of(&param_type) {
-                let var_id = param
-                    .var_id
-                    .expect("internal error: all custom parameters must have var_ids");
-                self.callee_stack.add_var(var_id, value.into_owned());
-                self.arg_index += 1;
-                Ok(self)
-            } else {
-                Err(ShellError::CantConvert {
+            if !value.is_subtype_of(&param_type) {
+                return Err(ShellError::CantConvert {
                     to_type: param_type.to_string(),
                     from_type: value.get_type().to_string(),
                     span: value.span(),
                     help: None,
-                })
+                });
             }
+
+            let var_id = param
+                .var_id
+                .expect("internal error: all custom parameters must have var_ids");
+            self.callee_stack.add_var(var_id, value.into_owned());
+            self.arg_index += 1;
+            Ok(self)
         } else {
             // assign arg to rest params
-            if let Some(rest_positional) = &signature.rest_positional {
-                let param_type = rest_positional.shape.to_type();
-                if value.is_subtype_of(&param_type) {
-                    self.rest_args.push(value.into_owned());
-                    Ok(self)
-                } else {
-                    Err(ShellError::CantConvert {
-                        to_type: param_type.to_string(),
-                        from_type: value.get_type().to_string(),
-                        span: value.span(),
-                        help: None,
-                    })
-                }
-            } else {
+            let Some(rest_positional) = &signature.rest_positional else {
                 // We do not consider it an error if more arguments
                 // are added than the closure takes. This makes it possible
                 // to omit any unused arguments in the closure definition.
-                Ok(self)
+                return Ok(self);
+            };
+
+            let param_type = rest_positional.shape.to_type();
+            if !value.is_subtype_of(&param_type) {
+                return Err(ShellError::CantConvert {
+                    to_type: param_type.to_string(),
+                    from_type: value.get_type().to_string(),
+                    span: value.span(),
+                    help: None,
+                });
             }
+
+            self.rest_args.push(value.into_owned());
+            Ok(self)
         }
     }
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -128,22 +128,29 @@ impl CallEval {
         value: Option<Cow<Value>>,
     ) -> Result<&mut Self, ShellError> {
         let named = signature.named.iter().find(|named| {
-            (short.is_some() && short == named.short.map(|x| x.to_string())) || long == named.long
+            long == named.long
+                || short
+                    .as_deref()
+                    .zip(named.short)
+                    .is_some_and(|(arg, param)| {
+                        let mut buf = [0; 4];
+                        param.encode_utf8(&mut buf) == arg
+                    })
         });
+
         if let Some(named) = named {
             let var_id = named
                 .var_id
                 .expect("internal error: all custom parameters must have var_ids");
-            if let Some(val) = value {
-                self.callee_stack.add_var(var_id, val.into_owned());
-            } else if let Some(val) = &named.default_value {
-                self.callee_stack.add_var(var_id, val.to_owned());
-            } else {
-                self.callee_stack
-                    .add_var(var_id, Value::bool(true, self.head_span));
-            }
+
+            let value = value
+                .or_else(|| named.default_value.as_ref().map(Cow::Borrowed))
+                .unwrap_or_else(|| Cow::Owned(Value::bool(true, self.head_span)));
+
+            self.callee_stack.add_var(var_id, value.into_owned());
             self.named_args.push(long.to_string());
         }
+
         Ok(self)
     }
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -205,7 +205,7 @@ impl CallEval {
             } else {
                 return Err(ShellError::MissingParameter {
                     param_name: param.name.to_string(),
-                    span: self.callee_span.to_owned(),
+                    span: self.callee_span,
                 });
             }
         }
@@ -213,7 +213,7 @@ impl CallEval {
             let span = if let Some(rest_item) = self.rest_args.first() {
                 rest_item.span()
             } else {
-                self.callee_span.to_owned()
+                self.callee_span
             };
             self.callee_stack.add_var(
                 rest_positional

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -313,11 +313,13 @@ impl Stack {
             })
     }
 
+    /// Like [`captures_to_stack_preserve_out_dest`], but sets the new scope up to collect output into a Value.
     pub fn captures_to_stack(&self, captures: Vec<(VarId, Value)>) -> Stack {
         self.captures_to_stack_preserve_out_dest(captures)
             .collect_value()
     }
 
+    /// Creates a derived stack for a new scope, with the given captures.
     pub fn captures_to_stack_preserve_out_dest(&self, captures: Vec<(VarId, Value)>) -> Stack {
         let mut env_vars = self.env_vars.clone();
         env_vars.push(Arc::new(HashMap::new()));

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -772,7 +772,9 @@ impl Signature {
     /// Returns an argument with the index `position`
     ///
     /// It will index, in order, required arguments, then optional, then the
-    /// trailing `...rest` argument.
+    /// trailing `...rest` argument. Note that the `...rest` argument must be
+    /// a [`Value::List`], therefore this method may not work as intended when
+    /// the closure uses a rest argument.
     pub fn get_positional(&self, position: usize) -> Option<&PositionalArg> {
         if position < self.required_positional.len() {
             self.required_positional.get(position)

--- a/tests/repl/mod.rs
+++ b/tests/repl/mod.rs
@@ -1,6 +1,7 @@
 mod test_alias;
 mod test_bits;
 mod test_cell_path;
+mod test_closures;
 mod test_commandline;
 mod test_conditionals;
 mod test_config;

--- a/tests/repl/test_closures.rs
+++ b/tests/repl/test_closures.rs
@@ -1,0 +1,64 @@
+use crate::repl::tests::{TestResult, fail_test, run_test};
+
+#[test]
+fn do_no_argument() -> TestResult {
+    let input = "do { 42 }";
+    let expected = "42";
+    run_test(input, expected)
+}
+
+#[test]
+fn do_one_argument() -> TestResult {
+    let input = "do {|x| $x } 42";
+    let expected = "42";
+    run_test(input, expected)
+}
+
+#[test]
+fn do_missing_argument() -> TestResult {
+    let input = "do {|x| $x}";
+    let expected = "nu::shell::missing_parameter";
+    fail_test(input, expected)
+}
+
+#[test]
+fn do_typed_argument() -> TestResult {
+    let input = "do {|x: int| $x} 42";
+    let expected = "42";
+    run_test(input, expected)
+}
+
+#[test]
+fn do_type_mismatch() -> TestResult {
+    let input = "do {|x: int| $x} 4.2";
+    let expected = "nu::shell::cant_convert";
+    fail_test(input, expected)
+}
+
+#[test]
+fn do_optional_argument() -> TestResult {
+    let input = "do {|x?| $x | describe}";
+    let expected = "nothing";
+    run_test(input, expected)
+}
+
+#[test]
+fn do_variable_argument() -> TestResult {
+    let input = "do {|...rest| $rest} 1 2 | to nuon";
+    let expected = "[1, 2]";
+    run_test(input, expected)
+}
+
+#[test]
+fn default() -> TestResult {
+    let input = "null | default { 42 }";
+    let expected = "42";
+    run_test(input, expected)
+}
+
+#[test]
+fn default_optional_argument() -> TestResult {
+    let input = "{} | default {|x?| if $x == null { 'no x' } else { $x } } foo | to nuon";
+    let expected = "{foo: \"no x\"}";
+    run_test(input, expected)
+}


### PR DESCRIPTION
* Closures with optional, default or rest arguments can be used in more places.
  * Optional closure arguments or arguments with default values used to throw a "variable not found" error in most cases (except `do`).
  * Giving a closure with a `...rest` parameter to a command like `items` used to have a bug, where only the last argument was given to the closure instead of a list of all arguments.
* Some checks on closure arguments with type annotations, which used to only happen for `do`, now apply to all commands that take a closure. Consequently, there may be some corner cases where code that previously ran is now rejected.
* Plugins which implement commands that handle closures probably have to be modified slightly (`ClosureEval::add_arg` now returns a `Result`).

## Release notes summary - What our users need to know

## Tasks after submitting
