### PR TITLE
fix(http): respect user-specified content-type for JSON variant media types

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -71,12 +71,7 @@ pub enum BodyType {
 /// Compares the media type portion of a Content-Type value against the
 /// expected type, ignoring any parameters such as `charset`.
 fn mime_type_eq(content_type: &str, expected: &str) -> bool {
-    content_type
-        .split(';')
-        .next()
-        .unwrap_or("")
-        .trim()
-        == expected
+    content_type.split(';').next().unwrap_or("").trim() == expected
 }
 
 impl From<Option<ContentType>> for BodyType {
@@ -1295,8 +1290,7 @@ mod test {
         );
 
         // Form with charset parameter should still match
-        let form_charset =
-            Some("application/x-www-form-urlencoded; charset=utf-8".to_string());
+        let form_charset = Some("application/x-www-form-urlencoded; charset=utf-8".to_string());
         assert_eq!(BodyType::Form, BodyType::from(form_charset));
     }
 


### PR DESCRIPTION
# Description

`http post` and `http patch` ignore the `--content-type` flag when the value contains the substring `application/json`. For example, `application/json-patch+json` (RFC 6902) or `application/merge-patch+json` (RFC 7396) are silently overwritten with `application/json; charset=utf-8`.

The root cause is that `BodyType::from()` uses `contains("application/json")` to classify the body type. This matches any content type that has that substring, routing it through the JSON serialization path where ureq forces its own Content-Type header.

This replaces the substring checks with exact media-type comparison that ignores parameters like `charset`, so JSON variant types fall through to the default send path which respects the user-provided header.

Closes #17640

# User-Facing Changes

`--content-type` values like `application/json-patch+json` are now sent as-is instead of being silently replaced with `application/json; charset=utf-8`.

# Tests + Formatting

Added unit tests for JSON variant and parameterized content types in the existing `test_body_type_from_content_type` test.