### PR TITLE
Drop mode preservation in order to fix copying of read-only directories

### DIFF
--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -333,23 +333,9 @@ fn make_attributes(preserve: Option<Value>) -> Result<uu_cp::Attributes, ShellEr
 
         Ok(attributes)
     } else {
-        // By default preseerve only mode
-        Ok(uu_cp::Attributes {
-            mode: ATTR_SET,
-            #[cfg(any(
-                target_os = "linux",
-                target_os = "freebsd",
-                target_os = "android",
-                target_os = "macos",
-                target_os = "netbsd",
-                target_os = "openbsd"
-            ))]
-            ownership: ATTR_UNSET,
-            timestamps: ATTR_UNSET,
-            context: ATTR_UNSET,
-            links: ATTR_UNSET,
-            xattr: ATTR_UNSET,
-        })
+        // By default don't preserve anything as per
+        // https://docs.rs/uu_cp/latest/uu_cp/struct.Attributes.html
+        Ok(uu_cp::Attributes::NONE)
     }
 }
 


### PR DESCRIPTION
Closes #17548

The new behavior aligns with the recommendation of returning Attributes::NONE when the preserve argument isn't explicitly set: https://docs.rs/uu_cp/latest/uu_cp/struct.Attributes.html

## Release notes summary - What our users need to know

Fixes an issue where read-only directories are unable to be copied due to the mode attribute being preserved by default. 