### PR TITLE
Enable `env_shlvl_in_repl` and `env_shlvl_in_exec_repl` tests

### DIFF
--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -250,8 +250,8 @@ fn env_shlvl_commandstring_does_not_increment() {
 // We've also learned that `-e 'exit'` is not enough to
 // prevent failures entirely. For now we're going to ignore
 // these tests until we can find a better solution.
-#[ignore = "Causing hangs when both tests overlap"]
 #[test]
+#[serial]
 fn env_shlvl_in_repl() {
     let actual = nu!(r#"
         $env.SHLVL = 5
@@ -261,8 +261,8 @@ fn env_shlvl_in_repl() {
     assert!(actual.out.ends_with("SHLVL:6"));
 }
 
-#[ignore = "Causing hangs when both tests overlap"]
 #[test]
+#[serial]
 fn env_shlvl_in_exec_repl() {
     let actual = nu!(r#"
         $env.SHLVL = 29


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

According to the ignore messages of the `env_shlvl_in_repl` and `env_shlvl_in_exec_repl` tests they caused the tests to hang when these two ran at the same time. #17086 tried to fix this explicitly using `nextest`. But since #17628 we're able to configure tests to run serially. So this PR marked these two as serial and made them no longer ignore.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
n/a