### PR TITLE
Allow disabling filtering in custom completions

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -284,6 +284,18 @@ fn customcompletions_no_sort() {
     );
 }
 
+#[test]
+fn customcompletions_no_filter() {
+    let mut completer = custom_completer_with_options(
+        "",
+        r#"filter: false"#,
+        &["zzzfoo", "foo", "not matched", "abcfoo"],
+    );
+    let suggestions = completer.complete("my-command foo", 14);
+    let expected_items = vec!["zzzfoo", "foo", "not matched", "abcfoo"];
+    match_suggestions(&expected_items, &suggestions);
+}
+
 #[rstest]
 #[case::happy("{ start: 1, end: 14 }", (7, 20))]
 #[case::no_start("{ end: 14 }", (17, 20))]


### PR DESCRIPTION
## Release notes summary - What our users need to know
Allow disabling filtering in custom completions

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)

## Details of the change
* Read 'filter' option (default true) from custom completion options.
* When filtering is disabled, return raw suggestions early and warn if sorting was requested, since sorting requires filtering.
* Added a unit test for the no-filter case.

<img width="1246" height="427" alt="image" src="https://github.com/user-attachments/assets/29bba7a0-797a-4acf-9b54-5f7abfc77908" />

@ysthakur 
Closes #15479 