### PR TITLE
test: Set HOME for test_config_path tests

### DIFF
--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -67,6 +67,9 @@ fn setup_fake_config(playground: &mut Playground) -> AbsolutePathBuf {
 }
 
 fn run(playground: &mut Playground, command: &str) -> String {
+    if let Ok(home) = std::env::var("HOME") {
+        playground.with_env("HOME", home.as_str());
+    }
     let result = playground.pipeline(command).execute().map_err(|e| {
         let outcome = e.output.map(|outcome| {
             format!(


### PR DESCRIPTION
This PR sets the `HOME` environment in the test playground if the outer process has it set. Without it, if `$env.HOME` is set in the process running tests, the playground process won't have this variable, and so, inside the playground, Nushell will use the password file to find the home directory on Linux. This causes three of the config path tests to fail on Linux when the two sources for home directory disagree.

This was found by @KaiSforza, who found in [#16848](https://github.com/nushell/nushell/pull/16848/files#diff-d20879fe15880267dc80df70a17d396186ab2fa5887e58ed57e3aa2bbf4572b2R42-R45) that in Nix's sandbox environment, three tests (`test_default_config_path`, `test_xdg_config_bad`, `test_xdg_config_empty`) were failing due to the `HOME` env var in the environment not matching the home directory set in the password file.

I confirmed that with this change, building the `default.nix` provided in the linked PR worked without having to skip the three previously failing tests.

## Release notes summary - What our users need to know

N/A