### PR TITLE
refactor(nu-protocol): replace panic with exit(1) in engine/stack.rs

### DIFF
--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -278,8 +278,8 @@ impl Stack {
                 ));
             }
         } else {
-            // TODO: Remove panic
-            panic!("internal error: no active overlay");
+            eprint!("internal error: no active overlay");
+            std::process::exit(1);
         }
     }
 


### PR DESCRIPTION
I used eprintln! to show the error message and replaced panic! with std::process::exit(1) for a more graceful exit.