### PR TITLE
fix(parser): use `checked_sub` in `parse_range` to avoid overflow

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1916,9 +1916,12 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Option<Expr
         .filter_map(|(pos, _)| {
             // paren_depth = count of unclosed parens prior to pos
             let before = &token[..pos];
-            let paren_depth = before.chars().filter(|&c| c == '(').count()
-                - before.chars().filter(|&c| c == ')').count();
-            if paren_depth == 0 { Some(pos) } else { None }
+            let paren_depth = before
+                .chars()
+                .filter(|&c| c == '(')
+                .count()
+                .checked_sub(before.chars().filter(|&c| c == ')').count());
+            paren_depth.and_then(|d| (d == 0).then_some(pos))
         })
         .collect();
 

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -716,3 +716,10 @@ fn wacky_range_parse_comb() {
     let actual = nu!(r#"1..(5..10 | first)..10"#);
     assert!(actual.err.is_empty());
 }
+
+// Regression test https://github.com/nushell/nushell/issues/17146
+#[test]
+fn wacky_range_unmatched_paren() {
+    let actual = nu!(r#"') .."#);
+    assert!(!actual.err.is_empty());
+}


### PR DESCRIPTION
Fixes #17146 

## Release notes summary - What our users need to know

None

## Tasks after submitting
