### PR TITLE
allow `view source` to store file location in metadata

### DIFF
--- a/crates/nu-command/tests/view_source.rs
+++ b/crates/nu-command/tests/view_source.rs
@@ -1,0 +1,30 @@
+use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
+use nu_test_support::nu;
+use nu_test_support::playground::Playground;
+
+#[test]
+fn view_source_returns_string() {
+    let actual = nu!(r#"def foo [] { echo hi }; view source foo"#);
+    assert_eq!(actual.out, "def foo [] { echo hi }");
+}
+
+#[test]
+fn datasource_filepath_metadata() {
+    Playground::setup("cd_ds_filepath_1", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
+            "mdata.nu",
+            r#"
+                def foo [] { echo hi }
+            "#,
+        )]);
+        let actual = nu!(
+            cwd: dirs.test(),
+            r#"
+        source mdata.nu
+        view source foo | metadata | get source
+        "#
+        );
+        // expect path printed somehow
+        assert!(actual.out.contains("mdata.nu"));
+    })
+}


### PR DESCRIPTION
I've often wondered when I do the `view source` command where is that command stored. This PR enables the `view source` command to show that location when piped through the `metadata` command. If the "source" is "entry #", then that means it was from the repl.

Thanks to @Juhan280 for helping figure out that my first way of doing this would break too many things.

## Release notes summary - What our users need to know

### Show source file location with `view source | metadata`

The `view source` command will show that file location of the source code when piped through the `metadata` command.
<img width="697" height="195" alt="image" src="https://github.com/user-attachments/assets/a4633c83-1537-40e3-976c-f77fb69c85be" />
```nushell
❯ view source env
def env [] { env details | flatten | table -e }
❯ view source env | metadata
╭──────────────┬───────────────────────────────────────────────────────────╮
│ span         │ {record 2 fields}                                         │
│ source       │ C:\Users\username\AppData\Roaming\nushell\scripts\defs.nu │
│ content_type │ application/x-nuscript                                    │
╰──────────────┴───────────────────────────────────────────────────────────╯
```
## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
