### PR TITLE
refactor(nu-parser): remove unreachable dead code in lex_item

### DIFF
--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -294,17 +294,6 @@ pub fn lex_item(
         );
     }
 
-    // If we didn't accumulate any characters, it's an unexpected error.
-    if *curr_offset - token_start == 0 {
-        return (
-            Token {
-                contents: TokenContents::Item,
-                span,
-            },
-            Some(ParseError::UnexpectedEof("command".to_string(), span)),
-        );
-    }
-
     let mut err = None;
     let output = match &input[(span.start - span_offset)..(span.end - span_offset)] {
         bytes if is_assignment_operator(bytes) => Token {


### PR DESCRIPTION
## Description

This PR removes an unreachable `curr_offset - token_start == 0` error branch in `lex_item`.

In the current control flow:

`lex_item` is only ever called from `lex_internal` (no other callers exist — verified via grep).

Before calling `lex_item`, `lex_internal` already handles and skips every character that could cause the while loop to exit immediately without advancing `curr_offset`:

- `' '`, `'\t'`, `additional_whitespace` → skipped explicitly
- `'\n'`, `'\r'` → handled as `Eol`
- `'|'` → handled as `Pipe` / `PipePipe`
- `';'` → handled as `Semicolon`
- `'#'` → handled as `Comment`

For characters in `special_tokens`, `is_special_item` fires first inside `lex_item` and increments `*curr_offset` before breaking, so `curr_offset - token_start` is 1, not 0.

As a result, by the time `lex_item` is entered, the first character is guaranteed to advance `curr_offset` by at least 1, making the `curr_offset - token_start == 0` branch unreachable.

## Before

`lex_item` contained a guard check after the main while loop:

```rust
// If we didn't accumulate any characters, it's an unexpected error.
if *curr_offset - token_start == 0 {
    return (
        Token { contents: TokenContents::Item, span },
        Some(ParseError::UnexpectedEof("command".to_string(), span)),
    );
}
```
This check was effectively unreachable due to lex_internal pre-filtering all characters that would trigger it.

## After
Removed the unreachable curr_offset - token_start == 0 branch.

No user-visible behavior is intended to change; this is a small internal simplification.

## User-facing impact
None (internal cleanup; no behavior change expected)




<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
