### PR TITLE
Make `rm` also like `mv, du, cp`

### DIFF
--- a/crates/nu-command/src/filesystem/du.rs
+++ b/crates/nu-command/src/filesystem/du.rs
@@ -67,7 +67,7 @@ impl Command for Du {
                 "Exclude files below this size",
                 Some('m'),
             )
-            .switch("all", "move hidden files if '*' is provided", Some('a'))
+            .switch("all", "Include hidden files if '*' is provided", Some('a'))
             .category(Category::FileSystem)
     }
 

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -61,7 +61,7 @@ impl Command for UCp {
                 None
             )
             .switch("debug", "explain how a file is copied. Implies -v", None)
-            .switch("all", "move hidden files if '*' is provided", Some('a'))
+            .switch("all", "Copy hidden files if '*' is provided", Some('a'))
             .rest("paths", SyntaxShape::OneOf(vec![SyntaxShape::GlobPattern, SyntaxShape::String]), "Copy SRC file/s to DEST.")
             .allow_variants_without_examples(true)
             .category(Category::FileSystem)

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -68,7 +68,7 @@ impl Command for UMv {
                 Some('u')
             )
             .switch("no-clobber", "do not overwrite an existing file", Some('n'))
-            .switch("all", "move hidden files if '*' is provided", Some('a'))
+            .switch("all", "Move hidden files if '*' is provided", Some('a'))
             .rest(
                 "paths",
                 SyntaxShape::OneOf(vec![SyntaxShape::GlobPattern, SyntaxShape::String]),


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
Added `--all` and `-a` to `rm` to make it behave like https://github.com/nushell/nushell/pull/17185. Additionally, some help description changes to better reflect the commands.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
Added `--all` and `-a` to `rm` to make it consistent with `mv`, `du`, `cp` commands.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
