### PR TITLE
add ut mit license

### DIFF
--- a/crates/nu-explore/src/explore_regex.rs
+++ b/crates/nu-explore/src/explore_regex.rs
@@ -1,5 +1,28 @@
 // Borrowed from the ut project and tweaked. Thanks!
 // https://github.com/ksdme/ut
+// Below is the ut license:
+// MIT License
+//
+// Copyright (c) 2025 Kilari Teja
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
     execute,


### PR DESCRIPTION
This PR just adds the https://github.com/ksdme/ut MIT license in the explore_reges.rs file.

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A