### PR TITLE
hacky way to enable dynamic experimental options

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/hide_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide_env.rs
@@ -59,6 +59,10 @@ impl Command for HideEnv {
                     });
                 }
             }
+
+            if name.item.eq_ignore_ascii_case(nu_experimental::ENV) {
+                nu_engine::sync_experimental_options_from_env(engine_state, stack, name.span)?;
+            }
         }
 
         Ok(PipelineData::empty())

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -256,13 +256,11 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
 
         // Platform
         #[cfg(all(feature = "os", not(target_arch = "wasm32")))]
-        if nu_experimental::NATIVE_CLIP.get() {
-            bind_command! {
-                ClipCommand,
-                ClipCopy,
-                ClipPaste,
-            };
-        }
+        bind_command! {
+            ClipCommand,
+            ClipCopy,
+            ClipPaste,
+        };
 
         #[cfg(feature = "os")]
         bind_command! {

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -67,6 +67,11 @@ impl Command for LoadEnv {
         for (env_var, rhs) in record {
             stack.add_env_var(env_var, rhs);
         }
+
+        if stack.has_env_var(engine_state, nu_experimental::ENV) {
+            nu_engine::sync_experimental_options_from_env(engine_state, stack, call.head)?;
+        }
+
         Ok(PipelineData::empty())
     }
 

--- a/crates/nu-command/src/platform/clip/command.rs
+++ b/crates/nu-command/src/platform/clip/command.rs
@@ -1,5 +1,7 @@
 use nu_engine::{command_prelude::*, get_full_help};
 
+use super::ensure_native_clip_enabled;
+
 #[derive(Clone)]
 pub struct ClipCommand;
 
@@ -29,6 +31,7 @@ impl Command for ClipCommand {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        ensure_native_clip_enabled(call.head)?;
         Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/platform/clip/copy.rs
+++ b/crates/nu-command/src/platform/clip/copy.rs
@@ -2,6 +2,8 @@ use super::clipboard::provider::{Clipboard, create_clipboard};
 use crate::viewers::render_value_as_plain_table_text;
 use nu_engine::command_prelude::*;
 
+use super::ensure_native_clip_enabled;
+
 #[derive(Clone)]
 pub struct ClipCopy;
 
@@ -45,6 +47,8 @@ impl Command for ClipCopy {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        ensure_native_clip_enabled(call.head)?;
+
         let value = input.into_value(call.head)?;
         let config = stack.get_config(engine_state);
 

--- a/crates/nu-command/src/platform/clip/mod.rs
+++ b/crates/nu-command/src/platform/clip/mod.rs
@@ -4,6 +4,26 @@ mod copy;
 mod get_config;
 mod paste;
 
+use nu_engine::command_prelude::{ShellError, Span};
+
 pub use command::ClipCommand;
 pub use copy::ClipCopy;
 pub use paste::ClipPaste;
+
+fn ensure_native_clip_enabled(span: Span) -> Result<(), ShellError> {
+    if nu_experimental::NATIVE_CLIP.get() {
+        return Ok(());
+    }
+
+    Err(ShellError::GenericError {
+        error: "native-clip experimental option is disabled".into(),
+        msg: format!(
+            "Enable {} with $env.{} = [native-clip]",
+            nu_experimental::NATIVE_CLIP.identifier(),
+            nu_experimental::ENV
+        ),
+        span: Some(span),
+        help: None,
+        inner: vec![],
+    })
+}

--- a/crates/nu-command/src/platform/clip/paste.rs
+++ b/crates/nu-command/src/platform/clip/paste.rs
@@ -5,6 +5,8 @@ use crate::{
 use nu_engine::command_prelude::*;
 use nu_protocol::Config;
 
+use super::ensure_native_clip_enabled;
+
 #[derive(Clone)]
 pub struct ClipPaste;
 
@@ -36,6 +38,8 @@ impl Command for ClipPaste {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        ensure_native_clip_enabled(call.head)?;
+
         let config = stack.get_config(engine_state);
         let text = create_clipboard(&config, engine_state, stack).get_text()?;
         if text.trim().is_empty() {

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -13,6 +13,72 @@ use std::{
 
 pub const ENV_CONVERSIONS: &str = "ENV_CONVERSIONS";
 
+pub fn sync_experimental_options_from_env(
+    engine_state: &EngineState,
+    stack: &Stack,
+    span: Span,
+) -> Result<(), ShellError> {
+    let Some(value) = stack.get_env_var(engine_state, nu_experimental::ENV) else {
+        nu_experimental::restore_startup_baseline();
+        return Ok(());
+    };
+
+    let env_value = match value {
+        Value::String { val, .. } => val.clone(),
+        Value::List { vals, .. } => {
+            let mut entries = Vec::with_capacity(vals.len());
+            for value in vals {
+                let Value::String { val, .. } = value else {
+                    return Err(ShellError::GenericError {
+                        error: format!("Invalid {} value", nu_experimental::ENV),
+                        msg: format!("{} list entries must be strings", nu_experimental::ENV),
+                        span: Some(value.span()),
+                        help: None,
+                        inner: vec![],
+                    });
+                };
+                entries.push(val.clone());
+            }
+            entries.join(",")
+        }
+        Value::Nothing { .. } => {
+            nu_experimental::restore_startup_baseline();
+            return Ok(());
+        }
+        value => {
+            return Err(ShellError::GenericError {
+                error: format!("Invalid {} value", nu_experimental::ENV),
+                msg: format!(
+                    "{} must be a string or list of strings",
+                    nu_experimental::ENV
+                ),
+                span: Some(value.span()),
+                help: None,
+                inner: vec![],
+            });
+        }
+    };
+
+    let warnings = nu_experimental::apply_runtime_value(&env_value);
+    if warnings.is_empty() {
+        return Ok(());
+    }
+
+    let warning = warnings
+        .into_iter()
+        .map(|(warning, _)| warning.to_string())
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    Err(ShellError::GenericError {
+        error: format!("Failed to parse {}", nu_experimental::ENV),
+        msg: warning,
+        span: Some(span),
+        help: None,
+        inner: vec![],
+    })
+}
+
 enum ConversionError {
     ShellError(ShellError),
     CellPathError,

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -21,6 +21,7 @@ use nu_utils::IgnoreCaseExt;
 
 use crate::{
     ENV_CONVERSIONS, convert_env_vars, eval::is_automatic_env_var, eval_block_with_early_return,
+    sync_experimental_options_from_env,
 };
 
 pub fn eval_ir_block<D: DebugContext>(
@@ -450,6 +451,7 @@ fn eval_instruction<D: DebugContext>(
             if !is_automatic_env_var(&key) {
                 let is_config = key == "config";
                 let update_conversions = key == ENV_CONVERSIONS;
+                let update_experimental_options = key == nu_experimental::ENV;
 
                 ctx.stack.add_env_var(key.into_owned(), value.clone());
 
@@ -458,6 +460,9 @@ fn eval_instruction<D: DebugContext>(
                 }
                 if update_conversions {
                     convert_env_vars(ctx.stack, ctx.engine_state, &value)?;
+                }
+                if update_experimental_options {
+                    sync_experimental_options_from_env(ctx.engine_state, ctx.stack, *span)?;
                 }
                 Ok(Continue)
             } else {

--- a/crates/nu-experimental/src/lib.rs
+++ b/crates/nu-experimental/src/lib.rs
@@ -41,6 +41,9 @@
 //! nu --experimental-options=[example]
 //! ```
 //!
+//! At runtime, setting `$env.NU_EXPERIMENTAL_OPTIONS` also updates active options.
+//! If the variable is removed, options are restored to their startup baseline.
+//!
 //! # For Embedders
 //!
 //! If you're embedding Nushell, prefer using [`parse_env`] or [`parse_iter`] to load options.
@@ -219,19 +222,36 @@ impl Hash for ExperimentalOption {
 
 /// Sets the state of all experimental option that aren't deprecated.
 ///
-/// # Safety
-/// This method is unsafe to emphasize that experimental options are not designed to change
+/// Experimental options are not designed to change
 /// dynamically at runtime.
 /// Changing their state at arbitrary points can lead to inconsistent behavior.
 /// You should set experimental options only during initialization, before the application fully
 /// starts.
-pub unsafe fn set_all(value: bool) {
+pub fn set_all(value: bool) {
     for option in ALL {
         match option.status() {
-            // SAFETY: The safety bounds for `ExperimentalOption.set` are the same as this function.
-            Status::OptIn | Status::OptOut => unsafe { option.set(value) },
+            Status::OptIn | Status::OptOut => option.value.store(value, Ordering::Relaxed),
             Status::DeprecatedDefault | Status::DeprecatedDiscard => {}
         }
+    }
+}
+
+/// Resets all experimental options to their default state.
+pub fn reset_all() {
+    for option in ALL {
+        option.value.store(None, Ordering::Relaxed);
+    }
+}
+
+/// Returns a snapshot of all effective experimental option values.
+pub fn snapshot_values() -> Vec<bool> {
+    ALL.iter().map(|option| option.get()).collect()
+}
+
+/// Sets all experimental options from a value snapshot.
+pub fn restore_values(values: &[bool]) {
+    for (option, value) in ALL.iter().zip(values.iter().copied()) {
+        option.value.store(value, Ordering::Relaxed);
     }
 }
 

--- a/crates/nu-experimental/src/parse.rs
+++ b/crates/nu-experimental/src/parse.rs
@@ -1,12 +1,14 @@
 use crate::{ALL, ExperimentalOption, Status};
 use itertools::Itertools;
-use std::{borrow::Cow, env, ops::Range, sync::atomic::Ordering};
+use std::{borrow::Cow, env, ops::Range, sync::OnceLock, sync::atomic::Ordering};
 use thiserror::Error;
 
 /// Environment variable used to load experimental options from.
 ///
 /// May be used like this: `NU_EXPERIMENTAL_OPTIONS=example nu`.
 pub const ENV: &str = "NU_EXPERIMENTAL_OPTIONS";
+
+static STARTUP_BASELINE: OnceLock<Vec<bool>> = OnceLock::new();
 
 /// Warnings that can happen while parsing experimental options.
 #[derive(Debug, Clone, Error, Eq, PartialEq)]
@@ -61,8 +63,7 @@ pub fn parse_iter<'i, Ctx: Clone>(
                     continue;
                 }
             };
-            // SAFETY: This is part of the expected parse function to be called at initialization.
-            unsafe { super::set_all(val) };
+            super::set_all(val);
             continue;
         }
 
@@ -113,15 +114,15 @@ pub fn parse_env() -> Vec<(ParseWarning, Range<usize>)> {
         return vec![];
     };
 
-    let mut entries = Vec::new();
-    let mut start = 0;
-    for (idx, c) in env.char_indices() {
-        if c == ',' {
-            entries.push((&env[start..idx], start..idx));
-            start = idx + 1;
-        }
-    }
-    entries.push((&env[start..], start..env.len()));
+    parse_value(&env)
+}
+
+/// Parse experimental options from a single string value.
+///
+/// Uses [`parse_iter`] internally. Each warning includes a `Range<usize>` pointing to the
+/// substring that triggered it.
+pub fn parse_value(value: &str) -> Vec<(ParseWarning, Range<usize>)> {
+    let entries = split_entries(value);
 
     parse_iter(entries.into_iter().map(|(entry, span)| {
         entry
@@ -129,6 +130,45 @@ pub fn parse_env() -> Vec<(ParseWarning, Range<usize>)> {
             .map(|(key, val)| (key.into(), Some(val.into()), span.clone()))
             .unwrap_or((entry.into(), None, span))
     }))
+}
+
+/// Apply a runtime value as a full replacement.
+///
+/// This resets all options to default state before parsing the new value, so unspecified options go back to defaults.
+pub fn apply_runtime_value(value: &str) -> Vec<(ParseWarning, Range<usize>)> {
+    crate::reset_all();
+    parse_value(value)
+}
+
+/// Save the current option states as startup baseline.
+///
+/// This should be called once after startup options (env + cli) are fully applied.
+pub fn snapshot_startup_baseline() {
+    let _ = STARTUP_BASELINE.set(crate::snapshot_values());
+}
+
+/// Restore the startup baseline if available, else restore defaults.
+pub fn restore_startup_baseline() {
+    if let Some(values) = STARTUP_BASELINE.get() {
+        crate::restore_values(values);
+    } else {
+        crate::reset_all();
+    }
+}
+
+fn split_entries(value: &str) -> Vec<(&str, Range<usize>)> {
+    let mut entries = Vec::new();
+
+    let mut start = 0;
+    for (idx, c) in value.char_indices() {
+        if c == ',' {
+            entries.push((&value[start..idx], start..idx));
+            start = idx + 1;
+        }
+    }
+    entries.push((&value[start..], start..value.len()));
+
+    entries
 }
 
 impl ParseWarning {

--- a/src/experimental_options.rs
+++ b/src/experimental_options.rs
@@ -71,6 +71,8 @@ pub fn load(engine_state: &EngineState, cli_args: &NushellCliArgs, has_script: b
             None => report_experimental_option_warning(None, &working_set, &diagnostic),
         }
     }
+
+    nu_experimental::snapshot_startup_baseline();
 }
 
 fn should_disable_experimental_options(has_script: bool, cli_args: &NushellCliArgs) -> bool {

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -201,6 +201,30 @@ fn env_conversion_on_assignment() {
 }
 
 #[test]
+fn experimental_options_can_be_set_with_env_assignment() {
+    let actual = nu!("$env.NU_EXPERIMENTAL_OPTIONS = [native-clip]; clip");
+
+    assert!(actual.out.contains("clip copy"));
+}
+
+#[test]
+fn experimental_options_can_be_set_with_load_env() {
+    let actual = nu!("load-env { NU_EXPERIMENTAL_OPTIONS: [native-clip] }; clip paste --help");
+
+    assert!(actual.out.contains("clip paste"));
+}
+
+#[test]
+fn hiding_experimental_options_restores_startup_state() {
+    let actual = nu!(
+        envs: vec![("NU_EXPERIMENTAL_OPTIONS".to_string(), "native-clip".to_string())],
+        "$env.NU_EXPERIMENTAL_OPTIONS = [native-clip=false]; hide-env NU_EXPERIMENTAL_OPTIONS; clip"
+    );
+
+    assert!(actual.out.contains("clip copy"));
+}
+
+#[test]
 fn std_log_env_vars_are_not_overridden() {
     let actual = nu_with_std!(
         envs: vec![


### PR DESCRIPTION
Threw this together quickly. Very hacky but working. It allows you to set experimental options dynamically via `$env.NU_EXPERIMENTAL_OPTIONS` like `$env.NU_EXPERIMENTAL_OPTIONS = [all=true]`.

![exp-opts](https://github.com/user-attachments/assets/b27c63a3-476f-45f6-982d-9e83bad85589)

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
