### PR TITLE
fix: complete symlinked directories with a trailing slash

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -92,8 +92,7 @@ fn complete_rec(
             let entry_name = entry.file_name().to_string_lossy().into_owned();
             let entry_isdir = entry.path().is_dir();
             let mut built = built.clone();
-            // Symlinks to directories shouldn't have a trailing slash (#13275)
-            built.isdir = entry_isdir && !entry.path().is_symlink();
+            built.isdir = entry_isdir;
 
             if !want_directory || entry_isdir {
                 if enable_exact_match && !multiple_exact_matches && has_more {

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1,7 +1,7 @@
 pub mod support;
 
 use std::{
-    fs::{FileType, ReadDir, read_dir},
+    fs::{ReadDir, read_dir},
     path::MAIN_SEPARATOR,
     sync::Arc,
 };
@@ -30,14 +30,20 @@ use support::{
 // *.nu files and subdirectories.
 pub fn match_dir_content_for_dotnu(dir: ReadDir, suggestions: &[Suggestion]) {
     let actual_dir_entries: Vec<_> = dir.filter_map(|c| c.ok()).collect();
-    let type_name_pairs: Vec<(FileType, String)> = actual_dir_entries
+    // Use entry.path().is_dir() instead of FileType::is_dir() so that symlinks
+    // to directories are treated the same way as the completer treats them.
+    let name_pairs: Vec<(bool, String)> = actual_dir_entries
         .into_iter()
-        .filter_map(|t| t.file_type().ok().zip(t.file_name().into_string().ok()))
+        .filter_map(|t| {
+            let is_dir = t.path().is_dir();
+            let name = t.file_name().into_string().ok()?;
+            Some((is_dir, name))
+        })
         .collect();
-    let mut simple_dir_entries: Vec<&str> = type_name_pairs
+    let mut simple_dir_entries: Vec<&str> = name_pairs
         .iter()
-        .filter_map(|(t, n)| {
-            if t.is_dir() || n.ends_with(".nu") {
+        .filter_map(|(is_dir, n)| {
+            if *is_dir || n.ends_with(".nu") {
                 Some(n.as_str())
             } else {
                 None
@@ -383,7 +389,7 @@ fn custom_completions_strip_ansi_from_record_values() {
     def comp [] { null }
     def my-command [arg: string@comp] {}",
     "my-command test", None,
-    vec![folder("test_a"), file("test_a_symlink"), folder("test_b")],
+    vec![folder("test_a"), folder("test_a_symlink"), folder("test_b")],
     4
 )]
 /// Custom function arguments mixed with subcommands
@@ -391,7 +397,7 @@ fn custom_completions_strip_ansi_from_record_values() {
     def foo [i: directory] {}
     def "foo test bar" [] {}"#,
     "foo test", None,
-    vec![folder("test_a"), file("test_a_symlink"), folder("test_b"), "foo test bar".into()],
+    vec![folder("test_a"), folder("test_a_symlink"), folder("test_b"), "foo test bar".into()],
     8
 )]
 /// If argument type is something like int/string, complete only subcommands
@@ -415,7 +421,7 @@ fn custom_completions_strip_ansi_from_record_values() {
     def foo [--test: directory] {}
     def "foo --test test" [] {}"#,
     "foo --test test", None,
-    vec![folder("test_a"), file("test_a_symlink"), folder("test_b"), "foo --test test".into()],
+    vec![folder("test_a"), folder("test_a_symlink"), folder("test_b"), "foo --test test".into()],
     "foo --test test".len()
 )]
 // Directory only
@@ -991,7 +997,7 @@ fn external_completer_fallback() {
     let block = "{|spans| null}";
     let input = "foo test";
 
-    let expected = [folder("test_a"), file("test_a_symlink"), folder("test_b")];
+    let expected = [folder("test_a"), folder("test_a_symlink"), folder("test_b")];
     let suggestions = run_external_completion(block, input);
     match_suggestions_by_string(&expected, &suggestions);
 
@@ -1241,7 +1247,7 @@ fn file_completions() {
         folder(dir.join("directory_completion")),
         file(dir.join("nushell")),
         folder(dir.join("test_a")),
-        file(dir.join("test_a_symlink")),
+        folder(dir.join("test_a_symlink")),
         folder(dir.join("test_b")),
         file(dir.join(".hidden_file")),
         folder(dir.join(".hidden_folder")),
@@ -1275,7 +1281,7 @@ fn file_completions() {
         folder(dir.join("directory_completion")),
         file(dir.join("nushell")),
         folder(dir.join("test_a")),
-        file(dir.join("test_a_symlink")),
+        folder(dir.join("test_a_symlink")),
         folder(dir.join("test_b")),
         file(dir.join(".hidden_file")),
         folder(dir.join(".hidden_folder")),
@@ -1359,7 +1365,7 @@ fn custom_command_rest_any_args_file_completions() {
         folder(dir.join("directory_completion")),
         file(dir.join("nushell")),
         folder(dir.join("test_a")),
-        file(dir.join("test_a_symlink")),
+        folder(dir.join("test_a_symlink")),
         folder(dir.join("test_b")),
         file(dir.join(".hidden_file")),
         folder(dir.join(".hidden_folder")),
@@ -1379,7 +1385,7 @@ fn custom_command_rest_any_args_file_completions() {
         folder(dir.join("directory_completion")),
         file(dir.join("nushell")),
         folder(dir.join("test_a")),
-        file(dir.join("test_a_symlink")),
+        folder(dir.join("test_a_symlink")),
         folder(dir.join("test_b")),
         file(dir.join(".hidden_file")),
         folder(dir.join(".hidden_folder")),
@@ -1701,7 +1707,7 @@ fn command_ls_with_filecompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1713,7 +1719,7 @@ fn command_ls_with_filecompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -1745,7 +1751,7 @@ fn command_open_with_filecompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1757,7 +1763,7 @@ fn command_open_with_filecompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -1789,7 +1795,7 @@ fn command_rm_with_globcompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1801,7 +1807,7 @@ fn command_rm_with_globcompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -1826,7 +1832,7 @@ fn command_cp_with_globcompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1838,7 +1844,7 @@ fn command_cp_with_globcompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -1863,7 +1869,7 @@ fn command_save_with_filecompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1875,7 +1881,7 @@ fn command_save_with_filecompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -1900,7 +1906,7 @@ fn command_touch_with_filecompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1912,7 +1918,7 @@ fn command_touch_with_filecompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -1937,7 +1943,7 @@ fn command_watch_with_filecompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1949,7 +1955,7 @@ fn command_watch_with_filecompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -2207,7 +2213,7 @@ fn folder_with_directorycompletions() {
         folder(dir.join("another")),
         folder(dir.join("directory_completion")),
         folder(dir.join("test_a")),
-        file(dir.join("test_a_symlink")),
+        folder(dir.join("test_a_symlink")),
         folder(dir.join("test_b")),
         folder(dir.join(".hidden_folder")),
     ];
@@ -2310,7 +2316,7 @@ fn folder_with_directorycompletions_with_three_trailing_dots() {
                 .join("...")
                 .join("test_a"),
         ),
-        file(
+        folder(
             dir.join("directory_completion")
                 .join("folder_inside_folder")
                 .join("...")
@@ -2388,7 +2394,7 @@ fn folder_with_directorycompletions_do_not_collapse_dots() {
                 .join("..")
                 .join("test_a"),
         ),
-        file(
+        folder(
             dir.join("directory_completion")
                 .join("folder_inside_folder")
                 .join("..")
@@ -2747,9 +2753,9 @@ fn alias_of_command_and_flags() {
 
     let suggestions = completer.complete("ll t", 4);
     #[cfg(windows)]
-    let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink", "test_b\\"];
+    let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink\\", "test_b\\"];
     #[cfg(not(windows))]
-    let expected_paths: Vec<_> = vec!["test_a/", "test_a_symlink", "test_b/"];
+    let expected_paths: Vec<_> = vec!["test_a/", "test_a_symlink/", "test_b/"];
 
     match_suggestions(&expected_paths, &suggestions)
 }
@@ -2766,9 +2772,9 @@ fn alias_of_basic_command() {
 
     let suggestions = completer.complete("ll t", 4);
     #[cfg(windows)]
-    let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink", "test_b\\"];
+    let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink\\", "test_b\\"];
     #[cfg(not(windows))]
-    let expected_paths: Vec<_> = vec!["test_a/", "test_a_symlink", "test_b/"];
+    let expected_paths: Vec<_> = vec!["test_a/", "test_a_symlink/", "test_b/"];
 
     match_suggestions(&expected_paths, &suggestions)
 }
@@ -2788,9 +2794,9 @@ fn alias_of_another_alias() {
 
     let suggestions = completer.complete("lf t", 4);
     #[cfg(windows)]
-    let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink", "test_b\\"];
+    let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink\\", "test_b\\"];
     #[cfg(not(windows))]
-    let expected_paths: Vec<_> = vec!["test_a/", "test_a_symlink", "test_b/"];
+    let expected_paths: Vec<_> = vec!["test_a/", "test_a_symlink/", "test_b/"];
 
     match_suggestions(&expected_paths, &suggestions)
 }
@@ -2848,7 +2854,7 @@ fn unknown_command_completion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -2860,7 +2866,7 @@ fn unknown_command_completion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -2884,7 +2890,7 @@ fn filecompletions_triggers_after_cursor() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -2896,7 +2902,7 @@ fn filecompletions_triggers_after_cursor() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",


### PR DESCRIPTION
Symlinks pointing to directories now receive a trailing slash during tab completion, consistent with regular directory completion behavior.

The previous behavior was set in #13275 to avoid issues with `rm symlink/`, but as noted by maintainers this is not a valid reason to affect completion behavior.

Updated all test expectations and fixed `match_dir_content_for_dotnu` to use `entry.path().is_dir()` which follows symlinks, consistent with how the completer behaves.

Fixes #17257

## Release notes summary - What our users need to know
Symlinks pointing to directories now get a trailing `/` during tab completion, making them behave like regular directories when navigating.

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)