### PR TITLE
Improve help text in nu-cmd-extra (Issue 5066)

### DIFF
--- a/crates/nu-cmd-extra/src/extra/filters/roll/roll_down.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/roll_down.rs
@@ -17,7 +17,7 @@ impl Command for RollDown {
         Signature::build(self.name())
             // TODO: It also operates on List
             .input_output_types(vec![(Type::table(), Type::table())])
-            .named("by", SyntaxShape::Int, "Number of rows to roll", Some('b'))
+            .named("by", SyntaxShape::Int, "Number of rows to roll.", Some('b'))
             .category(Category::Filters)
     }
 

--- a/crates/nu-cmd-extra/src/extra/filters/roll/roll_up.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/roll_up.rs
@@ -17,7 +17,7 @@ impl Command for RollUp {
         Signature::build(self.name())
             // TODO: It also operates on List
             .input_output_types(vec![(Type::table(), Type::table())])
-            .named("by", SyntaxShape::Int, "Number of rows to roll", Some('b'))
+            .named("by", SyntaxShape::Int, "Number of rows to roll.", Some('b'))
             .category(Category::Filters)
     }
 

--- a/crates/nu-cmd-extra/src/extra/filters/rotate.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/rotate.rs
@@ -16,7 +16,7 @@ impl Command for Rotate {
                 (Type::list(Type::Any), Type::table()),
                 (Type::String, Type::table()),
             ])
-            .switch("ccw", "rotate counter clockwise", None)
+            .switch("ccw", "Rotate counter clockwise.", None)
             .rest(
                 "rest",
                 SyntaxShape::String,

--- a/crates/nu-cmd-extra/src/extra/formats/to/html/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html/mod.rs
@@ -25,8 +25,12 @@ impl Command for ToHtml {
         Signature::build("to html")
             .input_output_types(vec![(Type::Nothing, Type::Any), (Type::Any, Type::String)])
             .allow_variants_without_examples(true)
-            .switch("html-color", "change ansi colors to html colors", Some('c'))
-            .switch("no-color", "remove all ansi colors in output", Some('n'))
+            .switch(
+                "html-color",
+                "Change ansi colors to html colors.",
+                Some('c'),
+            )
+            .switch("no-color", "Remove all ansi colors in output.", Some('n'))
             .switch(
                 "dark",
                 "indicate your background color is a darker color",
@@ -40,7 +44,7 @@ impl Command for ToHtml {
             .named(
                 "theme",
                 SyntaxShape::String,
-                "the name of the theme to use (github, blulocolight, ...); case-insensitive",
+                "The name of the theme to use (github, blulocolight, ...); case-insensitive.",
                 Some('t'),
             )
             .switch(
@@ -48,7 +52,7 @@ impl Command for ToHtml {
                 "produce a color table of all available themes",
                 Some('l'),
             )
-            .switch("raw", "do not escape html tags", Some('r'))
+            .switch("raw", "Do not escape html tags.", Some('r'))
             .category(Category::Formats)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/arccos.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccos.rs
@@ -10,7 +10,7 @@ impl Command for MathArcCos {
 
     fn signature(&self) -> Signature {
         Signature::build("math arccos")
-            .switch("degrees", "Return degrees instead of radians", Some('d'))
+            .switch("degrees", "Return degrees instead of radians.", Some('d'))
             .input_output_types(vec![
                 (Type::Number, Type::Float),
                 (

--- a/crates/nu-cmd-extra/src/extra/math/arcsin.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arcsin.rs
@@ -10,7 +10,7 @@ impl Command for MathArcSin {
 
     fn signature(&self) -> Signature {
         Signature::build("math arcsin")
-            .switch("degrees", "Return degrees instead of radians", Some('d'))
+            .switch("degrees", "Return degrees instead of radians.", Some('d'))
             .input_output_types(vec![
                 (Type::Number, Type::Float),
                 (

--- a/crates/nu-cmd-extra/src/extra/math/arctan.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arctan.rs
@@ -10,7 +10,7 @@ impl Command for MathArcTan {
 
     fn signature(&self) -> Signature {
         Signature::build("math arctan")
-            .switch("degrees", "Return degrees instead of radians", Some('d'))
+            .switch("degrees", "Return degrees instead of radians.", Some('d'))
             .input_output_types(vec![
                 (Type::Number, Type::Float),
                 (

--- a/crates/nu-cmd-extra/src/extra/math/cos.rs
+++ b/crates/nu-cmd-extra/src/extra/math/cos.rs
@@ -10,7 +10,7 @@ impl Command for MathCos {
 
     fn signature(&self) -> Signature {
         Signature::build("math cos")
-            .switch("degrees", "Use degrees instead of radians", Some('d'))
+            .switch("degrees", "Use degrees instead of radians.", Some('d'))
             .input_output_types(vec![
                 (Type::Number, Type::Float),
                 (

--- a/crates/nu-cmd-extra/src/extra/math/sin.rs
+++ b/crates/nu-cmd-extra/src/extra/math/sin.rs
@@ -10,7 +10,7 @@ impl Command for MathSin {
 
     fn signature(&self) -> Signature {
         Signature::build("math sin")
-            .switch("degrees", "Use degrees instead of radians", Some('d'))
+            .switch("degrees", "Use degrees instead of radians.", Some('d'))
             .input_output_types(vec![
                 (Type::Number, Type::Float),
                 (

--- a/crates/nu-cmd-extra/src/extra/math/tan.rs
+++ b/crates/nu-cmd-extra/src/extra/math/tan.rs
@@ -10,7 +10,7 @@ impl Command for MathTan {
 
     fn signature(&self) -> Signature {
         Signature::build("math tan")
-            .switch("degrees", "Use degrees instead of radians", Some('d'))
+            .switch("degrees", "Use degrees instead of radians.", Some('d'))
             .input_output_types(vec![
                 (Type::Number, Type::Float),
                 (


### PR DESCRIPTION
- filters/roll: roll_down, roll_up, rotate - consistent descriptions
- formats/to/html: improved command/flag descriptions
- math: arccos, arcsin, arctan, cos, sin, tan - period and clarity

Fixes #5066 (nu-cmd-extra scope only)

## Release notes summary - What our users need to know
Improves command and flag descriptions in `crates/nu-cmd-extra` so they follow the project's help-text style: start with a capital letter and end with a period.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
