### PR TITLE
`reject`: preserve metadata

### DIFF
--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -273,7 +273,7 @@ fn reject(
                 })
                 .into_pipeline_data(span, engine_state.signals().clone());
 
-            Ok(result)
+            Ok(result.set_metadata(metadata))
         }
 
         input => {


### PR DESCRIPTION
Refs https://discord.com/channels/601130461678272522/614593951969574961/1481099224853647401

## Release notes summary - What our users need to know

`reject` now preserves the stream metadata. For example, `ls | reject ...[]` will keep the LS_COLORS and ansi links.

## Tasks after submitting

None.
