### PR TITLE
fix(`std/help`): highlighting invalid syntax

### DIFF
--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -132,11 +132,16 @@ def highlight-description [] {
     if (config use-colors) {
         str replace -ar '(?<!`)`([^`]+)`(?!`)' {
             str trim -c '`'
-            | try {
-                nu-highlight --reject-garbage
-                | str replace -a (ansi rst) $"(ansi rst)(ansi i)"
-            } catch {
-                $"(ansi d)($in)(ansi rst_d)"
+            | do {||
+                let $input = $in
+
+                try {
+                    $input
+                    | nu-highlight --reject-garbage
+                    | str replace -a (ansi rst) $"(ansi rst)(ansi i)"
+                } catch {
+                    $"(ansi d)($input)(ansi rst_d)"
+                }
             }
             | $"(ansi i)($in)(ansi rst_i)"
         }


### PR DESCRIPTION
Fixed highlighting when syntax is invalid from #16931.

## Release notes summary - What our users need to know

## Tasks after submitting
