### PR TITLE
docs: fix typo in flags section comment

### DIFF
--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -841,7 +841,7 @@ fn write_flag_to_long_desc<F>(
 pub fn get_flags_section<F>(
     signature: &Signature,
     help_style: &HelpStyle,
-    mut formatter: F, // format default Value or text with code (because some calls cant access config or nu-highlight)
+    mut formatter: F, // format default Value or text with code (because some calls cannot access config or nu-highlight)
 ) -> String
 where
     F: FnMut(FormatterValue) -> String,


### PR DESCRIPTION
## Summary

Fix a typo in an internal documentation comment in `documentation.rs`.

## Related issue

N/A. This is a trivial comment-only fix.

## Guideline alignment

- Followed the repository contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
- The change is limited to an internal code comment and does not affect behavior.

## Validation/testing

Not run. This is a comment-only change.

## Release notes summary - What our users need to know

N/A. This is an internal comment typo fix only.

## Tasks after submitting

- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)

N/A for the task above because this PR does not change user-facing behavior or docs.
