### PR TITLE
feat(std/formats): set content-type metadata for ndjson, jsonl, ndnuon

### DIFF
--- a/crates/nu-std/std/formats/mod.nu
+++ b/crates/nu-std/std/formats/mod.nu
@@ -21,12 +21,12 @@ export def "from jsonl" []: string -> any {
 
 # Convert structured data to NDJSON (https://github.com/ndjson/ndjson-spec).
 export def "to ndjson" []: any -> string {
-    each { to json --raw } | to text
+    each { to json --raw } | to text | metadata set --content-type "application/x-ndjson"
 }
 
 # Convert structured data to JSONL (https://jsonlines.org/).
 export def "to jsonl" []: any -> string {
-    each { to json --raw } | to text
+    each { to json --raw } | to text | metadata set --content-type "application/jsonl"
 }
 
 # Convert from NDNUON (newline-delimited NUON) to structured data
@@ -36,5 +36,5 @@ export def "from ndnuon" []: [string -> any] {
 
 # Convert structured data to newline-delimited NUON (NDNUON)
 export def "to ndnuon" []: [any -> string] {
-    each { to nuon | str replace --all "\n" '\n' } | to text
+    each { to nuon | str replace --all "\n" '\n' } | to text | metadata set --content-type "application/x-ndnuon"
 }


### PR DESCRIPTION
## Release notes summary - What our users need to know

### Content types for `to ndjson | jsonl | ndnuon` are now set properly

The `to ndjson`, `to jsonl`, and `to ndnuon` commands in `std/formats` now set appropriate `content_type` metadata:

| Command | Content Type |
|---------|-------------|
| `to ndjson` | `application/x-ndjson` |
| `to jsonl` | `application/jsonl` |
| `to ndnuon` | `application/x-ndnuon` |

```nushell
> [{a: 1}] | to ndjson | metadata | get content_type
application/x-ndjson
```