### PR TITLE
Added record conversion to `into list`

### DIFF
--- a/crates/nu-std/std-rfc/conversions/mod.nu
+++ b/crates/nu-std/std-rfc/conversions/mod.nu
@@ -11,6 +11,7 @@ export def "into list" []: any -> list {
     range => {$input | each {||}}
     list => $input
     table => $input
+    record => {$input | transpose -d key value}
     _ => [ $input ]
   }
 }


### PR DESCRIPTION
## Release notes summary - What our users need to know

`into list` from `std-rfc/conversions` now handles `record` types.

```nushell
use std-rfc/conversions *
{ a: 3, b: 7, c: 10 } | into list
# => ╭───┬─────┬───────╮
# => │ # │ key │ value │
# => ├───┼─────┼───────┤
# => │ 0 │ a   │     3 │
# => │ 1 │ b   │     7 │
# => │ 2 │ c   │    10 │
# => ╰───┴─────┴───────╯
```