### PR TITLE
Update lscolors from 0.20 to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3623,9 +3623,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lscolors"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61183da5de8ba09a58e330d55e5ea796539d8443bd00fdeb863eac39724aa4ab"
+checksum = "d60e266dfb1426eb2d24792602e041131fdc0236bb7007abc0e589acafd60929"
 dependencies = [
  "aho-corasick",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ libc = "=0.2.178" # Pinned to avoid loongarch64 build failure with libc >= 0.2.1
 libproc = "0.14.11"
 log = "0.4"
 lru = "0.16"
-lscolors = { version = "0.20", default-features = false }
+lscolors = { version = "0.21", default-features = false }
 lsp-server = "0.7.9"
 lsp-types = { version = "0.97.0", features = ["proposed"] }
 lsp-textdocument = "0.5.0"


### PR DESCRIPTION
The breaking change in [0.21.0](https://github.com/sharkdp/lscolors/releases/tag/v0.21.0) appears to be just that the `crossterm` dependency (re-exported when the `crossterm` feature is enabled) is updated to version 0.29.

This was once proposed by dependabot in https://github.com/nushell/nushell/pull/17226, but @fdncred wrote, “we'd have to update nu-ansi-term first.” Now, several months later, 007b223acc1f0dd57ebbefc101ce1a6e46f707d0 has updated `nu-ansi-term` to the latest version, and this update doesn’t appear to have any messy consequences in `Cargo.lock`.

I confirmed that `cargo test --workspace --exact --skip commands::network::http::helpful_dns_error_for_unknown_domain` and `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` still pass.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io) **N/A**
