### PR TITLE
Bump `sysinfo` to latest 0.37.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7775,9 +7775,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.36.1"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ strip-ansi-escapes = "0.2.1"
 strum = "0.26"
 strum_macros = "0.27"
 syn = "2.0"
-sysinfo = "0.36"
+sysinfo = "0.37.2"
 tabled = { version = "0.20", default-features = false }
 tempfile = "3.23"
 thiserror = "2.0.12"


### PR DESCRIPTION
We were a bit behind, no breaking changes to take care of.

Prompted by #16973 but unsure if this provides resolution


## Release notes summary - What our users need to know
N/A
