### PR TITLE
add user `id` to `sys users`

### DIFF
--- a/crates/nu-command/src/system/sys/users.rs
+++ b/crates/nu-command/src/system/sys/users.rs
@@ -49,7 +49,19 @@ fn users(span: Span) -> Value {
                 .map(|group| Value::string(trim_cstyle_null(group.name()), span))
                 .collect();
 
+            // On Windows, Uid wraps a SID (Security Identifier) which is a string like "S-1-5-18"
+            // On Unix-like systems (macOS, Linux, BSD), Uid wraps a numeric u32 user ID
+            // We need conditional compilation to handle these platform differences
+            #[cfg(windows)]
+            let id_value = Value::string(user.id().to_string(), span);
+            #[cfg(not(windows))]
+            let id_value = {
+                let id_ref: &u32 = user.id();
+                Value::int((*id_ref) as i64, span)
+            };
+
             let record = record! {
+                "id" => id_value,
                 "name" => Value::string(trim_cstyle_null(user.name()), span),
                 "groups" => Value::list(groups, span),
             };


### PR DESCRIPTION
This PR adds the user id to the `sys users` output.

You can now do things like this on non-windows platforms. On Windows the user_id is a SID so it doesn't quite work the same.
```nushell
ps -l | where user_id == (sys users | where name == username).id.0
```

closes #17576

## Release notes summary - What our users need to know
Add user id to `sys users` output

## Tasks after submitting
N/A