### PR TITLE
Use `rustc` as external instead of `sleep` for highlight test

### DIFF
--- a/crates/nu-cli/tests/commands/nu_highlight.rs
+++ b/crates/nu-cli/tests/commands/nu_highlight.rs
@@ -16,7 +16,7 @@ fn nu_highlight_where_row_condition() {
 fn nu_highlight_aliased_external_resolved() {
     let actual = nu!(r#"$env.config.highlight_resolved_externals = true
         $env.config.color_config.shape_external_resolved = '#ffffff'
-        alias fff = ^sleep
+        alias fff = ^rustc
         ('fff' | nu-highlight) has (ansi $env.config.color_config.shape_external_resolved)"#);
 
     assert_eq!(actual.out, "true");


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

This fixes the tests for Windows machines that don't have `sleep` in their PATH. The CI probably contains the git binaries which contain `sleep`. A Windows machine with `git` and Rust installed usually has `git` in their PATH without the helper binaries. This fixes the test by using `rustc` which should be available on all machines running these tests.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

N/A