### PR TITLE
fix(completion): a regression on flags without a long name

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -396,10 +396,12 @@ impl NuCompleter {
         // unfinished argument completion for commands
         match &element_expression.expr {
             Expr::Call(call) => {
+                let signature = working_set.get_decl(call.decl_id).signature();
                 // NOTE: the argument to complete is not necessarily the last one
                 // for lsp completion, we don't trim the text,
                 // so that `def`s after pos can be completed
                 let mut positional_arg_indices = Vec::new();
+
                 for (arg_idx, arg) in call.arguments.iter().enumerate() {
                     let span = arg.span();
 
@@ -410,8 +412,6 @@ impl NuCompleter {
                         }
                         continue;
                     }
-
-                    let signature = working_set.get_decl(call.decl_id).signature();
 
                     // Get custom completion from PositionalArg or Flag
                     let completion = {

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -272,91 +272,65 @@ fn customcompletions_no_sort() {
     match_suggestions(&expected, &suggestions);
 }
 
+#[rstest]
 /// Fallback to file completions if custom completer returns null
-#[test]
-fn customcompletions_fallback() {
-    let (_, _, mut engine, mut stack) = new_engine();
-    let command = r#"
-        def comp [] { null }
-        def my-command [arg: string@comp] {}"#;
-    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
-
-    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
-    let completion_str = "my-command test";
-    let suggestions = completer.complete(completion_str, completion_str.len());
-    let expected = [folder("test_a"), file("test_a_symlink"), folder("test_b")];
-    match_suggestions_by_string(&expected, &suggestions);
-}
-
+#[case::fallback(r#"
+    def comp [] { null }
+    def my-command [arg: string@comp] {}"#,
+    "my-command test", None,
+    vec![folder("test_a"), file("test_a_symlink"), folder("test_b")]
+)]
 /// Custom function arguments mixed with subcommands
-#[test]
-fn custom_arguments_and_subcommands() {
-    let (_, _, mut engine, mut stack) = new_engine();
-    let command = r#"
-        def foo [i: directory] {}
-        def "foo test bar" [] {}"#;
-    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
-
-    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
-    let completion_str = "foo test";
-    let suggestions = completer.complete(completion_str, completion_str.len());
-    // including both subcommand and directory completions
-    let expected = [
-        folder("test_a"),
-        file("test_a_symlink"),
-        folder("test_b"),
-        "foo test bar".into(),
-    ];
-    match_suggestions_by_string(&expected, &suggestions);
-}
-
-/// Custom function flags mixed with subcommands
-#[test]
-fn custom_flags_and_subcommands() {
-    let (_, _, mut engine, mut stack) = new_engine();
-    let command = r#"
-        def foo [--test: directory] {}
-        def "foo --test bar" [] {}"#;
-    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
-
-    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
-    let completion_str = "foo --test";
-    let suggestions = completer.complete(completion_str, completion_str.len());
-    // including both flag and directory completions
-    let expected: Vec<_> = vec!["--test", "foo --test bar"];
-    match_suggestions(&expected, &suggestions);
-}
-
+#[case::arguments_and_subcommands(r#"
+    def foo [i: directory] {}
+    def "foo test bar" [] {}"#,
+    "foo test", None,
+    vec![folder("test_a"), file("test_a_symlink"), folder("test_b"), "foo test bar".into()]
+)]
 /// If argument type is something like int/string, complete only subcommands
-#[test]
-fn custom_arguments_vs_subcommands() {
+#[case::arguments_vs_subcommands(r#"
+    def foo [i: string] {}
+    def "foo test bar" [] {}"#,
+    "foo test", None,
+    vec!["foo test bar".into()]
+)]
+/// Custom function flags mixed with subcommands
+#[case::flags_and_subcommands(r#"
+    def foo [--test: directory] {}
+    def "foo --test bar" [] {}"#,
+    "foo --test", None,
+    vec!["--test".into(), "foo --test bar".into()]
+)]
+#[case::defined_inline(
+    "",
+    "export def say [
+    animal: string@[cat dog]
+    ] { }; say ", None,
+    vec!["cat".into(), "dog".into()]
+)]
+#[case::short_flags(
+    "def foo [-A, -B: string@[cat dog] ] {}",
+    "foo -B ", None,
+    vec!["cat".into(), "dog".into()]
+)]
+#[case::flag_name_vs_value(
+    "def foo [-A, -B: string@[cat dog] ] {}",
+    "foo -B cat", Some("foo -B".len()),
+    vec!["-B".into()]
+)]
+fn custom_completions(
+    #[case] command: &str,
+    #[case] input: &str,
+    #[case] pos: Option<usize>,
+    #[case] expected: Vec<String>,
+) {
     let (_, _, mut engine, mut stack) = new_engine();
-    let command = r#"
-        def foo [i: string] {}
-        def "foo test bar" [] {}"#;
     assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
-    let completion_str = "foo test";
-    let suggestions = completer.complete(completion_str, completion_str.len());
-    // including only subcommand completions
-    let expected: Vec<_> = vec!["foo test bar"];
-    match_suggestions(&expected, &suggestions);
-}
-
-#[test]
-fn custom_completions_defined_inline() {
-    let (_, _, engine, stack) = new_engine();
-
-    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
-    let completion_str = "def animals [] { [cat dog] }
-export def say [
-  animal: string@animals
-] { }; say ";
-    let suggestions = completer.complete(completion_str, completion_str.len());
-    // including only subcommand completions
-    let expected: Vec<_> = vec!["cat", "dog"];
-    match_suggestions(&expected, &suggestions);
+    // `pos` defaults to `input.len()` if set to None
+    let suggestions = completer.complete(input, pos.unwrap_or(input.len()));
+    match_suggestions_by_string(&expected, &suggestions);
 }
 
 #[test]

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -806,6 +806,9 @@ impl Signature {
 
     /// Find the matching long flag
     pub fn get_long_flag(&self, name: &str) -> Option<Flag> {
+        if name.is_empty() {
+            return None;
+        }
         for flag in &self.named {
             if flag.long == name {
                 return Some(flag.clone());


### PR DESCRIPTION
Fixes a regression caused by #15613

Originally reported by @Juhan280 [on discord](https://discord.com/channels/601130461678272522/614593951969574961/1434625084370456587)

## Release notes summary - What our users need to know

Fixed a regression of custom-completion for short flags without a long name.

## Tasks after submitting

None
