### PR TITLE
use graphemes instead of byte indexes in `explore regegx`

### DIFF
--- a/crates/nu-explore/src/explore_regex/app.rs
+++ b/crates/nu-explore/src/explore_regex/app.rs
@@ -691,6 +691,27 @@ mod tests {
         assert_eq!(app.quick_ref_scroll_h, 0);
     }
 
+    // ─── Unicode handling tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_compile_regex_with_unicode_pattern() {
+        let mut app = App::new(String::new());
+        app.regex_textarea = TextArea::new(vec!["\\p{L}+".to_string()]);
+        app.compile_regex();
+        assert!(app.compiled_regex.is_some());
+        assert!(app.regex_error.is_none());
+    }
+
+    #[test]
+    fn test_get_highlighted_text_with_unicode_sample() {
+        let mut app = App::new("12345abcde項目".to_string());
+        app.regex_textarea = TextArea::new(vec!["\\w+".to_string()]);
+        app.compile_regex();
+        let highlighted = app.get_highlighted_text();
+        // Should not panic and should produce some text
+        assert!(!highlighted.lines.is_empty());
+    }
+
     // ─── Helper ──────────────────────────────────────────────────────────────
 
     fn create_test_app() -> App<'static> {


### PR DESCRIPTION
This PR fixes a reported bug when pasting "12345abcde項目" into the Test String widget in the `explore regex` command. It employes more use of graphemes instead of byte indexes here to work around this problem.

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A
