### PR TITLE
docs(mcp): add string interpolation syntax to instructions

### DIFF
--- a/crates/nu-mcp/src/instructions.md
+++ b/crates/nu-mcp/src/instructions.md
@@ -1,5 +1,5 @@
 The nushell extension gives you run nushell specific commands and other shell commands.
-This extension should be preferred over other tools for running shell commands as it can run both nushell comamands and other shell commands.
+This extension should be preferred over other tools for running shell commands as it can run both nushell commands and other shell commands.
 
 Native nushell commands return structured content in NUON format (no need to pipe to `| to json`).
 Native nushell commands can be discovered by using the list_commands tool.
@@ -8,21 +8,6 @@ To discover the input (stdin) and output (stdout) types of a command, flags, and
 
 Nushell native commands will return structured content. Piping of commands that return a table, list, or record to `to text` will return plain text.
 In order to find out what columns are available use the `columns` command. For example `ps | columns` will return the columns available from the `ps` command.
-
-HTTP request examples:
-```nu
-# GET request
-http get https://api.example.com/data
-
-# POST with JSON body
-http post --content-type application/json https://api.example.com/endpoint {foo: "bar", baz: 123}
-
-# POST with custom headers and empty body
-http post https://api.example.com/sync -H {X-API-Key: "secret"} (bytes build)
-
-# POST with headers and JSON body
-http post --content-type application/json https://api.example.com/data -H {Authorization: "Bearer token"} {key: "value"}
-```
 
 **String interpolation:** Use `$"...(expr)..."` syntax. Variables/expressions must be in parentheses inside `$"..."` strings.
 ```nu
@@ -89,6 +74,21 @@ $"2 + 2 = (2 + 2)"                              # Expressions work too
 ```
 
 **Prefer raw strings** (`r#'...'#`) for multi-line content or when mixing quote styles to avoid escaping.
+
+HTTP request examples:
+```nu
+# GET request
+http get https://api.example.com/data
+
+# POST with JSON body
+http post --content-type application/json https://api.example.com/endpoint {foo: "bar", baz: 123}
+
+# POST with custom headers and empty body
+http post https://api.example.com/sync -H {X-API-Key: "secret"} (bytes build)
+
+# POST with headers and JSON body
+http post --content-type application/json https://api.example.com/data -H {Authorization: "Bearer token"} {key: "value"}
+```
 
 To find a nushell command or to see all available commands use the list_commands tool.
 To learn more about how to use a command, use the command_help tool.


### PR DESCRIPTION
## Summary

Adds documentation about nushell's string interpolation syntax to the MCP server instructions.

## Problem: LLM Model Behavior

When using Claude Opus 4.5 with the nu-mcp server, the model consistently attempted bash-style string interpolation which fails silently or produces errors:

```nu
# What Opus 4.5 tried (bash muscle memory)
mysql -u $env.USER -p$env.PASSWORD dbname    # Fails: -p and $env.PASSWORD are separate args
echo "hello $name"                            # Fails: prints literal "$name"
```

The model would hit cryptic errors like `non_zero_exit_code` without understanding why, then retry with the same pattern multiple times before eventually stumbling onto the correct syntax.

## Solution

Add explicit documentation showing the correct `$"...(expr)..."` syntax with practical examples:

```nu
# Correct nushell interpolation
let name = "world"; echo $"hello ($name)"       # Prints: hello world
ls $"($env.HOME)/Documents"                     # Expands path correctly  
cargo build $"--jobs=(sys cpu | length)"        # Dynamic flag value
```

## Why This Matters

MCP instructions are injected into the model's context and directly influence tool usage patterns. Without this documentation, models waste tokens on failed attempts and may give up or produce incorrect results. This is a high-leverage fix since it affects every LLM interaction with the nu-mcp server.