### PR TITLE
error_make: Add `Type::Any` to input type

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -12,17 +12,7 @@ impl Command for ErrorMake {
     fn signature(&self) -> Signature {
         Signature::build("error make")
             .category(Category::Core)
-            .input_output_types(vec![
-                // original nothing input type
-                (Type::Nothing, Type::Error),
-                // "foo" | error make
-                (Type::String, Type::Error),
-                // {...} | error make
-                // try {...} catch {error make}
-                (Type::record(), Type::Error),
-                // As a catch-all for when it's used in certain structures
-                (Type::Any, Type::Error),
-            ])
+            .input_output_types(vec![(Type::Any, Type::Error)])
             .optional(
                 "error_struct",
                 SyntaxShape::OneOf(vec![SyntaxShape::Record(vec![]), SyntaxShape::String]),


### PR DESCRIPTION
I added the `Type::Any` input so that this common structure will work:

```
# Match inputs that 
[{foo: bar} {foo: baz}]
| where foo == bar
| match $in {
    [] => []
    $x => {error make {msg: 'works'}}
}
```

Unsure if I should just remove the other types, as they do have some merit being listed in the help output.

## Release notes summary - What our users need to know

### `error make` might now be used in a match statement

Fix `error make` input when used in a match statement, example:
```
# Match inputs that 
[{foo: bar} {foo: baz}]
| where foo == bar
| match $in {
    [] => []
    $x => {error make {msg: 'works'}}
}
```

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
