### PR TITLE
fix: block captures redundant variables

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -7037,7 +7037,7 @@ pub fn discover_captures_in_expr(
                         } else {
                             let result = {
                                 let mut seen = vec![];
-                                seen_blocks.insert(block_id, output.clone());
+                                seen_blocks.insert(block_id, vec![]);
 
                                 let mut result = vec![];
                                 discover_captures_in_closure(

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -735,3 +735,100 @@ fn parse_let_pipeline_builtin_var() {
     let actual = nu!("1 | let $nu | let $in | let $it | let $env");
     assert!(actual.err.contains("nu::parser::name_is_builtin_var"))
 }
+
+#[test]
+fn issue_16769_recursive_module_command_variable_in_block() {
+    Playground::setup(
+        "issue_16769_recursive_module_command_variable_in_block",
+        |dirs, sandbox| {
+            sandbox
+                .with_files(&[FileWithContentToBeTrimmed(
+                    "b.nu",
+                    "
+                        export def f [] { each {f} }
+                    ",
+                )])
+                .with_files(&[FileWithContentToBeTrimmed(
+                    "a.nu",
+                    "
+                        use b.nu *
+                        let i = [];
+                        if true { $i | f }
+                    ",
+                )]);
+
+            let actual = nu!(cwd: dirs.test(), "nu a.nu");
+            assert!(actual.err.is_empty(), "unexpected error: {}", actual.err);
+        },
+    )
+}
+
+#[test]
+fn issue_16769_recursive_module_command_direct_recursion_closure() {
+    Playground::setup(
+        "issue_16769_recursive_module_command_direct_recursion_closure",
+        |dirs, sandbox| {
+            sandbox
+                .with_files(&[FileWithContentToBeTrimmed(
+                    "b.nu",
+                    "
+                        export def f [] { f }
+                    ",
+                )])
+                .with_files(&[FileWithContentToBeTrimmed(
+                    "a.nu",
+                    "
+                        use b.nu f
+                        { $in | f }
+                    ",
+                )]);
+
+            let actual = nu!(cwd: dirs.test(), "nu a.nu");
+            assert!(actual.err.is_empty(), "unexpected error: {}", actual.err);
+        },
+    )
+}
+
+#[test]
+fn issue_16769_recursive_module_command_source_def() {
+    Playground::setup(
+        "issue_16769_recursive_module_command_source_def",
+        |dirs, sandbox| {
+            sandbox
+                .with_files(&[FileWithContentToBeTrimmed(
+                    "b.nu",
+                    "
+                    export def f [] { each {f} }
+                ",
+                )])
+                .with_files(&[FileWithContentToBeTrimmed(
+                    "a.nu",
+                    "
+                    use b.nu f
+                    def a [] { $in | f }
+                ",
+                )]);
+
+            let actual = nu!(cwd: dirs.test(), "source a.nu; [] | f");
+            assert!(actual.err.is_empty(), "unexpected error: {}", actual.err);
+        },
+    )
+}
+
+#[test]
+fn issue_16209_mutual_recursion_closure_in_variable() {
+    let actual = nu!(r#"
+        def map [] {
+          return {
+           first: {|| $in | result second | $in + 3 }
+           second: {|| $in + 7 | result third | $in * 3 }
+           third: {|| $in }
+          }
+        }
+        def result [condition: string, ...args] {
+             do (map | get $condition) ...$args
+        }
+        map | describe
+    "#);
+    assert!(actual.err.is_empty(), "unexpected error: {}", actual.err);
+}


### PR DESCRIPTION
Closes #16769, #16209

The bug is actually tricky to understand, but I'll try my best to describe it. Shortly, function should not pre-fill its' captures from its' callsite.

Consider we have the following files:

```
# b.nu
export def f [] { each {f} }

# a.nu
use b.nu *
let i = []
if true { $i | f }
```

Running `nu a.nu` would fail with `variable_not_found $i`.  Walking parsing step-by-step (roughly):

- Step 1: Parsing `use b.nu *` and `b.nu`. Nothing is wrong here.
- Step 2: Parsing `let i = []`. Variable `$i` gets `VarId = V1`.
- Step 3: Parsing block `if true { $i | f }`
  - Parser sees `$i`: it is not defined in this block, so it's added to the `output` (field which is changed in this PR). `output` now is `[(V1, span)]`.
  - Parser sees `f`: `seen_blocks` (which is responsible for recursion-handling) doesn't have yet this block, so we enter the `else` branch: https://github.com/nushell/nushell/blob/b30f6f85f5b35c660552085abc5bdbcfb6450802/crates/nu-parser/src/parser.rs#L7030-L7041
  - As we remember, `output` contains `[(V1, span)]`, so it's now the value in `seen_blocks` for `f`'s `block_id`.
  - Then it discovers the recursion and later then it permanently stores `$i` as capture of `f`'s block. `f`'s block has nothing to do with `$i` and that's what is wrong here. `f`'s captures are initially polluted with unrelated references and that's what stored to the `block.captures`.
  - Even if there is some reference to the outside, it would be correctly discovered and added in `discover_captures_in_closure`.
- In runtime now block `f` requires `$i` to be on stack. And everything would be probably okay, BUT seems like there is another bug (or feature), which later can't find `$i` and fails with `variable_not_found` as a result.

Another example is a workaround, which makes everything work:

```
# b.nu
export def f [] { each {f} }

# a.nu
use b.nu *
let i = [];
if true {
  null | f
  $i | f
}
```

Another step-by-step analysis starting from `if true ...` block:

- Processing `null | f`
  - At this point $i has not been seen yet, so `output` is empty.
  - Parsing `null`, nothing added to the `output`.
  - `f` is not in `seen_blocks`, `block.captures.is_empty()` enters the mentioned above `else` branch.
  - `seen_blocks[f] = output.clone()`. `output` is empty, so `seen_blocks[f] = []`
  - Recursive analysis to find `f`'s captures, resulting captures are `[]`.
- Processing `$i | f`
  - `$i` is not local to this block, so it's added to the `output`. Now `output = [V1]`
  - `f` found in `seen_blocks` with `[]` value.
  - Taking the `Some(capture_list)` branch now: https://github.com/nushell/nushell/blob/b30f6f85f5b35c660552085abc5bdbcfb6450802/crates/nu-parser/src/parser.rs#L7018-L7030
  - `capture_list` is empty and nothing is added to the `output`.

## Release notes summary - What our users need to know

Fixed the `variable_not_found` error in scenarios with recursive functions.

## Tasks after submitting

None
