### PR TITLE
Increase help menu description rows from 10 to 15

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -100,7 +100,7 @@ const DEFAULT_HELP_MENU: &str = r#"
       col_width: 20
       col_padding: 2
       selection_rows: 4
-      description_rows: 10
+      description_rows: 15
   }
   style: {
       text: green,


### PR DESCRIPTION
A bug was reported that "save" didn't show all the parameters from within the help menu. I tracked it down to this setting.

Closes #17220

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A