### PR TITLE
feat(`group-by`): add example on how to delete the orignal columns

### DIFF
--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -223,6 +223,9 @@ impl Command for GroupBy {
         [storm, rs, "2021"]
     ]
     | group-by lang | update cells { reject lang }"#,
+                #[cfg(test)] // Cannot test this example, it requires the nu-cmd-extra crate.
+                result: None,
+                #[cfg(not(test))]
                 result: Some(Value::test_record(record! {
                         "rb" => Value::test_list(vec![Value::test_record(record! {
                                         "name" => Value::test_string("andres"),


### PR DESCRIPTION
~~Useful when printing info to remove having it twice, not that useful in a pipeline. Side note, but I spent like 20 minutes fiddling with the delimiters to add an example 😅~~

## Release notes summary - What our users need to know
Added a new example to the `group-by` command that shows how to remove the original columns using `update cells`.

- Before:
<img width="445" height="208" alt="image" src="https://github.com/user-attachments/assets/925ad13b-b879-4dbf-885b-ff0b1f514cc4" />

- After:
<img width="347" height="205" alt="image" src="https://github.com/user-attachments/assets/3b113e1d-9c41-4e6f-b6b9-8dde570854cf" />


## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [X] Added example