### PR TITLE
feat(mcp): respect --login flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -473,7 +473,7 @@ fn main() -> Result<()> {
                 parsed_nu_cli_args.plugin_file,
                 parsed_nu_cli_args.config_file,
                 parsed_nu_cli_args.env_file,
-                false,
+                parsed_nu_cli_args.login_shell.is_some(),
             );
         }
         nu_mcp::initialize_mcp_server(engine_state)?;


### PR DESCRIPTION
## Release notes summary - What our users need to know

Previously, MCP mode always passed `false` for login shell initialization, ignoring the `--login` flag. This prevented users from loading `login.nu` for session initialization in MCP mode.

Now MCP mode respects `--login` to enable session initialization via `login.nu`, matching standard shell behavior. When `nu --mcp --login` is used, it will load env.nu, config.nu, and login.nu just like a regular login shell.