### PR TITLE
Make `it` a reserved variable name

### DIFF
--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -55,8 +55,8 @@ fn ignore_error_works_with_list_stream() {
 }
 
 #[test]
-fn run_closure_with_it_using() {
-    let actual = nu!(r#"let x = {let it = 3; $it}; do $x"#);
+fn run_closure_with_do_using() {
+    let actual = nu!(r#"let x = {let var = 3; $var}; do $x"#);
     assert!(actual.err.is_empty());
     assert_eq!(actual.out, "3");
 }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -58,7 +58,7 @@ pub const ALIASABLE_PARSER_KEYWORDS: &[&[u8]] = &[
     b"overlay use",
 ];
 
-pub const RESERVED_VARIABLE_NAMES: [&str; 3] = ["in", "nu", "env"];
+pub const RESERVED_VARIABLE_NAMES: [&str; 4] = ["in", "nu", "env", "it"];
 
 /// These parser keywords cannot be aliased (either not possible, or support not yet added)
 pub const UNALIASABLE_PARSER_KEYWORDS: &[&[u8]] = &[


### PR DESCRIPTION
Currently Nushell only has 3 reserved variable names: `nu`, `env`, `in`.  So, it was possible to assign to the variable `it` and use it as normal.  But if `it` appeared in a pipeline later on, the original variable would get deleted.  This PR reserves `it`, forbidding the creation of user variables with this identifier.

Closes #17380

## Release notes summary - What our users need to know

`it` is now a reserved variable name.  If you had scripts which assigned `let $it` or `mut $it`, the variable name must be changed. 
