### PR TITLE
Only update PR labels on opened or ready PRs

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -3,7 +3,8 @@
 name: Label PRs
 
 on:
-  - pull_request_target
+  pull_request_target:
+    types: [opened, ready_for_review]
 
 jobs:
   triage:


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

Currently our CI is updating labels on every commit which is very annoying when some labels are incorrect. And since usually most PRs already touch all the relevant files on open, checking only at opening a PR should be good enough.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
n/a