### PR TITLE
disable auto tail and track previous row count in push_layer in explore

### DIFF
--- a/crates/nu-explore/src/explore/views/record/mod.rs
+++ b/crates/nu-explore/src/explore/views/record/mod.rs
@@ -586,6 +586,8 @@ fn push_layer(view: &mut RecordView, mut next_layer: RecordLayer) {
     }
 
     view.layer_stack.push(next_layer);
+    view.auto_tail = false;
+    view.previous_row_count = view.get_top_layer().record_values.len();
 }
 
 fn estimate_page_size(area: Rect, show_head: bool) -> u16 {


### PR DESCRIPTION
Problem
When using the `explore` command and drilling into a cell (pressing Enter) that contains a large dataset with many rows, the view unexpectedly jumps to the last page instead of starting at the top. This happens because the auto-tail logic incorrectly triggers when pushing a new layer to the view stack.

Solution
Modified the push_layer function in mod.rs to disable auto-tail mode and properly update the row count tracking when drilling into cells. This ensures new views start at the top while preserving auto-tail functionality for other use cases.

closes #17531

## Release notes summary - What our users need to know
Fix issue where drilling into a large dataset in `explore` opened on the last page instead of the top.

## Tasks after submitting
N/A