### PR TITLE
fix `let` and ensure glob variables expand correctly in runtime and tests

### DIFF
--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -1,4 +1,6 @@
+use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::nu;
+use nu_test_support::playground::Playground;
 use rstest::rstest;
 
 #[rstest]
@@ -107,6 +109,16 @@ fn let_with_external_failed() {
 fn let_glob_type() {
     let actual = nu!("let x: glob = 'aa'; $x | describe");
     assert_eq!(actual.out, "glob");
+}
+
+#[test]
+fn let_typed_glob_expands_in_ls() {
+    Playground::setup("let_glob_ls", |dirs, sandbox| {
+        sandbox.with_files(&[EmptyFile("a.toml"), EmptyFile("b.toml"), EmptyFile("c.txt")]);
+
+        let actual = nu!(cwd: dirs.test(), r#"let x: glob = "*.toml"; ls $x | length"#);
+        assert_eq!(actual.out, "2");
+    })
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -232,6 +232,28 @@ fn list_files_from_two_parents_up_using_multiple_dots() {
 }
 
 #[test]
+fn let_typed_glob_expands_in_ls() {
+    Playground::setup("ls_let_glob_expand", |dirs, sandbox| {
+        sandbox.with_files(&[EmptyFile("a.toml"), EmptyFile("b.toml"), EmptyFile("c.txt")]);
+
+        let actual = nu!(cwd: dirs.test(), r#"let g: glob = "*.toml"; ls $g | length"#);
+
+        assert_eq!(actual.out, "2");
+    })
+}
+
+#[test]
+fn let_into_glob_still_works_in_ls() {
+    Playground::setup("ls_into_glob_regression", |dirs, sandbox| {
+        sandbox.with_files(&[EmptyFile("a.toml"), EmptyFile("b.toml"), EmptyFile("c.txt")]);
+
+        let actual = nu!(cwd: dirs.test(), r#"let g = "*.toml" | into glob; ls $g | length"#);
+
+        assert_eq!(actual.out, "2");
+    })
+}
+
+#[test]
 fn lists_hidden_file_when_explicitly_specified() {
     Playground::setup("ls_test_7", |dirs, sandbox| {
         sandbox.with_files(&[

--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -1,4 +1,6 @@
+use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::nu;
+use nu_test_support::playground::Playground;
 use rstest::rstest;
 
 #[test]
@@ -161,6 +163,16 @@ fn mut_value_with_match() {
 fn mut_glob_type() {
     let actual = nu!("mut x: glob = 'aa'; $x | describe");
     assert_eq!(actual.out, "glob");
+}
+
+#[test]
+fn mut_typed_glob_expands_in_ls() {
+    Playground::setup("mut_glob_ls", |dirs, sandbox| {
+        sandbox.with_files(&[EmptyFile("a.toml"), EmptyFile("b.toml"), EmptyFile("c.txt")]);
+
+        let actual = nu!(cwd: dirs.test(), r#"mut x: glob = "*.toml"; ls $x | length"#);
+        assert_eq!(actual.out, "2");
+    })
 }
 
 #[test]

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -371,12 +371,17 @@ pub(crate) fn compile_let(
 
     let variable = working_set.get_variable(var_id);
 
-    // If the variable is a glob type variable, we should cast it with GlobFrom
+    // If the variable is annotated with type `glob`, convert the value to
+    // a `Glob` (expandable) *before* storing.  We use `GlobFrom { no_expand: false }`
+    // so the stored Value::Glob behaves like a glob literal and will expand at
+    // runtime (e.g. `let g: glob = "*.toml"; ls $g` should expand).  This
+    // mirrors the `into glob` conversion and matches interpreter coercion in
+    // `nu-cmd-lang::let` (see tests in `nu-command`).
     if variable.ty == Type::Glob {
         builder.push(
             Instruction::GlobFrom {
                 src_dst: io_reg,
-                no_expand: true,
+                no_expand: false,
             }
             .into_spanned(call.head),
         )?;


### PR DESCRIPTION
This PR fixes how globs work with `let`.

Closes #7579

## Release notes summary - What our users need to know

### Globs now work at assignment time.

#### Before
```nushell
❯ let g: glob = "*.toml"
❯ ls $g
Error: nu::shell::error

  × No matches found for DoNotExpand("*.toml")
   ╭─[entry #2:1:4]
 1 │ ls $g
   ·    ─┬
   ·     ╰── Pattern, file or folder not found
   ╰────
  help: no matches found
```
#### After
```nushell
❯ let g: glob = "*.toml"
❯ ls $g
╭─#─┬────────name─────────┬─type─┬───size───┬──modified───╮
│ 0 │ Cargo.toml          │ file │ 11.09 kB │ 7 hours ago │
│ 1 │ Cross.toml          │ file │    666 B │ 2 years ago │
│ 2 │ rust-toolchain.toml │ file │    939 B │ 3 weeks ago │
│ 3 │ typos.toml          │ file │    627 B │ 3 weeks ago │
╰───┴─────────────────────┴──────┴──────────┴─────────────╯
```
#### Still working
```nushell
❯ let g = "*.toml" | into glob
❯ ls $g
╭─#─┬────────name─────────┬─type─┬───size───┬──modified───╮
│ 0 │ Cargo.toml          │ file │ 11.09 kB │ 7 hours ago │
│ 1 │ Cross.toml          │ file │    666 B │ 2 years ago │
│ 2 │ rust-toolchain.toml │ file │    939 B │ 3 weeks ago │
│ 3 │ typos.toml          │ file │    627 B │ 3 weeks ago │
╰───┴─────────────────────┴──────┴──────────┴─────────────╯
❯ glob $g
╭───┬───────────────────────────────────────────────╮
│ 0 │ /home/fdncred/src/nushell/typos.toml          │
│ 1 │ /home/fdncred/src/nushell/Cargo.toml          │
│ 2 │ /home/fdncred/src/nushell/Cross.toml          │
│ 3 │ /home/fdncred/src/nushell/rust-toolchain.toml │
╰───┴───────────────────────────────────────────────╯
❯ ls ...(glob $g)
╭─#─┬─────────────────────name──────────────────────┬─type─┬───size───┬──modified───╮
│ 0 │ /home/fdncred/src/nushell/Cargo.toml          │ file │ 11.09 kB │ 7 hours ago │
│ 1 │ /home/fdncred/src/nushell/Cross.toml          │ file │    666 B │ 2 years ago │
│ 2 │ /home/fdncred/src/nushell/rust-toolchain.toml │ file │    939 B │ 3 weeks ago │
│ 3 │ /home/fdncred/src/nushell/typos.toml          │ file │    627 B │ 3 weeks ago │
╰───┴───────────────────────────────────────────────┴──────┴──────────┴─────────────╯
```

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
