### PR TITLE
fix `is-empty` / `is-not-empty` on `Empty` Pipelines

### DIFF
--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -28,7 +28,7 @@ pub fn empty(
         }
     } else {
         match input {
-            PipelineData::Empty => Ok(PipelineData::empty()),
+            PipelineData::Empty => Ok(Value::bool(!negate, head).into_pipeline_data()),
             PipelineData::ByteStream(stream, ..) => {
                 let span = stream.span();
                 match stream.reader() {


### PR DESCRIPTION
This PR changes how `is-empty` and `is-not-empty` work when the pipeline is `Pipeline:Empty` so that they return a boolean value as you would expect.

closes #17592

## Release notes summary - What our users need to know

### `is-empty` and `is-not-empty` return expected values from empty pipelines

The `is-empty` command and `is-not-empty` command now return a boolean value when the pipeline is `Pipeline::Empty`.
```nushell
> def get_null [] {}
> get_null | is-empty
true
> get_null | is-not-empty
false
```

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
