### PR TITLE
Re-introduce nu_expand_path for polars open/save

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/open.rs
@@ -154,7 +154,7 @@ fn command(
     let spanned_file: Spanned<String> = call.req(0)?;
     debug!("file: {}", spanned_file.item);
 
-    let resource = Resource::new(plugin, &spanned_file)?;
+    let resource = Resource::new(plugin, engine, &spanned_file)?;
     let type_option: Option<(String, Span)> = call
         .get_flag("type")?
         .map(|t: Spanned<String>| (t.item, t.span))

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
@@ -138,12 +138,12 @@ impl PluginCommand for SaveDF {
 
 fn command(
     plugin: &PolarsPlugin,
-    _engine: &EngineInterface,
+    engine: &EngineInterface,
     call: &EvaluatedCall,
     polars_object: PolarsPluginObject,
     spanned_file: Spanned<String>,
 ) -> Result<PipelineData, ShellError> {
-    let resource = Resource::new(plugin, &spanned_file)?;
+    let resource = Resource::new(plugin, engine, &spanned_file)?;
     let type_option: Option<(String, Span)> = call
         .get_flag("type")?
         .map(|t: Spanned<String>| (t.item, t.span))


### PR DESCRIPTION
## Release notes summary - What our users need to know
Fixes a regression that causes absolute paths to be required when opening files with the polars plugin.