### PR TITLE
Replace Span::unknown() with real spans in nu-command filters and strings

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -674,8 +674,9 @@ pub fn find_internal(
     search_term: &str,
     columns_to_search: &[&str],
     highlight: bool,
+    head: Span,
 ) -> Result<PipelineData, ShellError> {
-    let span = input.span().unwrap_or(Span::unknown());
+    let span = input.span().unwrap_or(head);
 
     let style_computer = StyleComputer::from_config(engine_state, stack);
     let string_style = style_computer.compute("string", &Value::string("search result", span));
@@ -686,7 +687,7 @@ pub fn find_internal(
 
     let regex = Regex::new(regex_str.as_str()).map_err(|e| ShellError::TypeMismatch {
         err_message: format!("invalid regex: {e}"),
-        span: Span::unknown(),
+        span: head,
     })?;
 
     let pattern = MatchPattern {

--- a/crates/nu-command/src/filters/sort.rs
+++ b/crates/nu-command/src/filters/sort.rs
@@ -170,7 +170,7 @@ impl Command for Sort {
                                 col.0.clone(),
                                 false,
                                 Casing::Sensitive,
-                                Span::unknown(),
+                                call.head,
                             )]
                         })
                         .map(|members| CellPath { members })

--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -56,8 +56,9 @@ impl Command for Uniq {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
         let mapper = Box::new(move |ms: ItemMapperState| -> ValueCounter {
-            item_mapper(ms.item, ms.flag_ignore_case, ms.index)
+            item_mapper(ms.item, ms.flag_ignore_case, ms.index, head)
         });
 
         let metadata = input.metadata();
@@ -121,10 +122,11 @@ pub struct ItemMapperState {
     pub item: Value,
     pub flag_ignore_case: bool,
     pub index: usize,
+    pub head: Span,
 }
 
-fn item_mapper(item: Value, flag_ignore_case: bool, index: usize) -> ValueCounter {
-    ValueCounter::new(item, flag_ignore_case, index)
+fn item_mapper(item: Value, flag_ignore_case: bool, index: usize, head: Span) -> ValueCounter {
+    ValueCounter::new(item, flag_ignore_case, index, head)
 }
 
 pub struct ValueCounter {
@@ -141,21 +143,22 @@ impl PartialEq<Self> for ValueCounter {
 }
 
 impl ValueCounter {
-    fn new(val: Value, flag_ignore_case: bool, index: usize) -> Self {
-        Self::new_vals_to_compare(val.clone(), flag_ignore_case, val, index)
+    fn new(val: Value, flag_ignore_case: bool, index: usize, head: Span) -> Self {
+        Self::new_vals_to_compare(val.clone(), flag_ignore_case, val, index, head)
     }
     pub fn new_vals_to_compare(
         val: Value,
         flag_ignore_case: bool,
         vals_to_compare: Value,
         index: usize,
+        head: Span,
     ) -> Self {
         ValueCounter {
             val,
             val_to_compare: if flag_ignore_case {
-                clone_to_folded_case(&vals_to_compare.with_span(Span::unknown()))
+                clone_to_folded_case(&vals_to_compare.with_span(head))
             } else {
-                vals_to_compare.with_span(Span::unknown())
+                vals_to_compare.with_span(head)
             },
             count: 1,
             index,
@@ -206,12 +209,16 @@ fn sort_attributes(val: Value) -> Value {
     }
 }
 
-fn generate_key(engine_state: &EngineState, item: &ValueCounter) -> Result<String, ShellError> {
+fn generate_key(
+    engine_state: &EngineState,
+    item: &ValueCounter,
+    head: Span,
+) -> Result<String, ShellError> {
     let value = sort_attributes(item.val_to_compare.clone()); //otherwise, keys could be different for Records
     nuon::to_nuon(
         engine_state,
         &value,
-        nuon::ToNuonConfig::default().span(Some(Span::unknown())),
+        nuon::ToNuonConfig::default().span(Some(head)),
     )
 }
 
@@ -259,12 +266,13 @@ pub fn uniq(
                 item,
                 flag_ignore_case,
                 index,
+                head,
             }))
         })
         .try_fold(
             HashMap::<String, ValueCounter>::new(),
             |mut counter, item| {
-                let key = generate_key(engine_state, &item);
+                let key = generate_key(engine_state, &item, head);
 
                 match key {
                     Ok(key) => {

--- a/crates/nu-command/src/filters/uniq_by.rs
+++ b/crates/nu-command/src/filters/uniq_by.rs
@@ -170,9 +170,15 @@ fn item_mapper_by_col(cols: Vec<String>) -> impl Fn(crate::ItemMapperState) -> c
     Box::new(move |ms: crate::ItemMapperState| -> crate::ValueCounter {
         let item_column_values = get_data_by_columns(&columns, &ms.item);
 
-        let col_vals = Value::list(item_column_values, Span::unknown());
+        let col_vals = Value::list(item_column_values, ms.head);
 
-        crate::ValueCounter::new_vals_to_compare(ms.item, ms.flag_ignore_case, col_vals, ms.index)
+        crate::ValueCounter::new_vals_to_compare(
+            ms.item,
+            ms.flag_ignore_case,
+            col_vals,
+            ms.index,
+            ms.head,
+        )
     })
 }
 

--- a/crates/nu-command/src/help/help_aliases.rs
+++ b/crates/nu-command/src/help/help_aliases.rs
@@ -80,6 +80,7 @@ pub fn help_aliases(
             &f.item,
             &["name", "description"],
             true,
+            head,
         );
     }
 

--- a/crates/nu-command/src/help/help_commands.rs
+++ b/crates/nu-command/src/help/help_commands.rs
@@ -61,6 +61,7 @@ pub fn help_commands(
             &f.item,
             &["name", "description", "search_terms"],
             true,
+            head,
         );
     }
 

--- a/crates/nu-command/src/help/help_externs.rs
+++ b/crates/nu-command/src/help/help_externs.rs
@@ -80,6 +80,7 @@ pub fn help_externs(
             &f.item,
             &["name", "description"],
             true,
+            head,
         );
     }
 

--- a/crates/nu-command/src/help/help_modules.rs
+++ b/crates/nu-command/src/help/help_modules.rs
@@ -88,6 +88,7 @@ pub fn help_modules(
             &f.item,
             &["name", "description"],
             true,
+            head,
         );
     }
 

--- a/crates/nu-command/src/strings/ansi/link.rs
+++ b/crates/nu-command/src/strings/ansi/link.rs
@@ -56,7 +56,7 @@ impl Command for AnsiLink {
                 example: "'file:///file.txt' | ansi link --text 'Open Me!'",
                 result: Some(Value::string(
                     "\u{1b}]8;;file:///file.txt\u{1b}\\Open Me!\u{1b}]8;;\u{1b}\\",
-                    Span::unknown(),
+                    Span::test_data(),
                 )),
             },
             Example {
@@ -64,7 +64,7 @@ impl Command for AnsiLink {
                 example: "'https://www.nushell.sh/' | ansi link",
                 result: Some(Value::string(
                     "\u{1b}]8;;https://www.nushell.sh/\u{1b}\\https://www.nushell.sh/\u{1b}]8;;\u{1b}\\",
-                    Span::unknown(),
+                    Span::test_data(),
                 )),
             },
             Example {

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -314,7 +314,7 @@ fn detect_columns(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let name_span = call.head;
-    let input_span = input.span().unwrap_or(Span::unknown());
+    let input_span = input.span().unwrap_or(name_span);
 
     // Handle different input types
     match input {
@@ -1006,13 +1006,13 @@ fn merge_record_impl(
         .skip(start_index)
         .map(|v| v.coerce_str().unwrap_or_default())
         .join(" ");
-    let binding = Value::string(combined, Span::unknown());
+    let binding = Value::string(combined, input_span);
     let last_seg = vals.split_off(end_index);
     vals.truncate(start_index);
     vals.push(binding);
     vals.extend(last_seg);
 
-    Record::from_raw_cols_vals(cols, vals, Span::unknown(), input_span)
+    Record::from_raw_cols_vals(cols, vals, input_span, input_span)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -278,7 +278,7 @@ impl Matcher {
             Matcher::Direct(lhs) => rhs == lhs,
             Matcher::Closure(closure) => closure
                 .run_with_value(rhs.clone())
-                .and_then(|data| data.into_value(Span::unknown()))
+                .and_then(|data| data.into_value(rhs.span()))
                 .map(|value| value.is_true())
                 .unwrap_or(false),
         })


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

Thread `call.head` into helper functions across `filters/`, `strings/`, and `help/` subdirectories of `nu-command`, replacing `Span::unknown()` with real spans for better error reporting.

**Changes:**
- Added `head: Span` parameter to `find_internal`, `ValueCounter`, `generate_key`, and `ItemMapperState` in `filters/`
- Used existing available spans (`input_span`, `rhs.span()`, `name_span`) in `strings/`
- Updated all callers in `help/` module for the new `find_internal` signature
- Changed test examples in `ansi/link.rs` from `Span::unknown()` to `Span::test_data()`

**11 files modified** across `filters/uniq.rs`, `filters/uniq_by.rs`, `filters/find.rs`, `filters/sort.rs`, `strings/detect_columns.rs`, `strings/split/list.rs`, `strings/ansi/link.rs`, and 4 help files.

Following the approach from #17842 (`which_.rs`): identify `Span::unknown()` in production code, find the nearest available real span (usually `call.head`), and thread it through function parameters.

## Release notes summary - What our users need to know

Replaced `Span::unknown()` with real spans in nu-command filters and strings. This improves error messages by providing accurate source locations when errors occur in `uniq`, `find`, `sort`, `detect columns`, `split list`, and related commands.