### PR TITLE
Fix `table -i false` panic when there is an index column

### DIFF
--- a/crates/nu-command/tests/commands/table.rs
+++ b/crates/nu-command/tests/commands/table.rs
@@ -4018,3 +4018,18 @@ fn configure_stream_size() {
         .out
     );
 }
+
+// Regression test for https://github.com/nushell/nushell/issues/17032
+// `table -i false` should not panic when there's an `index` column
+#[test]
+fn table_index_column_with_index_flag_false() {
+    let actual = nu!("[{index: 0, data: yes}] | table --index false --width 80");
+    assert_eq!(
+        actual.out,
+        "╭───────┬──────╮\
+         │ index │ data │\
+         ├───────┼──────┤\
+         │     0 │ yes  │\
+         ╰───────┴──────╯"
+    );
+}

--- a/crates/nu-table/src/types/expanded.rs
+++ b/crates/nu-table/src/types/expanded.rs
@@ -127,10 +127,10 @@ fn expand_list(input: &[Value], cfg: Cfg<'_>) -> TableResult {
     let with_index = has_index(&cfg.opts, &headers);
 
     // The header with the INDEX is removed from the table headers since
-    // it is added to the natural table index
+    // it is added to the natural table index (only when with_index is true)
     let headers: Vec<_> = headers
         .into_iter()
-        .filter(|header| header != INDEX_COLUMN_NAME)
+        .filter(|header| !with_index || header != INDEX_COLUMN_NAME)
         .collect();
     let with_header = !headers.is_empty();
     let row_offset = cfg.opts.index_offset;

--- a/crates/nu-table/src/types/general.rs
+++ b/crates/nu-table/src/types/general.rs
@@ -250,7 +250,8 @@ fn collect_headers(headers: Vec<String>, index: bool) -> Vec<NuRecordsValue> {
     }
 
     for text in headers {
-        if text == INDEX_COLUMN_NAME {
+        // Only filter out the INDEX column when we're adding our own index column
+        if index && text == INDEX_COLUMN_NAME {
             continue;
         }
 


### PR DESCRIPTION
Fix `table -i false` panic when there is an index column, should closes #17032

## Release notes summary - What our users need to know
`table -i false` no longer panic when there is an index column, e.g: `[{index: 0, data: yes}] | table -i false`

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
