### PR TITLE
feat: add ToStart/ToEnd reedline events

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -1043,6 +1043,8 @@ fn event_from_record(
         "down" => ReedlineEvent::Down,
         "right" => ReedlineEvent::Right,
         "left" => ReedlineEvent::Left,
+        "tostart" => ReedlineEvent::ToStart,
+        "toend" => ReedlineEvent::ToEnd,
         "nexthistory" => ReedlineEvent::NextHistory,
         "searchhistory" => ReedlineEvent::SearchHistory,
         // Handled above in `parse_event`:


### PR DESCRIPTION
Follow up to https://github.com/nushell/reedline/pull/1025 (sorry couldn't make it earlier)

## Release notes summary - What our users need to know
Two new reedline events added: `ToStart` and `ToEnd` to jump to the start/end of the buffer.

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
