### PR TITLE
[fix] fixed issue with alias "missing required flag" on create

### DIFF
--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -155,3 +155,9 @@ fn export_alias_with_overlay_use_works() {
     let actual = nu!("export alias teapot = overlay use");
     assert!(actual.err.is_empty())
 }
+
+#[test]
+fn alias_flag() {
+    let actual = nu!("alias si = stor import");
+    assert!(actual.err.is_empty());
+}

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1262,7 +1262,10 @@ pub fn parse_alias(
             if starting_error_count != working_set.parse_errors.len()
                 && let Some(e) = working_set.parse_errors.get(starting_error_count)
             {
-                if let ParseError::MissingPositional(..) = e {
+                if let ParseError::MissingPositional(..)
+                | ParseError::MissingRequiredFlag(..)
+                | ParseError::MissingFlagParam(..) = e
+                {
                     working_set
                         .parse_errors
                         .truncate(original_starting_error_count);


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
Added logic to treat Missing Required Flag the same as Missing Positional (i.e., alias parsing logic ignores those errors when returned from parse_call). I did a scan of similar types of parse errors and added MissingFlagParam, which I think should have the same treatment.

fixes #16847 
## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
