### PR TITLE
Immediately collect values of subexpressions

### DIFF
--- a/crates/nu-engine/src/compile/call.rs
+++ b/crates/nu-engine/src/compile/call.rs
@@ -120,6 +120,11 @@ pub(crate) fn compile_call(
                     arg_reg,
                 )?;
 
+                // Collect the argument to ensure that the first call argument
+                // is evaluated before the next argument begins evaluation.
+                // This prevents a race condition in multiple argument expressions with side effects
+                builder.push(Instruction::Collect { src_dst: arg_reg }.into_spanned(arg.span()))?;
+
                 Ok(arg_reg)
             })
             .transpose()?;


### PR DESCRIPTION
After a subexpression block is compiled, emit a `Collect` IR instruction (if the output `RedirectMode` is`Value`, e.g. the expression would be collected to a value anyway). This ensures multiple subexpressions in the same command will be evaluated sequentially. The motivating example was:
```nu
echo (fzf) (fzf)
```
which would previously call both instances of `fzf` and create two input screens at the same time, rendering the terminal unusable. But the same race condition exists with any other external command that has side effects.

Note: in the following IR, the values of the `fzf` call are only collected when the `push-positional` instructions execute, which is after both `call` instructions. So the two `fzf` calls are spawned,
and only afterwards is the first value collected (e.g. the selection result of `fzf` awaited).

```
> view ir { echo (fzf) (fzf)}
   0: drop                   %1
   1: load-literal           %2, glob-pattern("fzf", no_expand = false)
   2: push-positional        %2
   3: redirect-out           value
   4: call                   decl 143 "run-external", %1 # <- FIRST FZF
   5: drop                   %2
   6: load-literal           %3, glob-pattern("fzf", no_expand = false)
   7: push-positional        %3
   8: redirect-out           value
   9: call                   decl 143 "run-external", %2 # <- SECOND FZF
  10: push-positional        %1
  11: push-positional        %2
  12: redirect-out           caller    # <--- FIRST VALUE AWAITED HERE
  13: redirect-err           caller
  14: call                   decl
```

But the problem isn't just limited to command calls. This code has the same problem:

```
> view ir { (fzf) + (fzf) }
   0: drop                   %0
   1: load-literal           %1, glob-pattern("fzf", no_expand = false)
   2: push-positional        %1
   3: redirect-out           value
   4: call                   decl 143 "run-external", %0
   5: drop                   %1
   6: load-literal           %2, glob-pattern("fzf", no_expand = false)
   7: push-positional        %2
   8: redirect-out           value
   9: call                   decl 143 "run-external", %1
  10: binary-op              %0, Math(Add), %1
  11: span                   %0
  12: return                 %0
```

Note that there is again no instruction that collects the values, so the two `fzf` calls race (ignore that the + operator couldn't add strings, it's not relevant)

So I think the right place to fix this is to just collect the results of subexpressions in general. This fixes both problems above.

Fixes #17478

<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
