### PR TITLE
add `nu` to the ignore_list for `:try` in `explore`

### DIFF
--- a/crates/nu-explore/src/explore/nu_common/command.rs
+++ b/crates/nu-explore/src/explore/nu_common/command.rs
@@ -49,7 +49,11 @@ pub fn run_nu_command(
 }
 
 pub fn is_ignored_command(command: &str) -> bool {
-    matches!(command, "clear" | "explore" | "exit" | "nu")
+    let ignore_list: &[&str] = &["clear", "explore", "exit", "nu"];
+
+    command
+        .split_whitespace()
+        .any(|token| ignore_list.contains(&token))
 }
 
 fn eval_source2(
@@ -108,4 +112,36 @@ fn eval_source2(
         Some(Redirection::Pipe(OutDest::PipeSeparate)),
     );
     eval_block::<WithoutDebug>(engine_state, stack, &block, input).map(|p| p.body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_ignored_command_cases() {
+        let cases = [
+            ("Simple", "clear", true),
+            ("With flag", "clear -x", true),
+            ("Prepended", "sudo clear", true),
+            ("Appended", "exit now", true),
+            ("Valid", "ls -la", false),
+            ("Starts with ignored", "clearly ok", false),
+            (
+                "Starts with ignored existing command",
+                "nu_highlight",
+                false,
+            ),
+            ("Empty string", "", false),
+            ("Spaces only", "   ", false),
+        ];
+
+        for (name, input, expected) in cases {
+            assert_eq!(
+                is_ignored_command(input),
+                expected,
+                "Case failed for {name}: {input:?}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Disallow `nu` in the `explore` `:try` command

closes #17530

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A