### PR TITLE
refactor(parser): move the pipe tokens in AST 1 element ahead

### DIFF
--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -131,11 +131,11 @@ fn flatten_pipeline_element_into(
     pipeline_element: &PipelineElement,
     output: &mut Vec<(Span, FlatShape)>,
 ) {
+    flatten_expression_into(working_set, &pipeline_element.expr, output);
+
     if let Some(span) = pipeline_element.pipe {
         output.push((span, FlatShape::Pipe));
     }
-
-    flatten_expression_into(working_set, &pipeline_element.expr, output);
 
     if let Some(redirection) = pipeline_element.redirection.as_ref() {
         match redirection {

--- a/crates/nu-parser/src/lite_parser.rs
+++ b/crates/nu-parser/src/lite_parser.rs
@@ -332,8 +332,8 @@ pub fn lite_parse(
                             error = error
                                 .or(Some(ParseError::Expected("redirection target", token.span)));
                             command.push(span);
-                            pipeline.push(&mut command);
                             command.pipe = Some(token.span);
+                            pipeline.push(&mut command);
                         }
                         TokenContents::Eol => {
                             error = error
@@ -433,8 +433,8 @@ pub fn lite_parse(
                             {
                                 error = error.or(Some(err));
                             }
-                            pipeline.push(&mut command);
                             command.pipe = Some(token.span);
+                            pipeline.push(&mut command);
                         }
                         TokenContents::OutErrGreaterPipe => {
                             let target = LiteRedirectionTarget::Pipe {
@@ -445,12 +445,12 @@ pub fn lite_parse(
                             {
                                 error = error.or(Some(err));
                             }
-                            pipeline.push(&mut command);
                             command.pipe = Some(token.span);
+                            pipeline.push(&mut command);
                         }
                         TokenContents::Pipe => {
-                            pipeline.push(&mut command);
                             command.pipe = Some(token.span);
+                            pipeline.push(&mut command);
                         }
                         TokenContents::Eol => {
                             // Handle `[Command] [Pipe] ([Comment] | [Eol])+ [Command]`


### PR DESCRIPTION
Fixes #17957

This could potentially be dangerous! I have no idea whether there're features implemented based on this bug/feature.

This has a hard conflict with #17932, and is better addressed before that.

## Release notes summary - What our users need to know

Fixed a bug of lossy parsing of incomplete pipelines end with `|`, which is noticeable via REPL highlighting.