### PR TITLE
fix(view span): allow zero-length spans, reject spans that are out-of-bounds

### DIFF
--- a/crates/nu-command/src/debug/view_span.rs
+++ b/crates/nu-command/src/debug/view_span.rs
@@ -35,29 +35,38 @@ impl Command for ViewSpan {
         let start_span: Spanned<usize> = call.req(engine_state, stack, 0)?;
         let end_span: Spanned<usize> = call.req(engine_state, stack, 1)?;
 
-        let source = if start_span.item <= end_span.item {
-            let bin_contents =
-                engine_state.get_span_contents(Span::new(start_span.item, end_span.item));
-            Ok(
-                Value::string(String::from_utf8_lossy(bin_contents), call.head)
-                    .into_pipeline_data(),
-            )
+        let span = if start_span.item <= end_span.item {
+            Ok(Span::new(start_span.item, end_span.item))
         } else {
             Err(ShellError::GenericError {
-                error: "Cannot view span".to_string(),
+                error: "Invalid span".to_string(),
                 msg: "the start position of this span is later than the end position".to_string(),
                 span: Some(call.head),
                 help: None,
                 inner: vec![],
             })
+        }?;
+
+        let bin_contents = engine_state
+            .try_get_file_contents(span)
+            .map(String::from_utf8_lossy)
+            .ok_or_else(|| ShellError::GenericError {
+                error: "Cannot view span".to_string(),
+                msg: "this start and end does not correspond to a viewable value".to_string(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            })?;
+
+        let metadata = PipelineMetadata {
+            content_type: Some("application/x-nuscript".into()),
+            ..Default::default()
         };
 
-        source.map(|x| {
-            x.set_metadata(Some(PipelineMetadata {
-                content_type: Some("application/x-nuscript".into()),
-                ..Default::default()
-            }))
-        })
+        let value = Value::string(bin_contents, call.head)
+            .into_pipeline_data()
+            .set_metadata(Some(metadata));
+        Ok(value)
     }
 
     fn examples(&self) -> Vec<Example<'_>> {

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -751,13 +751,19 @@ impl EngineState {
     }
 
     pub fn get_span_contents(&self, span: Span) -> &[u8] {
-        for file in &self.files {
+        self.try_get_file_contents(span).unwrap_or(&[0u8; 0])
+    }
+
+    pub fn try_get_file_contents(&self, span: Span) -> Option<&[u8]> {
+        self.files.iter().find_map(|file| {
             if file.covered_span.contains_span(span) {
-                return &file.content
-                    [(span.start - file.covered_span.start)..(span.end - file.covered_span.start)];
+                let start = span.start - file.covered_span.start;
+                let end = span.end - file.covered_span.start;
+                Some(&file.content[start..end])
+            } else {
+                None
             }
-        }
-        &[0u8; 0]
+        })
     }
 
     /// If the span's content starts with the given prefix, return two subspans


### PR DESCRIPTION
[as discussed on Discord](https://discord.com/channels/601130461678272522/615962413203718156/1475760077477646428)

in `view span`:
1. instead of requiring `start` < `end`, we now require `start` <= `end` (and return an empty string), since otherwise, `view span` on a zero-length span will fail. for example, an empty file in `view files`.
2. when a span is not wholly contained inside a file, we used to silently return an empty string. this PR changes it to an error. no change in behavior for other code that uses `get_span_contents` - this function still returns an empty slice if it fails to match.

## Release notes summary

`view span` now allows zero-length spans and rejects spans that are out-of-bounds.