### PR TITLE
Swap order of user and default library directories, ensure $NU_LIB_DIRS is const

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -408,7 +408,7 @@ fn main() -> Result<()> {
             b"$NU_LIB_DIRS".into(),
             Span::unknown(),
             Type::List(Box::new(Type::String)),
-            false, // is_const
+            false, // is_mutable
         );
         working_set
             .set_variable_const_val(var_id, Value::list(all_lib_dir_values, Span::unknown()));


### PR DESCRIPTION
This PR is in response to https://github.com/nushell/nushell/pull/17563#issuecomment-4064367904. Thanks @aionescu.

## Release notes summary - What our users need to know
Nushell now resolves library paths with user‑provided `-I` entries before the default `NU_LIB_DIRS`, fixing cases where bundled modules shadowed user scripts. `NU_LIB_DIRS` is also correctly treated as immutable at startup to avoid unexpected mutation in config or scripts.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
