### PR TITLE
Revert "pipefail: enable by default"

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -328,7 +328,7 @@ If you create a custom command with this name, that will be used instead."#
         let child_pid = child.pid();
 
         // Wrap the output into a `PipelineData::byte_stream`.
-        let child = ChildProcess::new(
+        let mut child = ChildProcess::new(
             child,
             merged_stream,
             matches!(stderr, OutDest::Pipe),
@@ -343,6 +343,12 @@ If you create a custom command with this name, that will be used instead."#
                     .map(|it| it.to_string()),
             )),
         )?;
+
+        if matches!(stdout, OutDest::Pipe | OutDest::PipeSeparate)
+            || matches!(stderr, OutDest::Pipe | OutDest::PipeSeparate)
+        {
+            child.ignore_error(true);
+        }
 
         Ok(PipelineData::byte_stream(
             ByteStream::child(child, call.head),

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -626,9 +626,8 @@ fn eval_instruction<D: DebugContext>(
             #[cfg(feature = "os")]
             {
                 let mut original_exit = input.exit;
-                let result_exit_status_future = result
-                    .clone_exit_status_future()
-                    .map(|f| f.with_span(*span));
+                let result_exit_status_future =
+                    result.clone_exit_status_future().map(|f| (f, *span));
                 original_exit.push(result_exit_status_future);
                 ctx.put_reg(
                     *src_dst,

--- a/crates/nu-experimental/src/options/pipefail.rs
+++ b/crates/nu-experimental/src/options/pipefail.rs
@@ -16,7 +16,7 @@ impl ExperimentalOptionMarker for PipeFail {
     const DESCRIPTION: &'static str = "\
         If an external command fails within a pipeline, $env.LAST_EXIT_CODE is set \
         to the exit code of rightmost command which failed.";
-    const STATUS: Status = Status::OptOut;
+    const STATUS: Status = Status::OptIn;
     const SINCE: Version = (0, 107, 1);
     const ISSUE: u32 = 16760;
 }

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "os")]
-use crate::process::ExitStatusGuard;
+use crate::process::ExitStatusFuture;
 use crate::{
     ByteStream, ByteStreamSource, ByteStreamType, Config, ListStream, OutDest, PipelineMetadata,
     Range, ShellError, Signals, Span, Type, Value,
@@ -8,7 +8,12 @@ use crate::{
     location,
     shell_error::{io::IoError, location::Location},
 };
-use std::{borrow::Cow, io::Write, ops::Deref};
+use std::{
+    borrow::Cow,
+    io::Write,
+    ops::Deref,
+    sync::{Arc, Mutex},
+};
 
 const LINE_ENDING_PATTERN: &[char] = &['\r', '\n'];
 
@@ -868,16 +873,12 @@ impl PipelineData {
     // PipelineData might connect to a running process which has an exit status future
     // Use this method to retrieve that future, it's useful for implementing `pipefail` feature.
     #[cfg(feature = "os")]
-    pub fn clone_exit_status_future(&self) -> Option<ExitStatusGuard> {
+    pub fn clone_exit_status_future(&self) -> Option<Arc<Mutex<ExitStatusFuture>>> {
         match self {
             PipelineData::Empty | PipelineData::Value(..) | PipelineData::ListStream(..) => None,
             PipelineData::ByteStream(stream, ..) => match stream.source() {
                 ByteStreamSource::Read(..) | ByteStreamSource::File(..) => None,
-                ByteStreamSource::Child(c) => {
-                    let exit_future = c.clone_exit_status_future();
-                    let ignore_error = c.clone_ignore_error();
-                    Some(ExitStatusGuard::new(exit_future, ignore_error))
-                }
+                ByteStreamSource::Child(c) => Some(c.clone_exit_status_future()),
             },
         }
     }
@@ -1088,7 +1089,7 @@ fn value_to_bytes(value: Value) -> Result<Vec<u8>, ShellError> {
 pub struct PipelineExecutionData {
     pub body: PipelineData,
     #[cfg(feature = "os")]
-    pub exit: Vec<Option<ExitStatusGuard>>,
+    pub exit: Vec<Option<(Arc<Mutex<ExitStatusFuture>>, Span)>>,
 }
 
 impl Deref for PipelineExecutionData {
@@ -1113,9 +1114,7 @@ impl From<PipelineData> for PipelineExecutionData {
     #[cfg(feature = "os")]
     fn from(value: PipelineData) -> Self {
         let value_span = value.span().unwrap_or_else(Span::unknown);
-        let exit_status_future = value
-            .clone_exit_status_future()
-            .map(|f| f.with_span(value_span));
+        let exit_status_future = value.clone_exit_status_future().map(|f| (f, value_span));
         Self {
             body: value,
             exit: vec![exit_status_future],

--- a/crates/nu-protocol/src/process/child.rs
+++ b/crates/nu-protocol/src/process/child.rs
@@ -20,29 +20,23 @@ use std::{
 /// This is used to implement pipefail.
 #[cfg(feature = "os")]
 pub fn check_exit_status_future(
-    exit_status: Vec<Option<ExitStatusGuard>>,
+    exit_status: Vec<Option<(Arc<Mutex<ExitStatusFuture>>, Span)>>,
 ) -> Result<(), ShellError> {
-    for one_status in exit_status.into_iter().rev().flatten() {
-        check_exit_status_future_ok(one_status)?
+    for (future, span) in exit_status.into_iter().rev().flatten() {
+        check_exit_status_future_ok(future, span)?
     }
     Ok(())
 }
 
-fn check_exit_status_future_ok(exit_status_guard: ExitStatusGuard) -> Result<(), ShellError> {
-    let ignore_error = {
-        let guard = exit_status_guard
-            .ignore_error
-            .lock()
-            .expect("lock ignore_error should success");
-        *guard
-    };
-    let mut future = exit_status_guard
-        .exit_status_future
+fn check_exit_status_future_ok(
+    exit_status_future: Arc<Mutex<ExitStatusFuture>>,
+    span: Span,
+) -> Result<(), ShellError> {
+    let mut future = exit_status_future
         .lock()
         .expect("lock exit_status_future should success");
-    let span = exit_status_guard.span.unwrap_or_default();
     let exit_status = future.wait(span)?;
-    check_ok(exit_status, ignore_error, span)
+    check_ok(exit_status, false, span)
 }
 
 pub fn check_ok(status: ExitStatus, ignore_error: bool, span: Span) -> Result<(), ShellError> {
@@ -84,39 +78,6 @@ pub fn check_ok(status: ExitStatus, ignore_error: bool, span: Span) -> Result<()
                     }
                 })
             }
-        }
-    }
-}
-
-/// A wrapper for both `exit_status_future: Arc<Mutex<ExitStatusFuture>>`
-/// and `ignore_error: Arc<Mutex<bool>>`
-///
-/// It's useful for `pipefail` feature, which tracks exit status code with potentially
-/// ignore the error.
-#[derive(Debug)]
-pub struct ExitStatusGuard {
-    pub exit_status_future: Arc<Mutex<ExitStatusFuture>>,
-    pub ignore_error: Arc<Mutex<bool>>,
-    pub span: Option<Span>,
-}
-
-impl ExitStatusGuard {
-    pub fn new(
-        exit_status_future: Arc<Mutex<ExitStatusFuture>>,
-        ignore_error: Arc<Mutex<bool>>,
-    ) -> Self {
-        Self {
-            exit_status_future,
-            ignore_error,
-            span: None,
-        }
-    }
-
-    pub fn with_span(self, span: Span) -> Self {
-        Self {
-            exit_status_future: self.exit_status_future,
-            ignore_error: self.ignore_error,
-            span: Some(span),
         }
     }
 }
@@ -231,7 +192,7 @@ pub struct ChildProcess {
     pub stdout: Option<ChildPipe>,
     pub stderr: Option<ChildPipe>,
     exit_status: Arc<Mutex<ExitStatusFuture>>,
-    ignore_error: Arc<Mutex<bool>>,
+    ignore_error: bool,
     span: Span,
 }
 
@@ -364,16 +325,13 @@ impl ChildProcess {
                     .map(ExitStatusFuture::Running)
                     .unwrap_or(ExitStatusFuture::Finished(Ok(ExitStatus::Exited(0)))),
             )),
-            ignore_error: Arc::new(Mutex::new(false)),
+            ignore_error: false,
             span,
         }
     }
 
     pub fn ignore_error(&mut self, ignore: bool) -> &mut Self {
-        {
-            let mut ignore_error = self.ignore_error.lock().expect("lock should success");
-            *ignore_error = ignore;
-        }
+        self.ignore_error = ignore;
         self
     }
 
@@ -403,14 +361,7 @@ impl ChildProcess {
             .exit_status
             .lock()
             .expect("lock exit_status future should success");
-        let ignore_error = {
-            let guard = self
-                .ignore_error
-                .lock()
-                .expect("lock ignore error should success");
-            *guard
-        };
-        check_ok(exit_status.wait(self.span)?, ignore_error, self.span)?;
+        check_ok(exit_status.wait(self.span)?, self.ignore_error, self.span)?;
 
         Ok(bytes)
     }
@@ -455,14 +406,7 @@ impl ChildProcess {
             .exit_status
             .lock()
             .expect("lock exit_status future should success");
-        let ignore_error = {
-            let guard = self
-                .ignore_error
-                .lock()
-                .expect("lock ignore error should success");
-            *guard
-        };
-        check_ok(exit_status.wait(self.span)?, ignore_error, self.span)
+        check_ok(exit_status.wait(self.span)?, self.ignore_error, self.span)
     }
 
     pub fn try_wait(&mut self) -> Result<Option<ExitStatus>, ShellError> {
@@ -527,10 +471,6 @@ impl ChildProcess {
 
     pub fn clone_exit_status_future(&self) -> Arc<Mutex<ExitStatusFuture>> {
         self.exit_status.clone()
-    }
-
-    pub fn clone_ignore_error(&self) -> Arc<Mutex<bool>> {
-        self.ignore_error.clone()
     }
 }
 

--- a/tests/shell/pipeline/mod.rs
+++ b/tests/shell/pipeline/mod.rs
@@ -10,6 +10,15 @@ fn doesnt_break_on_utf8() {
 }
 
 #[test]
+fn non_zero_exit_code_in_middle_of_pipeline_ignored() {
+    let actual = nu!("nu -c 'print a b; exit 42' | collect");
+    assert_eq!(actual.out, "ab");
+
+    let actual = nu!("nu -c 'print a b; exit 42' | nu --stdin -c 'collect'");
+    assert_eq!(actual.out, "ab");
+}
+
+#[test]
 fn infinite_output_piped_to_value() {
     let actual = nu!("nu --testbin iecho x | 1");
     assert_eq!(actual.out, "1");


### PR DESCRIPTION
Reverts nushell/nushell#17449

@WindSoilder can you look into this. I think we need to revert the auto opt-in part back since it's causing problems and we have a release today https://github.com/nushell/nushell/issues/17674

We may not want to revert all of this, maybe just the opt-in parts?