### PR TITLE
Bump reedline to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6780,7 +6780,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.46.0"
-source = "git+https://github.com/nushell/reedline?branch=main#5c2f105bcff664f9fe9e4cef7699808abde4a335"
+source = "git+https://github.com/nushell/reedline?branch=main#00800775d207a6862493d961f14a1d93430a6524"
 dependencies = [
  "arboard",
  "chrono",


### PR DESCRIPTION
Bump Reedline to latest main so we get this fix to completion menus: https://github.com/nushell/reedline/pull/1040