### PR TITLE
feat: add support for custom history file path in config

### DIFF
--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -14,7 +14,7 @@ pub use datetime_format::DatetimeFormatConfig;
 pub use display_errors::DisplayErrors;
 pub use filesize::FilesizeConfig;
 pub use helper::extract_value;
-pub use history::{HistoryConfig, HistoryFileFormat};
+pub use history::{HistoryConfig, HistoryFileFormat, HistoryPath};
 pub use hooks::Hooks;
 pub use ls::LsConfig;
 pub use output::{BannerKind, ErrorStyle};

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -828,7 +828,7 @@ impl EngineState {
 
     /// Returns the configuration settings for command history or `None` if history is disabled
     pub fn history_config(&self) -> Option<HistoryConfig> {
-        self.history_enabled.then(|| self.config.history)
+        self.history_enabled.then(|| self.config.history.clone())
     }
 
     pub fn get_var(&self, var_id: VarId) -> &Variable {

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -3,7 +3,8 @@
 //! This enables you to assign `const`-constants and execute parse-time code dependent on this.
 //! e.g. `source $my_const`
 use crate::{
-    BlockId, Config, HistoryFileFormat, PipelineData, Record, ShellError, Span, Value, VarId,
+    BlockId, Config, HistoryFileFormat, HistoryPath, PipelineData, Record, ShellError, Span, Value,
+    VarId,
     ast::{Assignment, Block, Call, Expr, Expression, ExternalArgument},
     debugger::{DebugContext, WithoutDebug},
     engine::{EngineState, StateWorkingSet},
@@ -85,21 +86,33 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
 
     record.push(
         "history-path",
-        config_path.clone().map_or_else(
-            |e| e,
-            |mut path| {
-                match engine_state.config.history.file_format {
-                    HistoryFileFormat::Sqlite => {
-                        path.push("history.sqlite3");
-                    }
-                    HistoryFileFormat::Plaintext => {
-                        path.push("history.txt");
-                    }
-                }
-                let canon_hist_path = canonicalize_path(engine_state, &path);
+        match &engine_state.config.history.path {
+            HistoryPath::Disabled => Value::string("", span),
+            HistoryPath::Custom(custom_path) => {
+                let effective_path = if custom_path.is_dir() {
+                    custom_path.join(engine_state.config.history.file_format.default_file_name())
+                } else {
+                    custom_path.clone()
+                };
+                let canon_hist_path = canonicalize_path(engine_state, &effective_path);
                 Value::string(canon_hist_path.to_string_lossy(), span)
-            },
-        ),
+            }
+            HistoryPath::Default => config_path.clone().map_or_else(
+                |e| e,
+                |mut path| {
+                    match engine_state.config.history.file_format {
+                        HistoryFileFormat::Sqlite => {
+                            path.push("history.sqlite3");
+                        }
+                        HistoryFileFormat::Plaintext => {
+                            path.push("history.txt");
+                        }
+                    }
+                    let canon_hist_path = canonicalize_path(engine_state, &path);
+                    Value::string(canon_hist_path.to_string_lossy(), span)
+                },
+            ),
+        },
     );
 
     record.push(

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -64,6 +64,17 @@ $env.config.history.sync_on_enter = true
 # Default: false
 $env.config.history.isolation = false
 
+# history.path (string): Path to the history file.
+# If not set, Nushell will use the default location.
+# You can also provide a custom path for your history file.
+# Examples:
+# Use a custom location (e.g., in your home directory):
+$env.config.history.path = "~/custom/my-history.txt"
+# Default behavior:
+# If not set (null), Nushell stores history in the default config directory.
+# If set to a directory, the appropriate file name (e.g., history.txt) is used.
+# If set to a filename only, the file will be stored in $nu.default-config-dir.
+
 # ----------------------
 # Miscellaneous Settings
 # ----------------------

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -1,4 +1,5 @@
 use nu_path::{AbsolutePath, AbsolutePathBuf, Path};
+use nu_protocol::{HistoryConfig, HistoryFileFormat, HistoryPath};
 use nu_test_support::nu;
 use nu_test_support::playground::{Executable, Playground};
 use pretty_assertions::assert_eq;
@@ -314,4 +315,120 @@ fn commandstring_populates_config_record() {
     let actual = nu!(cmd);
 
     assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn history_config_disabled() {
+    let config = HistoryConfig {
+        path: HistoryPath::Disabled,
+        ..Default::default()
+    };
+
+    assert_eq!(config.file_path(), None);
+}
+
+#[test]
+fn history_path_disabled_null() {
+    Playground::setup("history_null", |_, playground| {
+        let config_path = playground.cwd().join("config.nu");
+        std::fs::write(&config_path, "$env.config.history.path = null").unwrap();
+
+        let actual = nu!(
+            cwd: playground.cwd(),
+            format!("nu --config '{}' -c '$nu.history-path'", config_path.to_string_lossy())
+        );
+
+        assert_eq!(actual.out, "");
+    });
+}
+
+#[test]
+fn history_path_custom_string() {
+    Playground::setup("history_custom", |_, playground| {
+        let custom_file = playground.cwd().join("my_history.txt");
+        let config_path = playground.cwd().join("config.nu");
+        std::fs::write(
+            &config_path,
+            format!(
+                "$env.config.history.path = '{}'",
+                custom_file.to_string_lossy()
+            ),
+        )
+        .unwrap();
+
+        let actual = nu!(
+            cwd: playground.cwd(),
+            format!("nu --config '{}' -c '$nu.history-path'", config_path.to_string_lossy())
+        );
+
+        assert_eq!(actual.out, custom_file.to_string_lossy().to_string());
+    });
+}
+
+#[test]
+fn history_config_default_path_plaintext() {
+    let config_dir = nu_path::nu_config_dir().unwrap();
+    let config = HistoryConfig {
+        path: HistoryPath::Default,
+        file_format: HistoryFileFormat::Plaintext,
+        ..Default::default()
+    };
+
+    let expected_path = config_dir.join("history.txt");
+    assert_eq!(config.file_path(), Some(expected_path.into()));
+}
+
+#[test]
+fn history_config_default_path_sqlite() {
+    let config_dir = nu_path::nu_config_dir().unwrap();
+    let config = HistoryConfig {
+        path: HistoryPath::Default,
+        file_format: HistoryFileFormat::Sqlite,
+        ..Default::default()
+    };
+
+    let expected_path = config_dir.join("history.sqlite3");
+    assert_eq!(config.file_path(), Some(expected_path.into()));
+}
+
+#[test]
+fn history_path_directory_appends_filename_plaintext() {
+    let dir = std::env::temp_dir();
+    let config = HistoryConfig {
+        path: HistoryPath::Custom(dir.clone()),
+        file_format: HistoryFileFormat::Plaintext,
+        ..Default::default()
+    };
+
+    assert_eq!(config.file_path(), Some(dir.join("history.txt")));
+}
+
+#[test]
+fn history_path_directory_appends_filename_sqlite() {
+    let dir = std::env::temp_dir();
+    let config = HistoryConfig {
+        path: HistoryPath::Custom(dir.clone()),
+        file_format: HistoryFileFormat::Sqlite,
+        ..Default::default()
+    };
+
+    assert_eq!(config.file_path(), Some(dir.join("history.sqlite3")));
+}
+
+#[test]
+fn history_path_default_shows_in_config() {
+    let actual = nu!(format!("nu --no-std-lib -n -c '$env.config.history.path'"));
+
+    assert_eq!(actual.out, "");
+}
+
+#[test]
+fn history_path_empty_string_means_default() {
+    let config = HistoryConfig {
+        path: HistoryPath::Default,
+        ..Default::default()
+    };
+    let config_dir = nu_path::nu_config_dir().unwrap();
+    let expected = config_dir.join("history.txt");
+    assert_eq!(config.file_path(), Some(expected.into()));
 }


### PR DESCRIPTION
Closes #17419

The PR adds support for configuring a custom history file path via `$env.config.history.path` in `config.nu`

## Release notes summary - What our users need to know
### History file path can now be configured
Nushell now supports configuring the history file path using `$env.config.history.path`. This value can be `null` or any custom location, which is particularly useful for TTY login scenarios where the `--no-history` flag cannot be used

```bash
$env.config.history.path = null  # disable history
$env.config.history.path = "/custom/history.txt"  # custom location
```

## Checks
- builds successfully with cargo build --release
- run `toolkit check pr` successfully
- manual testing: Setting $env.config.history.path = null prevents history file creation
- manual testing: Custom path works correctly