### PR TITLE
fix(parser): string interpolation with unclosed `)`

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2431,21 +2431,10 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
             }
         }
         InterpolationMode::Expression => {
-            let span = Span::new(token_start, end);
-
-            if delimiter_stack.is_empty() {
-                if token_start < end {
-                    let expr = parse_full_cell_path(working_set, None, span);
-                    output.push(expr);
-                }
-            } else {
-                let expected = delimiter_stack
-                    .last()
-                    .copied()
-                    .map(char::from)
-                    .unwrap_or(')')
-                    .to_string();
-                working_set.error(ParseError::Unclosed(expected, Span::new(end, end)));
+            if token_start < end {
+                let span = Span::new(token_start, end);
+                let expr = parse_full_cell_path(working_set, None, span);
+                output.push(expr);
             }
         }
     }

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1815,7 +1815,22 @@ mod string {
             let engine_state = EngineState::new();
             let mut working_set = StateWorkingSet::new(&engine_state);
 
-            let _ = parse(&mut working_set, None, b"$\"foo (2 + 3\"", true);
+            let block = parse(&mut working_set, None, b"$\"foo (2 + 3\"", true);
+            assert_eq!(block.len(), 1);
+
+            let pipeline = &block.pipelines[0];
+            assert_eq!(pipeline.len(), 1);
+            let element = &pipeline.elements[0];
+            assert!(element.redirection.is_none());
+
+            let subexprs: Vec<&Expr> = match &element.expr.expr {
+                Expr::StringInterpolation(expressions) => {
+                    expressions.iter().map(|e| &e.expr).collect()
+                }
+                _ => panic!("Expected an `Expr::StringInterpolation`"),
+            };
+
+            assert_eq!(subexprs.len(), 2);
 
             assert!(
                 working_set.parse_errors.iter().any(

--- a/tests/repl/test_strings.rs
+++ b/tests/repl/test_strings.rs
@@ -61,7 +61,7 @@ fn single_tick_interpolation() -> TestResult {
 
 #[test]
 fn unclosed_interpolation_subexpression() -> TestResult {
-    fail_test("$\"foo (2 + 3\"", "unclosed )")
+    fail_test("$\"foo (2 + 3\"", "expected closing )")
 }
 
 #[test]


### PR DESCRIPTION
Fixes #17846

<img width="505" height="226" alt="image" src="https://github.com/user-attachments/assets/71db3fa2-9662-470f-9d01-07868d060ce3" />

<img width="576" height="310" alt="image" src="https://github.com/user-attachments/assets/7ecd030a-1742-4b42-9b1b-f15912564ead" />

I have to say I didn't go over all possible scenarios of non-empty `delimiter_stack`, nasty edge cases are possible.
But `cargo fuzz` went well, so it shouldn't be that dangerous.

## Release notes summary - What our users need to know

Fixed a bug of lossy parsing of unclosed subexpressions in string interpolation, e.g. `$'(foo'`, which blocks completions inside all kinds of string interpolation subexpressions.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
