### PR TITLE
Fix history not saving when `exit` is in a pipeline

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -989,6 +989,13 @@ fn do_run_cmd(
         false,
     );
 
+    // Check if exit was requested from within the command pipeline.
+    // This happens when `exit` is part of a compound command like `"toto" ; exit`.
+    // By handling it here, we ensure the line_editor is properly dropped (saving history).
+    if let Some(exit_code) = engine_state.take_requested_exit() {
+        return cleanup_exit(line_editor, engine_state, exit_code);
+    }
+
     // if there was a warning before, and we got to this point, it means
     // the possible call to cleanup_exit did not occur.
     if had_warning_before && engine_state.is_interactive {

--- a/crates/nu-engine/src/exit.rs
+++ b/crates/nu-engine/src/exit.rs
@@ -2,6 +2,38 @@ use std::sync::atomic::Ordering;
 
 use nu_protocol::engine::EngineState;
 
+/// Request an exit from within a command pipeline.
+///
+/// This is called by the `exit` command when running in interactive mode.
+/// Instead of calling `std::process::exit()` directly (which would skip history saving),
+/// this function sets a flag that the REPL loop checks after command execution.
+///
+/// Returns `true` if exit was requested (or will be after killing jobs),
+/// `false` if there were background jobs and a warning was shown.
+pub fn request_exit(engine_state: &EngineState, exit_code: i32) -> bool {
+    let jobs = engine_state.jobs.lock().expect("failed to lock job table");
+
+    if engine_state.is_interactive
+        && jobs.iter().next().is_some()
+        && !engine_state.exit_warning_given.load(Ordering::SeqCst)
+    {
+        let job_count = jobs.iter().count();
+
+        println!("There are still background jobs running ({job_count}).");
+        println!("Running `exit` a second time will kill all of them.");
+
+        engine_state
+            .exit_warning_given
+            .store(true, Ordering::SeqCst);
+
+        return false;
+    }
+
+    // Request the exit - the REPL will handle it after command execution
+    engine_state.request_exit(exit_code);
+    true
+}
+
 /// Exit the process or clean jobs if appropriate.
 ///
 /// Drops `tag` and exits the current process if there are no running jobs, or if `exit_warning_given` is true.


### PR DESCRIPTION
## Description
Fixes #17351

Your `systemctl suspend ; exit` command? Yeah, it's been disappearing into the void. Not anymore! 🎉

**What was happening:**
- Standalone `exit` → properly saves history ✓
- `"toto" ; exit` → nope, history goes *poof* ✗

The `exit` command was too eager, calling `std::process::exit()` immediately when it was part of a pipeline, not giving history a chance to save.

**The fix:**
- Added a "hey I want to exit" flag to `EngineState`
- In interactive mode, `exit` now politely sets this flag instead of rage-quitting
- After the command finishes, the REPL checks the flag and exits gracefully (with history saved!)

## User-Facing Changes
Commands like `systemctl suspend ; exit` now properly save to history. No more retyping your favorite exit combos!

## Tests + Formatting
All tests pass, clippy is happy.