### PR TITLE
Allow `let` to be able to be used at the end of the pipeline

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/let_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/let_.rs
@@ -18,7 +18,7 @@ impl Command for Let {
             .input_output_types(vec![(Type::Any, Type::Nothing)])
             .allow_variants_without_examples(true)
             .required("var_name", SyntaxShape::VarWithOptType, "Variable name.")
-            .required(
+            .optional(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
                 "Equals sign followed by value.",
@@ -69,6 +69,11 @@ impl Command for Let {
             Example {
                 description: "Set a variable based on the condition",
                 example: "let x = if false { -1 } else { 1 }",
+                result: None,
+            },
+            Example {
+                description: "Set a variable to the output of a pipeline",
+                example: "ls | let files",
                 result: None,
             },
         ]

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6051,7 +6051,7 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
 
                 parse_call(working_set, &spans[pos..], spans[0])
             }
-            b"let" | b"const" | b"mut" => {
+            b"const" | b"mut" => {
                 working_set.error(ParseError::AssignInPipeline(
                     String::from_utf8(bytes)
                         .expect("builtin commands bytes should be able to convert to string"),


### PR DESCRIPTION
Fun change here. This PR allows the `let` command to be used at the end of a pipeline.

<img width="2316" height="1538" alt="image" src="https://github.com/user-attachments/assets/8acf9a8e-79c1-4be8-8fb6-93966f671fc4" />

Disallow infinite ranges when used with `let` at the end of the pipeline
<img width="1911" height="1203" alt="image" src="https://github.com/user-attachments/assets/dfed053c-8b5c-476c-9b09-c3df3ca7dc38" />

Related #16404, #11951

## Release notes summary - What our users need to know
The `let` command is now allowed to be at the end of the pipeline when a variable name is also provided.
```nushell
ls | get name | let files
```

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
