### PR TITLE
fix `detect columns` panic with unicode chars

### DIFF
--- a/crates/nu-command/tests/commands/detect_columns.rs
+++ b/crates/nu-command/tests/commands/detect_columns.rs
@@ -190,3 +190,17 @@ val1 val2 val3""#;
         "With --ignore-box-chars, separator is ignored and columns work"
     );
 }
+
+// Regression test for the panic reported when a data row contained a
+// multibyte character (… ellipsis) and a header offset landed inside it.
+// The command should complete successfully and provide the expected field.
+#[test]
+fn detect_columns_no_panic_with_multibyte_data() {
+    let input = r#"Name                   Id                                 Version      Match     Source
+katharsis              arghena.katharsis                  1.0.0-canar… Tag: rust winget"#;
+
+    let out = nu!(format!(
+        "$'{input}' | detect columns --ignore-box-chars | get Version | first"
+    ));
+    assert_eq!(out.out, "1.0.0-canar…");
+}


### PR DESCRIPTION
This PR fixes a panic in `detect columns --ignore-box-chars` by adjusting character boundary indexes.

## Release notes summary - What our users need to know
Fixes a panic with `detect columns --ignore-box-chars` by adjusting character boundary indexes.

## Before
```nushell
❯ let x = "Name                   Id                                 Version      Match     Source
katharsis              arghena.katharsis                  1.0.0-canar… Tag: rust winget"
❯ $x | detect columns --ignore-box-chars
Error:   × Main thread panicked.
  ├─▶ at crates/nu-command/src/strings/detect_columns.rs:737:30
  ╰─▶ byte index 71 is not a char boundary; it is inside '…' (bytes 69..72) of `katharsis              arghena.katharsis
      1.0.0-canar… Tag: rust winget`
  help: set the `RUST_BACKTRACE=1` environment variable to display a backtrace.
```
## After 
```nushell
❯ let x = "Name                   Id                                 Version      Match     Source
katharsis              arghena.katharsis                  1.0.0-canar… Tag: rust winget"
❯ $x | detect columns --ignore-box-chars
╭─#─┬───Name────┬────────Id─────────┬───Version────┬──Match───┬──Source──╮
│ 0 │ katharsis │ arghena.katharsis │ 1.0.0-canar… │ Tag: rus │ t winget │
╰───┴───────────┴───────────────────┴──────────────┴──────────┴──────────╯
```
I realize the split isn't very good here but the example above is not what `--ignore-box-chars` is meant for. This example is just to demonstrate that it doesn't panic. If you want a better split then use `--guess`.
```nushell
❯ $x | detect columns --guess
╭─#─┬───Name────┬────────Id─────────┬───Version────┬───Match───┬─Source─╮
│ 0 │ katharsis │ arghena.katharsis │ 1.0.0-canar… │ Tag: rust │ winget │
╰───┴───────────┴───────────────────┴──────────────┴───────────┴────────╯
```

## Tasks after submitting
N/A