### PR TITLE
fix: less LICENSE fetch url

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -227,7 +227,7 @@ def fetch-less [
     let less_zip = $'less-($arch).zip'
     print $'Fetching less archive: (ansi g)($less_zip)(ansi reset)'
     let url = $'https://github.com/jftuga/less-Windows/releases/download/less-v668/($less_zip)'
-    http get https://github.com/jftuga/less-Windows/blob/master/LICENSE | save -rf LICENSE-for-less.txt
+    http get https://github.com/jftuga/less-Windows/raw/master/LICENSE | save -rf LICENSE-for-less.txt
     http get $url | save -rf $less_zip
     unzip $less_zip
     rm $less_zip lesskey.exe


### PR DESCRIPTION
Fetching 'blob' would return Github's large HTML response _(technically - that does contain `less` license content)_. However, fetching 'raw' would exactly return the desired content.

<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

_Note: removed 'Release notes summary' section and 'Tasks after submitting' section given the inconsequential nature of this change._