### PR TITLE
add winresource metadata to cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,13 @@ pkg-fmt = "tgz"
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
 pkg-fmt = "zip"
 
+[package.metadata.winresource]
+LegalCopyright = "Copyright © 2019-2025 The Nushell Project Developers"
+FileDescription = "A new type of shell"
+FileVersion = "0.108.1"
+ProductVersion = "0.108.1"
+ProductName = "Nushell"
+
 [workspace]
 members = [
   "crates/nu_plugin_custom_values",

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -9,9 +9,6 @@ fn main() {
     {
         println!("cargo:rerun-if-changed=assets/nu_logo.ico");
         let mut res = winresource::WindowsResource::new();
-        res.set("ProductName", "Nushell");
-        res.set("FileDescription", "Nushell");
-        res.set("LegalCopyright", "Copyright (C) 2025");
         res.set_icon("assets/nu_logo.ico");
         res.compile()
             .expect("Failed to run the Windows resource compiler (rc.exe)");


### PR DESCRIPTION
This PR helps nushell on Windows to compile without a build warning from the winresource crate.

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
When bumping versions in the future, make sure to bump these two new versions as well.