### PR TITLE
docs: update command docs to include command type

### DIFF
--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -366,6 +366,12 @@ fn get_command_documentation(
         }))
     }
 
+    let _ = write!(
+        long_desc,
+        "\n{help_section_name}Command Type{RESET}:\n  > {}\n",
+        command.command_type()
+    );
+
     if !sig.required_positional.is_empty()
         || !sig.optional_positional.is_empty()
         || sig.rest_positional.is_some()


### PR DESCRIPTION
This PR updates the command help information to have `command type` information. This will help with the documentation so that people know which commands are plugins. It's not clear from the online docs what commands are plugins.

## Release notes summary - What our users need to know
### `help` now also shows command type
Add `command type` information to help.
```nushell
❯ help from ini
Parse text as .ini and create table.

Usage:
  > from ini {flags}

Flags:
  -h, --help: Display the help message for this command
  -q, --no-quote: Disable quote handling for values.
  -e, --no-escape: Disable escape sequence handling for values.
  -m, --indented-multiline-value: Allow values to continue on indented lines.
  -w, --preserve-key-leading-whitespace: Preserve leading whitespace in keys.

Command Type:
  > plugin

Input/output types:
  ╭─#─┬─input──┬─output─╮
  │ 0 │ string │ record │
  ╰───┴────────┴────────╯
```

closes https://github.com/nushell/nushell.github.io/issues/2138

## Tasks after submitting
The stdlib `help` command may need updating.
