### PR TITLE
feat(parser): add support for parsing return pipelines as subexpressions

### DIFF
--- a/crates/nu-parser/src/lite_parser.rs
+++ b/crates/nu-parser/src/lite_parser.rs
@@ -449,8 +449,21 @@ pub fn lite_parse(
                             command.pipe = Some(token.span);
                         }
                         TokenContents::Pipe => {
-                            pipeline.push(&mut command);
-                            command.pipe = Some(token.span);
+                            // If this command begins with `return` and doesn't have its own redirection, we want to treat the rest of the pipeline as the
+                            // return expression rather than splitting into a separate pipeline. That allows `return x | y` to be handled as a single `return`
+                            // call where the argument is `x | y`.
+                            let is_return = command
+                                .command_parts()
+                                .first()
+                                .map(|span| working_set.get_span_contents(*span) == b"return")
+                                .unwrap_or(false);
+
+                            if is_return && command.redirection.is_none() {
+                                command.push(token.span);
+                            } else {
+                                pipeline.push(&mut command);
+                                command.pipe = Some(token.span);
+                            }
                         }
                         TokenContents::Eol => {
                             // Handle `[Command] [Pipe] ([Comment] | [Eol])+ [Command]`

--- a/crates/nu-parser/src/lite_parser.rs
+++ b/crates/nu-parser/src/lite_parser.rs
@@ -449,21 +449,8 @@ pub fn lite_parse(
                             command.pipe = Some(token.span);
                         }
                         TokenContents::Pipe => {
-                            // If this command begins with `return` and doesn't have its own redirection, we want to treat the rest of the pipeline as the
-                            // return expression rather than splitting into a separate pipeline. That allows `return x | y` to be handled as a single `return`
-                            // call where the argument is `x | y`.
-                            let is_return = command
-                                .command_parts()
-                                .first()
-                                .map(|span| working_set.get_span_contents(*span) == b"return")
-                                .unwrap_or(false);
-
-                            if is_return && command.redirection.is_none() {
-                                command.push(token.span);
-                            } else {
-                                pipeline.push(&mut command);
-                                command.pipe = Some(token.span);
-                            }
+                            pipeline.push(&mut command);
+                            command.pipe = Some(token.span);
                         }
                         TokenContents::Eol => {
                             // Handle `[Command] [Pipe] ([Comment] | [Eol])+ [Command]`

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -149,6 +149,103 @@ pub fn parse_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteComma
     }
 }
 
+pub fn parse_return_keyword(
+    working_set: &mut StateWorkingSet,
+    lite_command: &LiteCommand,
+) -> Pipeline {
+    // If there is no pipeline after `return`, fall back to standard keyword parsing. This ensures `return`
+    // without pipeline behaves as before.
+    let command_parts = lite_command.command_parts();
+    if command_parts.len() <= 1 || lite_command.redirection.is_some() {
+        return parse_keyword(working_set, lite_command);
+    }
+
+    // Treat `return x | y` as a keyword-style pipeline when there is an actual pipeline after `return`.
+    // Otherwise, behave like a normal `return` call.
+    let has_pipe = command_parts
+        .iter()
+        .skip(1)
+        .any(|span| working_set.get_span_contents(*span) == b"|");
+
+    if !has_pipe {
+        return parse_keyword(working_set, lite_command);
+    }
+
+    // Parse the `return` call head so we can attach the full pipeline as a subexpression.
+    let return_head = match command_parts.first() {
+        Some(head) => *head,
+        None => return parse_keyword(working_set, lite_command),
+    };
+    let call_expr = parse_call(working_set, std::slice::from_ref(&return_head), return_head);
+
+    let Expression {
+        expr: Expr::Call(mut call),
+        ty,
+        ..
+    } = call_expr
+    else {
+        return Pipeline::from_vec(vec![call_expr]);
+    };
+
+    // Build a span that covers everything after the `return` keyword.
+    // We sort spans so `Span::merge` never sees out-of-order spans.
+    let tail_span = {
+        let mut spans: Vec<Span> = command_parts.iter().copied().skip(1).collect();
+        spans.extend(lite_command.comments.iter().copied());
+        spans.extend(
+            lite_command
+                .redirection
+                .as_ref()
+                .into_iter()
+                .flat_map(|r| r.spans()),
+        );
+        spans.sort_unstable_by_key(|span| (span.start, span.end));
+        spans.into_iter().reduce(Span::merge)
+    };
+
+    if let Some(tail_span) = tail_span {
+        let (tail_tokens, tail_error) = lex(
+            working_set.get_span_contents(tail_span),
+            tail_span.start,
+            &[],
+            &[],
+            false,
+        );
+        working_set.parse_errors.extend(tail_error);
+
+        trace!("parsing: return pipeline subexpression");
+        let tail_block = parse_block(working_set, &tail_tokens, tail_span, false, true);
+        let tail_ty = tail_block.output_type();
+        let tail_block_id = working_set.add_block(Arc::new(tail_block));
+        let tail_expr = Expression::new(
+            working_set,
+            Expr::Subexpression(tail_block_id),
+            tail_span,
+            tail_ty,
+        );
+
+        call.arguments = vec![Argument::Positional(tail_expr)];
+
+        let return_span = Span {
+            start: return_head.start,
+            end: tail_span.end,
+        };
+
+        Pipeline {
+            elements: vec![PipelineElement {
+                pipe: lite_command.pipe,
+                expr: Expression::new(working_set, Expr::Call(call), return_span, ty),
+                redirection: lite_command
+                    .redirection
+                    .as_ref()
+                    .map(|r| parse_redirection(working_set, r)),
+            }],
+        }
+    } else {
+        parse_keyword(working_set, lite_command)
+    }
+}
+
 pub fn parse_def_predecl(working_set: &mut StateWorkingSet, spans: &[Span]) {
     let mut pos = 0;
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6751,8 +6751,98 @@ pub(crate) fn redirecting_builtin_error(
     }
 }
 
+/// Checks whether a pipeline that starts with `return` and has more than one command should be
+/// re-parsed as a single `return` call whose argument is the rest of the pipeline wrapped in a
+/// subexpression.
+///
+/// For example, `return $x | str upcase` is re-interpreted as `return ($x | str upcase)`. This
+/// mirrors how `return` in Nushell should capture the full pipeline value, not just the first
+/// segment.
+fn parse_return_pipeline(
+    working_set: &mut StateWorkingSet,
+    pipeline: &LitePipeline,
+) -> Option<Pipeline> {
+    let first_command = pipeline.commands.first()?;
+
+    // Need at least two parts (the `return` keyword and its argument) and no redirection on the
+    // first command (e.g. `return foo o> file` is handled by the normal pipeline path).
+    if first_command.command_parts().len() < 2 || first_command.redirection.is_some() {
+        return None;
+    }
+
+    let first_element = parse_pipeline_element(working_set, first_command);
+    let Expression {
+        expr: Expr::Call(mut call),
+        ty,
+        ..
+    } = first_element.expr
+    else {
+        return None;
+    };
+
+    if working_set.get_decl(call.decl_id).name() != "return" {
+        return None;
+    }
+
+    // Collect spans for everything after the `return` keyword: the argument tokens on the first command (skipping the `return`
+    // keyword itself) followed by all subsequent pipeline commands (including their pipe connectors, inline comments, and any redirection spans).
+    let tail_span = first_command
+        .command_parts()
+        .iter()
+        .copied()
+        .skip(1)
+        .chain(pipeline.commands.iter().skip(1).flat_map(|command| {
+            command
+                .comments
+                .iter()
+                .copied()
+                .chain(command.pipe)
+                .chain(command.parts_including_redirection())
+        }))
+        .reduce(Span::merge)?;
+
+    let (tail_tokens, tail_error) = lex(
+        working_set.get_span_contents(tail_span),
+        tail_span.start,
+        &[],
+        &[],
+        false,
+    );
+    working_set.parse_errors.extend(tail_error);
+
+    trace!("parsing: return pipeline subexpression");
+    let tail_block = parse_block(working_set, &tail_tokens, tail_span, false, true);
+    let tail_ty = tail_block.output_type();
+    let tail_block_id = working_set.add_block(Arc::new(tail_block));
+    let tail_expr = Expression::new(
+        working_set,
+        Expr::Subexpression(tail_block_id),
+        tail_span,
+        tail_ty,
+    );
+
+    call.arguments = vec![Argument::Positional(tail_expr)];
+
+    let return_span = Span {
+        start: first_command.command_parts().first()?.start,
+        end: tail_span.end,
+    };
+
+    Some(Pipeline {
+        elements: vec![PipelineElement {
+            pipe: first_command.pipe,
+            expr: Expression::new(working_set, Expr::Call(call), return_span, ty),
+            redirection: None,
+        }],
+    })
+}
+
 pub fn parse_pipeline(working_set: &mut StateWorkingSet, pipeline: &LitePipeline) -> Pipeline {
     if pipeline.commands.len() > 1 {
+        if let Some(return_pipeline) = parse_return_pipeline(working_set, pipeline) {
+            return return_pipeline;
+        }
+
         // Parse a normal multi command pipeline
         let elements: Vec<_> = pipeline
             .commands

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6283,99 +6283,6 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
     }
 }
 
-fn parse_return_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
-    // If there is no pipeline after `return`, fall back to standard keyword parsing. This ensures `return`
-    // without pipeline behaves as before.
-    let command_parts = lite_command.command_parts();
-    if command_parts.len() <= 1 || lite_command.redirection.is_some() {
-        return parse_keyword(working_set, lite_command);
-    }
-
-    // Treat `return x | y` as a keyword-style pipeline when there is an actual pipeline after `return`.
-    // Otherwise, behave like a normal `return` call.
-    let has_pipe = command_parts
-        .iter()
-        .skip(1)
-        .any(|span| working_set.get_span_contents(*span) == b"|");
-
-    if !has_pipe {
-        return parse_keyword(working_set, lite_command);
-    }
-
-    // Parse the `return` call head so we can attach the full pipeline as a subexpression.
-    let return_head = match command_parts.first() {
-        Some(head) => *head,
-        None => return parse_keyword(working_set, lite_command),
-    };
-    let call_expr = parse_call(working_set, std::slice::from_ref(&return_head), return_head);
-
-    let Expression {
-        expr: Expr::Call(mut call),
-        ty,
-        ..
-    } = call_expr
-    else {
-        return Pipeline::from_vec(vec![call_expr]);
-    };
-
-    // Build a span that covers everything after the `return` keyword.
-    let tail_span = {
-        let tail_parts = command_parts.iter().copied().skip(1);
-        let span_iter = tail_parts
-            .chain(lite_command.comments.iter().copied())
-            .chain(
-                lite_command
-                    .redirection
-                    .as_ref()
-                    .into_iter()
-                    .flat_map(|r| r.spans()),
-            );
-        span_iter.reduce(Span::merge)
-    };
-
-    if let Some(tail_span) = tail_span {
-        let (tail_tokens, tail_error) = lex(
-            working_set.get_span_contents(tail_span),
-            tail_span.start,
-            &[],
-            &[],
-            false,
-        );
-        working_set.parse_errors.extend(tail_error);
-
-        trace!("parsing: return pipeline subexpression");
-        let tail_block = parse_block(working_set, &tail_tokens, tail_span, false, true);
-        let tail_ty = tail_block.output_type();
-        let tail_block_id = working_set.add_block(Arc::new(tail_block));
-        let tail_expr = Expression::new(
-            working_set,
-            Expr::Subexpression(tail_block_id),
-            tail_span,
-            tail_ty,
-        );
-
-        call.arguments = vec![Argument::Positional(tail_expr)];
-
-        let return_span = Span {
-            start: return_head.start,
-            end: tail_span.end,
-        };
-
-        Pipeline {
-            elements: vec![PipelineElement {
-                pipe: lite_command.pipe,
-                expr: Expression::new(working_set, Expr::Call(call), return_span, ty),
-                redirection: lite_command
-                    .redirection
-                    .as_ref()
-                    .map(|r| parse_redirection(working_set, r)),
-            }],
-        }
-    } else {
-        parse_keyword(working_set, lite_command)
-    }
-}
-
 pub fn parse_builtin_commands(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
@@ -6457,7 +6364,7 @@ pub fn parse_builtin_commands(
         b"source" | b"source-env" => parse_source(working_set, lite_command),
         b"hide" => parse_hide(working_set, lite_command),
         b"where" => parse_where(working_set, lite_command),
-        b"return" => parse_return_keyword(working_set, lite_command),
+        b"return" => crate::parse_keywords::parse_return_keyword(working_set, lite_command),
         // Only "plugin use" is a keyword
         #[cfg(feature = "plugin")]
         b"plugin"
@@ -6847,6 +6754,39 @@ pub(crate) fn redirecting_builtin_error(
 
 pub fn parse_pipeline(working_set: &mut StateWorkingSet, pipeline: &LitePipeline) -> Pipeline {
     if pipeline.commands.len() > 1 {
+        // Special-case `return` at the start of a pipeline. `return x | y` should be treated as
+        // `return (x | y)`, meaning that the entire remaining pipeline becomes the argument to
+        // the `return` keyword.
+        if let Some(first) = pipeline.commands.first()
+            && first.redirection.is_none()
+            && first
+                .command_parts()
+                .first()
+                .map(|span| working_set.get_span_contents(*span) == b"return")
+                .unwrap_or(false)
+        {
+            // Merge the entire pipeline into a single command so that `parse_return_keyword`
+            // can treat it as a keyword call with a subexpression argument.
+            let mut merged = first.clone();
+
+            if let Some(pipe_span) = first.pipe {
+                merged.parts.push(pipe_span);
+            }
+
+            for command in pipeline.commands.iter().skip(1) {
+                merged.parts.extend(command.parts.iter().copied());
+                merged.comments.extend(command.comments.iter().copied());
+                if let Some(redirection) = &command.redirection {
+                    merged.parts.extend(redirection.spans());
+                }
+                if let Some(pipe_span) = command.pipe {
+                    merged.parts.push(pipe_span);
+                }
+            }
+
+            return parse_builtin_commands(working_set, &merged);
+        }
+
         // Parse a normal multi command pipeline
         let elements: Vec<_> = pipeline
             .commands

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6283,6 +6283,99 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
     }
 }
 
+fn parse_return_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
+    // If there is no pipeline after `return`, fall back to standard keyword parsing. This ensures `return`
+    // without pipeline behaves as before.
+    let command_parts = lite_command.command_parts();
+    if command_parts.len() <= 1 || lite_command.redirection.is_some() {
+        return parse_keyword(working_set, lite_command);
+    }
+
+    // Treat `return x | y` as a keyword-style pipeline when there is an actual pipeline after `return`.
+    // Otherwise, behave like a normal `return` call.
+    let has_pipe = command_parts
+        .iter()
+        .skip(1)
+        .any(|span| working_set.get_span_contents(*span) == b"|");
+
+    if !has_pipe {
+        return parse_keyword(working_set, lite_command);
+    }
+
+    // Parse the `return` call head so we can attach the full pipeline as a subexpression.
+    let return_head = match command_parts.first() {
+        Some(head) => *head,
+        None => return parse_keyword(working_set, lite_command),
+    };
+    let call_expr = parse_call(working_set, std::slice::from_ref(&return_head), return_head);
+
+    let Expression {
+        expr: Expr::Call(mut call),
+        ty,
+        ..
+    } = call_expr
+    else {
+        return Pipeline::from_vec(vec![call_expr]);
+    };
+
+    // Build a span that covers everything after the `return` keyword.
+    let tail_span = {
+        let tail_parts = command_parts.iter().copied().skip(1);
+        let span_iter = tail_parts
+            .chain(lite_command.comments.iter().copied())
+            .chain(
+                lite_command
+                    .redirection
+                    .as_ref()
+                    .into_iter()
+                    .flat_map(|r| r.spans()),
+            );
+        span_iter.reduce(Span::merge)
+    };
+
+    if let Some(tail_span) = tail_span {
+        let (tail_tokens, tail_error) = lex(
+            working_set.get_span_contents(tail_span),
+            tail_span.start,
+            &[],
+            &[],
+            false,
+        );
+        working_set.parse_errors.extend(tail_error);
+
+        trace!("parsing: return pipeline subexpression");
+        let tail_block = parse_block(working_set, &tail_tokens, tail_span, false, true);
+        let tail_ty = tail_block.output_type();
+        let tail_block_id = working_set.add_block(Arc::new(tail_block));
+        let tail_expr = Expression::new(
+            working_set,
+            Expr::Subexpression(tail_block_id),
+            tail_span,
+            tail_ty,
+        );
+
+        call.arguments = vec![Argument::Positional(tail_expr)];
+
+        let return_span = Span {
+            start: return_head.start,
+            end: tail_span.end,
+        };
+
+        Pipeline {
+            elements: vec![PipelineElement {
+                pipe: lite_command.pipe,
+                expr: Expression::new(working_set, Expr::Call(call), return_span, ty),
+                redirection: lite_command
+                    .redirection
+                    .as_ref()
+                    .map(|r| parse_redirection(working_set, r)),
+            }],
+        }
+    } else {
+        parse_keyword(working_set, lite_command)
+    }
+}
+
 pub fn parse_builtin_commands(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
@@ -6364,6 +6457,7 @@ pub fn parse_builtin_commands(
         b"source" | b"source-env" => parse_source(working_set, lite_command),
         b"hide" => parse_hide(working_set, lite_command),
         b"where" => parse_where(working_set, lite_command),
+        b"return" => parse_return_keyword(working_set, lite_command),
         // Only "plugin use" is a keyword
         #[cfg(feature = "plugin")]
         b"plugin"
@@ -6751,98 +6845,8 @@ pub(crate) fn redirecting_builtin_error(
     }
 }
 
-/// Checks whether a pipeline that starts with `return` and has more than one command should be
-/// re-parsed as a single `return` call whose argument is the rest of the pipeline wrapped in a
-/// subexpression.
-///
-/// For example, `return $x | str upcase` is re-interpreted as `return ($x | str upcase)`. This
-/// mirrors how `return` in Nushell should capture the full pipeline value, not just the first
-/// segment.
-fn parse_return_pipeline(
-    working_set: &mut StateWorkingSet,
-    pipeline: &LitePipeline,
-) -> Option<Pipeline> {
-    let first_command = pipeline.commands.first()?;
-
-    // Need at least two parts (the `return` keyword and its argument) and no redirection on the
-    // first command (e.g. `return foo o> file` is handled by the normal pipeline path).
-    if first_command.command_parts().len() < 2 || first_command.redirection.is_some() {
-        return None;
-    }
-
-    let first_element = parse_pipeline_element(working_set, first_command);
-    let Expression {
-        expr: Expr::Call(mut call),
-        ty,
-        ..
-    } = first_element.expr
-    else {
-        return None;
-    };
-
-    if working_set.get_decl(call.decl_id).name() != "return" {
-        return None;
-    }
-
-    // Collect spans for everything after the `return` keyword: the argument tokens on the first command (skipping the `return`
-    // keyword itself) followed by all subsequent pipeline commands (including their pipe connectors, inline comments, and any redirection spans).
-    let tail_span = first_command
-        .command_parts()
-        .iter()
-        .copied()
-        .skip(1)
-        .chain(pipeline.commands.iter().skip(1).flat_map(|command| {
-            command
-                .comments
-                .iter()
-                .copied()
-                .chain(command.pipe)
-                .chain(command.parts_including_redirection())
-        }))
-        .reduce(Span::merge)?;
-
-    let (tail_tokens, tail_error) = lex(
-        working_set.get_span_contents(tail_span),
-        tail_span.start,
-        &[],
-        &[],
-        false,
-    );
-    working_set.parse_errors.extend(tail_error);
-
-    trace!("parsing: return pipeline subexpression");
-    let tail_block = parse_block(working_set, &tail_tokens, tail_span, false, true);
-    let tail_ty = tail_block.output_type();
-    let tail_block_id = working_set.add_block(Arc::new(tail_block));
-    let tail_expr = Expression::new(
-        working_set,
-        Expr::Subexpression(tail_block_id),
-        tail_span,
-        tail_ty,
-    );
-
-    call.arguments = vec![Argument::Positional(tail_expr)];
-
-    let return_span = Span {
-        start: first_command.command_parts().first()?.start,
-        end: tail_span.end,
-    };
-
-    Some(Pipeline {
-        elements: vec![PipelineElement {
-            pipe: first_command.pipe,
-            expr: Expression::new(working_set, Expr::Call(call), return_span, ty),
-            redirection: None,
-        }],
-    })
-}
-
 pub fn parse_pipeline(working_set: &mut StateWorkingSet, pipeline: &LitePipeline) -> Pipeline {
     if pipeline.commands.len() > 1 {
-        if let Some(return_pipeline) = parse_return_pipeline(working_set, pipeline) {
-            return return_pipeline;
-        }
-
         // Parse a normal multi command pipeline
         let elements: Vec<_> = pipeline
             .commands

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -2203,7 +2203,8 @@ mod mock {
     use super::*;
     use nu_engine::CallExt;
     use nu_protocol::{
-        Category, IntoPipelineData, PipelineData, ShellError, Type, Value, engine::Call,
+        Category, IntoPipelineData, PipelineData, ShellError, Type, Value,
+        engine::{Call, CommandType},
     };
 
     #[derive(Clone)]
@@ -2271,6 +2272,44 @@ mod mock {
                     SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
                     "Equals sign followed by value.",
                 )
+        }
+
+        fn run(
+            &self,
+            _engine_state: &EngineState,
+            _stack: &mut Stack,
+            _call: &Call,
+            _input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
+            todo!()
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct Return;
+
+    impl Command for Return {
+        fn name(&self) -> &str {
+            "return"
+        }
+
+        fn description(&self) -> &str {
+            "Mock return command."
+        }
+
+        fn signature(&self) -> nu_protocol::Signature {
+            Signature::build("return")
+                .input_output_types(vec![(Type::Nothing, Type::Any)])
+                .optional(
+                    "return_value",
+                    SyntaxShape::Any,
+                    "Optional value to return.",
+                )
+                .category(Category::Core)
+        }
+
+        fn command_type(&self) -> CommandType {
+            CommandType::Keyword
         }
 
         fn run(
@@ -3237,4 +3276,62 @@ fn parse_let_in_pipeline() {
         pipeline.elements[1].expr.expr,
         Expr::ExternalCall(_, _)
     ));
+}
+
+#[test]
+fn parse_return_pipeline_as_subexpression() {
+    // Register only the commands needed for this scenario so the parser resolves
+    // `return` and `ls` as internal commands instead of treating them as externals.
+    let mut engine_state = EngineState::new();
+    let delta = {
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        working_set.add_decl(Box::new(mock::Return));
+        working_set.add_decl(Box::new(mock::LsTest));
+        working_set.render()
+    };
+    engine_state
+        .merge_delta(delta)
+        .expect("Error merging delta");
+
+    let mut working_set = StateWorkingSet::new(&engine_state);
+    let block = parse(&mut working_set, None, b"return ls | first", true);
+
+    // The input is expected to be valid. Any parse error here would mean the test
+    // cannot make reliable assertions about the produced AST shape.
+    assert!(
+        working_set.parse_errors.is_empty(),
+        "Parse errors: {:?}",
+        working_set.parse_errors
+    );
+
+    // `return ...` should produce one top-level pipeline with a single element: the `return` call itself.
+    assert_eq!(block.pipelines.len(), 1);
+    let pipeline = &block.pipelines[0];
+    assert_eq!(pipeline.elements.len(), 1);
+
+    // The only top-level expression should be a command call, and specifically the `return` declaration we registered above.
+    let return_expr = &pipeline.elements[0].expr.expr;
+    let Expr::Call(call) = return_expr else {
+        panic!("Expected return call, found {return_expr:?}");
+    };
+    assert_eq!(working_set.get_decl(call.decl_id).name(), "return");
+
+    // `return` should receive exactly one argument: the expression `ls | first`.
+    assert_eq!(call.arguments.len(), 1);
+
+    // That argument must be positional and represented as a subexpression block. This is the key behavior being tested:
+    // the parser should group the pipeline as a single argument to `return` rather than parsing it as a top-level pipe.
+    let arg = call.arguments[0]
+        .expr()
+        .expect("return argument should be positional");
+    let arg_expr = &arg.expr;
+    let Expr::Subexpression(block_id) = arg_expr else {
+        panic!("Expected subexpression argument, found {arg_expr:?}");
+    };
+
+    // Validate the nested subexpression structure: one pipeline containing two elements (`ls` piped to `first`). This
+    // confirms the right-hand pipeline was captured inside `return`'s argument.
+    let subexpression = working_set.get_block(*block_id);
+    assert_eq!(subexpression.pipelines.len(), 1);
+    assert_eq!(subexpression.pipelines[0].elements.len(), 2);
 }

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -3279,6 +3279,23 @@ fn parse_let_in_pipeline() {
 }
 
 #[test]
+fn parse_non_return_pipeline_is_not_reparsed() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let block = parse(&mut working_set, None, b"ls | first", true);
+
+    assert!(
+        working_set.parse_errors.is_empty(),
+        "Parse errors: {:?}",
+        working_set.parse_errors
+    );
+
+    let pipeline = &block.pipelines[0];
+    assert_eq!(pipeline.elements.len(), 2);
+}
+
+#[test]
 fn parse_return_pipeline_as_subexpression() {
     // Register only the commands needed for this scenario so the parser resolves
     // `return` and `ls` as internal commands instead of treating them as externals.

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -400,6 +400,14 @@ fn early_return_from_for() {
 }
 
 #[test]
+fn early_return_from_pipeline() {
+    test_eval(
+        r#"do { return "something" | str replace "some" "no"; "ignored" }"#,
+        Eq("nothing"),
+    )
+}
+
+#[test]
 fn try_no_catch() {
     test_eval("try { error make { msg: foo } }; 'pass'", Eq("pass"))
 }

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -1225,6 +1225,13 @@ fn not_panic_with_recursive_call() {
     ]));
     assert_eq!(result.out, "false");
 
+    let result = nu!(nu_repl_code(&[
+        "def px [n=0] { let l = $in; if $n == 0 { return $l | describe } else { $l | px ($n - 1) } }",
+        "let x = 1",
+        "$x | px"
+    ]));
+    assert_eq!(result.out, "int");
+
     let result = nu!(
         cwd: "tests/parsing/samples",
         "nu recursive_func_with_alias.nu"


### PR DESCRIPTION
This PR allows the `return` command to have a pipeline. Previously the parser would interpret `return x | y` as `(return x) | y`. Now it interprets it as `return (x | y)`

closes #13648

## Release notes summary - What our users need to know
Allow the `return` command to have a pipeline. Previously the parser would interpret `return x | y` as `(return x) | y`. Now it interprets it as `return (x | y)`.

Example from issue after this PR
```nushell
❯ def nu-dirs [] { return $nu | transpose k v | where k like 'dir' }
❯ nu-dirs
╭─#─┬──────────k───────────┬─────────────────────v─────────────────────╮
│ 0 │ default-config-dir   │ C:\Users\username\AppData\Roaming\nushell │
│ 1 │ home-dir             │ C:\Users\username                         │
│ 2 │ data-dir             │ C:\Users\username\AppData\Roaming\nushell │
│ 3 │ cache-dir            │ C:\Users\username\AppData\Local\nushell   │
│ 4 │ vendor-autoload-dirs │ [list 2 items]                            │
│ 5 │ user-autoload-dirs   │ [list 1 item]                             │
│ 6 │ temp-dir             │ D:\Temp                                   │
╰─#─┴──────────k───────────┴─────────────────────v─────────────────────╯
```

### Before (incorrect rounding)
```nushell
❯ def t [] { return 1.04 | math round }
❯ t
1.04
❯ 1.04 | math round
1
```
### After (correct rounding)
```nushell
❯ def t [] { return 1.04 | math round }
❯ t
1
```


## Tasks after submitting
N/A