### PR TITLE
Add option to save leading-space commands to history.txt 

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -489,13 +489,13 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
 
     if let Some(history) = engine_state.history_config() {
         start_time = std::time::Instant::now();
-        
+
         line_editor = line_editor.with_history_exclusion_prefix(if history.ignore_space {
             Some(" ".into())
         } else {
             None
         });
-        
+
         if history.sync_on_enter
             && let Err(e) = line_editor.sync_history()
         {
@@ -1309,11 +1309,7 @@ fn update_line_editor_history(
     };
     let line_editor = line_editor
         .with_history_session_id(history_session_id)
-        .with_history_exclusion_prefix(if ignore_space {
-            Some(" ".into())
-        } else {
-            None
-        })
+        .with_history_exclusion_prefix(if ignore_space { Some(" ".into()) } else { None })
         .with_history(history);
 
     store_history_id_in_engine(engine_state, &line_editor);

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -490,11 +490,8 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
     if let Some(history) = engine_state.history_config() {
         start_time = std::time::Instant::now();
 
-        line_editor = line_editor.with_history_exclusion_prefix(if history.ignore_space {
-            Some(" ".into())
-        } else {
-            None
-        });
+        line_editor = line_editor
+            .with_history_exclusion_prefix(history.ignore_space_prefixed.then_some(" ".into()));
 
         if history.sync_on_enter
             && let Err(e) = line_editor.sync_history()
@@ -1283,7 +1280,7 @@ fn update_line_editor_history(
     line_editor: Reedline,
     history_session_id: Option<HistorySessionId>,
 ) -> Result<Reedline, ErrReport> {
-    let ignore_space = history.ignore_space;
+    let ignore_space_prefixed = history.ignore_space_prefixed;
     let history: Box<dyn reedline::History> = match history.file_format {
         HistoryFileFormat::Plaintext => Box::new(
             FileBackedHistory::with_file(history.max_size as usize, history_path)
@@ -1309,7 +1306,7 @@ fn update_line_editor_history(
     };
     let line_editor = line_editor
         .with_history_session_id(history_session_id)
-        .with_history_exclusion_prefix(if ignore_space { Some(" ".into()) } else { None })
+        .with_history_exclusion_prefix(ignore_space_prefixed.then_some(" ".into()))
         .with_history(history);
 
     store_history_id_in_engine(engine_state, &line_editor);

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -489,6 +489,13 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
 
     if let Some(history) = engine_state.history_config() {
         start_time = std::time::Instant::now();
+        
+        line_editor = line_editor.with_history_exclusion_prefix(if history.ignore_space {
+            Some(" ".into())
+        } else {
+            None
+        });
+        
         if history.sync_on_enter
             && let Err(e) = line_editor.sync_history()
         {
@@ -1276,6 +1283,7 @@ fn update_line_editor_history(
     line_editor: Reedline,
     history_session_id: Option<HistorySessionId>,
 ) -> Result<Reedline, ErrReport> {
+    let ignore_space = history.ignore_space;
     let history: Box<dyn reedline::History> = match history.file_format {
         HistoryFileFormat::Plaintext => Box::new(
             FileBackedHistory::with_file(history.max_size as usize, history_path)
@@ -1301,7 +1309,11 @@ fn update_line_editor_history(
     };
     let line_editor = line_editor
         .with_history_session_id(history_session_id)
-        .with_history_exclusion_prefix(Some(" ".into()))
+        .with_history_exclusion_prefix(if ignore_space {
+            Some(" ".into())
+        } else {
+            None
+        })
         .with_history(history);
 
     store_history_id_in_engine(engine_state, &line_editor);

--- a/crates/nu-protocol/src/config/history.rs
+++ b/crates/nu-protocol/src/config/history.rs
@@ -65,6 +65,7 @@ pub struct HistoryConfig {
     pub file_format: HistoryFileFormat,
     pub isolation: bool,
     pub path: HistoryPath,
+    pub ignore_space: bool,
 }
 
 impl IntoValue for HistoryPath {
@@ -86,11 +87,11 @@ impl IntoValue for HistoryConfig {
                 "file_format" => self.file_format.into_value(span),
                 "isolation" => self.isolation.into_value(span),
                 "path" => self.path.into_value(span),
+                "ignore_space" => self.ignore_space.into_value(span),
             },
             span,
         )
     }
-}
 
 impl HistoryConfig {
     pub fn file_path(&self) -> Option<PathBuf> {
@@ -119,6 +120,7 @@ impl Default for HistoryConfig {
             file_format: HistoryFileFormat::Plaintext,
             isolation: false,
             path: HistoryPath::Default,
+            ignore_space: true,
         }
     }
 }
@@ -165,6 +167,7 @@ impl UpdateFromValue for HistoryConfig {
                         errors.type_mismatch(path, Type::custom("string or nothing"), val);
                     }
                 },
+                "ignore_space" => self.ignore_space.update(val, path, errors),
                 _ => errors.unknown_option(path, val),
             }
         }

--- a/crates/nu-protocol/src/config/history.rs
+++ b/crates/nu-protocol/src/config/history.rs
@@ -65,7 +65,7 @@ pub struct HistoryConfig {
     pub file_format: HistoryFileFormat,
     pub isolation: bool,
     pub path: HistoryPath,
-    pub ignore_space: bool,
+    pub ignore_space_prefixed: bool,
 }
 
 impl IntoValue for HistoryPath {
@@ -87,11 +87,12 @@ impl IntoValue for HistoryConfig {
                 "file_format" => self.file_format.into_value(span),
                 "isolation" => self.isolation.into_value(span),
                 "path" => self.path.into_value(span),
-                "ignore_space" => self.ignore_space.into_value(span),
+                "ignore_space_prefixed" => self.ignore_space_prefixed.into_value(span),
             },
             span,
         )
     }
+}
 
 impl HistoryConfig {
     pub fn file_path(&self) -> Option<PathBuf> {
@@ -120,7 +121,7 @@ impl Default for HistoryConfig {
             file_format: HistoryFileFormat::Plaintext,
             isolation: false,
             path: HistoryPath::Default,
-            ignore_space: true,
+            ignore_space_prefixed: true,
         }
     }
 }
@@ -167,7 +168,7 @@ impl UpdateFromValue for HistoryConfig {
                         errors.type_mismatch(path, Type::custom("string or nothing"), val);
                     }
                 },
-                "ignore_space" => self.ignore_space.update(val, path, errors),
+                "ignore_space_prefixed" => self.ignore_space_prefixed.update(val, path, errors),
                 _ => errors.unknown_option(path, val),
             }
         }

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -75,11 +75,11 @@ $env.config.history.path = "~/custom/my-history.txt"
 # If set to a directory, the appropriate file name (e.g., history.txt) is used.
 # If set to a filename only, the file will be stored in $nu.default-config-dir.
 
-# history.ignore_space (bool): Whether commands that start with a space are saved to history.
-# true: Commands starting with a space will NOT be saved to history.
-# false: All commands will be saved to history, including those starting with a space.
+# history.ignore_space_prefixed (bool): Whether commands starting with leading whitespace are saved to history.
+# true: Commands starting with one or more spaces or tabs will NOT be saved.
+# false: All commands are saved, including those with any amount of leading whitespace.
 # Default: true
-$env.config.history.ignore_space = true
+$env.config.history.ignore_space_prefixed = true
 
 # ----------------------
 # Miscellaneous Settings

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -75,6 +75,12 @@ $env.config.history.path = "~/custom/my-history.txt"
 # If set to a directory, the appropriate file name (e.g., history.txt) is used.
 # If set to a filename only, the file will be stored in $nu.default-config-dir.
 
+# history.ignore_space (bool): Whether commands that start with a space are saved to history.
+# true: Commands starting with a space will NOT be saved to history.
+# false: All commands will be saved to history, including those starting with a space.
+# Default: true
+$env.config.history.ignore_space = true
+
 # ----------------------
 # Miscellaneous Settings
 # ----------------------

--- a/tests/repl/test_config.rs
+++ b/tests/repl/test_config.rs
@@ -176,3 +176,11 @@ fn mutate_nu_config_history_warning() -> TestResult {
         "history isolation only compatible with SQLite format",
     )
 }
+
+#[test]
+fn mutate_nu_config_history_ignore_space() -> TestResult {
+    run_test_std(
+        r#"$env.config.history.ignore_space = false; $env.config.history.ignore_space"#,
+        "false",
+    )
+}

--- a/tests/repl/test_config.rs
+++ b/tests/repl/test_config.rs
@@ -180,7 +180,7 @@ fn mutate_nu_config_history_warning() -> TestResult {
 #[test]
 fn mutate_nu_config_history_ignore_space() -> TestResult {
     run_test_std(
-        r#"$env.config.history.ignore_space = false; $env.config.history.ignore_space"#,
+        r#"$env.config.history.ignore_space_prefixed = false; $env.config.history.ignore_space_prefixed"#,
         "false",
     )
 }

--- a/tests/repl/test_config.rs
+++ b/tests/repl/test_config.rs
@@ -180,7 +180,7 @@ fn mutate_nu_config_history_warning() -> TestResult {
 #[test]
 fn mutate_nu_config_history_ignore_space() -> TestResult {
     run_test_std(
-        r#"$env.config.history.ignore_space_prefixed = false; $env.config.history.ignore_space_prefixed"#,
+        "$env.config.history.ignore_space_prefixed = false; $env.config.history.ignore_space_prefixed",
         "false",
     )
 }


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

This PR should close #17349 

Add config:

```nu
# history.ignore_space_prefixed (bool): Whether commands that start with a space are saved to history.
# true: Commands starting with a space will NOT be saved to history.
# false: All commands will be saved to history, including those starting with a space.
# Default: true
$env.config.history.ignore_space_prefixed = true
```
![brave_1KNtk1K7Fl](https://github.com/user-attachments/assets/ae031117-d37a-4eb3-8f50-838432110f0f)


## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
### New option to allow command with space prefixes to be recorded in history
Usually commands that start with a space are not recorded to the history.
With `$env.config.history.ignore_space_prefixed` this can be changed.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
