### PR TITLE
feat(mcp): add REPL-style state persistence across evaluations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,20 +2374,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows 0.61.3",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3543,19 +3529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3841,25 +3814,6 @@ dependencies = [
  "serde_urlencoded",
  "similar",
  "tokio",
-]
-
-[[package]]
-name = "moka"
-version = "0.12.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "loom",
- "parking_lot",
- "portable-atomic",
- "rustc_version",
- "smallvec",
- "tagptr",
- "thiserror 1.0.69",
- "uuid",
 ]
 
 [[package]]
@@ -4408,7 +4362,6 @@ dependencies = [
  "bytes",
  "futures",
  "indoc",
- "moka",
  "nu-cmd-lang",
  "nu-engine",
  "nu-parser",
@@ -7861,12 +7814,6 @@ dependencies = [
  "papergrid",
  "testing_table",
 ]
-
-[[package]]
-name = "tagptr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tango-bench"

--- a/crates/nu-mcp/Cargo.toml
+++ b/crates/nu-mcp/Cargo.toml
@@ -23,7 +23,6 @@ tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 bytes = { workspace = true }
 indoc = "2.0.6"
-moka = { version = "0.12.10", features = ["sync"] }
 nuon = { path = "../nuon", version = "0.109.2" }
 
 [features]

--- a/crates/nu-mcp/src/evaluate_tool.md
+++ b/crates/nu-mcp/src/evaluate_tool.md
@@ -65,9 +65,9 @@ polars open file.parquet | polars select name status | polars save file2
 other solutions may produce too large output because of hidden files! For example *do not* use `find` or `ls -r`.
 Use command_help tool to learn more about the `glob` command.
 
-**Important**: Each shell command runs in its own process. Things like directory changes or
-sourcing files do not persist between tool calls. So you may need to repeat them each time by
-stringing together commands, e.g. `cd example; ls` or `source env/bin/activate && pip install numpy`
-- Multiple commands: Use ; to chain commands, avoid newlines
-- Pathnames: Use absolute paths and avoid cd unless explicitly requested
-- Setting environment variables or other variables will not persist between calls
+**Important**: Variables and environment changes persist across tool calls (REPL-style).
+You can set a variable in one call and access it in subsequent calls:
+- `let x = 42` in one call, then `$x` in the next call returns 42
+- `$env.MY_VAR = "hello"` persists for later calls
+
+However, external processes run in their own environment. Use absolute paths when possible.

--- a/crates/nu-mcp/src/evaluation.rs
+++ b/crates/nu-mcp/src/evaluation.rs
@@ -1,7 +1,4 @@
-use std::sync::Arc;
-
 use crate::shell_error_to_mcp_error;
-use moka::sync::Cache;
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_protocol::{
@@ -11,29 +8,33 @@ use nu_protocol::{
 };
 use rmcp::ErrorData as McpError;
 
-/// Evaluates Nushell code in isolated contexts for MCP.
+/// Evaluates Nushell code in a persistent REPL-style context for MCP.
 ///
 /// # Architecture
 ///
-/// The evaluator maintains a pristine `EngineState` template. Each evaluation:
-/// 1. Clones the engine state (cheap due to internal `Arc`s)
-/// 2. Parses code into a `Block` and gets a `StateDelta` via `working_set.render()`
-/// 3. **Merges the delta** via `engine_state.merge_delta()` to register blocks
-/// 4. Evaluates the block with the merged state
+/// The evaluator maintains a persistent `EngineState` and `Stack` that carry
+/// state across evaluations—just like an interactive REPL session. Each evaluation:
+/// 1. Parses code into a `Block` and gets a `StateDelta` via `working_set.render()`
+/// 2. **Merges the delta** into the persistent engine state
+/// 3. Evaluates the block with the persistent state and stack
 ///
-/// Step 3 is critical: parsed blocks (including closures) are only stored in the
-/// `StateWorkingSet` initially. Without merging, `eval_block()` will panic with
-/// "missing block" when it tries to execute closures or other block references.
+/// Step 2 ensures parsed blocks (including closures) are registered and available.
 ///
-/// # Isolation
+/// # State Persistence
 ///
-/// Each evaluation gets its own cloned state, so variables/definitions from one
-/// evaluation don't persist to the next.
-///
-/// This architecture also enables future parallel evaluation of multiple pipelines.
+/// Variables, definitions, and environment changes persist across calls,
+/// enabling workflows like:
+/// ```nu
+/// $env.MY_VAR = "hello"  # First call
+/// $env.MY_VAR            # Second call returns "hello"
+/// ```
 pub struct Evaluator {
+    state: std::sync::Mutex<EvalState>,
+}
+
+struct EvalState {
     engine_state: EngineState,
-    cache: Cache<String, Arc<String>>,
+    stack: Stack,
 }
 
 impl Evaluator {
@@ -43,26 +44,19 @@ impl Evaluator {
         config.use_ansi_coloring = UseAnsiColoring::False;
         engine_state.set_config(config);
 
-        let cache = Cache::builder()
-            .max_capacity(100)
-            .time_to_live(std::time::Duration::from_secs(300))
-            .build();
         Self {
-            engine_state,
-            cache,
+            state: std::sync::Mutex::new(EvalState {
+                engine_state,
+                stack: Stack::new(),
+            }),
         }
     }
 
     pub fn eval(&self, nu_source: &str) -> Result<String, McpError> {
-        if let Some(cached) = self.cache.get(nu_source) {
-            return Ok((*cached).clone());
-        }
-
-        // Clone the pristine engine state for this evaluation
-        let mut engine_state = self.engine_state.clone();
+        let mut state = self.state.lock().expect("evaluator lock poisoned");
 
         let (block, delta) = {
-            let mut working_set = StateWorkingSet::new(&engine_state);
+            let mut working_set = StateWorkingSet::new(&state.engine_state);
 
             // Parse the source code
             let block = parse(&mut working_set, None, nu_source.as_bytes(), false);
@@ -76,7 +70,6 @@ impl Evaluator {
             }
 
             // Check for compile errors (IR compilation errors)
-            // These are caught during the parse/compile phase, before evaluation
             if let Some(err) = working_set.compile_errors.first() {
                 return Err(McpError::internal_error(
                     nu_protocol::format_cli_error(&working_set, err, None),
@@ -87,65 +80,65 @@ impl Evaluator {
             (block, working_set.render())
         };
 
-        // Merge the parsed blocks into the engine state so they're available during eval
+        // Destructure to satisfy the borrow checker
+        let EvalState {
+            engine_state,
+            stack,
+        } = &mut *state;
+
+        // Merge the parsed blocks into the persistent engine state
         engine_state
             .merge_delta(delta)
-            .map_err(|e| shell_error_to_mcp_error(e, &engine_state))?;
+            .map_err(|e| shell_error_to_mcp_error(e, engine_state))?;
 
-        // Eval the block with the input
-        let mut stack = Stack::new().collect_value();
-        let output =
-            eval_block::<WithoutDebug>(&engine_state, &mut stack, &block, PipelineData::empty())
-                .map_err(|e| shell_error_to_mcp_error(e, &engine_state))?;
+        // Eval the block with persistent state and stack
+        let output = eval_block::<WithoutDebug>(engine_state, stack, &block, PipelineData::empty())
+            .map_err(|e| shell_error_to_mcp_error(e, engine_state))?;
 
-        let result = self.process_pipeline(output, &engine_state)?;
-        self.cache
-            .insert(nu_source.to_string(), Arc::new(result.clone()));
-        Ok(result)
+        process_pipeline(output, engine_state)
+    }
+}
+
+fn process_pipeline(
+    pipeline_execution_data: PipelineExecutionData,
+    engine_state: &EngineState,
+) -> Result<String, McpError> {
+    let span = pipeline_execution_data.span();
+
+    if let PipelineData::ByteStream(stream, ..) = pipeline_execution_data.body {
+        let mut buffer: Vec<u8> = Vec::new();
+        stream
+            .write_to(&mut buffer)
+            .map_err(|e| shell_error_to_mcp_error(e, engine_state))?;
+        return Ok(String::from_utf8_lossy(&buffer).into_owned());
     }
 
-    fn process_pipeline(
-        &self,
-        pipeline_execution_data: PipelineExecutionData,
-        engine_state: &EngineState,
-    ) -> Result<String, McpError> {
-        let span = pipeline_execution_data.span();
-
-        if let PipelineData::ByteStream(stream, ..) = pipeline_execution_data.body {
-            let mut buffer: Vec<u8> = Vec::new();
-            stream
-                .write_to(&mut buffer)
-                .map_err(|e| shell_error_to_mcp_error(e, engine_state))?;
-            Ok(String::from_utf8_lossy(&buffer).into_owned())
-        } else {
-            // Collect all values from the pipeline
-            let mut values: Vec<Value> = Vec::new();
-            for item in pipeline_execution_data.body {
-                if let Value::Error { error, .. } = &item {
-                    return Err(shell_error_to_mcp_error(*error.clone(), engine_state));
-                }
-                values.push(item);
-            }
-
-            // Convert the entire result to NUON format
-            // If there's a single value, output it directly; otherwise wrap in a list
-            let value_to_convert = match values.len() {
-                1 => values
-                    .pop()
-                    .expect("values has exactly one element; this cannot fail"),
-                _ => Value::list(values, span.unwrap_or(Span::unknown())),
-            };
-
-            nuon::to_nuon(
-                engine_state,
-                &value_to_convert,
-                nuon::ToStyle::Raw,
-                Some(Span::unknown()),
-                false,
-            )
-            .map_err(|e| shell_error_to_mcp_error(e, engine_state))
+    // Collect all values from the pipeline
+    let mut values: Vec<Value> = Vec::new();
+    for item in pipeline_execution_data.body {
+        if let Value::Error { error, .. } = &item {
+            return Err(shell_error_to_mcp_error(*error.clone(), engine_state));
         }
+        values.push(item);
     }
+
+    // Convert the entire result to NUON format
+    // If there's a single value, output it directly; otherwise wrap in a list
+    let value_to_convert = match values.len() {
+        1 => values
+            .pop()
+            .expect("values has exactly one element; this cannot fail"),
+        _ => Value::list(values, span.unwrap_or(Span::unknown())),
+    };
+
+    nuon::to_nuon(
+        engine_state,
+        &value_to_convert,
+        nuon::ToStyle::Raw,
+        Some(Span::unknown()),
+        false,
+    )
+    .map_err(|e| shell_error_to_mcp_error(e, engine_state))
 }
 
 #[cfg(test)]
@@ -293,5 +286,41 @@ mod tests {
         );
         let output = result.unwrap();
         assert_eq!(output, "42", "Should return 42");
+    }
+
+    #[test]
+    fn test_repl_variable_persistence() {
+        let engine_state = create_default_context();
+        let evaluator = Evaluator::new(engine_state);
+
+        // Set a variable in first call
+        let result = evaluator.eval("let x = 42");
+        assert!(result.is_ok(), "Setting variable should succeed");
+
+        // Access the variable in second call - should persist
+        let result = evaluator.eval("$x");
+        assert!(
+            result.is_ok(),
+            "Variable should be accessible: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_repl_env_persistence() {
+        let engine_state = create_default_context();
+        let evaluator = Evaluator::new(engine_state);
+
+        // Set an env var in first call
+        let result = evaluator.eval("$env.TEST_VAR = 'hello_repl'");
+        assert!(result.is_ok(), "Setting env var should succeed");
+
+        // Access the env var in second call - should persist
+        let result = evaluator.eval("$env.TEST_VAR");
+        assert!(
+            result.is_ok(),
+            "Env var should be accessible: {:?}",
+            result.err()
+        );
     }
 }


### PR DESCRIPTION

<img width="790" height="245" alt="image" src="https://github.com/user-attachments/assets/c1091ed2-5a92-4ad9-969e-459902bf4f7b" />


## Summary

- Variables and environment changes now persist across MCP tool calls (REPL-style)
- Removed `moka` caching dependency (incompatible with stateful evaluation)
- Added tests for variable and env persistence
- Updated tool description to document REPL behavior

This enables workflows like:
```nu
$env.MY_VAR = "hello"  # First call
$env.MY_VAR             # Second call returns "hello"
```

### Key changes:
- [`crates/nu-mcp/src/evaluation.rs`](https://github.com/andrewgazelka/nushell/blob/feat/mcp-repl-state/crates/nu-mcp/src/evaluation.rs): Replaced isolated evaluation with persistent `Mutex<EvalState>` containing `EngineState` + `Stack`
- Removed result caching since state changes invalidate cached results
- Added `test_repl_variable_persistence` and `test_repl_env_persistence` tests

## Test plan
- [x] All existing tests pass
- [x] New persistence tests verify variables persist across calls
- [x] New persistence tests verify env vars persist across calls