### PR TITLE
revert 17606 make plugin handling more robust on startup

### DIFF
--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -141,7 +141,28 @@ pub fn read_plugin_file(engine_state: &mut EngineState, plugin_file: Option<Span
 
         let mut working_set = StateWorkingSet::new(engine_state);
 
-        nu_plugin_engine::load_plugin_file(&mut working_set, &contents, span);
+        let plugin_load_errors =
+            nu_plugin_engine::load_plugin_file(&mut working_set, &contents, span);
+
+        if plugin_load_errors > 0 {
+            report_shell_error(
+                None,
+                engine_state,
+                &ShellError::GenericError {
+                    error: format!(
+                        "Failed to load {plugin_load_errors} plugin entr{} from {}",
+                        if plugin_load_errors == 1 { "y" } else { "ies" },
+                        plugin_path.display(),
+                    ),
+                    msg: "plugins with incompatible or invalid registry data were skipped".into(),
+                    span,
+                    help: Some(
+                        "run `plugin list` and re-add outdated plugins with `plugin add`".into(),
+                    ),
+                    inner: vec![],
+                },
+            );
+        }
 
         if let Err(err) = engine_state.merge_delta(working_set.render()) {
             report_shell_error(None, engine_state, &err);

--- a/crates/nu-plugin-engine/src/init.rs
+++ b/crates/nu-plugin-engine/src/init.rs
@@ -221,13 +221,18 @@ pub fn load_plugin_file(
     working_set: &mut StateWorkingSet,
     plugin_registry_file: &PluginRegistryFile,
     span: Option<Span>,
-) {
+) -> usize {
+    let mut error_count = 0;
+
     for plugin in &plugin_registry_file.plugins {
         // Any errors encountered should just be logged.
         if let Err(err) = load_plugin_registry_item(working_set, plugin, span) {
+            error_count += 1;
             report_shell_error(None, working_set.permanent_state, &err)
         }
     }
+
+    error_count
 }
 
 /// Load a definition from the plugin file into the engine state

--- a/crates/nu-protocol/src/errors/report_error.rs
+++ b/crates/nu-protocol/src/errors/report_error.rs
@@ -172,13 +172,16 @@ fn report_error(
     error: &dyn miette::Diagnostic,
     default_code: &'static str,
 ) {
-    // Avoid eprintln! since it panics on broken stderr, which double-panics
-    // through miette's panic hook and aborts.
-    let _ = writeln!(
-        std::io::stderr(),
+    let report = format!(
         "Error: {:?}",
         CliError::new(stack, error, working_set, Some(default_code))
     );
+
+    // Avoid eprintln! since it panics on broken stderr, which double-panics
+    // through miette's panic hook and aborts.
+    if writeln!(std::io::stderr(), "{report}").is_err() {
+        let _ = writeln!(std::io::stdout(), "{report}");
+    }
     // reset vt processing, aka ansi because illbehaved externals can break it
     #[cfg(windows)]
     {
@@ -192,11 +195,14 @@ fn report_warning(
     warning: &dyn miette::Diagnostic,
     default_code: &'static str,
 ) {
-    let _ = writeln!(
-        std::io::stderr(),
+    let report = format!(
         "Warning: {:?}",
         CliError::new(stack, warning, working_set, Some(default_code))
     );
+
+    if writeln!(std::io::stderr(), "{report}").is_err() {
+        let _ = writeln!(std::io::stdout(), "{report}");
+    }
     // reset vt processing, aka ansi because illbehaved externals can break it
     #[cfg(windows)]
     {

--- a/tests/plugins/registry_file.rs
+++ b/tests/plugins/registry_file.rs
@@ -410,9 +410,12 @@ fn warning_on_invalid_plugin_item() {
         assert!(result.status.success());
         // The "example" plugin should be unaffected
         assert_eq!(r#"["example"]"#, out);
-        // The warning should be in there
-        assert!(err.contains("registered plugin data"));
-        assert!(err.contains("badtest"));
+        // The warning should be in there. In some terminals stderr may be unavailable,
+        // in which case diagnostics can be emitted via stdout.
+        let combined_output = format!("{out}\n{err}");
+        assert!(combined_output.contains("registered plugin data"));
+        assert!(combined_output.contains("badtest"));
+        assert!(combined_output.contains("Failed to load 1 plugin entry"));
     })
 }
 


### PR DESCRIPTION
This PR partially reverts #17606 and tries to make plugin handling at startup more robust. The reason for this PR is that if you have an old version of plugins on Windows and you startup nushell, with the current main branch, nushell just exits, no warnings, not error messages, no nothing.

## Release notes summary - What our users need to know
### Improved robustness of plugin handling on startup
The reason for this PR is that if you have an old version of plugins on Windows and you startup nushell, with the current main branch, nushell just exits, no warnings, not error messages, no nothing. With this PR, you now get something like this and nushell doesn't exit.
```nushell
Error: nu::shell::plugin_failed_to_load

  × Plugin failed to load: Plugin `gstat` is compiled for nushell version 0.110.1, which is not compatible with version 0.111.1

Error: nu::shell::io::broken_pipe

  × I/O error
  ╰─▶   × PluginWrite could not flush

   ╭────
 1 │ crates\nu-plugin-core\src\interface\mod.rs:117:17
   · ────────────────────────┬────────────────────────
   ·                         ╰── Broken pipe
   ╰────

Error: nu::shell::plugin_failed_to_load

  × Plugin failed to load: Plugin `gstat` is compiled for nushell version 0.110.1, which is not compatible with version 0.111.1
```

## Tasks after submitting
N/A