### PR TITLE
Allow `clip copy` to copy tables without ansi escapes

### DIFF
--- a/crates/nu-command/src/viewers/mod.rs
+++ b/crates/nu-command/src/viewers/mod.rs
@@ -3,3 +3,4 @@ mod table;
 
 pub use griddle::Griddle;
 pub use table::Table;
+pub(crate) use table::render_value_as_plain_table_text;


### PR DESCRIPTION
This PR removes the `--raw` option from the build-in `clip copy` and also defaults to allowing you to copy tables without ansi escape sequences with commands like `ls | clip copy`.

## Release notes summary - What our users need to know
### Built-in `clip copy` now behaves like `std/clip copy`
Copy nushell tables to the clipboard without ansi escape sequences.
```nushell
ls | clip copy
```

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
