### PR TITLE
fix(input listen): calculate timeout using elapsed start time rather than subtraction

### DIFF
--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -164,10 +164,7 @@ There are 4 `key_type` variants:
                 return Ok(event.into_pipeline_data());
             }
 
-            if let Some(t) = remaining_time.as_mut() {
-                let now = Instant::now();
-                *t -= now.duration_since(start);
-            }
+            remaining_time = timeout.map(|t| t.saturating_sub(start.elapsed()));
         }
     }
 }


### PR DESCRIPTION
Prevent panic in `input listen --timeout` by recomputing remaining time from the original timeout each iteration instead of cumulatively subtracting.

## Release notes summary - What our users need to know

Avoid `input listen --timeout` panic from double counting.

## Tasks after submitting
N/A