### PR TITLE
fix(http): apply TLS certificate verification to connection pool

### DIFF
--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -233,7 +233,7 @@ fn helper(
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
     let mut request = if args.pool {
-        http_client_pool(engine_state, stack).delete(&requested_url)
+        http_client_pool(engine_state, stack)?.delete(&requested_url)
     } else {
         let client = http_client(
             args.insecure,

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -208,7 +208,7 @@ fn helper(
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
     let mut request = if args.pool {
-        http_client_pool(engine_state, stack).get(&requested_url)
+        http_client_pool(engine_state, stack)?.get(&requested_url)
     } else {
         let client = http_client(
             args.insecure,

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -173,7 +173,7 @@ fn helper(
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
     let mut request = if args.pool {
-        http_client_pool(engine_state, stack).head(&requested_url)
+        http_client_pool(engine_state, stack)?.head(&requested_url)
     } else {
         let client = http_client(
             args.insecure,

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -168,7 +168,7 @@ fn helper(
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
     let mut request = if args.pool {
-        http_client_pool(engine_state, stack).options(&requested_url)
+        http_client_pool(engine_state, stack)?.options(&requested_url)
     } else {
         let client = http_client(
             args.insecure,

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -234,7 +234,7 @@ fn helper(
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
     let mut request = if args.pool {
-        http_client_pool(engine_state, stack).patch(&requested_url)
+        http_client_pool(engine_state, stack)?.patch(&requested_url)
     } else {
         let client = http_client(
             args.insecure,

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -258,7 +258,7 @@ fn helper(
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
     let mut request = if args.pool {
-        http_client_pool(engine_state, stack).post(&requested_url)
+        http_client_pool(engine_state, stack)?.post(&requested_url)
     } else {
         let client = http_client(
             args.insecure,

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -239,7 +239,7 @@ fn helper(
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
     let mut request = if args.pool {
-        http_client_pool(engine_state, stack).put(&requested_url)
+        http_client_pool(engine_state, stack)?.put(&requested_url)
     } else {
         let client = http_client(
             args.insecure,


### PR DESCRIPTION
## Description

The `http_client_pool()` function was missing TLS configuration, causing pooled HTTPS connections (via `--pool` flag) to not verify certificates. This fix aligns the pooled client behavior with the regular `http_client()` which properly applies `tls_config()`.

Changes:
- Adds `tls_config(false)` to enable certificate verification by default
- Changes return type to `Result<Arc<Agent>, ShellError>` to handle potential TLS initialization errors
- Updates all call sites to propagate errors with `?`

**Background:** I asked Claude to review the nushell HTTP code. It identified this inconsistency and implemented the fix. I don't have deep Rust expertise, so I'd appreciate review from maintainers familiar with this area.

## User-Facing Changes

Users of `http get --pool`, `http post --pool`, etc. will now have TLS certificate verification enabled by default, matching the behavior of non-pooled requests.

## Tests + Formatting

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` passes

## After Submitting

N/A

---

## Release notes summary

Fixed an inconsistency where `http` commands with `--pool` flag were not applying TLS certificate verification. Pooled HTTPS connections now properly validate certificates, matching the behavior of regular (non-pooled) requests.
