### PR TITLE
Add numeric outputs for `sys users` and `ls`

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1956,7 +1956,6 @@ fn flag_completions() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     // Test completions for the 'ls' flags
     let suggestions = completer.complete("ls -", 4);
-    assert_eq!(18, suggestions.len());
     let expected: Vec<_> = vec![
         "--all",
         "--directory",
@@ -1965,6 +1964,7 @@ fn flag_completions() {
         "--help",
         "--long",
         "--mime-type",
+        "--numeric",
         "--short-names",
         "--threads",
         "-a",
@@ -1974,9 +1974,12 @@ fn flag_completions() {
         "-h",
         "-l",
         "-m",
+        "-n",
         "-s",
         "-t",
     ];
+
+    assert_eq!(expected.len(), suggestions.len());
     // Match results
     match_suggestions(&expected, &suggestions);
 
@@ -2283,9 +2286,8 @@ fn variables_completions() {
     // Test completions for $nu
     let suggestions = completer.complete("$nu.", 4);
 
-    assert_eq!(20, suggestions.len());
-
-    let expected: Vec<_> = vec![
+    #[allow(unused_mut)]
+    let mut expected: Vec<_> = vec![
         "cache-dir",
         "config-path",
         "current-exe",
@@ -2301,13 +2303,17 @@ fn variables_completions() {
         "loginshell-path",
         "os-info",
         "pid",
-        "plugin-path",
         "startup-time",
         "temp-dir",
         "user-autoload-dirs",
         "vendor-autoload-dirs",
     ];
 
+    // Fixes an issue when running tests on specific crates
+    #[cfg(feature = "plugin")]
+    expected.insert(15, "plugin-path");
+
+    assert_eq!(expected.len(), suggestions.len());
     // Match results
     match_suggestions(&expected, &suggestions);
 

--- a/crates/nu-command/src/system/sys/users.rs
+++ b/crates/nu-command/src/system/sys/users.rs
@@ -14,6 +14,11 @@ impl Command for SysUsers {
         Signature::build("sys users")
             .category(Category::System)
             .input_output_types(vec![(Type::Nothing, Type::table())])
+            .switch(
+                "short",
+                "Short representation, only shows users not the groups for each user",
+                Some('s'),
+            )
     }
 
     fn description(&self) -> &str {
@@ -22,36 +27,81 @@ impl Command for SysUsers {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(users(call.head).into_pipeline_data())
+        let short = call.has_flag(engine_state, stack, "short")?;
+        Ok(users(short, call.head).into_pipeline_data())
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![Example {
-            description: "Show info about the system users",
-            example: "sys users",
-            result: None,
-        }]
+        vec![
+            Example {
+                description: "Show info about the system users",
+                example: "sys users",
+                result: Some(
+                    vec![record! {
+                        "name" => Value::string("root", Span::default()),
+                        "id" => Value::int(0, Span::default()),
+                        "groups" => vec![
+                            record! {
+                                "name" => Value::string("root", Span::default()),
+                                "id" => Value::int(0, Span::default()),
+                            }
+                        ]
+                        .into_value(Span::default())
+                    }]
+                    .into_value(Span::default()),
+                ),
+            },
+            Example {
+                description: "Show users without groups, significantly faster.",
+                example: "sys users --short",
+                result: Some(
+                    vec![record! {
+                        "name" => Value::string("root", Span::default()),
+                        "id" => Value::int(0, Span::default()),
+                    }]
+                    .into_value(Span::default()),
+                ),
+            },
+        ]
     }
 }
 
-fn users(span: Span) -> Value {
+fn users(short: bool, span: Span) -> Value {
     let users = Users::new_with_refreshed_list()
         .iter()
         .map(|user| {
-            let groups = user
-                .groups()
-                .iter()
-                .map(|group| Value::string(trim_cstyle_null(group.name()), span))
-                .collect();
-
-            let record = record! {
+            #[allow(unused_mut)]
+            let mut record = record! {
                 "name" => Value::string(trim_cstyle_null(user.name()), span),
-                "groups" => Value::list(groups, span),
+            };
+            #[cfg(unix)]
+            {
+                use num_traits::ToPrimitive;
+                record.insert("id", Value::int(user.id().to_i64().unwrap_or(-1), span));
+            }
+            if !short {
+                let groups: Vec<Value> = user
+                    .groups()
+                    .iter()
+                    .map(|group| {
+                        #[allow(unused_mut)]
+                        let mut rec = record! {
+                            "name" => Value::string(trim_cstyle_null(group.name()), span),
+                        };
+                        #[cfg(unix)]
+                        {
+                            use num_traits::ToPrimitive;
+                            rec.insert("id", Value::int(group.id().to_i64().unwrap_or(-1), span));
+                        }
+                        Value::record(rec, span)
+                    })
+                    .collect();
+                record.insert("groups", groups.into_value(span));
             };
 
             Value::record(record, span)


### PR DESCRIPTION
Prints everything as `int`s in nushell, so the permissions may look odd,
but they can be more easily used than turning them into a string which
would have to be re-converted into a useful data type.

---

Having the symbolic mode from `umask` is great, but having it output as an octal string allows for some easier conversions. Instead of having to read characters and sum up based on those characters, `ls -l --numeric` can be used to get the permissions as a number, which can be much more useful for scripting or checking permissions.

This pull request also adds a flag and numeric output to `sys users`. The flag, `--short`, skips the `user.groups()` call. The normal `sys users` takes almost 100x more time to return compared to `sys users --short`.

This might cause some problems if a user has a `group in (sys users | get 0.groups)` call or something, since it is no longer a simple list, but a table.

Some of the numeric stuff is simply ignored on Windows, but if someone could test it that would be awesome. This is a bit specific to unix platforms, so I'm not sure if this is okay to add like this.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
