### PR TITLE
Improve help text in nu-cmd-lang (core commands)

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/alias.rs
@@ -50,7 +50,7 @@ impl Command for Alias {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Alias ll to ls -l",
+            description: "Alias ll to ls -l.",
             example: "alias ll = ls -l",
             result: Some(Value::nothing(Span::test_data())),
         }]

--- a/crates/nu-cmd-lang/src/core_commands/attr/category.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/category.rs
@@ -51,7 +51,7 @@ impl Command for AttrCategory {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Add a category to a custom command",
+            description: "Add a category to a custom command.",
             example: r###"# Double numbers
     @category math
     def double []: [number -> number] { $in * 2 }"###,

--- a/crates/nu-cmd-lang/src/core_commands/attr/complete.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/complete.rs
@@ -51,7 +51,7 @@ impl Command for AttrComplete {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Use another command as completion source",
+            description: "Use another command as completion source.",
             example: "\
                 def complete-foo [spans: list<string>] {\n    \
                     [bar baz qux spam eggs] | where $it not-in $spans\n\
@@ -112,7 +112,7 @@ impl Command for AttrCompleteExternal {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Use the external completer for a wrapper command",
+            description: "Use the external completer for a wrapper command.",
             example: "\
                 @complete external\n\
                 def --wrapped jc [...args] {\n    \

--- a/crates/nu-cmd-lang/src/core_commands/attr/deprecated.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/deprecated.rs
@@ -88,13 +88,13 @@ impl Command for AttrDeprecated {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Add a deprecation warning to a custom command",
+                description: "Add a deprecation warning to a custom command.",
                 example: r###"@deprecated
     def outdated [] {}"###,
                 result: Some(Value::nothing(Span::test_data())),
             },
             Example {
-                description: "Add a deprecation warning with a custom message",
+                description: "Add a deprecation warning with a custom message.",
                 example: r###"@deprecated "Use my-new-command instead."
     @category deprecated
     def my-old-command [] {}"###,

--- a/crates/nu-cmd-lang/src/core_commands/attr/example.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/example.rs
@@ -114,7 +114,7 @@ impl Command for AttrExample {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Add examples to custom command",
+            description: "Add examples to custom command.",
             example: r###"# Double numbers
     @example "double an int" { 2 | double } --result 4
     @example "double a float" { 0.25 | double } --result 0.5

--- a/crates/nu-cmd-lang/src/core_commands/attr/search_terms.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/search_terms.rs
@@ -47,7 +47,7 @@ impl Command for AttrSearchTerms {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Add search terms to a custom command",
+            description: "Add search terms to a custom command.",
             example: r###"# Double numbers
     @search-terms multiply times
     def double []: [number -> number] { $in * 2 }"###,

--- a/crates/nu-cmd-lang/src/core_commands/break_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/break_.rs
@@ -47,7 +47,7 @@ impl Command for Break {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Break out of a loop",
+            description: "Break out of a loop.",
             example: r#"loop { break }"#,
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/collect.rs
+++ b/crates/nu-cmd-lang/src/core_commands/collect.rs
@@ -96,12 +96,12 @@ is particularly large, this can cause high memory usage."#
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Use the second value in the stream",
+                description: "Use the second value in the stream.",
                 example: "[1 2 3] | collect { |x| $x.1 }",
                 result: Some(Value::test_int(2)),
             },
             Example {
-                description: "Read and write to the same file",
+                description: "Read and write to the same file.",
                 example: "open file.txt | collect | save -f file.txt",
                 result: None,
             },

--- a/crates/nu-cmd-lang/src/core_commands/const_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/const_.rs
@@ -17,7 +17,11 @@ impl Command for Const {
         Signature::build("const")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("const_name", SyntaxShape::VarWithOptType, "Constant name.")
+            .required(
+                "const_name",
+                SyntaxShape::VarWithOptType,
+                "The constant name to create.",
+            )
             .required(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
@@ -75,7 +79,7 @@ impl Command for Const {
                 result: None,
             },
             Example {
-                description: "Create a composite constant value",
+                description: "Create a composite constant value.",
                 example: "const x = { a: 10, b: 20 }",
                 result: None,
             },

--- a/crates/nu-cmd-lang/src/core_commands/continue_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/continue_.rs
@@ -46,7 +46,7 @@ impl Command for Continue {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Continue a loop from the next iteration",
+            description: "Continue a loop from the next iteration.",
             example: r#"for i in 1..10 { if $i == 5 { continue }; print $i }"#,
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -16,11 +16,11 @@ impl Command for Def {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("def")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("def_name", SyntaxShape::String, "Command name.")
-            .required("params", SyntaxShape::Signature, "Parameters.")
-            .required("block", SyntaxShape::Closure(None), "Body of the definition.")
-            .switch("env", "keep the environment defined inside the command", None)
-            .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
+            .required("def_name", SyntaxShape::String, "The command name to define.")
+            .required("params", SyntaxShape::Signature, "The command parameters, a comma-separated list inside [].")
+            .required("block", SyntaxShape::Closure(None), "The body of the command, a list of instructions inside {}.")
+            .switch("env", "Keep the environment defined inside the command.", None)
+            .switch("wrapped", "Treat unknown flags and arguments as strings (requires ...rest-like parameter in signature).", None)
             .category(Category::Core)
     }
 
@@ -46,32 +46,32 @@ impl Command for Def {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Define a command and run it",
+                description: "Define a command and run it.",
                 example: r#"def say-hi [] { echo 'hi' }; say-hi"#,
                 result: Some(Value::test_string("hi")),
             },
             Example {
-                description: "Define a command and run it with parameter(s)",
+                description: "Define a command and run it with parameter(s).",
                 example: r#"def say-sth [sth: string] { echo $sth }; say-sth hi"#,
                 result: Some(Value::test_string("hi")),
             },
             Example {
-                description: "Set environment variable by call a custom command",
+                description: "Set environment variable by call a custom command.",
                 example: r#"def --env foo [] { $env.BAR = "BAZ" }; foo; $env.BAR"#,
                 result: Some(Value::test_string("BAZ")),
             },
             Example {
-                description: "cd affects the environment, so '--env' is required to change directory from within a command",
+                description: "cd affects the environment, so '--env' is required to change directory from within a command.",
                 example: r#"def --env gohome [] { cd ~ }; gohome; $env.PWD == ('~' | path expand)"#,
                 result: Some(Value::test_string("true")),
             },
             Example {
-                description: "Define a custom wrapper for an external command",
+                description: "Define a custom wrapper for an external command.",
                 example: r#"def --wrapped my-echo [...rest] { ^echo ...$rest }; my-echo -e 'spam\tspam'"#,
                 result: Some(Value::test_string("spam\tspam")),
             },
             Example {
-                description: "Define a custom command with a type signature. Passing a non-int value will result in an error",
+                description: "Define a custom command with a type signature. Passing a non-int value will result in an error.",
                 example: r#"def only_int []: int -> int { $in }; 42 | only_int"#,
                 result: Some(Value::test_int(42)),
             },

--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -66,12 +66,12 @@ impl Command for Describe {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Describe the type of a string",
+                description: "Describe the type of a string.",
                 example: "'hello' | describe",
                 result: Some(Value::test_string("string")),
             },
             Example {
-                description: "Describe the type of a record in a detailed way",
+                description: "Describe the type of a record in a detailed way.",
                 example: "{shell:'true', uwu:true, features: {bugs:false, multiplatform:true, speed: 10}, fib: [1 1 2 3 5 8], on_save: {|x| $'Saving ($x)'}, first_commit: 2019-05-10, my_duration: (4min + 20sec)} | describe -d",
                 result: Some(Value::test_record(record!(
                     "type" => Value::test_string("record"),
@@ -188,7 +188,7 @@ impl Command for Describe {
                 ))),
             },
             Example {
-                description: "Describe the type of a stream with detailed information",
+                description: "Describe the type of a stream with detailed information.",
                 example: "[1 2 3] | each {|i| echo $i} | describe -d",
                 result: None, // Give "Running external commands not supported" error
                               // result: Some(Value::test_record(record!(
@@ -206,13 +206,13 @@ impl Command for Describe {
                               // ))),
             },
             Example {
-                description: "Describe a stream of data, collecting it first",
+                description: "Describe a stream of data, collecting it first.",
                 example: "[1 2 3] | each {|i| echo $i} | describe",
                 result: None, // Give "Running external commands not supported" error
                               // result: Some(Value::test_string("list<int> (stream)")),
             },
             Example {
-                description: "Describe the input but do not collect streams",
+                description: "Describe the input but do not collect streams.",
                 example: "[1 2 3] | each {|i| echo $i} | describe --no-collect",
                 result: None, // Give "Running external commands not supported" error
                               // result: Some(Value::test_string("stream")),

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -199,47 +199,47 @@ impl Command for Do {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Run the closure",
+                description: "Run the closure.",
                 example: r#"do { echo hello }"#,
                 result: Some(Value::test_string("hello")),
             },
             Example {
-                description: "Run a stored first-class closure",
+                description: "Run a stored first-class closure.",
                 example: r#"let text = "I am enclosed"; let hello = {|| echo $text}; do $hello"#,
                 result: Some(Value::test_string("I am enclosed")),
             },
             Example {
-                description: "Run the closure and ignore both shell and external program errors",
+                description: "Run the closure and ignore both shell and external program errors.",
                 example: r#"do --ignore-errors { thisisnotarealcommand }"#,
                 result: None,
             },
             Example {
-                description: "Abort the pipeline if a program returns a non-zero exit code",
+                description: "Abort the pipeline if a program returns a non-zero exit code.",
                 example: r#"do --capture-errors { nu --commands 'exit 1' } | myscarycommand"#,
                 result: None,
             },
             Example {
-                description: "Run the closure with a positional, type-checked parameter",
+                description: "Run the closure with a positional, type-checked parameter.",
                 example: r#"do {|x:int| 100 + $x } 77"#,
                 result: Some(Value::test_int(177)),
             },
             Example {
-                description: "Run the closure with pipeline input",
+                description: "Run the closure with pipeline input.",
                 example: r#"77 | do { 100 + $in }"#,
                 result: Some(Value::test_int(177)),
             },
             Example {
-                description: "Run the closure with a default parameter value",
+                description: "Run the closure with a default parameter value.",
                 example: r#"77 | do {|x=100| $x + $in }"#,
                 result: Some(Value::test_int(177)),
             },
             Example {
-                description: "Run the closure with two positional parameters",
+                description: "Run the closure with two positional parameters.",
                 example: r#"do {|x,y| $x + $y } 77 100"#,
                 result: Some(Value::test_int(177)),
             },
             Example {
-                description: "Run the closure and keep changes to the environment",
+                description: "Run the closure and keep changes to the environment.",
                 example: r#"do --env { $env.foo = 'bar' }; $env.foo"#,
                 result: Some(Value::test_string("bar")),
             },

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -18,7 +18,7 @@ impl Command for ErrorMake {
                 SyntaxShape::OneOf(vec![SyntaxShape::Record(vec![]), SyntaxShape::String]),
                 "The error to create.",
             )
-            .switch("unspanned", "remove the labels from the error", Some('u'))
+            .switch("unspanned", "Remove the labels from the error.", Some('u'))
     }
 
     fn description(&self) -> &str {
@@ -67,22 +67,22 @@ the most recent `error make`."
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Create a simple, default error",
+                description: "Create a simple, default error.",
                 example: "error make",
                 result: None,
             },
             Example {
-                description: "Create a simple error from a string",
+                description: "Create a simple error from a string.",
                 example: "error make 'my error message'",
                 result: None,
             },
             Example {
-                description: "Create a simple error from an `error_struct` record",
+                description: "Create a simple error from an `error_struct` record.",
                 example: "error make {msg: 'my error message'}",
                 result: None,
             },
             Example {
-                description: "A complex error utilizing spans and inners",
+                description: "A complex error utilizing spans and inners.",
                 example: r#"def foo [x: int, y: int] {
         let z = $x + $y
         error make {
@@ -100,12 +100,12 @@ the most recent `error make`."
                 result: None,
             },
             Example {
-                description: "Chain errors using a pipeline",
+                description: "Chain errors using a pipeline.",
                 example: r#"try {error make "foo"} catch {error make "bar"}"#,
                 result: None,
             },
             Example {
-                description: "Chain errors using arguments (note the extra command in `catch`)",
+                description: "Chain errors using arguments (note the extra command in `catch`).",
                 example: r#"try {
         error make "foo"
     } catch {|err|

--- a/crates/nu-cmd-lang/src/core_commands/export.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export.rs
@@ -40,7 +40,7 @@ impl Command for ExportCommand {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Export a definition from a module",
+            description: "Export a definition from a module.",
             example: r#"module utils { export def my-command [] { "hello" } }; use utils my-command; my-command"#,
             result: Some(Value::test_string("hello")),
         }]

--- a/crates/nu-cmd-lang/src/core_commands/export_alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_alias.rs
@@ -50,7 +50,7 @@ impl Command for ExportAlias {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Alias ll to ls -l and export it from a module",
+            description: "Alias ll to ls -l and export it from a module.",
             example: "module spam { export alias ll = ls -l }",
             result: Some(Value::nothing(Span::test_data())),
         }]

--- a/crates/nu-cmd-lang/src/core_commands/export_const.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_const.rs
@@ -17,7 +17,11 @@ impl Command for ExportConst {
         Signature::build("export const")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("const_name", SyntaxShape::VarWithOptType, "Constant name.")
+            .required(
+                "const_name",
+                SyntaxShape::VarWithOptType,
+                "The constant name to create and export.",
+            )
             .required(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
@@ -47,7 +51,7 @@ impl Command for ExportConst {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Re-export a command from another module",
+            description: "Re-export a constant from another module.",
             example: r#"module spam { export const foo = 3; }
     module eggs { export use spam foo }
     use eggs foo

--- a/crates/nu-cmd-lang/src/core_commands/export_def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_def.rs
@@ -16,11 +16,11 @@ impl Command for ExportDef {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export def")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("def_name", SyntaxShape::String, "Command name.")
-            .required("params", SyntaxShape::Signature, "Parameters.")
-            .required("block", SyntaxShape::Block, "Body of the definition.")
-            .switch("env", "keep the environment defined inside the command", None)
-            .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
+            .required("def_name", SyntaxShape::String, "Command name to define.")
+            .required("params", SyntaxShape::Signature, "Command parameters: comma-separated list inside [].")
+            .required("block", SyntaxShape::Block, "Command body: list of instructions inside {}.")
+            .switch("env", "Environment: defined inside the command.", None)
+            .switch("wrapped", "Unknown flags and arguments: strings that require rest-like parameter in signature.", None)
             .category(Category::Core)
     }
 
@@ -45,7 +45,7 @@ impl Command for ExportDef {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Define a custom command in a module and call it",
+            description: "Define a custom command in a module and call it.",
             example: r#"module spam { export def foo [] { "foo" } }; use spam foo; foo"#,
             result: Some(Value::test_string("foo")),
         }]

--- a/crates/nu-cmd-lang/src/core_commands/export_extern.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_extern.rs
@@ -16,8 +16,16 @@ impl Command for ExportExtern {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export extern")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("def_name", SyntaxShape::String, "Definition name.")
-            .required("params", SyntaxShape::Signature, "Parameters.")
+            .required(
+                "def_name",
+                SyntaxShape::String,
+                "The name of the external command signature to define and export.",
+            )
+            .required(
+                "params",
+                SyntaxShape::Signature,
+                "The parameters for the external command signature.",
+            )
             .category(Category::Core)
     }
 
@@ -42,7 +50,7 @@ impl Command for ExportExtern {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Export the signature for an external command",
+            description: "Export the signature for an external command.",
             example: r#"export extern echo [text: string]"#,
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/export_module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_module.rs
@@ -47,7 +47,7 @@ impl Command for ExportModule {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Define a custom command in a submodule of a module and call it",
+            description: "Define a custom command in a submodule of a module and call it.",
             example: r#"module spam {
         export module eggs {
             export def foo [] { "foo" }

--- a/crates/nu-cmd-lang/src/core_commands/export_use.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_use.rs
@@ -156,7 +156,7 @@ impl Command for ExportUse {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Re-export a command from another module",
+            description: "Re-export a command from another module.",
             example: r#"module spam { export def foo [] { "foo" } }
     module eggs { export use spam foo }
     use eggs foo

--- a/crates/nu-cmd-lang/src/core_commands/extern_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/extern_.rs
@@ -16,8 +16,16 @@ impl Command for Extern {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("extern")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("def_name", SyntaxShape::String, "Definition name.")
-            .required("params", SyntaxShape::Signature, "Parameters.")
+            .required(
+                "def_name",
+                SyntaxShape::String,
+                "The name of the external command signature to define.",
+            )
+            .required(
+                "params",
+                SyntaxShape::Signature,
+                "The parameters for the external command signature.",
+            )
             .category(Category::Core)
     }
 
@@ -42,7 +50,7 @@ impl Command for Extern {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Write a signature for an external command",
+            description: "Write a signature for an external command.",
             example: r#"extern echo [text: string]"#,
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -58,17 +58,17 @@ impl Command for For {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Print the square of each integer",
+                description: "Print the square of each integer.",
                 example: "for x in [1 2 3] { print ($x * $x) }",
                 result: None,
             },
             Example {
-                description: "Work with elements of a range",
+                description: "Work with elements of a range.",
                 example: "for $x in 1..3 { print $x }",
                 result: None,
             },
             Example {
-                description: "Number each item and print a message",
+                description: "Number each item and print a message.",
                 example: r#"for $it in (['bob' 'fred'] | enumerate) { print $"($it.index) is ($it.item)" }"#,
                 result: None,
             },

--- a/crates/nu-cmd-lang/src/core_commands/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide.rs
@@ -53,12 +53,12 @@ This command is a parser keyword. For details, check:
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Hide the alias just defined",
+                description: "Hide the alias just defined.",
                 example: r#"alias lll = ls -l; hide lll"#,
                 result: None,
             },
             Example {
-                description: "Hide a custom command",
+                description: "Hide a custom command.",
                 example: r#"def say-hi [] { echo 'Hi!' }; hide say-hi"#,
                 result: None,
             },

--- a/crates/nu-cmd-lang/src/core_commands/hide_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide_env.rs
@@ -66,7 +66,7 @@ impl Command for HideEnv {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Hide an environment variable",
+            description: "Hide an environment variable.",
             example: r#"$env.HZ_ENV_ABC = 1; hide-env HZ_ENV_ABC; 'HZ_ENV_ABC' in $env"#,
             result: Some(Value::test_bool(false)),
         }]

--- a/crates/nu-cmd-lang/src/core_commands/if_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/if_.rs
@@ -115,17 +115,17 @@ impl Command for If {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Output a value if a condition matches, otherwise return nothing",
+                description: "Output a value if a condition matches, otherwise return nothing.",
                 example: "if 2 < 3 { 'yes!' }",
                 result: Some(Value::test_string("yes!")),
             },
             Example {
-                description: "Output a value if a condition matches, else return another value",
+                description: "Output a value if a condition matches, else return another value.",
                 example: "if 5 < 3 { 'yes!' } else { 'no!' }",
                 result: Some(Value::test_string("no!")),
             },
             Example {
-                description: "Chain multiple if's together",
+                description: "Chain multiple if's together.",
                 example: "if 5 < 3 { 'yes!' } else if 4 < 5 { 'no!' } else { 'okay!' }",
                 result: Some(Value::test_string("no!")),
             },

--- a/crates/nu-cmd-lang/src/core_commands/ignore.rs
+++ b/crates/nu-cmd-lang/src/core_commands/ignore.rs
@@ -56,7 +56,7 @@ impl Command for Ignore {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Ignore the output of an echo command",
+            description: "Ignore the output of an echo command.",
             example: "echo done | ignore",
             result: Some(Value::nothing(Span::test_data())),
         }]

--- a/crates/nu-cmd-lang/src/core_commands/let_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/let_.rs
@@ -17,7 +17,11 @@ impl Command for Let {
         Signature::build("let")
             .input_output_types(vec![(Type::Any, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("var_name", SyntaxShape::VarWithOptType, "Variable name.")
+            .required(
+                "var_name",
+                SyntaxShape::VarWithOptType,
+                "The variable name to create.",
+            )
             .optional(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
@@ -57,22 +61,22 @@ impl Command for Let {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Set a variable to a value",
+                description: "Set a variable to a value.",
                 example: "let x = 10",
                 result: None,
             },
             Example {
-                description: "Set a variable to the result of an expression",
+                description: "Set a variable to the result of an expression.",
                 example: "let x = 10 + 100",
                 result: None,
             },
             Example {
-                description: "Set a variable based on the condition",
+                description: "Set a variable based on the condition.",
                 example: "let x = if false { -1 } else { 1 }",
                 result: None,
             },
             Example {
-                description: "Set a variable to the output of a pipeline",
+                description: "Set a variable to the output of a pipeline.",
                 example: "ls | let files",
                 result: None,
             },

--- a/crates/nu-cmd-lang/src/core_commands/loop_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/loop_.rs
@@ -47,7 +47,7 @@ impl Command for Loop {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Loop while a condition is true",
+            description: "Loop while a condition is true.",
             example: "mut x = 0; loop { if $x > 10 { break }; $x = $x + 1 }; $x",
             result: Some(Value::test_int(11)),
         }]

--- a/crates/nu-cmd-lang/src/core_commands/match_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/match_.rs
@@ -52,42 +52,42 @@ impl Command for Match {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Match on a value",
+                description: "Match on a value.",
                 example: "match 3 { 1 => 'one', 2 => 'two', 3 => 'three' }",
                 result: Some(Value::test_string("three")),
             },
             Example {
-                description: "Match against alternative values",
+                description: "Match against alternative values.",
                 example: "match 'three' { 1 | 'one' => '-', 2 | 'two' => '--', 3 | 'three' => '---' }",
                 result: Some(Value::test_string("---")),
             },
             Example {
-                description: "Match on a value in range",
+                description: "Match on a value in range.",
                 example: "match 3 { 1..10 => 'yes!' }",
                 result: Some(Value::test_string("yes!")),
             },
             Example {
-                description: "Match on a field in a record",
+                description: "Match on a field in a record.",
                 example: "match {a: 100} { {a: $my_value} => { $my_value } }",
                 result: Some(Value::test_int(100)),
             },
             Example {
-                description: "Match with a catch-all",
+                description: "Match with a catch-all.",
                 example: "match 3 { 1 => { 'yes!' }, _ => { 'no!' } }",
                 result: Some(Value::test_string("no!")),
             },
             Example {
-                description: "Match against a list",
+                description: "Match against a list.",
                 example: "match [1, 2, 3] { [$a, $b, $c] => { $a + $b + $c }, _ => 0 }",
                 result: Some(Value::test_int(6)),
             },
             Example {
-                description: "Match against pipeline input",
+                description: "Match against pipeline input.",
                 example: "{a: {b: 3}} | match $in {{a: { $b }} => ($b + 10) }",
                 result: Some(Value::test_int(13)),
             },
             Example {
-                description: "Match with a guard",
+                description: "Match with a guard.",
                 example: "match [1 2 3] {
         [$x, ..$y] if $x == 1 => { 'good list' },
         _ => { 'not a very good list' }

--- a/crates/nu-cmd-lang/src/core_commands/module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/module.rs
@@ -48,17 +48,17 @@ impl Command for Module {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Define a custom command in a module and call it",
+                description: "Define a custom command in a module and call it.",
                 example: r#"module spam { export def foo [] { "foo" } }; use spam foo; foo"#,
                 result: Some(Value::test_string("foo")),
             },
             Example {
-                description: "Define an environment variable in a module",
+                description: "Define an environment variable in a module.",
                 example: r#"module foo { export-env { $env.FOO = "BAZ" } }; use foo; $env.FOO"#,
                 result: Some(Value::test_string("BAZ")),
             },
             Example {
-                description: "Define a custom command that participates in the environment in a module and call it",
+                description: "Define a custom command that participates in the environment in a module and call it.",
                 example: r#"module foo { export def --env bar [] { $env.FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR"#,
                 result: Some(Value::test_string("BAZ")),
             },

--- a/crates/nu-cmd-lang/src/core_commands/mut_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/mut_.rs
@@ -17,7 +17,11 @@ impl Command for Mut {
         Signature::build("mut")
             .input_output_types(vec![(Type::Any, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("var_name", SyntaxShape::VarWithOptType, "Variable name.")
+            .required(
+                "var_name",
+                SyntaxShape::VarWithOptType,
+                "The mutable variable name to create.",
+            )
             .required(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
@@ -57,22 +61,22 @@ impl Command for Mut {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Set a mutable variable to a value, then update it",
+                description: "Set a mutable variable to a value, then update it.",
                 example: "mut x = 10; $x = 12",
                 result: None,
             },
             Example {
-                description: "Upsert a value inside a mutable data structure",
+                description: "Upsert a value inside a mutable data structure.",
                 example: "mut a = {b:{c:1}}; $a.b.c = 2",
                 result: None,
             },
             Example {
-                description: "Set a mutable variable to the result of an expression",
+                description: "Set a mutable variable to the result of an expression.",
                 example: "mut x = 10 + 100",
                 result: None,
             },
             Example {
-                description: "Set a mutable variable based on the condition",
+                description: "Set a mutable variable based on the condition.",
                 example: "mut x = if false { -1 } else { 1 }",
                 result: None,
             },

--- a/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
@@ -103,7 +103,7 @@ impl Command for OverlayHide {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Keep a custom command after hiding the overlay",
+                description: "Keep a custom command after hiding the overlay.",
                 example: r#"module spam { export def foo [] { "foo" } }
     overlay use spam
     def bar [] { "bar" }
@@ -113,21 +113,21 @@ impl Command for OverlayHide {
                 result: None,
             },
             Example {
-                description: "Hide an overlay created from a file",
+                description: "Hide an overlay created from a file.",
                 example: r#"'export alias f = "foo"' | save spam.nu
     overlay use spam.nu
     overlay hide spam"#,
                 result: None,
             },
             Example {
-                description: "Hide the last activated overlay",
+                description: "Hide the last activated overlay.",
                 example: r#"module spam { export-env { $env.FOO = "foo" } }
     overlay use spam
     overlay hide"#,
                 result: None,
             },
             Example {
-                description: "Keep the current working directory when removing an overlay",
+                description: "Keep the current working directory when removing an overlay.",
                 example: r#"overlay new spam
     cd some-dir
     overlay hide --keep-env [ PWD ] spam"#,

--- a/crates/nu-cmd-lang/src/core_commands/overlay/list.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/list.rs
@@ -79,7 +79,7 @@ impl Command for OverlayList {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "List all overlays with their active status",
+                description: "List all overlays with their active status.",
                 example: r#"module spam { export def foo [] { "foo" } }
     overlay use spam
     overlay list"#,
@@ -89,7 +89,7 @@ impl Command for OverlayList {
                 })])),
             },
             Example {
-                description: "Get overlay status after hiding",
+                description: "Get overlay status after hiding.",
                 example: r#"module spam { export def foo [] { "foo" } }
     overlay use spam
     overlay hide spam

--- a/crates/nu-cmd-lang/src/core_commands/overlay/new.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/new.rs
@@ -66,7 +66,7 @@ This command is a parser keyword. For details, check:
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Create an empty overlay",
+            description: "Create an empty overlay.",
             example: r#"overlay new spam"#,
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -187,28 +187,28 @@ impl Command for OverlayUse {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Create an overlay from a module",
+                description: "Create an overlay from a module.",
                 example: r#"module spam { export def foo [] { "foo" } }
     overlay use spam
     foo"#,
                 result: None,
             },
             Example {
-                description: "Create an overlay from a module and rename it",
+                description: "Create an overlay from a module and rename it.",
                 example: r#"module spam { export def foo [] { "foo" } }
     overlay use spam as spam_new
     foo"#,
                 result: None,
             },
             Example {
-                description: "Create an overlay with a prefix",
+                description: "Create an overlay with a prefix.",
                 example: r#"'export def foo { "foo" }'
     overlay use --prefix spam
     spam foo"#,
                 result: None,
             },
             Example {
-                description: "Create an overlay from a file",
+                description: "Create an overlay from a file.",
                 example: r#"'export-env { $env.FOO = "foo" }' | save spam.nu
     overlay use spam.nu
     $env.FOO"#,

--- a/crates/nu-cmd-lang/src/core_commands/return_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/return_.rs
@@ -50,7 +50,7 @@ impl Command for Return {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Return early",
+            description: "Return early.",
             example: r#"def foo [] { return }"#,
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/scope/aliases.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/aliases.rs
@@ -34,7 +34,7 @@ impl Command for ScopeAliases {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Show the aliases in the current scope",
+            description: "Show the aliases in the current scope.",
             example: "scope aliases",
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/scope/commands.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/commands.rs
@@ -34,7 +34,7 @@ impl Command for ScopeCommands {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Show the commands in the current scope",
+            description: "Show the commands in the current scope.",
             example: "scope commands",
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/scope/engine_stats.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/engine_stats.rs
@@ -35,7 +35,7 @@ impl Command for ScopeEngineStats {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Show the stats on the current engine state",
+            description: "Show the stats on the current engine state.",
             example: "scope engine-stats",
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/scope/externs.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/externs.rs
@@ -34,7 +34,7 @@ impl Command for ScopeExterns {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Show the known externals in the current scope",
+            description: "Show the known externals in the current scope.",
             example: "scope externs",
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/scope/modules.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/modules.rs
@@ -34,7 +34,7 @@ impl Command for ScopeModules {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Show the modules in the current scope",
+            description: "Show the modules in the current scope.",
             example: "scope modules",
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/scope/variables.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/variables.rs
@@ -34,7 +34,7 @@ impl Command for ScopeVariables {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Show the variables in the current scope",
+            description: "Show the variables in the current scope.",
             example: "scope variables",
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -87,17 +87,17 @@ impl Command for Try {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Try to run a division by zero",
+                description: "Try to run a division by zero.",
                 example: "try { 1 / 0 }",
                 result: None,
             },
             Example {
-                description: "Try to run a division by zero and return a string instead",
+                description: "Try to run a division by zero and return a string instead.",
                 example: "try { 1 / 0 } catch { 'divided by zero' }",
                 result: Some(Value::test_string("divided by zero")),
             },
             Example {
-                description: "Try to run a division by zero and report the message",
+                description: "Try to run a division by zero and report the message.",
                 example: "try { 1 / 0 } catch { |err| $err.msg }",
                 result: None,
             },

--- a/crates/nu-cmd-lang/src/core_commands/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/use_.rs
@@ -169,32 +169,32 @@ This command is a parser keyword. For details, check:
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Define a custom command in a module and call it",
+                description: "Define a custom command in a module and call it.",
                 example: r#"module spam { export def foo [] { "foo" } }; use spam foo; foo"#,
                 result: Some(Value::test_string("foo")),
             },
             Example {
-                description: "Define a custom command that participates in the environment in a module and call it",
+                description: "Define a custom command that participates in the environment in a module and call it.",
                 example: r#"module foo { export def --env bar [] { $env.FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR"#,
                 result: Some(Value::test_string("BAZ")),
             },
             Example {
-                description: "Use a plain module name to import its definitions qualified by the module name",
+                description: "Use a plain module name to import its definitions qualified by the module name.",
                 example: r#"module spam { export def foo [] { "foo" }; export def bar [] { "bar" } }; use spam; (spam foo) + (spam bar)"#,
                 result: Some(Value::test_string("foobar")),
             },
             Example {
-                description: "Specify * to use all definitions in a module",
+                description: "Specify * to use all definitions in a module.",
                 example: r#"module spam { export def foo [] { "foo" }; export def bar [] { "bar" } }; use spam *; (foo) + (bar)"#,
                 result: Some(Value::test_string("foobar")),
             },
             Example {
-                description: "To use commands with spaces, like subcommands, surround them with quotes",
+                description: "To use commands with spaces, like subcommands, surround them with quotes.",
                 example: r#"module spam { export def 'foo bar' [] { "baz" } }; use spam 'foo bar'; foo bar"#,
                 result: Some(Value::test_string("baz")),
             },
             Example {
-                description: "To use multiple definitions from a module, wrap them in a list",
+                description: "To use multiple definitions from a module, wrap them in a list.",
                 example: r#"module spam { export def foo [] { "foo" }; export def 'foo bar' [] { "baz" } }; use spam ['foo', 'foo bar']; (foo) + (foo bar)"#,
                 result: Some(Value::test_string("foobaz")),
             },

--- a/crates/nu-cmd-lang/src/core_commands/version.rs
+++ b/crates/nu-cmd-lang/src/core_commands/version.rs
@@ -87,7 +87,7 @@ impl Command for Version {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Display Nu version",
+            description: "Display Nu version.",
             example: "version",
             result: None,
         }]

--- a/crates/nu-cmd-lang/src/core_commands/while_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/while_.rs
@@ -56,7 +56,7 @@ impl Command for While {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Loop while a condition is true",
+            description: "Loop while a condition is true.",
             example: "mut x = 0; while $x < 10 { $x = $x + 1 }",
             result: None,
         }]


### PR DESCRIPTION
Part of help text improvements (#5066). 
Adds consistent phrasing and periods to command descriptions and example descriptions in nu-cmd-lang.

Improves help text for core language commands in `nu-cmd-lang`: example descriptions, parameter/argument descriptions, and a few switch descriptions so they’re clearer and consistent.

## Changes
- **Example descriptions**: End with a period and use consistent phrasing (e.g. "Display Nu version." instead of "Display Nu version").
- **Parameter/argument descriptions**: Replace terse labels with short, command-specific descriptions (e.g. "Constant name." → "The constant name to create.", "Definition name." / "Parameters." → "The name of the external command signature to define." and "The parameters for the external command signature.").
- **Switch descriptions**: Clarified where needed (e.g. in `export def` for `--env` and `--wrapped`).

Scope is limited to `crates/nu-cmd-lang` (core commands: `def`, `let`, `mut`, `const`, `module`, `overlay`, `scope`, `extern`, `export *`, `try`, `if`, `for`, `loop`, `while`, `break`, `continue`, `return`, and related attribute commands). No behavior changes.


## Release notes summary - What our users need to know
- **Help**: Clearer, more consistent help text for core language commands (`def`, `let`, `mut`, `const`, `module`, `overlay`, `scope`, `extern`, `export *`, control flow, and attribute commands). Example and parameter descriptions now end with periods and use clearer wording.

## Tasks after submitting
