### PR TITLE
fix $env.NU_LIB_DIRS behavior

### DIFF
--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -1072,6 +1072,8 @@ const NU_LIB_DIRS = []
 #     ($nu.data-dir | path join 'completions')
 # ]
 # An environment variable version ($env.NU_LIB_DIRS) is searched after the constant.
+# If provided from the parent process, use the platform path-list separator
+# (`:` on Unix, `;` on Windows), similar to PATH.
 
 # NU_PLUGIN_DIRS (const): Directories searched for plugin binaries.
 # Default includes <config-dir>/plugins.
@@ -1081,6 +1083,8 @@ const NU_PLUGIN_DIRS = []
 # const NU_PLUGIN_DIRS = [
 #     ($nu.default-config-dir | path join 'plugins')
 # ]
+# If provided from the parent process, use the platform path-list separator
+# (`:` on Unix, `;` on Windows), similar to PATH.
 
 # -----------------
 # Path Manipulation


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

As discussed in https://discord.com/channels/601130461678272522/1471135935088300227/1471324015736914041

## Release notes summary - What our users need to know

Fixed `$env.NU_LIB_DIRS` not loading libraries.
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
