### PR TITLE
Display the help for the aliased command when calling `help <alias>`

### DIFF
--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -87,10 +87,8 @@ pub fn get_full_help(
         long_desc
     };
 
-    if let Some(alias) = command.as_alias()
-        && let Some(command) = &alias.command
-    {
-        let nested_help = get_full_help(command.as_ref(), engine_state, stack);
+    if let Some(cmd) = command.as_alias().and_then(|alias| alias.command.as_ref()) {
+        let nested_help = get_full_help(cmd.as_ref(), engine_state, stack);
         if !nested_help.is_empty() {
             final_help.push_str("\n\n");
             final_help.push_str(&nested_help);


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
When aliasing a command, the help for that command is also displayed:

```nu
✦ > ❯ : alias psl = ps --long

✦ > ❯ : help psl
Alias for ps --long

Alias: ps

Expansion:
  ps --long

View information about system processes.

Search terms: procedures, operations, tasks, ops

Usage:
  > ps {flags}

Flags:
  -h, --help: Display the help message for this command
  -l, --long: list all available columns for each entry

Input/output types:
  ╭───┬─────────┬────────╮
  │ # │  input  │ output │
  ├───┼─────────┼────────┤
  │ 0 │ nothing │ table  │
  ╰───┴─────────┴────────╯

Examples:
  List the system processes
  > ps

  List the top 5 system processes with the highest memory usage
  > ps | sort-by mem | last 5

  List the top 3 system processes with the highest CPU usage
  > ps | sort-by cpu | last 3

  List the system processes with 'nu' in their names
  > ps | where name =~ 'nu'

  Get the parent process id of the current nu process
  > ps | where pid == $nu.pid | get ppid
```