### PR TITLE
Fix OSC 9;9 path reporting in Windows Terminal (Fixes #17300)

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -1058,6 +1058,12 @@ fn run_shell_integration_osc7(
     if let Ok(path) = engine_state.cwd_as_string(Some(stack)) {
         let start_time = Instant::now();
 
+        let path = if cfg!(windows) {
+            path.replace('\\', "/")
+        } else {
+            path
+        };
+
         // Otherwise, communicate the path as OSC 7 (often used for spawning new tabs in the same dir)
         run_ansi_sequence(&format!(
             "\x1b]7;file://{}{}{}\x1b\\",
@@ -1083,10 +1089,7 @@ fn run_shell_integration_osc9_9(engine_state: &EngineState, stack: &mut Stack, u
 
         // Otherwise, communicate the path as OSC 9;9 from ConEmu (often used for spawning new tabs in the same dir)
         // This is helpful in Windows Terminal with Duplicate Tab
-        run_ansi_sequence(&format!(
-            "\x1b]9;9;{}\x1b\\",
-            percent_encoding::utf8_percent_encode(&path, percent_encoding::CONTROLS)
-        ));
+        run_ansi_sequence(&format!("\x1b]9;9;{}\x1b\\", path));
 
         perf!(
             "communicate path to terminal with osc9;9",


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know

Fixed the issue where "Duplicate Pane" in Windows Terminal failed when the current path contained Chinese characters by removing unnecessary URL-encoding in OSC 9;9 sequences.

## Details
Fixes #17300.

In Windows Terminal, the "Duplicate Pane" and "Duplicate Tab" features rely on the OSC 9;9 sequence to determine the working directory of the new instance. 

Previously, Nushell was percent-encoding (URL-encoding) these paths. This caused Windows Terminal to receive a path like `C:\%E4%BD%A0%E5%A5%BD`, which it couldn't resolve to a physical directory, leading to the duplication failing or falling back to the home directory.

This PR:
1. Removes the percent-encoding for OSC 9;9, sending the raw path string instead (consistent with ConEmu's original specification).
2. Improves OSC 7 compatibility on Windows by ensuring forward slashes are used in the generated `file://` URI.

also I have to apologize for using LLM (cursor+gemini3pro) to help me locate the problem and fix it (because I myself is not very familiar with such technical problems). However, I have manually reviewed the changes and verified the fix in my local Windows environment. I have also ensured that the code complies with Nushell's contribution guidelines by running `toolkit check pr`.

Note: Some completion tests failed locally as following, but they seem unrelated to this PR's changes as they are pre-existing issues on my Windows environment.

```
failures:
    completions::command_argument_completions::case_02_arguments_and_subcommands
    completions::command_argument_completions::case_05_flag_value_and_subcommands
    completions::folder_with_directorycompletions
    completions::folder_with_directorycompletions_do_not_collapse_dots
    completions::folder_with_directorycompletions_with_three_trailing_dots
```

## Tasks after submitting
Actually no other needs.
