### PR TITLE
fix: allow default argument to have the same name as parameter

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4121,6 +4121,15 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
 
     let mut args: Vec<Arg> = vec![];
     let mut parse_mode = ParseMode::Arg;
+    // Track variables whose name→VarId mappings have not yet been inserted
+    // into the overlay scope
+    //
+    // We defer all insertions until the entire signature is parsed so that
+    // default value expressions always resolve to outer scope variables,
+    // not to sibling parameters
+    //
+    // See #15306
+    let mut pending_scope_inserts: Vec<(Vec<u8>, VarId)> = vec![];
 
     for (index, token) in output.iter().enumerate() {
         let last_token = index == output.len() - 1;
@@ -4218,12 +4227,9 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                     span,
                                 );
 
-                                let var_id = working_set.add_variable(
-                                    variable_name,
-                                    span,
-                                    Type::Bool,
-                                    false,
-                                );
+                                let var_id =
+                                    working_set.add_variable_without_scope(span, Type::Bool, false);
+                                pending_scope_inserts.push((variable_name, var_id));
 
                                 // If there's no short flag, exit now. Otherwise, parse it.
                                 if flags.len() == 1 {
@@ -4313,12 +4319,9 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                     span,
                                 );
 
-                                let var_id = working_set.add_variable(
-                                    variable_name,
-                                    span,
-                                    Type::Bool,
-                                    false,
-                                );
+                                let var_id =
+                                    working_set.add_variable_without_scope(span, Type::Bool, false);
+                                pending_scope_inserts.push((variable_name, var_id));
 
                                 args.push(Arg::Flag {
                                     flag: Flag {
@@ -4391,12 +4394,9 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                     span,
                                 );
 
-                                let var_id = working_set.add_variable(
-                                    optional_param.to_vec(),
-                                    span,
-                                    Type::Any,
-                                    false,
-                                );
+                                let var_id =
+                                    working_set.add_variable_without_scope(span, Type::Any, false);
+                                pending_scope_inserts.push((optional_param.to_vec(), var_id));
 
                                 args.push(Arg::Positional {
                                     arg: PositionalArg {
@@ -4427,7 +4427,8 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                 ensure_not_reserved_variable_name(working_set, contents, span);
 
                                 let var_id =
-                                    working_set.add_variable(contents_vec, span, Type::Any, false);
+                                    working_set.add_variable_without_scope(span, Type::Any, false);
+                                pending_scope_inserts.push((contents_vec, var_id));
 
                                 args.push(Arg::RestPositional(PositionalArg {
                                     desc: String::new(),
@@ -4454,7 +4455,8 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                 ensure_not_reserved_variable_name(working_set, &contents_vec, span);
 
                                 let var_id =
-                                    working_set.add_variable(contents_vec, span, Type::Any, false);
+                                    working_set.add_variable_without_scope(span, Type::Any, false);
+                                pending_scope_inserts.push((contents_vec, var_id));
 
                                 // Positional arg, required
                                 args.push(Arg::Positional {
@@ -4713,6 +4715,10 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
             }
             _ => {}
         }
+    }
+
+    for (name, var_id) in pending_scope_inserts {
+        working_set.insert_variable_into_scope(name, var_id);
     }
 
     let mut sig = Signature::new(String::new());

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -614,24 +614,29 @@ impl<'a> StateWorkingSet<'a> {
         None
     }
 
-    pub fn add_variable(
-        &mut self,
-        mut name: Vec<u8>,
-        span: Span,
-        ty: Type,
-        mutable: bool,
-    ) -> VarId {
+    pub fn add_variable(&mut self, name: Vec<u8>, span: Span, ty: Type, mutable: bool) -> VarId {
+        let var_id = self.add_variable_without_scope(span, ty, mutable);
+        self.insert_variable_into_scope(name, var_id);
+        var_id
+    }
+
+    /// Like [`add_variable`](Self::add_variable) but does **not** insert the
+    /// name→VarId mapping into the current overlay scope. The caller must
+    /// later call [`insert_variable_into_scope`](Self::insert_variable_into_scope)
+    /// to make the variable visible by name.
+    pub fn add_variable_without_scope(&mut self, span: Span, ty: Type, mutable: bool) -> VarId {
         let next_id = self.next_var_id();
-        // correct name if necessary
+        self.delta.vars.push(Variable::new(span, ty, mutable));
+        next_id
+    }
+
+    /// Insert a previously created variable into the current overlay's scope.
+    /// The `name` will have a `$` prefix prepended if it doesn't already have one.
+    pub fn insert_variable_into_scope(&mut self, mut name: Vec<u8>, var_id: VarId) {
         if !name.starts_with(b"$") {
             name.insert(0, b'$');
         }
-
-        self.last_overlay_mut().insert_variable(name, next_id);
-
-        self.delta.vars.push(Variable::new(span, ty, mutable));
-
-        next_id
+        self.last_overlay_mut().insert_variable(name, var_id);
     }
 
     /// Returns the current working directory as a String, which is guaranteed to be canonicalized.

--- a/tests/repl/test_engine.rs
+++ b/tests/repl/test_engine.rs
@@ -15,6 +15,35 @@ fn proper_shadow() -> TestResult {
 }
 
 #[test]
+fn param_default_value_does_not_shadow_const() -> TestResult {
+    run_test("const foo = 123; def bar [foo = $foo] { $foo }; bar", "123")
+}
+
+#[test]
+fn flag_default_value_does_not_shadow_const() -> TestResult {
+    run_test(
+        "const foo = 123; def bar [--foo = $foo] { $foo }; bar",
+        "123",
+    )
+}
+
+#[test]
+fn param_default_value_overridden_by_argument() -> TestResult {
+    run_test(
+        "const foo = 123; def bar [foo = $foo] { $foo }; bar 456",
+        "456",
+    )
+}
+
+#[test]
+fn sibling_param_default_does_not_shadow_const() -> TestResult {
+    run_test(
+        "const foo = 123; def bar [foo = $foo, a: int = $foo] { $foo + $a }; bar",
+        "246",
+    )
+}
+
+#[test]
 fn in_variable_1() -> TestResult {
     run_test(r#"[3] | if $in.0 > 4 { "yay!" } else { "boo" }"#, "boo")
 }


### PR DESCRIPTION
Closes #15306

Previously it was impossible to use the same name for a default argument and a parameter, as during parsing it would incorrectly resolve to the parameter itself. To overcome this issue I've splitted `add_variable` into two functions: `add_variable_without_scope` and `insert_variable_into_scope` (which is called after entire signature parsing), so default values always resolve to the outer scope.

## Release notes summary - What our users need to know

Default arguments now allowed to have the same name as the parameter.

## Tasks after submitting

None