### PR TITLE
Issue 5066 PR 4 (of 10 total)  Improve help text for format commands.

### DIFF
--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -48,7 +48,7 @@ impl Command for FromCsv {
                 "allow the number of fields in records to be variable",
                 None,
             )
-            .switch("no-infer", "no field type inferencing", None)
+            .switch("no-infer", "No field type inferencing.", None)
             .param(
                 Flag::new("trim")
                     .short('t')
@@ -79,7 +79,7 @@ impl Command for FromCsv {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Convert comma-separated data to a table",
+                description: "Convert comma-separated data to a table.",
                 example: "\"ColA,ColB\n1,2\" | from csv",
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "ColA" => Value::test_int(1),
@@ -87,7 +87,7 @@ impl Command for FromCsv {
                 })])),
             },
             Example {
-                description: "Convert comma-separated data to a table, allowing variable number of columns per row",
+                description: "Convert comma-separated data to a table, allowing variable number of columns per row.",
                 example: "\"ColA,ColB\n1,2\n3,4,5\n6\" | from csv --flexible",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
@@ -105,32 +105,32 @@ impl Command for FromCsv {
                 ])),
             },
             Example {
-                description: "Convert comma-separated data to a table, ignoring headers",
+                description: "Convert comma-separated data to a table, ignoring headers.",
                 example: "open data.txt | from csv --noheaders",
                 result: None,
             },
             Example {
-                description: "Convert semicolon-separated data to a table",
+                description: "Convert semicolon-separated data to a table.",
                 example: "open data.txt | from csv --separator ';'",
                 result: None,
             },
             Example {
-                description: "Convert comma-separated data to a table, ignoring lines starting with '#'",
+                description: "Convert comma-separated data to a table, ignoring lines starting with '#'.",
                 example: "open data.txt | from csv --comment '#'",
                 result: None,
             },
             Example {
-                description: "Convert comma-separated data to a table, dropping all possible whitespaces around header names and field values",
+                description: "Convert comma-separated data to a table, dropping all possible whitespaces around header names and field values.",
                 example: "open data.txt | from csv --trim all",
                 result: None,
             },
             Example {
-                description: "Convert comma-separated data to a table, dropping all possible whitespaces around header names",
+                description: "Convert comma-separated data to a table, dropping all possible whitespaces around header names.",
                 example: "open data.txt | from csv --trim headers",
                 result: None,
             },
             Example {
-                description: "Convert comma-separated data to a table, dropping all possible whitespaces around field values",
+                description: "Convert comma-separated data to a table, dropping all possible whitespaces around field values.",
                 example: "open data.txt | from csv --trim fields",
                 result: None,
             },

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -12,14 +12,18 @@ impl Command for FromJson {
     }
 
     fn description(&self) -> &str {
-        "Convert from json to structured data."
+        "Convert JSON text into structured data."
     }
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("from json")
             .input_output_types(vec![(Type::String, Type::Any)])
-            .switch("objects", "treat each line as a separate value", Some('o'))
-            .switch("strict", "follow the json specification exactly", Some('s'))
+            .switch("objects", "Treat each line as a separate value.", Some('o'))
+            .switch(
+                "strict",
+                "Follow the json specification exactly.",
+                Some('s'),
+            )
             .category(Category::Formats)
     }
 
@@ -27,14 +31,14 @@ impl Command for FromJson {
         vec![
             Example {
                 example: r#"'{ "a": 1 }' | from json"#,
-                description: "Converts json formatted string to table",
+                description: "Converts json formatted string to table.",
                 result: Some(Value::test_record(record! {
                     "a" => Value::test_int(1),
                 })),
             },
             Example {
                 example: r#"'{ "a": 1, "b": [1, 2] }' | from json"#,
-                description: "Converts json formatted string to table",
+                description: "Converts json formatted string to table.",
                 result: Some(Value::test_record(record! {
                     "a" => Value::test_int(1),
                     "b" => Value::test_list(vec![Value::test_int(1), Value::test_int(2)]),
@@ -42,7 +46,7 @@ impl Command for FromJson {
             },
             Example {
                 example: r#"'{ "a": 1, "b": 2 }' | from json -s"#,
-                description: "Parse json strictly which will error on comments and trailing commas",
+                description: "Parse json strictly which will error on comments and trailing commas.",
                 result: Some(Value::test_record(record! {
                     "a" => Value::test_int(1),
                     "b" => Value::test_int(2),
@@ -51,7 +55,7 @@ impl Command for FromJson {
             Example {
                 example: r#"'{ "a": 1 }
 { "b": 2 }' | from json --objects"#,
-                description: "Parse a stream of line-delimited JSON values",
+                description: "Parse a stream of line-delimited JSON values.",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {"a" => Value::test_int(1)}),
                     Value::test_record(record! {"b" => Value::test_int(2)}),

--- a/crates/nu-command/src/formats/from/msgpack.rs
+++ b/crates/nu-command/src/formats/from/msgpack.rs
@@ -27,7 +27,7 @@ impl Command for FromMsgpack {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_output_type(Type::Binary, Type::Any)
-            .switch("objects", "Read multiple objects from input", None)
+            .switch("objects", "Read multiple objects from input.", None)
             .category(Category::Formats)
     }
 
@@ -51,7 +51,7 @@ MessagePack: https://msgpack.org/
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Read a list of values from MessagePack",
+                description: "Read a list of values from MessagePack.",
                 example: "0x[93A3666F6F2AC2] | from msgpack",
                 result: Some(Value::test_list(vec![
                     Value::test_string("foo"),
@@ -60,7 +60,7 @@ MessagePack: https://msgpack.org/
                 ])),
             },
             Example {
-                description: "Read a stream of multiple values from MessagePack",
+                description: "Read a stream of multiple values from MessagePack.",
                 example: "0x[81A76E757368656C6CA5726F636B73A9736572696F75736C79] | from msgpack --objects",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
@@ -70,7 +70,7 @@ MessagePack: https://msgpack.org/
                 ])),
             },
             Example {
-                description: "Read a table from MessagePack",
+                description: "Read a table from MessagePack.",
                 example: "0x[9282AA6576656E745F6E616D65B141706F6C6C6F203131204C616E64696E67A474696D65C70CFF00000000FFFFFFFFFF2CAB5B82AA6576656E745F6E616D65B44E757368656C6C20666972737420636F6D6D6974A474696D65D6FF5CD5ADE0] | from msgpack",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {

--- a/crates/nu-command/src/formats/from/msgpackz.rs
+++ b/crates/nu-command/src/formats/from/msgpackz.rs
@@ -17,7 +17,7 @@ impl Command for FromMsgpackz {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_output_type(Type::Binary, Type::Any)
-            .switch("objects", "Read multiple objects from input", None)
+            .switch("objects", "Read multiple objects from input.", None)
             .category(Category::Formats)
     }
 

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -22,14 +22,14 @@ impl Command for FromNuon {
         vec![
             Example {
                 example: "'{ a:1 }' | from nuon",
-                description: "Converts nuon formatted string to table",
+                description: "Converts nuon formatted string to table.",
                 result: Some(Value::test_record(record! {
                     "a" => Value::test_int(1),
                 })),
             },
             Example {
                 example: "'{ a:1, b: [1, 2] }' | from nuon",
-                description: "Converts nuon formatted string to table",
+                description: "Converts nuon formatted string to table.",
                 result: Some(Value::test_record(record! {
                     "a" => Value::test_int(1),
                     "b" => Value::test_list(vec![Value::test_int(1), Value::test_int(2)]),
@@ -37,7 +37,7 @@ impl Command for FromNuon {
             },
             Example {
                 example: "'{a:1,b:[1,2]}' | from nuon",
-                description: "Converts raw nuon formatted string to table",
+                description: "Converts raw nuon formatted string to table.",
                 result: Some(Value::test_record(record! {
                     "a" => Value::test_int(1),
                     "b" => Value::test_list(vec![Value::test_int(1), Value::test_int(2)]),

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -53,12 +53,12 @@ impl Command for FromOds {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Convert binary .ods data to a table",
+                description: "Convert binary .ods data to a table.",
                 example: "open --raw test.ods | from ods",
                 result: None,
             },
             Example {
-                description: "Convert binary .ods data to a table, specifying the tables",
+                description: "Convert binary .ods data to a table, specifying the tables.",
                 example: "open --raw test.ods | from ods --sheets [Spreadsheet1]",
                 result: None,
             },

--- a/crates/nu-command/src/formats/from/ssv.rs
+++ b/crates/nu-command/src/formats/from/ssv.rs
@@ -19,7 +19,7 @@ impl Command for FromSsv {
                 "don't treat the first row as column names",
                 Some('n'),
             )
-            .switch("aligned-columns", "assume columns are aligned", Some('a'))
+            .switch("aligned-columns", "Assume columns are aligned.", Some('a'))
             .named(
                 "minimum-spaces",
                 SyntaxShape::Int,
@@ -38,7 +38,7 @@ impl Command for FromSsv {
             Example {
                 example: r#"'FOO   BAR
 1   2' | from ssv"#,
-                description: "Converts ssv formatted string to table",
+                description: "Converts ssv formatted string to table.",
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "FOO" => Value::test_string("1"),
                     "BAR" => Value::test_string("2"),
@@ -47,7 +47,7 @@ impl Command for FromSsv {
             Example {
                 example: r#"'FOO   BAR
 1   2' | from ssv --noheaders"#,
-                description: "Converts ssv formatted string to table but not treating the first row as column names",
+                description: "Converts ssv formatted string to table but not treating the first row as column names.",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
                         "column0" => Value::test_string("FOO"),

--- a/crates/nu-command/src/formats/from/toml.rs
+++ b/crates/nu-command/src/formats/from/toml.rs
@@ -37,7 +37,7 @@ impl Command for FromToml {
         vec![
             Example {
                 example: "'a = 1' | from toml",
-                description: "Converts toml formatted string to record",
+                description: "Converts toml formatted string to record.",
                 result: Some(Value::test_record(record! {
                     "a" => Value::test_int(1),
                 })),
@@ -45,7 +45,7 @@ impl Command for FromToml {
             Example {
                 example: "'a = 1
 b = [1, 2]' | from toml",
-                description: "Converts toml formatted string to record",
+                description: "Converts toml formatted string to record.",
                 result: Some(Value::test_record(record! {
                     "a" =>  Value::test_int(1),
                     "b" =>  Value::test_list(vec![

--- a/crates/nu-command/src/formats/from/tsv.rs
+++ b/crates/nu-command/src/formats/from/tsv.rs
@@ -40,7 +40,7 @@ impl Command for FromTsv {
                 "allow the number of fields in records to be variable",
                 None,
             )
-            .switch("no-infer", "no field type inferencing", None)
+            .switch("no-infer", "No field type inferencing.", None)
             .param(
                 Flag::new("trim")
                     .short('t')
@@ -71,7 +71,7 @@ impl Command for FromTsv {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Convert tab-separated data to a table",
+                description: "Convert tab-separated data to a table.",
                 example: "\"ColA\tColB\n1\t2\" | from tsv",
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "ColA" =>  Value::test_int(1),
@@ -79,7 +79,7 @@ impl Command for FromTsv {
                 })])),
             },
             Example {
-                description: "Convert comma-separated data to a table, allowing variable number of columns per row and ignoring headers",
+                description: "Convert comma-separated data to a table, allowing variable number of columns per row and ignoring headers.",
                 example: "\"value 1\nvalue 2\tdescription 2\" | from tsv --flexible --noheaders",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
@@ -92,27 +92,27 @@ impl Command for FromTsv {
                 ])),
             },
             Example {
-                description: "Create a tsv file with header columns and open it",
+                description: "Create a tsv file with header columns and open it.",
                 example: r#"$'c1(char tab)c2(char tab)c3(char nl)1(char tab)2(char tab)3' | save tsv-data | open tsv-data | from tsv"#,
                 result: None,
             },
             Example {
-                description: "Create a tsv file without header columns and open it",
+                description: "Create a tsv file without header columns and open it.",
                 example: r#"$'a1(char tab)b1(char tab)c1(char nl)a2(char tab)b2(char tab)c2' | save tsv-data | open tsv-data | from tsv --noheaders"#,
                 result: None,
             },
             Example {
-                description: "Create a tsv file without header columns and open it, removing all unnecessary whitespaces",
+                description: "Create a tsv file without header columns and open it, removing all unnecessary whitespaces.",
                 example: r#"$'a1(char tab)b1(char tab)c1(char nl)a2(char tab)b2(char tab)c2' | save tsv-data | open tsv-data | from tsv --trim all"#,
                 result: None,
             },
             Example {
-                description: "Create a tsv file without header columns and open it, removing all unnecessary whitespaces in the header names",
+                description: "Create a tsv file without header columns and open it, removing all unnecessary whitespaces in the header names.",
                 example: r#"$'a1(char tab)b1(char tab)c1(char nl)a2(char tab)b2(char tab)c2' | save tsv-data | open tsv-data | from tsv --trim headers"#,
                 result: None,
             },
             Example {
-                description: "Create a tsv file without header columns and open it, removing all unnecessary whitespaces in the field values",
+                description: "Create a tsv file without header columns and open it, removing all unnecessary whitespaces in the field values.",
                 example: r#"$'a1(char tab)b1(char tab)c1(char nl)a2(char tab)b2(char tab)c2' | save tsv-data | open tsv-data | from tsv --trim fields"#,
                 result: None,
             },

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -54,12 +54,12 @@ impl Command for FromXlsx {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Convert binary .xlsx data to a table",
+                description: "Convert binary .xlsx data to a table.",
                 example: "open --raw test.xlsx | from xlsx",
                 result: None,
             },
             Example {
-                description: "Convert binary .xlsx data to a table, specifying the tables",
+                description: "Convert binary .xlsx data to a table, specifying the tables.",
                 example: "open --raw test.xlsx | from xlsx --sheets [Spreadsheet1]",
                 result: None,
             },

--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -15,7 +15,7 @@ impl Command for FromXml {
     fn signature(&self) -> Signature {
         Signature::build("from xml")
             .input_output_types(vec![(Type::String, Type::record())])
-            .switch("keep-comments", "add comment nodes to result", None)
+            .switch("keep-comments", "Add comment nodes to result.", None)
             .switch(
                 "allow-dtd",
                 "allow parsing documents with DTDs (may result in exponential entity expansion)",
@@ -71,7 +71,7 @@ string. This way content of every tag is always a table and is easier to parse"#
 <note>
   <remember>Event</remember>
 </note>' | from xml"#,
-            description: "Converts xml formatted string to record",
+            description: "Converts xml formatted string to record.",
             result: Some(Value::test_record(record! {
                 COLUMN_TAG_NAME =>     Value::test_string("note"),
                 COLUMN_ATTRS_NAME =>   Value::test_record(Record::new()),

--- a/crates/nu-command/src/formats/from/yaml.rs
+++ b/crates/nu-command/src/formats/from/yaml.rs
@@ -209,14 +209,14 @@ pub fn get_examples() -> Vec<Example<'static>> {
     vec![
         Example {
             example: "'a: 1' | from yaml",
-            description: "Converts yaml formatted string to table",
+            description: "Converts yaml formatted string to table.",
             result: Some(Value::test_record(record! {
                 "a" => Value::test_int(1),
             })),
         },
         Example {
             example: "'[ a: 1, b: [1, 2] ]' | from yaml",
-            description: "Converts yaml formatted string to table",
+            description: "Converts yaml formatted string to table.",
             result: Some(Value::test_list(vec![
                 Value::test_record(record! {
                     "a" => Value::test_int(1),
@@ -259,14 +259,14 @@ mod test {
         }
         let tt: Vec<TestCase> = vec![
             TestCase {
-                description: "Double Curly Braces With Quotes",
+                description: "Double Curly Braces With Quotes.",
                 input: r#"value: "{{ something }}""#,
                 expected: Ok(Value::test_record(record! {
                     "value" => Value::test_string("{{ something }}"),
                 })),
             },
             TestCase {
-                description: "Double Curly Braces Without Quotes",
+                description: "Double Curly Braces Without Quotes.",
                 input: r#"value: {{ something }}"#,
                 expected: Ok(Value::test_record(record! {
                     "value" => Value::test_string("{{ something }}"),

--- a/crates/nu-command/src/formats/to/command.rs
+++ b/crates/nu-command/src/formats/to/command.rs
@@ -9,7 +9,7 @@ impl Command for To {
     }
 
     fn description(&self) -> &str {
-        "Translate structured data to a format."
+        "Translate structured data to various formats."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/formats/to/csv.rs
+++ b/crates/nu-command/src/formats/to/csv.rs
@@ -43,22 +43,22 @@ impl Command for ToCsv {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Outputs a CSV string representing the contents of this table",
+                description: "Outputs a CSV string representing the contents of this table.",
                 example: "[[foo bar]; [1 2]] | to csv",
                 result: Some(Value::test_string("foo,bar\n1,2\n")),
             },
             Example {
-                description: "Outputs a CSV string representing the contents of this table",
+                description: "Outputs a CSV string representing the contents of this table.",
                 example: "[[foo bar]; [1 2]] | to csv --separator ';' ",
                 result: Some(Value::test_string("foo;bar\n1;2\n")),
             },
             Example {
-                description: "Outputs a CSV string representing the contents of this record",
+                description: "Outputs a CSV string representing the contents of this record.",
                 example: "{a: 1 b: 2} | to csv",
                 result: Some(Value::test_string("a,b\n1,2\n")),
             },
             Example {
-                description: "Outputs a CSV stream with column names pre-determined",
+                description: "Outputs a CSV stream with column names pre-determined.",
                 example: "[[foo bar baz]; [1 2 3]] | to csv --columns [baz foo]",
                 result: Some(Value::test_string("baz,foo\n3,1\n")),
             },

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -91,19 +91,19 @@ impl Command for ToJson {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Outputs a JSON string, with default indentation, representing the contents of this table",
+                description: "Outputs a JSON string, with default indentation, representing the contents of this table.",
                 example: "[a b c] | to json",
                 result: Some(Value::test_string("[\n  \"a\",\n  \"b\",\n  \"c\"\n]")),
             },
             Example {
-                description: "Outputs a JSON string, with 4-space indentation, representing the contents of this table",
+                description: "Outputs a JSON string, with 4-space indentation, representing the contents of this table.",
                 example: "[Joe Bob Sam] | to json --indent 4",
                 result: Some(Value::test_string(
                     "[\n    \"Joe\",\n    \"Bob\",\n    \"Sam\"\n]",
                 )),
             },
             Example {
-                description: "Outputs an unformatted JSON string representing the contents of this table",
+                description: "Outputs an unformatted JSON string representing the contents of this table.",
                 example: "[1 2 3] | to json -r",
                 result: Some(Value::test_string("[1,2,3]")),
             },

--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -81,7 +81,7 @@ impl Command for ToMd {
                 "Escapes Markdown special characters",
                 Some('m'),
             )
-            .switch("escape-html", "Escapes HTML special characters", Some('t'))
+            .switch("escape-html", "Escapes HTML special characters.", Some('t'))
             .switch(
                 "escape-all",
                 "Escapes both Markdown and HTML special characters",
@@ -103,66 +103,66 @@ impl Command for ToMd {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Outputs an MD string representing the contents of this table",
+                description: "Outputs an MD string representing the contents of this table.",
                 example: "[[foo bar]; [1 2]] | to md",
                 result: Some(Value::test_string(
                     "| foo | bar |\n| --- | --- |\n| 1 | 2 |",
                 )),
             },
             Example {
-                description: "Optionally, output a formatted markdown string",
+                description: "Optionally, output a formatted markdown string.",
                 example: "[[foo bar]; [1 2]] | to md --pretty",
                 result: Some(Value::test_string(
                     "| foo | bar |\n| --- | --- |\n| 1   | 2   |",
                 )),
             },
             Example {
-                description: "Treat each row as a markdown element",
+                description: "Treat each row as a markdown element.",
                 example: r#"[{"H1": "Welcome to Nushell" } [[foo bar]; [1 2]]] | to md --per-element --pretty"#,
                 result: Some(Value::test_string(
                     "# Welcome to Nushell\n| foo | bar |\n| --- | --- |\n| 1   | 2   |",
                 )),
             },
             Example {
-                description: "Render a list (unordered by default)",
+                description: "Render a list (unordered by default).",
                 example: "[0 1 2] | to md",
                 result: Some(Value::test_string("* 0\n* 1\n* 2")),
             },
             Example {
-                description: "Separate list into markdown tables",
+                description: "Separate list into markdown tables.",
                 example: "[ {foo: 1, bar: 2} {foo: 3, bar: 4} {foo: 5}] | to md --per-element",
                 result: Some(Value::test_string(
                     "| foo | bar |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |\n\n| foo |\n| --- |\n| 5 |",
                 )),
             },
             Example {
-                description: "Center a column of a markdown table",
+                description: "Center a column of a markdown table.",
                 example: "[ {foo: 1, bar: 2} {foo: 3, bar: 4}] | to md --pretty --center [bar]",
                 result: Some(Value::test_string(
                     "| foo | bar |\n| --- |:---:|\n| 1   |  2  |\n| 3   |  4  |",
                 )),
             },
             Example {
-                description: "Escape markdown special characters",
+                description: "Escape markdown special characters.",
                 example: r#"[ {foo: "_1_", bar: "\# 2"} {foo: "[3]", bar: "4|5"}] | to md --escape-md"#,
                 result: Some(Value::test_string(
                     "| foo | bar |\n| --- | --- |\n| \\_1\\_ | \\# 2 |\n| \\[3\\] | 4\\|5 |",
                 )),
             },
             Example {
-                description: "Escape html special characters",
+                description: "Escape html special characters.",
                 example: r#"[ {a: p, b: "<p>Welcome to nushell</p>"}] | to md --escape-html"#,
                 result: Some(Value::test_string(
                     "| a | b |\n| --- | --- |\n| p | &lt;p&gt;Welcome to nushell&lt;&#x2f;p&gt; |",
                 )),
             },
             Example {
-                description: "Render a list as an ordered markdown list",
+                description: "Render a list as an ordered markdown list.",
                 example: "[one two three] | to md --list ordered",
                 result: Some(Value::test_string("1. one\n2. two\n3. three")),
             },
             Example {
-                description: "Render a list without markers",
+                description: "Render a list without markers.",
                 example: "[one two three] | to md --list none",
                 result: Some(Value::test_string("one\ntwo\nthree")),
             },

--- a/crates/nu-command/src/formats/to/msgpack.rs
+++ b/crates/nu-command/src/formats/to/msgpack.rs
@@ -51,17 +51,17 @@ MessagePack: https://msgpack.org/
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Convert a list of values to MessagePack",
+                description: "Convert a list of values to MessagePack.",
                 example: "[foo, 42, false] | to msgpack",
                 result: Some(Value::test_binary(b"\x93\xA3\x66\x6F\x6F\x2A\xC2")),
             },
             Example {
-                description: "Convert a range to a MessagePack array",
+                description: "Convert a range to a MessagePack array.",
                 example: "1..10 | to msgpack",
                 result: Some(Value::test_binary(b"\x9A\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A"))
             },
             Example {
-                description: "Convert a table to MessagePack",
+                description: "Convert a table to MessagePack.",
                 example: "[
         [event_name time];
         ['Apollo 11 Landing' 1969-07-24T16:50:35]

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -90,36 +90,36 @@ impl Command for ToNuon {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Outputs a NUON string representing the contents of this list, compact by default",
+                description: "Outputs a NUON string representing the contents of this list, compact by default.",
                 example: "[1 2 3] | to nuon",
                 result: Some(Value::test_string("[1, 2, 3]")),
             },
             Example {
-                description: "Outputs a NUON array of ints, with pretty indentation",
+                description: "Outputs a NUON array of ints, with pretty indentation.",
                 example: "[1 2 3] | to nuon --indent 2",
                 result: Some(Value::test_string("[\n  1,\n  2,\n  3\n]")),
             },
             Example {
-                description: "Overwrite any set option with --raw",
+                description: "Overwrite any set option with --raw.",
                 example: "[1 2 3] | to nuon --indent 2 --raw",
                 result: Some(Value::test_string("[1,2,3]")),
             },
             Example {
-                description: "A more complex record with multiple data types",
+                description: "A more complex record with multiple data types.",
                 example: "{date: 2000-01-01, data: [1 [2 3] 4.56]} | to nuon --indent 2",
                 result: Some(Value::test_string(
                     "{\n  date: 2000-01-01T00:00:00+00:00,\n  data: [\n    1,\n    [\n      2,\n      3\n    ],\n    4.56\n  ]\n}",
                 )),
             },
             Example {
-                description: "A more complex record with --raw",
+                description: "A more complex record with --raw.",
                 example: "{date: 2000-01-01, data: [1 [2 3] 4.56]} | to nuon --raw",
                 result: Some(Value::test_string(
                     "{date:2000-01-01T00:00:00+00:00,data:[1,[2,3],4.56]}",
                 )),
             },
             Example {
-                description: "Use raw string syntax for strings with quotes or backslashes",
+                description: "Use raw string syntax for strings with quotes or backslashes.",
                 example: r#"'hello "world"' | to nuon --raw-strings"#,
                 result: Some(Value::test_string(r#"r#'hello "world"'#"#)),
             },

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -36,7 +36,7 @@ impl Command for ToText {
     }
 
     fn description(&self) -> &str {
-        "Converts data into simple text."
+        "Convert data into plain text format."
     }
 
     fn run(
@@ -132,22 +132,22 @@ impl Command for ToText {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Outputs data as simple text with a trailing newline",
+                description: "Outputs data as simple text with a trailing newline.",
                 example: "[1] | to text",
                 result: Some(Value::test_string("1".to_string() + LINE_ENDING)),
             },
             Example {
-                description: "Outputs data as simple text without a trailing newline",
+                description: "Outputs data as simple text without a trailing newline.",
                 example: "[1] | to text --no-newline",
                 result: Some(Value::test_string("1")),
             },
             Example {
-                description: "Outputs external data as simple text",
+                description: "Outputs external data as simple text.",
                 example: "git help -a | lines | find -r '^ ' | to text",
                 result: None,
             },
             Example {
-                description: "Outputs records as simple text",
+                description: "Outputs records as simple text.",
                 example: "ls | to text",
                 result: None,
             },

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -27,7 +27,7 @@ impl Command for ToToml {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Outputs an TOML string representing the contents of this record",
+            description: "Outputs an TOML string representing the contents of this record.",
             example: r#"{foo: 1 bar: 'qwe'} | to toml"#,
             result: Some(Value::test_string("foo = 1\nbar = \"qwe\"\n")),
         }]

--- a/crates/nu-command/src/formats/to/tsv.rs
+++ b/crates/nu-command/src/formats/to/tsv.rs
@@ -41,17 +41,17 @@ impl Command for ToTsv {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Outputs a TSV string representing the contents of this table",
+                description: "Outputs a TSV string representing the contents of this table.",
                 example: "[[foo bar]; [1 2]] | to tsv",
                 result: Some(Value::test_string("foo\tbar\n1\t2\n")),
             },
             Example {
-                description: "Outputs a TSV string representing the contents of this record",
+                description: "Outputs a TSV string representing the contents of this record.",
                 example: "{a: 1 b: 2} | to tsv",
                 result: Some(Value::test_string("a\tb\n1\t2\n")),
             },
             Example {
-                description: "Outputs a TSV stream with column names pre-determined",
+                description: "Outputs a TSV stream with column names pre-determined.",
                 example: "[[foo bar baz]; [1 2 3]] | to tsv --columns [baz foo]",
                 result: Some(Value::test_string("baz\tfoo\n3\t1\n")),
             },

--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -52,33 +52,33 @@ Additionally any field which is: empty record, empty list or null, can be omitte
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Outputs an XML string representing the contents of this table",
+                description: "Outputs an XML string representing the contents of this table.",
                 example: r#"{tag: note attributes: {} content : [{tag: remember attributes: {} content : [{tag: null attributes: null content : Event}]}]} | to xml"#,
                 result: Some(Value::test_string(
                     "<note><remember>Event</remember></note>",
                 )),
             },
             Example {
-                description: "When formatting xml null and empty record fields can be omitted and strings can be written without a wrapping record",
+                description: "When formatting xml null and empty record fields can be omitted and strings can be written without a wrapping record.",
                 example: r#"{tag: note content : [{tag: remember content : [Event]}]} | to xml"#,
                 result: Some(Value::test_string(
                     "<note><remember>Event</remember></note>",
                 )),
             },
             Example {
-                description: "Optionally, formats the text with a custom indentation setting",
+                description: "Optionally, formats the text with a custom indentation setting.",
                 example: r#"{tag: note content : [{tag: remember content : [Event]}]} | to xml --indent 3"#,
                 result: Some(Value::test_string(
                     "<note>\n   <remember>Event</remember>\n</note>",
                 )),
             },
             Example {
-                description: "Produce less escaping sequences in resulting xml",
+                description: "Produce less escaping sequences in resulting xml.",
                 example: r#"{tag: note attributes: {a: "'qwe'\\"} content: ["\"'"]} | to xml --partial-escape"#,
                 result: Some(Value::test_string(r#"<note a="'qwe'\">"'</note>"#)),
             },
             Example {
-                description: "Save space using self-closed tags",
+                description: "Save space using self-closed tags.",
                 example: r#"{tag: root content: [[tag]; [a] [b] [c]]} | to xml --self-closed"#,
                 result: Some(Value::test_string(r#"<root><a/><b/><c/></root>"#)),
             },

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -26,7 +26,7 @@ impl Command for ToYaml {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Outputs a YAML string representing the contents of this table",
+            description: "Outputs a YAML string representing the contents of this table.",
             example: r#"[[foo bar]; ["1" "2"]] | to yaml"#,
             result: Some(Value::test_string("- foo: '1'\n  bar: '2'\n")),
         }]
@@ -72,7 +72,7 @@ impl Command for ToYml {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Outputs a YAML string representing the contents of this table",
+            description: "Outputs a YAML string representing the contents of this table.",
             example: r#"[[foo bar]; ["1" "2"]] | to yml"#,
             result: Some(Value::test_string("- foo: '1'\n  bar: '2'\n")),
         }]


### PR DESCRIPTION
## Release notes summary - What our users need to know
Help text for format commands (`from csv`, `from json`, `to json`, `to nuon`, `to text`, and related `from`/`to` commands) is now more consistent and easier to read: example and flag descriptions use consistent capitalization and punctuation, and a few command descriptions are clearer. Behavior of these commands is unchanged.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
