### PR TITLE
Add `error_lines` and `error_style = tree` settings

### DIFF
--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -69,6 +69,7 @@ pub struct Config {
     pub cursor_shape: CursorShapeConfig,
     pub datetime_format: DatetimeFormatConfig,
     pub error_style: ErrorStyle,
+    pub error_lines: i64,
     pub display_errors: DisplayErrors,
     pub use_kitty_protocol: bool,
     pub highlight_resolved_externals: bool,
@@ -124,7 +125,8 @@ impl Default for Config {
 
             keybindings: Vec::new(),
 
-            error_style: ErrorStyle::Fancy,
+            error_style: ErrorStyle::default(),
+            error_lines: 1,
             display_errors: DisplayErrors::default(),
 
             use_kitty_protocol: false,
@@ -204,6 +206,17 @@ impl UpdateFromValue for Config {
                 "hooks" => self.hooks.update(val, path, errors),
                 "datetime_format" => self.datetime_format.update(val, path, errors),
                 "error_style" => self.error_style.update(val, path, errors),
+                "error_lines" => {
+                    if let Ok(lines) = val.as_int() {
+                        if lines >= 0 {
+                            self.error_lines = lines;
+                        } else {
+                            errors.invalid_value(path, "an int greater than or equal to 0", val);
+                        }
+                    } else {
+                        errors.type_mismatch(path, Type::Int, val);
+                    }
+                }
                 "recursion_limit" => {
                     if let Ok(limit) = val.as_int() {
                         if limit > 1 {

--- a/crates/nu-protocol/src/config/output.rs
+++ b/crates/nu-protocol/src/config/output.rs
@@ -2,11 +2,13 @@ use super::{config_update_string_enum, prelude::*};
 
 use crate::{self as nu_protocol};
 
-#[derive(Clone, Copy, Debug, IntoValue, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Default, Debug, IntoValue, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ErrorStyle {
+    #[default]
     Fancy,
     Plain,
     Short,
+    Nested,
 }
 
 impl FromStr for ErrorStyle {
@@ -17,7 +19,8 @@ impl FromStr for ErrorStyle {
             "fancy" => Ok(Self::Fancy),
             "plain" => Ok(Self::Plain),
             "short" => Ok(Self::Short),
-            _ => Err("'fancy', 'plain', or 'short'"),
+            "nested" => Ok(Self::Nested),
+            _ => Err("'fancy', 'plain', 'short' or 'nested'"),
         }
     }
 }

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -271,11 +271,12 @@ $env.config.use_ansi_coloring = "auto"
 # Error Display Settings
 # ----------------------
 
-# error_style (string): How errors are displayed.
-# "fancy": Use line-drawing characters to point to error location.
-# "plain": Plain-text errors suitable for screen readers.
-# "short": Concise, single-line error messages.
-# Default: "fancy"
+# error_style (string): One of "fancy", "plain", "short" or "nested"
+# Plain: Display plain-text errors for screen-readers
+# Fancy: Display errors using line-drawing characters to point to the span in which the
+#        problem occurred.
+# Short: Display errors as concise, single-line messages similar to classic shells.
+# Nested: Same as Fancy but with nesting for related errors.
 $env.config.error_style = "fancy"
 
 # display_errors.exit_code (bool): Show Nushell error when external command returns non-zero.
@@ -290,6 +291,10 @@ $env.config.display_errors.exit_code = false
 # false: Don't show error for signal termination.
 # Default: true
 $env.config.display_errors.termination_signal = true
+
+# error_lines (int):
+# Sets the number of context lines in the error output. Must be a positive integer.
+$env.config.error_lines = 1
 
 # -------------
 # Table Display


### PR DESCRIPTION
With the new inner `error make` options, the `.show_related_errors_as_nested()` setting makes a lot of sense, I but did not want to enable it by default. This adds a new error mode that uses the nested error style. I called it 'tree', but if it makes more sense to call it 'nested' or 'nest' then that's fine as well.

Also added a setting to change the number of context lines shown for the labels. Sometimes this can let labels get squashed into one block of code, making it easier to read.

This also sets a `#[default]` for the `ErrorStyle`.
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

* New option for `$env.config.error_style` to show related/nested errors: `tree`
* New setting to change the number of lines printed for error context (default: 1): `$env.config.error_lines`

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
