### PR TITLE
refactor(explore): conditionalize arboard feature in edtui

### DIFF
--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -36,10 +36,15 @@ lscolors = { workspace = true, default-features = false, features = [
 ratatui = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 strip-ansi-escapes = { workspace = true }
+tui-tree-widget = "0.24"
+unicode-segmentation = { workspace = true }
+unicode-width = { workspace = true }
+
+[target.'cfg(any(windows, target_os = "macos", target_os = "linux"))'.dependencies]
 edtui = { version = "0.11.1", default-features = false, features = [
     "system-editor",
     "arboard",
 ] }
-tui-tree-widget = "0.24"
-unicode-segmentation = { workspace = true }
-unicode-width = { workspace = true }
+
+[target.'cfg(not(any(windows, target_os = "macos", target_os = "linux")))'.dependencies]
+edtui = { version = "0.11.1", default-features = false, features = [ "system-editor" ] }


### PR DESCRIPTION
Restrict the 'arboard' feature of edtui to Windows, macOS, and Linux. This ensures the crate compiles on platforms where clipboard support via arboard is unavailable or unsupported.

See #17612 

## Release notes summary - What our users need to know
Users don't need to know this.