### PR TITLE
fix(parser, completion): wrong span of `export def/extern` with attributes & snippet completion for attributable commands

### DIFF
--- a/crates/nu-cli/src/completions/attribute_completions.rs
+++ b/crates/nu-cli/src/completions/attribute_completions.rs
@@ -70,10 +70,14 @@ impl Completer for AttributableCompletion {
                         start: span.start - offset,
                         end: span.end - offset,
                     },
-                    append_whitespace: false,
+                    append_whitespace: true,
                     ..Default::default()
                 },
-                kind: Some(SuggestionKind::Command(cmd.command_type(), None)),
+                kind: Some(SuggestionKind::Command(
+                    cmd.command_type(),
+                    // for snippet completion in LSP
+                    working_set.find_decl(s.as_bytes()),
+                )),
             });
         }
 

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1953,6 +1953,9 @@ fn attributable_completions() {
 
     // Match results
     match_suggestions(&expected, &suggestions);
+
+    // Append space set to true
+    assert!(suggestions[0].append_whitespace);
 }
 
 #[test]

--- a/crates/nu-lsp/src/completion.rs
+++ b/crates/nu-lsp/src/completion.rs
@@ -516,6 +516,19 @@ mod tests {
             "kind": 12
         }])
     )]
+    #[case::attributable_command_with_snippet(
+        "command.nu", (21, 0),
+        None,
+        serde_json::json!([{
+            "label": "def",
+            "labelDetails": { "description": "keyword" },
+            "textEdit": {
+                "range": { "start": { "line": 21, "character": 0 }, "end": { "line": 21, "character": 0 } },
+                "newText": "def ${1:def_name} ${2:params} ${3:block}"
+            },
+            "kind": 14
+        }])
+    )]
     fn completion_single_request(
         #[case] filename: &str,
         #[case] cursor_position: (u32, u32),

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -1082,6 +1082,21 @@ mod tests {
         "workspace/baz.nu", (10, 7),
         serde_json::json!([make_highlight(10, 4, 10, 12), make_highlight(11, 1, 11, 8)])
     )]
+    // Regression tests for https://github.com/nushell/nushell/pull/16696
+    #[case::export_def_with_attributes(
+        "workspace/foo.nu", (25, 3),
+        serde_json::json!([
+            make_highlight(0, 0, 0, 10),
+            make_highlight(6, 0, 6, 11),
+            make_highlight(10, 4, 10, 14),
+            make_highlight(25, 2, 25, 13),
+            make_highlight(32, 0, 32, 10),
+        ])
+    )]
+    #[case::export_extern_with_attributes(
+        "workspace/foo.nu", (28, 3),
+        serde_json::json!([make_highlight(28, 2, 28, 15), make_highlight(35, 0, 35, 13)])
+    )]
     fn document_highlight_request(
         #[case] filename: &str,
         #[case] cursor_position: (u32, u32),

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1407,7 +1407,6 @@ fn warp_export_call(
         }
         Some(Expr::AttributeBlock(ab)) => {
             if let Expr::Call(def_call) = &mut ab.item.expr {
-                def_call.head = Span::concat(&spans[0..=1]);
                 def_call.decl_id = export_decl_id;
                 return true;
             }

--- a/tests/fixtures/lsp/workspace/foo.nu
+++ b/tests/fixtures/lsp/workspace/foo.nu
@@ -21,4 +21,16 @@ export module cst_mod {
       export const var_name = "const value"
     }
   }
+
+  @category foo
+  export  def module_attribute_foo [] { }
+
+  @complete external
+  export extern module_attribute_baz []
 }
+
+@category foo
+export def block_attribute_foo [] { }
+
+@complete external
+export extern block_attribute_baz []


### PR DESCRIPTION
Technically they are 2 independent changes. But they're small and easy to review, and both related to attributable commands.

## Release notes summary - What our users need to know

Fixed a regression introduced in #16696 where `export def`/`export extern` with attributes has incorrect command span.

## Tasks after submitting
