### PR TITLE
revert: allow default values in external signatures

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4615,14 +4615,7 @@ pub fn parse_signature_helper(
                             parse_mode = ParseMode::AfterType;
                         }
                         ParseMode::DefaultValue => {
-                            if is_external {
-                                working_set.error(ParseError::LabeledError(
-                                    "Default values are not allowed for external commands."
-                                        .to_string(),
-                                    "Remove the default value.".to_string(),
-                                    span,
-                                ));
-                            } else if let Some(last) = args.last_mut() {
+                            if !is_external && let Some(last) = args.last_mut() {
                                 let expression = parse_value(working_set, span, &SyntaxShape::Any);
 
                                 //TODO check if we're replacing a custom parameter already

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -827,11 +827,8 @@ fn extern_with_reserved_variable_name_2() -> TestResult {
 }
 
 #[test]
-fn extern_errors_with_default_value_in_signature() -> TestResult {
-    fail_test(
-        "extern cmd [in: bool=true]",
-        "Default values are not allowed for external commands",
-    )
+fn extern_allows_default_value_in_signature() -> TestResult {
+    run_test("extern cmd [in: bool=true]", "")
 }
 
 #[test]


### PR DESCRIPTION
For help messaging, as noted [here](https://github.com/nushell/nushell/pull/17903#issuecomment-4180421671)

## Release notes summary - What our users need to know

None, updated in #17903

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
