### PR TITLE
deduplicated types in type_check process to improve error message

### DIFF
--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -784,6 +784,8 @@ pub fn check_pipeline_type(
 
     for elem in &pipeline.elements {
         current_types = std::mem::take(&mut new_types);
+        current_types.sort();
+        current_types.dedup();
 
         if elem.redirection.is_some() {
             new_types = vec![Type::Any];

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 #[cfg(test)]
 use strum_macros::EnumIter;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Hash, Ord, PartialOrd)]
 #[cfg_attr(test, derive(EnumIter))]
 pub enum Type {
     /// Top type, supertype of all types

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -296,3 +296,11 @@ fn pipeline_multiple_types_propagate_error() -> TestResult {
         "parser::input_type_mismatch",
     )
 }
+
+#[test]
+fn array_of_wrong_types() -> TestResult {
+    fail_test(
+        "0..128 | each {} | into string | bytes collect",
+        "command doesn't support list<string>, record, string, or table input",
+    )
+}


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
This PR is intended to fix the issue with error messages documented in #16717, by sorting and deduplicating the current_type param in check_type.rs. 

Fixes https://github.com/nushell/nushell/issues/16717.
## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
