### PR TITLE
Fix `flatten` silently dropping data when conflicting column appears after flattened column

### DIFF
--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -1,6 +1,7 @@
 use indexmap::IndexMap;
 use nu_engine::command_prelude::*;
 use nu_protocol::ast::PathMember;
+use std::collections::HashSet;
 
 #[derive(Clone)]
 pub struct Flatten;
@@ -154,6 +155,9 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
         Value::Record { val, .. } => {
             let mut out = IndexMap::<String, Value>::new();
             let mut inner_table = None;
+            // Collect all parent column names upfront so we can detect
+            // conflicts with inner columns regardless of column order.
+            let all_parent_columns: HashSet<String> = val.columns().cloned().collect();
 
             for (column_index, (column, value)) in val.into_owned().into_iter().enumerate() {
                 let column_requested = columns.iter().find(|c| c.to_column_name() == column);
@@ -164,7 +168,9 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                     Value::Record { ref val, .. } => {
                         if need_flatten {
                             for (col, val) in val.clone().into_owned() {
-                                if out.contains_key(&col) {
+                                // Check against all parent columns except the one
+                                // being flattened (which is being replaced by its contents).
+                                if col != column && all_parent_columns.contains(&col) {
                                     out.insert(format!("{column}_{col}"), val);
                                 } else {
                                     out.insert(col, val);
@@ -268,7 +274,10 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                             // this can avoid output column order changed.
                             if index == parent_column_index {
                                 for (col, val) in &inner_record {
-                                    if record.contains(col) {
+                                    // Check against all parent columns, not just
+                                    // already-inserted ones, to handle conflicts
+                                    // regardless of column order.
+                                    if all_parent_columns.contains(col) {
                                         record.push(
                                             format!("{parent_column_name}_{col}"),
                                             val.clone(),
@@ -286,7 +295,7 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                         // the flattened column may be the last column in the original table.
                         if index == parent_column_index {
                             for (col, val) in inner_record {
-                                if record.contains(&col) {
+                                if all_parent_columns.contains(&col) {
                                     record.push(format!("{parent_column_name}_{col}"), val);
                                 } else {
                                     record.push(col, val);

--- a/crates/nu-command/tests/commands/flatten.rs
+++ b/crates/nu-command/tests/commands/flatten.rs
@@ -140,6 +140,35 @@ fn flatten_table_columns_explicitly() {
 }
 
 #[test]
+fn flatten_renames_conflicting_column_when_parent_column_appears_after() {
+    // Regression test for issue #13271: flatten should rename conflicting
+    // columns regardless of whether the parent's conflicting column appears
+    // before or after the flattened column.
+    let actual = nu!("[[b, a]; [[[a]; [9]], 1]] | flatten -a b | columns | str join ','");
+    assert_eq!(actual.out, "b_a,a");
+
+    let actual = nu!("[[b, a]; [[[a]; [9]], 1]] | flatten -a b | get b_a | first");
+    assert_eq!(actual.out, "9");
+
+    let actual = nu!("[[b, a]; [[[a]; [9]], 1]] | flatten -a b | get a | first");
+    assert_eq!(actual.out, "1");
+}
+
+#[test]
+fn flatten_renames_conflicting_column_in_record_regardless_of_order() {
+    // Record case: inner record column conflicts with a parent column
+    // that appears after the flattened column.
+    let actual = nu!("{b: {a: 9}, a: 1} | flatten b | columns | str join ','");
+    assert_eq!(actual.out, "b_a,a");
+
+    let actual = nu!("{b: {a: 9}, a: 1} | flatten b | get b_a | first");
+    assert_eq!(actual.out, "9");
+
+    let actual = nu!("{b: {a: 9}, a: 1} | flatten b | get a | first");
+    assert_eq!(actual.out, "1");
+}
+
+#[test]
 fn flatten_more_than_one_column_that_are_subtables_not_supported() {
     let sample = r#"
                 [


### PR DESCRIPTION
## Summary

- Fix a bug where `flatten` silently dropped data when the parent record had a conflicting column name that appeared **after** the column being flattened
- The conflict detection only checked already-inserted columns, missing conflicts with columns not yet processed
- Now collects all parent column names upfront into a `HashSet` before the loop, so conflict detection works regardless of column order
- Added regression tests for both the table and record cases

### Before

```nushell
> [[b, a]; [[[a]; [9]], 1]] | flatten -a b
╭───┬───╮
│ # │ a │
├───┼───┤
│ 0 │ 1 │
╰───┴───╯
# Inner value 9 is silently lost!
```

### After

```nushell
> [[b, a]; [[[a]; [9]], 1]] | flatten -a b
╭───┬─────┬───╮
│ # │ b_a │ a │
├───┼─────┼───┤
│ 0 │   9 │ 1 │
╰───┴─────┴───╯
```

## Release notes summary

Fixed a bug where `flatten` would silently drop data when a nested record/table had column names conflicting with parent columns that appeared later in the record. Conflicting columns are now correctly renamed regardless of column order.

Closes #13271