### PR TITLE
build: fix cross compilation to/from windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,7 +277,7 @@ same-file = "1.0.6"
 # Our dependencies don't use OpenSSL on Windows
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
-[target.'cfg(windows)'.build-dependencies]
+[build-dependencies]
 winresource = "0.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]

--- a/scripts/build.rs
+++ b/scripts/build.rs
@@ -1,21 +1,18 @@
 fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect("set by cargo");
     println!("cargo:rerun-if-changed=scripts/build.rs");
     println!(
         "cargo:rustc-env=NU_FEATURES={}",
         std::env::var("CARGO_CFG_FEATURE").expect("set by cargo")
     );
 
-    #[cfg(windows)]
-    {
+    if target_os == "windows" {
         println!("cargo:rerun-if-changed=assets/nu_logo.ico");
         let mut res = winresource::WindowsResource::new();
         res.set_icon("assets/nu_logo.ico");
         res.compile()
             .expect("Failed to run the Windows resource compiler (rc.exe)");
-    }
-
-    #[cfg(not(windows))]
-    {
+    } else {
         // Tango uses dynamic linking, to allow us to dynamically change between two bench suit at runtime.
         // This is currently not supported on non nightly rust, on windows.
         println!("cargo:rustc-link-arg-benches=-rdynamic");


### PR DESCRIPTION
Check target os at runtime.

From https://crates.io/crates/winresource#using-winresource:
> Please note: Using `#[cfg(target_os = "windows")]` in `build.rs` may not work as expected because `build.rs` is executed on the host. This means that `target_os` is always equal to `host_os` when compiling `build.rs`. E.g. if we use `rustc` on Linux and want to cross-compile binaries that run on Windows, `target_os` in build.rs is `"linux"`. However, `CARGO_CFG_TARGET_OS` should always be defined and contains the actual target operating system, though it can only be checked at runtime of the build script.


## Release notes summary - What our users need to know
N/A