### PR TITLE
fix: wrong arg order of buffer_editor for `config nu`

### DIFF
--- a/crates/nu-command/src/env/config/config_.rs
+++ b/crates/nu-command/src/env/config/config_.rs
@@ -100,8 +100,8 @@ pub(super) fn start_editor(
     command.envs(envs);
 
     // Configure args.
-    command.arg(config_path);
     command.args(editor_args);
+    command.arg(config_path);
 
     // Spawn the child process. On Unix, also put the child process to
     // foreground if we're in an interactive session.


### PR DESCRIPTION
Fixes #16734 

## Release notes summary - What our users need to know

Fixed a bug of wrong argument order when calling `$env.config.buffer_editor` from `config nu`.

## Tasks after submitting
