### PR TITLE
fix: Add error handling for rounding non finite numbers

### DIFF
--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -139,7 +139,7 @@ fn operate(value: Value, head: Span, precision: Option<i64>) -> Value {
                 return Value::error(
                     ShellError::UnsupportedInput {
                         msg: "cannot round non-finite number".into(),
-                        input: " ".into(),
+                        input: "value originates from here".into(),
                         msg_span: span,
                         input_span: span,
                     },


### PR DESCRIPTION
Fixes #16927 

## Release notes summary - What our users need to know
`math round` now returns an error when trying to round non-finite numbers (inf or nan), instead of converting them to large integer values.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
