### PR TITLE
Don't canonicalize config path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use miette::Result;
 use nu_cli::gather_parent_env_vars;
 use nu_engine::{convert_env_values, exit::cleanup_exit};
 use nu_lsp::LanguageServer;
-use nu_path::canonicalize_with;
+use nu_path::{absolute_with, canonicalize_with};
 use nu_protocol::{
     ByteStream, Config, IntoValue, PipelineData, ShellError, Span, Spanned, Type, Value,
     engine::{EngineState, Stack},
@@ -31,7 +31,12 @@ use nu_std::load_standard_library;
 use nu_utils::perf;
 use run::{run_commands, run_file, run_repl};
 use signals::ctrlc_protection;
-use std::{borrow::Cow, path::PathBuf, str::FromStr, sync::Arc};
+use std::{
+    borrow::Cow,
+    path::{PathBuf, absolute},
+    str::FromStr,
+    sync::Arc,
+};
 
 /// Get the directory where the Nushell executable is located.
 fn current_exe_directory() -> PathBuf {
@@ -120,7 +125,7 @@ fn main() -> Result<()> {
         && !xdg_config_home.is_empty()
     {
         if nushell_config_path
-            != canonicalize_with(&xdg_config_home, &init_cwd)
+            != absolute_with(&xdg_config_home, &init_cwd)
                 .unwrap_or(PathBuf::from(&xdg_config_home))
                 .join("nushell")
         {
@@ -133,7 +138,7 @@ fn main() -> Result<()> {
                 },
             );
         } else if let Some(old_config) = dirs::config_dir()
-            .and_then(|p| p.canonicalize().ok())
+            .and_then(|p| absolute(p).ok())
             .map(|p| p.join("nushell"))
         {
             let xdg_config_empty = nushell_config_path

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -2,7 +2,7 @@ use nu_path::{AbsolutePath, AbsolutePathBuf, Path};
 use nu_test_support::nu;
 use nu_test_support::playground::{Executable, Playground};
 use pretty_assertions::assert_eq;
-use std::fs::{self, File};
+use std::fs;
 
 #[cfg(not(target_os = "windows"))]
 fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
@@ -39,31 +39,6 @@ fn non_xdg_config_dir() -> AbsolutePathBuf {
         AbsolutePathBuf::try_from(config_dir).expect("Invalid config directory");
     config_dir_nushell.push("nushell");
     config_dir_nushell
-}
-
-/// Make the config directory a symlink that points to a temporary folder, and also makes
-/// the nushell directory inside a symlink.
-/// Returns the path to the `nushell` config folder inside, via the symlink.
-fn setup_fake_config(playground: &mut Playground) -> AbsolutePathBuf {
-    let config_real = "config_real";
-    let config_link = "config_link";
-    let nushell_real = "nushell_real";
-    let nushell_link = Path::new(config_real)
-        .join("nushell")
-        .into_os_string()
-        .into_string()
-        .unwrap();
-
-    let config_home = playground.cwd().join(config_link);
-
-    playground.mkdir(nushell_real);
-    playground.mkdir(config_real);
-    playground.symlink(nushell_real, &nushell_link);
-    playground.symlink(config_real, config_link);
-    playground.with_env("XDG_CONFIG_HOME", config_home.to_str().unwrap());
-
-    let path = config_home.join("nushell");
-    path.canonicalize().map(Into::into).unwrap_or(path)
 }
 
 fn run(playground: &mut Playground, command: &str) -> String {
@@ -118,44 +93,41 @@ fn test_config_path_helper(
         let _ = fs::create_dir_all(config_dir_nushell);
     }
 
-    let config_dir_nushell = config_dir_nushell
-        .canonicalize()
-        .expect("canonicalize config dir failed");
+    let config_dir_nushell =
+        std::path::absolute(config_dir_nushell).expect("canonicalize config dir failed");
     let actual = run(playground, "$nu.default-config-dir");
     assert_eq!(actual, adjust_canonicalization(&config_dir_nushell));
 
     let config_path = config_dir_nushell.join("config.nu");
     // We use canonicalize here in case the config or env is symlinked since $nu.config-path is returning the canonicalized path in #8653
     let canon_config_path =
-        adjust_canonicalization(std::fs::canonicalize(&config_path).unwrap_or(config_path.into()));
+        adjust_canonicalization(std::path::absolute(&config_path).unwrap_or(config_path));
     let actual = run(playground, "$nu.config-path");
     assert_eq!(actual, canon_config_path);
 
     let env_path = config_dir_nushell.join("env.nu");
     let canon_env_path =
-        adjust_canonicalization(std::fs::canonicalize(&env_path).unwrap_or(env_path.into()));
+        adjust_canonicalization(std::path::absolute(&env_path).unwrap_or(env_path));
     let actual = run(playground, "$nu.env-path");
     assert_eq!(actual, canon_env_path);
 
     let history_path = config_dir_nushell.join("history.txt");
-    let canon_history_path = adjust_canonicalization(
-        std::fs::canonicalize(&history_path).unwrap_or(history_path.into()),
-    );
+    let canon_history_path =
+        adjust_canonicalization(std::path::absolute(&history_path).unwrap_or(history_path));
     let actual = run(playground, "$nu.history-path");
     assert_eq!(actual, canon_history_path);
 
     let login_path = config_dir_nushell.join("login.nu");
     let canon_login_path =
-        adjust_canonicalization(std::fs::canonicalize(&login_path).unwrap_or(login_path.into()));
+        adjust_canonicalization(std::path::absolute(&login_path).unwrap_or(login_path));
     let actual = run(playground, "$nu.loginshell-path");
     assert_eq!(actual, canon_login_path);
 
     #[cfg(feature = "plugin")]
     {
         let plugin_path = config_dir_nushell.join("plugin.msgpackz");
-        let canon_plugin_path = adjust_canonicalization(
-            std::fs::canonicalize(&plugin_path).unwrap_or(plugin_path.into()),
-        );
+        let canon_plugin_path =
+            adjust_canonicalization(std::path::absolute(&plugin_path).unwrap_or(plugin_path));
         let actual = run(playground, "$nu.plugin-path");
         assert_eq!(actual, canon_plugin_path);
     }
@@ -167,80 +139,6 @@ fn test_default_config_path() {
     Playground::setup("default_config_path", |_, playground| {
         test_config_path_helper(playground, non_xdg_config_dir());
     });
-}
-
-/// Make the config folder a symlink to a temporary folder without any config files
-/// and see if the config files' paths are properly canonicalized
-#[test]
-fn test_default_symlinked_config_path_empty() {
-    Playground::setup("symlinked_empty_config_dir", |_, playground| {
-        let config_dir_nushell = setup_fake_config(playground);
-        test_config_path_helper(playground, config_dir_nushell);
-    });
-}
-
-/// Like [`test_default_symlinked_config_path_empty`], but fill the temporary folder
-/// with broken symlinks and see if they're properly canonicalized
-#[test]
-fn test_default_symlink_config_path_broken_symlink_config_files() {
-    Playground::setup(
-        "symlinked_cfg_dir_with_symlinked_cfg_files_broken",
-        |_, playground| {
-            let fake_config_dir_nushell = setup_fake_config(playground);
-
-            let fake_dir = "fake";
-            playground.mkdir(fake_dir);
-            let fake_dir = Path::new(fake_dir);
-
-            for config_file in [
-                "config.nu",
-                "env.nu",
-                "history.txt",
-                "history.sqlite3",
-                "login.nu",
-                "plugin.msgpackz",
-            ] {
-                let fake_file = fake_dir.join(config_file);
-                File::create(playground.cwd().join(&fake_file)).unwrap();
-
-                playground.symlink(&fake_file, fake_config_dir_nushell.join(config_file));
-            }
-
-            // Windows doesn't allow creating a symlink without the file existing,
-            // so we first create original files for the symlinks, then delete them
-            // to break the symlinks
-            std::fs::remove_dir_all(playground.cwd().join(fake_dir)).unwrap();
-
-            test_config_path_helper(playground, fake_config_dir_nushell);
-        },
-    );
-}
-
-/// Like [`test_default_symlinked_config_path_empty`], but fill the temporary folder
-/// with working symlinks to empty files and see if they're properly canonicalized
-#[test]
-fn test_default_config_path_symlinked_config_files() {
-    Playground::setup(
-        "symlinked_cfg_dir_with_symlinked_cfg_files",
-        |_, playground| {
-            let fake_config_dir_nushell = setup_fake_config(playground);
-
-            for config_file in [
-                "config.nu",
-                "env.nu",
-                "history.txt",
-                "history.sqlite3",
-                "login.nu",
-                "plugin.msgpackz",
-            ] {
-                let empty_file = playground.cwd().join(format!("empty-{config_file}"));
-                File::create(&empty_file).unwrap();
-                playground.symlink(empty_file, fake_config_dir_nushell.join(config_file));
-            }
-
-            test_config_path_helper(playground, fake_config_dir_nushell);
-        },
-    );
 }
 
 #[test]


### PR DESCRIPTION
Continuing the removal of `canonicalize`. I've done the config path separately from the others because I needed to be careful not to unintentionally change behaviour.

I have removed the tests that were designed for testing that paths are canonicalized, since those are no longer needed.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

The configuration file paths are no longer canonicalized.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own 
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
-->