### PR TITLE
fix--propagate more descriptive error message for rm Os errors

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -419,7 +419,13 @@ fn rm(
                 };
 
                 if let Err(e) = result {
-                    Err(ShellError::Io(IoError::new(e, span, f)))
+                    let original_error = e.to_string();
+                    Err(ShellError::Io(IoError::new_with_additional_context(
+                        e,
+                        span,
+                        f,
+                        original_error,
+                    )))
                 } else if verbose {
                     let msg = if interactive && !confirmed {
                         "not deleted"


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
This makes a descriptive error message for particular IO / OS errors on the "rm" command. This would be helpful in the associated issue, where MacOS will silently deny access in some circumstances, and it can appear to users as an inconsistency within Nushell

related to #17057

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
