### PR TITLE
Replace Span::unknown() with real spans in plugin crates

### DIFF
--- a/crates/nu-plugin-core/src/interface/stream/mod.rs
+++ b/crates/nu-plugin-core/src/interface/stream/mod.rs
@@ -151,6 +151,8 @@ pub trait FromShellError {
 }
 
 // For List streams.
+// Note: Span::unknown() is unavoidable here because this is called from Iterator::next(),
+// which has no span context. The ShellError itself carries its own span information.
 impl FromShellError for Value {
     fn from_shell_error(err: ShellError) -> Self {
         Value::error(err, Span::unknown())

--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -1049,14 +1049,13 @@ impl PluginInterface {
         &self,
         value: PluginCustomValueWithSource,
         other_value: Value,
+        span: Span,
     ) -> Result<Option<Ordering>, ShellError> {
         // Check that the value came from the right source
-        value.verify_source(Span::unknown(), &self.state.source)?;
+        value.verify_source(span, &self.state.source)?;
 
-        // Note: the protocol is always designed to have a span with the custom value, but this
-        // operation doesn't support one.
         let call = PluginCall::CustomValueOp(
-            value.without_source().into_spanned(Span::unknown()),
+            value.without_source().into_spanned(span),
             CustomValueOp::PartialCmp(other_value),
         );
         match self.plugin_call(call, None)? {
@@ -1106,10 +1105,11 @@ impl PluginInterface {
 
     /// Notify the plugin about a dropped custom value.
     pub fn custom_value_dropped(&self, value: PluginCustomValue) -> Result<(), ShellError> {
-        // Make sure we don't block here. This can happen on the receiver thread, which would cause a deadlock. We should not try to receive the response - just let it be discarded.
+        // Make sure we don't block here. This can happen on the receiver thread, which would cause
+        // a deadlock. We should not try to receive the response - just let it be discarded.
         //
-        // Note: the protocol is always designed to have a span with the custom value, but this
-        // operation doesn't support one.
+        // Note: Span::unknown() is used here because this is called from Drop, which has no span
+        // context available.
         drop(self.write_plugin_call(
             PluginCall::CustomValueOp(value.into_spanned(Span::unknown()), CustomValueOp::Dropped),
             None,

--- a/crates/nu-plugin-engine/src/plugin_custom_value_with_source/mod.rs
+++ b/crates/nu-plugin-engine/src/plugin_custom_value_with_source/mod.rs
@@ -205,9 +205,7 @@ impl CustomValue for PluginCustomValueWithSource {
     fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
         self.get_plugin(Some(other.span()), "perform comparison")
             .and_then(|plugin| {
-                // We're passing Span::unknown() here because we don't have one, and it probably
-                // shouldn't matter here and is just a consequence of the API
-                plugin.custom_value_partial_cmp(self.clone(), other.clone())
+                plugin.custom_value_partial_cmp(self.clone(), other.clone(), other.span())
             })
             .unwrap_or_else(|err| {
                 // We can't do anything with the error other than log it.

--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -346,7 +346,8 @@ impl PluginTest {
                 PluginCustomValueWithSource::add_source_in(&mut b_serialized, &self.source)?;
                 // Now get the plugin reference and execute the comparison
                 let persistent = self.source.persistent(None)?.get_plugin(None)?;
-                let ordering = persistent.custom_value_partial_cmp(serialized, b_serialized)?;
+                let ordering =
+                    persistent.custom_value_partial_cmp(serialized, b_serialized, a.span())?;
                 Ok(matches!(
                     ordering.map(Ordering::from),
                     Some(Ordering::Equal)


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

Thread real span values through plugin infrastructure instead of using `Span::unknown()`.

- Updated `custom_value_partial_cmp()` in `nu-plugin-engine` to accept a `span` parameter, sourced from the Value's own span
- Updated callers in `plugin_custom_value_with_source` and `plugin_test` to pass the Value's own span
- Documented unavoidable `Span::unknown()` cases (`Drop` impl in `custom_value_dropped`, `Iterator::next` in stream error handling) with comments

**Crates affected:** `nu-plugin-engine`, `nu-plugin-core` (comment only), `nu-plugin-test-support`

## Release notes summary - What our users need to know

Replaced `Span::unknown()` with real spans in plugin crates. Plugin custom value comparison errors now report accurate source locations.