### PR TITLE
Fix duplicate PWD error messages when directory is deleted

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -325,6 +325,11 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
         hostname,
     } = ctx;
 
+    // Reset the cwd error flag at the start of each REPL iteration.
+    // This prevents duplicate "$env.PWD points to a non-existent directory" errors
+    // when multiple operations try to access the cwd in the same iteration.
+    engine_state.reset_cwd_error_reported();
+
     let mut start_time = std::time::Instant::now();
     // Before doing anything, merge the environment from the previous REPL iteration into the
     // permanent state.

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -135,6 +135,11 @@ pub struct EngineState {
     //
     // This ensures that running exit twice will terminate the program correctly
     pub exit_warning_given: Arc<AtomicBool>,
+
+    // Tracks whether a cwd error has already been reported in the current REPL cycle.
+    // This prevents duplicate "$env.PWD points to a non-existent directory" messages
+    // when multiple operations try to access the cwd in the same iteration.
+    pub cwd_error_reported_this_cycle: Arc<AtomicBool>,
 }
 
 // The max number of compiled regexes to keep around in a LRU cache, arbitrarily chosen
@@ -217,7 +222,27 @@ impl EngineState {
             },
             root_job_sender: send,
             exit_warning_given: Arc::new(AtomicBool::new(false)),
+            cwd_error_reported_this_cycle: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Reset the cwd error reported flag. Should be called at the start of each REPL iteration.
+    pub fn reset_cwd_error_reported(&self) {
+        self.cwd_error_reported_this_cycle
+            .store(false, Ordering::SeqCst);
+    }
+
+    /// Check if a cwd error has already been reported this REPL cycle.
+    pub fn is_cwd_error_reported(&self) -> bool {
+        self.cwd_error_reported_this_cycle.load(Ordering::SeqCst)
+    }
+
+    /// Mark that a cwd error has been reported this REPL cycle.
+    /// Returns true if this is the first report (and it was marked), false if already reported.
+    pub fn mark_cwd_error_reported(&self) -> bool {
+        !self
+            .cwd_error_reported_this_cycle
+            .swap(true, Ordering::SeqCst)
     }
 
     pub fn signals(&self) -> &Signals {
@@ -359,10 +384,22 @@ impl EngineState {
             }
         }
 
-        let cwd = self.cwd(Some(stack))?;
-        std::env::set_current_dir(cwd).map_err(|err| {
-            IoError::new_internal(err, "Could not set current dir", crate::location!())
-        })?;
+        // Only validate and set cwd if we haven't already reported a cwd error this cycle.
+        // This prevents duplicate error messages when cwd is invalid.
+        if !self.is_cwd_error_reported() {
+            match self.cwd(Some(stack)) {
+                Ok(cwd) => {
+                    std::env::set_current_dir(cwd).map_err(|err| {
+                        IoError::new_internal(err, "Could not set current dir", crate::location!())
+                    })?;
+                }
+                Err(err) => {
+                    // Mark that we've encountered a cwd error so it's only reported once
+                    self.mark_cwd_error_reported();
+                    return Err(err);
+                }
+            }
+        }
 
         if let Some(config) = stack.config.take() {
             // If config was updated in the stack, replace it.


### PR DESCRIPTION
## Summary
- Fixes the annoying 4-5 duplicate "$env.PWD points to a non-existent directory" errors when running commands from a deleted directory
- Adds a `cwd_error_reported_this_cycle` flag to track when a cwd error has been reported in the current REPL iteration
- Only reports the error once per REPL cycle, subsequent cwd checks skip validation if we already know it's bad

## Test plan
1. Start nushell in an interactive session
2. Create and cd into a temporary directory: `mkdir /tmp/test_dir && cd /tmp/test_dir`
3. In another terminal, delete that directory: `rm -rf /tmp/test_dir`
4. Back in nushell, run any command like `ls`
5. Verify that the "$env.PWD points to a non-existent directory" error only appears once instead of 4-5 times

Closes #17284