### PR TITLE
Replace Span::unknown() with real spans in remaining nu-command files

### DIFF
--- a/crates/nu-command/src/database/commands/query_db.rs
+++ b/crates/nu-command/src/database/commands/query_db.rs
@@ -105,7 +105,7 @@ stor open | query db "SELECT data->'baz' AS baz FROM my_table" | update baz {fro
         let sql: Spanned<String> = call.req(engine_state, stack, 0)?;
         let params_value: Value = call
             .get_flag(engine_state, stack, "params")?
-            .unwrap_or_else(|| Value::nothing(Span::unknown()));
+            .unwrap_or_else(|| Value::nothing(call.head));
 
         let params = nu_value_to_params(engine_state, params_value, call.head)?;
 

--- a/crates/nu-command/src/filesystem/du.rs
+++ b/crates/nu-command/src/filesystem/du.rs
@@ -210,7 +210,7 @@ fn du_for_one_pattern(
         None => nu_engine::glob_from(
             &Spanned {
                 item: NuGlob::Expand("*".into()),
-                span: Span::unknown(),
+                span,
             },
             current_dir,
             span,

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -330,7 +330,7 @@ fn ls_for_one_pattern(
     signals: Signals,
     cwd: PathBuf,
 ) -> Result<PipelineData, ShellError> {
-    fn create_pool(num_threads: usize) -> Result<rayon::ThreadPool, ShellError> {
+    fn create_pool(num_threads: usize, call_span: Span) -> Result<rayon::ThreadPool, ShellError> {
         match rayon::ThreadPoolBuilder::new()
             .num_threads(num_threads)
             .build()
@@ -339,7 +339,7 @@ fn ls_for_one_pattern(
                 ShellError::Generic(GenericError::new(
                     "Error creating thread pool",
                     e.to_string(),
-                    Span::unknown(),
+                    call_span,
                 ))
             }),
             Ok(pool) => Ok(pool),
@@ -484,9 +484,9 @@ fn ls_for_one_pattern(
                 )
             })?
             .get();
-        create_pool(count)?
+        create_pool(count, call_span)?
     } else {
-        create_pool(1)?
+        create_pool(1, call_span)?
     };
 
     pool.install(|| {

--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -220,15 +220,15 @@ impl Job {
             let tag = record
                 .get(COLUMN_TAG_NAME)
                 .cloned()
-                .unwrap_or_else(|| Value::nothing(Span::unknown()));
+                .unwrap_or_else(|| Value::nothing(entry_span));
             let attrs = record
                 .get(COLUMN_ATTRS_NAME)
                 .cloned()
-                .unwrap_or_else(|| Value::nothing(Span::unknown()));
+                .unwrap_or_else(|| Value::nothing(entry_span));
             let content = record
                 .get(COLUMN_CONTENT_NAME)
                 .cloned()
-                .unwrap_or_else(|| Value::nothing(Span::unknown()));
+                .unwrap_or_else(|| Value::nothing(entry_span));
 
             let content_span = content.span();
             let tag_span = tag.span();

--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -147,18 +147,14 @@ pub fn cal(
         style_computer,
     )?;
 
-    let mut table_no_index = ast::Call::new(Span::unknown());
+    let mut table_no_index = ast::Call::new(tag);
     table_no_index.add_named((
         Spanned {
             item: "index".to_string(),
-            span: Span::unknown(),
+            span: tag,
         },
         None,
-        Some(Expression::new_unknown(
-            Expr::Bool(false),
-            Span::unknown(),
-            Type::Bool,
-        )),
+        Some(Expression::new_unknown(Expr::Bool(false), tag, Type::Bool)),
     ));
 
     let cal_table_output =
@@ -375,8 +371,7 @@ fn add_month_to_table(
                     && current_day == adjusted_day_number
                 {
                     // This colors the current day
-                    let header_style =
-                        style_computer.compute("header", &Value::nothing(Span::unknown()));
+                    let header_style = style_computer.compute("header", &Value::nothing(tag));
 
                     value = Value::string(
                         header_style

--- a/crates/nu-command/src/misc/source.rs
+++ b/crates/nu-command/src/misc/source.rs
@@ -81,11 +81,11 @@ impl Command for Source {
         // Add env vars so they are available to the script
         stack.add_env_var(
             "FILE_PWD".to_string(),
-            Value::string(parent.to_string_lossy(), Span::unknown()),
+            Value::string(parent.to_string_lossy(), call.head),
         );
         stack.add_env_var(
             "CURRENT_FILE".to_string(),
-            Value::string(file_path.to_string_lossy(), Span::unknown()),
+            Value::string(file_path.to_string_lossy(), call.head),
         );
 
         let eval_block_with_early_return = get_eval_block_with_early_return(engine_state);

--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -446,10 +446,10 @@ fn display(help: &str, engine_state: &EngineState, stack: &mut Stack, span: Span
                     engine_state,
                     stack,
                     &Call::new(span),
-                    Value::string(item, Span::unknown()).into_pipeline_data(),
+                    Value::string(item, span).into_pipeline_data(),
                 );
 
-                if let Ok(value) = result.and_then(|data| data.into_value(Span::unknown())) {
+                if let Ok(value) = result.and_then(|data| data.into_value(span)) {
                     match value.coerce_into_string() {
                         Ok(s) => {
                             build.push_str(&s);

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -1002,10 +1002,7 @@ fn transform_response_using_content_type(
             .map_err(|err| {
                 LabeledError::new(err.to_string())
                     .with_help("cannot parse")
-                    .with_label(
-                        format!("Cannot parse URL: {requested_url}"),
-                        Span::unknown(),
-                    )
+                    .with_label(format!("Cannot parse URL: {requested_url}"), span)
             })?
             .path_segments()
             .and_then(|mut segments| segments.next_back())

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -222,7 +222,7 @@ impl UrlComponents {
                     left_message: format!("Mismatch, query string from params is: {qs}"),
                     left_span: value_span,
                     right_message: format!("instead query is: {q}"),
-                    right_span: self.query_span.unwrap_or(Span::unknown()),
+                    right_span: self.query_span.unwrap_or(value_span),
                 });
             }
 
@@ -272,7 +272,7 @@ impl UrlComponents {
                         left_message: format!("Mismatch, query param is: {s}"),
                         left_span: value_span,
                         right_message: format!("instead query string from params is: {q}"),
-                        right_span: self.params_span.unwrap_or(Span::unknown()),
+                        right_span: self.params_span.unwrap_or(value_span),
                     });
                 }
 

--- a/crates/nu-command/src/platform/dir_info.rs
+++ b/crates/nu-command/src/platform/dir_info.rs
@@ -239,8 +239,8 @@ impl From<FileInfo> for Value {
                     "path" => Value::string(f.path.display().to_string(), f.tag),
                     "apparent" => Value::filesize(f.size as i64, f.tag),
                     "physical" => Value::filesize(f.blocks.unwrap_or(0) as i64, f.tag),
-                    "directories" => Value::nothing(Span::unknown()),
-                    "files" => Value::nothing(Span::unknown()),
+                    "directories" => Value::nothing(f.tag),
+                    "files" => Value::nothing(f.tag),
                 },
                 f.tag,
             )

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -122,19 +122,20 @@ impl Default for InputListConfig {
 }
 
 impl InputListConfig {
-    fn from_nu_config(config: &nu_protocol::Config, style_computer: &StyleComputer) -> Self {
+    fn from_nu_config(
+        config: &nu_protocol::Config,
+        style_computer: &StyleComputer,
+        span: Span,
+    ) -> Self {
         let mut ret = Self::default();
 
         // Get styles from color_config (same as regular table command and find)
-        let color_config_header =
-            style_computer.compute("header", &Value::string("", Span::unknown()));
-        let color_config_separator =
-            style_computer.compute("separator", &Value::nothing(Span::unknown()));
+        let color_config_header = style_computer.compute("header", &Value::string("", span));
+        let color_config_separator = style_computer.compute("separator", &Value::nothing(span));
         let color_config_search_result =
-            style_computer.compute("search_result", &Value::string("", Span::unknown()));
-        let color_config_hints = style_computer.compute("hints", &Value::nothing(Span::unknown()));
-        let color_config_row_index =
-            style_computer.compute("row_index", &Value::string("", Span::unknown()));
+            style_computer.compute("search_result", &Value::string("", span));
+        let color_config_hints = style_computer.compute("hints", &Value::nothing(span));
+        let color_config_row_index = style_computer.compute("row_index", &Value::string("", span));
 
         ret.table_header = color_config_header;
         ret.table_separator = color_config_separator;
@@ -330,7 +331,7 @@ Use --no-footer and --no-separator to hide the footer and separator line."#
         let per_column = call.has_flag(engine_state, stack, "per-column")?;
         let config = stack.get_config(engine_state);
         let style_computer = StyleComputer::from_config(engine_state, stack);
-        let mut input_list_config = InputListConfig::from_nu_config(&config, &style_computer);
+        let mut input_list_config = InputListConfig::from_nu_config(&config, &style_computer, head);
         if no_footer {
             input_list_config.show_footer = false;
         }

--- a/crates/nu-command/src/stor/insert.rs
+++ b/crates/nu-command/src/stor/insert.rs
@@ -147,7 +147,7 @@ fn handle(
             other => Err(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "record".into(),
                 wrong_type: other.get_type().to_string(),
-                dst_span: Span::unknown(),
+                dst_span: span,
                 src_span: other.span(),
             }),
         })

--- a/crates/nu-command/src/stor/update.rs
+++ b/crates/nu-command/src/stor/update.rs
@@ -131,7 +131,7 @@ fn handle(
                 val => Err(ShellError::OnlySupportsThisInputType {
                     exp_input_type: "record".into(),
                     wrong_type: val.get_type().to_string(),
-                    dst_span: Span::unknown(),
+                    dst_span: span,
                     src_span: val.span(),
                 }),
             }

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -597,7 +597,7 @@ fn handle_record(
     };
 
     if let Some(limit) = input.cfg.abbreviation {
-        record = make_record_abbreviation(record, limit);
+        record = make_record_abbreviation(record, limit, span);
     }
 
     let config = input.get_config();
@@ -666,7 +666,7 @@ fn handle_record(
     Ok(data)
 }
 
-fn make_record_abbreviation(mut record: Record, limit: usize) -> Record {
+fn make_record_abbreviation(mut record: Record, limit: usize, span: Span) -> Record {
     if record.len() <= limit * 2 + 1 {
         return record;
     }
@@ -676,7 +676,7 @@ fn make_record_abbreviation(mut record: Record, limit: usize) -> Record {
     let mut record_iter = record.into_iter();
     record = Record::with_capacity(limit * 2 + 1);
     record.extend(record_iter.by_ref().take(limit));
-    record.push(String::from("..."), Value::string("...", Span::unknown()));
+    record.push(String::from("..."), Value::string("...", span));
     record.extend(record_iter.skip(prev_len - 2 * limit));
     record
 }
@@ -975,8 +975,12 @@ impl Iterator for PagingTableCreator {
 
         match self.table_config.abbreviation {
             Some(abbr) => {
-                (batch, _, end) =
-                    stream_collect_abbreviated(&mut self.stream, abbr, self.engine_state.signals());
+                (batch, _, end) = stream_collect_abbreviated(
+                    &mut self.stream,
+                    abbr,
+                    self.engine_state.signals(),
+                    self.head,
+                );
             }
             None => {
                 // Pull from stream until time runs out or we have enough items
@@ -1070,6 +1074,7 @@ fn stream_collect_abbreviated(
     stream: impl Iterator<Item = Value>,
     size: usize,
     signals: &Signals,
+    span: Span,
 ) -> (Vec<Value>, usize, bool) {
     let mut end = true;
     let mut read = 0;
@@ -1100,7 +1105,7 @@ fn stream_collect_abbreviated(
 
     let have_filled_list = head.len() == size && tail.len() == size;
     if have_filled_list {
-        let dummy = get_abbreviated_dummy(&head, &tail);
+        let dummy = get_abbreviated_dummy(&head, &tail, span);
         head.insert(size, dummy)
     }
 
@@ -1109,8 +1114,8 @@ fn stream_collect_abbreviated(
     (head, read, end)
 }
 
-fn get_abbreviated_dummy(head: &[Value], tail: &VecDeque<Value>) -> Value {
-    let dummy = || Value::string(String::from("..."), Span::unknown());
+fn get_abbreviated_dummy(head: &[Value], tail: &VecDeque<Value>, span: Span) -> Value {
+    let dummy = || Value::string(String::from("..."), span);
     let is_record_list = is_record_list(head.iter()) && is_record_list(tail.iter());
 
     if is_record_list {
@@ -1122,7 +1127,7 @@ fn get_abbreviated_dummy(head: &[Value], tail: &VecDeque<Value>) -> Value {
                 .columns()
                 .map(|key| (key.clone(), dummy()))
                 .collect(),
-            Span::unknown(),
+            span,
         )
     } else {
         dummy()


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

Thread `call.head` and other available spans into helper functions across the remaining `nu-command` subdirectories, replacing `Span::unknown()` with real spans.

- `generators/cal.rs` (4): use existing `tag` (alias for `call.head`)
- `formats/to/xml.rs` (3): use `entry_span` from record entries
- `stor/insert.rs`, `stor/update.rs` (2): thread `span` through `handle()`
- `platform/input/list.rs` (5): add `span: Span` to `from_nu_config`
- `platform/dir_info.rs` (2): use `f.tag`
- `viewers/table.rs` (3): add `span` to `make_record_abbreviation`, `stream_collect_abbreviated`, `get_abbreviated_dummy`
- `filesystem/du.rs`, `filesystem/ls.rs` (2): use available span/`call_span`
- `database/commands/query_db.rs` (1): use `call.head`
- `misc/source.rs` (2), `misc/tutor.rs` (2): thread span
- `network/http/client.rs` (1), `network/url/join.rs` (2): use available spans

Part of the ongoing effort to replace `Span::unknown()` with real spans (see #17842, #17872, #17871, #17876, #17877).

## Release notes summary - What our users need to know

Replaced `Span::unknown()` with real spans across remaining nu-command files including `cal`, `to xml`, `stor insert/update`, `input list`, `du`, `ls`, `table`, `source`, `tutor`, `http`, and `url join`. Error messages from these commands now report accurate source locations.