### PR TITLE
Use native cert store on Android for rustls

### DIFF
--- a/crates/nu-command/src/network/tls/impl_rustls.rs
+++ b/crates/nu-command/src/network/tls/impl_rustls.rs
@@ -103,9 +103,9 @@ pub fn tls_config(allow_insecure: bool) -> Result<TlsConfig, ShellError> {
             let certs = RootCerts::PlatformVerifier;
 
             // Use native cert store instead of platform verifier on Android, as we cannot use the
-            // `platform-android-verifier-android` crate properly as we don't build a proper 
+            // `platform-android-verifier-android` crate properly as we don't build a proper
             // android app but rather just a binary that is executed in termux.
-            // Otherwise this guide would be really relevant: 
+            // Otherwise this guide would be really relevant:
             // https://github.com/rustls/rustls-platform-verifier/blob/1099f161bfc5e3ac7f90aad88b1bf788e72906cb/README.md#android
             #[cfg(all(feature = "os", target_os = "android"))]
             let certs = native_certs();
@@ -125,10 +125,10 @@ pub fn tls_config(allow_insecure: bool) -> Result<TlsConfig, ShellError> {
 }
 
 /// Load certificates from the platform certificate store.
-/// 
-/// This method of loading certs is discouraged by the rustls team, see 
+///
+/// This method of loading certs is discouraged by the rustls team, see
 /// [here](https://github.com/rustls/rustls-native-certs).
-/// However this impl still works and is expected to work, especially for platforms that not 
+/// However this impl still works and is expected to work, especially for platforms that not
 /// properly support `rustls-platform-verifier`.
 #[cfg(feature = "os")]
 pub fn native_certs() -> RootCerts {


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

- fixes #16792

We usually use `rustls-platform-verifier` for TLS certificate verification, as it's the option recommended by the rustls team. However, it doesn't work properly on Android. It relies on Java Native Interface calls, which we can't make in Termux since Nushell is not a full Android app. So, [this tutorial](https://github.com/rustls/rustls-platform-verifier/tree/v/0.5.3/rustls-platform-verifier#android) doesn't apply in our case.

As a workaround, we can use `rustls-native-certs` to load the system's certificate store instead. While it's not the preferred solution, it’s still supported and works fine. With it, we're able to load certificates correctly, and commands like `http get https://example.com` work again.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

`http` commands using HTTPS now work again on Android when compiled with the default `rustls-tls` feature.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
