### PR TITLE
fix: use `writeln!` instead of `format!` and `write_all`

### DIFF
--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -349,6 +349,7 @@ mod child_pgroup {
         unistd::{self, Pid},
     };
     use std::{
+        io::Write,
         os::{
             fd::{AsFd, BorrowedFd},
             unix::prelude::CommandExt,
@@ -428,8 +429,10 @@ mod child_pgroup {
             // Use write_all instead of eprintln! to avoid panicking (and
             // subsequently aborting due to a double-panic) when stderr is
             // unavailable — e.g. the terminal has already been torn down.
-            let msg = format!("ERROR: reset foreground id failed, tcsetpgrp result: {e:?}\n");
-            let _ = std::io::Write::write_all(&mut std::io::stderr(), msg.as_bytes());
+            let _ = writeln!(
+                std::io::stderr(),
+                "ERROR: reset foreground id failed, tcsetpgrp result: {e:?}"
+            );
         }
     }
 }


### PR DESCRIPTION
`writeln!` writes directly to stderr without the intermediate heap allocation that `format!` + `write_all` requires.

- This is a follow-up to #17581

## Release notes summary - What our users need to know

N/A I think, this is solely about avoiding one allocation when writing to stderr.

