### PR TITLE
fix(parser): an edge case of parse_unit_value

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2969,7 +2969,9 @@ pub fn parse_unit_value<'res>(
     transform: fn(String) -> String,
 ) -> Option<ParseUnitResult<'res>> {
     if bytes.len() < 2
-        || !(bytes[0].is_ascii_digit() || (bytes[0] == b'-' && bytes[1].is_ascii_digit()))
+        || !(bytes[0].is_ascii_digit()
+            || bytes[0] == b'.'
+            || (bytes[0] == b'-' && bytes[1].is_ascii_digit()))
     {
         return None;
     }

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -812,6 +812,11 @@ fn extern_errors_with_no_space_between_params_and_name_2() -> TestResult {
 }
 
 #[test]
+fn duration_with_float_number() -> TestResult {
+    run_test(".6min", "36sec")
+}
+
+#[test]
 fn duration_with_underscores_1() -> TestResult {
     run_test("420_min", "7hr")
 }


### PR DESCRIPTION
Fixes the 1st issue of #17913

The other issue requires more changes. Maybe I don't know some background stories, but current `parse_unit_value` looks really weirdly complicated in my eyes. I may overhaul it in the future if I get more motivated.

## Release notes summary - What our users need to know

Fixed a bug of duration/filesize parsing with numbers started by `.`, e.g. `.5sec`

## Tasks after submitting

N/A