### PR TITLE
refactor(mcp): extract tool descriptions to markdown files

### DIFF
--- a/crates/nu-mcp/src/evaluate_tool.md
+++ b/crates/nu-mcp/src/evaluate_tool.md
@@ -1,0 +1,73 @@
+Execute a command in the nushell.
+This will return the output and error concatenated into a single string, as
+you would see from running on the command line. There will also be an indication
+of if the command succeeded or failed.
+
+Avoid commands that produce a large amount of output, and consider piping those outputs to files.
+If you need to run a long lived command, background it - e.g. `job spawn { uvicorn main:app }` so that
+this tool does not run indefinitely.
+
+Command Equivalents to Bash:
+
+| Bash Command | Nushell Command | Description |
+|--------------|-----------------|-------------|
+| `mkdir -p <path>` | `mkdir <path>` | Creates the given path, creating parents as necessary |
+| `> <path>`  | `o> <path>` | Save command output to a file |
+| `>> <path>` | `o>> <path>` | Append command output to a file |
+| `> /dev/null` | `ignore` | Discard command output |
+| `> /dev/null 2>&1` | `o+e>| ignore` | Discard command output, including stderr |
+| `command 2>&1` | `command o+e>| ...` | Redirect stderr to stdout (use `o+e>` or `out+err>`) |
+| `cmd1 \| tee log.txt \| cmd2` | `cmd1 \| tee { save log.txt } \| cmd2` | Tee command output to a log file |
+| `command \| head -5` | `command \| first 5` | Limit the output to the first 5 rows of an internal command (see also last and skip) |
+| `cat <path>` | `open --raw <path>` | Display the contents of the given file |
+| `cat <(<command1>) <(<command2>)` | `[(command1), (command2)] \| str join` | Concatenate the outputs of command1 and command2 |
+| `cat <path> <(<command>)` | `[(open --raw <path>), (command)] \| str join` | Concatenate the contents of the given file and output of command |
+| `for f in *.md; do echo $f; done` | `ls *.md \| each { $in.name }` | Iterate over a list and return results |
+| `for i in $(seq 1 10); do echo $i; done` | `for i in 1..10 { print $i }` | Iterate over a list and run a command on results |
+| `cp <source> <dest>` | `cp <source> <dest>` | Copy file to new location |
+| `rm -rf <path>` | `rm -r <path>` | Recursively removes the given path |
+| `date -d <date>` | `"<date>" \| into datetime -f <format>` | Parse a date (format documentation) |
+| `sed` | `str replace` | Find and replace a pattern in a string |
+| `grep <pattern>` | `where $it =~ <substring>` or `find <substring>` | Filter strings that contain the substring |
+| `command1 && command2` | `command1; command2` | Run a command, and if it's successful run a second |
+| `stat $(which git)` | `stat ...(which git).path` | Use command output as argument for other command |
+| `echo /tmp/$RANDOM` | `$"/tmp/(random int)"` | Use command output in a string |
+| `cargo b --jobs=$(nproc)` | `cargo b $"--jobs=(sys cpu \| length)"` | Use command output in an option |
+| `echo $PATH` | `$env.PATH (Non-Windows) or $env.Path (Windows)` | See the current path |
+| `echo $?` | `$env.LAST_EXIT_CODE` | See the exit status of the last executed command |
+| `export` | `$env` | List the current environment variables |
+| `FOO=BAR ./bin` | `FOO=BAR ./bin` | Update environment for a command |
+| `echo $FOO` | `$env.FOO` | Use environment variables |
+| `echo ${FOO:-fallback}` | `$env.FOO? \| default "ABC"` | Use a fallback in place of an unset variable |
+| `type FOO` | `which FOO` | Display information about a command (builtin, alias, or executable) |
+| `\` | `( <command> )` | A command can span multiple lines when wrapped with ( and ) |
+
+If the polars commands are available, prefer it for working with parquet, jsonl, ndjson, csv files, and avro files.
+It is much more efficient than the other Nushell commands or other non-nushell commands.
+It exposes much of the functionality of the polars dataframe library. Start the pipeline with `plugin use polars`
+
+An example of converting a nushell table output to a polars dataframe:
+```nu
+ps | polars into-df | polars collect
+```
+
+An example of converting a polars dataframe back to a nushell table in order to run other nushell commands:
+```nu
+polars open file.parquet | polars into-nu
+```
+
+An example of opening a parquet file, selecting columns, and saving to a new parquet file:
+```nu
+polars open file.parquet | polars select name status | polars save file2
+```
+
+**Important**: The `glob` command should be used exclusively when you need to locate a file or a code reference,
+other solutions may produce too large output because of hidden files! For example *do not* use `find` or `ls -r`.
+Use command_help tool to learn more about the `glob` command.
+
+**Important**: Each shell command runs in its own process. Things like directory changes or
+sourcing files do not persist between tool calls. So you may need to repeat them each time by
+stringing together commands, e.g. `cd example; ls` or `source env/bin/activate && pip install numpy`
+- Multiple commands: Use ; to chain commands, avoid newlines
+- Pathnames: Use absolute paths and avoid cd unless explicitly requested
+- Setting environment variables or other variables will not persist between calls

--- a/crates/nu-mcp/src/instructions.md
+++ b/crates/nu-mcp/src/instructions.md
@@ -1,0 +1,30 @@
+The nushell extension gives you run nushell specific commands and other shell commands.
+This extension should be preferred over other tools for running shell commands as it can run both nushell comamands and other shell commands.
+
+Native nushell commands return structured content in NUON format (no need to pipe to `| to json`).
+Native nushell commands can be discovered by using the list_commands tool.
+Prefer nushell native commands where possible as they provide structured data in a pipeline, versus text output.
+To discover the input (stdin) and output (stdout) types of a command, flags, and positional arguments use the command_help tool.
+
+Nushell native commands will return structured content. Piping of commands that return a table, list, or record to `to text` will return plain text.
+In order to find out what columns are available use the `columns` command. For example `ps | columns` will return the columns available from the `ps` command.
+
+HTTP request examples:
+```nu
+# GET request
+http get https://api.example.com/data
+
+# POST with JSON body
+http post --content-type application/json https://api.example.com/endpoint {foo: "bar", baz: 123}
+
+# POST with custom headers and empty body
+http post https://api.example.com/sync -H {X-API-Key: "secret"} (bytes build)
+
+# POST with headers and JSON body
+http post --content-type application/json https://api.example.com/data -H {Authorization: "Bearer token"} {key: "value"}
+```
+
+To find a nushell command or to see all available commands use the list_commands tool.
+To learn more about how to use a command, use the command_help tool.
+You can use the eval tool to run any command that would work on the relevant operating system.
+Use the eval tool as needed to locate files or interact with the project.

--- a/crates/nu-mcp/src/server.rs
+++ b/crates/nu-mcp/src/server.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use indoc::formatdoc;
 use nu_protocol::{UseAnsiColoring, engine::EngineState};
 use rmcp::{
     ErrorData as McpError, ServerHandler,
@@ -61,79 +60,8 @@ By default all available commands will be returned. To find a specific command b
         self.evaluator.eval(&cmd, cursor).map(Json)
     }
 
-    #[tool(description = r#"Execute a command in the nushell.
-    This will return the output and error concatenated into a single string, as
-    you would see from running on the command line. There will also be an indication
-    of if the command succeeded or failed.
-
-    Avoid commands that produce a large amount of output, and consider piping those outputs to files.
-    If you need to run a long lived command, background it - e.g. `job spawn { uvicorn main:app }` so that
-    this tool does not run indefinitely.
-
-    Command Equlivalents to Bash:
-
-    | Bash Command | Nushell Command | Description |
-    |--------------|-----------------|-------------|
-    | `mkdir -p <path>` | `mkdir <path>` | Creates the given path, creating parents as necessary |
-    | `> <path>`  | `o> <path>` | Save command output to a file |
-    | `>> <path>` | `o>> <path>` | Append command output to a file |
-    | `> /dev/null`	| `ignore`	| Discard command output | 
-    | `> /dev/null 2>&1` |	`o+e>| ignore`	| Discard command output, including stderr | 
-    | `cmd1 | tee log.txt | cmd2` |	`cmd1 | tee { save log.txt } | cmd2` |	Tee command output to a log file |
-    | `command | head -5`	| `command | first 5` |	Limit the output to the first 5 rows of an internal command (see also last and skip) |
-    | `cat <path>`	| `open --raw <path>`	| Display the contents of the given file |
-    | `cat <(<command1>) <(<command2>)`	| `[(command1), (command2)] | str join`	| Concatenate the outputs of command1 and command2 |
-    | `cat <path> <(<command>)`	| `[(open --raw <path>), (command)] | str join`	| Concatenate the contents of the given file and output of command |
-    | `for f in *.md; do echo $f; done` | `ls *.md | each { $in.name }`	| Iterate over a list and return results |
-    | `for i in $(seq 1 10); do echo $i; done` | `for i in 1..10 { print $i }` | Iterate over a list and run a command on results |
-    | `cp <source> <dest>`	| `cp <source> <dest>`	| Copy file to new location |
-    | `rm -rf <path>`	| `rm -r <path>` |	Recursively removes the given path |
-    | `date -d <date>`	| `"<date>" | into datetime -f <format>`	| Parse a date (format documentation) |
-    | `sed`	| `str replace`	| Find and replace a pattern in a string | 
-    | `grep <pattern>`	| `where $it =~ <substring>` or `find <substring>`	| Filter strings that contain the substring |
-    | `command1 && command2` | `command1; command2`	| Run a command, and if it's successful run a second |
-    | `stat $(which git)`	| `stat ...(which git).path`	| Use command output as argument for other command |
-    | `echo /tmp/$RANDOM`	| `$"/tmp/(random int)"` |	Use command output in a string |
-    | `cargo b --jobs=$(nproc)`	| `cargo b $"--jobs=(sys cpu | length)"` | Use command output in an option |
-    | `echo $PATH`	| `$env.PATH (Non-Windows) or $env.Path (Windows)`	| See the current path |
-    | `echo $?`	| `$env.LAST_EXIT_CODE`	| See the exit status of the last executed command |
-    | `export` | `$env`	| List the current environment variables |
-    | `FOO=BAR ./bin` | `FOO=BAR ./bin`	| Update environment for a command |
-    | `echo $FOO` |	`$env.FOO` | Use environment variables |
-    | `echo ${FOO:-fallback}` | `$env.FOO? | default "ABC"`	| Use a fallback in place of an unset variable |
-    | `type FOO` | `which FOO` | Display information about a command (builtin, alias, or executable) |
-    | `\` | `( <command> )`	| A command can span multiple lines when wrapped with ( and ) |
-
-    If the polars commands are available, prefer it for working with parquet, jsonl, ndjson, csv files, and avro files. 
-    It is much more efficient than the other Nushell commands or other non-nushell commands. 
-    It exposes much of the functionality of the polars dataframe library. Start the pipeline with `plugin use polars`
-
-    An example of converting a nushell table output to a polars dataframe:
-    ```nu
-    ps | polars into-df | polars collect
-    ```
-
-    An example of converting a polars dataframe back to a nushell table in order to run other nushell commands:
-    ```nu
-    polars open file.parquet | polars into-nu
-    ````
-
-    An example of opening a parquet file, selecting columns, and saving to a new parquet file:
-    ```nu
-    polars open file.parquet | polars select name status | polars save file2
-    ```
-
-    **Important**: The `glob` command should be used exclusively when you need to locate a file or a code reference,
-    other solutions may produce too large output because of hidden files! For example *do not* use `find` or `ls -r`. 
-    Use command_help tool to learn more about the `glob` command.
-
-    **Important**: Each shell command runs in its own process. Things like directory changes or
-    sourcing files do not persist between tool calls. So you may need to repeat them each time by
-    stringing together commands, e.g. `cd example; ls` or `source env/bin/activate && pip install numpy`
-    - Multiple commands: Use ; to chain commands, avoid newlines
-    - Pathnames: Use absolute paths and avoid cd unless explicitly requested
-    - Setting environment variables or other variables will not persist between calls 
-    "#)]
+    #[doc = include_str!("evaluate_tool.md")]
+    #[tool]
     async fn evaluate(
         &self,
         Parameters(NuSourceRequest { input, cursor }): Parameters<NuSourceRequest>,
@@ -170,23 +98,7 @@ struct NuSourceRequest {
 impl ServerHandler for NushellMcpServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
-            instructions: Some(formatdoc! {r#"
-            The nushell extension gives you run nushell specific commands and other shell commands. 
-            This extension should be preferred over other tools for running shell commands as it can run both nushell comamands and other shell commands.
-
-            Native nushell commands return structured content. Native nushell commands cam be discovered by using the list_commands tool. 
-            Prefer nushell native commands where possible as they provided structured data in a pipeline, versus text output.
-            To discover the input (stdin) and output (stdout) types of a command, flags, and positioanal arguments use the command_help tool.
-
-            Nushell native commands will return structured content. Piping of commands that return a table, list, or record to `to text` will return plain text and `to json` will return json text. 
-            In order to find out what columns are available use the `columns` command. For example `ps | columns` will return the columns available from the `ps` command.
-
-            To find a nushell command or to see all available commands use the list_commands tool.
-            To learn more about how to use a command, use the command_help tool.
-            You can use the eval tool to run any command that would work on the relevant operating system.
-            Use the eval tool as needed to locate files or interact with the project.
-            "#
-            }),
+            instructions: Some(include_str!("instructions.md").to_string()),
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             ..Default::default()
         }


### PR DESCRIPTION
## Summary

- Move evaluate tool description to `evaluate_tool.md`
- Move server instructions to `instructions.md`
- Use `include_str!` instead of inline strings for better maintainability
- Add NUON format note (no need for `| to json`)
- Add HTTP request examples (`bytes build`, `--content-type`)
- Add `2>&1 -> o+e>` redirect syntax to bash equivalents table