### PR TITLE
Apply `#[doc(no_inline)]` to `prelude` modules

### DIFF
--- a/crates/nu-engine/src/command_prelude.rs
+++ b/crates/nu-engine/src/command_prelude.rs
@@ -1,4 +1,7 @@
+#[doc(no_inline)]
 pub use crate::CallExt;
+
+#[doc(no_inline)]
 pub use nu_protocol::{
     ByteStream, ByteStreamType, Category, Completion, ErrSpan, Example, Flag,
     IntoInterruptiblePipelineData, IntoPipelineData, IntoSpanned, IntoValue, PipelineData,

--- a/crates/nu-protocol/src/config/prelude.rs
+++ b/crates/nu-protocol/src/config/prelude.rs
@@ -1,4 +1,11 @@
+#[doc(no_inline)]
 pub(super) use super::{ConfigPath, UpdateFromValue, error::ConfigErrors};
+
+#[doc(no_inline)]
 pub use crate::{IntoValue, ShellError, ShellWarning, Span, Type, Value, record};
+
+#[doc(no_inline)]
 pub use serde::{Deserialize, Serialize};
+
+#[doc(no_inline)]
 pub use std::str::FromStr;


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

Some prelude modules don't use `#[doc(no_inline)]` which causes both rust-analyzer and the docs tool to sometimes prefer the prelude module instead of the full path. Preludes are nice but should not be partially imported usually.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
n/a
