### PR TITLE
fix(http): handle x- vendor prefix in Content-Type for automatic parsing

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -1013,7 +1013,10 @@ fn transform_response_using_content_type(
                     .extension()
                     .map(|name| name.to_string_lossy().to_string())
             }),
-        _ => Some(content_type.subtype().to_string()),
+        _ => {
+            let subtype = content_type.subtype().as_str();
+            Some(subtype.strip_prefix("x-").unwrap_or(subtype).to_string())
+        }
     };
 
     let output = response_to_buffer(resp, engine_state, span);

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -299,6 +299,22 @@ fn http_get_with_unknown_mime_type() -> Result {
 }
 
 #[test]
+fn http_get_with_x_prefixed_mime_type() -> Result {
+    let mut server = Server::new();
+    let _mock = server
+        .mock("GET", "/foo")
+        .with_status(200)
+        // `application/x-nuon` is the documented MIME type for nuon in nushell
+        .with_header("content-type", "application/x-nuon")
+        .with_body("[1 2 3]")
+        .create();
+
+    let code = format!("http get {url}/foo", url = server.url());
+
+    test().run(code).expect_value_eq([1, 2, 3])
+}
+
+#[test]
 fn http_get_timeout() -> Result {
     let mut server = Server::new();
     let _mock = server


### PR DESCRIPTION
Fixes #17921.

`http get` auto-parses responses by looking up a `from <subtype>` command. For `application/x-nuon` (the [documented MIME type](https://www.nushell.sh/lang-guide/chapters/mime_types.html#mime-types-for-nushell) for nuon), `subtype()` returns `"x-nuon"` — but `from x-nuon` does not exist.

Strip the `x-` prefix before the lookup so `application/x-nuon` → `from nuon`, `application/x-yaml` → `from yaml`, etc.

```rust
// before
_ => Some(content_type.subtype().to_string()),

// after
_ => {
    let subtype = content_type.subtype().as_str();
    Some(subtype.strip_prefix("x-").unwrap_or(subtype).to_string())
}
```

## Release notes summary - What our users need to know
`http get` now also automatically parses `x-`-prefixed mime types like `application/x-nuon`.