### PR TITLE
add http pool cmd

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -408,6 +408,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             HttpPost,
             HttpPut,
             HttpOptions,
+            HttpPool,
             Port,
             VersionCheck,
         }


### PR DESCRIPTION
I forgot adding `http pool` cmd in #17157.  Which is reported by @Tyarel8 .

## Release notes summary - What our users need to know
NaN

## Tasks after submitting