### PR TITLE
fix: replace eprintln! with writeln! in error reporting to prevent double-panic

### DIFF
--- a/crates/nu-protocol/src/errors/report_error.rs
+++ b/crates/nu-protocol/src/errors/report_error.rs
@@ -2,6 +2,7 @@
 //!
 //! Relies on the `miette` crate for pretty layout
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::io::Write;
 
 use crate::{
     CompileError, Config, ErrorStyle, ParseError, ParseWarning, ShellError, ShellWarning,
@@ -171,7 +172,10 @@ fn report_error(
     error: &dyn miette::Diagnostic,
     default_code: &'static str,
 ) {
-    eprintln!(
+    // Avoid eprintln! since it panics on broken stderr, which double-panics
+    // through miette's panic hook and aborts.
+    let _ = writeln!(
+        std::io::stderr(),
         "Error: {:?}",
         CliError::new(stack, error, working_set, Some(default_code))
     );
@@ -188,7 +192,8 @@ fn report_warning(
     warning: &dyn miette::Diagnostic,
     default_code: &'static str,
 ) {
-    eprintln!(
+    let _ = writeln!(
+        std::io::stderr(),
         "Warning: {:?}",
         CliError::new(stack, warning, working_set, Some(default_code))
     );


### PR DESCRIPTION
## Release notes summary

Fixed a crash when nushell tries to report an error after its terminal has already been torn down (e.g. the terminal emulator crashes).

## Motivation

`report_error` and `report_warning` in `report_error.rs` use
`eprintln!` to print diagnostics. When stderr is gone (terminal
crash, broken pipe), `eprintln!` panics. That panic fires miette's
panic hook, which also writes to stderr, causing a double-panic
and SIGABRT. Switching to `writeln!` + `let _ =` silently discards
the error when stderr is unavailable.

This is a follow-up to #17581 which fixed a similar bug in
`ForegroundGuard::reset()`.

## Context

When the terminal emulator (e.g. kitty) crashes, stderr becomes
invalid for all child processes. If nushell happens to be reporting
an error at that moment, the `eprintln!` in `report_error`/`report_warning`
triggers the double-panic abort path.

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
