### PR TITLE
add `--timeout` flag to `input listen`

### DIFF
--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -28,18 +28,18 @@ impl Command for InputListen {
             .named(
                 "types",
                 SyntaxShape::List(Box::new(SyntaxShape::String)),
-                "Listen for event of specified types only (can be one of: focus, key, mouse, paste, resize)",
+                "Listen for event of specified types only (can be one of: focus, key, mouse, paste, resize).",
                 Some('t'),
             )
             .switch(
                 "raw",
-                "Add raw_code field with numeric value of keycode and raw_flags with bit mask flags",
+                "Add raw_code field with numeric value of keycode and raw_flags with bit mask flags.",
                 Some('r'),
             )
             .named(
                 "timeout",
                 SyntaxShape::Duration,
-                "How long to wait for input before returning",
+                "How long to wait for input before returning.",
                 Some('o')
             )
             .input_output_types(vec![(


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->
Would like some feedback on this PR.
It's pretty basic and tossed together in a couple minutes, it appears to work with basic testing but I can't test on Windows which I know is a different ballgame. I'm not doing anything fancy and the actual "handle input" part is very minimally changed, so it should work nevertheless.

For DRY purposes I believe it's safe in crossterm to `.expect("...")` on a `read()` call that was preceded by an `Ok(true)` poll, so the logic could be changed to poll in all cases and only construct a nu error when polling failed for some reason.
But I'm not sure, and don't want to use that approach without the go-ahead.

Also, the timeout behavior I decided on is to error for timeout, but another option is to return nothing, so as to differentiate between "error when reading/polling the input" or "timed out and no input was provided".

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
Added `input listen --timeout` flag that returns an error if no input was provided before the timeout.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
