### PR TITLE
update `entry` to `repl_entry` for better understanding

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -150,7 +150,7 @@ pub(crate) fn add_menus(
                 let mut working_set = StateWorkingSet::new(&engine_state);
                 let output = parse(
                     &mut working_set,
-                    Some(name), // format!("entry #{}", entry_num)
+                    Some(name), // format!("repl_entry #{}", entry_num)
                     definition.as_bytes(),
                     true,
                 );

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -109,7 +109,7 @@ pub fn evaluate_repl(
             engine_state,
             &mut unique_stack,
             s.item.as_bytes(),
-            &format!("entry #{entry_num}"),
+            &format!("repl_entry #{entry_num}"),
             PipelineData::empty(),
             false,
         );
@@ -1004,7 +1004,7 @@ fn do_run_cmd(
         engine_state,
         stack,
         s.as_bytes(),
-        &format!("entry #{entry_num}"),
+        &format!("repl_entry #{entry_num}"),
         PipelineData::empty(),
         false,
     );

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -289,7 +289,7 @@ fn evaluate_source(
         let mut working_set = StateWorkingSet::new(engine_state);
         let output = parse(
             &mut working_set,
-            Some(fname), // format!("entry #{}", entry_num)
+            Some(fname), // format!("repl_entry #{}", entry_num)
             source,
             false,
         );

--- a/crates/nu-explore/src/explore/nu_common/command.rs
+++ b/crates/nu-explore/src/explore/nu_common/command.rs
@@ -67,7 +67,7 @@ fn eval_source2(
         let mut working_set = StateWorkingSet::new(engine_state);
         let output = parse(
             &mut working_set,
-            Some(fname), // format!("entry #{}", entry_num)
+            Some(fname), // format!("repl_entry #{}", entry_num)
             source,
             false,
         );

--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -105,7 +105,7 @@ impl PluginTest {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let mut working_set = StateWorkingSet::new(&self.engine_state);
-        let fname = format!("entry #{}", self.entry_num);
+        let fname = format!("repl_entry #{}", self.entry_num);
         self.entry_num += 1;
 
         // Parse the source code


### PR DESCRIPTION
This PR changes the `entry #` text to `repl_entry #` so that it's easier for users to understand. You see this with `view files` or with `which` for a command that you specified on the repl.


## Release notes summary - What our users need to know

### Changed source of repl entries

Changed `entry #` to `repl_entry #` so that it's easier to understand that the source is from the repl.
```nushell
❯ def l [] { ls -am | sort-by type name }
❯ which l
╭─#─┬─command─┬─────path──────┬──type──╮
│ 0 │ l       │ repl_entry #2 │ custom │
╰─#─┴─command─┴─────path──────┴──type──╯
```

## Tasks after submitting
N/A