### PR TITLE
update assert_cmd to 2.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,13 +228,12 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.16"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
 dependencies = [
  "anstyle",
  "bstr",
- "doc-comment",
  "libc",
  "predicates",
  "predicates-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,7 +271,7 @@ nix = { workspace = true, default-features = false, features = [
 nu-test-support = { path = "./crates/nu-test-support", version = "0.110.1" }
 nu-plugin-protocol = { path = "./crates/nu-plugin-protocol", version = "0.110.1" }
 nu-plugin-core = { path = "./crates/nu-plugin-core", version = "0.110.1" }
-assert_cmd = "2.0"
+assert_cmd = "2.1.1"
 dirs = { workspace = true }
 tango-bench = "0.6"
 pretty_assertions = { workspace = true }

--- a/tests/integration/cli.rs
+++ b/tests/integration/cli.rs
@@ -1,11 +1,11 @@
-use assert_cmd::prelude::*;
+use assert_cmd::cargo_bin;
 use std::process::Command;
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 #[test]
 fn help_shows_usage() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd.arg("--help").output()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
 
@@ -18,7 +18,7 @@ fn help_shows_usage() -> TestResult {
 
 #[test]
 fn help_lists_all_flags() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd.arg("--help").output()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
 
@@ -74,7 +74,7 @@ fn help_lists_all_flags() -> TestResult {
 
 #[test]
 fn short_value_with_equals_runs() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-c=print 1"])
         .output()?;
@@ -88,7 +88,7 @@ fn short_value_with_equals_runs() -> TestResult {
 
 #[test]
 fn version_flag_prints_version() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd.arg("--version").output()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
 
@@ -100,7 +100,7 @@ fn version_flag_prints_version() -> TestResult {
 
 #[test]
 fn inline_short_value_is_rejected() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-cfoo"])
         .output()?;
@@ -114,7 +114,7 @@ fn inline_short_value_is_rejected() -> TestResult {
 
 #[test]
 fn unknown_flag_suggests_correction() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--comma"])
         .output()?;
@@ -128,7 +128,7 @@ fn unknown_flag_suggests_correction() -> TestResult {
 
 #[test]
 fn experimental_options_accepts_bracketed_list() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -147,7 +147,7 @@ fn experimental_options_accepts_bracketed_list() -> TestResult {
 
 #[test]
 fn experimental_options_accepts_comma_list() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -166,7 +166,7 @@ fn experimental_options_accepts_comma_list() -> TestResult {
 
 #[test]
 fn experimental_options_rejects_invalid_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -188,7 +188,7 @@ fn experimental_options_rejects_invalid_value() -> TestResult {
 
 #[test]
 fn experimental_options_missing_value_lists_modes() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--experimental-options"])
         .output()?;
@@ -202,7 +202,7 @@ fn experimental_options_missing_value_lists_modes() -> TestResult {
 
 #[test]
 fn table_mode_rejects_invalid_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--table-mode", "rounde"])
         .output()?;
@@ -217,7 +217,7 @@ fn table_mode_rejects_invalid_value() -> TestResult {
 
 #[test]
 fn table_mode_missing_value_lists_modes() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-m"])
         .output()?;
@@ -231,7 +231,7 @@ fn table_mode_missing_value_lists_modes() -> TestResult {
 
 #[test]
 fn table_mode_accepts_valid_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -250,7 +250,7 @@ fn table_mode_accepts_valid_value() -> TestResult {
 
 #[test]
 fn login_flag_runs() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-l", "-c", "print 1"])
         .output()?;
@@ -262,7 +262,7 @@ fn login_flag_runs() -> TestResult {
 
 #[test]
 fn config_flag_accepts_path() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--config", "missing.nu", "--no-std-lib", "-c", "print 1"])
         .output()?;
@@ -274,7 +274,7 @@ fn config_flag_accepts_path() -> TestResult {
 
 #[test]
 fn env_config_flag_accepts_path() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--env-config",
@@ -292,7 +292,7 @@ fn env_config_flag_accepts_path() -> TestResult {
 
 #[test]
 fn include_path_accepts_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -311,7 +311,7 @@ fn include_path_accepts_value() -> TestResult {
 
 #[test]
 fn execute_flag_accepts_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-e", "print 1"])
         .output()?;
@@ -325,7 +325,7 @@ fn execute_flag_accepts_value() -> TestResult {
 
 #[test]
 fn interactive_and_login_flags_run() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-il", "-c", "print 1"])
         .output()?;
@@ -337,7 +337,7 @@ fn interactive_and_login_flags_run() -> TestResult {
 
 #[test]
 fn no_newline_flag_suppresses_newline() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -358,7 +358,7 @@ fn no_newline_flag_suppresses_newline() -> TestResult {
 
 #[test]
 fn no_history_flag_runs() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-history", "--no-std-lib", "-c", "print 1"])
         .output()?;
@@ -370,7 +370,7 @@ fn no_history_flag_runs() -> TestResult {
 
 #[test]
 fn log_flags_accept_values() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -395,7 +395,7 @@ fn log_flags_accept_values() -> TestResult {
 
 #[test]
 fn log_level_rejects_invalid_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--log-level", "infos"])
         .output()?;
@@ -410,7 +410,7 @@ fn log_level_rejects_invalid_value() -> TestResult {
 
 #[test]
 fn log_target_rejects_invalid_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--log-target", "std"])
         .output()?;
@@ -425,7 +425,7 @@ fn log_target_rejects_invalid_value() -> TestResult {
 
 #[test]
 fn log_include_rejects_invalid_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -445,7 +445,7 @@ fn log_include_rejects_invalid_value() -> TestResult {
 
 #[test]
 fn log_exclude_rejects_invalid_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -465,7 +465,7 @@ fn log_exclude_rejects_invalid_value() -> TestResult {
 
 #[test]
 fn log_level_missing_value_lists_modes() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--log-level"])
         .output()?;
@@ -479,7 +479,7 @@ fn log_level_missing_value_lists_modes() -> TestResult {
 
 #[test]
 fn log_target_missing_value_lists_modes() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--log-target"])
         .output()?;
@@ -493,7 +493,7 @@ fn log_target_missing_value_lists_modes() -> TestResult {
 
 #[test]
 fn log_include_missing_value_lists_modes() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--log-include"])
         .output()?;
@@ -507,7 +507,7 @@ fn log_include_missing_value_lists_modes() -> TestResult {
 
 #[test]
 fn log_exclude_missing_value_lists_modes() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--log-exclude"])
         .output()?;
@@ -521,7 +521,7 @@ fn log_exclude_missing_value_lists_modes() -> TestResult {
 
 #[test]
 fn stdin_flag_runs() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -539,7 +539,7 @@ fn stdin_flag_runs() -> TestResult {
 
 #[test]
 fn testbin_flag_accepts_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--testbin", "cococo", "--no-std-lib", "-c", "print 1"])
         .output()?;
@@ -551,7 +551,7 @@ fn testbin_flag_accepts_value() -> TestResult {
 
 #[test]
 fn testbin_rejects_invalid_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--testbin", "cocooo"])
         .output()?;
@@ -566,7 +566,7 @@ fn testbin_rejects_invalid_value() -> TestResult {
 
 #[test]
 fn testbin_missing_value_lists_modes() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--testbin"])
         .output()?;
@@ -580,7 +580,7 @@ fn testbin_missing_value_lists_modes() -> TestResult {
 
 #[test]
 fn error_style_flag_accepts_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -599,7 +599,7 @@ fn error_style_flag_accepts_value() -> TestResult {
 
 #[test]
 fn error_style_rejects_invalid_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--error-style", "fanc"])
         .output()?;
@@ -614,7 +614,7 @@ fn error_style_rejects_invalid_value() -> TestResult {
 
 #[test]
 fn error_style_missing_value_lists_modes() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--error-style"])
         .output()?;
@@ -628,7 +628,7 @@ fn error_style_missing_value_lists_modes() -> TestResult {
 
 #[test]
 fn ide_flags_accept_values() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -653,7 +653,7 @@ fn ide_flags_accept_values() -> TestResult {
 
 #[test]
 fn ide_ast_flag_runs() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -671,7 +671,7 @@ fn ide_ast_flag_runs() -> TestResult {
 
 #[test]
 fn lsp_flag_accepts_run() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--lsp"])
         .output()?;
@@ -687,7 +687,7 @@ fn lsp_flag_accepts_run() -> TestResult {
 fn mcp_flag_runs_when_enabled() -> TestResult {
     #[cfg(feature = "mcp")]
     {
-        let mut cmd = Command::cargo_bin("nu")?;
+        let mut cmd = Command::new(cargo_bin!());
         let output = cmd
             .args(["--no-config-file", "--no-std-lib", "--mcp"])
             .output()?;
@@ -702,7 +702,7 @@ fn mcp_flag_runs_when_enabled() -> TestResult {
 fn plugin_flags_accept_paths_when_enabled() -> TestResult {
     #[cfg(feature = "plugin")]
     {
-        let mut cmd = Command::cargo_bin("nu")?;
+        let mut cmd = Command::new(cargo_bin!());
         let output = cmd
             .args([
                 "--plugin-config",
@@ -725,7 +725,7 @@ fn plugin_flags_accept_paths_when_enabled() -> TestResult {
 fn plugins_requires_absolute_paths() -> TestResult {
     #[cfg(feature = "plugin")]
     {
-        let mut cmd = Command::cargo_bin("nu")?;
+        let mut cmd = Command::new(cargo_bin!());
         let output = cmd
             .args([
                 "--no-config-file",
@@ -745,7 +745,7 @@ fn plugins_requires_absolute_paths() -> TestResult {
 
 #[test]
 fn login_shell_sets_dash_name() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd.arg("-c").arg("print 1").output()?;
 
     assert!(output.status.success());
@@ -755,7 +755,7 @@ fn login_shell_sets_dash_name() -> TestResult {
 
 #[test]
 fn double_dash_preserves_script_args() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd.args(["--help", "--", "--flag", "value"]).output()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
 
@@ -768,7 +768,7 @@ fn double_dash_preserves_script_args() -> TestResult {
 // Tests for --log-include with various formats
 #[test]
 fn log_include_accepts_single_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -786,7 +786,7 @@ fn log_include_accepts_single_value() -> TestResult {
 
 #[test]
 fn log_include_accepts_multiple_values_space_separated() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -805,7 +805,7 @@ fn log_include_accepts_multiple_values_space_separated() -> TestResult {
 
 #[test]
 fn log_include_accepts_comma_separated_no_brackets() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -823,7 +823,7 @@ fn log_include_accepts_comma_separated_no_brackets() -> TestResult {
 
 #[test]
 fn log_include_accepts_comma_separated_with_spaces() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -841,7 +841,7 @@ fn log_include_accepts_comma_separated_with_spaces() -> TestResult {
 
 #[test]
 fn log_include_accepts_bracketed_list() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -859,7 +859,7 @@ fn log_include_accepts_bracketed_list() -> TestResult {
 
 #[test]
 fn log_include_accepts_bracketed_list_with_spaces() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -877,7 +877,7 @@ fn log_include_accepts_bracketed_list_with_spaces() -> TestResult {
 
 #[test]
 fn log_include_rejects_invalid_level() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -898,7 +898,7 @@ fn log_include_rejects_invalid_level() -> TestResult {
 // Tests for --log-exclude with various formats
 #[test]
 fn log_exclude_accepts_single_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -916,7 +916,7 @@ fn log_exclude_accepts_single_value() -> TestResult {
 
 #[test]
 fn log_exclude_accepts_multiple_values_space_separated() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -935,7 +935,7 @@ fn log_exclude_accepts_multiple_values_space_separated() -> TestResult {
 
 #[test]
 fn log_exclude_accepts_comma_separated() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -953,7 +953,7 @@ fn log_exclude_accepts_comma_separated() -> TestResult {
 
 #[test]
 fn log_exclude_accepts_bracketed_list() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -971,7 +971,7 @@ fn log_exclude_accepts_bracketed_list() -> TestResult {
 
 #[test]
 fn log_exclude_rejects_invalid_level() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -992,7 +992,7 @@ fn log_exclude_rejects_invalid_level() -> TestResult {
 // Additional test for --experimental-options to test the specific case from the regression
 #[test]
 fn experimental_options_accepts_unquoted_bracketed_multivalue() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -1013,7 +1013,7 @@ fn experimental_options_accepts_unquoted_bracketed_multivalue() -> TestResult {
 
 #[test]
 fn experimental_options_accepts_all() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -1033,7 +1033,7 @@ fn experimental_options_accepts_all() -> TestResult {
 
 #[test]
 fn parses_combined_shorts_with_value_last() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-ilc", "print 1"])
         .output()?;
@@ -1044,7 +1044,7 @@ fn parses_combined_shorts_with_value_last() -> TestResult {
 
 #[test]
 fn accepts_combined_shorts_without_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-il", "-c", "print 1"])
         .output()?;
@@ -1055,7 +1055,7 @@ fn accepts_combined_shorts_without_value() -> TestResult {
 
 #[test]
 fn accepts_split_shorts_for_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -1073,7 +1073,7 @@ fn accepts_split_shorts_for_value() -> TestResult {
 
 #[test]
 fn accepts_group_then_value_flag() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-il", "-c", "print 1"])
         .output()?;
@@ -1084,7 +1084,7 @@ fn accepts_group_then_value_flag() -> TestResult {
 
 #[test]
 fn accepts_group_then_value_flag_with_equals() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-il", "-c=print 1"])
         .output()?;
@@ -1095,7 +1095,7 @@ fn accepts_group_then_value_flag_with_equals() -> TestResult {
 
 #[test]
 fn missing_table_mode_lists_values() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-m"])
         .output()?;
@@ -1108,7 +1108,7 @@ fn missing_table_mode_lists_values() -> TestResult {
 
 #[test]
 fn missing_error_style_lists_values() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--error-style"])
         .output()?;
@@ -1121,7 +1121,7 @@ fn missing_error_style_lists_values() -> TestResult {
 
 #[test]
 fn missing_testbin_lists_values() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--testbin"])
         .output()?;
@@ -1134,7 +1134,7 @@ fn missing_testbin_lists_values() -> TestResult {
 
 #[test]
 fn rejects_invalid_testbin_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -1154,7 +1154,7 @@ fn rejects_invalid_testbin_value() -> TestResult {
 
 #[test]
 fn missing_log_level_lists_values() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--log-level"])
         .output()?;
@@ -1167,7 +1167,7 @@ fn missing_log_level_lists_values() -> TestResult {
 
 #[test]
 fn missing_log_target_lists_values() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--log-target"])
         .output()?;
@@ -1180,7 +1180,7 @@ fn missing_log_target_lists_values() -> TestResult {
 
 #[test]
 fn rejects_value_flag_not_last() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-cil"])
         .output()?;
@@ -1193,7 +1193,7 @@ fn rejects_value_flag_not_last() -> TestResult {
 
 #[test]
 fn rejects_inline_short_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-cfoo"])
         .output()?;
@@ -1206,7 +1206,7 @@ fn rejects_inline_short_value() -> TestResult {
 
 #[test]
 fn rejects_combined_inline_short_value() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-abcfoo"])
         .output()?;
@@ -1219,7 +1219,7 @@ fn rejects_combined_inline_short_value() -> TestResult {
 
 #[test]
 fn accepts_short_value_with_equals() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-c=print 1"])
         .output()?;
@@ -1230,7 +1230,7 @@ fn accepts_short_value_with_equals() -> TestResult {
 
 #[test]
 fn suggests_unknown_flags() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "--comma", "ls"])
         .output()?;
@@ -1249,7 +1249,7 @@ fn suggests_unknown_flags() -> TestResult {
 // Tests for --no-config-file flag
 #[test]
 fn no_config_file_flag_prevents_config_loading() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-c", "print 'ok'"])
         .output()?;
@@ -1262,7 +1262,7 @@ fn no_config_file_flag_prevents_config_loading() -> TestResult {
 
 #[test]
 fn no_config_file_short_flag_works() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["-n", "--no-std-lib", "-c", "print 'ok'"])
         .output()?;
@@ -1276,7 +1276,7 @@ fn no_config_file_short_flag_works() -> TestResult {
 // Tests for --no-std-lib flag
 #[test]
 fn no_std_lib_flag_prevents_std_loading() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-c", "print 'ok'"])
         .output()?;
@@ -1290,7 +1290,7 @@ fn no_std_lib_flag_prevents_std_loading() -> TestResult {
 // Tests for --include-path with various formats
 #[test]
 fn include_path_accepts_single_path() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -1310,7 +1310,7 @@ fn include_path_accepts_single_path() -> TestResult {
 
 #[test]
 fn include_path_short_flag_works() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -1330,7 +1330,7 @@ fn include_path_short_flag_works() -> TestResult {
 
 #[test]
 fn include_path_accepts_multiple_paths_separated() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let paths = format!(".{sep}tests", sep = '\x1e');
     let output = cmd
         .args([
@@ -1352,7 +1352,7 @@ fn include_path_accepts_multiple_paths_separated() -> TestResult {
 // Tests for --no-newline with commands
 #[test]
 fn no_newline_with_commands_suppresses_final_newline() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -1374,7 +1374,7 @@ fn no_newline_with_commands_suppresses_final_newline() -> TestResult {
 
 #[test]
 fn no_newline_only_affects_result_not_print() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -1403,7 +1403,7 @@ fn script_can_receive_arguments() -> TestResult {
     // We'll use a simple script that just works
     std::fs::write(&script_path, "# This is a test script\nprint 'script ran'")?;
 
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -1427,7 +1427,7 @@ fn script_path_can_have_args_after_it() -> TestResult {
 
     std::fs::write(&script_path, "print 'ok'")?;
 
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -1453,7 +1453,7 @@ fn script_with_nu_flags_before_script_name() -> TestResult {
 
     std::fs::write(&script_path, "print 'flags work'")?;
 
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-config-file",
@@ -1475,7 +1475,7 @@ fn script_with_nu_flags_before_script_name() -> TestResult {
 // Tests for combined flags with scripts
 #[test]
 fn combined_short_flags_work_with_commands() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd.args(["-nc", "print 'ok'"]).output()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
 
@@ -1508,7 +1508,7 @@ fn table_mode_accepts_all_valid_modes() -> TestResult {
     ];
 
     for mode in modes {
-        let mut cmd = Command::cargo_bin("nu")?;
+        let mut cmd = Command::new(cargo_bin!());
         let output = cmd
             .args([
                 "--no-config-file",
@@ -1532,7 +1532,7 @@ fn error_style_accepts_all_valid_styles() -> TestResult {
     let styles = ["fancy", "plain", "short"];
 
     for style in styles {
-        let mut cmd = Command::cargo_bin("nu")?;
+        let mut cmd = Command::new(cargo_bin!());
         let output = cmd
             .args([
                 "--no-config-file",
@@ -1556,7 +1556,7 @@ fn log_level_accepts_all_valid_levels() -> TestResult {
     let levels = ["error", "warn", "info", "debug", "trace"];
 
     for level in levels {
-        let mut cmd = Command::cargo_bin("nu")?;
+        let mut cmd = Command::new(cargo_bin!());
         let output = cmd
             .args([
                 "--no-config-file",
@@ -1582,7 +1582,7 @@ fn log_target_accepts_all_valid_targets() -> TestResult {
     let targets = ["stdout", "stderr", "mixed"];
 
     for target in targets {
-        let mut cmd = Command::cargo_bin("nu")?;
+        let mut cmd = Command::new(cargo_bin!());
         let output = cmd
             .args([
                 "--no-config-file",
@@ -1603,7 +1603,7 @@ fn log_target_accepts_all_valid_targets() -> TestResult {
 // Test combining multiple flags in different orders
 #[test]
 fn multiple_flags_in_various_orders_work() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args([
             "--no-std-lib",
@@ -1626,7 +1626,7 @@ fn multiple_flags_in_various_orders_work() -> TestResult {
 // Test that --commands and --execute are mutually exclusive behaviors
 #[test]
 fn commands_flag_exits_after_execution() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let output = cmd
         .args(["--no-config-file", "--no-std-lib", "-c", "print 'test'"])
         .output()?;
@@ -1640,7 +1640,7 @@ fn commands_flag_exits_after_execution() -> TestResult {
 // Test stdin flag with piped input
 #[test]
 fn stdin_flag_with_commands_receives_input() -> TestResult {
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     let mut child = cmd
         .args(["--no-config-file", "--no-std-lib", "--stdin", "-c", "$in"])
         .stdin(std::process::Stdio::piped())

--- a/tests/repl/tests.rs
+++ b/tests/repl/tests.rs
@@ -1,4 +1,4 @@
-use assert_cmd::prelude::*;
+use assert_cmd::cargo_bin;
 use pretty_assertions::assert_eq;
 use std::collections::HashMap;
 use std::io::Write;
@@ -11,7 +11,7 @@ pub fn run_test_with_env(input: &str, expected: &str, env: &HashMap<&str, &str>)
     let mut file = NamedTempFile::new()?;
     let name = file.path();
 
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     cmd.arg("--no-config-file");
     cmd.arg(name).envs(env);
 
@@ -25,7 +25,7 @@ pub fn run_test(input: &str, expected: &str) -> TestResult {
     let mut file = NamedTempFile::new()?;
     let name = file.path();
 
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     cmd.arg("--no-std-lib");
     cmd.arg("--no-config-file");
     cmd.arg(name);
@@ -44,7 +44,7 @@ pub fn run_test_std(input: &str, expected: &str) -> TestResult {
     let mut file = NamedTempFile::new()?;
     let name = file.path();
 
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     cmd.arg("--no-config-file");
     cmd.arg(name);
     cmd.env(
@@ -79,7 +79,7 @@ pub fn run_test_contains(input: &str, expected: &str) -> TestResult {
     let mut file = NamedTempFile::new()?;
     let name = file.path();
 
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     cmd.arg("--no-std-lib");
     cmd.arg("--no-config-file");
     cmd.arg(name);
@@ -107,7 +107,7 @@ pub fn test_ide_contains(input: &str, ide_commands: &[&str], expected: &str) -> 
     let mut file = NamedTempFile::new()?;
     let name = file.path();
 
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     cmd.arg("--no-std-lib");
     cmd.arg("--no-config-file");
     for ide_command in ide_commands {
@@ -138,7 +138,7 @@ pub fn fail_test(input: &str, expected: &str) -> TestResult {
     let mut file = NamedTempFile::new()?;
     let name = file.path();
 
-    let mut cmd = Command::cargo_bin("nu")?;
+    let mut cmd = Command::new(cargo_bin!());
     cmd.arg("--no-std-lib");
     cmd.arg("--no-config-file");
     cmd.arg(name);


### PR DESCRIPTION
As title, assert_cmd deprecates the usage of `Command::cargo_bin("nu")`, we should use `Command::new(cargo_bin!())` instead

## Release notes summary - What our users need to know
NaN

## Tasks after submitting
NaN
