### PR TITLE
Add `--strict` flag to `first` and `last` command, to raise error on empty list.

### DIFF
--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -105,6 +105,13 @@ fn does_not_error_on_empty_list_when_no_rows_given() {
 }
 
 #[test]
+fn error_on_empty_list_when_no_rows_given_in_strict_mode() {
+    let actual = nu!("[] | first --strict | describe");
+
+    assert!(actual.err.contains("index too large"));
+}
+
+#[test]
 fn gets_first_bytes_and_drops_content_type() {
     let actual = nu!(format!(
         "open {} | first 3 | metadata | get content_type? | describe",

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -97,6 +97,12 @@ fn fail_on_non_iterator() {
 }
 
 #[test]
+fn errors_on_empty_list_when_no_rows_given_in_strict_mode() {
+    let actual = nu!("[] | last --strict");
+    assert!(actual.err.contains("index too large"));
+}
+
+#[test]
 fn does_not_error_on_empty_list_when_no_rows_given() {
     let actual = nu!("[] | last | describe");
 


### PR DESCRIPTION
As title, this pr adds `--strict` flag to `first` and `last` command, so they will raise error on empty list.  This is a follow up to #17054

## Release notes summary - What our users need to know
By default, `first` and `last` will return `null` on empty list, this pr is going to add `--strict` to make it returns on error.

```
> [] | first --strict
Error: nu::shell::access_beyond_end

  × Row number too large (empty content).
   ╭─[entry #1:1:6]
 1 │ [] | first --strict
   ·      ──┬──
   ·        ╰── index too large (empty content)
   ╰────
```

## Tasks after submitting
NaN