### PR TITLE
feat(`http head`): add `--status-code` flag to just retrieve the code

### DIFF
--- a/crates/nu-command/tests/commands/network/http/head.rs
+++ b/crates/nu-command/tests/commands/network/http/head.rs
@@ -89,3 +89,25 @@ fn http_head_redirect_mode_error() {
         "Redirect encountered when redirect handling mode was 'error' (301 Moved Permanently)"
     ));
 }
+
+#[test]
+fn http_head_status_code_500() {
+    let mut server = Server::new();
+
+    let _mock = server.mock("HEAD", "/").with_status(502).create();
+
+    let actual = nu!(format!("http head --status-code {url}", url = server.url()));
+
+    assert_eq!(&actual.out, "502");
+}
+
+#[test]
+fn http_head_status_code_200() {
+    let mut server = Server::new();
+
+    let _mock = server.mock("HEAD", "/").with_status(200).create();
+
+    let actual = nu!(format!("http head --status-code {url}", url = server.url()));
+
+    assert_eq!(&actual.out, "200");
+}


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
Added a handy way of getting just the status code of a request. Doing `http get -fe $url | get status` already works, but that unnecessarily retrieves the whole request body and can take much longer.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
`http head` has a new flag `--status-code` that returns only the status code as an `int`eger and won't error on non 4xx requests.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [x] Added tests
