### PR TITLE
Add configuration option for whether to show hints

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -420,7 +420,7 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
     let style_computer = StyleComputer::from_config(engine_state, &stack_arc);
 
     start_time = std::time::Instant::now();
-    line_editor = if config.use_ansi_coloring.get(engine_state) {
+    line_editor = if config.use_ansi_coloring.get(engine_state) && config.show_hints {
         line_editor.with_hinter(Box::new({
             // As of Nov 2022, "hints" color_config closures only get `null` passed in.
             let style = style_computer.compute("hints", &Value::nothing(Span::unknown()));

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -54,6 +54,7 @@ pub struct Config {
     pub use_ansi_coloring: UseAnsiColoring,
     pub completions: CompletionConfig,
     pub edit_mode: EditBindings,
+    pub show_hints: bool,
     pub history: HistoryConfig,
     pub keybindings: Vec<ParsedKeybinding>,
     pub menus: Vec<ParsedMenu>,
@@ -111,6 +112,7 @@ impl Default for Config {
             use_ansi_coloring: UseAnsiColoring::default(),
             bracketed_paste: true,
             edit_mode: EditBindings::default(),
+            show_hints: true,
 
             shell_integration: ShellIntegrationConfig::default(),
 
@@ -162,6 +164,7 @@ impl UpdateFromValue for Config {
                 "float_precision" => self.float_precision.update(val, path, errors),
                 "use_ansi_coloring" => self.use_ansi_coloring.update(val, path, errors),
                 "edit_mode" => self.edit_mode.update(val, path, errors),
+                "show_hints" => self.show_hints.update(val, path, errors),
                 "shell_integration" => self.shell_integration.update(val, path, errors),
                 "buffer_editor" => match val {
                     Value::Nothing { .. } | Value::String { .. } => {

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -114,6 +114,11 @@ $env.config.cursor_shape.emacs = "inherit"         # Cursor shape in emacs mode
 $env.config.cursor_shape.vi_insert = "block"       # Cursor shape in vi-insert mode
 $env.config.cursor_shape.vi_normal = "underscore"  # Cursor shape in normal vi mode
 
+# show_hints (bool): Enable or disable hints for completions or the history
+# true: show hints
+# false: don't show hints
+$env.config.show_hints = true
+
 # --------------------
 # Completions Behavior
 # --------------------


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

Fixes #7245.

I added a configuration option `show_hints` that can be used to disable hints.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

### New Configuration Option: `$env.config.show_hints`

You can now disable hints for completions and the history by setting `$env.config.show_hints = false`.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
