### PR TITLE
feat: multiline with backslash

### DIFF
--- a/crates/nu-command/tests/commands/platform/ansi_.rs
+++ b/crates/nu-command/tests/commands/platform/ansi_.rs
@@ -4,7 +4,7 @@ use nu_test_support::nu;
 fn test_ansi_shows_error_on_escape() {
     let actual = nu!(r"ansi --escape \");
 
-    assert!(actual.err.contains("no need for escape characters"))
+    assert!(actual.err.contains("Unexpected end of code"))
 }
 
 #[test]

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -16,6 +16,7 @@ pub enum TokenContents {
     ErrGreaterGreaterThan,
     OutErrGreaterThan,
     OutErrGreaterGreaterThan,
+    MultiLine,
     Eol,
 }
 
@@ -672,6 +673,16 @@ fn lex_internal(
         } else if c == b' ' || c == b'\t' || additional_whitespace.contains(&c) {
             // If the next character is non-newline whitespace, skip it.
             curr_offset += 1;
+        } else if c == b'\\'
+            && (matches!(state.input.get(curr_offset + 1), Some(b'\n' | b'\r'))
+                || state.input.get(curr_offset + 1).is_none())
+        {
+            let idx = curr_offset;
+            curr_offset += 1;
+            state.output.push(Token::new(
+                TokenContents::MultiLine,
+                Span::new(state.span_offset + idx, state.span_offset + idx + 1),
+            ));
         } else {
             let (token, err) = lex_item(
                 state.input,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1737,6 +1737,7 @@ fn parse_binary_with_base(
                 | TokenContents::ErrGreaterGreaterThan
                 | TokenContents::OutErrGreaterThan
                 | TokenContents::OutErrGreaterGreaterThan
+                | TokenContents::MultiLine
                 | TokenContents::AssignmentOperator => {
                     working_set.error(ParseError::Expected("binary", span));
                     return garbage(working_set, span);

--- a/crates/nu-parser/tests/test_lex.rs
+++ b/crates/nu-parser/tests/test_lex.rs
@@ -25,6 +25,29 @@ fn lex_newline() {
 }
 
 #[test]
+fn lex_multiline() {
+    let file = b"let x = \\\n300";
+    let output = lex(file, 0, &[], &[], true);
+
+    assert!(output.0.contains(&Token {
+        contents: TokenContents::MultiLine,
+        span: Span::new(8, 9)
+    }))
+}
+
+#[test]
+fn lex_multiline_trailing() {
+    let file = b"let x = \\";
+    let output = lex(file, 0, &[], &[], true);
+
+    assert!(output.0.contains(&Token {
+        contents: TokenContents::MultiLine,
+        span: Span::new(8, 9)
+    }));
+    assert!(output.1.is_none());
+}
+
+#[test]
 fn lex_annotations_list() {
     let file = b"items: list<string>";
 


### PR DESCRIPTION
Hello, this PR aims to add support for multiline. I understand that there were arguments against it because Windows path uses the backslash. To address this, this PR considers a backslash as a multiline only if it precedes a newline. If this solution is not satisfactory, we can enable this feature behind a feature gate in settings, allowing users to toggle its on/off. Please let me know your thoughts.
