### PR TITLE
Replace uses of canonicalize in nu-command

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -131,7 +131,7 @@ fn rm(
     let home: Option<String> = nu_path::home_dir().map(|path| {
         {
             if path.exists() {
-                nu_path::canonicalize_with(&path, &currentdir_path).unwrap_or(path.into())
+                nu_path::absolute_with(&path, &currentdir_path).unwrap_or(path.into())
             } else {
                 path.into()
             }

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -116,7 +116,7 @@ impl Command for Watch {
             .item
             .trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
 
-        let path = nu_path::canonicalize_with(path_no_whitespace, cwd).map_err(|err| {
+        let path = nu_path::absolute_with(path_no_whitespace, cwd).map_err(|err| {
             ShellError::Io(IoError::new(
                 err,
                 path_arg.span,

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -1102,8 +1102,7 @@ fn render_path_name(
             prefix_with_reset: false,
         });
 
-    let full_path = PathBuf::from(stripped_path.as_ref())
-        .canonicalize()
+    let full_path = std::path::absolute(stripped_path.as_ref())
         .unwrap_or_else(|_| PathBuf::from(stripped_path.as_ref()));
 
     let full_path_link = make_clickable_link(


### PR DESCRIPTION
This uses the newly created `absolute_with` to replace most direct uses of `canoncalize_with` in commands. There is one case in `cd` where canoncalization is deliberate so that's kept as-is. https://github.com/nushell/nushell/blob/77103b92c67bba8b327d597721b021a7fff2fc19/crates/nu-command/src/filesystem/cd.rs#L75-L77

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

`rm`, `watch` and `source` no longer canonicalize paths.

The file path links in table view will no longer be canoncalized if you click them.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
-->