### PR TITLE
Increase help indention to fix the docs build error

### DIFF
--- a/crates/nu-command/src/platform/clip/paste.rs
+++ b/crates/nu-command/src/platform/clip/paste.rs
@@ -26,8 +26,8 @@ impl Command for ClipPaste {
 
     fn description(&self) -> &str {
         "Output the current clipboard content.
- By default, it tries to parse clipboard content as JSON and outputs the corresponding Nushell value.
- This behavior can be inverted using `$env.config.clip.default_raw = true`."
+  By default, it tries to parse clipboard content as JSON and outputs the corresponding Nushell value.
+  This behavior can be inverted using `$env.config.clip.default_raw = true`."
     }
     fn run(
         &self,


### PR DESCRIPTION
Increase help indention to fix the docs build error here: https://github.com/nushell/nushell.github.io/actions/runs/22445283076/job/64997947375?pr=2126#step:5:16

After this change the generated doc `commands/docs/clip_paste.md` will be valid:

```diff
diff --git a/commands/docs/clip_paste.md b/commands/docs/clip_paste.md
index 13a0ff51..6d3d6949 100644
--- a/commands/docs/clip_paste.md
+++ b/commands/docs/clip_paste.md
@@ -5,12 +5,12 @@ categories: |
 version: 0.111.0
 system: |
   Output the current clipboard content.
- By default, it tries to parse clipboard content as JSON and outputs the corresponding Nushell value.
- This behavior can be inverted using `$env.config.clip.default_raw = true`.
+  By default, it tries to parse clipboard content as JSON and outputs the corresponding Nushell value.
+  This behavior can be inverted using `$env.config.clip.default_raw = true`.
 usage: |
   Output the current clipboard content.
- By default, it tries to parse clipboard content as JSON and outputs the corresponding Nushell value.
- This behavior can be inverted using `$env.config.clip.default_raw = true`.
+  By default, it tries to parse clipboard content as JSON and outputs the corresponding Nushell value.
+  This behavior can be inverted using `$env.config.clip.default_raw = true`.
 editLink: false
 contributors: false
 ---
```