### PR TITLE
Add a check to avoid duplicate histogram output column names 

### DIFF
--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -221,9 +221,18 @@ fn run_histogram(
         }
     }
 
+    let forbidden_colun_names = ["count", "quantile", "percentage", freq_column.as_str()];
     let value_column_name = column_name
         .map(|x| x.item)
+        .map(|name| {
+            if forbidden_colun_names.contains(&name.as_str()) {
+                "value".to_string()
+            } else {
+                name
+            }
+        })
         .unwrap_or_else(|| "value".to_string());
+
     Ok(histogram_impl(
         inputs,
         &value_column_name,

--- a/crates/nu-command/tests/commands/histogram.rs
+++ b/crates/nu-command/tests/commands/histogram.rs
@@ -98,3 +98,21 @@ fn count_with_normalize_percentage() {
 
     assert_eq!(actual.out, bit_json);
 }
+
+#[test]
+fn column_name_conflicting_with_reserved_maps_to_value() {
+    let actual = nu!(r#"
+        1..100
+        | each { {count: ($in mod 11) } }
+        | histogram count
+        | columns
+        | sort
+        | to json
+    "#);
+
+    // "count" is a reserved column name, so the value column should fall back to "value"
+    assert_eq!(
+        actual.out,
+        r#"[  "count",  "frequency",  "percentage",  "quantile",  "value"]"#
+    );
+}


### PR DESCRIPTION
This adds a simple check to prevent histogram output from having overlapping names when a named column is passed to the histogram. So now histograms _of_ columns named "count", "frequency" (or the frequency user-defined name), "quantile", "percentage" will have sensible output.

fixes #17463

## Release notes summary - What our users need to know
Adds a simple check to prevent histogram output from having overlapping names when a named column is passed to the histogram. So now histograms _of_ columns named "count", "frequency" (or the frequency user-defined name), "quantile", "percentage" will have sensible output.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
