### PR TITLE
make `sys host` and `uname` const commands

### DIFF
--- a/crates/nu-command/src/system/sys/host.rs
+++ b/crates/nu-command/src/system/sys/host.rs
@@ -22,10 +22,23 @@ impl Command for SysHost {
         "View information about the system host."
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,
         _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(host(call.head).into_pipeline_data())
+    }
+
+    fn run_const(
+        &self,
+        _working_set: &StateWorkingSet,
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {


### PR DESCRIPTION
This PR changes the `sys host` command and the `uname` command to `const` commands.

closes #17591
## Release notes summary - What our users need to know
The `sys host` command and the `uname` command are now `const` commands.

## Tasks after submitting
N/A