### PR TITLE
Add `month_name` column to `cal --month-names`

### DIFF
--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -47,7 +47,7 @@ impl Command for Cal {
             )
             .switch(
                 "month-names",
-                "Display the month names instead of integers",
+                "Display the month names in a separate column",
                 None,
             )
             .input_output_types(vec![
@@ -346,14 +346,18 @@ fn add_month_to_table(
             );
         }
 
-        if should_show_month_column || should_show_month_names {
-            let month_value = if should_show_month_names {
-                Value::string(month_helper.month_name.clone(), tag)
-            } else {
-                Value::int(month_helper.selected_month as i64, tag)
-            };
+        if should_show_month_column {
+            record.insert(
+                "month".to_string(),
+                Value::int(month_helper.selected_month as i64, tag),
+            );
+        }
 
-            record.insert("month".to_string(), month_value);
+        if should_show_month_names {
+            record.insert(
+                "month_name".to_string(),
+                Value::string(month_helper.month_name.clone(), tag),
+            );
         }
 
         for day in &days_of_the_week {

--- a/crates/nu-command/tests/commands/cal.rs
+++ b/crates/nu-command/tests/commands/cal.rs
@@ -14,12 +14,23 @@ fn cal_full_year() {
 #[test]
 fn cal_february_2020_leap_year() {
     let actual = nu!(r#"
-    cal --as-table -ym --full-year 2020 --month-names | where month == "february" | to json -r
+    cal --as-table -y --full-year 2020 --month-names | where month_name == "february" | to json -r
     "#);
 
-    let cal_february_json = r#"[{"year":2020,"month":"february","su":null,"mo":null,"tu":null,"we":null,"th":null,"fr":null,"sa":1},{"year":2020,"month":"february","su":2,"mo":3,"tu":4,"we":5,"th":6,"fr":7,"sa":8},{"year":2020,"month":"february","su":9,"mo":10,"tu":11,"we":12,"th":13,"fr":14,"sa":15},{"year":2020,"month":"february","su":16,"mo":17,"tu":18,"we":19,"th":20,"fr":21,"sa":22},{"year":2020,"month":"february","su":23,"mo":24,"tu":25,"we":26,"th":27,"fr":28,"sa":29}]"#;
+    let cal_february_json = r#"[{"year":2020,"month_name":"february","su":null,"mo":null,"tu":null,"we":null,"th":null,"fr":null,"sa":1},{"year":2020,"month_name":"february","su":2,"mo":3,"tu":4,"we":5,"th":6,"fr":7,"sa":8},{"year":2020,"month_name":"february","su":9,"mo":10,"tu":11,"we":12,"th":13,"fr":14,"sa":15},{"year":2020,"month_name":"february","su":16,"mo":17,"tu":18,"we":19,"th":20,"fr":21,"sa":22},{"year":2020,"month_name":"february","su":23,"mo":24,"tu":25,"we":26,"th":27,"fr":28,"sa":29}]"#;
 
     assert_eq!(actual.out, cal_february_json);
+}
+
+#[test]
+fn cal_month_int_matches_name() {
+    let actual = nu!(r#"
+        cal --as-table --full-year 2015 --month --month-names | where month_name == "august" and month == 8 | to json -r
+    "#);
+
+    let cal_august_json = r#"[{"month":8,"month_name":"august","su":null,"mo":null,"tu":null,"we":null,"th":null,"fr":null,"sa":1},{"month":8,"month_name":"august","su":2,"mo":3,"tu":4,"we":5,"th":6,"fr":7,"sa":8},{"month":8,"month_name":"august","su":9,"mo":10,"tu":11,"we":12,"th":13,"fr":14,"sa":15},{"month":8,"month_name":"august","su":16,"mo":17,"tu":18,"we":19,"th":20,"fr":21,"sa":22},{"month":8,"month_name":"august","su":23,"mo":24,"tu":25,"we":26,"th":27,"fr":28,"sa":29},{"month":8,"month_name":"august","su":30,"mo":31,"tu":null,"we":null,"th":null,"fr":null,"sa":null}]"#;
+
+    assert_eq!(actual.out, cal_august_json);
 }
 
 #[test]
@@ -43,10 +54,10 @@ fn cal_rows_in_2020() {
 #[test]
 fn cal_week_day_start_mo() {
     let actual = nu!(r#"
-    cal --as-table --full-year 2020 -m --month-names --week-start mo | where month == january | to json -r
+    cal --as-table --full-year 2020 -m --month-names --week-start mo | where month_name == january | to json -r
     "#);
 
-    let cal_january_json = r#"[{"month":"january","mo":null,"tu":null,"we":1,"th":2,"fr":3,"sa":4,"su":5},{"month":"january","mo":6,"tu":7,"we":8,"th":9,"fr":10,"sa":11,"su":12},{"month":"january","mo":13,"tu":14,"we":15,"th":16,"fr":17,"sa":18,"su":19},{"month":"january","mo":20,"tu":21,"we":22,"th":23,"fr":24,"sa":25,"su":26},{"month":"january","mo":27,"tu":28,"we":29,"th":30,"fr":31,"sa":null,"su":null}]"#;
+    let cal_january_json = r#"[{"month":1,"month_name":"january","mo":null,"tu":null,"we":1,"th":2,"fr":3,"sa":4,"su":5},{"month":1,"month_name":"january","mo":6,"tu":7,"we":8,"th":9,"fr":10,"sa":11,"su":12},{"month":1,"month_name":"january","mo":13,"tu":14,"we":15,"th":16,"fr":17,"sa":18,"su":19},{"month":1,"month_name":"january","mo":20,"tu":21,"we":22,"th":23,"fr":24,"sa":25,"su":26},{"month":1,"month_name":"january","mo":27,"tu":28,"we":29,"th":30,"fr":31,"sa":null,"su":null}]"#;
 
     assert_eq!(actual.out, cal_january_json);
 }


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
Fixes: #17301

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
Changed the behavior of `cal --month-names` to create a new `month_name` column instead of overriding `month`.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
