### PR TITLE
Added CARGO_ and RUSTUP_ environment variables back to test environment

### DIFF
--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -433,17 +433,16 @@ fn setup_command(executable_path: &AbsolutePath, target_cwd: &AbsolutePath) -> C
         .env("PWD", target_cwd); // setting PWD is enough to set cwd;
 
     // Need these extra environments from before the environment is cleared.
-    #[cfg(windows)]
-    {
-        let envs: std::collections::HashMap<String, String> = std::env::vars()
-            .filter(|(n, _)| {
-                n.starts_with("System") // System variables for disks, paths, etc.
-                    || n == "NUSHELL_CARGO_PROFILE" // Variable for crate::fs::binaries()
-                    || n == "PATHEXT" // Needed for Windows translate `nu` to `.../nu.exe`
-            })
-            .collect();
-        command.envs(envs);
-    };
+    let envs: std::collections::HashMap<String, String> = std::env::vars()
+        .filter(|(n, _)| {
+            n.starts_with("System") // System variables for disks, paths, etc.
+                || n == "NUSHELL_CARGO_PROFILE" // Variable for crate::fs::binaries()
+                || n == "PATHEXT" // Needed for Windows translate `nu` to `.../nu.exe`
+                || n.starts_with("CARGO_")
+                || n.starts_with("RUSTUP_")
+        })
+        .collect();
+    command.envs(envs);
 
     command
 }


### PR DESCRIPTION
#17185 # Release notes summary - What our users need to know

Fixes an issue caused by #17085. In that PR, the environment is reset before running tests. That's a good thing, but it breaks tests entirely if your Cargo environment is customized using environment variables. This adds back in `CARGO_*` and `RUSTUP_*` environment variables to help ensure a proper test run.

## Tasks after submitting

N/A
