### PR TITLE
Handle non-UTF-8 bytes in `lines` with lossy conversion instead of erroring

### DIFF
--- a/crates/nu-command/tests/commands/lines.rs
+++ b/crates/nu-command/tests/commands/lines.rs
@@ -57,3 +57,16 @@ fn lines_on_error() {
 
     assert!(actual.err.contains("Is a directory"));
 }
+
+#[test]
+fn lines_handles_non_utf8_bytes() {
+    // Create a file with invalid UTF-8 bytes and verify `lines` doesn't error
+    let actual = nu!(r#"
+        0x[68 65 6C 6C 6F 0A 77 6F 72 6C 64 FF FE 0A 66 6F 6F]
+        | save --force /tmp/nu_test_non_utf8.txt
+        ; open --raw /tmp/nu_test_non_utf8.txt | lines | length
+    "#);
+
+    assert_eq!(actual.out, "3");
+    assert!(actual.err.is_empty() || !actual.err.contains("Non-UTF8"));
+}

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -853,9 +853,7 @@ impl Iterator for Lines {
             match self.reader.read_until(b'\n', &mut buf) {
                 Ok(0) => None,
                 Ok(_) => {
-                    let Ok(mut string) = String::from_utf8(buf) else {
-                        return Some(Err(ShellError::NonUtf8 { span: self.span }));
-                    };
+                    let mut string = String::from_utf8_lossy(&buf).into_owned();
                     trim_end_newline(&mut string);
                     Some(Ok(string))
                 }


### PR DESCRIPTION
## Summary

- Change `ByteStream::Lines` iterator to use `String::from_utf8_lossy()` instead of strict `String::from_utf8()`, replacing invalid UTF-8 bytes with the Unicode replacement character (U+FFFD) instead of erroring with `NonUtf8`
- This makes `open file | lines` and `open --raw file | lines` work on files containing invalid UTF-8 bytes (e.g., binary data mixed with text, zsh history files)

### Before
```nushell
> open ~/.zsh_history | lines
Error: nu::parser::non_utf8
  x Non-UTF8 string
  help: see `decode` for handling character sets other than UTF-8
```

### After
```nushell
> open /tmp/test_invalid_utf8.txt | lines
╭───┬─────────╮
│ 0 │ hello   │
│ 1 │ world�� │
│ 2 │ foo     │
╰───┴─────────╯
```

This matches the behavior of `decode utf-8` which already uses lossy conversion.

Fixes #6880

## Release notes summary

`lines` now handles files containing non-UTF-8 bytes by replacing invalid sequences with the Unicode replacement character (�) instead of erroring. This makes it possible to process files like zsh history that may contain invalid UTF-8 bytes.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p nu-protocol -p nu-command -- -D warnings -D clippy::unwrap_used` passes
- [x] All existing `lines` tests pass
- [x] New test `lines_handles_non_utf8_bytes` verifies the fix
- [x] Manual verification with `open --raw` and `open` on files with invalid UTF-8