### PR TITLE
Add trailing slash for dir symlink completion (Issue #17257)

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -85,8 +85,7 @@ fn complete_rec(
             let entry_isdir = entry.path().is_dir();
             let mut built = built.clone();
             built.parts.push(entry_name.clone());
-            // Symlinks to directories shouldn't have a trailing slash (#13275)
-            built.isdir = entry_isdir && !entry.path().is_symlink();
+            built.isdir = entry_isdir;
 
             if !want_directory || entry_isdir {
                 if enable_exact_match && !multiple_exact_matches && has_more {


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
This PR fixes #17257 by reverting the changes made in PR #14667. A trailing slash will be added upon auto-completing a symlink to a directory.

```bash
mkdir test-dir
ln -s test-dir test-link
rm test-l<tab> # auto-completes to test-link/
```


## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- Review if this behavior is desired since it doesn't follow the convention of `bash`.

