### PR TITLE
feat(completion): cellpath completion now fallback to type based when value is unknown

### DIFF
--- a/crates/nu-cli/src/completions/cell_path_completions.rs
+++ b/crates/nu-cli/src/completions/cell_path_completions.rs
@@ -72,11 +72,9 @@ impl Completer for CellPathCompletion<'_> {
             for suggestion in get_suggestions_by_value(&value, current_span) {
                 matcher.add_semantic_suggestion(suggestion);
             }
-        } else {
-            if let Some(ty) = type_follow_cell_path(&self.full_cell_path.head.ty, path_members) {
-                for suggestion in get_suggestions_by_type(ty, current_span) {
-                    matcher.add_semantic_suggestion(suggestion);
-                }
+        } else if let Some(ty) = type_follow_cell_path(&self.full_cell_path.head.ty, path_members) {
+            for suggestion in get_suggestions_by_type(ty, current_span) {
+                matcher.add_semantic_suggestion(suggestion);
             }
         }
 

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -2664,6 +2664,7 @@ fn record_cell_path_completions(#[case] input: &str) {
 #[case("($foo).", ["a"].into())]
 #[case("($foo).a.", ["b"].into())]
 #[case("$bar.", ["a", "b"].into())]
+#[case("($bar).", ["a", "b"].into())]
 fn table_cell_path_completions(#[case] input: &str, #[case] expected: Vec<&str>) {
     let (_, _, mut engine, mut stack) = new_engine();
     let command = r#"let foo = [{a:{b:1}}, {a:{b:2}}]; const bar = [[a b]; [1 2]]"#;


### PR DESCRIPTION
## Release notes summary - What our users need to know

### Cell path completion now works at a slightly broader range

```nushell
let foo = {a: b}
# ($foo).<tab>
```

## Tasks after submitting

None