### PR TITLE
feat: make `Span`'s `Debug` impl succinct

### DIFF
--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -136,10 +136,23 @@ impl<T> IntoSpanned for T {
 /// Spans are a global offset across all seen files, which are cached in the engine's state. The start and
 /// end offset together make the inclusive start/exclusive end pair for where to underline to highlight
 /// a given point of interest.
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Span {
     pub start: usize,
     pub end: usize,
+}
+
+impl fmt::Debug for Span {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const TEST_DATA: Span = Span::test_data();
+        const UNKNOWN: Span = Span::unknown();
+
+        match *self {
+            TEST_DATA => write!(f, "Span(TEST)"),
+            UNKNOWN => write!(f, "Span(UNKNOWN)"),
+            Span { start, end } => write!(f, "Span[{start}..{end}]"),
+        }
+    }
 }
 
 impl Span {


### PR DESCRIPTION
I think `Span`'s `Debug` text takes up much more space than needed and makes `Debug` text of anything containing `Span`s look extremely verbose.

This PR provides a one line format that also special-cases `Span::test()` and `Span::unknown()`.

<table width="100%">
<tbody>
<tr>
<td width="500">

### Before

</td>
<td width="500">

### After

</td>
</tr>
<tr>
<td>

```
Span {
	start: 1024,
	end: 1036,
}
```

</td>
<td>

```
Span[1024..1036]
                        

```

</td>
</tr>
<tr>
<td>

```
Span {
	start: 9223372036854775807,
	end: 9223372036854775807,
}
```

</td>
<td>

```
Span(TEST)


```

</td>
</tr>
<tr>
<td>

```
Span {
	start: 0,
	end: 0,
}
```

</td>
<td>

```
Span(UNKNOWN)


```

</td>
</tr>
</tbody>
</table>

As part of a larger error:

```
Error: TestError {
    location: tests/const_/mod.rs:36:22,
    kind: UnexpectedValue {
        expected: Int {
            val: 42,
            internal_span: Span {
            	start: 9223372036854775807,
            	end: 9223372036854775807,
            },
        },
        got: Int {
            val: 10,
            internal_span: Span {
            	start: 130819,
            	end: 130821,
            },
        },
    },
}
```

```
Error: TestError {
    location: tests/const_/mod.rs:36:22,
    kind: UnexpectedValue {
        expected: Int {
            val: 42,
            internal_span: Span(TEST),
        },
        got: Int {
            val: 10,
            internal_span: Span[130819..130821],
        },
    },
}
```

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A
