### PR TITLE
add `--large` flag to `open` command to allow large files to be opened via memory mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,6 +4158,7 @@ dependencies = [
  "log",
  "lscolors",
  "md-5",
+ "memmap2",
  "mime",
  "mime_guess",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,7 @@ windows = "0.62"
 windows-sys = "0.61"
 winreg = "0.55"
 memchr = "2.7.4"
+memmap2 = "0.9"
 webpki-roots = "1.0"
 
 [workspace.lints.clippy]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -72,6 +72,7 @@ lscolors = { workspace = true, default-features = false, features = [
 	"nu-ansi-term",
 ] }
 md5 = { workspace = true }
+memmap2 = { workspace = true }
 mime = { workspace = true }
 mime_guess = { workspace = true }
 multipart-rs = { workspace = true, optional = true }


### PR DESCRIPTION
This is kind of test to see if using a memmap helps nushell work better on large files. I'm looking for help testing this.
- Does it save memory?
- Is it faster?
- Are there any errors or panics?

```nushell
open --large some_big_file.txt | some_pipeline
```

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
