### PR TITLE
refactor: deprecate `metadata set --merge` in favor of closure form

### DIFF
--- a/crates/nu-command/src/debug/metadata_set.rs
+++ b/crates/nu-command/src/debug/metadata_set.rs
@@ -56,8 +56,7 @@ impl Command for MetadataSet {
             since: Some("0.111.0".into()),
             expected_removal: Some("0.112.0".into()),
             help: Some(
-                "Use the closure parameter instead: `metadata set {|m| $m | merge {key: value}}`"
-                    .into(),
+                "Use the closure parameter instead: `metadata set { merge {key: value} }`".into(),
             ),
         }]
     }


### PR DESCRIPTION
## Summary

- Deprecates `--merge` flag on `metadata set` (since 0.111.0, removal in 0.112.0)
- The closure form (`metadata set { merge {key: value} }`) handles custom metadata correctly and doesn't suffer from the built-in key collision bug

Related: #17535 — the `--merge` flag doesn't properly handle built-in metadata keys like `source`. Rather than fixing `--merge`, this deprecates it since the closure form already covers the use case without the bug. The issue will be fully resolved when `--merge` is removed in 0.112.0.

## Release notes summary

### `metadata set` should now be used with closures instead of the `--merge` flag

`metadata set --merge` is now deprecated and will be removed in 0.112.0. Use the closure form instead:

```nushell
# before
"data" | metadata set --merge {key: value}

# after
"data" | metadata set {|| merge {key: value} }
```