### PR TITLE
Replace more `canonicalize` with `absolute`

### DIFF
--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -1,6 +1,6 @@
 use crate::util::eval_source;
 #[cfg(feature = "plugin")]
-use nu_path::canonicalize_with;
+use nu_path::absolute_with;
 #[cfg(feature = "plugin")]
 use nu_protocol::{ParseError, PluginRegistryFile, Spanned, engine::StateWorkingSet};
 use nu_protocol::{
@@ -169,12 +169,14 @@ pub fn add_plugin_file(engine_state: &mut EngineState, plugin_file: Option<Spann
         if let Some(plugin_file) = plugin_file {
             let path = Path::new(&plugin_file.item);
             let path_dir = path.parent().unwrap_or(path);
-            // Just try to canonicalize the directory of the plugin file first.
-            if let Ok(path_dir) = canonicalize_with(path_dir, &cwd) {
-                // Try to canonicalize the actual filename, but it's ok if that fails. The file doesn't
-                // have to exist.
+            // Just try the absolute directory of the plugin file first.
+            if let Ok(path_dir) = absolute_with(path_dir, &cwd)
+                && path_dir.exists()
+            {
+                // Get an absolute path to the file.
+                // We don't need to check if it exists.
                 let path = path_dir.join(path.file_name().unwrap_or(path.as_os_str()));
-                let path = canonicalize_with(&path, &cwd).unwrap_or(path);
+                let path = absolute_with(&path, &cwd).unwrap_or(path);
                 engine_state.plugin_path = Some(path)
             } else {
                 // It's an error if the directory for the plugin file doesn't exist.
@@ -189,10 +191,9 @@ pub fn add_plugin_file(engine_state: &mut EngineState, plugin_file: Option<Spann
             }
         } else if let Some(plugin_path) = nu_path::nu_config_dir() {
             // Path to store plugins signatures
-            let mut plugin_path =
-                canonicalize_with(&plugin_path, &cwd).unwrap_or(plugin_path.into());
+            let mut plugin_path = absolute_with(&plugin_path, &cwd).unwrap_or(plugin_path.into());
             plugin_path.push(PLUGIN_FILE);
-            let plugin_path = canonicalize_with(&plugin_path, &cwd).unwrap_or(plugin_path);
+            let plugin_path = absolute_with(&plugin_path, &cwd).unwrap_or(plugin_path);
             engine_state.plugin_path = Some(plugin_path);
         }
     }
@@ -251,12 +252,12 @@ pub fn migrate_old_plugin_file(engine_state: &EngineState) -> bool {
     };
 
     let Some(config_dir) =
-        nu_path::nu_config_dir().and_then(|dir| nu_path::canonicalize_with(dir, &cwd).ok())
+        nu_path::nu_config_dir().and_then(|dir| nu_path::absolute_with(dir, &cwd).ok())
     else {
         return false;
     };
 
-    let Ok(old_plugin_file_path) = nu_path::canonicalize_with(OLD_PLUGIN_FILE, &config_dir) else {
+    let Ok(old_plugin_file_path) = nu_path::absolute_with(OLD_PLUGIN_FILE, &config_dir) else {
         return false;
     };
 

--- a/crates/nu-cmd-plugin/src/commands/plugin/add.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/add.rs
@@ -99,8 +99,7 @@ apparent the next time `nu` is next launched with that plugin registry file.
         let shell_expanded = shell
             .as_ref()
             .map(|s| {
-                nu_path::canonicalize_with(&s.item, &cwd)
-                    .map_err(|err| IoError::new(err, s.span, None))
+                nu_path::absolute_with(&s.item, &cwd).map_err(|err| IoError::new(err, s.span, None))
             })
             .transpose()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use miette::Result;
 use nu_cli::gather_parent_env_vars;
 use nu_engine::{convert_env_values, exit::cleanup_exit};
 use nu_lsp::LanguageServer;
-use nu_path::{absolute_with, canonicalize_with};
+use nu_path::absolute_with;
 use nu_protocol::{
     ByteStream, Config, IntoValue, PipelineData, ShellError, Span, Spanned, Type, Value,
     engine::{EngineState, Stack},
@@ -432,8 +432,8 @@ fn main() -> Result<()> {
 
         let mut working_set = StateWorkingSet::new(&engine_state);
         for plugin_filename in plugins {
-            // Make sure the plugin filenames are canonicalized
-            let filename = canonicalize_with(&plugin_filename.item, &init_cwd)
+            // Make sure the plugin filenames are absolute
+            let filename = absolute_with(&plugin_filename.item, &init_cwd)
                 .map_err(|err| {
                     nu_protocol::shell_error::io::IoError::new(
                         err,


### PR DESCRIPTION
The (final?) PR in the series that replaces path `canonicalize` with `absolute`. I'm leaving tests alone for now to be on the safe side and, besides, there's less real need to change them.

This is a mostly straight forward replacement as nushell usually only cares about getting an absolute path. There are however a few places where it's also being used as a kind of `exists()` function.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own 
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
-->