### PR TITLE
fix: failed to parse manifest error

### DIFF
--- a/crates/nu-parser/fuzz/Cargo.toml
+++ b/crates/nu-parser/fuzz/Cargo.toml
@@ -2,8 +2,7 @@
 name = "nu-parser-fuzz"
 version = "0.0.0"
 publish = false
-edition.workspace = true
-rust-version.workspace = true
+edition = "2024"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/nu-path/fuzz/Cargo.toml
+++ b/crates/nu-path/fuzz/Cargo.toml
@@ -2,8 +2,7 @@
 name = "nu-path-fuzz"
 version = "0.0.0"
 publish = false
-edition.workspace = true
-rust-version.workspace = true
+edition = "2024"
 
 [package.metadata]
 cargo-fuzz = true


### PR DESCRIPTION
Fix https://github.com/nushell/nushell/pull/17931#discussion_r3019117351

Removed `rust-version` to avoid duplicating MSRV in these unpublished fuzz crates.