### PR TITLE
fix interpolation without closing paren

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2427,13 +2427,21 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
             }
         }
         InterpolationMode::Expression => {
-            if token_start < end {
-                let span = Span::new(token_start, end);
+            let span = Span::new(token_start, end);
 
-                if delimiter_stack.is_empty() {
+            if delimiter_stack.is_empty() {
+                if token_start < end {
                     let expr = parse_full_cell_path(working_set, None, span);
                     output.push(expr);
                 }
+            } else {
+                let expected = delimiter_stack
+                    .last()
+                    .copied()
+                    .map(char::from)
+                    .unwrap_or(')')
+                    .to_string();
+                working_set.error(ParseError::Unclosed(expected, Span::new(end, end)));
             }
         }
     }

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1813,6 +1813,20 @@ mod string {
 
             assert!(working_set.parse_errors.is_empty());
         }
+
+        #[test]
+        pub fn parse_string_interpolation_unclosed_subexpression() {
+            let engine_state = EngineState::new();
+            let mut working_set = StateWorkingSet::new(&engine_state);
+
+            let _ = parse(&mut working_set, None, b"$\"foo (2 + 3\"", true);
+
+            assert!(
+                working_set.parse_errors.iter().any(
+                    |err| matches!(err, ParseError::Unclosed(delimiter, _) if delimiter == ")")
+                )
+            );
+        }
     }
 
     #[test]

--- a/tests/repl/test_strings.rs
+++ b/tests/repl/test_strings.rs
@@ -58,6 +58,11 @@ fn single_tick_interpolation() -> TestResult {
 }
 
 #[test]
+fn unclosed_interpolation_subexpression() -> TestResult {
+    fail_test("$\"foo (2 + 3\"", "unclosed )")
+}
+
+#[test]
 fn detect_newlines() -> TestResult {
     run_test("'hello\r\nworld' | lines | get 0 | str length", "5")
 }


### PR DESCRIPTION
This PR fixes #17669 where if a closing paren is left out of an interpolated string the parser doesn't catch it.


closes #17669 
## Release notes summary - What our users need to know

Fix a parser bug with string interpolation.

### Before
```nushell
❯ $"foo (2 + 3"
foo
```

### After
```nushell
❯ $"foo (2 + 3"
Error: nu::parser::unclosed_delimiter

  × Unclosed delimiter.
   ╭─[repl_entry #1:1:13]
 1 │ $"foo (2 + 3"
   ·             ▲
   ·             ╰── unclosed )
   ╰────
❯ $"foo (2 + 3)"
foo 5
```

## Tasks after submitting
N/A