### PR TITLE
Give `http get` command tests with socks proxy more time to execute

### DIFF
--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -332,7 +332,9 @@ fn http_get_response_metadata() {
 #[case::all_proxy("ALL_PROXY")]
 #[case::http_proxy("HTTP_PROXY")]
 #[case::https_proxy("HTTPS_PROXY")]
-#[timeout(std::time::Duration::from_secs(5))]
+#[timeout(std::time::Duration::from_secs(10))]
+#[nu_test_support::test]
+#[serial]
 fn http_get_with_socks5_proxy(#[case] proxy_env: &str) {
     use nu_test_support::net::{Address, proxy::Socks5Proxy};
     use std::net::Ipv4Addr;


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

The `http get` commands using the SOCKS proxy for testing like to fail in CI. This should give them a bit more room to breath. Maybe this fixes the CI erroring.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
n/a