### PR TITLE
fix: explore search positions cursor on matched row

### DIFF
--- a/crates/nu-explore/src/explore/views/record/mod.rs
+++ b/crates/nu-explore/src/explore/views/record/mod.rs
@@ -868,11 +868,7 @@ mod tests {
     #[test]
     fn test_show_data_positions_window_on_matched_row() {
         // Create a table with 3 columns and 3 data rows
-        let columns = vec![
-            "name".to_string(),
-            "size".to_string(),
-            "type".to_string(),
-        ];
+        let columns = vec!["name".to_string(), "size".to_string(), "type".to_string()];
         let records = vec![
             vec![
                 Value::string("file_a", Span::test_data()),


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

Closes #17687.

When searching in `explore` with `/` or `?`, the view scrolled one row past the match, hiding it above the visible window.

**Root cause:** In `RecordView::show_data()` (introduced in #17289), `data_row` was offset by `+1` before being passed to `set_window_start_position()`, with the comment `// +1 for header row`. However, `WindowCursor2D` operates on **0-indexed data rows** — the header is not part of the row index. The header is rendered separately by `TableWidget::render_table_horizontal()`, which slices directly into the data array (`self.data[self.index_row..]`) and then offsets `data_y` to account for the header during rendering. The `+1` therefore caused an off-by-one, positioning the window start one row below the actual match.

**Fix:** Pass `data_row` directly to `set_window_start_position()` without the `+1` offset. Added a clarifying comment explaining why no header offset is needed. Added a test covering matches in first, middle, and last data rows as well as header matches.

## Release notes summary - What our users need to know

Fixed a bug where searching in `explore` (`/` or `?`) would scroll the view one row past the match instead of positioning on the matched row.

## Tasks after submitting

N/A