### PR TITLE
ci: add affected-crate detection to skip unchanged tests

### DIFF
--- a/.affected.toml
+++ b/.affected.toml
@@ -1,0 +1,4 @@
+ignore = ["*.md", "docs/**", ".github/**", "LICENSE*", "*.txt", "*.yml", "*.yaml", "*.nu"]
+
+[test]
+cargo = "cargo test -p {package}"

--- a/.github/workflows/affected-test.yml
+++ b/.github/workflows/affected-test.yml
@@ -1,0 +1,81 @@
+# Experimental: Run tests only for crates affected by a PR.
+# Nushell currently runs --workspace --exclude nu_plugin_* — this workflow
+# uses the Cargo dependency graph to test only what changed.
+#
+# Tool: https://github.com/Rani367/affected
+
+name: Affected Tests (experimental)
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  detect:
+    name: Detect affected crates
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.affected.outputs.matrix }}
+      has_affected: ${{ steps.affected.outputs.has_affected }}
+      count: ${{ steps.affected.outputs.count }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: Rani367/setup-affected@750ce2e1ff1be73b511666ea7ddc9a76b4dd80f2 # v1
+
+      - name: Detect affected crates
+        id: affected
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: affected ci --merge-base "origin/${BASE_REF:-main}"
+
+      - name: Summary
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          AFFECTED_COUNT: ${{ steps.affected.outputs.count }}
+        run: |
+          {
+            echo "### Affected Crates (${AFFECTED_COUNT})"
+            echo ""
+            affected list --merge-base "origin/${BASE_REF:-main}" --explain
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  test:
+    name: "test / ${{ matrix.package }}"
+    needs: detect
+    if: needs.detect.outputs.has_affected == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix: ${{ fromJson(needs.detect.outputs.matrix) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-on-failure: true
+
+      - name: "Test ${{ matrix.package }}"
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: cargo test -p "$PACKAGE"


### PR DESCRIPTION
## Problem

This repo has **41 crates** in its Cargo workspace. CI currently runs `cargo test --workspace --exclude nu_plugin_*` on every PR.

I analyzed the last 12 commits on `main`:

| Commit | Message | Affected | Total | Reduction |
|--------|---------|----------|-------|-----------|
| `8a5a9ae` | allow par-each to stream except with --keep-order | 31 | 41 | **24%** |
| `26e3790` | Add test_cell_path!() macro | 32 | 41 | **22%** |
| `d1db88c` | refactor(nu-command): update tests for reject | 32 | 41 | **22%** |
| `664e699` | Streamline CI Cargo Checks | 37 | 41 | **10%** |

Related: #10729 (Better way to sync CI tests with `toolkit check pr`)

## What this PR adds

- **`.affected.toml`** — config file (ignores docs/markdown/CI/nushell script files)
- **`.github/workflows/affected-test.yml`** — experimental workflow that:
  1. Detects affected crates via `affected ci` (reads `cargo metadata`, diffs changed files, walks dependency graph)
  2. Creates a dynamic GitHub Actions matrix
  3. Runs `cargo test -p <crate>` per affected crate

**This runs alongside existing CI — it does NOT replace anything.**

## What `affected` is

[`affected`](https://github.com/Rani367/affected) — single 5MB Rust binary, zero config, MIT licensed. Auto-detects Cargo workspaces. Has a [GitHub Action](https://github.com/Rani367/setup-affected) and [PR comment bot](https://github.com/Rani367/affected-pr-comment).