### PR TITLE
Added --prefix/--suffix to join to disambiguate columns

### DIFF
--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -143,6 +143,15 @@ impl Command for Join {
                     "x_b" => Value::test_int(30),
                 })])),
             },
+            Example {
+                description: "Join multiple tables with a prefix for the right table's columns",
+                example: "[{id: 1 x: 10}] | join --prefix r_ [{id: 1 x: 20}] id",
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                    "id" => Value::test_int(1),
+                    "x" => Value::test_int(10),
+                    "r_x" => Value::test_int(20),
+                })])),
+            },
         ]
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/nushell/nushell/issues/17387

- Add join --prefix and join --suffix to rename right-table columns and avoid collisions when joining multiple tables.
- Make default collision handling safer by ensuring generated column names are truly unique (appends additional _ as needed).
- Add an example test covering multi-join with distinct suffixes.

<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know

`join` now supports `--prefix` and `--suffix` to disambiguate columns from the right table when joining tables with overlapping column names, making it easier to chain multiple joins without losing columns.
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)


Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=191128130