### PR TITLE
Fix http DNS resolution "Service not supported" error in Docker containers

### DIFF
--- a/crates/nu-command/src/network/http/resolver.rs
+++ b/crates/nu-command/src/network/http/resolver.rs
@@ -22,14 +22,10 @@ impl Resolver for DnsLookupResolver {
     ) -> Result<ResolvedSocketAddrs, ureq::Error> {
         let host = uri.host();
         // Determine the port: use explicit port if provided, otherwise derive from scheme
-        let port = uri
-            .port_u16()
-            .or_else(|| match uri.scheme_str() {
-                Some("https") => Some(443),
-                Some("http") => Some(80),
-                _ => None,
-            })
-            .unwrap_or(80);
+        let port = uri.port_u16().unwrap_or_else(|| match uri.scheme_str() {
+            Some("https") => 443,
+            _ => 80, // http commands only support HTTP/HTTPS, default to port 80
+        });
 
         // Pass None as service to avoid "Service not supported for this socket type" errors
         // in certain environments (e.g., Docker containers on some Linux distributions).


### PR DESCRIPTION
Try to fix #17117 

Fixes `http` commands failing with "Service not supported for this socket type" error in certain Linux environments (particularly Docker containers running Debian Trixie).

The `DnsLookupResolver` was passing the URL scheme (e.g., `"https"`) as the `service` parameter to `getaddrinfo()`, On some glibc versions, this triggers EAI_SOCKTYPE when the service name lookup conflicts with default socket type hints.

BTW: When service is None, the sockaddr returned by getaddrinfo has port 0, causing ureq to attempt connecting to port 0, which results in a timeout.

After these changes it doesn't rely on system service name resolution, while preserving IPv6 `flowinfo` and `scope_id`.

I have test these changes in a docker container and make sure it works as expected.

## Release notes summary - What our users need to know
http commands work with "Service not supported for this socket type" error in certain Linux environments (particularly Docker containers running Debian Trixie).

## Tasks after submitting

Maybe we should release another patch release?
