### PR TITLE
Add `definition` column to `which` command for aliases

### DIFF
--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -19,7 +19,10 @@ fn which_alias_ls() {
 fn which_custom_alias() {
     let actual = nu!(r#"alias foo = print "foo!"; which foo | to nuon"#);
 
-    assert_eq!(actual.out, r#"[[command, path, type]; [foo, "", alias]]"#);
+    assert_eq!(
+        actual.out,
+        r#"[[command, path, type, definition]; [foo, "", alias, "print \"foo!\""]]"#
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR should close #17335 

<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
The `which` command now includes a `definition` column when inspecting aliases, showing the command the alias expands to.

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)