### PR TITLE
fix the off-by-1 jump scrolling in `explore` when searching

### DIFF
--- a/crates/nu-explore/src/explore/views/record/mod.rs
+++ b/crates/nu-explore/src/explore/views/record/mod.rs
@@ -323,10 +323,9 @@ impl View for RecordView {
             for (data_row, cells) in layer.record_values.iter().enumerate() {
                 if data_pos >= i && data_pos < i + cells.len() {
                     let column = data_pos - i;
-                    let row = data_row + 1; // +1 for header row
                     self.get_top_layer_mut()
                         .cursor
-                        .set_window_start_position(row, column);
+                        .set_window_start_position(data_row, column);
                     return true;
                 }
                 i += cells.len();


### PR DESCRIPTION
This PR fixes the off-by-1 scrolling when doing a search in the `explore` command.

Closes #17687

1. my initial problem before this PR was `$nu | explore` - continues to work after this PR
2. `ls | explore` - reported in the issue works well after this PR
3. `open Cargo.toml | decode | explore` - works well after this PR
4. I also tested with `$env.config.table.header_on_separator` `true` and `false`.

I introduced this bug in an earlier PR. Thanks @0xRozier for helping find the fix.

## Release notes summary - What our users need to know
Fix the problem where searching in the `explore` command was off by 1 which caused the hit to sometimes be hidden.

## Tasks after submitting
There's another bug I found with `open Cargo.toml` then `e` then `/crate`. It doesn't scroll the screen to the right to show the hits, but that is for another PR.