### PR TITLE
Fix trailing slash for symlink dir completions

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -92,8 +92,7 @@ fn complete_rec(
             let entry_name = entry.file_name().to_string_lossy().into_owned();
             let entry_isdir = entry.path().is_dir();
             let mut built = built.clone();
-            // Symlinks to directories shouldn't have a trailing slash (#13275)
-            built.isdir = entry_isdir && !entry.path().is_symlink();
+            built.isdir = entry_isdir;
 
             if !want_directory || entry_isdir {
                 if enable_exact_match && !multiple_exact_matches && has_more {

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -383,7 +383,7 @@ fn custom_completions_strip_ansi_from_record_values() {
     def comp [] { null }
     def my-command [arg: string@comp] {}",
     "my-command test", None,
-    vec![folder("test_a"), file("test_a_symlink"), folder("test_b")],
+    vec![folder("test_a"), folder("test_a_symlink"), folder("test_b")],
     4
 )]
 /// Custom function arguments mixed with subcommands
@@ -391,7 +391,7 @@ fn custom_completions_strip_ansi_from_record_values() {
     def foo [i: directory] {}
     def "foo test bar" [] {}"#,
     "foo test", None,
-    vec![folder("test_a"), file("test_a_symlink"), folder("test_b"), "foo test bar".into()],
+    vec![folder("test_a"), folder("test_a_symlink"), folder("test_b"), "foo test bar".into()],
     8
 )]
 /// If argument type is something like int/string, complete only subcommands
@@ -415,7 +415,7 @@ fn custom_completions_strip_ansi_from_record_values() {
     def foo [--test: directory] {}
     def "foo --test test" [] {}"#,
     "foo --test test", None,
-    vec![folder("test_a"), file("test_a_symlink"), folder("test_b"), "foo --test test".into()],
+    vec![folder("test_a"), folder("test_a_symlink"), folder("test_b"), "foo --test test".into()],
     "foo --test test".len()
 )]
 // Directory only
@@ -991,7 +991,7 @@ fn external_completer_fallback() {
     let block = "{|spans| null}";
     let input = "foo test";
 
-    let expected = [folder("test_a"), file("test_a_symlink"), folder("test_b")];
+    let expected = [folder("test_a"), folder("test_a_symlink"), folder("test_b")];
     let suggestions = run_external_completion(block, input);
     match_suggestions_by_string(&expected, &suggestions);
 
@@ -1241,7 +1241,7 @@ fn file_completions() {
         folder(dir.join("directory_completion")),
         file(dir.join("nushell")),
         folder(dir.join("test_a")),
-        file(dir.join("test_a_symlink")),
+        folder(dir.join("test_a_symlink")),
         folder(dir.join("test_b")),
         file(dir.join(".hidden_file")),
         folder(dir.join(".hidden_folder")),
@@ -1275,7 +1275,7 @@ fn file_completions() {
         folder(dir.join("directory_completion")),
         file(dir.join("nushell")),
         folder(dir.join("test_a")),
-        file(dir.join("test_a_symlink")),
+        folder(dir.join("test_a_symlink")),
         folder(dir.join("test_b")),
         file(dir.join(".hidden_file")),
         folder(dir.join(".hidden_folder")),
@@ -1359,7 +1359,7 @@ fn custom_command_rest_any_args_file_completions() {
         folder(dir.join("directory_completion")),
         file(dir.join("nushell")),
         folder(dir.join("test_a")),
-        file(dir.join("test_a_symlink")),
+        folder(dir.join("test_a_symlink")),
         folder(dir.join("test_b")),
         file(dir.join(".hidden_file")),
         folder(dir.join(".hidden_folder")),
@@ -1379,7 +1379,7 @@ fn custom_command_rest_any_args_file_completions() {
         folder(dir.join("directory_completion")),
         file(dir.join("nushell")),
         folder(dir.join("test_a")),
-        file(dir.join("test_a_symlink")),
+        folder(dir.join("test_a_symlink")),
         folder(dir.join("test_b")),
         file(dir.join(".hidden_file")),
         folder(dir.join(".hidden_folder")),
@@ -1701,7 +1701,7 @@ fn command_ls_with_filecompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1713,7 +1713,7 @@ fn command_ls_with_filecompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -1745,7 +1745,7 @@ fn command_open_with_filecompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1757,7 +1757,7 @@ fn command_open_with_filecompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -1789,7 +1789,7 @@ fn command_rm_with_globcompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1801,7 +1801,7 @@ fn command_rm_with_globcompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -1826,7 +1826,7 @@ fn command_cp_with_globcompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1838,7 +1838,7 @@ fn command_cp_with_globcompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -1863,7 +1863,7 @@ fn command_save_with_filecompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1875,7 +1875,7 @@ fn command_save_with_filecompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -1900,7 +1900,7 @@ fn command_touch_with_filecompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1912,7 +1912,7 @@ fn command_touch_with_filecompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -1937,7 +1937,7 @@ fn command_watch_with_filecompletion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -1949,7 +1949,7 @@ fn command_watch_with_filecompletion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -2207,7 +2207,7 @@ fn folder_with_directorycompletions() {
         folder(dir.join("another")),
         folder(dir.join("directory_completion")),
         folder(dir.join("test_a")),
-        file(dir.join("test_a_symlink")),
+        folder(dir.join("test_a_symlink")),
         folder(dir.join("test_b")),
         folder(dir.join(".hidden_folder")),
     ];
@@ -2310,7 +2310,7 @@ fn folder_with_directorycompletions_with_three_trailing_dots() {
                 .join("...")
                 .join("test_a"),
         ),
-        file(
+        folder(
             dir.join("directory_completion")
                 .join("folder_inside_folder")
                 .join("...")
@@ -2388,7 +2388,7 @@ fn folder_with_directorycompletions_do_not_collapse_dots() {
                 .join("..")
                 .join("test_a"),
         ),
-        file(
+        folder(
             dir.join("directory_completion")
                 .join("folder_inside_folder")
                 .join("..")
@@ -2747,9 +2747,9 @@ fn alias_of_command_and_flags() {
 
     let suggestions = completer.complete("ll t", 4);
     #[cfg(windows)]
-    let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink", "test_b\\"];
+    let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink\\", "test_b\\"];
     #[cfg(not(windows))]
-    let expected_paths: Vec<_> = vec!["test_a/", "test_a_symlink", "test_b/"];
+    let expected_paths: Vec<_> = vec!["test_a/", "test_a_symlink/", "test_b/"];
 
     match_suggestions(&expected_paths, &suggestions)
 }
@@ -2766,9 +2766,9 @@ fn alias_of_basic_command() {
 
     let suggestions = completer.complete("ll t", 4);
     #[cfg(windows)]
-    let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink", "test_b\\"];
+    let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink\\", "test_b\\"];
     #[cfg(not(windows))]
-    let expected_paths: Vec<_> = vec!["test_a/", "test_a_symlink", "test_b/"];
+    let expected_paths: Vec<_> = vec!["test_a/", "test_a_symlink/", "test_b/"];
 
     match_suggestions(&expected_paths, &suggestions)
 }
@@ -2788,9 +2788,9 @@ fn alias_of_another_alias() {
 
     let suggestions = completer.complete("lf t", 4);
     #[cfg(windows)]
-    let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink", "test_b\\"];
+    let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink\\", "test_b\\"];
     #[cfg(not(windows))]
-    let expected_paths: Vec<_> = vec!["test_a/", "test_a_symlink", "test_b/"];
+    let expected_paths: Vec<_> = vec!["test_a/", "test_a_symlink/", "test_b/"];
 
     match_suggestions(&expected_paths, &suggestions)
 }
@@ -2848,7 +2848,7 @@ fn unknown_command_completion() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -2860,7 +2860,7 @@ fn unknown_command_completion() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",
@@ -2884,7 +2884,7 @@ fn filecompletions_triggers_after_cursor() {
         "directory_completion\\",
         "nushell",
         "test_a\\",
-        "test_a_symlink",
+        "test_a_symlink\\",
         "test_b\\",
         ".hidden_file",
         ".hidden_folder\\",
@@ -2896,7 +2896,7 @@ fn filecompletions_triggers_after_cursor() {
         "directory_completion/",
         "nushell",
         "test_a/",
-        "test_a_symlink",
+        "test_a_symlink/",
         "test_b/",
         ".hidden_file",
         ".hidden_folder/",


### PR DESCRIPTION
## Release notes summary - What our users need to know
Symlinked directories are completed with a trailing path separator again, so file completion now treats them like normal directories.

## What changed
- Removes the special-case that suppressed the trailing separator for symlinked directories in file completion.
- Updates existing `nu-cli` completion expectations to match the restored behavior.

Fixes #17257.

## Testing
- `cargo fmt --all -- --check` ?
- Attempted `cargo test -p nu-cli -- --list` with the default MSVC toolchain, but this environment does not have `link.exe` / Visual C++ build tools.
- Attempted a GNU fallback by installing `LLVM-MinGW`, adding the `x86_64-pc-windows-gnu` target, and installing the `stable-x86_64-pc-windows-gnu` toolchain. That still failed here because the linker could not resolve `-lgcc` / `-lgcc_eh` from the installed GNU toolchain.

So formatting was verified, but I could not complete the test run in this machine due missing native Windows linker support.
