### PR TITLE
Update `--allow-dtd` hint phrasing for `from xml`

### DIFF
--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -288,7 +288,7 @@ fn process_xml_parse_error(source: String, err: roxmltree::Error, span: Span) ->
             make_xml_error("The root node was opened but never closed.", span)
         }
         roxmltree::Error::DtdDetected => make_xml_error(
-            "XML document with DTD detected.\nDTDs are disabled by default to prevent denial-of-service attacks (use `from xml --allow-dtd` to bypass this funtionality)",
+            "XML document with DTD detected.\nDTDs are disabled by default to prevent denial-of-service attacks (use `from xml --allow-dtd` to bypass this functionality)",
             span,
         ),
         roxmltree::Error::NodesLimitReached => make_xml_error("Node limit was reached.", span),


### PR DESCRIPTION
Following #17145, I'm not sure what would be a better approach to resolve it.

The `use --allow-dtd to parse anyway` hint is emitted by the invocation of `from xml`, even though the error message highlights `open` as its cause.

One option would be simply to paraphrase the hint so it's something more like `use 'from xml --allow-dtd' to parse anyway`, which will probably be less confusing in regard to how/where the flag should be applied, and still make sense when emitted by `from xml` itself.

The other is to add `--allow-dtd` and simply forward it to all underlying converters when present.
This is the change introduced in this PR.
The main downside to it that I see (apart from the current naive impl) is that now we introduce a new flag for `open`, which is used only for one parser as of now.

Also, I'm not sure if my following assumption is valid:
```rust
if call.has_flag(engine_state, stack, "allow-dtd")? {
    // ...
    call.get_flag_span(stack, "allow-dtd")
        .expect("An existing flag should have a span"),
    // ...
}
```