### PR TITLE
Reworked another deprecated `metadata set` example

### DIFF
--- a/crates/nu-command/src/debug/metadata_set.rs
+++ b/crates/nu-command/src/debug/metadata_set.rs
@@ -200,6 +200,7 @@ impl Command for MetadataSet {
             Example {
                 description: "Merge custom metadata.",
                 example: r#""data" | metadata set {|| merge {custom_key: "value"}} | metadata | get custom_key"#,
+                result: None,
             },
             Example {
                 description: "Set metadata using a closure.",


### PR DESCRIPTION
## Release notes summary - What our users need to know

* Changed example which was using the deprecated `--merge` flag to suggested syntax
* Updated `--merge` help description with "(DEPRECATED)" notice
* Updated help text on `--path-columns` to be more clear

## Tasks after submitting

N/A