### PR TITLE
Bump reedline to latest main (reedline#991)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6478,7 +6478,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.44.0"
-source = "git+https://github.com/nushell/reedline?branch=main#07fe597169ca7a96910161f42bf8d52d8cb3ef5c"
+source = "git+https://github.com/nushell/reedline?branch=main#b81c351884a8fa949bc9ce717f6af05db2a47a7f"
 dependencies = [
  "arboard",
  "chrono",


### PR DESCRIPTION
Bump Reedline to latest main to include https://github.com/nushell/reedline/pull/991, which fixes a bug in completion menu highlighting.

## Release notes summary - What our users need to know

N/A

## Tasks after submitting

None