### PR TITLE
nu-table: Change width estimation in case of header_on_border

### DIFF
--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -1206,7 +1206,7 @@ fn truncate_columns_by_head(
     //       rather than removing last column.
     //
     //       We intentionally check only last column.
-    //       Allthough space could be given from any column.
+    //       Although space could be given from any column.
     let last_column_width = widths[truncate_pos - 1];
     let last_column_width_min = NuRecordsValue::width(&data[0][truncate_pos - 1]) + pad;
     let last_column_width_free = last_column_width - last_column_width_min;


### PR DESCRIPTION
Hi @fdncred 

I've made a small patch.
Seems like this is what you wanted.

Have not tested properly.
And maybe the CI will be red.

close #17768 

##### WAS

```
│ 36 │ crates/nu-command/tests/commands/table.rs            │      1384 │ ... │
│ 37 │ crates/nu-command/tests/commands/table.rs            │      1415 │ ... │
│ 38 │ crates/nu-command/tests/commands/table.rs            │      1540 │ ... │
│ 39 │ crates/nu-command/tests/commands/table.rs            │      1861 │ ... │
│ 40 │ crates/nu-command/tests/commands/table.rs            │      1892 │ ... │
│ 41 │ crates/nu-command/tests/commands/table.rs            │      2017 │ ... │
│ 42 │ crates/nu-command/tests/commands/table.rs            │      2240 │ ... │
│ 43 │ crates/nu-command/tests/commands/table.rs            │      2275 │ ... │
│ 44 │ crates/nu-command/tests/commands/table.rs            │      2409 │ ... │
│ 45 │                                                      │           │ ... │
╰─#──┴─────────────────────────path─────────────────────────┴─line_numb─┴─...─
```

##### NOW

```
│ 37 │ crates/nu-command/tests/commands/table.rs            │ ... │
│ 38 │ crates/nu-command/tests/commands/table.rs            │ ... │
│ 39 │ crates/nu-command/tests/commands/table.rs            │ ... │
│ 40 │ crates/nu-command/tests/commands/table.rs            │ ... │
│ 41 │ crates/nu-command/tests/commands/table.rs            │ ... │
│ 42 │ crates/nu-command/tests/commands/table.rs            │ ... │
│ 43 │ crates/nu-command/tests/commands/table.rs            │ ... │
│ 44 │ crates/nu-command/tests/commands/table.rs            │ ... │
│ 45 │                                                      │ ... │
╰─#──┴─────────────────────────path─────────────────────────┴─...─╯
```
