### PR TITLE
fix rm -f when some files not found

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -465,10 +465,20 @@ fn rm(
             Ok(None) => {}
             Ok(Some(msg)) => eprintln!("{msg}"),
             Err(err) => {
-                if cmd_result.is_ok() {
-                    cmd_result = Err(err);
-                } else {
-                    report_shell_error(Some(stack), engine_state, &err)
+                if !(force
+                    && matches!(
+                        err,
+                        ShellError::Io(IoError {
+                            kind: shell_error::io::ErrorKind::Std(std::io::ErrorKind::NotFound, ..),
+                            ..
+                        })
+                    ))
+                {
+                    if cmd_result.is_ok() {
+                        cmd_result = Err(err);
+                    } else {
+                        report_shell_error(Some(stack), engine_state, &err)
+                    }
                 }
             }
         }

--- a/crates/nu-std/tests/test_std_util.nu
+++ b/crates/nu-std/tests/test_std_util.nu
@@ -74,7 +74,7 @@ def path_add_expand [] {
         assert equal (get_path) ([$link_dir])
     }
 
-    rm $real_dir $link_dir
+    rm -f $real_dir $link_dir
 }
 
 @test

--- a/crates/nu-std/tests/test_util.nu
+++ b/crates/nu-std/tests/test_util.nu
@@ -74,7 +74,7 @@ def path_add_expand [] {
         assert equal (get_path) ([$link_dir])
     }
 
-    do -i { rm $real_dir $link_dir }
+    rm -f $real_dir $link_dir
 }
 
 @test


### PR DESCRIPTION
Fix CI failure after #17237
I don't know how can it happened, but it seems that `rm -f` inside tests should fix the problem.

## Release notes summary - What our users need to know
NaN

## Tasks after submitting