### PR TITLE
`first` and `last` return `nothing` on empty results

### DIFF
--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -115,7 +115,9 @@ fn first_helper(
                         if let Some(val) = vals.first_mut() {
                             Ok(std::mem::take(val).into_pipeline_data())
                         } else {
-                            Err(ShellError::AccessEmptyContent { span: head })
+                            // There are no values, so return nothing instead of an error so
+                            // that users can pipe this through 'default' if they want to.
+                            Ok(Value::nothing(head).into_pipeline_data_with_metadata(metadata))
                         }
                     } else {
                         vals.truncate(rows);
@@ -127,7 +129,9 @@ fn first_helper(
                         if let Some(&val) = val.first() {
                             Ok(Value::int(val.into(), span).into_pipeline_data())
                         } else {
-                            Err(ShellError::AccessEmptyContent { span: head })
+                            // There are no values, so return nothing instead of an error so
+                            // that users can pipe this through 'default' if they want to.
+                            Ok(Value::nothing(head).into_pipeline_data_with_metadata(metadata))
                         }
                     } else {
                         val.truncate(rows);
@@ -140,7 +144,9 @@ fn first_helper(
                         if let Some(v) = iter.next() {
                             Ok(v.into_pipeline_data())
                         } else {
-                            Err(ShellError::AccessEmptyContent { span: head })
+                            // There are no values, so return nothing instead of an error so
+                            // that users can pipe this through 'default' if they want to.
+                            Ok(Value::nothing(head).into_pipeline_data_with_metadata(metadata))
                         }
                     } else {
                         Ok(iter.take(rows).into_pipeline_data_with_metadata(
@@ -165,7 +171,9 @@ fn first_helper(
                 if let Some(v) = stream.into_iter().next() {
                     Ok(v.into_pipeline_data())
                 } else {
-                    Err(ShellError::AccessEmptyContent { span: head })
+                    // There are no values, so return nothing instead of an error so
+                    // that users can pipe this through 'default' if they want to.
+                    Ok(Value::nothing(head).into_pipeline_data_with_metadata(metadata))
                 }
             } else {
                 Ok(PipelineData::list_stream(

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -111,7 +111,9 @@ impl Command for Last {
                     if let Some(last) = buf.pop_back() {
                         Ok(last.into_pipeline_data())
                     } else {
-                        Err(ShellError::AccessEmptyContent { span: head })
+                        // There are no values, so return nothing instead of an error so
+                        // that users can pipe this through 'default' if they want to.
+                        Ok(Value::nothing(head).into_pipeline_data_with_metadata(metadata))
                     }
                 } else {
                     Ok(Value::list(buf.into(), head).into_pipeline_data_with_metadata(metadata))
@@ -125,7 +127,9 @@ impl Command for Last {
                             if let Some(v) = vals.pop() {
                                 Ok(v.into_pipeline_data())
                             } else {
-                                Err(ShellError::AccessEmptyContent { span: head })
+                                // There are no values, so return nothing instead of an error so
+                                // that users can pipe this through 'default' if they want to.
+                                Ok(Value::nothing(head).into_pipeline_data_with_metadata(metadata))
                             }
                         } else {
                             let i = vals.len().saturating_sub(rows);
@@ -138,7 +142,9 @@ impl Command for Last {
                             if let Some(val) = val.pop() {
                                 Ok(Value::int(val.into(), span).into_pipeline_data())
                             } else {
-                                Err(ShellError::AccessEmptyContent { span: head })
+                                // There are no values, so return nothing instead of an error so
+                                // that users can pipe this through 'default' if they want to.
+                                Ok(Value::nothing(head).into_pipeline_data_with_metadata(metadata))
                             }
                         } else {
                             let i = val.len().saturating_sub(rows);
@@ -178,7 +184,10 @@ impl Command for Last {
                                             Value::int(buf[0] as i64, head).into_pipeline_data()
                                         );
                                     } else {
-                                        return Err(ShellError::AccessEmptyContent { span: head });
+                                        // There are no values, so return nothing instead of an error so
+                                        // that users can pipe this through 'default' if they want to.
+                                        return Ok(Value::nothing(head)
+                                            .into_pipeline_data_with_metadata(metadata));
                                     }
                                 } else {
                                     return Ok(Value::binary(buf, head).into_pipeline_data());

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -98,10 +98,10 @@ fn errors_on_negative_rows() {
 }
 
 #[test]
-fn errors_on_empty_list_when_no_rows_given() {
-    let actual = nu!("[] | first");
+fn does_not_error_on_empty_list_when_no_rows_given() {
+    let actual = nu!("[] | first | describe");
 
-    assert!(actual.err.contains("index too large"));
+    assert!(actual.out.contains("nothing"));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -97,8 +97,22 @@ fn fail_on_non_iterator() {
 }
 
 #[test]
-fn errors_on_empty_list_when_no_rows_given() {
+fn does_not_error_on_empty_list_when_no_rows_given() {
+    let actual = nu!("[] | last | describe");
+
+    assert!(actual.out.contains("nothing"));
+}
+
+#[test]
+fn returns_nothing_on_empty_list_when_no_rows_given() {
     let actual = nu!("[] | last");
 
-    assert!(actual.err.contains("index too large"));
+    assert_eq!(actual.out, "");
+}
+
+#[test]
+fn returns_d_on_empty_list_when_no_rows_given_with_default() {
+    let actual = nu!("[a b] | where $it == 'c' | last | default 'd'");
+
+    assert_eq!(actual.out, "d");
 }


### PR DESCRIPTION
This PR changes the behavior of `first` and `last` when encountering empty results. This is done so that one can more easily use `default` to provide a default value when results are empty. e.g.
```nushell
[a b] | where $it == 'c' | last | default 'd'
# => d
```

## Release notes summary - What our users need to know

We changed the behavior of `first` and `last` when encountering empty results. Previously `first` and `last` would error on an empty list. They now return `null` instead.

This is done so that one can more easily use `default` to provide a default value when results are empty. e.g.
```nushell
[a b] | where $it == 'c' | last | default 'd'
# => d

[] | first | default 'hi'
# => hi
```

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
