### PR TITLE
docs: fix typo in completer comment

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -407,7 +407,7 @@ impl NuCompleter {
                     // 1. Flag name: 2 sources combined:
                     //    * Signature based internal flags
                     //    * Command-wide external flags
-                    // 2. Flag value/positional: try the followings in order:
+                    // 2. Flag value/positional: try the following in order:
                     //    1. Custom completion
                     //    2. Command-wide completion
                     //    3. Dynamic completion defined in trait `Command`


### PR DESCRIPTION
## Summary
- fix a typo in the completion ordering comment

## Related issue
- N/A

## Guideline alignment
- Reviewed [CONTRIBUTING.md](https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md) and the PR template
- Kept this to a single technical comment change in one file with no behavior change

## Release notes summary - What our users need to know

N/A

## Validation/testing note
- Not run locally; comment-only change

## Tasks after submitting
- [x] Update the documentation (N/A: no user-facing change)
