### PR TITLE
feat(nu-command): add `--keep-last` flag for `uniq-by` command

### DIFF
--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -245,7 +245,7 @@ pub fn uniq(
     let flag_only_uniques = call.has_flag(engine_state, stack, "unique")?;
 
     // for uniq-by command
-    let flag_from_last = call.has_flag(engine_state, stack, "from-last")?;
+    let flag_keep_last = call.has_flag(engine_state, stack, "keep-last")?;
 
     let signals = engine_state.signals().clone();
     let uniq_values = input
@@ -270,7 +270,7 @@ pub fn uniq(
                     Ok(key) => {
                         match counter.get_mut(&key) {
                             Some(x) => {
-                                if flag_from_last {
+                                if flag_keep_last {
                                     x.val = item.val;
                                 }
                                 x.count += 1;

--- a/crates/nu-command/src/filters/uniq_by.rs
+++ b/crates/nu-command/src/filters/uniq_by.rs
@@ -25,7 +25,7 @@ impl Command for UniqBy {
                 Some('c'),
             )
             .switch(
-                "from-last",
+                "keep-last",
                 "Return the last occurrence of each unique value instead of the first.",
                 Some('l'),
             )
@@ -109,7 +109,7 @@ impl Command for UniqBy {
             },
             Example {
                 description: "Get rows from table filtered by column uniqueness, keeping the last occurrence of each duplicate.",
-                example: "[[fruit count]; [apple 9] [apple 2] [pear 3] [orange 7]] | uniq-by fruit --from-last",
+                example: "[[fruit count]; [apple 9] [apple 2] [pear 3] [orange 7]] | uniq-by fruit --keep-last",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
                         "fruit" => Value::test_string("apple"),


### PR DESCRIPTION
## Release notes summary - What our users need to know

### New flag `--keep-last` for `uniq-by`

Added `--keep-last` flag for the `uniq-by` command. This lets you keep the last row for each key instead of the first. It is handy when later entries should override earlier ones, like when reading a log of state changes.

Example:

```nushell
> [[fruit count]; [apple 9] [apple 2] [pear 3] [orange 7]] | uniq-by fruit --keep-last
╭───┬────────┬───────╮
│ # │ fruit  │ count │
├───┼────────┼───────┤
│ 0 │ apple  │     2 │
│ 1 │ pear   │     3 │
│ 2 │ orange │     7 │
╰───┴────────┴───────╯
```

## Tasks after submitting
N/A