### PR TITLE
fix: avoid panic in replace_in_variable for permanent blocks

### DIFF
--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -494,7 +494,7 @@ impl Expression {
             | Expr::Subexpression(block_id) => {
                 let mut block = Block::clone(working_set.get_block(*block_id));
                 block.replace_in_variable(working_set, new_var_id);
-                *working_set.get_block_mut(*block_id) = block;
+                *block_id = working_set.add_block(Arc::new(block));
             }
             Expr::UnaryNot(expr) => {
                 expr.replace_in_variable(working_set, new_var_id);


### PR DESCRIPTION
> The solution was solely generated by `claude code`

## Release notes summary - What our users need to know

Fix a panic when typing expressions like `pathopens.d | vd $in` in the REPL. The panic occurred during syntax highlighting when `replace_in_variable` tried to mutate a block in the permanent (immutable) engine state.

## Description

During syntax highlighting, a fresh `StateWorkingSet` is created and the input is re-parsed. When the parser encounters `$in` in a pipeline element, `wrap_expr_with_collect` calls `replace_in_variable`, which recursively processes nested blocks. If a block ID refers to a permanent block, `get_block_mut` panics.

The fix: instead of mutating the block in place, add the modified block as a new delta block and update the `block_id` reference.

```
-  *working_set.get_block_mut(*block_id) = block;
+  *block_id = working_set.add_block(Arc::new(block));
```

**Note:** `completions::variables_completions` test in `nu-cli` is failing on `main` before this change (pre-existing, unrelated).