### PR TITLE
fix duplicate custom commands from showing up

### DIFF
--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -12,7 +12,7 @@ use nu_protocol::{
 use nu_utils::terminal_size;
 use std::{
     borrow::Cow,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt::Write,
     sync::{Arc, LazyLock},
 };
@@ -291,11 +291,13 @@ fn get_command_documentation(
     // - Subcommands are included violating module scoping
     //   - https://github.com/nushell/nushell/issues/11447
     //   - https://github.com/nushell/nushell/issues/11625
+    // - Duplicate entries may appear when a single declaration is visible under multiple names (e.g. script `main` rewritten to filename plus an alias).
+    //   See https://github.com/nushell/nushell/issues/17719.
     let mut subcommands = vec![];
     let signatures = engine_state.get_signatures_and_declids(true);
+    // track which declarations we've already added to `subcommands`
+    let mut seen = HashSet::new();
     for (sig, decl_id) in signatures {
-        let command_type = engine_state.get_decl(decl_id).command_type();
-
         // Prefer the overlay-visible declaration name (if any) for display and matching.
         // Fall back to the signature's name if not present.
         let display_name = engine_state
@@ -303,10 +305,24 @@ fn get_command_documentation(
             .map(|bytes| String::from_utf8_lossy(bytes).to_string())
             .unwrap_or_else(|| sig.name.clone());
 
-        // Don't display removed/deprecated commands in the Subcommands list
-        if display_name.starts_with(&format!("{cmd_name} "))
+        // Don't display removed/deprecated commands in the Subcommands list. We consider a signature a subcommand when either the overlay-visible
+        // `display_name` begins with `cmd_name ` *or* the canonical signature name does; the latter covers cases where `display_name` returns the
+        // alias instead of the script-qualified name due to hashmap ordering.
+        if (display_name.starts_with(&format!("{cmd_name} "))
+            || sig.name.starts_with(&format!("{cmd_name} ")))
             && !matches!(sig.category, Category::Removed)
+            && seen.insert(decl_id)
         {
+            let command_type = engine_state.get_decl(decl_id).command_type();
+
+            // choose which name to show: prefer the overlay-visible one if it actually matches the prefix, otherwise fall back to the canonical
+            // signature name (which is usually the script-qualified form).
+            let name_to_print = if display_name.starts_with(&format!("{cmd_name} ")) {
+                display_name.clone()
+            } else {
+                sig.name.clone()
+            };
+
             // If it's a plugin, alias, or custom command, display that information in the help
             if command_type == CommandType::Plugin
                 || command_type == CommandType::Alias
@@ -314,14 +330,14 @@ fn get_command_documentation(
             {
                 subcommands.push(format!(
                     "  {help_subcolor_one}{} {help_section_name}({}){RESET} - {}",
-                    display_name,
+                    name_to_print,
                     command_type,
                     highlight_code(&sig.description, engine_state, stack)
                 ));
             } else {
                 subcommands.push(format!(
                     "  {help_subcolor_one}{}{RESET} - {}",
-                    display_name,
+                    name_to_print,
                     highlight_code(&sig.description, engine_state, stack)
                 ));
             }
@@ -331,6 +347,8 @@ fn get_command_documentation(
     if !subcommands.is_empty() {
         let _ = write!(long_desc, "\n{help_section_name}Subcommands{RESET}:\n");
         subcommands.sort();
+        // sort may not remove duplicates when two different names map to the same description string; dedup to be safe.
+        subcommands.dedup();
         long_desc.push_str(&subcommands.join("\n"));
         long_desc.push('\n');
     }

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -322,6 +322,31 @@ fn main_script_can_have_subcommands2() {
     })
 }
 
+// regression test for https://github.com/nushell/nushell/issues/17719
+#[test]
+fn script_help_shows_single_subcommand() {
+    Playground::setup("main_subcommands_help", |dirs, sandbox| {
+        sandbox.mkdir("main_subcommands_help");
+        sandbox.with_files(&[FileWithContent(
+            "script.nu",
+            r#"def "main bar" [] {}
+               def "main" [] { help main }"#,
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), "nu script.nu --help");
+
+        let out = &actual.out;
+        let count_script = out.matches("script.nu bar").count();
+        let count_main = out.matches("main bar").count();
+        assert_eq!(
+            count_script + count_main,
+            1,
+            "help output should list exactly one of 'script.nu bar' or 'main bar', got:\n{}",
+            out
+        );
+    })
+}
+
 #[test]
 fn source_empty_file() {
     Playground::setup("source_empty_file", |dirs, sandbox| {


### PR DESCRIPTION
This PR tries to fix #17719 duplicate subcommands from showing up by tracking them and deduping them.

Test Steps
1. create new file named `foo`
```sh
#!/usr/bin/env nu

def "main bar" [] {}
def "main" [] { help main }
```
2. change permissions - `chmod +x foo`
3. run it - note now there is only 1 subcommand
```nushell
❯ ./foo
Usage:
  > main

Subcommands:
  foo bar (custom) -

Flags:
  -h, --help: Display the help message for this command

Input/output types:
  ╭───┬───────┬────────╮
  │ # │ input │ output │
  ├───┼───────┼────────┤
  │ 0 │ any   │ any    │
  ╰───┴───────┴────────╯
```

Previously it had duplicate subcommands like tihs.
```nushell
Subcommands:
  foo bar (custom) -
  foo bar (custom) -
```

closes #17719 
## Release notes summary - What our users need to know
Fixes a bug where creating nushell scripts with subcommands would show duplicate subcommands.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
