### PR TITLE
normalize slashes for `which` output

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2211,7 +2211,10 @@ pub fn parse_module_file_or_dir(
             return None;
         };
 
-        let mod_nu_path = module_path.clone().join("mod.nu");
+        let mod_nu_path = module_path
+            .clone()
+            .join("mod.nu")
+            .normalize_slashes_forward();
 
         if !(mod_nu_path.exists() && mod_nu_path.is_file()) {
             working_set.error(ParseError::ModuleMissingModNuFile(

--- a/crates/nu-protocol/src/parser_path.rs
+++ b/crates/nu-protocol/src/parser_path.rs
@@ -154,4 +154,51 @@ impl ParserPath {
             ),
         }
     }
+
+    /// Normalizes a path to use platform-native separators
+    fn normalize_native(path: &str) -> PathBuf {
+        Path::new(&path)
+            .components()
+            .fold(PathBuf::new(), |mut acc, comp| {
+                acc.push(comp);
+                acc
+            })
+    }
+
+    /// Normalizes a path to always use forward slashes (good for display, configs, cross-platform strings)
+    fn normalize_forward(path: impl AsRef<Path>) -> PathBuf {
+        PathBuf::from(
+            path.as_ref()
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR, "/"),
+        )
+    }
+
+    pub fn normalize_slashes_forward(self) -> Self {
+        match self {
+            ParserPath::RealPath(p) => ParserPath::RealPath(Self::normalize_forward(p)),
+            ParserPath::VirtualFile(p, file_id) => {
+                ParserPath::VirtualFile(Self::normalize_forward(p), file_id)
+            }
+            ParserPath::VirtualDir(p, entries) => {
+                ParserPath::VirtualDir(Self::normalize_forward(p), entries)
+            }
+        }
+    }
+
+    pub fn normalize_slashes_native(self) -> Self {
+        match self {
+            ParserPath::RealPath(p) => {
+                ParserPath::RealPath(Self::normalize_native(p.to_string_lossy().as_ref()))
+            }
+            ParserPath::VirtualFile(p, file_id) => ParserPath::VirtualFile(
+                Self::normalize_native(p.to_string_lossy().as_ref()),
+                file_id,
+            ),
+            ParserPath::VirtualDir(p, entries) => ParserPath::VirtualDir(
+                Self::normalize_native(p.to_string_lossy().as_ref()),
+                entries,
+            ),
+        }
+    }
 }


### PR DESCRIPTION
This PR tries to normalize paths for the `which` command but it does it further upstream in the code.

## Release notes summary - What our users need to know

### Normalize paths for `which` command. 

Windows users will notice this more.

#### Before
```nushell
❯ use std\clip copy # or use std/clip copy
❯ which copy
╭─#─┬─command─┬──────path───────┬──type──╮
│ 0 │ copy    │ std/clip\mod.nu │ custom │
╰─#─┴─command─┴──────path───────┴──type──╯
```
#### After
```nushell
❯ use std\clip copy # or use std/clip copy
❯ which copy
╭─#─┬─command─┬──────path───────┬──type──╮
│ 0 │ copy    │ std/clip/mod.nu │ custom │
╰─#─┴─command─┴──────path───────┴──type──╯
```

## Tasks after submitting
N/A