### PR TITLE
allow par-each to stream except with --keep-order via mspc

### DIFF
--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -2,6 +2,13 @@ use super::utils::chain_error_with_input;
 use nu_engine::{ClosureEval, ClosureEvalOnce, command_prelude::*};
 use nu_protocol::{Signals, engine::Closure, shell_error::generic::GenericError};
 use rayon::prelude::*;
+use std::{
+    sync::mpsc::{self, RecvTimeoutError},
+    time::Duration,
+};
+
+const STREAM_BUFFER_SIZE: usize = 64;
+const CTRL_C_CHECK_INTERVAL: Duration = Duration::from_millis(100);
 
 #[derive(Clone)]
 pub struct ParEach;
@@ -115,6 +122,7 @@ impl Command for ParEach {
         let threads: Option<usize> = call.get_flag(engine_state, stack, "threads")?;
         let max_threads = threads.unwrap_or(0);
         let keep_order = call.has_flag(engine_state, stack, "keep-order")?;
+        let signals = engine_state.signals().clone();
 
         let input = input.into_stream_or_original(engine_state);
         let metadata = input.metadata();
@@ -135,21 +143,55 @@ impl Command for ParEach {
             PipelineData::Value(value, ..) => {
                 let span = value.span();
                 match value {
-                    Value::List { vals, .. } => Ok(create_pool(max_threads, head)?.install(|| {
-                        let par_iter = vals.into_par_iter().enumerate();
-                        let mapped = parallel_closure_map(engine_state, stack, &closure, par_iter);
-                        apply_order(mapped.collect())
-                            .into_pipeline_data(span, engine_state.signals().clone())
-                    })),
-                    Value::Range { val, .. } => Ok(create_pool(max_threads, head)?.install(|| {
-                        let par_iter = val
-                            .into_range_iter(span, Signals::empty())
-                            .enumerate()
-                            .par_bridge();
-                        let mapped = parallel_closure_map(engine_state, stack, &closure, par_iter);
-                        apply_order(mapped.collect())
-                            .into_pipeline_data(span, engine_state.signals().clone())
-                    })),
+                    Value::List { vals, .. } => {
+                        let pool = create_pool(max_threads, head)?;
+                        if keep_order {
+                            Ok(pool.install(|| {
+                                let par_iter = vals.into_par_iter().enumerate();
+                                let mapped =
+                                    parallel_closure_map(engine_state, stack, &closure, par_iter);
+                                apply_order(mapped.collect())
+                                    .into_pipeline_data(span, signals.clone())
+                            }))
+                        } else {
+                            let par_iter = vals.into_par_iter();
+                            Ok(stream_parallel_values(
+                                engine_state,
+                                stack,
+                                closure.clone(),
+                                pool,
+                                span,
+                                signals.clone(),
+                                par_iter,
+                            ))
+                        }
+                    }
+                    Value::Range { val, .. } => {
+                        let pool = create_pool(max_threads, head)?;
+                        if keep_order {
+                            Ok(pool.install(|| {
+                                let par_iter = val
+                                    .into_range_iter(span, signals.clone())
+                                    .enumerate()
+                                    .par_bridge();
+                                let mapped =
+                                    parallel_closure_map(engine_state, stack, &closure, par_iter);
+                                apply_order(mapped.collect())
+                                    .into_pipeline_data(span, signals.clone())
+                            }))
+                        } else {
+                            let par_iter = val.into_range_iter(span, signals.clone()).par_bridge();
+                            Ok(stream_parallel_values(
+                                engine_state,
+                                stack,
+                                closure.clone(),
+                                pool,
+                                span,
+                                signals.clone(),
+                                par_iter,
+                            ))
+                        }
+                    }
                     // This match allows non-iterables to be accepted,
                     // which is currently considered undesirable (Nov 2022).
                     value => {
@@ -158,27 +200,56 @@ impl Command for ParEach {
                 }
             }
             PipelineData::ListStream(stream, ..) => {
-                Ok(create_pool(max_threads, head)?.install(|| {
-                    let par_iter = stream.into_iter().enumerate().par_bridge();
-                    let mapped = parallel_closure_map(engine_state, stack, &closure, par_iter);
+                let pool = create_pool(max_threads, head)?;
+                if keep_order {
+                    Ok(pool.install(|| {
+                        let par_iter = stream.into_iter().enumerate().par_bridge();
+                        let mapped = parallel_closure_map(engine_state, stack, &closure, par_iter);
 
-                    apply_order(mapped.collect())
-                        .into_pipeline_data(head, engine_state.signals().clone())
-                }))
+                        apply_order(mapped.collect()).into_pipeline_data(head, signals.clone())
+                    }))
+                } else {
+                    let par_iter = stream.into_iter().par_bridge();
+                    Ok(stream_parallel_values(
+                        engine_state,
+                        stack,
+                        closure.clone(),
+                        pool,
+                        head,
+                        signals.clone(),
+                        par_iter,
+                    ))
+                }
             }
             PipelineData::ByteStream(stream, ..) => {
                 if let Some(chunks) = stream.chunks() {
-                    Ok(create_pool(max_threads, head)?.install(|| {
+                    let pool = create_pool(max_threads, head)?;
+                    if keep_order {
+                        Ok(pool.install(|| {
+                            let par_iter = chunks
+                                .enumerate()
+                                .map(move |(idx, val)| {
+                                    (idx, val.unwrap_or_else(|err| Value::error(err, head)))
+                                })
+                                .par_bridge();
+                            let mapped =
+                                parallel_closure_map(engine_state, stack, &closure, par_iter);
+                            apply_order(mapped.collect()).into_pipeline_data(head, signals.clone())
+                        }))
+                    } else {
                         let par_iter = chunks
-                            .enumerate()
-                            .map(move |(idx, val)| {
-                                (idx, val.unwrap_or_else(|err| Value::error(err, head)))
-                            })
+                            .map(move |val| val.unwrap_or_else(|err| Value::error(err, head)))
                             .par_bridge();
-                        let mapped = parallel_closure_map(engine_state, stack, &closure, par_iter);
-                        apply_order(mapped.collect())
-                            .into_pipeline_data(head, engine_state.signals().clone())
-                    }))
+                        Ok(stream_parallel_values(
+                            engine_state,
+                            stack,
+                            closure.clone(),
+                            pool,
+                            head,
+                            signals.clone(),
+                            par_iter,
+                        ))
+                    }
                 } else {
                     Ok(PipelineData::empty())
                 }
@@ -187,6 +258,98 @@ impl Command for ParEach {
         .and_then(|x| x.filter(|v| !v.is_nothing(), engine_state.signals()))
         .map(|data| data.set_metadata(metadata))
     }
+}
+
+fn stream_parallel_values(
+    engine_state: &EngineState,
+    stack: &Stack,
+    closure: Closure,
+    pool: rayon::ThreadPool,
+    span: Span,
+    signals: Signals,
+    input: impl ParallelIterator<Item = Value> + 'static,
+) -> PipelineData {
+    let (tx, rx) = mpsc::sync_channel(STREAM_BUFFER_SIZE);
+    let worker_engine_state = engine_state.clone();
+    let worker_stack = stack.clone();
+    let worker_signals = signals.clone();
+
+    pool.install(|| {
+        rayon::spawn(move || {
+            let map_signals = worker_signals.clone();
+            let send_signals = worker_signals.clone();
+
+            let _ = input
+                .map_init(
+                    move || ClosureEval::new(&worker_engine_state, &worker_stack, closure.clone()),
+                    move |closure_eval, value| {
+                        if map_signals.interrupted() {
+                            return Err(());
+                        }
+
+                        let value = run_closure_on_value(closure_eval, value);
+
+                        if map_signals.interrupted() {
+                            Err(())
+                        } else {
+                            Ok(value)
+                        }
+                    },
+                )
+                .try_for_each(move |value| match value {
+                    Ok(value) => {
+                        if send_signals.interrupted() {
+                            Err(())
+                        } else {
+                            tx.send(value).map_err(|_| ())
+                        }
+                    }
+                    Err(()) => Err(()),
+                });
+        });
+    });
+
+    ReceiverIter::new(rx, signals).into_pipeline_data(span, Signals::empty())
+}
+
+// Polls channel reads so Ctrl+C can stop blocked receives promptly.
+struct ReceiverIter {
+    receiver: mpsc::Receiver<Value>,
+    signals: Signals,
+}
+
+impl ReceiverIter {
+    fn new(receiver: mpsc::Receiver<Value>, signals: Signals) -> Self {
+        Self { receiver, signals }
+    }
+}
+
+impl Iterator for ReceiverIter {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.signals.interrupted() {
+                return None;
+            }
+
+            match self.receiver.recv_timeout(CTRL_C_CHECK_INTERVAL) {
+                Ok(value) => return Some(value),
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(RecvTimeoutError::Disconnected) => return None,
+            }
+        }
+    }
+}
+
+fn run_closure_on_value(closure_eval: &mut ClosureEval, value: Value) -> Value {
+    let span = value.span();
+    let is_error = value.is_error();
+
+    closure_eval
+        .run_with_value(value)
+        .and_then(|data| data.into_value(span))
+        .unwrap_or_else(|err| Value::error(chain_error_with_input(err, is_error, span), span))
 }
 
 fn parallel_closure_map(
@@ -198,14 +361,7 @@ fn parallel_closure_map(
     input.map_init(
         move || ClosureEval::new(engine_state, stack, closure.clone()),
         |closure_eval, (index, value)| {
-            let span = value.span();
-            let is_error = value.is_error();
-            let value = closure_eval
-                .run_with_value(value)
-                .and_then(|data| data.into_value(span))
-                .unwrap_or_else(|err| {
-                    Value::error(chain_error_with_input(err, is_error, span), span)
-                });
+            let value = run_closure_on_value(closure_eval, value);
 
             (index, value)
         },

--- a/crates/nu-command/tests/commands/par_each.rs
+++ b/crates/nu-command/tests/commands/par_each.rs
@@ -7,3 +7,27 @@ fn par_each_does_not_flatten_nested_structures() -> Result {
 
     test().run(code).expect_value_eq([[1, 1], [2, 2], [3, 3]])
 }
+
+#[test]
+fn par_each_streams_when_keep_order_is_not_set() -> Result {
+    // If `par-each` tries to collect first, this would never finish.
+    let code = "1.. | par-each --threads 1 {|x| $x } | first 3";
+
+    test().run(code).expect_value_eq([1, 2, 3])
+}
+
+#[test]
+fn par_each_streams_with_list_stream_input() -> Result {
+    // `each` turns the input into a ListStream. If `par-each` collects first,
+    // this pipeline would never finish on an unbounded input.
+    let code = "1.. | each {|x| $x } | par-each --threads 1 {|x| $x } | first 3";
+
+    test().run(code).expect_value_eq([1, 2, 3])
+}
+
+#[test]
+fn par_each_keep_order_preserves_input_order() -> Result {
+    let code = "[3 1 2] | par-each --threads 4 --keep-order {|x| $x }";
+
+    test().run(code).expect_value_eq([3, 1, 2])
+}


### PR DESCRIPTION
Enable `par-each` to stream except when using `--keep-order` flag since that has to collect in order to sort.

closes #13720

## Release notes summary - What our users need to know
### Unordered `par-each` is now streaming
Allow `par-each` to stream. The following example will print out a new value each second that passes.
```nushell
❯ [7,8,9,10] | each {|x| sleep 1sec; $x} | par-each {|el| $el} | each {|x| print $x}
7
8
9
10
```

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
