### PR TITLE
Fix `ansi strip` ignoring the first provided cell path

### DIFF
--- a/crates/nu-command/src/strings/ansi/strip.rs
+++ b/crates/nu-command/src/strings/ansi/strip.rs
@@ -51,7 +51,7 @@ impl Command for AnsiStrip {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
         let config = stack.get_config(engine_state);
         let args = Arguments { cell_paths, config };
@@ -59,11 +59,29 @@ impl Command for AnsiStrip {
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![Example {
-            description: "Strip ANSI escape sequences from a string",
-            example: r#"$'(ansi green)(ansi cursor_on)hello' | ansi strip"#,
-            result: Some(Value::test_string("hello")),
-        }]
+        vec![
+            Example {
+                description: "Strip ANSI escape sequences from a string",
+                example: r#"$'(ansi green)(ansi cursor_on)hello' | ansi strip"#,
+                result: Some(Value::test_string("hello")),
+            },
+            Example {
+                description: "Strip ANSI escape sequences from a record field",
+                example: r#"{ greeting: $'hello (ansi red)world' exclamation: false } | ansi strip greeting"#,
+                result: Some(Value::test_record(record! {
+                    "greeting" => Value::test_string("hello world"),
+                    "exclamation" => Value::test_bool(false)
+                })),
+            },
+            Example {
+                description: "Strip ANSI escape sequences from multiple table columns",
+                example: r#"[[language feature]; [$'(ansi red)rust' $'(ansi i)safety']] | ansi strip language feature"#,
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                    "language" => Value::test_string("rust"),
+                    "feature" => Value::test_string("safety")
+                })])),
+            },
+        ]
     }
 }
 


### PR DESCRIPTION
Fixes #13740.

`ansi strip` ignored the first provided cell path due to using an invalid starting position when handling rest arguments.

See https://github.com/nushell/nushell/issues/13740#issuecomment-3422774349 for details.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

Fixed `ansi strip` ignoring the first provided cell path.
