### PR TITLE
Bump Reedline to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6415,7 +6415,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.43.0"
-source = "git+https://github.com/nushell/reedline?branch=main#0bb9acad41e659866fc567e7f638ece881489d6c"
+source = "git+https://github.com/nushell/reedline?branch=main#40c562cc858061797fb00ae71c070fe8cb390def"
 dependencies = [
  "arboard",
  "chrono",


### PR DESCRIPTION
Use the latest commit of Reedline on the `main` branch so we can use [#798](https://github.com/nushell/reedline/pull/798) (Add match_indices field to Suggestion)

<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

N/A

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Make use of the new Suggestion field in https://github.com/nushell/nushell/pull/15887
