### PR TITLE
nu-protocol: add take_metadata and with_path_columns

### DIFF
--- a/crates/nu-protocol/src/pipeline/metadata.rs
+++ b/crates/nu-protocol/src/pipeline/metadata.rs
@@ -33,6 +33,13 @@ impl PipelineMetadata {
         }
     }
 
+    pub fn with_path_columns(self, path_columns: Vec<String>) -> Self {
+        Self {
+            path_columns,
+            ..self
+        }
+    }
+
     pub fn with_content_type(self, content_type: Option<String>) -> Self {
         Self {
             content_type,

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -68,7 +68,8 @@ impl PipelineData {
     /// Returns a clone of the metadata if it exists.
     ///
     /// Note: This performs a deep clone of heap-allocated structures.
-    /// Use [`.metadata_ref()`](Self::metadata_ref) or [`.metadata_mut()`](Self::metadata_mut) to avoid unnecessary allocations.
+    /// Use [`.metadata_ref()`](Self::metadata_ref), [`.metadata_mut()`](Self::metadata_mut)
+    /// or [`.take_metadata()`](Self::take_metadata) to avoid unnecessary allocations.
     pub fn metadata(&self) -> Option<PipelineMetadata> {
         self.metadata_ref().cloned()
     }
@@ -90,6 +91,16 @@ impl PipelineData {
             PipelineData::Value(_, meta)
             | PipelineData::ListStream(_, meta)
             | PipelineData::ByteStream(_, meta) => meta.as_mut(),
+        }
+    }
+
+    /// Take the metadata out of pipeline if it exists.
+    pub fn take_metadata(&mut self) -> Option<PipelineMetadata> {
+        match self {
+            PipelineData::Empty => None,
+            PipelineData::Value(_, meta)
+            | PipelineData::ListStream(_, meta)
+            | PipelineData::ByteStream(_, meta) => meta.take(),
         }
     }
 


### PR DESCRIPTION
- Add `PipelineMetadata::with_path_columns`
- Add `PipelineData::take_metadata` to allow moving metadata without cloning.

## Release notes summary - What our users need to know
N/A