### PR TITLE
fix: median should use sorted len

### DIFF
--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -100,7 +100,7 @@ pub fn median(values: &[Value], span: Span, head: Span) -> Result<Value, ShellEr
 
     match take {
         Pick::Median => {
-            let idx = (sorted.len() / 2) as usize;
+            let idx = sorted.len() / 2;
             Ok(sorted
                 .get(idx)
                 .ok_or_else(|| ShellError::UnsupportedInput {


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

fix: `math median` should use sorted length instead of input length

When NaN values are present in the input, `math median` filters them out
before sorting, but it was using the original `values.len()` to determine
even/odd and compute indices. This produced incorrect results because the
index calculation was based on a length that included the filtered-out NaN
values.

This fix moves the even/odd check and index calculations to use
`sorted.len()` (after NaN filtering) so the median is computed correctly.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

### Fixed `math median` returning incorrect results when NaN values are present in the input

`math median` did include `NaN` values for its calculation, this is fixed now.

**Before:**
```nushell
> [NaN NaN 1 2 3 4] | math median
3.5
```

**After:**
```nushell
> [NaN NaN 1 2 3 4] | math median
2.5
```

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
