### PR TITLE
fix(nu-command/reject): make `reject` command forward error value properly

### DIFF
--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -279,8 +279,11 @@ fn reject(
             let result = stream
                 .into_iter()
                 .map(move |mut value| {
-                    let span = value.span();
+                    if let Value::Error { .. } = value {
+                        return value;
+                    }
 
+                    let span = value.span();
                     for cell_path in new_columns.iter() {
                         if let Err(error) = value.remove_data_at_cell_path(&cell_path.members) {
                             return Value::error(error, span);


### PR DESCRIPTION
fixes #17953 

## Release notes summary - What our users need to know
### Fixed error propagation for `reject
Fixed an error in `reject` command where an error value in the input would return `column_not_found` error instead of propagating the error.

#### Before
```nushell
❯ ls | insert foo { error make { msg: 'boo' } } | reject name
Error: nu::shell::column_not_found

  × Cannot find column 'name'
   ╭─[repl_entry #12:1:6]
 1 │ ls | insert foo { error make { msg: 'boo' } } | reject name
   ·      ───┬──                                            ──┬─
   ·         │                                                ╰── cannot find column 'name'
   ·         ╰── value originates here
   ╰────
```
#### After
```nushell
❯ ls | insert foo { error make { msg: 'boo' } } | reject name
Error: nu::shell::error

  × boo
   ╭─[repl_entry #1:1:31]
 1 │  ls | insert foo { error make { msg: 'boo' } } | reject name
   ·                               ──────────────
   ╰────
```
