### PR TITLE
input -s: always write "\n" when user finished typing.

### DIFF
--- a/crates/nu-command/src/platform/input/legacy_input.rs
+++ b/crates/nu-command/src/platform/input/legacy_input.rs
@@ -125,9 +125,7 @@ pub trait LegacyInput {
             }
         }
         crossterm::terminal::disable_raw_mode().map_err(&from_io_error)?;
-        if !suppress_output {
-            std::io::stdout().write_all(b"\n").map_err(&from_io_error)?;
-        }
+        std::io::stdout().write_all(b"\n").map_err(&from_io_error)?;
         match default_val {
             Some(val) if buf.is_empty() => Ok(Value::string(val, call.head).into_pipeline_data()),
             _ => Ok(Value::string(buf, call.head).into_pipeline_data()),


### PR DESCRIPTION
Fixes: #14902

I think appending newline when user finished typing is more friendly to user.

## Release notes summary - What our users need to know
`input -s` will append newline when user finished typing.