### PR TITLE
Introduce `str lcp` for `std-rfc`

### DIFF
--- a/crates/nu-std/std-rfc/str/mod.nu
+++ b/crates/nu-std/std-rfc/str/mod.nu
@@ -188,6 +188,14 @@ alias "str lcp" = lcp
 @example "List of 1" { [abc] | str lcp } --result {prefix: abc, rest: [""] success: true}
 @example "Matching prefix" { [abc abd] | str lcp } --result {prefix: ab, rest: [c d], success: true}
 @example "Non-matching prefix" { [qwe asd zxc] | str lcp } --result {prefix: "", rest: [qwe asd zxc], success: false}
+@example "Format package version differences" {
+  let pkg_current = "acme-3.4.5"
+  let pkg_updated = "acme-3.6.0"
+
+  let diff = [$pkg_current $pkg_updated] | str lcp
+
+  $"($diff.prefix)>>>($diff.rest.0) => ($diff.rest.1)<<<"
+} --result "acme-3.>>>4.5 => 6.0<<<"
 export def lcp []: list<string> -> record<prefix: string, rest: list<string>, success: bool> {
     match ($in | length) {
       0 => {prefix: "", rest: [], success: false}

--- a/crates/nu-std/std-rfc/str/mod.nu
+++ b/crates/nu-std/std-rfc/str/mod.nu
@@ -180,3 +180,43 @@ export def align [
     }
     | str join (char nl)
 }
+
+alias "str lcp" = lcp
+
+# Given list of strings, find the longest common prefix and return the remaining parts of input.
+@example "No matching prefix" { [] | str lcp  } --result { prefix: "", rest: [] success: false }
+@example "List of 1" { ["abc"] | str lcp } --result { prefix: "abc", rest: [""] success: true }
+@example "Matching prefix" { [abc abd] | str lcp } --result { prefix: "ab", rest: [c d], success: true }
+@example "Non-matching prefix" { [qwe asd zxc] | str lcp } --result { prefix: "", rest: [qwe asd zxc], success: false }
+export def lcp []: list<string> -> record<prefix: string, rest: list<string>, success: bool> {
+    match ($in | length) {
+      0 => { prefix: "", rest: [], success: false }
+      1 => { prefix: ($in | get 0), rest: [""], success: true }
+      _ => {
+        let chars: list<list<string>> = $in | each { |value| $value | split chars --grapheme-clusters }
+        let shortest = $in
+            | enumerate
+            | sort-by { $in.item | str length }
+            | get 0
+
+        let shortest_chars = $chars | get $shortest.index
+        mut prefix_len = 0
+
+        for i in 0..<($shortest.item | str length) {
+          if ($chars | all { |row|
+              ($row | get $i) == ($shortest_chars | get $i)
+            }) {
+            $prefix_len = $prefix_len + 1
+          } else {
+            break
+          }
+        }
+
+        let split_at = $prefix_len
+        let prefix = $shortest_chars | first $split_at | str join
+        let rest = $chars | each { |value| $value | slice $split_at.. | str join }
+
+        { prefix: $prefix, rest: $rest, success: ($split_at > 0) }
+      }
+    }
+}

--- a/crates/nu-std/std-rfc/str/mod.nu
+++ b/crates/nu-std/std-rfc/str/mod.nu
@@ -184,29 +184,29 @@ export def align [
 alias "str lcp" = lcp
 
 # Given list of strings, find the longest common prefix and return the remaining parts of input.
-@example "No matching prefix" { [] | str lcp  } --result { prefix: "", rest: [] success: false }
-@example "List of 1" { ["abc"] | str lcp } --result { prefix: "abc", rest: [""] success: true }
-@example "Matching prefix" { [abc abd] | str lcp } --result { prefix: "ab", rest: [c d], success: true }
-@example "Non-matching prefix" { [qwe asd zxc] | str lcp } --result { prefix: "", rest: [qwe asd zxc], success: false }
+@example "No matching prefix" { [] | str lcp  } --result {prefix: "", rest: [] success: false}
+@example "List of 1" { [abc] | str lcp } --result {prefix: abc, rest: [""] success: true}
+@example "Matching prefix" { [abc abd] | str lcp } --result {prefix: ab, rest: [c d], success: true}
+@example "Non-matching prefix" { [qwe asd zxc] | str lcp } --result {prefix: "", rest: [qwe asd zxc], success: false}
 export def lcp []: list<string> -> record<prefix: string, rest: list<string>, success: bool> {
     match ($in | length) {
-      0 => { prefix: "", rest: [], success: false }
-      1 => { prefix: ($in | get 0), rest: [""], success: true }
+      0 => {prefix: "", rest: [], success: false}
+      1 => {prefix: $in.0?, rest: [""], success: true}
       _ => {
-        let chars: list<list<string>> = $in | each { |value| $value | split chars --grapheme-clusters }
+        let chars: list<list<string>> = $in | each {|value| $value | split chars --grapheme-clusters }
         let shortest = $in
             | enumerate
             | sort-by { $in.item | str length }
-            | get 0
+            | get --optional 0
 
-        let shortest_chars = $chars | get $shortest.index
+        let shortest_chars = $chars | get --optional $shortest.index
         mut prefix_len = 0
 
         for i in 0..<($shortest.item | str length) {
-          if ($chars | all { |row|
-              ($row | get $i) == ($shortest_chars | get $i)
+          if ($chars | all {|row|
+              ($row | get --optional $i) == ($shortest_chars | get --optional $i)
             }) {
-            $prefix_len = $prefix_len + 1
+            $prefix_len += 1
           } else {
             break
           }
@@ -214,9 +214,9 @@ export def lcp []: list<string> -> record<prefix: string, rest: list<string>, su
 
         let split_at = $prefix_len
         let prefix = $shortest_chars | first $split_at | str join
-        let rest = $chars | each { |value| $value | slice $split_at.. | str join }
+        let rest = $chars | each {|value| $value | slice $split_at.. | str join }
 
-        { prefix: $prefix, rest: $rest, success: ($split_at > 0) }
+        {prefix: $prefix, rest: $rest, success: ($split_at > 0)}
       }
     }
 }

--- a/crates/nu-std/tests/test_std-rfc_str.nu
+++ b/crates/nu-std/tests/test_std-rfc_str.nu
@@ -427,3 +427,118 @@ def str-align_empty_input_noop [] {
 
     assert equal $actual $expected
 }
+
+@test
+def str-lcp_simple [] {
+    let expected = {prefix: "let ", rest: ["a = 1", "max = 2", "very_long_variable_name = 3"], success: true}
+
+    let actual = [
+        "let a = 1"
+        "let max = 2"
+        "let very_long_variable_name = 3"
+    ] | str lcp
+
+    assert equal $actual $expected
+}
+
+@test
+def str-lcp_empty_list [] {
+    let actual = [] | str lcp
+    let expected = {prefix: "", rest: [], success: false}
+
+    assert equal $actual $expected
+}
+
+@test
+def str-lcp_single_item [] {
+    let actual = ["abc"] | str lcp
+    let expected = {prefix: "abc", rest: [""], success: true}
+
+    assert equal $actual $expected
+}
+
+@test
+def str-lcp_no_common_prefix [] {
+    let actual = ["qwe", "asd", "zxc"] | str lcp
+    let expected = {prefix: "", rest: ["qwe", "asd", "zxc"], success: false}
+
+    assert equal $actual $expected
+}
+
+@test
+def str-lcp_all_identical [] {
+    let actual = ["abc", "abc", "abc"] | str lcp
+    let expected = {prefix: "abc", rest: ["", "", ""], success: true}
+
+    assert equal $actual $expected
+}
+
+@test
+def str-lcp_one_string_is_full_prefix [] {
+    # One string is a prefix of another — the shorter string sets the boundary
+    let actual = ["abc", "abcdef"] | str lcp
+    let expected = {prefix: "abc", rest: ["", "def"], success: true}
+
+    assert equal $actual $expected
+}
+
+@test
+def str-lcp_shortest_not_first [] {
+    # The shortest input does not have to be first; output order must be preserved
+    let actual = ["abcdef", "abcghi", "abc"] | str lcp
+    let expected = {prefix: "abc", rest: ["def", "ghi", ""], success: true}
+
+    assert equal $actual $expected
+}
+
+@test
+def str-lcp_empty_string_in_list [] {
+    # An empty string means there can be no common prefix
+    let actual = ["", "abc"] | str lcp
+    let expected = {prefix: "", rest: ["", "abc"], success: false}
+
+    assert equal $actual $expected
+}
+
+@test
+def str-lcp_case_sensitive [] {
+    # Matching is case-sensitive: "Abc" vs "abc" share no common prefix
+    let actual = ["Abc", "abc"] | str lcp
+    let expected = {prefix: "", rest: ["Abc", "abc"], success: false}
+
+    assert equal $actual $expected
+}
+
+@test
+def str-lcp_unicode [] {
+    # Unicode strings with a common prefix
+    let actual = ["héllo", "héros"] | str lcp
+    let expected = {prefix: "hé", rest: ["llo", "ros"], success: true}
+
+    assert equal $actual $expected
+}
+
+@test
+def str-lcp_grapheme_clusters [] {
+    # Emoji are multi-byte grapheme clusters; ensure they are treated as single units
+    let actual = ["😀 hello", "😀 world"] | str lcp
+    let expected = {prefix: "😀 ", rest: ["hello", "world"], success: true}
+
+    assert equal $actual $expected
+}
+
+@test
+def str-lcp_two_items_same_prefix [] {
+    let actual = ["abc", "abd"] | str lcp
+    let expected = {prefix: "ab", rest: ["c", "d"], success: true}
+
+    assert equal $actual $expected
+}
+
+@test
+def str-lcp_single_char_prefix [] {
+    let actual = ["apple", "avocado", "apricot"] | str lcp
+    let expected = {prefix: "a", rest: ["pple", "vocado", "pricot"], success: true}
+
+    assert equal $actual $expected
+}

--- a/typos.toml
+++ b/typos.toml
@@ -34,3 +34,4 @@ enabled_indented_mutiline_value = "enabled_indented_mutiline_value"
 
 [default.extend-words]
 ratatui = "ratatui"
+abd = "abd"


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
introduces `std-rfc`/`str lcp` calculating longest common prefix for a list of strings 

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
