### PR TITLE
feat(plugins): allow plugin commands to define aliases

### DIFF
--- a/crates/nu-plugin-engine/src/init.rs
+++ b/crates/nu-plugin-engine/src/init.rs
@@ -270,6 +270,14 @@ pub fn load_plugin_registry_item(
 
             // Create the declarations from the commands
             for signature in commands {
+                // Create alias declarations before creating the main one
+                for alias in &signature.sig.aliases {
+                    let mut alias_sig = signature.clone();
+                    alias_sig.sig.name = alias.clone();
+                    alias_sig.sig.aliases.clear();
+                    let alias_decl = PluginDeclaration::new(plugin.clone(), alias_sig);
+                    working_set.add_decl(Box::new(alias_decl));
+                }
                 let decl = PluginDeclaration::new(plugin.clone(), signature.clone());
                 working_set.add_decl(Box::new(decl));
             }

--- a/crates/nu-plugin-test-support/src/fake_register.rs
+++ b/crates/nu-plugin-test-support/src/fake_register.rs
@@ -17,6 +17,14 @@ pub fn fake_register(
 
     for command in plugin.commands() {
         let signature = create_plugin_signature(command.deref());
+        // Create alias declarations
+        for alias in &signature.sig.aliases {
+            let mut alias_sig = signature.clone();
+            alias_sig.sig.name = alias.clone();
+            alias_sig.sig.aliases.clear();
+            let alias_decl = PluginDeclaration::new(reg_plugin.clone(), alias_sig);
+            working_set.add_decl(Box::new(alias_decl));
+        }
         let decl = PluginDeclaration::new(reg_plugin.clone(), signature);
         working_set.add_decl(Box::new(decl));
     }

--- a/crates/nu-plugin-test-support/tests/hello/mod.rs
+++ b/crates/nu-plugin-test-support/tests/hello/mod.rs
@@ -28,6 +28,10 @@ impl SimplePluginCommand for Hello {
         "Print a friendly greeting"
     }
 
+    fn aliases(&self) -> Vec<&str> {
+        vec!["hi"]
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(PluginCommand::name(self)).input_output_type(Type::Nothing, Type::String)
     }
@@ -84,6 +88,19 @@ fn test_requiring_nu_cmd_lang_commands() -> Result<(), ShellError> {
 
     let result = PluginTest::new("hello", HelloPlugin.into())?
         .eval("do { let greeting = hello; $greeting }")?
+        .into_value(Span::test_data())?;
+
+    assert_eq!(Value::test_string("Hello, World!"), result);
+
+    Ok(())
+}
+
+#[test]
+fn test_alias_resolves_to_command() -> Result<(), ShellError> {
+    use nu_protocol::Span;
+
+    let result = PluginTest::new("hello", HelloPlugin.into())?
+        .eval("hi")?
         .into_value(Span::test_data())?;
 
     assert_eq!(Value::test_string("Hello, World!"), result);

--- a/crates/nu-plugin/src/plugin/command.rs
+++ b/crates/nu-plugin/src/plugin/command.rs
@@ -115,6 +115,14 @@ pub trait PluginCommand: Sync {
         vec![]
     }
 
+    /// Aliases for the command.
+    ///
+    /// These are alternative names that will resolve to the same command. For example, a command
+    /// named `from yaml` might define `from yml` as an alias.
+    fn aliases(&self) -> Vec<&str> {
+        vec![]
+    }
+
     /// Examples, in Nu, of how the command might be used.
     ///
     /// The examples are not restricted to only including this command, and may demonstrate
@@ -275,6 +283,14 @@ pub trait SimplePluginCommand: Sync {
         vec![]
     }
 
+    /// Aliases for the command.
+    ///
+    /// These are alternative names that will resolve to the same command. For example, a command
+    /// named `from yaml` might define `from yml` as an alias.
+    fn aliases(&self) -> Vec<&str> {
+        vec![]
+    }
+
     /// Examples, in Nu, of how the command might be used.
     ///
     /// The examples are not restricted to only including this command, and may demonstrate
@@ -373,6 +389,10 @@ where
         <Self as SimplePluginCommand>::search_terms(self)
     }
 
+    fn aliases(&self) -> Vec<&str> {
+        <Self as SimplePluginCommand>::aliases(self)
+    }
+
     fn signature(&self) -> Signature {
         <Self as SimplePluginCommand>::signature(self)
     }
@@ -418,6 +438,13 @@ pub fn create_plugin_signature(command: &(impl PluginCommand + ?Sized)) -> Plugi
             .search_terms(
                 command
                     .search_terms()
+                    .into_iter()
+                    .map(String::from)
+                    .collect(),
+            )
+            .aliases(
+                command
+                    .aliases()
                     .into_iter()
                     .map(String::from)
                     .collect(),

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -470,9 +470,15 @@ where
 
     // Build commands map, to make running a command easier
     let mut commands: HashMap<String, _> = HashMap::new();
+    // Map alias names to their primary command name
+    let mut alias_map: HashMap<String, String> = HashMap::new();
 
     for command in plugin.commands() {
-        if let Some(previous) = commands.insert(command.name().into(), command) {
+        let primary_name: String = command.name().into();
+        for alias in command.aliases() {
+            alias_map.insert(alias.to_string(), primary_name.clone());
+        }
+        if let Some(previous) = commands.insert(primary_name, command) {
             eprintln!(
                 "Plugin `{plugin_name}` warning: command `{}` shadowed by another command with the \
                     same name. Check your commands' `name()` methods",
@@ -514,7 +520,8 @@ where
             // of the references after we catch the unwind, and immediately exit.
             let unwind_result = std::panic::catch_unwind(AssertUnwindSafe(|| {
                 let CallInfo { name, call, input } = call_info;
-                let result = if let Some(command) = commands.get(&name) {
+                let resolved_name = alias_map.get(&name).unwrap_or(&name);
+                let result = if let Some(command) = commands.get(resolved_name) {
                     command.run(plugin, &engine, &call, input)
                 } else {
                     Err(
@@ -548,7 +555,8 @@ where
                     arg_type,
                     call,
                 } = get_dynamic_completion_info;
-                let items = if let Some(command) = commands.get(&name) {
+                let resolved_name = alias_map.get(&name).unwrap_or(&name);
+                let items = if let Some(command) = commands.get(resolved_name) {
                     let arg_type = arg_type.into();
                     command.get_dynamic_completion(
                         plugin,
@@ -751,7 +759,15 @@ fn print_help(plugin: &impl Plugin, encoder: impl PluginEncoder) {
 
     plugin.commands().into_iter().for_each(|command| {
         let signature = command.signature();
+        let aliases = command.aliases();
         let res = write!(help, "\nCommand: {}", command.name())
+            .and_then(|_| {
+                if !aliases.is_empty() {
+                    writeln!(help, "\nAliases: {}", aliases.join(", "))
+                } else {
+                    Ok(())
+                }
+            })
             .and_then(|_| writeln!(help, "\nDescription:\n > {}", command.description()))
             .and_then(|_| {
                 if !command.extra_description().is_empty() {

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -316,6 +316,8 @@ pub struct Signature {
     pub description: String,
     pub extra_description: String,
     pub search_terms: Vec<String>,
+    #[serde(default)]
+    pub aliases: Vec<String>,
     pub required_positional: Vec<PositionalArg>,
     pub optional_positional: Vec<PositionalArg>,
     pub rest_positional: Option<PositionalArg>,
@@ -351,6 +353,7 @@ impl Signature {
             description: String::new(),
             extra_description: String::new(),
             search_terms: vec![],
+            aliases: vec![],
             required_positional: vec![],
             optional_positional: vec![],
             rest_positional: None,
@@ -459,6 +462,12 @@ impl Signature {
     /// Add search terms to the signature
     pub fn search_terms(mut self, terms: Vec<String>) -> Signature {
         self.search_terms = terms;
+        self
+    }
+
+    /// Set aliases for the command
+    pub fn aliases(mut self, aliases: Vec<String>) -> Signature {
+        self.aliases = aliases;
         self
     }
 


### PR DESCRIPTION
Closes #17754

Plugin commands currently have no way to define aliases. Built-in commands
like `from yaml`/`from yml` work around this by duplicating the entire
command struct. Plugin developers face the same problem but worse — they
must define completely separate `PluginCommand` structs for each alias.

This adds an `aliases` field to `Signature` and wires it through the plugin
system so that plugin (and built-in) commands can declare alias names that
resolve to the same command.

### Changes

- Add `aliases: Vec<String>` to `Signature` (`#[serde(default)]` for
  backward compat with existing plugin registries)
- Add `fn aliases()` default method to `PluginCommand` and
  `SimplePluginCommand` traits
- Register alias→primary-name mapping in plugin-side `serve_plugin_io()`
- Create alias `PluginDeclaration`s on the engine side in
  `load_plugin_registry_item()` and in test support `fake_register()`
- Display aliases in plugin `print_help()`

### Tests

- Added `test_alias_resolves_to_command` verifying that alias `hi`
  resolves and produces the same output as primary command `hello`

## Release notes summary - What our users need to know

Plugin commands can now define aliases by implementing `fn aliases()` on
their `PluginCommand` or `SimplePluginCommand`. This avoids having to
duplicate entire command structs just to provide an alternative name.

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)