### PR TITLE
Exclude nu-test-support for loongarch64 to avoid build error of release script

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -235,9 +235,10 @@ def fetch-less [
 
 def 'cargo-build-nu' [] {
     if $os =~ 'windows' {
-        cargo build --release --all --target $target
+        cargo build --release --workspace --exclude nu-test-support --target $target
     } else {
-        cargo build --release --all --target $target --features=static-link-openssl
+        # Exclude nu-test-support for loongarch64 to avoid build error
+        cargo build --release --workspace --exclude nu-test-support --target $target --features=static-link-openssl
     }
 }
 


### PR DESCRIPTION
Exclude nu-test-support for loongarch64 to avoid build error of release script
Should fix https://github.com/nushell/nushell/issues/17806
Build test: https://github.com/nushell/nightly/actions/runs/23171735430