### PR TITLE
fixed handling of ranges with respect to parentheses

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1911,8 +1911,16 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Option<Expr
         return None;
     }
 
-    // First, figure out what exact operators are used and determine their positions
-    let dotdot_pos: Vec<_> = token.match_indices("..").map(|(pos, _)| pos).collect();
+    let dotdot_pos: Vec<_> = token
+        .match_indices("..")
+        .filter_map(|(pos, _)| {
+            // paren_depth = count of unclosed parens prior to pos
+            let before = &token[..pos];
+            let paren_depth = before.chars().filter(|&c| c == '(').count()
+                - before.chars().filter(|&c| c == ')').count();
+            if paren_depth == 0 { Some(pos) } else { None }
+        })
+        .collect();
 
     let (next_op_pos, range_op_pos) = match dotdot_pos.len() {
         1 => (None, dotdot_pos[0]),

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -679,3 +679,40 @@ fn parse_const_signature_missing_colon() {
     let actual = nu!("const a string = 'Hello World\n'");
     assert!(actual.err.contains("nu::parser::extra_tokens"));
 }
+
+/// https://github.com/nushell/nushell/issues/16969
+#[test]
+fn wacky_range_parse() {
+    let actual = nu!(r#"0..(1..2 | first)"#);
+    assert!(actual.err.is_empty());
+}
+
+#[test]
+fn wacky_range_parse_lt() {
+    let actual = nu!(r#"0..<(1..2 | first)"#);
+    assert!(actual.err.is_empty());
+}
+
+#[test]
+fn wacky_range_parse_eq() {
+    let actual = nu!(r#"0..=(1..2 | first)"#);
+    assert!(actual.err.is_empty());
+}
+
+#[test]
+fn wacky_range_parse_no_end() {
+    let actual = nu!(r#"..(1..2 | first)"#);
+    assert!(actual.err.is_empty());
+}
+
+#[test]
+fn wacky_range_parse_regression() {
+    let actual = nu!(r#"1..(5)..10"#);
+    assert!(actual.err.is_empty());
+}
+
+#[test]
+fn wacky_range_parse_comb() {
+    let actual = nu!(r#"1..(5..10 | first)..10"#);
+    assert!(actual.err.is_empty());
+}


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
added logic to exclude parenthesized expressions in the search for the optional second piece of a range expression, ex

```0..(1..2 | first)```

will now parse as a simple range `0..1` rather than an invalid complex range `0..(1..2`

fixes #16969 

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
