### PR TITLE
update the sqlite history timestamp and duration with nushell values

### DIFF
--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -51,7 +51,7 @@ which = { workspace = true }
 [features]
 plugin = ["nu-plugin-engine"]
 system-clipboard = ["reedline/system_clipboard"]
-sqlite = ["reedline/sqlite", "nu-protocol/sqlite"]
+sqlite = ["reedline/sqlite", "nu-protocol/sqlite", "nu-command/sqlite"]
 
 [lints]
 workspace = true

--- a/crates/nu-cli/src/commands/history/history_.rs
+++ b/crates/nu-cli/src/commands/history/history_.rs
@@ -166,6 +166,9 @@ impl Command for History {
                             .to_string(),
                     );
                 }
+                table = table
+                    .with_unix_millis_datetime_column(fields::START_TIMESTAMP.to_string())
+                    .with_millis_duration_column(fields::DURATION.to_string());
                 Ok(PipelineData::Value(
                     Value::custom(Box::new(table), head),
                     None,

--- a/crates/nu-cli/tests/commands/history_output.rs
+++ b/crates/nu-cli/tests/commands/history_output.rs
@@ -1,0 +1,58 @@
+use nu_test_support::{Outcome, nu};
+use tempfile::TempDir;
+
+struct Test {
+    cfg_dir: TempDir,
+}
+
+const IMPORT_SINGLE_HISTORY_RECORD: &str = "[[command start_timestamp duration exit_status cwd]; [echo (date now) 30ms 0 /tmp]] | history import";
+
+impl Test {
+    fn new() -> Self {
+        let cfg_dir = tempfile::Builder::new()
+            .prefix("history_output_test")
+            .tempdir()
+            .unwrap();
+        std::fs::write(
+            cfg_dir.path().join("env.nu"),
+            "$env.config.history.file_format = 'sqlite'",
+        )
+        .unwrap();
+        Self { cfg_dir }
+    }
+
+    fn nu(&self, cmd: impl AsRef<str>) -> Outcome {
+        let env = [(
+            "XDG_CONFIG_HOME".to_string(),
+            self.cfg_dir.path().to_str().unwrap().to_string(),
+        )];
+        let env_config = self.cfg_dir.path().join("env.nu");
+        nu!(envs: env, env_config: env_config, cmd.as_ref())
+    }
+
+    fn import_single_history_record(&self) -> Outcome {
+        self.nu(IMPORT_SINGLE_HISTORY_RECORD)
+    }
+}
+
+#[test]
+fn sqlite_history_last_returns_date_for_start_timestamp() {
+    let test = Test::new();
+
+    let import_result = test.import_single_history_record();
+    assert!(import_result.status.success(), "{}", import_result.err);
+
+    let actual = test.nu("history | last | get start_timestamp | describe");
+    assert_eq!(actual.out, "datetime");
+}
+
+#[test]
+fn sqlite_history_last_returns_duration_for_duration_column() {
+    let test = Test::new();
+
+    let import_result = test.import_single_history_record();
+    assert!(import_result.status.success(), "{}", import_result.err);
+
+    let actual = test.nu("history | last | get duration | describe");
+    assert_eq!(actual.out, "duration");
+}

--- a/crates/nu-cli/tests/commands/mod.rs
+++ b/crates/nu-cli/tests/commands/mod.rs
@@ -3,3 +3,6 @@ mod nu_highlight;
 
 #[cfg(feature = "sqlite")]
 mod history_import;
+
+#[cfg(feature = "sqlite")]
+mod history_output;

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -11,6 +11,7 @@ use rusqlite::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::BTreeMap,
     fs::File,
     io::Read,
     path::{Path, PathBuf},
@@ -102,7 +103,7 @@ impl SQLiteDatabase {
         call_span: Span,
     ) -> Result<Value, ShellError> {
         let conn = open_sqlite_db(&self.path, call_span)?;
-        let stream = run_sql_query(conn, sql, params, &self.signals)
+        let stream = run_sql_query(conn, sql, params, &self.signals, None)
             .map_err(|e| e.into_shell_error(sql.span, "Failed to query SQLite database"))?;
 
         Ok(stream)
@@ -428,9 +429,10 @@ fn run_sql_query(
     sql: &Spanned<String>,
     params: NuSqlParams,
     signals: &Signals,
+    column_adapters: Option<&BTreeMap<String, SQLiteColumnAdapter>>,
 ) -> Result<Value, SqliteOrShellError> {
     let stmt = conn.prepare(&sql.item)?;
-    prepared_statement_to_nu_list(stmt, params, sql.span, signals)
+    prepared_statement_to_nu_list(stmt, params, sql.span, signals, column_adapters)
 }
 
 // This is taken from to text local_into_string but tweaks it a bit so that certain formatting does not happen
@@ -599,6 +601,7 @@ fn prepared_statement_to_nu_list(
     params: NuSqlParams,
     call_span: Span,
     signals: &Signals,
+    column_adapters: Option<&BTreeMap<String, SQLiteColumnAdapter>>,
 ) -> Result<Value, SqliteOrShellError> {
     let columns: Vec<TypedColumn> = stmt
         .columns()
@@ -606,28 +609,40 @@ fn prepared_statement_to_nu_list(
         .map(TypedColumn::from_rusqlite_column)
         .collect();
 
-    // I'm very sorry for this repetition
-    // I tried scoping the match arms to the query_map alone, but lifetime and closure reference escapes
-    // got heavily in the way
+    fn collect_row_values(
+        row_results: impl IntoIterator<Item = Result<Value, SqliteError>>,
+        signals: &Signals,
+        call_span: Span,
+    ) -> Result<Vec<Value>, SqliteOrShellError> {
+        let mut row_values = vec![];
+
+        for row_result in row_results {
+            signals.check(&call_span)?;
+            if let Ok(row_value) = row_result {
+                row_values.push(row_value);
+            }
+        }
+
+        Ok(row_values)
+    }
+
+    // Both parameter styles need separate query_map calls because rusqlite uses
+    // different parameter reference types for positional and named bindings.
+    // Keep the row processing shared through `collect_row_values`.
     let row_values = match params {
         NuSqlParams::List(params) => {
             let refs: Vec<&dyn ToSql> = params.iter().map(|value| &**value).collect();
 
             let row_results = stmt.query_map(refs.as_slice(), |row| {
-                Ok(convert_sqlite_row_to_nu_value(row, call_span, &columns))
+                Ok(convert_sqlite_row_to_nu_value(
+                    row,
+                    call_span,
+                    &columns,
+                    column_adapters,
+                ))
             })?;
 
-            // we collect all rows before returning them. Not ideal but it's hard/impossible to return a stream from a CustomValue
-            let mut row_values = vec![];
-
-            for row_result in row_results {
-                signals.check(&call_span)?;
-                if let Ok(row_value) = row_result {
-                    row_values.push(row_value);
-                }
-            }
-
-            row_values
+            collect_row_values(row_results, signals, call_span)?
         }
         NuSqlParams::Named(pairs) => {
             let refs: Vec<_> = pairs
@@ -636,20 +651,15 @@ fn prepared_statement_to_nu_list(
                 .collect();
 
             let row_results = stmt.query_map(refs.as_slice(), |row| {
-                Ok(convert_sqlite_row_to_nu_value(row, call_span, &columns))
+                Ok(convert_sqlite_row_to_nu_value(
+                    row,
+                    call_span,
+                    &columns,
+                    column_adapters,
+                ))
             })?;
 
-            // we collect all rows before returning them. Not ideal but it's hard/impossible to return a stream from a CustomValue
-            let mut row_values = vec![];
-
-            for row_result in row_results {
-                signals.check(&call_span)?;
-                if let Ok(row_value) = row_result {
-                    row_values.push(row_value);
-                }
-            }
-
-            row_values
+            collect_row_values(row_results, signals, call_span)?
         }
     };
 
@@ -671,27 +681,77 @@ fn read_entire_sqlite_db(
         let table_name: String = row?;
         // TODO: Should use params here?
         let table_stmt = conn.prepare(&format!("select * from [{table_name}]"))?;
-        let rows =
-            prepared_statement_to_nu_list(table_stmt, NuSqlParams::default(), call_span, signals)?;
+        let rows = prepared_statement_to_nu_list(
+            table_stmt,
+            NuSqlParams::default(),
+            call_span,
+            signals,
+            None,
+        )?;
         tables.push(table_name, rows);
     }
 
     Ok(Value::record(tables, call_span))
 }
 
-pub fn convert_sqlite_row_to_nu_value(row: &Row, span: Span, columns: &[TypedColumn]) -> Value {
+pub fn convert_sqlite_row_to_nu_value(
+    row: &Row,
+    span: Span,
+    columns: &[TypedColumn],
+    column_adapters: Option<&BTreeMap<String, SQLiteColumnAdapter>>,
+) -> Value {
     let record = columns
         .iter()
         .enumerate()
         .map(|(i, col)| {
+            let adapter = column_adapters
+                .and_then(|adapters| adapters.get(&col.name))
+                .copied();
             (
                 col.name.clone(),
-                convert_sqlite_value_to_nu_value(row.get_ref_unwrap(i), col.decl_type, span),
+                convert_sqlite_value_to_nu_value_with_adapter(
+                    row.get_ref_unwrap(i),
+                    col.decl_type,
+                    adapter,
+                    span,
+                ),
             )
         })
         .collect();
 
     Value::record(record, span)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SQLiteColumnAdapter {
+    /// Convert integer values interpreted as Unix epoch milliseconds into Nu datetimes.
+    UnixMillisToDate,
+    /// Convert integer values interpreted as milliseconds into Nu durations.
+    MillisToDuration,
+}
+
+fn convert_sqlite_value_to_nu_value_with_adapter(
+    value: ValueRef,
+    decl_type: Option<DeclType>,
+    adapter: Option<SQLiteColumnAdapter>,
+    span: Span,
+) -> Value {
+    match adapter {
+        Some(SQLiteColumnAdapter::UnixMillisToDate) => match value {
+            ValueRef::Integer(i) => chrono::DateTime::from_timestamp_millis(i)
+                .map(|datetime| Value::date(datetime.into(), span))
+                .unwrap_or_else(|| Value::int(i, span)),
+            _ => convert_sqlite_value_to_nu_value(value, decl_type, span),
+        },
+        Some(SQLiteColumnAdapter::MillisToDuration) => match value {
+            ValueRef::Integer(i) => i
+                .checked_mul(1_000_000)
+                .map(|nanos| Value::duration(nanos, span))
+                .unwrap_or_else(|| Value::int(i, span)),
+            _ => convert_sqlite_value_to_nu_value(value, decl_type, span),
+        },
+        None => convert_sqlite_value_to_nu_value(value, decl_type, span),
+    }
 }
 
 pub fn convert_sqlite_value_to_nu_value(
@@ -759,6 +819,8 @@ pub struct SQLiteQueryBuilder {
     pub sql_params: Vec<String>,    // parameters for the where clause
     pub sql_order_by: Option<String>, // e.g., "id DESC"
     pub sql_limit: Option<i64>,
+    #[serde(default)]
+    pub column_adapters: BTreeMap<String, SQLiteColumnAdapter>,
     #[serde(skip, default = "Signals::empty")]
     signals: Signals,
 }
@@ -773,6 +835,7 @@ impl SQLiteQueryBuilder {
             sql_params: Vec::new(),
             sql_order_by: None,
             sql_limit: None,
+            column_adapters: BTreeMap::new(),
             signals,
         }
     }
@@ -798,6 +861,25 @@ impl SQLiteQueryBuilder {
         self
     }
 
+    pub fn with_column_adapter(
+        mut self,
+        column_name: String,
+        adapter: SQLiteColumnAdapter,
+    ) -> Self {
+        self.column_adapters.insert(column_name, adapter);
+        self
+    }
+
+    /// Register a datetime adapter for a column containing Unix epoch milliseconds.
+    pub fn with_unix_millis_datetime_column(self, column_name: String) -> Self {
+        self.with_column_adapter(column_name, SQLiteColumnAdapter::UnixMillisToDate)
+    }
+
+    /// Register a duration adapter for a column containing milliseconds.
+    pub fn with_millis_duration_column(self, column_name: String) -> Self {
+        self.with_column_adapter(column_name, SQLiteColumnAdapter::MillisToDuration)
+    }
+
     pub fn build_sql(&self) -> String {
         let select = self.sql_select.as_deref().unwrap_or("*");
         let mut sql = format!("SELECT {} FROM [{}]", select, self.table_name);
@@ -821,14 +903,16 @@ impl SQLiteQueryBuilder {
         let conn = open_sqlite_db(&self.db_path, call_span)?;
         let sql = self.build_sql();
         let params = NuSqlParams::List(Vec::new()); // FIXME: handle params properly
+        let query = Spanned {
+            item: sql,
+            span: call_span,
+        };
         run_sql_query(
             conn,
-            &Spanned {
-                item: sql,
-                span: call_span,
-            },
+            &query,
             params,
             &self.signals,
+            (!self.column_adapters.is_empty()).then_some(&self.column_adapters),
         )
         .map(IntoPipelineData::into_pipeline_data)
         .map_err(|e| e.into_shell_error(call_span, "Failed to execute query"))
@@ -1204,5 +1288,73 @@ mod test {
         )
         .with_limit(10);
         assert_eq!(table.build_sql(), "SELECT * FROM [test] LIMIT 10");
+    }
+
+    #[test]
+    fn sqlite_table_execute_with_column_adapters() {
+        use tempfile::NamedTempFile;
+
+        let temp_file = NamedTempFile::new().unwrap();
+        let db_path = temp_file.path().to_path_buf();
+        let signals = Signals::empty();
+
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute(
+                "CREATE TABLE history (start_timestamp INTEGER, duration INTEGER)",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO history (start_timestamp, duration) VALUES (1736041045123, 30002)",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO history (start_timestamp, duration) VALUES (NULL, NULL)",
+                [],
+            )
+            .unwrap();
+        }
+
+        let table = SQLiteQueryBuilder::new(db_path, "history".to_string(), signals)
+            .with_select("start_timestamp, duration".to_string())
+            .with_unix_millis_datetime_column("start_timestamp".to_string())
+            .with_millis_duration_column("duration".to_string());
+
+        let result = table.execute(Span::test_data()).unwrap();
+        let value = result.into_value(Span::test_data()).unwrap();
+
+        if let Value::List { vals, .. } = value {
+            assert_eq!(vals.len(), 2);
+
+            if let Value::Record { val: first, .. } = &vals[0] {
+                assert!(matches!(
+                    first.get("start_timestamp"),
+                    Some(Value::Date { .. })
+                ));
+                assert!(matches!(
+                    first.get("duration"),
+                    Some(Value::Duration { .. })
+                ));
+            } else {
+                panic!("Expected first row to be a record");
+            }
+
+            if let Value::Record { val: second, .. } = &vals[1] {
+                assert!(matches!(
+                    second.get("start_timestamp"),
+                    Some(Value::Nothing { .. })
+                ));
+                assert!(matches!(
+                    second.get("duration"),
+                    Some(Value::Nothing { .. })
+                ));
+            } else {
+                panic!("Expected second row to be a record");
+            }
+        } else {
+            panic!("Expected list");
+        }
     }
 }


### PR DESCRIPTION
This PR tries to update the sqlite output of the history file by adding column adapters so we can maintain speed but still get nushell values out of the command.

closes #17666

## Release notes summary - What our users need to know

### `history` now returns date values for sqlite-based history
Update the sqlite output of the history file by adding column adapters so we can maintain speed but still get nushell values out of the command.

#### Before
```nushell
❯ history | last
╭─────────────────┬────────────────────────────╮
│ start_timestamp │ 1772317356190              │
│ command         │ history | last             │
│ cwd             │ /Users/fdncred/src/nushell │
│ duration        │                            │
│ exit_status     │                            │
╰─────────────────┴────────────────────────────╯
❯ history | last 3
╭─#─┬─start_timestamp─┬─────command──────┬────────────cwd─────────────┬─duration─┬─exit_status─╮
│ 0 │   1772317254249 │ exit             │ /Users/fdncred/src/nushell │          │             │
│ 1 │   1772317356190 │ history | last   │ /Users/fdncred/src/nushell │        3 │           0 │
│ 2 │   1772317382357 │ history | last 3 │ /Users/fdncred/src/nushell │          │             │
╰───┴─────────────────┴──────────────────┴────────────────────────────┴──────────┴─────────────╯
```
#### After
```nushell
❯ history | last
╭─────────────────┬────────────────────────────╮
│ start_timestamp │ now                        │
│ command         │ history | last             │
│ cwd             │ /Users/fdncred/src/nushell │
│ duration        │                            │
│ exit_status     │                            │
╰─────────────────┴────────────────────────────╯
❯ history | last 3
╭─#─┬─start_timestamp─┬─────command──────┬────────────cwd─────────────┬─duration─┬─exit_status─╮
│ 0 │ 24 seconds ago  │ exit             │ /Users/fdncred/src/nushell │          │             │
│ 1 │ now             │ history | last   │ /Users/fdncred/src/nushell │     23ms │           0 │
│ 2 │ now             │ history | last 3 │ /Users/fdncred/src/nushell │          │             │
╰───┴─────────────────┴──────────────────┴────────────────────────────┴──────────┴─────────────╯
```

## Tasks after submitting
N/A

/cc @NotTheDr01ds 