### PR TITLE
Add `--optional` flag to `std-rfc/iter only`

### DIFF
--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -203,6 +203,9 @@ def only-error [msg: string, meta: record, label: string]: nothing -> error {
 @example "Get the only item in a list, ensuring it exists and there's no additional items" --result 5 {
   [5] | only
 }
+@example "Get the item (if present) from a list that has no more than one item" --result null {
+  [] | only
+}
 @example "Get the `name` column of the only row in a table" --result "foo" {
   [{name: foo, id: 5}] | only name
 }
@@ -210,10 +213,12 @@ def only-error [msg: string, meta: record, label: string]: nothing -> error {
   ls | where name == "foo.txt" | only modified
 }
 export def only [
+  --optional # Return `null` if there are no elements (does not affect behavior of the `cell_path` argument)
   cell_path?: cell-path # The cell path to access within the only element.
 ]: [table -> any, list -> any] {
   let pipe = {in: $in, meta: (metadata $in)}
   match $pipe.in {
+    [] if $optional => null
     [] => (only-error "expected non-empty table/list" $pipe.meta "empty")
     [$one] => ($one | if $cell_path != null { get $cell_path } else { })
     _ => (only-error "expected only one element in table/list" $pipe.meta "has more than one element")


### PR DESCRIPTION
## Release notes summary - What our users need to know

### Add `--optional` flag to `std-rfc/iter only`

Specifying `--optional` to `std-rfc/iter only` will make it return `null` if given an empty array, instead of making an error.

## Additional note

If `--optional ` is specified alongside a cell path, the cell-path lookup behavior remains equivalent to `get <cell-path>`, not `get --optional <cell-path>`. If a user wants the other behavior, it's much clearer to do `iter only --optional | get --optional <cell-path>`. 

This way, if `iter only --optional` returns `null`, you know for sure that the list was either empty or contained a single null element. Otherwise, it also might contain a record or something that just had a different shape than expected.