### PR TITLE
Updated `metadata-set` example to use `--path-columns` syntax

### DIFF
--- a/crates/nu-command/src/debug/metadata_set.rs
+++ b/crates/nu-command/src/debug/metadata_set.rs
@@ -24,7 +24,7 @@ impl Command for MetadataSet {
             )
             .switch(
                 "datasource-ls",
-                "Assign the DataSource::Ls metadata to the input.",
+                "(DEPRECATED) Assign the DataSource::Ls metadata to the input.",
                 Some('l'),
             )
             .named(
@@ -190,11 +190,6 @@ impl Command for MetadataSet {
             Example {
                 description: "Set the metadata of a file path.",
                 example: "'crates' | metadata set --datasource-filepath $'(pwd)/crates'",
-                result: None,
-            },
-            Example {
-                description: "Set the path columns metadata.",
-                example: "glob * | wrap path | metadata set --path-columns [path]",
                 result: None,
             },
             Example {


### PR DESCRIPTION
## Release notes summary - What our users need to know

* Reworks the existing `--datasource-ls` example to use `--path-columns`
* Adds "(DEPRECATED)" to the `--datasource-ls` help text
* Removes the other `--path-columns` example as it is no longer necessary.


## Tasks after submitting

N/A