### PR TITLE
make `detect columns` more robust + refactor + new switch

### DIFF
--- a/crates/nu-command/tests/commands/detect_columns.rs
+++ b/crates/nu-command/tests/commands/detect_columns.rs
@@ -98,7 +98,95 @@ drwxr-xr-x  4 root root 4.0K Mar 20 08:18 ~
 
 #[test]
 fn detect_columns_may_fail() {
-    let out =
-        nu!(r#""meooooow cat\nkitty kitty woof" | try { detect columns } catch { "failed" }"#);
+    // Test case where column detection produces duplicate column names.
+    // With our updated implementation, when detection fails due to mismatched
+    // columns, data goes to "data" column instead of throwing an error.
+    // But duplicate column headers still cause an error.
+    let out = nu!(r#""cat cat\nkitty woof" | try { detect columns } catch { "failed" }"#);
     assert_eq!(out.out, "failed");
+}
+
+#[test]
+fn detect_columns_preserves_original_content_on_mismatch() {
+    // Test with iptab-like output containing box drawing characters.
+    // When column detection fails (headers don't match data rows),
+    // all rows should be output in a consistent "data" column,
+    // preserving the original content including box characters.
+    let iptab_sample = r#""+----------------------------------------------+
+| addrs   bits   pref   class  mask            |
++----------------------------------------------+
+|     1      0    /32          255.255.255.255 |
+|     2      1    /31          255.255.255.254 |
++----------------------------------------------+""#;
+
+    // All rows should be in the "data" column when detection fails (6 lines total)
+    let out = nu!(format!(
+        r#"{} | detect columns | get data | length"#,
+        iptab_sample
+    ));
+    assert_eq!(out.out, "6", "All rows should be in the data column");
+
+    // The "data" column should contain the full original text, including 'addrs'
+    let out = nu!(format!(
+        r#"{} | detect columns | get data | any {{|l| $l | str contains "addrs"}}"#,
+        iptab_sample
+    ));
+    assert_eq!(
+        out.out, "true",
+        "Line data should preserve original content including 'addrs'"
+    );
+
+    // Verify the box-only lines still have box characters (+ and -)
+    let out2 = nu!(format!(
+        r#"{} | detect columns | get data | any {{|l| ($l | str contains "+") and ($l | str contains "-")}}"#,
+        iptab_sample
+    ));
+    assert_eq!(
+        out2.out, "true",
+        "Box-only lines should preserve + and - characters"
+    );
+
+    // Verify data lines preserve the pipe | characters
+    let out3 = nu!(format!(
+        r#"{} | detect columns | get data | where {{|l| $l | str contains "addrs"}} | first | str contains "|""#,
+        iptab_sample
+    ));
+    assert_eq!(
+        out3.out, "true",
+        "Data lines should preserve pipe | characters"
+    );
+}
+
+#[test]
+fn detect_columns_ignore_box_chars_flag() {
+    // When --ignore-box-chars is used, lines consisting entirely of box drawing
+    // characters should be ignored
+
+    // Simple test: header line is good, separator line is ignored
+    let simple_sample = r#""col1 col2 col3
+----+----+----
+val1 val2 val3""#;
+
+    // Without flag: separator line causes column mismatch, so all rows go to "data"
+    // (including the first line which is used as header attempt)
+    let out = nu!(format!(
+        r#"{} | detect columns | get data? | length"#,
+        simple_sample
+    ));
+    // Header is "col1 col2 col3" (3 cols), separator is "----+----+----" (1 col),
+    // Since first data row (separator) doesn't match header, all 3 rows go to "data"
+    assert_eq!(
+        out.out, "3",
+        "Without --ignore-box-chars, all rows go to data column when detection fails"
+    );
+
+    // With --ignore-box-chars flag: the separator line is ignored
+    let out2 = nu!(format!(
+        r#"{} | detect columns --ignore-box-chars | get col1 | first"#,
+        simple_sample
+    ));
+    assert_eq!(
+        out2.out, "val1",
+        "With --ignore-box-chars, separator is ignored and columns work"
+    );
 }


### PR DESCRIPTION
This PR is intended to make `detect columns` better by supporting more input like input from `iptab` which looks like this below and adding a new switch `--ignore-box-chars`:
```
+----------------------------------------------+
| addrs   bits   pref   class  mask            |
+----------------------------------------------+
|     1      0    /32          255.255.255.255 |
|     2      1    /31          255.255.255.254 |
|     4      2    /30          255.255.255.252 |
|     8      3    /29          255.255.255.248 |
|    16      4    /28          255.255.255.240 |
|    32      5    /27          255.255.255.224 |
|    64      6    /26          255.255.255.192 |
|   128      7    /25          255.255.255.128 |
|   256      8    /24      1C  255.255.255.0   |
|   512      9    /23      2C  255.255.254.0   |
|    1K     10    /22      4C  255.255.252.0   |
|    2K     11    /21      8C  255.255.248.0   |
|    4K     12    /20     16C  255.255.240.0   |
|    8K     13    /19     32C  255.255.224.0   |
|   16K     14    /18     64C  255.255.192.0   |
|   32K     15    /17    128C  255.255.128.0   |
```
<img width="1924" height="857" alt="image" src="https://github.com/user-attachments/assets/6a075d31-2668-4c25-8895-98cf2e389337" />

This PR adds a new switch `--ignore-box-chars` that is meant to ignore all the ascii and unicode box characters hopefully allowing more data to be detected and processed.

I also took the time to refactor the code to hopefully make it more maintainable.

I haven't done a lot of testing but this may close #13721 as well.

## Release notes summary - What our users need to know
Enable `detect columns` to be more robust, specifically for handling the output of tablelike structures that are created with ascii or unicode table characters like we use in nushell today. Many tools are starting to use this columnar data output so hopefully this will enable nushell to be able to parse this data better.

## Tasks after submitting
N/A