### PR TITLE
Update the names in `keybindings list`

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -1092,6 +1092,7 @@ pub(crate) fn display_reedline_event(event: ReedlineEventDiscriminants) -> Optio
         RED::Submit => "Submit",
         RED::SubmitOrNewline => "SubmitOrNewline",
         RED::Esc => "Esc",
+        RED::Edit => "event: { edit: <edit> }",
         RED::Repaint => "Repaint",
         RED::PreviousHistory => "PreviousHistory",
         RED::Up => "Up",
@@ -1102,6 +1103,8 @@ pub(crate) fn display_reedline_event(event: ReedlineEventDiscriminants) -> Optio
         RED::Left => "Left",
         RED::NextHistory => "NextHistory",
         RED::SearchHistory => "SearchHistory",
+        RED::Multiple => "event: { send: list<event> }",
+        RED::UntilFound => "event: { until: list<event> }",
         RED::Menu => "Menu name: <string>",
         RED::MenuNext => "MenuNext",
         RED::MenuPrevious => "MenuPrevious",
@@ -1116,8 +1119,6 @@ pub(crate) fn display_reedline_event(event: ReedlineEventDiscriminants) -> Optio
         RED::ViChangeMode => "ViChangeMode mode: <string>",
         // Non-sensical for user configuration
         RED::Mouse | RED::Resize => return None,
-        // These are not usable in `send`
-        RED::Edit | RED::Multiple | RED::UntilFound => return None,
     })
 }
 


### PR DESCRIPTION
- `Value` have been converted to lowercase since nushell expects them to be lowercase.
- `Optional[]` is replaced with `?` syntax. As nushell marks optional parameter with `?` in command definatioins.
- Some `ReedlineEvent`s are removed from `keybindings list` as they cannot be used directly in the `send` field of event.

## Release notes summary - What our users need to know
`keybindings list` command is updated with new descriptions. `CutFromStartLinewise` / `CutToEndLinewise` now takes `keep_line` instead of `value` as its parameter for clarity.