### PR TITLE
Update winresource versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ pkg-fmt = "tgz"
 pkg-fmt = "zip"
 
 [package.metadata.winresource]
-LegalCopyright = "Copyright © 2019-2025 The Nushell Project Developers"
+LegalCopyright = "Copyright © 2019-2026 The Nushell Project Developers"
 FileDescription = "A new type of shell"
-FileVersion = "0.108.1"
-ProductVersion = "0.108.1"
+FileVersion = "0.111.1"
+ProductVersion = "0.111.1"
 ProductName = "Nushell"
 
 [workspace]


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

The `make_release/bump_version.nu` script did not update the versions in the winresource metadata.

These ones:
https://github.com/nushell/nushell/blob/698da1110c5b24edf6e95bdc0a69f3617e1fcde0/Cargo.toml#L34-L35

With https://github.com/nushell/nu_scripts/pull/1230 is that fixed now. This PR updates the values to be at the current version.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
n/a