### PR TITLE
pipefail: fixing freeze when assigning a large result of an external command to a variable.

### DIFF
--- a/crates/nu-command/tests/commands/table.rs
+++ b/crates/nu-command/tests/commands/table.rs
@@ -512,6 +512,9 @@ fn external_with_too_much_stdout_should_not_hang_nu() {
         ");
 
         assert_eq!(actual.out, large_file_body);
+
+        let actual = nu!(cwd: dirs.test(), "let x = cat a_large_file.txt; $x");
+        assert_eq!(actual.out, large_file_body);
     })
 }
 

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -173,13 +173,14 @@ impl<'a> EvalContext<'a> {
         // NOTE: in collect, it maybe good to pick the inner PipelineData
         // directly, and drop the ExitStatus queue.
         let data = self.take_reg(reg_id);
+        let body = data.body;
+        let span = body.span().unwrap_or(fallback_span);
+        let result = body.into_value(span);
         #[cfg(feature = "os")]
         if nu_experimental::PIPE_FAIL.get() {
             check_exit_status_future(data.exit)?
         }
-        let data = data.body;
-        let span = data.span().unwrap_or(fallback_span);
-        data.into_value(span)
+        result
     }
 
     /// Get a string from data or produce evaluation error if it's invalid UTF-8


### PR DESCRIPTION
As title, the issue happened because `collect_reg` checks `exit_code` first, then consuming `stdout/stderr` of an external command, it's a wrong order because if the command has too much output, it hangs and never run to finish.

This pr fixes the order, so nushell no longer hang when checking `exit_code`.

## Release notes summary - What our users need to know

### Fix hang when capturing large external command output

In pipefail, nushell no longer hang when assigning too many output of a external command to a variable, for example:
```nushell
> use std
> "a" | std repeat (1 * 1024 * 1024) o> ttt.txt
> let x = (cat ttt.txt)
```

## Tasks after submitting
NaN
