### PR TITLE
bump the rust-toolchain to 1.90.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://www.nushell.sh"
 license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
-rust-version = "1.89.0"
+rust-version = "1.90.0"
 version = "0.109.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -14,4 +14,4 @@ profile = "default"
 # so that we give repo maintainers and package managers a chance to update to a more
 # recent version of rust. However, if there is a "cool new feature" that we want to
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
-channel = "1.89.0"
+channel = "1.90.0"


### PR DESCRIPTION
This PR bumps the rust-toolchain to 1.90.0. The newest toolchain will be released in 3 days. However, I've seen that vscode on Windows will not run with 1.89.0 anymore and requires at least 1.90.0.

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A
