### PR TITLE
Add required fields for crate publish to `nu-mcp`

### DIFF
--- a/crates/nu-mcp/Cargo.toml
+++ b/crates/nu-mcp/Cargo.toml
@@ -2,6 +2,11 @@
 name = "nu-mcp"
 version = "0.107.1"
 edition = "2024"
+authors = ["The Nushell Project Developers"]
+description = "Modules to run a model context protocol (MCP) server that provides Nushell as a tool."
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu-mcp"
+homepage = "https://www.nushell.sh"
+license = "MIT"
 
 [dependencies]
 futures = "0.3.31"


### PR DESCRIPTION
`nu-mcp` would not be accepted to crates.io without a license
specification, author, and description. This would block the `0.108.0`
release.

[as per my last email](https://github.com/nushell/nushell/pull/16693#discussion_r2356744964)

## Release notes summary - What our users need to know
N/A
