### PR TITLE
chore: update to noun to use list of recors syntax when applicable

### DIFF
--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -236,33 +236,54 @@ fn value_to_string(
                         format!("{idt}{string}")
                     })
                     .collect();
-                let headers_output = headers.join(&format!(",{sep}{nl}{idt_pt}"));
 
-                let mut table_output = vec![];
-                for val in vals {
-                    let mut row = vec![];
+                let record_rows = |fmt_row: &dyn Fn(Vec<String>) -> String| {
+                    vals.iter()
+                        .filter_map(|val| {
+                            let Value::Record { val, .. } = val else {
+                                return None;
+                            };
+                            Some(
+                                val.values()
+                                    .map(|v| {
+                                        value_to_string_without_quotes(
+                                            engine_state,
+                                            v,
+                                            span,
+                                            depth + 2,
+                                            indent,
+                                            options,
+                                        )
+                                    })
+                                    .collect::<Result<Vec<_>, _>>()
+                                    .map(fmt_row),
+                            )
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                };
 
-                    if let Value::Record { val, .. } = val {
-                        for val in val.values() {
-                            row.push(value_to_string_without_quotes(
-                                engine_state,
-                                val,
-                                span,
-                                depth + 2,
-                                indent,
-                                options,
-                            )?);
-                        }
-                    }
+                if indent.is_some_and(|i| !i.is_empty()) {
+                    let header_row = format!("[ {} ];", headers.join(", "));
 
-                    table_output.push(row.join(&format!(",{sep}{nl}{idt_pt}")));
+                    let value_rows = record_rows(&|row| format!("[ {} ]", row.join(", ")))?
+                        .join(&format!(",{nl}{idt_po}"));
+
+                    Ok(format!(
+                        "[{nl}{idt_po}{}{sep}{nl}{idt_po}{}{nl}{idt}]",
+                        header_row, value_rows
+                    ))
+                } else {
+                    let headers_output = headers.join(&format!(",{sep}{nl}{idt_pt}"));
+
+                    let table_output =
+                        record_rows(&|row| row.join(&format!(",{sep}{nl}{idt_pt}")))?
+                            .join(&format!("{nl}{idt_po}],{sep}{nl}{idt_po}[{nl}{idt_pt}"));
+
+                    Ok(format!(
+                        "[{nl}{idt_po}[{nl}{idt_pt}{}{nl}{idt_po}];{sep}{nl}{idt_po}[{nl}{idt_pt}{}{nl}{idt_po}]{nl}{idt}]",
+                        headers_output, table_output
+                    ))
                 }
-
-                Ok(format!(
-                    "[{nl}{idt_po}[{nl}{idt_pt}{}{nl}{idt_po}];{sep}{nl}{idt_po}[{nl}{idt_pt}{}{nl}{idt_po}]{nl}{idt}]",
-                    headers_output,
-                    table_output.join(&format!("{nl}{idt_po}],{sep}{nl}{idt_po}[{nl}{idt_pt}"))
-                ))
             } else if is_table && options.list_of_records {
                 let mut collection = vec![];
                 let row_indent = if indent == Some("") { Some("") } else { None };


### PR DESCRIPTION
This or will update `to noun --indent` to use list of records syntax when applicable, this relates to #16320, this is only applicable in case's where it can be used for example  `[{column1: 1, column2: 2}, {column1: 3, column2: 4}] | to nuon --indent 2` here this is applicable because we use the header values `column1` and `column2` to define the pair values, this is not applicable in this case `[1 2 3] | to nuon --indent 2` and will be pretty printed in the table-literal syntax as before

## Release notes summary - What our users need to know
to `nuon --indent` now prints lists of records in a clearer format when the data has named fields

```bash
> [{column1: 1, column2: 2}, {column1: 3, column2: 4}] | to nuon --indent 2                                                    
[
  [ "column1", "column2" ];
  [ 1, 2 ],
  [ 3, 4 ]
]
```

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
