### PR TITLE
into datetime: Allow floats as input

### DIFF
--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -79,6 +79,7 @@ impl Command for IntoDatetime {
             .input_output_types(vec![
                 (Type::Date, Type::Date),
                 (Type::Int, Type::Date),
+                (Type::Float, Type::Date),
                 (Type::String, Type::Date),
                 (
                     Type::List(Box::new(Type::String)),
@@ -347,6 +348,10 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
     let timestamp = match input {
         Value::Int { val, .. } => Ok(*val),
         Value::String { val, .. } => val.parse::<i64>(),
+        Value::Float { val, .. } => {
+            // Assume floats are going to be written as `seconds`
+            Ok((*val * 1_000_000_000.0) as i64)
+        }
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => return input.clone(),
         other => {
@@ -505,6 +510,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
     match input {
         Value::String { val, .. } => parse_as_string(val),
         Value::Int { val, .. } => parse_as_string(&val.to_string()),
+        Value::Float { val, .. } => parse_as_string(&val.to_string()),
 
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),

--- a/crates/nu-command/tests/commands/into_datetime.rs
+++ b/crates/nu-command/tests/commands/into_datetime.rs
@@ -51,6 +51,13 @@ fn into_datetime_from_record_round_trip() {
 }
 
 #[test]
+fn into_datetime_float() {
+    let actual = nu!(r#"(1.743348798 | into datetime | into int) == 1743348798"#);
+
+    assert!(actual.out.contains("true"));
+}
+
+#[test]
 fn into_datetime_table_column() {
     let actual = nu!(r#"[[date]; ["2022-01-01"] ["2023-01-01"]] | into datetime date"#);
 


### PR DESCRIPTION
Treats them as seconds, so we multiply to get to an i64 of nanoseconds.

## Release notes summary - What our users need to know
Allow `into datetime` to take a float as input. Example: `1743348798.0 | into datetime`
## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
