### PR TITLE
chore: Update to noun output to be more compact when `--indent n` is used

### DIFF
--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -263,9 +263,9 @@ fn value_to_string(
                 };
 
                 if indent.is_some_and(|i| !i.is_empty()) {
-                    let header_row = format!("[ {} ];", headers.join(", "));
+                    let header_row = format!("[{}];", headers.join(", "));
 
-                    let value_rows = record_rows(&|row| format!("[ {} ]", row.join(", ")))?
+                    let value_rows = record_rows(&|row| format!("[{}]", row.join(", ")))?
                         .join(&format!(",{nl}{idt_po}"));
 
                     Ok(format!(


### PR DESCRIPTION
to nuon --indent now outputs data more compactly for improved readability. This relates to #16320, the idea is to make the output of  `to noun --indent` output format not take up so many lines

## Release notes summary - What our users need to know
### More compact output for `to nuon --indent n`
to `nuon --indent n` will print in a more compact output
#### Before
```bash
> [{column1: 1, column2: 2}, {column1: 3, column2: 4}] | to nuon --indent 2
[
  [
    "column1",
    "column2"
  ];
  [
    1,
    2
  ],
  [
    3,
    4
  ]
]
```
#### After
```bash
> [{column1: 1, column2: 2}, {column1: 3, column2: 4}] | to nuon --indent 2                                                    
[
  ["column1", "column2"];
  [1, 2],
  [3, 4]
]
```


## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
[ ] Update the [documentation](https://github.com/nushell/nushell.github.io)