### PR TITLE
merge_predecl don't move all predecls to overlay

### DIFF
--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -215,13 +215,6 @@ impl<'a> StateWorkingSet<'a> {
             .map(|(name, decl_id)| self.last_overlay_mut().predecls.insert(name, decl_id));
     }
 
-    fn move_predecls_to_overlay(&mut self) {
-        let predecls: HashMap<Vec<u8>, DeclId> =
-            self.delta.last_scope_frame_mut().predecls.drain().collect();
-
-        self.last_overlay_mut().predecls.extend(predecls);
-    }
-
     pub fn hide_decl(&mut self, name: &[u8]) -> Option<DeclId> {
         let mut removed_overlays = vec![];
         let mut visibility: Visibility = Visibility::new();
@@ -949,8 +942,6 @@ impl<'a> StateWorkingSet<'a> {
             .active_overlays
             .retain(|id| id != &overlay_id);
         last_scope_frame.active_overlays.push(overlay_id);
-
-        self.move_predecls_to_overlay();
 
         self.use_decls(definitions.decls);
         self.use_modules(definitions.modules);

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -148,6 +148,25 @@ fn def_before_overlay_use_should_work() {
 }
 
 #[test]
+fn define_module_before_overlay_inside_func_should_work() {
+    let inp = &[
+        r#"
+def main [] {
+  module spam { export def foo [] { "foo" } }
+  overlay use spam
+  def bar [] { "bar" }
+  overlay hide spam
+  bar # Returns bar
+};"#,
+        "main",
+    ];
+
+    let actual = nu!(&inp.join("; "));
+
+    assert!(actual.err.contains("Command `bar` not found"));
+}
+
+#[test]
 fn add_overlay_env() {
     let inp = &[
         r#"module spam { export-env { $env.FOO = "foo" } }"#,


### PR DESCRIPTION
Fixes: #14739

Given the example:
```nushell
#!/usr/bin/env nu

def something [] { "example" }

module spam {}
overlay use spam
def bar [] { "bar" }
overlay hide spam
bar # Returns bar
```

The issue is happened when:
1. nushell parses a scripts, it makes a `preparse` to all custom commands.  
2. When parse `def something`, it calls `parse_def` then calls `merge_predecl`
3. All custom commands in the current scope are moved to overlay `zero`.  But `bar` should not be moved at that time.

So I think it's good to move just the command `something` to overlay `zero`.

Also we don't need to move predecls to overlay when adding overlays, it can move some functions to wrong overlay.

## Release notes summary - What our users need to know
### Overlay works more reliable inside script.
```nushell
#!/usr/bin/env nu

def something [] { "example" }

module spam {}
overlay use spam
def bar [] { "bar" }
overlay hide spam
bar
```
`bar` won't be available to use after `overlay hide spam`.

## Tasks after submitting
NaN