### PR TITLE
update reedline to the latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.44.0"
-source = "git+https://github.com/nushell/reedline?branch=main#32a33663536897ff2fa15c467558cfb0a3682f10"
+source = "git+https://github.com/nushell/reedline?branch=main#07fe597169ca7a96910161f42bf8d52d8cb3ef5c"
 dependencies = [
  "arboard",
  "chrono",


### PR DESCRIPTION
Update reedline to the latest commit (https://github.com/nushell/reedline/commit/07fe597169ca7a96910161f42bf8d52d8cb3ef5c)

## Release notes summary - What our users need to know
Includes https://github.com/nushell/reedline/pull/988, which reverses a behavioral change introduced in `reedline` 0.44 that resulted in more-eager-than-expected kitty protocol checks.

## Tasks after submitting
n/a