### PR TITLE
Add GetBlockIR engine call to plugin protocol

### DIFF
--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -1390,6 +1390,9 @@ pub(crate) fn handle_engine_call(
                 EngineCallResponse::empty()
             }
         }),
+        EngineCall::GetBlockIR(block_id) => context
+            .get_block_ir(block_id)
+            .map(|ir| EngineCallResponse::IrBlock(Box::new(ir))),
         EngineCall::CallDecl {
             decl_id,
             call,


### PR DESCRIPTION
This extends the plugin protocol to allow plugins to request the compiled
IR (Intermediate Representation) for a block. This enables plugins to
inspect and compile closure code rather than just executing it.

The goal is this is to allow me to implement ebpf compilation as a plugin https://github.com/tom-lubenow/nushell/pull/4
which needs access to the IR so that it can compile nushell closures to ebpf, allowing people to write entire ebpf programs in nushell. At present, my implementation is done as a built-in command as it uses the IR.

## Release notes summary - What our users need to know
- New plugin interface: `get_block_ir(&self, block_id: BlockId) -> Result<IrBlock, ShellError>`

## Tasks after submitting
- [X] Update the [documentation](https://github.com/nushell/nushell.github.io)
