### PR TITLE
fix: block duplication for aliased ones only in `replace_in_variable`

### DIFF
--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -839,6 +839,27 @@ pub fn parse_attributes_external_alias() {
 }
 
 #[test]
+pub fn parse_aliased_variable_in() {
+    // https://github.com/nushell/nushell/issues/13706
+    // https://github.com/nushell/nushell/issues/17538
+    let mut engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    working_set.add_decl(Box::new(Alias));
+    working_set.add_decl(Box::new(AttrEcho));
+
+    let source = b"alias e = attr echo ($in)";
+    let _ = parse(&mut working_set, None, source, false);
+    let _ = engine_state.merge_delta(working_set.render());
+
+    let mut working_set = StateWorkingSet::new(&engine_state);
+    let source = b"1 | e";
+    let _ = parse(&mut working_set, None, source, false);
+
+    assert!(working_set.parse_errors.is_empty());
+}
+
+#[test]
 pub fn parse_if_in_const_expression() {
     // https://github.com/nushell/nushell/issues/15321
     let mut engine_state = EngineState::new();

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -494,7 +494,13 @@ impl Expression {
             | Expr::Subexpression(block_id) => {
                 let mut block = Block::clone(working_set.get_block(*block_id));
                 block.replace_in_variable(working_set, new_var_id);
-                *block_id = working_set.add_block(Arc::new(block));
+                if block_id.get() < working_set.permanent_state.num_blocks() {
+                    // For aliased blocks, duplicate to avoid panics
+                    // TODO: consider making them mutable in the future
+                    *block_id = working_set.add_block(Arc::new(block));
+                } else {
+                    *working_set.get_block_mut(*block_id) = block;
+                }
             }
             Expr::UnaryNot(expr) => {
                 expr.replace_in_variable(working_set, new_var_id);


### PR DESCRIPTION
Partially reverts #17539.

It now uses in-place replacement when feasible. +1 test case.

## Release notes summary - What our users need to know

Fixes panics caused by referencing `$in` in aliases