### PR TITLE
Upgrade nushell to 0.109.1 for release and nightly workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -46,7 +46,7 @@ jobs:
         uses: hustcer/setup-nu@v3
         if: github.repository == 'nushell/nightly'
         with:
-          version: 0.105.1
+          version: 0.109.1
 
       # Synchronize the main branch of nightly repo with the main branch of Nushell official repo
       - name: Prepare for Nightly Release
@@ -188,7 +188,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
       with:
-        version: 0.105.1
+        version: 0.109.1
 
     - name: Release Nu Binary
       id: nu
@@ -263,7 +263,7 @@ jobs:
       - name: Setup Nushell
         uses: hustcer/setup-nu@v3
         with:
-          version: 0.105.1
+          version: 0.109.1
 
       # Keep the last a few releases
       - name: Delete Older Releases

--- a/.github/workflows/release-msi.yml
+++ b/.github/workflows/release-msi.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
       with:
-        version: 0.105.1
+        version: 0.109.1
 
     - name: Release MSI Packages
       id: nu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
       with:
-        version: 0.105.1
+        version: 0.109.1
 
     - name: Release Nu Binary
       id: nu


### PR DESCRIPTION
Upgrade nushell to 0.109.1 for release and nightly workflow
They work well in nightly repo: https://github.com/nushell/nightly/actions/runs/20014599357/job/57389617001