### PR TITLE
fix: Read vendor autoload files in non-interactive modes

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -79,6 +79,11 @@ pub(crate) fn run_commands(
         }
 
         perf!("read login.nu", start_time, use_color);
+
+        // load vendor and user autoload files
+        let start_time = std::time::Instant::now();
+        config_files::read_vendor_autoload_files(engine_state, &mut stack);
+        perf!("read vendor autoload files", start_time, use_color);
     }
 
     // Before running commands, set up the startup time
@@ -158,6 +163,11 @@ pub(crate) fn run_file(
             );
         }
         perf!("read config.nu", start_time, use_color);
+
+        // load vendor and user autoload files
+        let start_time = std::time::Instant::now();
+        config_files::read_vendor_autoload_files(engine_state, &mut stack);
+        perf!("read vendor autoload files", start_time, use_color);
     }
 
     // Regenerate the $nu constant to contain the startup time and any other potential updates


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

I noticed a bug in https://github.com/conda-forge/nushell-feedstock/pull/46 when trying to use the `NU_VENDOR_AUTOLOAD_DIR` feature for the conda ecosystem: it only works when using nu in REPL mode but not when using nu in script mode.

This PR also reads the vendor autoload files when using nu to run scripts.

## Release notes summary - What our users need to know

Vendor autoload files are now executed in all non-interactive modes (`nu -c "..."` and `nu script.nu`), not just the interactive REPL.

<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->