### PR TITLE
Add support for `list-of-records` serialization in `to nuon` command

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -36,7 +36,12 @@ impl Command for ToNuon {
             .switch(
                 "raw-strings",
                 "Use raw string syntax (r#'...'#) for strings with quotes or backslashes.",
-                None,
+                Some('R'),
+            )
+            .switch(
+                "list-of-records",
+                "Serialize table values as list-of-records instead of table syntax.",
+                Some('l'),
             )
             .category(Category::Formats)
     }
@@ -59,6 +64,7 @@ impl Command for ToNuon {
 
         let serialize_types = call.has_flag(engine_state, stack, "serialize")?;
         let raw_strings = call.has_flag(engine_state, stack, "raw-strings")?;
+        let list_of_records = call.has_flag(engine_state, stack, "list-of-records")?;
         let style = if call.has_flag(engine_state, stack, "raw")? {
             nuon::ToStyle::Raw
         } else if let Some(t) = call.get_flag(engine_state, stack, "tabs")? {
@@ -76,7 +82,8 @@ impl Command for ToNuon {
             .style(style)
             .span(Some(span))
             .serialize_types(serialize_types)
-            .raw_strings(raw_strings);
+            .raw_strings(raw_strings)
+            .list_of_records(list_of_records);
 
         match nuon::to_nuon(engine_state, &value, config) {
             Ok(serde_nuon_string) => Ok(Value::string(serde_nuon_string, span)
@@ -122,6 +129,16 @@ impl Command for ToNuon {
                 description: "Use raw string syntax for strings with quotes or backslashes.",
                 example: r#"'hello "world"' | to nuon --raw-strings"#,
                 result: Some(Value::test_string(r#"r#'hello "world"'#"#)),
+            },
+            Example {
+                description: "Serialize table values as a list of records instead of table syntax.",
+                example: "[[a, b]; [1, 2], [3, 4]] | to nuon --list-of-records",
+                result: Some(Value::test_string("[{a: 1, b: 2}, {a: 3, b: 4}]")),
+            },
+            Example {
+                description: "Serialize table values as list of records with pretty indentation.",
+                example: "[[a, b]; [1, 2], [3, 4]] | to nuon --list-of-records --indent 2",
+                result: Some(Value::test_string("[\n  {a: 1, b: 2},\n  {a: 3, b: 4}\n]")),
             },
         ]
     }

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -49,6 +49,37 @@ fn to_nuon_table() {
 }
 
 #[test]
+fn to_nuon_table_as_list_of_records() {
+    let actual = nu!(r#"
+        [[a, b]; [1, 2], [3, 4]]
+        | to nuon --list-of-records
+    "#);
+
+    assert_eq!(actual.out, "[{a: 1, b: 2}, {a: 3, b: 4}]");
+}
+
+#[test]
+fn to_nuon_table_as_list_of_records_indented() {
+    let actual = nu!(r#"
+        [[a, b]; [1, 2], [3, 4]]
+        | to nuon --list-of-records --indent 2
+        | str contains "\n"
+    "#);
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn to_nuon_table_as_list_of_records_is_recursive() {
+    let actual = nu!(r#"
+        {outer: [[a, b]; [1, 2], [3, 4]]}
+        | to nuon --list-of-records
+    "#);
+
+    assert_eq!(actual.out, "{outer: [{a: 1, b: 2}, {a: 3, b: 4}]}");
+}
+
+#[test]
 fn from_nuon_illegal_table() {
     let actual = nu!(r#"
         "[[repeated repeated]; [abc, xyz], [def, ijk]]"

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -25,6 +25,8 @@ pub struct ToNuonConfig {
     pub serialize_types: bool,
     /// Prefer raw string syntax (`r#'...'#`) when strings contain quotes or backslashes
     pub raw_strings: bool,
+    /// Serialize list-of-records values as list-of-records instead of table syntax
+    pub list_of_records: bool,
 }
 
 impl ToNuonConfig {
@@ -49,6 +51,12 @@ impl ToNuonConfig {
     /// Prefer raw string syntax when strings contain quotes or backslashes
     pub fn raw_strings(mut self, raw_strings: bool) -> Self {
         self.raw_strings = raw_strings;
+        self
+    }
+
+    /// Serialize list-of-records values as list-of-records instead of table syntax
+    pub fn list_of_records(mut self, list_of_records: bool) -> Self {
+        self.list_of_records = list_of_records;
         self
     }
 }
@@ -127,11 +135,21 @@ pub fn to_nuon(
         span,
         0,
         indentation.as_deref(),
-        config.serialize_types,
-        config.raw_strings,
+        StringifyOptions {
+            serialize_types: config.serialize_types,
+            raw_strings: config.raw_strings,
+            list_of_records: config.list_of_records,
+        },
     )?;
 
     Ok(res)
+}
+
+#[derive(Clone, Copy)]
+struct StringifyOptions {
+    serialize_types: bool,
+    raw_strings: bool,
+    list_of_records: bool,
 }
 
 fn value_to_string(
@@ -140,8 +158,7 @@ fn value_to_string(
     span: Span,
     depth: usize,
     indent: Option<&str>,
-    serialize_types: bool,
-    raw_strings: bool,
+    options: StringifyOptions,
 ) -> Result<String, ShellError> {
     let (nl, sep, kv_sep) = get_true_separators(indent);
     let idt = get_true_indentation(depth, indent);
@@ -164,10 +181,10 @@ fn value_to_string(
             Ok(format!("0x[{s}]"))
         }
         Value::Closure { val, .. } => {
-            if serialize_types {
+            if options.serialize_types {
                 Ok(quote_string(
                     &val.coerce_into_string(engine_state, span)?,
-                    raw_strings,
+                    options.raw_strings,
                 ))
             } else {
                 Err(ShellError::UnsupportedInput {
@@ -203,7 +220,10 @@ fn value_to_string(
         Value::Int { val, .. } => Ok(val.to_string()),
         Value::List { vals, .. } => {
             let headers = get_columns(vals);
-            if !headers.is_empty() && vals.iter().all(|x| x.columns().eq(headers.iter())) {
+            let is_table =
+                !headers.is_empty() && vals.iter().all(|x| x.columns().eq(headers.iter()));
+
+            if is_table && !options.list_of_records {
                 // Table output
                 let headers: Vec<String> = headers
                     .iter()
@@ -230,8 +250,7 @@ fn value_to_string(
                                 span,
                                 depth + 2,
                                 indent,
-                                serialize_types,
-                                raw_strings,
+                                options,
                             )?);
                         }
                     }
@@ -244,6 +263,28 @@ fn value_to_string(
                     headers_output,
                     table_output.join(&format!("{nl}{idt_po}],{sep}{nl}{idt_po}[{nl}{idt_pt}"))
                 ))
+            } else if is_table && options.list_of_records {
+                let mut collection = vec![];
+                let row_indent = if indent == Some("") { Some("") } else { None };
+
+                for val in vals {
+                    collection.push(format!(
+                        "{idt_po}{}",
+                        value_to_string_without_quotes(
+                            engine_state,
+                            val,
+                            span,
+                            depth + 1,
+                            row_indent,
+                            options,
+                        )?
+                    ));
+                }
+
+                Ok(format!(
+                    "[{nl}{}{nl}{idt}]",
+                    collection.join(&format!(",{sep}{nl}"))
+                ))
             } else {
                 let mut collection = vec![];
                 for val in vals {
@@ -255,8 +296,7 @@ fn value_to_string(
                             span,
                             depth + 1,
                             indent,
-                            serialize_types,
-                            raw_strings,
+                            options,
                         )?
                     ));
                 }
@@ -287,8 +327,7 @@ fn value_to_string(
                         span,
                         depth + 1,
                         indent,
-                        serialize_types,
-                        raw_strings,
+                        options,
                     )?
                 ));
             }
@@ -299,8 +338,8 @@ fn value_to_string(
         }
         // All strings outside data structures are quoted because they are in 'command position'
         // (could be mistaken for commands by the Nu parser)
-        Value::String { val, .. } => Ok(quote_string(val, raw_strings)),
-        Value::Glob { val, .. } => Ok(quote_string(val, raw_strings)),
+        Value::String { val, .. } => Ok(quote_string(val, options.raw_strings)),
+        Value::Glob { val, .. } => Ok(quote_string(val, options.raw_strings)),
     }
 }
 
@@ -338,25 +377,16 @@ fn value_to_string_without_quotes(
     span: Span,
     depth: usize,
     indent: Option<&str>,
-    serialize_types: bool,
-    raw_strings: bool,
+    options: StringifyOptions,
 ) -> Result<String, ShellError> {
     match v {
         Value::String { val, .. } => Ok({
             if needs_quoting(val) {
-                quote_string(val, raw_strings)
+                quote_string(val, options.raw_strings)
             } else {
                 val.clone()
             }
         }),
-        _ => value_to_string(
-            engine_state,
-            v,
-            span,
-            depth,
-            indent,
-            serialize_types,
-            raw_strings,
-        ),
+        _ => value_to_string(engine_state, v, span, depth, indent, options),
     }
 }


### PR DESCRIPTION
This PR follows the discussion in https://github.com/nushell/nushell/discussions/16319 and enables `to nuon` to output a list of records.

## Release notes summary - What our users need to know
### New flag ` --list-of-records` for `to nuon`
Add support for `list-of-records` serialization in `to nuon` command to return tables as a list of records instead of inline tables.
```nushell
❯ ls | to nuon --list-of-records
[{name: assets, type: dir, size: 4096b, modified: 2024-04-04T13:52:36.476801098-05:00}, {name: ast-grep, type: dir, size: 4096b, modified: 2025-11-18T13:30:11.363297741-06:00}, {name: benches, type: dir, size: 4096b, modified: 2025-11-18T13:30:11.363297741-06:00}, {name: clippy, type: dir, size: 4096b, modified: 2025-02-28T09:50:31.158860628-06:00}, {name: crates, type: dir, size: 4096b, modified: 2026-02-25T13:07:09.599693881-06:00}, {name: devdocs, type: dir, size: 4096b, modified: 2025-11-18T13:30:11.454964408-06:00}, {name: docker, type: dir, size: 4096b, modified: 2025-02-28T09:50:31.298860628-06:00}, {name: scripts, type: dir, size: 4096b, modified: 2026-02-25T08:14:40.029802188-06:00}, {name: src, type: dir, size: 4096b, modified: 2026-02-17T07:50:15.287285276-06:00}, {name: target, type: dir, size: 4096b, modified: 2026-02-23T08:09:36.070592259-06:00}, {name: tests, type: dir, size: 4096b, modified: 2026-02-25T13:07:09.635693857-06:00}, {name: toolkit, type: dir, size: 4096b, modified: 2025-11-18T13:30:11.454964408-06:00}, {name: wix, type: dir, size: 4096b, modified: 2026-01-22T11:37:02.215586759-06:00}, {name: "agents.md", type: file, size: 1982b, modified: 2026-02-13T08:00:31.982552025-06:00}, {name: "Cargo.lock", type: file, size: 241482b, modified: 2026-02-26T09:07:11.301117229-06:00}, {name: "Cargo.toml", type: file, size: 11098b, modified: 2026-02-25T13:07:09.607693876-06:00}, {name: "CITATION.cff", type: file, size: 812b, modified: 2024-06-10T15:49:33.872607473-05:00}, {name: "CODE_OF_CONDUCT.md", type: file, size: 3444b, modified: 2024-04-04T13:52:36.466801097-05:00}, {name: "CONTRIBUTING.md", type: file, size: 18387b, modified: 2026-01-22T11:37:02.165586759-06:00}, {name: "Cross.toml", type: file, size: 666b, modified: 2024-04-11T15:58:01.003303985-05:00}, {name: LICENSE, type: file, size: 1094b, modified: 2025-02-28T09:50:31.158860628-06:00}, {name: "README.md", type: file, size: 12504b, modified: 2025-11-18T13:30:11.363297741-06:00}, {name: "rust-toolchain.toml", type: file, size: 939b, modified: 2026-01-22T11:37:02.215586759-06:00}, {name: "SECURITY.md", type: file, size: 2681b, modified: 2025-11-18T13:30:11.363297741-06:00}, {name: "sgconfig.yml", type: file, size: 210b, modified: 2025-11-18T13:30:11.454964408-06:00}, {name: "toolkit.nu", type: file, size: 58b, modified: 2025-11-18T13:30:11.454964408-06:00}, {name: "typos.toml", type: file, size: 696b, modified: 2026-02-25T08:14:40.038468857-06:00}]
```
```nushell
❯ ls | to nuon --list-of-records --indent 2
[
  {name: assets, type: dir, size: 4096b, modified: 2024-04-04T13:52:36.476801098-05:00},
  {name: ast-grep, type: dir, size: 4096b, modified: 2025-11-18T13:30:11.363297741-06:00},
  {name: benches, type: dir, size: 4096b, modified: 2025-11-18T13:30:11.363297741-06:00},
  {name: clippy, type: dir, size: 4096b, modified: 2025-02-28T09:50:31.158860628-06:00},
  {name: crates, type: dir, size: 4096b, modified: 2026-02-25T13:07:09.599693881-06:00},
  {name: devdocs, type: dir, size: 4096b, modified: 2025-11-18T13:30:11.454964408-06:00},
  {name: docker, type: dir, size: 4096b, modified: 2025-02-28T09:50:31.298860628-06:00},
  {name: scripts, type: dir, size: 4096b, modified: 2026-02-25T08:14:40.029802188-06:00},
  {name: src, type: dir, size: 4096b, modified: 2026-02-17T07:50:15.287285276-06:00},
  {name: target, type: dir, size: 4096b, modified: 2026-02-23T08:09:36.070592259-06:00},
  {name: tests, type: dir, size: 4096b, modified: 2026-02-25T13:07:09.635693857-06:00},
  {name: toolkit, type: dir, size: 4096b, modified: 2025-11-18T13:30:11.454964408-06:00},
  {name: wix, type: dir, size: 4096b, modified: 2026-01-22T11:37:02.215586759-06:00},
  {name: "agents.md", type: file, size: 1982b, modified: 2026-02-13T08:00:31.982552025-06:00},
  {name: "Cargo.lock", type: file, size: 241482b, modified: 2026-02-26T09:07:11.301117229-06:00},
  {name: "Cargo.toml", type: file, size: 11098b, modified: 2026-02-25T13:07:09.607693876-06:00},
  {name: "CITATION.cff", type: file, size: 812b, modified: 2024-06-10T15:49:33.872607473-05:00},
  {name: "CODE_OF_CONDUCT.md", type: file, size: 3444b, modified: 2024-04-04T13:52:36.466801097-05:00},
  {name: "CONTRIBUTING.md", type: file, size: 18387b, modified: 2026-01-22T11:37:02.165586759-06:00},
  {name: "Cross.toml", type: file, size: 666b, modified: 2024-04-11T15:58:01.003303985-05:00},
  {name: LICENSE, type: file, size: 1094b, modified: 2025-02-28T09:50:31.158860628-06:00},
  {name: "README.md", type: file, size: 12504b, modified: 2025-11-18T13:30:11.363297741-06:00},
  {name: "rust-toolchain.toml", type: file, size: 939b, modified: 2026-01-22T11:37:02.215586759-06:00},
  {name: "SECURITY.md", type: file, size: 2681b, modified: 2025-11-18T13:30:11.363297741-06:00},
  {name: "sgconfig.yml", type: file, size: 210b, modified: 2025-11-18T13:30:11.454964408-06:00},
  {name: "toolkit.nu", type: file, size: 58b, modified: 2025-11-18T13:30:11.454964408-06:00},
  {name: "typos.toml", type: file, size: 696b, modified: 2026-02-25T08:14:40.038468857-06:00}
]
```

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
