### PR TITLE
Replace Span::unknown() with Span::test_data() in test code

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -38,7 +38,7 @@ fn setup_engine() -> EngineState {
 fn setup_stack_and_engine_from_command(command: &str) -> (Stack, EngineState) {
     let mut engine = setup_engine();
     let commands = Spanned {
-        span: Span::unknown(),
+        span: Span::test_data(),
         item: command.to_string(),
     };
 
@@ -74,7 +74,7 @@ fn bench_command(
     engine: EngineState,
 ) -> impl IntoBenchmarks {
     let commands = Spanned {
-        span: Span::unknown(),
+        span: Span::test_data(),
         item: command.into(),
     };
     [benchmark_fn(name, move |b| {
@@ -146,7 +146,7 @@ fn bench_load_use_standard_lib() -> impl IntoBenchmarks {
         let engine = nu_cmd_extra::add_extra_command_context(setup_engine());
         let commands = Spanned {
             item: "use std".into(),
-            span: Span::unknown(),
+            span: Span::test_data(),
         };
         b.iter(move || {
             let mut engine = engine.clone();

--- a/crates/nu-cli/src/commands/history/history_import.rs
+++ b/crates/nu-cli/src/commands/history/history_import.rs
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn test_item_from_value_string() -> Result<(), ShellError> {
-        let item = item_from_value(Value::string("foo", Span::unknown()))?;
+        let item = item_from_value(Value::string("foo", Span::test_data()))?;
         assert_eq!(
             item,
             HistoryItem {
@@ -318,7 +318,7 @@ mod tests {
 
     #[test]
     fn test_item_from_value_record() {
-        let span = Span::unknown();
+        let span = Span::test_data();
         let rec = new_record(&[
             ("command", Value::string("foo", span)),
             (
@@ -357,7 +357,7 @@ mod tests {
 
     #[test]
     fn test_item_from_value_record_extra_field() {
-        let span = Span::unknown();
+        let span = Span::test_data();
         let rec = new_record(&[
             ("command_line", Value::string("foo", span)),
             ("id_nonexistent", Value::int(1, span)),
@@ -367,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_item_from_value_record_bad_type() {
-        let span = Span::unknown();
+        let span = Span::test_data();
         let rec = new_record(&[
             ("command_line", Value::string("foo", span)),
             ("id", Value::string("one".to_string(), span)),
@@ -376,7 +376,7 @@ mod tests {
     }
 
     fn new_record(rec: &[(&'static str, Value)]) -> Value {
-        let span = Span::unknown();
+        let span = Span::test_data();
         let rec = Record::from_raw_cols_vals(
             rec.iter().map(|(col, _)| col.to_string()).collect(),
             rec.iter().map(|(_, val)| val.clone()).collect(),

--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -195,7 +195,7 @@ mod tests {
         let mut stack = Stack::new();
         stack.add_env_var(
             PROMPT_COMMAND.into(),
-            Value::string("test", Span::unknown()),
+            Value::string("test", Span::test_data()),
         );
 
         let mut nu_prompt = NushellPrompt::new();

--- a/crates/nu-cli/tests/completions/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/completions/support/completions_helpers.rs
@@ -182,7 +182,7 @@ pub fn new_dotnu_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
     let mut working_set = StateWorkingSet::new(&engine_state);
     let var_id = working_set.add_variable(
         b"$NU_LIB_DIRS".into(),
-        Span::unknown(),
+        Span::test_data(),
         nu_protocol::Type::List(Box::new(nu_protocol::Type::String)),
         false,
     );
@@ -280,7 +280,7 @@ pub fn merge_input(
             engine_state,
             stack,
             &block,
-            PipelineData::value(Value::nothing(Span::unknown()), None),
+            PipelineData::value(Value::nothing(Span::test_data()), None),
         )
         .is_ok()
     );

--- a/crates/nu-color-config/src/color_config.rs
+++ b/crates/nu-color-config/src/color_config.rs
@@ -140,7 +140,7 @@ mod tests {
         // Test case 3: some values are valid
         let record = record! {
             "bg" =>      Value::test_string("green"),
-            "invalid" => Value::nothing(Span::unknown()),
+            "invalid" => Value::nothing(Span::test_data()),
         };
         let expected_style = NuStyle {
             bg: Some("green".to_string()),
@@ -154,7 +154,7 @@ mod tests {
     fn test_parse_map_entry() {
         let mut hm = HashMap::new();
         let key = "test_key".to_owned();
-        let value = Value::string("red", Span::unknown());
+        let value = Value::string("red", Span::test_data());
         parse_map_entry(&mut hm, &key, &value);
         assert_eq!(hm.get(&key), Some(&lookup_ansi_color_style("red")));
     }

--- a/crates/nu-command/src/charting/hashable_value.rs
+++ b/crates/nu-command/src/charting/hashable_value.rs
@@ -235,7 +235,7 @@ mod test {
         ];
         for (val, expect_hashable_val) in values.into_iter() {
             assert_eq!(
-                HashableValue::from_value(val, Span::unknown()).unwrap(),
+                HashableValue::from_value(val, Span::test_data()).unwrap(),
                 expect_hashable_val
             );
         }
@@ -273,7 +273,7 @@ mod test {
             ),
         ];
         for v in values {
-            assert!(HashableValue::from_value(v, Span::unknown()).is_err())
+            assert!(HashableValue::from_value(v, Span::test_data()).is_err())
         }
     }
 
@@ -291,7 +291,7 @@ mod test {
         for val in values.into_iter() {
             let expected_val = val.clone();
             assert_eq!(
-                HashableValue::from_value(val, Span::unknown())
+                HashableValue::from_value(val, Span::test_data())
                     .unwrap()
                     .into_value(),
                 expected_val

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -3614,7 +3614,7 @@ mod test {
             .map(|s| SelectItem {
                 name: s.to_string(),
                 cells: None,
-                value: nu_protocol::Value::nothing(nu_protocol::Span::unknown()),
+                value: nu_protocol::Value::nothing(nu_protocol::Span::test_data()),
             })
             .collect();
         let leaked: &'static [SelectItem] = Box::leak(options.into_boxed_slice());

--- a/crates/nu-command/src/stor/create.rs
+++ b/crates/nu-command/src/stor/create.rs
@@ -176,7 +176,7 @@ mod test {
     #[test]
     fn test_process_with_valid_parameters() {
         let table_name = Some("test_table".to_string());
-        let span = Span::unknown();
+        let span = Span::test_data();
         let db = Box::new(SQLiteDatabase::new(
             std::path::Path::new(MEMORY_DB),
             Signals::empty(),
@@ -195,7 +195,7 @@ mod test {
     #[test]
     fn test_process_with_missing_table_name() {
         let table_name = None;
-        let span = Span::unknown();
+        let span = Span::test_data();
         let db = Box::new(SQLiteDatabase::new(
             std::path::Path::new(MEMORY_DB),
             Signals::empty(),
@@ -220,7 +220,7 @@ mod test {
     #[test]
     fn test_process_with_missing_columns() {
         let table_name = Some("test_table".to_string());
-        let span = Span::unknown();
+        let span = Span::test_data();
         let db = Box::new(SQLiteDatabase::new(
             std::path::Path::new(MEMORY_DB),
             Signals::empty(),
@@ -240,7 +240,7 @@ mod test {
     #[test]
     fn test_process_with_unsupported_column_data_type() {
         let table_name = Some("test_table".to_string());
-        let span = Span::unknown();
+        let span = Span::test_data();
         let db = Box::new(SQLiteDatabase::new(
             std::path::Path::new(MEMORY_DB),
             Signals::empty(),

--- a/crates/nu-command/src/stor/insert.rs
+++ b/crates/nu-command/src/stor/insert.rs
@@ -237,7 +237,7 @@ mod test {
         conn.execute(create_stmt, [])
             .expect("Failed to create table as part of test.");
         let table_name = Some("test_process_with_simple_parameters".to_string());
-        let span = Span::unknown();
+        let span = Span::test_data();
         let mut columns = Record::new();
         columns.insert("int_column".to_string(), Value::test_int(42));
         columns.insert("real_column".to_string(), Value::test_float(3.1));
@@ -275,7 +275,7 @@ mod test {
         conn.execute(create_stmt, [])
             .expect("Failed to create table as part of test.");
         let table_name = Some("test_process_string_with_space".to_string());
-        let span = Span::unknown();
+        let span = Span::test_data();
         let mut columns = Record::new();
         columns.insert(
             "str_column".to_string(),
@@ -303,7 +303,7 @@ mod test {
         conn.execute(create_stmt, [])
             .expect("Failed to create table as part of test.");
         let table_name = Some("test_errors_when_string_too_long".to_string());
-        let span = Span::unknown();
+        let span = Span::test_data();
         let mut columns = Record::new();
         columns.insert(
             "str_column".to_string(),
@@ -331,7 +331,7 @@ mod test {
         conn.execute(create_stmt, [])
             .expect("Failed to create table as part of test.");
         let table_name = Some("test_errors_when_param_is_wrong_type".to_string());
-        let span = Span::unknown();
+        let span = Span::test_data();
         let mut columns = Record::new();
         columns.insert(
             "int_column".to_string(),
@@ -359,7 +359,7 @@ mod test {
         conn.execute(create_stmt, [])
             .expect("Failed to create table as part of test.");
         let table_name = Some("test_errors_when_column_doesnt_exist".to_string());
-        let span = Span::unknown();
+        let span = Span::test_data();
         let mut columns = Record::new();
         columns.insert(
             "not_a_column".to_string(),
@@ -379,7 +379,7 @@ mod test {
         ));
 
         let table_name = Some("test_errors_when_table_doesnt_exist".to_string());
-        let span = Span::unknown();
+        let span = Span::test_data();
         let mut columns = Record::new();
         columns.insert(
             "str_column".to_string(),
@@ -427,7 +427,7 @@ mod test {
         let result = process(
             &EngineState::new(),
             Some("test_insert_json".to_owned()),
-            Span::unknown(),
+            Span::test_data(),
             &db,
             row,
         );

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -743,30 +743,31 @@ mod test {
 
             let cwd = dirs.test().as_std_path();
 
-            let actual = expand_glob("*.txt", cwd, Span::unknown(), Signals::empty()).unwrap();
+            let actual = expand_glob("*.txt", cwd, Span::test_data(), Signals::empty()).unwrap();
             let expected = &["a.txt", "b.txt"];
             assert_eq!(actual, expected);
 
-            let actual = expand_glob("./*.txt", cwd, Span::unknown(), Signals::empty()).unwrap();
+            let actual = expand_glob("./*.txt", cwd, Span::test_data(), Signals::empty()).unwrap();
             assert_eq!(actual, expected);
 
-            let actual = expand_glob("'*.txt'", cwd, Span::unknown(), Signals::empty()).unwrap();
+            let actual = expand_glob("'*.txt'", cwd, Span::test_data(), Signals::empty()).unwrap();
             let expected = &["'*.txt'"];
             assert_eq!(actual, expected);
 
-            let actual = expand_glob(".", cwd, Span::unknown(), Signals::empty()).unwrap();
+            let actual = expand_glob(".", cwd, Span::test_data(), Signals::empty()).unwrap();
             let expected = &["."];
             assert_eq!(actual, expected);
 
-            let actual = expand_glob("./a.txt", cwd, Span::unknown(), Signals::empty()).unwrap();
+            let actual = expand_glob("./a.txt", cwd, Span::test_data(), Signals::empty()).unwrap();
             let expected = &["./a.txt"];
             assert_eq!(actual, expected);
 
-            let actual = expand_glob("[*.txt", cwd, Span::unknown(), Signals::empty()).unwrap();
+            let actual = expand_glob("[*.txt", cwd, Span::test_data(), Signals::empty()).unwrap();
             let expected = &["[*.txt"];
             assert_eq!(actual, expected);
 
-            let actual = expand_glob("~/foo.txt", cwd, Span::unknown(), Signals::empty()).unwrap();
+            let actual =
+                expand_glob("~/foo.txt", cwd, Span::test_data(), Signals::empty()).unwrap();
             let home = dirs::home_dir().expect("failed to get home dir");
             let expected: Vec<OsString> = vec![home.join("foo.txt").into()];
             assert_eq!(actual, expected);
@@ -792,12 +793,12 @@ mod test {
         assert_eq!(buf, b"");
 
         let mut buf = vec![];
-        let input = PipelineData::value(Value::string("foo", Span::unknown()), None);
+        let input = PipelineData::value(Value::string("foo", Span::test_data()), None);
         write_pipeline_data(engine_state.clone(), stack.clone(), input, &mut buf).unwrap();
         assert_eq!(buf, b"foo");
 
         let mut buf = vec![];
-        let input = PipelineData::value(Value::binary(b"foo", Span::unknown()), None);
+        let input = PipelineData::value(Value::binary(b"foo", Span::test_data()), None);
         write_pipeline_data(engine_state.clone(), stack.clone(), input, &mut buf).unwrap();
         assert_eq!(buf, b"foo");
 
@@ -805,7 +806,7 @@ mod test {
         let input = PipelineData::byte_stream(
             ByteStream::read(
                 b"foo".as_slice(),
-                Span::unknown(),
+                Span::test_data(),
                 Signals::empty(),
                 ByteStreamType::Unknown,
             ),

--- a/crates/nu-command/tests/commands/database/into_sqlite.rs
+++ b/crates/nu-command/tests/commands/database/into_sqlite.rs
@@ -325,7 +325,7 @@ fn into_sqlite_big_insert() {
                 .upsert_cell_path(
                     &[PathMember::String {
                         val: "somedate".into(),
-                        span: Span::unknown(),
+                        span: Span::test_data(),
                         optional: false,
                         casing: Casing::Sensitive,
                     }],
@@ -339,7 +339,7 @@ fn into_sqlite_big_insert() {
                 &engine_state,
                 &value,
                 nuon::ToNuonConfig::default()
-                    .span(Some(Span::unknown()))
+                    .span(Some(Span::test_data()))
                     .serialize_types(serialize_types),
             )
             .unwrap()
@@ -392,17 +392,17 @@ impl From<TestRow> for Value {
     fn from(row: TestRow) -> Self {
         Value::record(
             record! {
-                "somebool" => Value::bool(row.0, Span::unknown()),
-                "someint" => Value::int(row.1, Span::unknown()),
-                "somefloat" => Value::float(row.2, Span::unknown()),
-                "somefilesize" => Value::filesize(row.3, Span::unknown()),
-                "someduration" => Value::duration(row.4, Span::unknown()),
-                "somedate" => Value::date(row.5, Span::unknown()),
-                "somestring" => Value::string(row.6, Span::unknown()),
-                "somebinary" => Value::binary(row.7, Span::unknown()),
-                "somenull" => Value::nothing(Span::unknown()),
+                "somebool" => Value::bool(row.0, Span::test_data()),
+                "someint" => Value::int(row.1, Span::test_data()),
+                "somefloat" => Value::float(row.2, Span::test_data()),
+                "somefilesize" => Value::filesize(row.3, Span::test_data()),
+                "someduration" => Value::duration(row.4, Span::test_data()),
+                "somedate" => Value::date(row.5, Span::test_data()),
+                "somestring" => Value::string(row.6, Span::test_data()),
+                "somebinary" => Value::binary(row.7, Span::test_data()),
+                "somenull" => Value::nothing(Span::test_data()),
             },
-            Span::unknown(),
+            Span::test_data(),
         )
     }
 }

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -544,7 +544,7 @@ mod tests {
                 engine_state,
                 stack,
                 &block,
-                PipelineData::value(Value::nothing(Span::unknown()), None),
+                PipelineData::value(Value::nothing(Span::test_data()), None),
             )
             .is_ok()
         );

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -1141,7 +1141,7 @@ fn interface_get_dynamic_completion() -> Result<(), ShellError> {
         call: DynamicCompletionCall {
             call: nu_protocol::ast::Call {
                 decl_id: Id::new(3),
-                head: Span::unknown(),
+                head: Span::test_data(),
                 arguments: vec![],
                 parser_info: HashMap::new(),
             },
@@ -1163,7 +1163,7 @@ fn interface_get_dynamic_completion() -> Result<(), ShellError> {
         call: DynamicCompletionCall {
             call: nu_protocol::ast::Call {
                 decl_id: Id::new(3),
-                head: Span::unknown(),
+                head: Span::test_data(),
                 arguments: vec![],
                 parser_info: HashMap::new(),
             },

--- a/crates/nu-protocol/tests/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/tests/pipeline/byte_stream.rs
@@ -275,11 +275,11 @@ pub fn test_max_end_inclusive() {
 
 fn create_range(start: i64, end: i64, inclusion: RangeInclusion) -> IntRange {
     IntRange::new(
-        Value::int(start, Span::unknown()),
+        Value::int(start, Span::test_data()),
         Value::nothing(Span::test_data()),
-        Value::int(end, Span::unknown()),
+        Value::int(end, Span::test_data()),
         inclusion,
-        Span::unknown(),
+        Span::test_data(),
     )
     .unwrap()
 }

--- a/crates/nu_plugin_polars/src/cache/mod.rs
+++ b/crates/nu_plugin_polars/src/cache/mod.rs
@@ -222,7 +222,7 @@ mod test {
                 uuid: Uuid::new_v4(),
                 value: PolarsPluginObject::NuPolarsTestData(Uuid::new_v4(), "object_0".into()),
                 created: Local::now().into(),
-                span: Span::unknown(),
+                span: Span::test_data(),
                 reference_count: 1,
             },
         );
@@ -234,7 +234,7 @@ mod test {
                 uuid: Uuid::new_v4(),
                 value: PolarsPluginObject::NuPolarsTestData(Uuid::new_v4(), "object_1".into()),
                 created: Local::now().into(),
-                span: Span::unknown(),
+                span: Span::test_data(),
                 reference_count: 1,
             },
         );

--- a/crates/nu_plugin_polars/src/dataframe/values/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/mod.rs
@@ -475,82 +475,82 @@ mod test {
     #[test]
     fn test_dtype_str_to_schema_simple_types() {
         let dtype = "bool";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Boolean;
         assert_eq!(schema, expected);
 
         let dtype = "u8";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::UInt8;
         assert_eq!(schema, expected);
 
         let dtype = "u16";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::UInt16;
         assert_eq!(schema, expected);
 
         let dtype = "u32";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::UInt32;
         assert_eq!(schema, expected);
 
         let dtype = "u64";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::UInt64;
         assert_eq!(schema, expected);
 
         let dtype = "i8";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Int8;
         assert_eq!(schema, expected);
 
         let dtype = "i16";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Int16;
         assert_eq!(schema, expected);
 
         let dtype = "i32";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Int32;
         assert_eq!(schema, expected);
 
         let dtype = "i64";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Int64;
         assert_eq!(schema, expected);
 
         let dtype = "str";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::String;
         assert_eq!(schema, expected);
 
         let dtype = "binary";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Binary;
         assert_eq!(schema, expected);
 
         let dtype = "date";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Date;
         assert_eq!(schema, expected);
 
         let dtype = "time";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Time;
         assert_eq!(schema, expected);
 
         let dtype = "null";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Null;
         assert_eq!(schema, expected);
 
         let dtype = "unknown";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Unknown(UnknownKind::Any);
         assert_eq!(schema, expected);
 
         let dtype = "object";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Object("unknown");
         assert_eq!(schema, expected);
     }
@@ -558,54 +558,54 @@ mod test {
     #[test]
     fn test_dtype_str_schema_datetime() {
         let dtype = "datetime<ms, *>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Datetime(TimeUnit::Milliseconds, None);
         assert_eq!(schema, expected);
 
         let dtype = "datetime<us, *>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Datetime(TimeUnit::Microseconds, None);
         assert_eq!(schema, expected);
 
         let dtype = "datetime<μs, *>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Datetime(TimeUnit::Microseconds, None);
         assert_eq!(schema, expected);
 
         let dtype = "datetime<ns, *>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Datetime(TimeUnit::Nanoseconds, None);
         assert_eq!(schema, expected);
 
         let dtype = "datetime<ms, UTC>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Datetime(TimeUnit::Milliseconds, Some(timezone_utc()));
         assert_eq!(schema, expected);
 
         let dtype = "invalid";
-        let schema = str_to_dtype(dtype, Span::unknown());
+        let schema = str_to_dtype(dtype, Span::test_data());
         assert!(schema.is_err())
     }
 
     #[test]
     fn test_dtype_str_schema_duration() {
         let dtype = "duration<ms>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Duration(TimeUnit::Milliseconds);
         assert_eq!(schema, expected);
 
         let dtype = "duration<us>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Duration(TimeUnit::Microseconds);
         assert_eq!(schema, expected);
 
         let dtype = "duration<μs>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Duration(TimeUnit::Microseconds);
         assert_eq!(schema, expected);
 
         let dtype = "duration<ns>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Duration(TimeUnit::Nanoseconds);
         assert_eq!(schema, expected);
     }
@@ -613,17 +613,17 @@ mod test {
     #[test]
     fn test_dtype_str_schema_decimal() {
         let dtype = "decimal<7,2>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Decimal(7usize, 2usize);
         assert_eq!(schema, expected);
 
         // "*" is not a permitted value for scale
         let dtype = "decimal<7,*>";
-        let schema = str_to_dtype(dtype, Span::unknown());
+        let schema = str_to_dtype(dtype, Span::test_data());
         assert!(matches!(schema, Err(ShellError::Generic(_))));
 
         let dtype = "decimal<*,2>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::Decimal(DEC128_MAX_PREC, 2usize);
         assert_eq!(schema, expected);
     }
@@ -631,32 +631,32 @@ mod test {
     #[test]
     fn test_dtype_str_to_schema_list_types() {
         let dtype = "list<i32>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::List(Box::new(DataType::Int32));
         assert_eq!(schema, expected);
 
         let dtype = "list<duration<ms>>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::List(Box::new(DataType::Duration(TimeUnit::Milliseconds)));
         assert_eq!(schema, expected);
 
         let dtype = "list<datetime<ms, *>>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::List(Box::new(DataType::Datetime(TimeUnit::Milliseconds, None)));
         assert_eq!(schema, expected);
 
         let dtype = "list<decimal<7,2>>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::List(Box::new(DataType::Decimal(7usize, 2usize)));
         assert_eq!(schema, expected);
 
         let dtype = "list<decimal<*,2>>";
-        let schema = str_to_dtype(dtype, Span::unknown()).unwrap();
+        let schema = str_to_dtype(dtype, Span::test_data()).unwrap();
         let expected = DataType::List(Box::new(DataType::Decimal(DEC128_MAX_PREC, 2usize)));
         assert_eq!(schema, expected);
 
         let dtype = "list<decimal<7,*>>";
-        let schema = str_to_dtype(dtype, Span::unknown());
-        assert!(matches!(schema, Err(ShellError::Generic(_))));
+        let schema = str_to_dtype(dtype, Span::test_data());
+        assert!(matches!(schema, Err(ShellError::Generic(_))))
     }
 }

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_schema/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_schema/mod.rs
@@ -154,7 +154,7 @@ mod test {
             "address" => Value::test_record(address)
         });
 
-        let schema = value_to_schema(&plugin, &value, Span::unknown()).unwrap();
+        let schema = value_to_schema(&plugin, &value, Span::test_data()).unwrap();
         let expected = Schema::from_iter(vec![
             Field::new("name".into(), DataType::String),
             Field::new("age".into(), DataType::Int32),

--- a/crates/nu_plugin_query/src/query_web.rs
+++ b/crates/nu_plugin_query/src/query_web.rs
@@ -476,7 +476,7 @@ mod tests {
     fn null_spanned<T: ToOwned + ?Sized>(input: &T) -> Spanned<T::Owned> {
         Spanned {
             item: input.to_owned(),
-            span: Span::unknown(),
+            span: Span::test_data(),
         }
     }
 
@@ -585,10 +585,10 @@ mod tests {
             null_spanned("a"),
             &Value::list(
                 vec![
-                    Value::string("href".to_string(), Span::unknown()),
-                    Value::string("target".to_string(), Span::unknown()),
+                    Value::string("href".to_string(), Span::test_data()),
+                    Value::string("target".to_string(), Span::test_data()),
                 ],
-                Span::unknown(),
+                Span::test_data(),
             ),
             null_spanned(&false),
             /* document = */ false,

--- a/crates/nuon/src/lib.rs
+++ b/crates/nuon/src/lib.rs
@@ -152,7 +152,7 @@ mod tests {
                     Value::test_int(2),
                     Value::test_int(42),
                     RangeInclusion::Inclusive,
-                    Span::unknown(),
+                    Span::test_data(),
                 )
                 .unwrap(),
             ))),

--- a/tests/integration/shell_integration.rs
+++ b/tests/integration/shell_integration.rs
@@ -23,23 +23,23 @@ fn create_test_engine() -> (EngineState, Stack, Arc<Config>) {
     // Set up simple prompt environment variables with literal strings
     stack.add_env_var(
         "PROMPT_COMMAND".to_string(),
-        Value::string("❯ ".to_string(), Span::unknown()),
+        Value::string("❯ ".to_string(), Span::test_data()),
     );
     stack.add_env_var(
         "PROMPT_INDICATOR".to_string(),
-        Value::string("> ".to_string(), Span::unknown()),
+        Value::string("> ".to_string(), Span::test_data()),
     );
     stack.add_env_var(
         "PROMPT_COMMAND_RIGHT".to_string(),
-        Value::string("~/code".to_string(), Span::unknown()),
+        Value::string("~/code".to_string(), Span::test_data()),
     );
     stack.add_env_var(
         "PROMPT_MULTILINE_INDICATOR".to_string(),
-        Value::string("... ".to_string(), Span::unknown()),
+        Value::string("... ".to_string(), Span::test_data()),
     );
     stack.add_env_var(
         "PWD".to_string(),
-        Value::string("/test".to_string(), Span::unknown()),
+        Value::string("/test".to_string(), Span::test_data()),
     );
 
     let config = engine_state.get_config().clone();
@@ -127,7 +127,7 @@ fn test_update_prompt_with_missing_vars() {
     let mut stack = Stack::new();
     stack.add_env_var(
         "PWD".to_string(),
-        Value::string("/test".to_string(), Span::unknown()),
+        Value::string("/test".to_string(), Span::test_data()),
     );
 
     let config = (*engine_state.get_config()).clone();


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

Replace `Span::unknown()` with `Span::test_data()` across all test code in the codebase. `Span::test_data()` returns `Span::new(0, 0)` and is specifically designed for test contexts, semantically distinguishing test spans from genuinely unknown spans.

**20 files modified** across:
- `benches/benchmarks.rs`
- `tests/integration/shell_integration.rs`
- Test helpers and `#[cfg(test)]` modules in `nu-cli`, `nu-color-config`, `nu-command`, `nu-lsp`, `nu-plugin-engine`, `nu-protocol`, `nu_plugin_polars`, `nu_plugin_query`, `nuon`

No production code was changed — only test modules and test support files.

Part of the ongoing effort to replace `Span::unknown()` with real spans (see #17842, #17872, #17871, #17876, #17877, #17888).

## Release notes summary - What our users need to know

Internal change only: test code now uses `Span::test_data()` instead of `Span::unknown()` to better distinguish test spans from genuinely unknown spans. No user-facing behavior changes.