### PR TITLE
Add new `term theme` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.10.0",
  "crossterm_winapi",
- "mio 1.0.3",
+ "mio 1.1.0",
  "parking_lot",
  "rustix 0.38.42",
  "signal-hook",
@@ -1450,7 +1450,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio 1.0.3",
+ "mio 1.1.0",
  "parking_lot",
  "rustix 1.0.7",
  "serde",
@@ -3820,14 +3820,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4272,6 +4272,7 @@ dependencies = [
  "sysinfo",
  "tabled",
  "tempfile",
+ "terminal-colorsaurus",
  "titlecase",
  "toml",
  "trash",
@@ -7481,12 +7482,12 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 1.0.3",
+ "mio 1.1.0",
  "signal-hook",
 ]
 
@@ -7933,6 +7934,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal-colorsaurus"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8909f33134da34b43f69145e748790de650a6abd84faf1f82e773444dd293ec8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "memchr",
+ "mio 1.1.0",
+ "terminal-trx",
+ "windows-sys 0.61.0",
+ "xterm-color",
+]
+
+[[package]]
+name = "terminal-trx"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662a3cd5ca570df622e848ef18b50c151e65c9835257465417242243b0bce783"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8114,7 +8141,7 @@ dependencies = [
  "bytes",
  "io-uring",
  "libc",
- "mio 1.0.3",
+ "mio 1.1.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -9931,6 +9958,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xterm-color"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de5f056fb9dc8b7908754867544e26145767187aaac5a98495e88ad7cb8a80f"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,7 @@ syn = "2.0"
 sysinfo = "0.37.2"
 tabled = { version = "0.20", default-features = false }
 tempfile = "3.23"
+terminal-colorsaurus = "1.0"
 thiserror = "2.0.12"
 titlecase = "3.6"
 toml = "0.8"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -109,6 +109,7 @@ sha2 = { workspace = true }
 strum = { workspace = true }
 sysinfo = { workspace = true }
 tabled = { workspace = true, features = ["ansi"], default-features = false }
+terminal-colorsaurus = {workspace = true}
 titlecase = { workspace = true }
 toml = { workspace = true, features = ["preserve_order"] }
 unicode-segmentation = { workspace = true }

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -267,6 +267,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             Term,
             TermSize,
             TermQuery,
+            TermTheme,
             Whoami,
         };
 

--- a/crates/nu-command/src/platform/mod.rs
+++ b/crates/nu-command/src/platform/mod.rs
@@ -17,7 +17,7 @@ pub use input::InputListen;
 pub use is_terminal::IsTerminal;
 pub use kill::Kill;
 pub use sleep::Sleep;
-pub use term::{Term, TermQuery, TermSize};
+pub use term::{Term, TermQuery, TermSize, TermTheme};
 #[cfg(unix)]
 pub use ulimit::ULimit;
 pub use whoami::Whoami;

--- a/crates/nu-command/src/platform/term/mod.rs
+++ b/crates/nu-command/src/platform/term/mod.rs
@@ -1,7 +1,9 @@
 mod term_;
 mod term_query;
 mod term_size;
+mod term_theme;
 
 pub use term_::Term;
 pub use term_query::TermQuery;
 pub use term_size::TermSize;
+pub use term_theme::TermTheme;

--- a/crates/nu-command/src/platform/term/term_theme.rs
+++ b/crates/nu-command/src/platform/term/term_theme.rs
@@ -1,0 +1,175 @@
+use std::time::Duration;
+
+use nu_engine::{CallExt, command_prelude::IoError};
+use nu_protocol::{
+    Category, Example, IntoPipelineData, ShellError, Signature, SyntaxShape, Type, Value,
+    engine::Command, record,
+};
+use terminal_colorsaurus::{QueryOptions, ThemeMode, color_palette};
+
+#[derive(Clone)]
+pub struct TermTheme;
+
+impl Command for TermTheme {
+    fn name(&self) -> &str {
+        "term theme"
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("term theme")
+            .category(Category::Platform)
+            .input_output_type(
+                Type::Nothing,
+                Type::Record(
+                    [
+                        (
+                            "background".into(),
+                            Type::Record(
+                                [
+                                    ("r".into(), Type::Int),
+                                    ("g".into(), Type::Int),
+                                    ("b".into(), Type::Int),
+                                ]
+                                .into(),
+                            ),
+                        ),
+                        (
+                            "foreground".into(),
+                            Type::Record(
+                                [
+                                    ("r".into(), Type::Int),
+                                    ("g".into(), Type::Int),
+                                    ("b".into(), Type::Int),
+                                ]
+                                .into(),
+                            ),
+                        ),
+                        ("mode".into(), Type::String),
+                    ]
+                    .into(),
+                ),
+            )
+            .named(
+                "timeout",
+                SyntaxShape::Duration,
+                "Maximum time to wait for a response from the terminal (default is 1s)",
+                Some('t'),
+            )
+    }
+
+    fn description(&self) -> &str {
+        "Query the terminal for the current background and foreground colors."
+    }
+
+    fn extra_description(&self) -> &str {
+        "This queries the terminal using the `OSC 10` and `OSC 11` terminal sequences and returns a record containing the current background and foreground colors in 8bit RGB format.
+
+Also returns whether this color scheme is considered light (dark text on light background) or dark (light text on dark background), based on the perceived lightness of the background and foreground colors."
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                example: "term theme",
+                description: "Query the current terminal theme",
+                result: Some(Value::test_record(record! {
+                    "background" => Value::test_record(record! {
+                        "r" => Value::test_int(239),
+                        "g" => Value::test_int(241),
+                        "b" => Value::test_int(245),
+                    }),
+                    "foreground" => Value::test_record(record! {
+                        "r" => Value::test_int(76),
+                        "g" => Value::test_int(79),
+                        "b" => Value::test_int(105),
+                    }),
+                    "mode" => Value::test_string("light"),
+                })),
+            },
+            Example {
+                example: "term theme --timeout 2s",
+                description: "Query the current terminal theme with a custom timeout (in case of high latency such as an SSH connection)",
+                result: Some(Value::test_record(record! {
+                    "background" => Value::test_record(record! {
+                        "r" => Value::test_int(239),
+                        "g" => Value::test_int(241),
+                        "b" => Value::test_int(245),
+                    }),
+                    "foreground" => Value::test_record(record! {
+                        "r" => Value::test_int(76),
+                        "g" => Value::test_int(79),
+                        "b" => Value::test_int(105),
+                    }),
+                    "mode" => Value::test_string("light"),
+                })),
+            },
+        ]
+    }
+
+    fn run(
+        &self,
+        engine_state: &nu_protocol::engine::EngineState,
+        stack: &mut nu_protocol::engine::Stack,
+        call: &nu_protocol::engine::Call,
+        _input: nu_protocol::PipelineData,
+    ) -> Result<nu_protocol::PipelineData, ShellError> {
+        let head = call.head;
+        let mut query_options = QueryOptions::default();
+        if let Some(d) = call.get_flag::<Duration>(engine_state, stack, "timeout")? {
+            query_options.timeout = d;
+        }
+        let palette = color_palette(query_options).map_err(|e| match &e {
+            terminal_colorsaurus::Error::Io(io) => IoError::new(io, head, None).into(),
+            terminal_colorsaurus::Error::Parse(_items) => ShellError::GenericError {
+                error: "Terminal returned a color in an unsupported format".into(),
+                msg: e.to_string(),
+                span: Some(head),
+                help: None,
+                inner: vec![],
+            },
+            terminal_colorsaurus::Error::Timeout(_duration) => ShellError::GenericError {
+                error: "Timeout expired".into(),
+                msg: e.to_string(),
+                span: Some(head),
+                help: Some("If your terminal supports querying background and foreground colors, consider using a higher timeout value with `--timeout` in case there is a high latency.".into()),
+                inner: vec![],
+            },
+            terminal_colorsaurus::Error::UnsupportedTerminal(err) => ShellError::GenericError {
+                error: "Unsupported terminal".into(),
+                msg: err.to_string(),
+                span: Some(head),
+                help: None,
+                inner: vec![],
+            },
+            _ => ShellError::GenericError {
+                error: "Unexpected error".into(),
+                msg: e.to_string(),
+                span: Some(head),
+                help: None,
+                inner: vec![],
+            },
+        })?;
+        let (bg_r, bg_g, bg_b) = palette.background.scale_to_8bit();
+        let (fg_r, fg_g, fg_b) = palette.foreground.scale_to_8bit();
+        Ok(Value::record(
+            record! {
+                "background" => Value::record(record! {
+                    "r" => Value::int(bg_r as i64, head),
+                    "g" => Value::int(bg_g as i64, head),
+                    "b" => Value::int(bg_b as i64, head),
+                }, head),
+                "foreground" => Value::record(record! {
+                    "r" => Value::int(fg_r as i64, head),
+                    "g" => Value::int(fg_g as i64, head),
+                    "b" => Value::int(fg_b as i64, head),
+                }, head),
+                "mode" => match palette.theme_mode() {
+                    ThemeMode::Dark => Value::string("dark", head),
+                    ThemeMode::Light => Value::string("light", head),
+                }
+            },
+            head,
+        )
+        .into_pipeline_data())
+    }
+}


### PR DESCRIPTION
Add a new `term theme` command that returns some information about the current terminal theme: background color, foreground color, and whether the current theme is considered "dark" or "light".

This could somewhat be achieved with the current `term query` command, but it is quite fiddly as different terminals expect different terminators, and might return colors in different formats. This new command uses the [`terminal-colorsaurus`](https://docs.rs/terminal-colorsaurus/latest/terminal_colorsaurus/) crate which handles all that complexity. It is fast, widely used, tested on a wide range of terminals, and good at detecting if the current terminal supports querying or not.

Note: currently the colors are returned as records with `r`, `g` and `b` fields (in 8bit format). I'm not sure if that's the most useful or convenient format 🤷🏻‍♂️ Happy to get suggestions.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
