### PR TITLE
fix std repeat returning empty list on null input

### DIFF
--- a/crates/nu-std/std/util/mod.nu
+++ b/crates/nu-std/std/util/mod.nu
@@ -94,7 +94,7 @@ export def repeat [
         return []
     }
 
-    1..$n | each { $item }
+    1..$n | each --keep-empty { $item }
 }
 
 # null device file


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
Fixes #17331 
Not sure if this is considered a bug. If not, or if the "no pipeline input -> null list" behavior isn't preferable, feel free to close this and the associated issue.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
Using `std repeat` with no pipeline input, or `nothing` type input, now generates a list of `null` items with the provided length. 

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)

