### PR TITLE
fix: use write_all instead of eprintln! to avoid double-panic on stderr teardown

### DIFF
--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -425,7 +425,11 @@ mod child_pgroup {
     /// Reset the foreground process group to the shell
     pub fn reset() {
         if let Err(e) = unistd::tcsetpgrp(unsafe { stdin_fd() }, unistd::getpgrp()) {
-            eprintln!("ERROR: reset foreground id failed, tcsetpgrp result: {e:?}");
+            // Use write_all instead of eprintln! to avoid panicking (and
+            // subsequently aborting due to a double-panic) when stderr is
+            // unavailable — e.g. the terminal has already been torn down.
+            let msg = format!("ERROR: reset foreground id failed, tcsetpgrp result: {e:?}\n");
+            let _ = std::io::Write::write_all(&mut std::io::stderr(), msg.as_bytes());
         }
     }
 }


### PR DESCRIPTION
## Release notes summary

Fixed a crash when nushell exits after its terminal has already been torn down (e.g. closing an editor with an embedded nushell terminal).

## Motivation

`ForegroundGuard::reset()` uses `eprintln!` to report `tcsetpgrp`
failures, but when the PTY is already gone (terminal teardown,
EIO on stderr), `eprintln!` panics on write failure. Since this
runs during cleanup, the panic can double-fault and abort the
process, so this commit switches to `write_all` + `let _ =` to
silently discard the error when stderr is unavailable.

## Context

I hit this in neovim, closing a terminal buffer running nushell
would abort instead of exiting cleanly.

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)