### PR TITLE
Pin reedline to 0.45 for 0.110 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6447,8 +6447,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.44.0"
-source = "git+https://github.com/nushell/reedline?branch=main#6ceda50065fce791bb0b89c76fe1c45789ea0d5c"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67478e45862a0c29fd99658e382c07b1b80b9c1b7d946ce6bd2e4a679141554b"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ getrandom = "0.2" # pick same version that rand requires
 rand_chacha = "0.9"
 ratatui = "0.29"
 rayon = "1.11"
-reedline = "0.44.0"
+reedline = "0.45.0"
 rmp = "0.8.15"
 rmp-serde = "1.3.1"
 roxmltree = "0.20"
@@ -376,7 +376,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+# reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # nu-ansi-term = { git = "https://github.com/nushell/nu-ansi-term.git", branch = "main" }
 
 # Run all benchmarks with `cargo bench`


### PR DESCRIPTION
Pin Reedline to v0.45 for the 0.110.0 Nushell release (https://github.com/nushell/reedline/releases/tag/v0.45.0)