### PR TITLE
Allow showing an error source for generic errors

### DIFF
--- a/crates/nu-protocol/src/errors/report_error.rs
+++ b/crates/nu-protocol/src/errors/report_error.rs
@@ -238,14 +238,10 @@ impl std::fmt::Debug for CliError<'_> {
                     .color(ansi_support)
                     .unicode(ansi_support)
                     .terminal_links(ansi_support)
-                    .context_lines(error_lines as usize);
+                    .context_lines(error_lines as usize)
+                    .with_cause_chain();
                 match style {
-                    ErrorStyle::Nested => Box::new(
-                        handler
-                            .show_related_errors_as_nested()
-                            .with_cause_chain()
-                            .build(),
-                    ),
+                    ErrorStyle::Nested => Box::new(handler.show_related_errors_as_nested().build()),
                     _ => Box::new(handler.build()),
                 }
             }

--- a/crates/nu-protocol/src/errors/shell_error/generic.rs
+++ b/crates/nu-protocol/src/errors/shell_error/generic.rs
@@ -1,10 +1,14 @@
-use crate::{ShellError, Span, shell_error::SpanOrLocation};
+use crate::{
+    ShellError, Span,
+    shell_error::{ErrorSite, ErrorSource},
+};
 use miette::Diagnostic;
 use nu_utils::location::Location;
 use std::{
     borrow::Cow,
-    error::Error,
+    error::Error as StdError,
     fmt::{self, Display},
+    sync::Arc,
 };
 
 /// Default code that [`GenericError`] is using as error code.
@@ -36,13 +40,16 @@ pub struct GenericError {
     pub msg: Cow<'static, str>,
 
     /// The error origin: either a user span or an internal Rust location.
-    pub source: SpanOrLocation,
+    pub site: ErrorSite,
 
     /// Optional additional guidance for the user.
     pub help: Option<Cow<'static, str>>,
 
     /// Related errors that provide more context.
     pub inner: Vec<ShellError>,
+
+    /// Optional error source.
+    pub source: Option<ErrorSource>,
 }
 
 impl GenericError {
@@ -67,9 +74,10 @@ impl GenericError {
             code: DEFAULT_CODE.into(),
             error: error.into(),
             msg: msg.into(),
-            source: SpanOrLocation::Span(span),
+            site: ErrorSite::Span(span),
             help: None,
             inner: Vec::new(),
+            source: None,
         }
     }
 
@@ -87,9 +95,10 @@ impl GenericError {
             code: DEFAULT_CODE.into(),
             error: error.into(),
             msg: msg.into(),
-            source: SpanOrLocation::Location(location.to_string()),
+            site: ErrorSite::Location(location.to_string()),
             help: None,
             inner: Vec::new(),
+            source: None,
         }
     }
 
@@ -107,9 +116,10 @@ impl GenericError {
             code: DEFAULT_CODE.into(),
             error: error.into(),
             msg: msg.into(),
-            source: SpanOrLocation::Location(location.into().to_string()),
+            site: ErrorSite::Location(location.into().to_string()),
             help: None,
             inner: Vec::new(),
+            source: None,
         }
     }
 
@@ -136,16 +146,24 @@ impl GenericError {
             ..self
         }
     }
+
+    /// Attaches error source that can be used to render error chains.
+    pub fn with_source(self, source: impl StdError + Send + Sync + 'static) -> Self {
+        Self {
+            source: Some(ErrorSource(Arc::new(source))),
+            ..self
+        }
+    }
 }
 
 impl Display for GenericError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let GenericError { error, msg, .. } = self;
-        write!(f, "{error}: {msg}")
+        let GenericError { error, .. } = self;
+        write!(f, "{error}")
     }
 }
 
-impl Error for GenericError {}
+impl StdError for GenericError {}
 
 impl Diagnostic for GenericError {
     fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
@@ -153,9 +171,9 @@ impl Diagnostic for GenericError {
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-        let span = match &self.source {
-            SpanOrLocation::Span(span) => (*span).into(),
-            SpanOrLocation::Location(location) => miette::SourceSpan::new(0.into(), location.len()),
+        let span = match &self.site {
+            ErrorSite::Span(span) => (*span).into(),
+            ErrorSite::Location(location) => miette::SourceSpan::new(0.into(), location.len()),
         };
 
         let label = miette::LabeledSpan::new_with_span(Some(self.msg.to_string()), span);
@@ -163,9 +181,9 @@ impl Diagnostic for GenericError {
     }
 
     fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-        match &self.source {
-            SpanOrLocation::Span(_) => None,
-            SpanOrLocation::Location(location) => Some(location as &dyn miette::SourceCode),
+        match &self.site {
+            ErrorSite::Span(_) => None,
+            ErrorSite::Location(location) => Some(location as &dyn miette::SourceCode),
         }
     }
 
@@ -182,5 +200,9 @@ impl Diagnostic for GenericError {
                 self.inner.iter().map(|err| err as &dyn Diagnostic),
             )),
         }
+    }
+
+    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+        self.source.as_ref().map(|err| err as &dyn Diagnostic)
     }
 }

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -10,7 +10,7 @@ use generic::GenericError;
 use job::JobError;
 use miette::{Diagnostic, LabeledSpan, NamedSource};
 use serde::{Deserialize, Serialize};
-use std::num::NonZeroI32;
+use std::{error::Error as StdError, num::NonZeroI32, sync::Arc};
 use thiserror::Error;
 
 pub mod bridge;
@@ -1672,7 +1672,7 @@ fn shell_error_serialize_roundtrip() {
 /// When no user span is available (for internal errors), store a
 /// [`Location`](nu_utils::location::Location) string instead.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum SpanOrLocation {
+pub enum ErrorSite {
     /// A span in user-provided Nushell code.
     Span(Span),
 
@@ -1682,6 +1682,18 @@ pub enum SpanOrLocation {
     /// For usage with [`miette`] it's easier to hold a string here instead of a
     /// [`Location`](nu_utils::location::Location).
     Location(String),
+}
+
+// TODO: implement further chaining than just one
+#[derive(Debug, Error, Clone, Diagnostic)]
+#[error(transparent)]
+pub struct ErrorSource(Arc<dyn StdError + Send + Sync>);
+
+impl PartialEq for ErrorSource {
+    fn eq(&self, other: &Self) -> bool {
+        // TODO: implement this less wasteful
+        self.0.to_string() == other.0.to_string()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

Sometimes generic errors have an underlying error from a remote crate. These errors don't have labels or spans which makes showing them not nice. Often these errors are therefore promoted into a generic error with a new message and span. But sometimes we want to do an operation and get a rather generic error back, this makes it hard to just show that error. It would be nicer to show that error aswell as our custom data and span. This PR allows this by using `miette`'s error chaining which shows a source error like this:
<img width="411" height="202" alt="image" src="https://github.com/user-attachments/assets/edc444e9-4c4f-410a-8200-1f261c928f6a" />

This way we can have our nice errors and still show the original unspanned error.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
n/a
