### PR TITLE
fix: support IPv6 link-local addresses with zone IDs in http commands

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -162,7 +162,7 @@ pub fn http_client_pool(
     #[cfg(feature = "native-tls")]
     let connector = connector.chain(NativeTlsConnector::default());
 
-    let resolver = DnsLookupResolver;
+    let resolver = DnsLookupResolver::new(None);
     let agent = ureq::Agent::with_parts(config_builder.build(), connector, resolver);
 
     let arc_agent = Arc::new(agent);
@@ -182,6 +182,7 @@ pub fn reset_http_client_pool(
         allow_insecure,
         redirect_mode,
         unix_socket_path,
+        None,
         engine_state,
         stack,
     )?;
@@ -194,6 +195,7 @@ pub fn http_client(
     allow_insecure: bool,
     redirect_mode: RedirectMode,
     unix_socket_path: Option<PathBuf>,
+    zone_id: Option<String>,
     engine_state: &EngineState,
     stack: &mut Stack,
 ) -> Result<ureq::Agent, ShellError> {
@@ -241,15 +243,48 @@ pub fn http_client(
     #[cfg(feature = "native-tls")]
     let connector = connector.chain(NativeTlsConnector::default());
 
-    let resolver = DnsLookupResolver;
+    let resolver = DnsLookupResolver::new(zone_id);
     Ok(ureq::Agent::with_parts(config, connector, resolver))
+}
+
+/// Extracts an IPv6 zone ID from a URL string, returning the cleaned URL and zone ID.
+///
+/// IPv6 link-local addresses use zone IDs (e.g., `fe80::1%eth0`) to specify the network
+/// interface. In URLs, the `%` is encoded as `%25` (e.g., `http://[fe80::1%25eth0]:8080/`).
+/// Since `url::Url::parse()` doesn't support zone IDs, this function strips them before
+/// parsing and returns them separately for use in DNS resolution.
+fn extract_ipv6_zone_id(url: &str) -> (String, Option<String>) {
+    if let Some(bracket_start) = url.find('[')
+        && let Some(bracket_end) = url[bracket_start..].find(']').map(|i| bracket_start + i)
+    {
+        let bracket_content = &url[bracket_start + 1..bracket_end];
+
+        // Check for %25-encoded zone ID first, then raw %
+        let zone_sep = bracket_content
+            .find("%25")
+            .map(|pos| (pos, 3))
+            .or_else(|| bracket_content.find('%').map(|pos| (pos, 1)));
+
+        if let Some((sep_pos, sep_len)) = zone_sep {
+            let zone_id = &bracket_content[sep_pos + sep_len..];
+            if !zone_id.is_empty() {
+                let cleaned = format!(
+                    "{}{}",
+                    &url[..bracket_start + 1 + sep_pos],
+                    &url[bracket_end..]
+                );
+                return (cleaned, Some(zone_id.to_string()));
+            }
+        }
+    }
+    (url.to_string(), None)
 }
 
 pub fn http_parse_url(
     call: &Call,
     span: Span,
     raw_url: Value,
-) -> Result<Spanned<(String, Url)>, ShellError> {
+) -> Result<Spanned<(String, Url, Option<String>)>, ShellError> {
     let url_span = raw_url.span();
     let mut requested_url = raw_url.coerce_into_string()?;
     if requested_url.starts_with(':') {
@@ -258,7 +293,9 @@ pub fn http_parse_url(
         requested_url = format!("http://{requested_url}");
     }
 
-    let url = match url::Url::parse(&requested_url) {
+    let (parse_url, zone_id) = extract_ipv6_zone_id(&requested_url);
+
+    let url = match url::Url::parse(&parse_url) {
         Ok(u) => u,
         Err(_e) => {
             return Err(ShellError::UnsupportedInput {
@@ -270,7 +307,7 @@ pub fn http_parse_url(
         }
     };
 
-    Ok((requested_url, url).into_spanned(url_span))
+    Ok((parse_url, url, zone_id).into_spanned(url_span))
 }
 
 pub fn http_parse_redirect_mode(mode: Option<Spanned<String>>) -> Result<RedirectMode, ShellError> {
@@ -1290,6 +1327,48 @@ mod test {
 
         let none = None;
         assert_eq!(BodyType::Unknown(none.clone()), BodyType::from(none));
+    }
+
+    #[test]
+    fn test_extract_ipv6_zone_id_percent25_encoded() {
+        let (url, zone) = extract_ipv6_zone_id("http://[fe80::1%25eth0]:8080/path");
+        assert_eq!(url, "http://[fe80::1]:8080/path");
+        assert_eq!(zone, Some("eth0".to_string()));
+    }
+
+    #[test]
+    fn test_extract_ipv6_zone_id_raw_percent() {
+        let (url, zone) = extract_ipv6_zone_id("http://[fe80::1%eth0]:8080/path");
+        assert_eq!(url, "http://[fe80::1]:8080/path");
+        assert_eq!(zone, Some("eth0".to_string()));
+    }
+
+    #[test]
+    fn test_extract_ipv6_zone_id_none_for_regular_ipv6() {
+        let (url, zone) = extract_ipv6_zone_id("http://[::1]:8080/path");
+        assert_eq!(url, "http://[::1]:8080/path");
+        assert_eq!(zone, None);
+    }
+
+    #[test]
+    fn test_extract_ipv6_zone_id_none_for_ipv4() {
+        let (url, zone) = extract_ipv6_zone_id("http://192.168.1.1:8080/path");
+        assert_eq!(url, "http://192.168.1.1:8080/path");
+        assert_eq!(zone, None);
+    }
+
+    #[test]
+    fn test_extract_ipv6_zone_id_numeric() {
+        let (url, zone) = extract_ipv6_zone_id("http://[fe80::1%2512]:8080/");
+        assert_eq!(url, "http://[fe80::1]:8080/");
+        assert_eq!(zone, Some("12".to_string()));
+    }
+
+    #[test]
+    fn test_extract_ipv6_zone_id_preserves_query() {
+        let (url, zone) = extract_ipv6_zone_id("http://[fe80::1%25wlan0]:80/path?key=val");
+        assert_eq!(url, "http://[fe80::1]:80/path?key=val");
+        assert_eq!(zone, Some("wlan0".to_string()));
     }
 
     #[test]

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -222,7 +222,7 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: (requested_url, _, zone_id),
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
@@ -230,13 +230,14 @@ fn helper(
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
+    let mut request = if args.pool && zone_id.is_none() {
         http_client_pool(engine_state, stack)?.delete(&requested_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            zone_id,
             engine_state,
             stack,
         )?;

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -199,7 +199,7 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: (requested_url, _, zone_id),
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
@@ -207,13 +207,14 @@ fn helper(
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
+    let mut request = if args.pool && zone_id.is_none() {
         http_client_pool(engine_state, stack)?.get(&requested_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            zone_id,
             engine_state,
             stack,
         )?;

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -176,7 +176,7 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: (requested_url, _, zone_id),
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
@@ -184,13 +184,14 @@ fn helper(
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
+    let mut request = if args.pool && zone_id.is_none() {
         http_client_pool(engine_state, stack)?.head(&requested_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            zone_id,
             engine_state,
             stack,
         )?;

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -172,7 +172,7 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: (requested_url, _, zone_id),
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
     let redirect_mode = RedirectMode::Follow;
@@ -180,13 +180,14 @@ fn helper(
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
+    let mut request = if args.pool && zone_id.is_none() {
         http_client_pool(engine_state, stack)?.options(&requested_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            zone_id,
             engine_state,
             stack,
         )?;

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -223,7 +223,7 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: (requested_url, _, zone_id),
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
@@ -231,13 +231,14 @@ fn helper(
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
+    let mut request = if args.pool && zone_id.is_none() {
         http_client_pool(engine_state, stack)?.patch(&requested_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            zone_id,
             engine_state,
             stack,
         )?;

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -247,7 +247,7 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: (requested_url, _, zone_id),
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
@@ -255,13 +255,14 @@ fn helper(
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
+    let mut request = if args.pool && zone_id.is_none() {
         http_client_pool(engine_state, stack)?.post(&requested_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            zone_id,
             engine_state,
             stack,
         )?;

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -228,7 +228,7 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: (requested_url, _, zone_id),
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
@@ -236,13 +236,14 @@ fn helper(
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
+    let mut request = if args.pool && zone_id.is_none() {
         http_client_pool(engine_state, stack)?.put(&requested_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            zone_id,
             engine_state,
             stack,
         )?;

--- a/crates/nu-command/src/network/http/resolver.rs
+++ b/crates/nu-command/src/network/http/resolver.rs
@@ -11,7 +11,15 @@ use ureq::{
 };
 
 #[derive(Debug)]
-pub struct DnsLookupResolver;
+pub struct DnsLookupResolver {
+    zone_id: Option<String>,
+}
+
+impl DnsLookupResolver {
+    pub fn new(zone_id: Option<String>) -> Self {
+        Self { zone_id }
+    }
+}
 
 impl Resolver for DnsLookupResolver {
     fn resolve(
@@ -27,10 +35,21 @@ impl Resolver for DnsLookupResolver {
             _ => 80, // http commands only support HTTP/HTTPS, default to port 80
         });
 
+        // If a zone ID was extracted from an IPv6 link-local URL, append it to the host.
+        // POSIX getaddrinfo natively handles "fe80::1%eth0" and returns SocketAddrV6
+        // with the correct scope_id set.
+        let host_with_zone;
+        let lookup_host = if let (Some(h), Some(zone)) = (host, &self.zone_id) {
+            host_with_zone = format!("{h}%{zone}");
+            Some(host_with_zone.as_str())
+        } else {
+            host
+        };
+
         // Pass None as service to avoid "Service not supported for this socket type" errors
         // in certain environments (e.g., Docker containers on some Linux distributions).
         // We'll set the port manually on each resolved address.
-        let addr_info_iter = dns_lookup::getaddrinfo(host, None, None)
+        let addr_info_iter = dns_lookup::getaddrinfo(lookup_host, None, None)
             .map_err(|err| ureq::Error::Other(Box::new(LookupError(err))))?;
 
         let ip_family = config.ip_family();


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

Fixes #9065

`url::Url::parse()` (WHATWG URL standard) rejects IPv6 zone IDs like `%25eth0` in URLs. This means `http get "http://[fe80::1%25eth0]:8080/"` fails with a parse error, making it impossible to reach link-local IPv6 addresses.

The fix has 3 layers:

1. **Zone ID extraction** (`client.rs`): `extract_ipv6_zone_id()` detects zone IDs in IPv6 URLs (both `%25`-encoded and raw `%` forms), strips them before `url::Url::parse()`, and returns the zone ID separately.

2. **Resolver integration** (`resolver.rs`): `DnsLookupResolver` gains a `zone_id` field. When set, the zone ID is appended to the host before calling `dns_lookup::getaddrinfo()`, which natively handles `fe80::1%eth0` and returns `SocketAddrV6` with the correct `sin6_scope_id`. Works cross-platform.

3. **Thread zone ID through HTTP commands**: Each command (`get`/`post`/`put`/`patch`/`delete`/`head`/`options`) passes the zone ID to `http_client()`. When a zone ID is present and connection pooling is enabled, it falls back to a non-pooled connection since the shared pool resolver can't hold per-request zone IDs.

Design notes:
- The cleaned URL (zone ID stripped) is what ureq sees, since `http::Uri` also doesn't support zone IDs
- Zone ID is injected only at the DNS resolver level — the correct abstraction point
- `getaddrinfo` handles interface-name-to-scope-id conversion, no platform-specific code needed

## Release notes summary - What our users need to know

HTTP commands (`http get`, `http post`, etc.) now support IPv6 link-local addresses with zone IDs, e.g. `http get "http://[fe80::1%25eth0]:8080/"`. Previously these URLs failed to parse.

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)