### PR TITLE
fix(parser): record keys parsed as strings

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6520,7 +6520,7 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
                 ));
                 garbage(working_set, curr_span)
             } else {
-                let field = parse_value(working_set, curr_span, &SyntaxShape::Any);
+                let field = parse_value(working_set, curr_span, &SyntaxShape::String);
                 if let Some(error) = check_record_key_or_value(working_set, &field, "key") {
                     working_set.error(error);
                     garbage(working_set, field.span)

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -1095,6 +1095,19 @@ fn record_missing_value() -> TestResult {
 }
 
 #[test]
+fn record_type_inferred() -> TestResult {
+    fail_test(
+        r#"let foo: string = { 1: 1 }"#,
+        "expected string, found record<1: int>",
+    )
+}
+
+#[test]
+fn record_force_string_key_names() -> TestResult {
+    run_test(r#"{1kb: 1}.1kb"#, "1")
+}
+
+#[test]
 fn def_requires_body_closure() -> TestResult {
     fail_test("def a [] (echo 4)", "expected definition body closure")
 }


### PR DESCRIPTION
Closes #17599 

## Release notes summary - What our users need to know

Fixed a bug where numerical keys in records mess up type inference, e.g. `let foo: string = {1: 1}` is allowed before the fix. As a side effect, previously forbidden key names, like`{1kb: 1}`, are valid now.

## Tasks after submitting

None
