### PR TITLE
fix(parser): improve alias expression error message to use user-friendly descriptions

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1216,16 +1216,12 @@ pub fn parse_alias(
                 && first_bytes != b"match"
                 && is_math_expression_like(working_set, replacement_spans[0])
             {
-                // TODO: Maybe we need to implement a Display trait for Expression?
                 let starting_error_count = working_set.parse_errors.len();
                 let expr = parse_expression(working_set, replacement_spans);
                 working_set.parse_errors.truncate(starting_error_count);
 
-                let msg = format!("{:?}", expr.expr);
-                let msg_parts: Vec<&str> = msg.split('(').collect();
-
                 working_set.error(ParseError::CantAliasExpression(
-                    msg_parts[0].to_string(),
+                    expr.expr.description().to_string(),
                     replacement_spans[0],
                 ));
                 return alias_pipeline;

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -63,6 +63,54 @@ pub enum Expr {
 const _: () = assert!(std::mem::size_of::<Expr>() <= 40);
 
 impl Expr {
+    /// Returns a user-friendly description of the expression variant.
+    ///
+    /// This is used in error messages to avoid exposing internal Rust type names
+    /// (e.g. "FullCellPath") to users.
+    pub fn description(&self) -> &str {
+        match self {
+            Expr::AttributeBlock(_) => "an attribute block",
+            Expr::Bool(_) => "a boolean",
+            Expr::Int(_) => "an integer",
+            Expr::Float(_) => "a float",
+            Expr::Binary(_) => "a binary value",
+            Expr::Range(_) => "a range",
+            Expr::Var(_) => "a variable",
+            Expr::VarDecl(_) => "a variable declaration",
+            Expr::Call(_) => "a command call",
+            Expr::ExternalCall(_, _) => "an external command call",
+            Expr::Operator(_) => "an operator",
+            Expr::RowCondition(_) => "a row condition",
+            Expr::UnaryNot(_) => "a negation",
+            Expr::BinaryOp(_, _, _) => "a binary operation",
+            Expr::Collect(_, _) => "a collect expression",
+            Expr::Subexpression(_) => "a subexpression",
+            Expr::Block(_) => "a block",
+            Expr::Closure(_) => "a closure",
+            Expr::MatchBlock(_) => "a match block",
+            Expr::List(_) => "a list",
+            Expr::Table(_) => "a table",
+            Expr::Record(_) => "a record",
+            Expr::Keyword(_) => "a keyword",
+            Expr::ValueWithUnit(_) => "a value with unit",
+            Expr::DateTime(_) => "a datetime",
+            Expr::Filepath(_, _) => "a filepath",
+            Expr::Directory(_, _) => "a directory",
+            Expr::GlobPattern(_, _) => "a glob pattern",
+            Expr::String(_) => "a string",
+            Expr::RawString(_) => "a raw string",
+            Expr::CellPath(_) => "a cell path",
+            Expr::FullCellPath(_) => "a cell path expression",
+            Expr::ImportPattern(_) => "an import pattern",
+            Expr::Overlay(_) => "an overlay",
+            Expr::Signature(_) => "a signature",
+            Expr::StringInterpolation(_) => "a string interpolation",
+            Expr::GlobInterpolation(_, _) => "a glob interpolation",
+            Expr::Nothing => "a nothing",
+            Expr::Garbage => "a garbage expression",
+        }
+    }
+
     pub fn pipe_redirection(
         &self,
         working_set: &StateWorkingSet,


### PR DESCRIPTION
## Description

Fixes #10088

The `CantAliasExpression` error previously exposed internal Rust type names to users. For example, running:

```nushell
alias foo = $bar.baz
```

Would produce:

```
aliasing FullCellPath is not supported
```

The names like `FullCellPath`, `BinaryOp`, `Subexpression`, etc. are internal AST node names that are meaningless to users.

This PR adds a `description()` method to the `Expr` enum that returns user-friendly descriptions for each variant, and uses it in the error message. Now the same example produces:

```
aliasing a cell path expression is not supported
```

Other examples of improved messages:
- `alias foo = 'hello'` → "aliasing **a string** is not supported" (was "String")
- `alias foo = 1 + 2` → "aliasing **a binary operation** is not supported" (was "BinaryOp")
- `alias foo = 0..12` → "aliasing **a range** is not supported" (was "Range")
- `alias foo = ([1 2 3] | length)` → "aliasing **a subexpression** is not supported" (was "Subexpression")

This also resolves the TODO comment at the call site that said "Maybe we need to implement a Display trait for Expression?"

## Release notes summary

Error messages for invalid alias expressions now show user-friendly descriptions instead of internal Rust type names. The error code `nu::parser::cant_alias_expression` is unchanged.

**Before:**
```
  × Can't create alias to expression.
   ╭─[entry #1:1:1]
 1 │ alias foo = $bar.baz
   ·             ── aliasing FullCellPath is not supported
   ╰────
  help: Only command calls can be aliased.
```

**After:**
```
  × Can't create alias to expression.
   ╭─[entry #1:1:1]
 1 │ alias foo = $bar.baz
   ·             ── aliasing a cell path expression is not supported
   ╰────
  help: Only command calls can be aliased.
```

## Tests + Formatting

- `cargo check -p nu-protocol -p nu-parser` passes
- `cargo test -p nu-parser --lib` passes (5/5 tests)
- `cargo clippy -p nu-protocol` and `cargo clippy -p nu-parser` pass
- `cargo fmt -- --check` passes
- Existing tests in `alias.rs` that check for `cant_alias_expression` continue to pass since they check the error code, not the message text

## After Submitting

N/A