### PR TITLE
fix(`version check`): output type is record not string

### DIFF
--- a/crates/nu-command/src/network/version_check.rs
+++ b/crates/nu-command/src/network/version_check.rs
@@ -25,7 +25,7 @@ impl Command for VersionCheck {
     fn signature(&self) -> Signature {
         Signature::build("version check")
             .category(Category::Platform)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Nothing, Type::record())])
     }
 
     fn examples(&self) -> Vec<Example<'_>> {


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
https://discord.com/channels/601130461678272522/601130461678272524/1429159141116608655

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
Fixed the output type of `version check` to be `record` instead of `string`.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->

