### PR TITLE
fix: drain registers before jumping to finally block

### DIFF
--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -236,8 +236,10 @@ fn eval_ir_block_impl<D: DebugContext>(
                     && next_pc == finally_handler.handler_index
                 {
                     for reg in ctx.registers.iter_mut() {
-                        let data = std::mem::replace(&mut reg.body, PipelineData::Empty);
-                        let _ = data.drain();
+                        if matches!(reg.body, PipelineData::ByteStream(..)) {
+                            let data = std::mem::replace(&mut reg.body, PipelineData::Empty);
+                            let _ = data.drain();
+                        }
                     }
                 }
                 pc = next_pc;


### PR DESCRIPTION
## Release notes summary - What our users need to know
The `finally` block now correctly waits for external commands

## Description

If the `try` block contained an external command (for example, ^ping), execution immediately jumped to the `finally` block, and only then was the result of the external command printed to stdout.

Now, before jumping to the `finally` block, `PipelineData::drain()` is called if the next instruction is associated with `finally`, this ensures that `wait()` is called in the ByteStream in ByteStreamSource::child.

## Example
```nu
try {
    ^ping -n 3 127.0.0.1
} finally {
    print "finally ran"
}
```
| Version | Behavior |
| :--- | :--- |
| **Before** | `finally ran` prints first, then `ping` output appears. |
| **After** | `ping` output finishes completely, then `finally ran` prints. |

This change ensures execution order is preserved, though it may slightly alter the timing of commands that rely on background execution.

Fixes #17715