### PR TITLE
fix: preserve metadata when rendering `Custom` value in `table` command

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -479,8 +479,10 @@ fn handle_table_command(mut input: CmdInput<'_>) -> ShellResult<PipelineData> {
             // instead of stdout.
             Err(*error)
         }
-        PipelineData::Value(Value::Custom { val, .. }, ..) => {
-            let base_pipeline = val.to_base_value(span)?.into_pipeline_data();
+        PipelineData::Value(Value::Custom { val, .. }, metadata) => {
+            let base_pipeline = val
+                .to_base_value(span)?
+                .into_pipeline_data_with_metadata(metadata);
             Table.run(input.engine_state, input.stack, input.call, base_pipeline)
         }
         PipelineData::Value(Value::Range { val, .. }, metadata) => {


### PR DESCRIPTION


## Release notes summary - What our users need to know
### `table` command now respects metadata of `Custom` values.

```nushell
# before nushell didn't render the `cwd` column like paths
# now it does
history | metadata set --path-columns [cwd] | table --icons
```