### PR TITLE
fix(mktemp): make --tmpdir behaviour aligned with coreutils/uutils

### DIFF
--- a/crates/nu-command/src/filesystem/mktemp.rs
+++ b/crates/nu-command/src/filesystem/mktemp.rs
@@ -44,7 +44,7 @@ impl Command for Mktemp {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Make a temporary file with the given suffix in the current working directory.",
+                description: "Make a temporary file with the given suffix in the system temp directory.",
                 example: "mktemp --suffix .txt",
                 result: Some(Value::test_string("/tmp/tmp.lekjbhelyx.txt")),
             },


### PR DESCRIPTION
Fixes #16318 

## Release notes summary - What our users need to know

Running `mktemp` without template will now create tmp files in tmpdir instead of current dir.

## Tasks after submitting
N/A
