### PR TITLE
Add `metadata_ref` and `metadata_mut` methods to `PipelineData`

### DIFF
--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -69,7 +69,7 @@ impl PipelineData {
     /// Returns a clone of the metadata if it exists.
     ///
     /// Note: This performs a deep clone of heap-allocated structures.
-    /// Use [`Self::metadata_ref`] or [`Self::metadata_mut`] to avoid unnecessary allocations.
+    /// Use [`.metadata_ref()`](Self::metadata_ref) or [`.metadata_mut()`](Self::metadata_mut) to avoid unnecessary allocations.
     pub fn metadata(&self) -> Option<PipelineMetadata> {
         self.metadata_ref().cloned()
     }


### PR DESCRIPTION
Add two new methods to PipelineData to prevent unnecessary cloning.

## Release notes summary - What our users need to know
*N/A*

## Tasks after submitting
*N/A*
