### PR TITLE
Changed home-path/temp-path to home-dir/temp-dir

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ Read cargo's documentation for more details: https://doc.rust-lang.org/cargo/ref
 - To redirect trace logs to a file, enable the `--log-target file` switch.
   ```nushell
   cargo run --release -- --log-level trace --log-target file
-  open $"($nu.temp-path)/nu-($nu.pid).log"
+  open $"($nu.temp-dir)/nu-($nu.pid).log"
   ```
 
 ### Experimental options

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -2294,7 +2294,7 @@ fn variables_completions() {
         "env-path",
         "history-enabled",
         "history-path",
-        "home-path",
+        "home-dir",
         "is-interactive",
         "is-login",
         "is-lsp",
@@ -2303,7 +2303,7 @@ fn variables_completions() {
         "pid",
         "plugin-path",
         "startup-time",
-        "temp-path",
+        "temp-dir",
         "user-autoload-dirs",
         "vendor-autoload-dirs",
     ];
@@ -2316,7 +2316,7 @@ fn variables_completions() {
 
     assert_eq!(3, suggestions.len());
 
-    let expected: Vec<_> = vec!["history-enabled", "history-path", "home-path"];
+    let expected: Vec<_> = vec!["history-enabled", "history-path", "home-dir"];
 
     // Match results
     match_suggestions(&expected, &suggestions);

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1716,7 +1716,7 @@ mod string {
             let engine_state = EngineState::new();
             let mut working_set = StateWorkingSet::new(&engine_state);
 
-            let block = parse(&mut working_set, None, b"^echo ($nu.home-path)/path", true);
+            let block = parse(&mut working_set, None, b"^echo ($nu.home-dir)/path", true);
 
             assert!(working_set.parse_errors.is_empty());
 

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -136,15 +136,15 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
     }
 
     record.push(
-        "home-path",
+        "home-dir",
         if let Some(path) = nu_path::home_dir() {
             let canon_home_path = canonicalize_path(engine_state, path.as_ref());
             Value::string(canon_home_path.to_string_lossy(), span)
         } else {
             Value::error(
                 ShellError::GenericError {
-                    error: "setting $nu.home-path failed".into(),
-                    msg: "Could not get home path".into(),
+                    error: "setting $nu.home-dir failed".into(),
+                    msg: "Could not get home directory".into(),
                     span: Some(span),
                     help: None,
                     inner: vec![],
@@ -216,7 +216,7 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
         ),
     );
 
-    record.push("temp-path", {
+    record.push("temp-dir", {
         let canon_temp_path = canonicalize_path(engine_state, &std::env::temp_dir());
         Value::string(canon_temp_path.to_string_lossy(), span)
     });

--- a/crates/nu-std/tests/test_dirs.nu
+++ b/crates/nu-std/tests/test_dirs.nu
@@ -9,7 +9,7 @@ use std/log
 @before-each
 def before-each [] {
     # need some directories to play with
-    let base_path = ($nu.temp-path | path join $"test_dirs_(random uuid)")
+    let base_path = ($nu.temp-dir | path join $"test_dirs_(random uuid)")
     let path_a = ($base_path | path join "a")
     let path_b = ($base_path | path join "b")
 

--- a/crates/nu-std/tests/test_std_util.nu
+++ b/crates/nu-std/tests/test_std_util.nu
@@ -56,8 +56,8 @@ def path_add_expand [] {
     use std/assert
 
     # random paths to avoid collision, especially if left dangling on failure
-    let real_dir = $nu.temp-path | path join $"real-dir-(random chars)"
-    let link_dir = $nu.temp-path | path join $"link-dir-(random chars)"
+    let real_dir = $nu.temp-dir | path join $"real-dir-(random chars)"
+    let link_dir = $nu.temp-dir | path join $"link-dir-(random chars)"
     mkdir $real_dir
     let path_name = if $nu.os-info.family == 'windows' {
         mklink /D $link_dir $real_dir

--- a/crates/nu-std/tests/test_util.nu
+++ b/crates/nu-std/tests/test_util.nu
@@ -56,8 +56,8 @@ def path_add_expand [] {
     use std/assert
 
     # random paths to avoid collision, especially if left dangling on failure
-    let real_dir = $nu.temp-path | path join $"real-dir-(random chars)"
-    let link_dir = $nu.temp-path | path join $"link-dir-(random chars)"
+    let real_dir = $nu.temp-dir | path join $"real-dir-(random chars)"
+    let link_dir = $nu.temp-dir | path join $"link-dir-(random chars)"
     mkdir $real_dir
     let path_name = if $nu.os-info.family == 'windows' {
         mklink /D $link_dir $real_dir

--- a/crates/nu-utils/src/default_files/default_env.nu
+++ b/crates/nu-utils/src/default_files/default_env.nu
@@ -4,7 +4,7 @@
 # version = "0.109.2"
 
 $env.PROMPT_COMMAND = {||
-    let dir = match (do -i { $env.PWD | path relative-to $nu.home-path }) {
+    let dir = match (do -i { $env.PWD | path relative-to $nu.home-dir }) {
         null => $env.PWD
         '' => '~'
         $relative_pwd => ([~ $relative_pwd] | path join)

--- a/toolkit/artifact/mod.nu
+++ b/toolkit/artifact/mod.nu
@@ -35,7 +35,7 @@ export def --wrapped "run pr" [
   let span = (metadata $head).span
   let number = { item: $number, span: (metadata $number).span }
 
-  let dir = $nu.temp-path | path join "nushell-run-pr"
+  let dir = $nu.temp-dir | path join "nushell-run-pr"
   mkdir $dir
 
   let platform = get-platform $span


### PR DESCRIPTION
Based on a Discord discussion yesterday where it was pointed out that `home-path` and `temp-path` are inconsistently named when compared to the other *directories* in `$nu`.

## Release notes summary - What our users need to know

For consistency with other `$nu` fields:

* `$nu.temp-path` has been renamed to `$nu.temp-dir`
* `$nu.home-path` has been renamed to `$nu.home-dir`

## Tasks after submitting

- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
