### PR TITLE
`http` commands' output metadata properly includes content-type

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -315,7 +315,8 @@ pub fn response_to_buffer(
     };
 
     // Extract response metadata before consuming the body
-    let metadata = extract_response_metadata(&response, span);
+    let metadata =
+        extract_response_metadata(&response, span).with_content_type(content_type_lowercase);
 
     let reader = UreqTimeoutExtractorReader {
         r: response.into_body().into_reader(),

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -338,6 +338,26 @@ fn http_get_response_metadata() -> Result {
     test().run(code).expect_value_eq(200)
 }
 
+#[test]
+fn http_get_content_type_metadata() -> Result {
+    let mut server = Server::new();
+
+    let _mock = server
+        .mock("GET", "/")
+        .with_status(200)
+        .with_header("content-type", "application/nuon")
+        .with_body("[1 2 3]")
+        .create();
+
+    let code = "
+        let url = $in
+        http get --raw $url | metadata | $in.content_type
+    ";
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("application/nuon")
+}
+
 #[cfg(unix)]
 #[rstest::rstest]
 #[case::all_proxy("ALL_PROXY")]


### PR DESCRIPTION
`http *` commands didn't include the content-type (`PipelineMetadata::content_type`) in the metadata, only including it as part of the http headers (in `PipelineMetadata::custom`) metadata.

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A