### PR TITLE
feat: `group-by` flag to delete column after grouping by it

### DIFF
--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -377,6 +377,16 @@ fn group_cell_path(
         if prune {
             // it's okay if this fails since pruning is best-effort
             let _ = value.remove_data_at_cell_path(&column_name.members);
+
+            // also try pruning parent, if it has now become empty
+            let parent = column_name.members.split_last().map(|(_, head)| head);
+
+            if let Some(parent) = parent
+                && let Ok(parent_value) = value.follow_cell_path(parent)
+                && parent_value.is_empty()
+            {
+                let _ = value.remove_data_at_cell_path(parent);
+            }
         }
 
         groups.entry(key).or_default().push(value);


### PR DESCRIPTION


## Release notes summary - What our users need to know
### New flag `--prune` for `group-by`
Adds `group-by --prune` to delete the column(s) used for grouping when the arguments are cell paths; closure arguments are unaffected. If pruning leaves a parent empty (e.g., due to nested columns), the parent is removed as well.`

```nushell
> let table = [[name, meta]; [andres, {lang: rb, year: "2019"}], [jt, {lang: rs, year: "2019"}], [storm, {lang: rs, year: "2021"}], [kai, {lang: rb, year: "2021"}]]

> $table
╭───┬────────┬─────────────────╮
│ # │  name  │      meta       │
├───┼────────┼─────────────────┤
│ 0 │ andres │ ╭──────┬──────╮ │
│   │        │ │ lang │ rb   │ │
│   │        │ │ year │ 2019 │ │
│   │        │ ╰──────┴──────╯ │
│ 1 │ jt     │ ╭──────┬──────╮ │
│   │        │ │ lang │ rs   │ │
│   │        │ │ year │ 2019 │ │
│   │        │ ╰──────┴──────╯ │
│ 2 │ storm  │ ╭──────┬──────╮ │
│   │        │ │ lang │ rs   │ │
│   │        │ │ year │ 2021 │ │
│   │        │ ╰──────┴──────╯ │
│ 3 │ kai    │ ╭──────┬──────╮ │
│   │        │ │ lang │ rb   │ │
│   │        │ │ year │ 2021 │ │
│   │        │ ╰──────┴──────╯ │
╰───┴────────┴─────────────────╯
> $table | group-by meta.year --prune
╭──────┬────────────────────────────────╮
│      │ ╭───┬────────┬───────────────╮ │
│ 2019 │ │ # │  name  │     meta      │ │
│      │ ├───┼────────┼───────────────┤ │
│      │ │ 0 │ andres │ ╭──────┬────╮ │ │
│      │ │   │        │ │ lang │ rb │ │ │
│      │ │   │        │ ╰──────┴────╯ │ │
│      │ │ 1 │ jt     │ ╭──────┬────╮ │ │
│      │ │   │        │ │ lang │ rs │ │ │
│      │ │   │        │ ╰──────┴────╯ │ │
│      │ ╰───┴────────┴───────────────╯ │
│      │ ╭───┬───────┬───────────────╮  │
│ 2021 │ │ # │ name  │     meta      │  │
│      │ ├───┼───────┼───────────────┤  │
│      │ │ 0 │ storm │ ╭──────┬────╮ │  │
│      │ │   │       │ │ lang │ rs │ │  │
│      │ │   │       │ ╰──────┴────╯ │  │
│      │ │ 1 │ kai   │ ╭──────┬────╮ │  │
│      │ │   │       │ │ lang │ rb │ │  │
│      │ │   │       │ ╰──────┴────╯ │  │
│      │ ╰───┴───────┴───────────────╯  │
╰──────┴────────────────────────────────╯
> $table | group-by meta.year meta.lang --prune # also removes the parent if it's now empty
╭──────┬─────────────────────────╮
│      │ ╭────┬────────────────╮ │
│ 2019 │ │    │ ╭───┬────────╮ │ │
│      │ │ rb │ │ # │  name  │ │ │
│      │ │    │ ├───┼────────┤ │ │
│      │ │    │ │ 0 │ andres │ │ │
│      │ │    │ ╰───┴────────╯ │ │
│      │ │    │ ╭───┬──────╮   │ │
│      │ │ rs │ │ # │ name │   │ │
│      │ │    │ ├───┼──────┤   │ │
│      │ │    │ │ 0 │ jt   │   │ │
│      │ │    │ ╰───┴──────╯   │ │
│      │ ╰────┴────────────────╯ │
│      │ ╭────┬───────────────╮  │
│ 2021 │ │    │ ╭───┬───────╮ │  │
│      │ │ rs │ │ # │ name  │ │  │
│      │ │    │ ├───┼───────┤ │  │
│      │ │    │ │ 0 │ storm │ │  │
│      │ │    │ ╰───┴───────╯ │  │
│      │ │    │ ╭───┬──────╮  │  │
│      │ │ rb │ │ # │ name │  │  │
│      │ │    │ ├───┼──────┤  │  │
│      │ │    │ │ 0 │ kai  │  │  │
│      │ │    │ ╰───┴──────╯  │  │
│      │ ╰────┴───────────────╯  │
╰──────┴─────────────────────────╯
```

## Motivation

for my use, I always want to delete the column after grouping.
the help text suggests `update cells { reject column-name }` for this, but I find this cumbersome.

feel free to suggest a better name for the flag.
