### PR TITLE
Allow setting the NU_COMMIT_HASH as an env variable

### DIFF
--- a/crates/nu-cmd-lang/build.rs
+++ b/crates/nu-cmd-lang/build.rs
@@ -3,7 +3,12 @@ use std::process::Command;
 fn main() {
     // Look up the current Git commit ourselves instead of relying on shadow_rs,
     // because shadow_rs does it in a really slow-to-compile way (it builds libgit2)
-    let hash = get_git_hash().unwrap_or_default();
+    // Allow overriding it with `NU_COMMIT_HASH` from outside, such as with nix.
+    let hash = get_git_hash().unwrap_or(
+        option_env!("NU_COMMIT_HASH")
+            .unwrap_or_default()
+            .to_string(),
+    );
     println!("cargo:rustc-env=NU_COMMIT_HASH={hash}");
     shadow_rs::ShadowBuilder::builder()
         .build()


### PR DESCRIPTION
Allows overriding the `NU_COMMIT_HASH` variable if the build source is not a git repository. Useful for `nix` builds and on other systems where the whole repo is not present during the build process.

<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
