### PR TITLE
fix: handle `application/x-nuon` content-type in http commands

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -1013,7 +1013,15 @@ fn transform_response_using_content_type(
                     .extension()
                     .map(|name| name.to_string_lossy().to_string())
             }),
-        _ => Some(content_type.subtype().to_string()),
+        _ => {
+            let subtype = content_type.subtype().as_str();
+            Some(
+                subtype
+                    .strip_prefix("x-")
+                    .unwrap_or(subtype)
+                    .to_string(),
+            )
+        }
     };
 
     let output = response_to_buffer(resp, engine_state, span);

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -299,6 +299,23 @@ fn http_get_with_unknown_mime_type() -> Result {
 }
 
 #[test]
+fn http_get_with_x_prefix_mime_type() -> Result {
+    let mut server = Server::new();
+    let _mock = server
+        .mock("GET", "/foo")
+        .with_status(200)
+        // `application/x-nuon` is the correct MIME type for nuon data format
+        .with_header("content-type", "application/x-nuon")
+        .with_body("[1 2 3]")
+        .create();
+
+    // `x-` prefix should be stripped so `from nuon` is used as the converter
+    let code = format!("http get {url}/foo", url = server.url());
+
+    test().run(code).expect_value_eq([1, 2, 3])
+}
+
+#[test]
 fn http_get_timeout() -> Result {
     let mut server = Server::new();
     let _mock = server


### PR DESCRIPTION
# Description

Fixes #17921

The `http` commands (e.g. `http get`) automatically parse responses based on their content-type by looking up a `from {subtype}` converter. For `application/nuon`, this correctly finds `from nuon`. However, `application/x-nuon` — which is the [correct MIME type for nuon data format](https://www.nushell.sh/lang-guide/chapters/mime_types.html) — produces subtype `x-nuon`, and `from x-nuon` doesn't exist.

This PR strips the `x-` prefix from MIME subtypes when looking up converters, so `application/x-nuon` correctly maps to `from nuon`. The `x-` prefix is a standard MIME convention for unregistered/vendor types, so this fix is general-purpose and will work for any `x-` prefixed content type that has a matching converter.

# User-Facing Changes

`http get` (and other `http` commands) now correctly auto-parse responses with `application/x-nuon` content-type using `from nuon`, instead of returning raw bytes.

# Tests + Formatting

Added `http_get_with_x_prefix_mime_type` test that verifies `application/x-nuon` responses are parsed as nuon. All existing http tests continue to pass.