### PR TITLE
Update rmcp to version 1.3.0 and adjust session manager configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6954,9 +6954,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rmcp"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
+checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
 dependencies = [
  "async-trait",
  "base64",
@@ -6985,9 +6985,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/nu-mcp/Cargo.toml
+++ b/crates/nu-mcp/Cargo.toml
@@ -18,7 +18,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.111.1", features = ["plugi
 nu-engine = { path = "../nu-engine", version = "0.111.1" }
 nu-parser = { path = "../nu-parser", version = "0.111.1" }
 
-rmcp = { version = "1.2.0", features = ["server", "transport-io", "schemars", "transport-streamable-http-server"] }
+rmcp = { version = "1.3.0", features = ["server", "transport-io", "schemars", "transport-streamable-http-server"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "service"] }
 schemars = "1.2.1"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/nu-mcp/src/lib.rs
+++ b/crates/nu-mcp/src/lib.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -20,7 +19,6 @@ use rmcp::{
 };
 use server::NushellMcpServer;
 use tokio::runtime::Runtime;
-use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use tracing_subscriber::EnvFilter;
 
@@ -116,13 +114,13 @@ async fn run_http_server(
     // Create cancellation token to propagate shutdown to all sessions/streams
     let cancellation_token = CancellationToken::new();
 
-    let session_manager = Arc::new(LocalSessionManager {
-        sessions: RwLock::new(HashMap::new()),
-        session_config: SessionConfig {
-            channel_capacity: SESSION_CHANNEL_CAPACITY,
-            keep_alive: Some(SESSION_KEEP_ALIVE),
-        },
-    });
+    let mut session_config = SessionConfig::default();
+    session_config.channel_capacity = SESSION_CHANNEL_CAPACITY;
+    session_config.keep_alive = Some(SESSION_KEEP_ALIVE);
+
+    let mut session_manager = LocalSessionManager::default();
+    session_manager.session_config = session_config;
+    let session_manager = Arc::new(session_manager);
 
     let service = TowerToHyperService::new(StreamableHttpService::new(
         {


### PR DESCRIPTION
This PR updates rmcp to 1.3.0

## Release notes summary - What our users need to know
N/A

## Tasks after submitting
N/A