### PR TITLE
clippy: fix format_push_string lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,9 +218,10 @@ webpki-roots = "1.0"
 [workspace.lints.clippy]
 # Warning: workspace lints affect library code as well as tests, so don't enable lints that would be too noisy in tests like that.
 # todo = "warn"
+format_push_string = "warn"
+result_large_err = "allow"
 unchecked_duration_subtraction = "warn"
 used_underscore_binding = "warn"
-result_large_err = "allow"
 
 [lints]
 workspace = true

--- a/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
@@ -1,4 +1,7 @@
-use std::io::{self, Read, Write};
+use std::{
+    fmt::Write as _,
+    io::{self, Read, Write},
+};
 
 use nu_cmd_base::input_handler::{CmdArgument, operate};
 use nu_engine::command_prelude::*;
@@ -199,7 +202,7 @@ fn convert_to_smallest_number_type(num: i64, span: Span, little_endian: bool) ->
         let bytes = v.to_ne_bytes(); // Endianness does not affect `i8`
         let mut raw_string = "".to_string();
         for ch in bytes {
-            raw_string.push_str(&format!("{ch:08b} "));
+            let _ = write!(raw_string, "{ch:08b} ");
         }
         Value::string(raw_string.trim(), span)
     } else if let Some(v) = num.to_i16() {
@@ -210,7 +213,7 @@ fn convert_to_smallest_number_type(num: i64, span: Span, little_endian: bool) ->
         };
         let mut raw_string = "".to_string();
         for ch in bytes {
-            raw_string.push_str(&format!("{ch:08b} "));
+            let _ = write!(raw_string, "{ch:08b} ");
         }
         Value::string(raw_string.trim(), span)
     } else if let Some(v) = num.to_i32() {
@@ -221,7 +224,7 @@ fn convert_to_smallest_number_type(num: i64, span: Span, little_endian: bool) ->
         };
         let mut raw_string = "".to_string();
         for ch in bytes {
-            raw_string.push_str(&format!("{ch:08b} "));
+            let _ = write!(raw_string, "{ch:08b} ");
         }
         Value::string(raw_string.trim(), span)
     } else {
@@ -232,7 +235,7 @@ fn convert_to_smallest_number_type(num: i64, span: Span, little_endian: bool) ->
         };
         let mut raw_string = "".to_string();
         for ch in bytes {
-            raw_string.push_str(&format!("{ch:08b} "));
+            let _ = write!(raw_string, "{ch:08b} ");
         }
         Value::string(raw_string.trim(), span)
     }
@@ -243,7 +246,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         Value::Binary { val, .. } => {
             let mut raw_string = "".to_string();
             for ch in val {
-                raw_string.push_str(&format!("{ch:08b} "));
+                let _ = write!(raw_string, "{ch:08b} ");
             }
             Value::string(raw_string.trim(), span)
         }
@@ -258,7 +261,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             let raw_bytes = val.as_bytes();
             let mut raw_string = "".to_string();
             for ch in raw_bytes {
-                raw_string.push_str(&format!("{ch:08b} "));
+                let _ = write!(raw_string, "{ch:08b} ");
             }
             Value::string(raw_string.trim(), span)
         }

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -13,7 +13,7 @@ use nu_utils::terminal_size;
 use std::{
     borrow::Cow,
     collections::HashMap,
-    fmt::Write,
+    fmt::Write as _,
     sync::{Arc, LazyLock},
 };
 
@@ -237,10 +237,10 @@ fn get_alias_documentation(
 
     let alias_name = &sig.name;
 
-    long_desc.push_str(&format!(
-        "{help_section_name}Alias{RESET}: {help_subcolor_one}{alias_name}{RESET}"
-    ));
-    long_desc.push_str("\n\n");
+    let _ = writeln!(
+        long_desc,
+        "{help_section_name}Alias{RESET}: {help_subcolor_one}{alias_name}{RESET}\n"
+    );
 
     let Some(alias) = command.as_alias() else {
         // this is already checked in `help alias`, but just omit the expansion if this is somehow not actually an alias
@@ -250,10 +250,11 @@ fn get_alias_documentation(
     let alias_expansion =
         String::from_utf8_lossy(engine_state.get_span_contents(alias.wrapped_call.span));
 
-    long_desc.push_str(&format!(
+    let _ = write!(
+        long_desc,
         "{help_section_name}Expansion{RESET}:\n  {}",
         nu_highlight_string(&alias_expansion, engine_state, stack)
-    ));
+    );
 }
 
 fn get_command_documentation(


### PR DESCRIPTION
Follow-up to https://github.com/nushell/nushell/pull/17613

https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string
