### PR TITLE
allow streaming to commands with union-typed pipeline input

### DIFF
--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -159,6 +159,7 @@ impl PipelineData {
     pub fn is_subtype_of(&self, other: &Type) -> bool {
         match (self, other) {
             (_, Type::Any) => true,
+            (data, Type::OneOf(oneof)) => oneof.iter().any(|t| data.is_subtype_of(t)),
             (PipelineData::Empty, Type::Nothing) => true,
             (PipelineData::Value(val, ..), ty) => val.is_subtype_of(ty),
 

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -182,6 +182,25 @@ fn collection_supertype_inference(
 }
 
 #[test]
+fn pipeline_oneof() -> TestResult {
+    // Empty is compatible with oneof<nothing, ..>
+    run_test(
+        "def f []: [oneof<int, nothing> -> nothing] { describe }; f",
+        "nothing",
+    )?;
+    // ByteStream is compatible with oneof<binary, ..>
+    run_test(
+        "def f []: [oneof<int, binary> -> nothing] { describe }; [0x[01]] | bytes collect | f",
+        "binary (stream)",
+    )?;
+    // ListStream is compatible with oneof<list, ..>>
+    run_test(
+        "def f []: [oneof<string, list<int>> -> nothing] { describe }; [1] | each {} | f",
+        "list<int> (stream)",
+    )
+}
+
+#[test]
 fn transpose_into_load_env() -> TestResult {
     run_test(
         "[[col1, col2]; [a, 10], [b, 20]] | transpose --ignore-titles -r -d | load-env; $env.a",


### PR DESCRIPTION
Closes #17031

## Release notes summary - What our users need to know
Commands whose input signatures are declared with `oneof` now accept
streams instead of erroring:

```
> def f []: [oneof<list> -> nothing] {}
> [] | each {} | f
Error: nu::shell::only_supports_this_input_type

  × Input type not supported.
   ╭─[entry #2:1:6]
 1 │ [] | each {} | f
   ·      ──┬─      ┬
   ·        │       ╰── only oneof<list<any>> input data is supported
   ·        ╰── input type: list<any>
```