### PR TITLE
Upgrade interprocess to 2.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "894148491d817cb36b6f778017b8ac46b17408d522dd90f539d677ea938362eb"
+checksum = "53bf2b0e0785c5394a7392f66d7c4fb9c653633c29b27a932280da3cb344c66a"
 dependencies = [
  "doctest-file",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ http = "1.4.0"
 human-date-parser = "0.3.1"
 indexmap = "2.13"
 indicatif = "0.18"
-interprocess = "=2.2.2" # Pinned: 2.3.0 has armv7 build failure (i32: From<u32> not satisfied)
+interprocess = "2.3.1"
 is_executable = "1.0"
 itertools = "0.14"
 lean_string = { version = "0.5", features = ["serde"] }


### PR DESCRIPTION
Upgrade interprocess to 2.3.1
More detail: https://github.com/nushell/nushell/pull/17506#issuecomment-3864854059
Testing workflow: https://github.com/nushell/nightly/actions/runs/21789825503