### PR TITLE
Use `TryIntoValue` for `PipelineData`

### DIFF
--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -190,7 +190,7 @@ impl<T: Completer> Completer for CustomCompletion<T> {
         let mut should_filter = true;
 
         // Parse result
-        let suggestions = match result.and_then(|data| data.into_value(span)) {
+        let suggestions = match result.and_then(|data| data.try_into_value(span)) {
             Ok(value) => match &value {
                 Value::Record { val, .. } => {
                     let completions = val
@@ -435,7 +435,7 @@ fn convert_whole_command_completion_results(
     result: Result<PipelineData, nu_protocol::ShellError>,
     command_span: Span,
 ) -> Option<Vec<SemanticSuggestion>> {
-    let value = match result.and_then(|pipeline_data| pipeline_data.into_value(span)) {
+    let value = match result.and_then(|pipeline_data| pipeline_data.try_into_value(span)) {
         Ok(value) => value,
         Err(err) => {
             log::error!(

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -4,7 +4,7 @@ use nu_engine::{compile, eval_call};
 use nu_parser::flatten_expression;
 use nu_protocol::{
     BlockId, DeclId, GetSpan, IntoSpanned, PipelineData, Record, ShellError, Span, Spanned,
-    SuggestionKind, Type, Value, VarId,
+    SuggestionKind, TryIntoValue, Type, Value, VarId,
     ast::{Argument, Call, Expr, Expression},
     debugger::WithoutDebug,
     engine::{Closure, EngineState, Stack, StateWorkingSet},

--- a/crates/nu-cli/src/hints/external_hinter.rs
+++ b/crates/nu-cli/src/hints/external_hinter.rs
@@ -2,7 +2,7 @@ use log::error;
 use nu_ansi_term::Style;
 use nu_engine::ClosureEvalOnce;
 use nu_protocol::{
-    PipelineData, Record, Span, Value,
+    PipelineData, Record, Span, TryIntoValue, Value,
     engine::{Closure, EngineState, Stack},
 };
 use reedline::{Hinter, History};

--- a/crates/nu-cli/src/hints/external_hinter.rs
+++ b/crates/nu-cli/src/hints/external_hinter.rs
@@ -72,7 +72,7 @@ impl ExternalHinter {
         let result = ClosureEvalOnce::new(self.engine_state.as_ref(), &stack, self.closure.clone())
             .add_arg(Value::record(context, span))
             .run_with_input(PipelineData::empty())
-            .and_then(|data| data.into_value(span));
+            .and_then(|data| data.try_into_value(span));
 
         match result {
             Ok(Value::String { val, .. }) => Ok(Some(HintResult {

--- a/crates/nu-cli/src/menus/menu_completions.rs
+++ b/crates/nu-cli/src/menus/menu_completions.rs
@@ -60,7 +60,7 @@ impl Completer for NuMenuCompleter {
         let res = eval_block::<WithoutDebug>(&self.engine_state, &mut self.stack, block, input)
             .map(|p| p.body);
 
-        if let Ok(values) = res.and_then(|data| data.into_value(self.span)) {
+        if let Ok(values) = res.and_then(|data| data.try_into_value(self.span)) {
             convert_to_suggestions(values, line, pos, self.only_buffer_difference)
         } else {
             Vec::new()

--- a/crates/nu-cli/src/menus/menu_completions.rs
+++ b/crates/nu-cli/src/menus/menu_completions.rs
@@ -1,6 +1,6 @@
 use nu_engine::eval_block;
 use nu_protocol::{
-    BlockId, IntoPipelineData, Span, Value,
+    BlockId, IntoPipelineData, Span, TryIntoValue, Value,
     debugger::WithoutDebug,
     engine::{EngineState, Stack},
 };

--- a/crates/nu-cmd-extra/src/extra/filters/each_while.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/each_while.rs
@@ -82,7 +82,7 @@ impl Command for EachWhile {
                     .map_while(move |value| {
                         match closure
                             .run_with_value(value)
-                            .and_then(|data| data.into_value(head))
+                            .and_then(|data| data.try_into_value(head))
                         {
                             Ok(value) => (!value.is_nothing()).then_some(value),
                             Err(_) => None,
@@ -100,7 +100,7 @@ impl Command for EachWhile {
                             let value = value.ok()?;
                             match closure
                                 .run_with_value(value)
-                                .and_then(|data| data.into_value(span))
+                                .and_then(|data| data.try_into_value(span))
                             {
                                 Ok(value) => (!value.is_nothing()).then_some(value),
                                 Err(_) => None,

--- a/crates/nu-cmd-extra/src/extra/filters/each_while.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/each_while.rs
@@ -1,5 +1,5 @@
 use nu_engine::{ClosureEval, ClosureEvalOnce, command_prelude::*};
-use nu_protocol::engine::Closure;
+use nu_protocol::{TryIntoValue, engine::Closure};
 
 #[derive(Clone)]
 pub struct EachWhile;

--- a/crates/nu-cmd-extra/src/extra/filters/roll/roll_down.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/roll_down.rs
@@ -57,7 +57,7 @@ impl Command for RollDown {
         let by: Option<usize> = call.get_flag(engine_state, stack, "by")?;
         let metadata = input.take_metadata();
 
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         let rotated_value = vertical_rotate_value(value, by, VerticalDirection::Down)?;
 
         Ok(rotated_value.into_pipeline_data().set_metadata(metadata))

--- a/crates/nu-cmd-extra/src/extra/filters/roll/roll_down.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/roll_down.rs
@@ -1,5 +1,6 @@
 use super::{VerticalDirection, vertical_rotate_value};
 use nu_engine::command_prelude::*;
+use nu_protocol::TryIntoValue;
 
 #[derive(Clone)]
 pub struct RollDown;

--- a/crates/nu-cmd-extra/src/extra/filters/roll/roll_left.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/roll_left.rs
@@ -1,5 +1,6 @@
 use super::{HorizontalDirection, horizontal_rotate_value};
 use nu_engine::command_prelude::*;
+use nu_protocol::TryIntoValue;
 
 #[derive(Clone)]
 pub struct RollLeft;

--- a/crates/nu-cmd-extra/src/extra/filters/roll/roll_left.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/roll_left.rs
@@ -95,7 +95,7 @@ impl Command for RollLeft {
         let metadata = input.take_metadata();
 
         let cells_only = call.has_flag(engine_state, stack, "cells-only")?;
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         let rotated_value =
             horizontal_rotate_value(value, by, cells_only, &HorizontalDirection::Left)?;
 

--- a/crates/nu-cmd-extra/src/extra/filters/roll/roll_right.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/roll_right.rs
@@ -1,5 +1,6 @@
 use super::{HorizontalDirection, horizontal_rotate_value};
 use nu_engine::command_prelude::*;
+use nu_protocol::TryIntoValue;
 
 #[derive(Clone)]
 pub struct RollRight;

--- a/crates/nu-cmd-extra/src/extra/filters/roll/roll_right.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/roll_right.rs
@@ -95,7 +95,7 @@ impl Command for RollRight {
         let metadata = input.take_metadata();
 
         let cells_only = call.has_flag(engine_state, stack, "cells-only")?;
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         let rotated_value =
             horizontal_rotate_value(value, by, cells_only, &HorizontalDirection::Right)?;
 

--- a/crates/nu-cmd-extra/src/extra/filters/roll/roll_up.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/roll_up.rs
@@ -57,7 +57,7 @@ impl Command for RollUp {
         let by: Option<usize> = call.get_flag(engine_state, stack, "by")?;
         let metadata = input.take_metadata();
 
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         let rotated_value = vertical_rotate_value(value, by, VerticalDirection::Up)?;
 
         Ok(rotated_value.into_pipeline_data_with_metadata(metadata))

--- a/crates/nu-cmd-extra/src/extra/filters/roll/roll_up.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/roll_up.rs
@@ -1,5 +1,6 @@
 use super::{VerticalDirection, vertical_rotate_value};
 use nu_engine::command_prelude::*;
+use nu_protocol::TryIntoValue;
 
 #[derive(Clone)]
 pub struct RollUp;

--- a/crates/nu-cmd-extra/src/extra/filters/update_cells.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/update_cells.rs
@@ -1,5 +1,5 @@
 use nu_engine::{ClosureEval, command_prelude::*};
-use nu_protocol::{PipelineIterator, engine::Closure};
+use nu_protocol::{PipelineIterator, TryIntoValue, engine::Closure};
 use std::collections::HashSet;
 
 #[derive(Clone)]

--- a/crates/nu-cmd-extra/src/extra/filters/update_cells.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/update_cells.rs
@@ -188,7 +188,7 @@ impl Iterator for UpdateCellIterator {
 fn eval_value(closure: &mut ClosureEval, span: Span, value: Value) -> Value {
     closure
         .run_with_value(value)
-        .and_then(|data| data.into_value(span))
+        .and_then(|data| data.try_into_value(span))
         .unwrap_or_else(|err| Value::error(err, span))
 }
 

--- a/crates/nu-cmd-extra/src/extra/strings/format/command.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/command.rs
@@ -1,7 +1,8 @@
 use itertools::Itertools;
 use nu_engine::command_prelude::*;
 use nu_protocol::{
-    Config, ListStream, ast::PathMember, casing::Casing, shell_error::generic::GenericError,
+    Config, ListStream, TryIntoValue, ast::PathMember, casing::Casing,
+    shell_error::generic::GenericError,
 };
 
 #[derive(Clone)]

--- a/crates/nu-cmd-extra/src/extra/strings/format/command.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/command.rs
@@ -39,7 +39,7 @@ impl Command for FormatPattern {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let pattern: Spanned<String> = call.req(engine_state, stack, 0)?;
-        let input_val = input.into_value(call.head)?;
+        let input_val = input.try_into_value(call.head)?;
 
         let ops = extract_formatting_operations(pattern, call.head)?;
         let config = stack.get_config(engine_state);

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -131,7 +131,7 @@ the most recent `error make`."
         };
         let show_labels: bool = !call.has_flag(engine_state, stack, "unspanned")?;
 
-        let inners = match ErrorInfo::from_value(input.into_value(call.head)?) {
+        let inners = match ErrorInfo::from_value(input.try_into_value(call.head)?) {
             Ok(v) => vec![v.into_value(call.head)],
             Err(_) => vec![],
         };

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::{ErrorLabel, ErrorSource, FromValue, IntoValue, LabeledError};
+use nu_protocol::{ErrorLabel, ErrorSource, FromValue, IntoValue, LabeledError, TryIntoValue};
 
 #[derive(Clone)]
 pub struct ErrorMake;

--- a/crates/nu-cmd-lang/src/core_commands/let_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/let_.rs
@@ -1,8 +1,6 @@
 use nu_engine::command_prelude::*;
 use nu_engine::eval_expression;
-use nu_protocol::ast::Expr;
-use nu_protocol::debugger::WithoutDebug;
-use nu_protocol::engine::CommandType;
+use nu_protocol::{TryIntoValue, ast::Expr, debugger::WithoutDebug, engine::CommandType};
 
 #[derive(Clone)]
 pub struct Let;

--- a/crates/nu-cmd-lang/src/core_commands/let_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/let_.rs
@@ -83,11 +83,11 @@ impl Command for Let {
                 }
             }
             // Discard input when using = syntax
-            let _ = input.into_value(call.head)?;
+            let _ = input.try_into_value(call.head)?;
             eval_expression::<WithoutDebug>(engine_state, stack, initial_value_expr)?
         } else {
             // Use pipeline input directly when no = is provided
-            input.into_value(call.head)?
+            input.try_into_value(call.head)?
         };
 
         // If the variable is declared `: glob` and the RHS is a string,

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -1,7 +1,8 @@
 use itertools::Itertools;
 use nu_engine::{command_prelude::*, compile};
 use nu_protocol::{
-    Range, ast::Block, debugger::WithoutDebug, engine::StateWorkingSet, report_shell_error,
+    Range, TryIntoValue, ast::Block, debugger::WithoutDebug, engine::StateWorkingSet,
+    report_shell_error,
 };
 use std::{
     sync::Arc,

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -131,7 +131,7 @@ pub fn eval_block(
 
     nu_engine::eval_block::<WithoutDebug>(engine_state, &mut stack, &block, input)
         .map(|p| p.body)
-        .and_then(|data| data.into_value(Span::test_data()))
+        .and_then(|data| data.try_into_value(Span::test_data()))
         .unwrap_or_else(|err| {
             report_shell_error(None, engine_state, &err);
             panic!("test eval error in `{}`: {:?}", "TODO", err)

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -59,7 +59,7 @@ impl<'a> StyleComputer<'a> {
                 let result = ClosureEvalOnce::new(self.engine_state, self.stack, closure.clone())
                     .debug(false)
                     .run_with_value(value.clone())
-                    .and_then(|data| data.into_value(*span));
+                    .and_then(|data| data.try_into_value(*span));
 
                 match result {
                     Ok(value) => {

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -2,7 +2,7 @@ use crate::{TextStyle, color_record_to_nustyle, lookup_ansi_color_style, text_st
 use nu_ansi_term::{Color, Style};
 use nu_engine::ClosureEvalOnce;
 use nu_protocol::{
-    Span, Value,
+    Span, TryIntoValue, Value,
     engine::{Closure, EngineState, Stack},
     report_shell_error,
 };

--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -138,7 +138,7 @@ impl Command for Histogram {
         };
 
         let span = call.head;
-        let data_as_value = input.into_value(span)?;
+        let data_as_value = input.try_into_value(span)?;
         let value_span = data_as_value.span();
         // `input` is not a list, here we can return an error.
         run_histogram(

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -87,7 +87,7 @@ impl SQLiteDatabase {
     }
 
     pub fn try_from_pipeline(input: PipelineData, span: Span) -> Result<Self, ShellError> {
-        let value = input.into_value(span)?;
+        let value = input.try_into_value(span)?;
         Self::try_from_value(value)
     }
 
@@ -1153,7 +1153,7 @@ impl CustomValue for SQLiteQueryBuilder {
     }
 
     fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
-        self.execute(span).and_then(|pd| pd.into_value(span))
+        self.execute(span).and_then(|pd| pd.try_into_value(span))
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -1355,7 +1355,7 @@ mod test {
 
         let table = SQLiteQueryBuilder::new(db_path, "test".to_string(), signals);
         let result = table.execute(Span::test_data()).unwrap();
-        let value = result.into_value(Span::test_data()).unwrap();
+        let value = result.try_into_value(Span::test_data()).unwrap();
 
         if let Value::List { vals, .. } = value {
             assert_eq!(vals.len(), 2);
@@ -1388,7 +1388,7 @@ mod test {
 
         let table = SQLiteQueryBuilder::new(db_path, "test".to_string(), signals).with_limit(2);
         let result = table.execute(Span::test_data()).unwrap();
-        let value = result.into_value(Span::test_data()).unwrap();
+        let value = result.try_into_value(Span::test_data()).unwrap();
 
         if let Value::List { vals, .. } = value {
             assert_eq!(vals.len(), 2);
@@ -1427,7 +1427,7 @@ mod test {
             .with_order_by("rowid DESC".to_string())
             .with_limit(2);
         let result = table.execute(Span::test_data()).unwrap();
-        let value = result.into_value(Span::test_data()).unwrap();
+        let value = result.try_into_value(Span::test_data()).unwrap();
 
         if let Value::List { vals, .. } = value {
             assert_eq!(vals.len(), 2);
@@ -1517,7 +1517,7 @@ mod test {
             .with_millis_duration_column("duration".to_string());
 
         let result = table.execute(Span::test_data()).unwrap();
-        let value = result.into_value(Span::test_data()).unwrap();
+        let value = result.try_into_value(Span::test_data()).unwrap();
 
         if let Value::List { vals, .. } = value {
             assert_eq!(vals.len(), 2);

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -3,9 +3,9 @@ use super::definitions::{
     db_index::DbIndex, db_table::DbTable,
 };
 use nu_protocol::{
-    CustomValue, IntoPipelineData, PipelineData, Record, ShellError, Signals, Span, Spanned, Value,
-    ast, casing::Casing, engine::EngineState, shell_error::generic::GenericError,
-    shell_error::io::IoError,
+    CustomValue, IntoPipelineData, PipelineData, Record, ShellError, Signals, Span, Spanned,
+    TryIntoValue, Value, ast, casing::Casing, engine::EngineState,
+    shell_error::generic::GenericError, shell_error::io::IoError,
 };
 use rusqlite::{
     Connection, Error as SqliteError, OpenFlags, Row, Statement, ToSql, types::ValueRef,

--- a/crates/nu-command/src/debug/inspect.rs
+++ b/crates/nu-command/src/debug/inspect.rs
@@ -29,7 +29,7 @@ impl Command for Inspect {
         mut input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let input_metadata = input.take_metadata();
-        let input_val = input.into_value(call.head)?;
+        let input_val = input.try_into_value(call.head)?;
         if input_val.is_nothing() {
             return Err(ShellError::PipelineEmpty {
                 dst_span: call.head,

--- a/crates/nu-command/src/debug/metadata_set.rs
+++ b/crates/nu-command/src/debug/metadata_set.rs
@@ -105,7 +105,7 @@ impl Command for MetadataSet {
 
             let result = ClosureEvalOnce::new(engine_state, stack, closure)
                 .run_with_value(metadata_value)?
-                .into_value(head)?;
+                .try_into_value(head)?;
 
             let result_record = result.as_record().map_err(|err| {
                 ShellError::Generic(

--- a/crates/nu-command/src/debug/profile.rs
+++ b/crates/nu-command/src/debug/profile.rs
@@ -156,7 +156,7 @@ confusing the id/parent_id hierarchy. The --expr flag is helpful for investigati
         let pipeline_data = result?;
 
         // Collect the output
-        let _ = pipeline_data.into_value(call.span());
+        let _ = pipeline_data.try_into_value(call.span());
 
         Ok(engine_state
             .deactivate_debugger()

--- a/crates/nu-command/src/debug/timeit.rs
+++ b/crates/nu-command/src/debug/timeit.rs
@@ -70,7 +70,7 @@ This command will bubble up any errors encountered when running the closure. The
 
         // Get the start time after all other computation has been done.
         let start_time = Instant::now();
-        let closure_output = closure.run_with_input(input)?.into_value(call.head)?;
+        let closure_output = closure.run_with_input(input)?.try_into_value(call.head)?;
         let time = Value::duration(start_time.elapsed().as_nanos() as i64, call.head);
 
         let output = if include_output {

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -244,7 +244,7 @@ impl Command for Save {
                         .map(|()| PipelineData::empty());
                 }
 
-                let bytes = value_to_bytes(converted.into_value(span)?)?;
+                let bytes = value_to_bytes(converted.try_into_value(span)?)?;
 
                 // Only open file after successful conversion
                 let (mut file, _) =

--- a/crates/nu-command/src/filters/chunk_by.rs
+++ b/crates/nu-command/src/filters/chunk_by.rs
@@ -235,7 +235,7 @@ where
 {
     chunk_iter_by(iterator, signals, move |value| {
         match closure.run_with_value(value.clone()) {
-            Ok(data) => data.into_value(head).unwrap_or_else(|error| {
+            Ok(data) => data.try_into_value(head).unwrap_or_else(|error| {
                 Value::error(chain_error_with_input(error, value.is_error(), head), head)
             }),
 

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -172,7 +172,7 @@ fn default(
     // and set the default value for the specified record columns
     if !columns.is_empty() {
         if let PipelineData::Value(Value::Record { .. }, _) = input {
-            let record = input.into_value(input_span)?.into_record()?;
+            let record = input.try_into_value(input_span)?.into_record()?;
             fill_record(
                 record,
                 input_span,
@@ -278,7 +278,7 @@ impl DefaultValue {
                 let value = closure
                     .item
                     .run_with_input(PipelineData::empty())?
-                    .into_value(closure.span)?;
+                    .try_into_value(closure.span)?;
                 *self = DefaultValue::Calculated(value.clone());
                 Ok(value)
             }

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -241,7 +241,7 @@ fn each_map(value: Value, closure: &mut ClosureEval, head: Span) -> Result<Value
     let is_error = value.is_error();
     closure
         .run_with_value(value)
-        .and_then(|pipeline_data| pipeline_data.into_value(head))
+        .and_then(|pipeline_data| pipeline_data.try_into_value(head))
         .map_err(|error| chain_error_with_input(error, is_error, span))
 }
 

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -212,7 +212,7 @@ fn first_helper(
                             // For single element, limit 1
                             let new_table = table.clone().with_limit(1);
                             let result = new_table.execute(head)?;
-                            let value = result.into_value(head)?;
+                            let value = result.try_into_value(head)?;
                             if let Value::List { vals, .. } = value {
                                 if let Some(val) = vals.into_iter().next() {
                                     Ok(val.into_pipeline_data_with_metadata(input_meta))

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -253,7 +253,7 @@ fn action(
 
         let paths = std::iter::once(cell_path).chain(rest);
 
-        let input = input.into_value(span)?;
+        let input = input.try_into_value(span)?;
 
         let mut any_cell_path_is_index = false;
 

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -410,7 +410,7 @@ fn group_closure(
     for value in values {
         let key = closure
             .run_with_value(value.clone())?
-            .into_value(span)?
+            .try_into_value(span)?
             .to_expanded_string(", ", config);
 
         groups.entry(key).or_default().push(value);

--- a/crates/nu-command/src/filters/headers.rs
+++ b/crates/nu-command/src/filters/headers.rs
@@ -60,7 +60,7 @@ impl Command for Headers {
         let config = &stack.get_config(engine_state);
         let metadata = input.take_metadata();
         let span = input.span().unwrap_or(call.head);
-        let value = input.into_value(span)?;
+        let value = input.try_into_value(span)?;
         let Value::List { vals: table, .. } = value else {
             return Err(ShellError::TypeMismatch {
                 err_message: "not a table".to_string(),

--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -191,7 +191,7 @@ fn insert_recursive(
                         let value = value.unwrap_or(Value::nothing(head_span));
                         let new_value = ClosureEvalOnce::new(engine_state, stack, *val)
                             .run_with_value(value.clone())?
-                            .into_value(head_span)?;
+                            .try_into_value(head_span)?;
 
                         pre_elems.push(new_value);
                         if !end_of_stream {
@@ -304,7 +304,9 @@ fn insert_value_by_closure(
     span: Span,
     cell_path: &[PathMember],
 ) -> Result<(), ShellError> {
-    let new_value = closure.run_with_value(value.clone())?.into_value(span)?;
+    let new_value = closure
+        .run_with_value(value.clone())?
+        .try_into_value(span)?;
     value.insert_data_at_cell_path(cell_path, new_value, span)
 }
 
@@ -326,7 +328,7 @@ fn insert_single_value_by_closure(
     } else {
         value.clone()
     };
-    let new_value = closure.run_with_value(arg)?.into_value(span)?;
+    let new_value = closure.run_with_value(arg)?.try_into_value(span)?;
     value.insert_data_at_cell_path(cell_path, new_value, span)
 }
 

--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -56,7 +56,7 @@ impl Command for Items {
                                     .add_arg(Value::string(col, span))
                                     .add_arg(val)
                                     .run_with_input(PipelineData::empty())
-                                    .and_then(|data| data.into_value(head));
+                                    .and_then(|data| data.try_into_value(head));
 
                                 match result {
                                     Ok(value) => Some(value),

--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -99,7 +99,7 @@ impl Command for Join {
         };
 
         // FIXME: we should handle ListStreams properly instead of collecting
-        let collected_input = input.into_value(span)?;
+        let collected_input = input.try_into_value(span)?;
 
         match (&collected_input, &table_2, &l_on, &r_on) {
             (

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -219,7 +219,7 @@ impl Command for Last {
                                     .with_order_by("rowid DESC".to_string())
                                     .with_limit(1);
                                 let result = new_table.execute(head)?;
-                                let value = result.into_value(head)?;
+                                let value = result.try_into_value(head)?;
                                 if let Value::List { vals, .. } = value {
                                     if let Some(val) = vals.into_iter().next() {
                                         Ok(val.into_pipeline_data_with_metadata(metadata))
@@ -243,7 +243,7 @@ impl Command for Last {
                                     .with_order_by("rowid DESC".to_string())
                                     .with_limit(rows as i64);
                                 let result = new_table.execute(head)?;
-                                let value = result.into_value(head)?;
+                                let value = result.try_into_value(head)?;
 
                                 if let Value::List { mut vals, .. } = value {
                                     // Reverse the results to restore original order

--- a/crates/nu-command/src/filters/merge/deep.rs
+++ b/crates/nu-command/src/filters/merge/deep.rs
@@ -135,7 +135,7 @@ The way lists and tables are merged is controlled by the `--strategy` flag:
         // collect input before typechecking, so tables are detected as such
         let input_span = input.span().unwrap_or(head);
         let metadata = input.take_metadata();
-        let input = input.into_value(input_span)?;
+        let input = input.try_into_value(input_span)?;
 
         let strategy = match strategy_flag.as_deref() {
             None | Some("table") => MergeStrategy::Deep(ListMerge::Elementwise),

--- a/crates/nu-command/src/filters/merge/merge_.rs
+++ b/crates/nu-command/src/filters/merge/merge_.rs
@@ -94,7 +94,7 @@ repeating this process with row 1, and so on."
         // collect input before typechecking, so tables are detected as such
         let input_span = input.span().unwrap_or(head);
         let metadata = input.take_metadata();
-        let input = input.into_value(input_span)?;
+        let input = input.try_into_value(input_span)?;
 
         typecheck_merge(&input, &merge_value, head)?;
 

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -348,7 +348,7 @@ fn run_closure_on_value(closure_eval: &mut ClosureEval, value: Value) -> Value {
 
     closure_eval
         .run_with_value(value)
-        .and_then(|data| data.into_value(span))
+        .and_then(|data| data.try_into_value(span))
         .unwrap_or_else(|err| Value::error(chain_error_with_input(err, is_error, span), span))
 }
 

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -119,7 +119,7 @@ impl Command for Reduce {
                 .add_arg(value)
                 .add_arg(acc.clone())
                 .run_with_input(PipelineData::value(acc, None))?
-                .into_value(head)?;
+                .try_into_value(head)?;
         }
 
         Ok(acc.with_span(head).into_pipeline_data())

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -298,7 +298,7 @@ fn reject(
         }
 
         input => {
-            let mut val = input.into_value(span)?;
+            let mut val = input.try_into_value(span)?;
 
             for cell_path in new_columns {
                 val.remove_data_at_cell_path(&cell_path.members)?;

--- a/crates/nu-command/src/filters/skip/skip_until.rs
+++ b/crates/nu-command/src/filters/skip/skip_until.rs
@@ -85,7 +85,7 @@ impl Command for SkipUntil {
             .skip_while(move |value| {
                 closure
                     .run_with_value(value.clone())
-                    .and_then(|data| data.into_value(head))
+                    .and_then(|data| data.try_into_value(head))
                     .map(|cond| cond.is_false())
                     .unwrap_or(false)
             })

--- a/crates/nu-command/src/filters/skip/skip_while.rs
+++ b/crates/nu-command/src/filters/skip/skip_while.rs
@@ -90,7 +90,7 @@ impl Command for SkipWhile {
             .skip_while(move |value| {
                 closure
                     .run_with_value(value.clone())
-                    .and_then(|data| data.into_value(head))
+                    .and_then(|data| data.try_into_value(head))
                     .map(|cond| cond.is_true())
                     .unwrap_or(false)
             })

--- a/crates/nu-command/src/filters/sort.rs
+++ b/crates/nu-command/src/filters/sort.rs
@@ -147,7 +147,7 @@ impl Command for Sort {
 
         let span = input.span().unwrap_or(call.head);
         let metadata = input.take_metadata();
-        let value = input.into_value(span)?;
+        let value = input.try_into_value(span)?;
         let sorted: Value = match value {
             Value::Record { val, .. } => {
                 // Records have two sorting methods, toggled by presence or absence of -v

--- a/crates/nu-command/src/filters/take/take_until.rs
+++ b/crates/nu-command/src/filters/take/take_until.rs
@@ -78,7 +78,7 @@ impl Command for TakeUntil {
             .take_while(move |value| {
                 closure
                     .run_with_value(value.clone())
-                    .and_then(|data| data.into_value(head))
+                    .and_then(|data| data.try_into_value(head))
                     .map(|cond| cond.is_false())
                     .unwrap_or(false)
             })

--- a/crates/nu-command/src/filters/take/take_while.rs
+++ b/crates/nu-command/src/filters/take/take_while.rs
@@ -81,7 +81,7 @@ impl Command for TakeWhile {
             .take_while(move |value| {
                 closure
                     .run_with_value(value.clone())
-                    .and_then(|data| data.into_value(head))
+                    .and_then(|data| data.try_into_value(head))
                     .map(|cond| cond.is_true())
                     .unwrap_or(false)
             })

--- a/crates/nu-command/src/filters/tee.rs
+++ b/crates/nu-command/src/filters/tee.rs
@@ -274,7 +274,7 @@ use it in your pipeline."
             } else {
                 // Otherwise, we can spawn a thread with the input value, but we have nowhere to
                 // send an error to other than just trying to print it to stderr.
-                let value = input.into_value(span)?;
+                let value = input.try_into_value(span)?;
                 let value_clone = value.clone();
                 tee_once(stack.clone(), engine_state_arc, move || {
                     eval_block(value_clone.into_pipeline_data_with_metadata(metadata_clone))

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -272,7 +272,7 @@ fn update_value_by_closure(
     let new_value = closure
         .add_arg(value.clone())
         .run_with_input(value_at_path.into_owned().into_pipeline_data())?
-        .into_value(span)?;
+        .try_into_value(span)?;
 
     value.update_data_at_cell_path(cell_path, new_value)
 }
@@ -307,7 +307,7 @@ fn update_single_value_by_closure(
     let new_value = closure
         .add_arg(arg.clone())
         .run_with_input(value_at_path.into_owned().into_pipeline_data())?
-        .into_value(span)?;
+        .try_into_value(span)?;
 
     value.update_data_at_cell_path(cell_path, new_value)
 }

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -217,7 +217,7 @@ fn upsert_recursive(
                     if let Value::Closure { val, .. } = replacement {
                         ClosureEvalOnce::new(engine_state, stack, *val)
                             .run_with_value(value)?
-                            .into_value(head_span)?
+                            .try_into_value(head_span)?
                     } else {
                         replacement
                     }
@@ -337,7 +337,7 @@ fn upsert_value_by_closure(
     let new_value = closure
         .add_arg(value.clone())
         .run_with_input(input)?
-        .into_value(span)?;
+        .try_into_value(span)?;
 
     value.upsert_data_at_cell_path(cell_path, new_value)
 }
@@ -371,7 +371,7 @@ fn upsert_single_value_by_closure(
     let new_value = closure
         .add_arg(arg)
         .run_with_input(input)?
-        .into_value(span)?;
+        .try_into_value(span)?;
 
     value.upsert_data_at_cell_path(cell_path, new_value)
 }

--- a/crates/nu-command/src/filters/utils.rs
+++ b/crates/nu-command/src/filters/utils.rs
@@ -32,7 +32,10 @@ pub fn boolean_fold(
 
     for value in input {
         engine_state.signals().check(&head)?;
-        let pred = closure.run_with_value(value)?.into_value(head)?.is_true();
+        let pred = closure
+            .run_with_value(value)?
+            .try_into_value(head)?
+            .is_true();
 
         if pred == accumulator {
             return Ok(Value::bool(accumulator, head).into_pipeline_data());

--- a/crates/nu-command/src/filters/utils.rs
+++ b/crates/nu-command/src/filters/utils.rs
@@ -1,6 +1,6 @@
 use nu_engine::{CallExt, ClosureEval};
 use nu_protocol::{
-    IntoPipelineData, PipelineData, ShellError, Span, Value,
+    IntoPipelineData, PipelineData, ShellError, Span, TryIntoValue, Value,
     engine::{Call, Closure, EngineState, Stack},
 };
 

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -72,7 +72,7 @@ Row conditions cannot be stored in a variable. To pass a condition with a variab
             .filter_map(move |value| {
                 match closure
                     .run_with_value(value.clone())
-                    .and_then(|data| data.into_value(head))
+                    .and_then(|data| data.try_into_value(head))
                 {
                     Ok(cond) => cond.is_true().then_some(value),
                     Err(err) => Some(Value::error(err, head)),

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -44,7 +44,7 @@ impl Command for Wrap {
                 .map(move |x| Value::record(record! { name.clone() => x }, span))
                 .into_pipeline_data_with_metadata(span, engine_state.signals().clone(), metadata)),
             PipelineData::ByteStream(stream, ..) => Ok(Value::record(
-                record! { name => stream.into_value()? },
+                record! { name => stream.try_into_value()? },
                 span,
             )
             .into_pipeline_data_with_metadata(metadata)),

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -44,7 +44,7 @@ impl Command for Wrap {
                 .map(move |x| Value::record(record! { name.clone() => x }, span))
                 .into_pipeline_data_with_metadata(span, engine_state.signals().clone(), metadata)),
             PipelineData::ByteStream(stream, ..) => Ok(Value::record(
-                record! { name => stream.try_into_value()? },
+                record! { name => stream.try_into_value(span)? },
                 span,
             )
             .into_pipeline_data_with_metadata(metadata)),

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -1,8 +1,8 @@
 use csv::WriterBuilder;
 use nu_cmd_base::formats::to::delimited::merge_descriptors;
 use nu_protocol::{
-    ByteStream, ByteStreamType, Config, PipelineData, ShellError, Signals, Span, Spanned, Value,
-    shell_error::generic::GenericError, shell_error::io::IoError,
+    ByteStream, ByteStreamType, Config, PipelineData, ShellError, Signals, Span, Spanned,
+    TryIntoValue, Value, shell_error::generic::GenericError, shell_error::io::IoError,
 };
 use std::{iter, sync::Arc};
 

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -124,7 +124,7 @@ pub fn to_delimited_data(
         None => {
             // The columns were not provided. We need to detect them, and in order to do so, we have
             // to convert the input into a value first, so that we can find all of them
-            let value = input.into_value(span)?;
+            let value = input.try_into_value(span)?;
             let columns = match &value {
                 Value::List { vals, .. } => merge_descriptors(vals),
                 Value::Record { val, .. } => val.columns().cloned().collect(),

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -56,7 +56,7 @@ impl Command for ToJson {
         let span = call.head;
         // allow ranges to expand and turn into array
         let input = input.try_expand_range()?;
-        let value = input.into_value(span)?;
+        let value = input.try_into_value(span)?;
         let ty = value.get_type();
         let json_value = value_to_json_value(engine_state, value, span, serialize_types)?;
 

--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -1388,7 +1388,7 @@ mod tests {
             Span::test_data(),
         )
         .unwrap()
-        .into_value(Span::test_data())
+        .try_into_value(Span::test_data())
         .unwrap()
         .into_string()
         .unwrap();
@@ -1418,7 +1418,7 @@ mod tests {
             Span::test_data(),
         )
         .unwrap()
-        .into_value(Span::test_data())
+        .try_into_value(Span::test_data())
         .unwrap()
         .into_string()
         .unwrap();
@@ -1447,7 +1447,7 @@ mod tests {
             Span::test_data(),
         )
         .unwrap()
-        .into_value(Span::test_data())
+        .try_into_value(Span::test_data())
         .unwrap()
         .into_string()
         .unwrap();
@@ -1477,7 +1477,7 @@ mod tests {
             Span::test_data(),
         )
         .unwrap()
-        .into_value(Span::test_data())
+        .try_into_value(Span::test_data())
         .unwrap()
         .into_string()
         .unwrap();
@@ -1503,7 +1503,7 @@ mod tests {
             Span::test_data(),
         )
         .unwrap()
-        .into_value(Span::test_data())
+        .try_into_value(Span::test_data())
         .unwrap()
         .into_string()
         .unwrap();
@@ -1536,7 +1536,7 @@ mod tests {
             Span::test_data(),
         )
         .unwrap()
-        .into_value(Span::test_data())
+        .try_into_value(Span::test_data())
         .unwrap()
         .into_string()
         .unwrap();

--- a/crates/nu-command/src/formats/to/msgpack.rs
+++ b/crates/nu-command/src/formats/to/msgpack.rs
@@ -87,7 +87,7 @@ MessagePack: https://msgpack.org/
             .with_content_type(Some("application/x-msgpack".into()));
 
         let value_span = input.span().unwrap_or(call.head);
-        let value = input.into_value(value_span)?;
+        let value = input.try_into_value(value_span)?;
         let mut out = vec![];
 
         let serialize_types = call.has_flag(engine_state, stack, "serialize")?;

--- a/crates/nu-command/src/formats/to/msgpackz.rs
+++ b/crates/nu-command/src/formats/to/msgpackz.rs
@@ -77,7 +77,7 @@ impl Command for ToMsgpackz {
         let serialize_types = call.has_flag(engine_state, stack, "serialize")?;
 
         let value_span = input.span().unwrap_or(call.head);
-        let value = input.into_value(value_span)?;
+        let value = input.try_into_value(value_span)?;
         let mut out_buf = vec![];
         let mut out = brotli::CompressorWriter::new(
             &mut out_buf,

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -76,7 +76,7 @@ impl Command for ToNuon {
             .unwrap_or_default()
             .with_content_type(Some("application/x-nuon".into()));
 
-        let value = input.into_value(span)?;
+        let value = input.try_into_value(span)?;
 
         let config = nuon::ToNuonConfig::default()
             .style(style)

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -179,7 +179,7 @@ fn to_toml(
     serialize_types: bool,
 ) -> Result<PipelineData, ShellError> {
     let metadata = input.take_metadata();
-    let value = input.into_value(span)?;
+    let value = input.try_into_value(span)?;
 
     let toml_value = value_to_toml_value(engine_state, &value, span, serialize_types)?;
     match toml_value {

--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -132,7 +132,7 @@ impl Job {
             .take_metadata()
             .unwrap_or_default()
             .with_content_type(Some("application/xml".into()));
-        let value = input.into_value(head)?;
+        let value = input.try_into_value(head)?;
 
         self.write_xml_entry(value, true).and_then(|_| {
             let b = self.writer.into_inner().into_inner();

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -140,7 +140,7 @@ fn to_yaml(
         .unwrap_or_default()
         // Per RFC-9512, application/yaml should be used
         .with_content_type(Some("application/yaml".into()));
-    let value = input.into_value(head)?;
+    let value = input.try_into_value(head)?;
 
     let yaml_value = value_to_yaml_value(engine_state, &value, serialize_types)?;
     match serde_yaml::to_string(&yaml_value) {

--- a/crates/nu-command/src/generators/generate.rs
+++ b/crates/nu-command/src/generators/generate.rs
@@ -242,7 +242,7 @@ fn parse_closure_result(
 
         Ok(other) => {
             let error = other
-                .into_value(head)
+                .try_into_value(head)
                 .map(|val| {
                     ShellError::Generic(GenericError::new(
                         "Invalid block return",

--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -449,7 +449,7 @@ fn display(help: &str, engine_state: &EngineState, stack: &mut Stack, span: Span
                     Value::string(item, span).into_pipeline_data(),
                 );
 
-                if let Ok(value) = result.and_then(|data| data.into_value(span)) {
+                if let Ok(value) = result.and_then(|data| data.try_into_value(span)) {
                     match value.coerce_into_string() {
                         Ok(s) => {
                             build.push_str(&s);

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -347,7 +347,7 @@ fn extract_response_metadata(response: &Response, span: Span) -> PipelineMetadat
     let status = Value::int(response.status().as_u16().into(), span);
 
     let headers_value = headers_to_nu(&extract_response_headers(response), span)
-        .and_then(|data| data.into_value(span))
+        .and_then(|data| data.try_into_value(span))
         .unwrap_or(Value::nothing(span));
 
     let urls = Value::list(
@@ -1124,11 +1124,11 @@ pub(crate) fn request_handle_response(
         let response_status = resp.status();
 
         let request_headers_value = headers_to_nu(&headers, span)
-            .and_then(|data| data.into_value(span))
+            .and_then(|data| data.try_into_value(span))
             .unwrap_or(Value::nothing(span));
 
         let response_headers_value = headers_to_nu(&extract_response_headers(&resp), span)
-            .and_then(|data| data.into_value(span))
+            .and_then(|data| data.try_into_value(span))
             .unwrap_or(Value::nothing(span));
 
         let headers = record! {
@@ -1143,7 +1143,7 @@ pub(crate) fn request_handle_response(
                 .collect(),
             span,
         );
-        let body = consume_response_body(resp)?.into_value(span)?;
+        let body = consume_response_body(resp)?.try_into_value(span)?;
 
         let full_response = Value::record(
             record! {

--- a/crates/nu-command/src/network/url/build_query.rs
+++ b/crates/nu-command/src/network/url/build_query.rs
@@ -64,7 +64,7 @@ impl Command for UrlBuildQuery {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         let input_span = input.span().unwrap_or(head);
-        let value = input.into_value(input_span)?;
+        let value = input.try_into_value(input_span)?;
         let span = value.span();
         let output = match value {
             Value::Record { ref val, .. } => record_to_query_string(val, span, head),

--- a/crates/nu-command/src/network/url/parse.rs
+++ b/crates/nu-command/src/network/url/parse.rs
@@ -54,7 +54,7 @@ impl Command for UrlParse {
         let base: Option<Spanned<String>> = call.get_flag(engine_state, stack, "base")?;
 
         parse(
-            input.into_value(call.head)?,
+            input.try_into_value(call.head)?,
             call.head,
             &stack.get_config(engine_state),
             base.map(|b| b.item),

--- a/crates/nu-command/src/network/url/split_query.rs
+++ b/crates/nu-command/src/network/url/split_query.rs
@@ -85,7 +85,7 @@ impl Command for UrlSplitQuery {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         let span = value.span();
         let query = value.to_expanded_string("", &stack.get_config(engine_state));
         let table = query_string_to_table(&query, call.head, span)?;

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -168,11 +168,11 @@ fn run(call: &Call, args: &Arguments, input: PipelineData) -> Result<PipelineDat
     match input {
         PipelineData::Value(val, md) => Ok(PipelineData::value(handle_value(val, args, head), md)),
         PipelineData::ListStream(stream, metadata) => Ok(PipelineData::value(
-            handle_value(stream.try_into_value()?, args, head),
+            handle_value(stream.try_into_value(head)?, args, head),
             metadata,
         )),
         PipelineData::ByteStream(stream, metadata) => Ok(PipelineData::value(
-            handle_value(stream.try_into_value()?, args, head),
+            handle_value(stream.try_into_value(head)?, args, head),
             metadata,
         )),
         PipelineData::Empty => Err(ShellError::PipelineEmpty { dst_span: head }),

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -168,11 +168,11 @@ fn run(call: &Call, args: &Arguments, input: PipelineData) -> Result<PipelineDat
     match input {
         PipelineData::Value(val, md) => Ok(PipelineData::value(handle_value(val, args, head), md)),
         PipelineData::ListStream(stream, metadata) => Ok(PipelineData::value(
-            handle_value(stream.into_value()?, args, head),
+            handle_value(stream.try_into_value()?, args, head),
             metadata,
         )),
         PipelineData::ByteStream(stream, metadata) => Ok(PipelineData::value(
-            handle_value(stream.into_value()?, args, head),
+            handle_value(stream.try_into_value()?, args, head),
             metadata,
         )),
         PipelineData::Empty => Err(ShellError::PipelineEmpty { dst_span: head }),

--- a/crates/nu-command/src/platform/clip/copy.rs
+++ b/crates/nu-command/src/platform/clip/copy.rs
@@ -45,7 +45,7 @@ impl Command for ClipCopy {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         let config = stack.get_config(engine_state);
 
         Self::copy_text(engine_state, stack, &value, call.head, &config)?;

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -690,7 +690,7 @@ impl InputList {
                         ClosureEval::new(engine_state, stack, Closure::clone(closure));
                     closure_eval
                         .run_with_value(value.clone())
-                        .and_then(|data| data.into_value(span))
+                        .and_then(|data| data.try_into_value(span))
                         .map(|v| v.to_expanded_string(", ", config))
                         .unwrap_or_else(|_| value.to_expanded_string(", ", config))
                 }

--- a/crates/nu-command/src/sort_utils.rs
+++ b/crates/nu-command/src/sort_utils.rs
@@ -264,10 +264,10 @@ pub fn compare_key_closure(
 ) -> Result<Ordering, ShellError> {
     let left_key = closure_eval
         .run_with_value(left.clone())?
-        .into_value(span)?;
+        .try_into_value(span)?;
     let right_key = closure_eval
         .run_with_value(right.clone())?
-        .into_value(span)?;
+        .try_into_value(span)?;
     compare_values(&left_key, &right_key, insensitive, natural)
 }
 
@@ -284,7 +284,7 @@ pub fn compare_custom_closure(
             Value::list(vec![left.clone(), right.clone()], span),
             None,
         ))
-        .and_then(|data| data.into_value(span))
+        .and_then(|data| data.try_into_value(span))
         .map(|val| {
             if val.is_true() {
                 Ordering::Less

--- a/crates/nu-command/src/sort_utils.rs
+++ b/crates/nu-command/src/sort_utils.rs
@@ -1,6 +1,6 @@
 use nu_engine::ClosureEval;
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{PipelineData, Record, ShellError, Span, Value, ast::CellPath};
+use nu_protocol::{PipelineData, Record, ShellError, Span, TryIntoValue, Value, ast::CellPath};
 use nu_utils::IgnoreCaseExt;
 use std::cmp::Ordering;
 

--- a/crates/nu-command/src/strings/detect_type.rs
+++ b/crates/nu-command/src/strings/detect_type.rs
@@ -137,7 +137,7 @@ impl Command for DetectType {
         let display_as_filesize = call.has_flag(engine_state, stack, "prefer-filesize")?;
         let prefer_dmy = call.has_flag(engine_state, stack, "prefer-dmy")?;
         let metadata = input.take_metadata();
-        let val = input.into_value(call.head)?;
+        let val = input.try_into_value(call.head)?;
         process(val, metadata, display_as_filesize, prefer_dmy, span)
     }
 }
@@ -729,7 +729,7 @@ mod test {
         let span = Span::test_data();
         let result = process(Value::string(input, span), None, false, false, span)
             .unwrap()
-            .into_value(span)
+            .try_into_value(span)
             .unwrap();
 
         if let Value::Date { val, .. } = result {
@@ -761,7 +761,7 @@ mod test {
         let span = Span::test_data();
         let result = process(Value::string(input, span), None, false, true, span)
             .unwrap()
-            .into_value(span)
+            .try_into_value(span)
             .unwrap();
 
         if let Value::Date { val, .. } = result {

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -280,7 +280,7 @@ impl Matcher {
             Matcher::Direct(lhs) => rhs == lhs,
             Matcher::Closure(closure) => closure
                 .run_with_value(rhs.clone())
-                .and_then(|data| data.into_value(rhs.span()))
+                .and_then(|data| data.try_into_value(rhs.span()))
                 .map(|value| value.is_true())
                 .unwrap_or(false),
         })

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -281,7 +281,7 @@ fn action(
                         let span = closure.span;
                         let result: Result<Value, ShellError> = closure_eval
                             .run_with_value(Value::string(find.item.clone(), find.span))
-                            .and_then(|result| result.into_value(span));
+                            .and_then(|result| result.try_into_value(span));
                         match result {
                             Ok(Value::String { val, .. }) => Ok(Arc::new(val.into_spanned(span))),
                             Ok(res) => Err((
@@ -363,7 +363,7 @@ fn action(
                             };
                             let result: Result<Value, ShellError> = closure_eval
                                 .run_with_input(PipelineData::value(value, None))
-                                .and_then(|result| result.into_value(span));
+                                .and_then(|result| result.try_into_value(span));
                             match result {
                                 Ok(Value::String { val, .. }) => val.to_string(),
                                 Ok(res) => {

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -224,7 +224,7 @@ pub(crate) fn render_value_as_plain_table_text(
     let input = value.into_pipeline_data();
     let input = CmdInput::parse(engine_state, stack, &call, input)?;
     let output = handle_table_command(input)?;
-    let output = output.into_value(span)?;
+    let output = output.try_into_value(span)?;
     let config = stack.get_config(engine_state);
 
     let text = match output {

--- a/crates/nu-engine/src/command_prelude.rs
+++ b/crates/nu-engine/src/command_prelude.rs
@@ -5,8 +5,8 @@ pub use crate::CallExt;
 pub use nu_protocol::{
     ByteStream, ByteStreamType, Category, Completion, ErrSpan, Example, Flag,
     IntoInterruptiblePipelineData, IntoPipelineData, IntoSpanned, IntoValue, PipelineData,
-    PositionalArg, Record, ShellError, ShellWarning, Signature, Span, Spanned, SyntaxShape, Type,
-    Value,
+    PositionalArg, Record, ShellError, ShellWarning, Signature, Span, Spanned, SyntaxShape,
+    TryIntoValue, Type, Value,
     ast::CellPath,
     engine::{Call, Command, EngineState, Stack, StateWorkingSet},
     record,

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -130,7 +130,7 @@ fn try_nu_highlight(
         &(&call).into(),
         Value::string(code_string, head).into_pipeline_data(),
     )
-    .and_then(|pipe| pipe.into_value(head))
+    .and_then(|pipe| pipe.try_into_value(head))
     .and_then(|val| val.coerce_into_string())
     .ok()
 }

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -2,7 +2,7 @@ use crate::eval_call;
 use fancy_regex::{Captures, Regex};
 use nu_protocol::{
     Category, Config, IntoPipelineData, PipelineData, PositionalArg, Signature, Span, SpanId,
-    Spanned, SyntaxShape, Type, Value,
+    Spanned, SyntaxShape, TryIntoValue, Type, Value,
     ast::{Argument, Call, Expr, Expression, RecordItem},
     debugger::WithoutDebug,
     engine::CommandType,

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -55,7 +55,7 @@ pub fn convert_env_vars(
             let new_val = ClosureEvalOnce::new(engine_state, stack, conversion.clone())
                 .debug(false)
                 .run_with_value(val.clone())?
-                .into_value(val.span())?;
+                .try_into_value(val.span())?;
 
             stack.add_env_var(key.to_string(), new_val);
         }
@@ -320,7 +320,7 @@ fn get_converted_value(
         ClosureEvalOnce::new(engine_state, stack, conversion.clone())
             .debug(false)
             .run_with_value(orig_val.clone())?
-            .into_value(orig_val.span())?,
+            .try_into_value(orig_val.span())?,
     )
 }
 

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -1,7 +1,7 @@
 use crate::ClosureEvalOnce;
 use nu_path::absolute_with;
 use nu_protocol::{
-    ShellError, Span, Type, Value, VarId,
+    ShellError, Span, TryIntoValue, Type, Value, VarId,
     ast::Expr,
     engine::{Call, EngineState, EnvName, Stack},
     shell_error::generic::GenericError,

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -267,7 +267,7 @@ pub fn eval_expression_with_input<D: DebugContext>(
                     let stack = &mut stack.start_collect_value();
                     // FIXME: protect this collect with ctrl-c
                     input = eval_subexpression::<D>(engine_state, stack, block, input)?
-                        .into_value(*span)?
+                        .try_into_value(*span)?
                         .follow_cell_path(&full_cell_path.tail)?
                         .into_owned()
                         .into_pipeline_data()
@@ -276,21 +276,21 @@ pub fn eval_expression_with_input<D: DebugContext>(
                 }
             }
             _ => {
-                let input_value = input.into_value(expr.span)?;
+                let input_value = input.try_into_value(expr.span)?;
                 stack.add_var(nu_protocol::IN_VARIABLE_ID, input_value);
                 input = eval_expression::<D>(engine_state, stack, expr)?.into_pipeline_data();
             }
         },
 
         Expr::StringInterpolation(_) | Expr::GlobInterpolation(_, _) => {
-            let input_value = input.into_value(expr.span)?;
+            let input_value = input.try_into_value(expr.span)?;
             stack.add_var(nu_protocol::IN_VARIABLE_ID, input_value);
             let value = eval_expression::<D>(engine_state, stack, expr)?;
             input = PipelineData::Value(value, None);
         }
 
         _ => {
-            let input_value = input.into_value(expr.span)?;
+            let input_value = input.try_into_value(expr.span)?;
             stack.add_var(nu_protocol::IN_VARIABLE_ID, input_value);
             let value = eval_expression::<D>(engine_state, stack, expr)?;
             input = PipelineData::Value(value, None);
@@ -343,7 +343,7 @@ pub fn eval_collect<D: DebugContext>(
 
     let metadata = input.take_metadata().and_then(|m| m.for_collect());
 
-    let input = input.into_value(span)?;
+    let input = input.try_into_value(span)?;
 
     stack.add_var(var_id, input.clone());
 
@@ -430,7 +430,7 @@ impl Eval for EvalRuntime {
         _: Span,
     ) -> Result<Value, ShellError> {
         // FIXME: protect this collect with ctrl-c
-        eval_call::<D>(engine_state, stack, call, PipelineData::empty())?.into_value(call.head)
+        eval_call::<D>(engine_state, stack, call, PipelineData::empty())?.try_into_value(call.head)
     }
 
     fn eval_external_call(
@@ -442,7 +442,7 @@ impl Eval for EvalRuntime {
     ) -> Result<Value, ShellError> {
         let span = head.span(&engine_state);
         // FIXME: protect this collect with ctrl-c
-        eval_external(engine_state, stack, head, args, PipelineData::empty())?.into_value(span)
+        eval_external(engine_state, stack, head, args, PipelineData::empty())?.try_into_value(span)
     }
 
     fn eval_collect<D: DebugContext>(
@@ -454,7 +454,7 @@ impl Eval for EvalRuntime {
         // It's a little bizarre, but the expression can still have some kind of result even with
         // nothing input
         eval_collect::<D>(engine_state, stack, var_id, expr, PipelineData::empty())?
-            .into_value(expr.span)
+            .try_into_value(expr.span)
     }
 
     fn eval_subexpression<D: DebugContext>(
@@ -465,7 +465,8 @@ impl Eval for EvalRuntime {
     ) -> Result<Value, ShellError> {
         let block = engine_state.get_block(block_id);
         // FIXME: protect this collect with ctrl-c
-        eval_subexpression::<D>(engine_state, stack, block, PipelineData::empty())?.into_value(span)
+        eval_subexpression::<D>(engine_state, stack, block, PipelineData::empty())?
+            .try_into_value(span)
     }
 
     fn regex_match(

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -3,7 +3,7 @@ use crate::eval_ir::eval_ir_block;
 use crate::get_full_help;
 use nu_protocol::{
     BlockId, Config, ENV_VARIABLE_ID, IntoPipelineData, PipelineData, PipelineExecutionData,
-    ShellError, Span, Value, VarId,
+    ShellError, Span, TryIntoValue, Value, VarId,
     ast::{Assignment, Block, Call, Expr, Expression, ExternalArgument, PathMember},
     debugger::DebugContext,
     engine::{Closure, EngineState, Stack},

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -6,7 +6,7 @@ use nu_protocol::process::check_exit_status_future;
 use nu_protocol::{
     DeclId, ENV_VARIABLE_ID, Flag, IntoPipelineData, IntoSpanned, ListStream, OutDest,
     PipelineData, PipelineExecutionData, PositionalArg, Range, Record, RegId, ShellError, Signals,
-    Signature, Span, Spanned, Type, Value, VarId,
+    Signature, Span, Spanned, TryIntoValue, Type, Value, VarId,
     ast::{Bits, Block, Boolean, CellPath, Comparison, Math, Operator},
     combined_type_string,
     debugger::DebugContext,

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -197,7 +197,7 @@ impl<'a> EvalContext<'a> {
         #[cfg(not(feature = "os"))]
         let body = self.take_reg(reg_id).body;
         let span = body.span().unwrap_or(fallback_span);
-        body.into_value(span)
+        body.try_into_value(span)
     }
 
     /// Get a string from data or produce evaluation error if it's invalid UTF-8
@@ -850,7 +850,7 @@ fn eval_instruction<D: DebugContext>(
             let mut data = ctx.take_reg(*src_dst).body;
             let metadata = data.take_metadata();
             // Change the span because we're modifying it
-            let mut value = data.into_value(*span)?;
+            let mut value = data.try_into_value(*span)?;
             let path = ctx.take_reg(*path);
             let new_value = ctx.collect_reg(*new_value, *span)?;
             if let PipelineData::Value(Value::CellPath { val: path, .. }, _) = path.body {
@@ -1638,7 +1638,7 @@ fn collect(
     if nu_experimental::PIPE_FAIL.get() && !ignore_error {
         check_exit_status_future(pipe.exit)?;
     }
-    let value = data.into_value(span)?;
+    let value = data.try_into_value(span)?;
     Ok(PipelineData::value(value, metadata))
 }
 

--- a/crates/nu-explore/src/explore/nu_common/value.rs
+++ b/crates/nu-explore/src/explore/nu_common/value.rs
@@ -64,7 +64,7 @@ fn collect_byte_stream(
         },
         Err(stream) => {
             let value = stream
-                .into_value()
+                .try_into_value()
                 .unwrap_or_else(|err| Value::error(err, span));
 
             columns.push("".into());

--- a/crates/nu-explore/src/explore/nu_common/value.rs
+++ b/crates/nu-explore/src/explore/nu_common/value.rs
@@ -1,7 +1,9 @@
 use super::NuSpan;
 use anyhow::Result;
 use nu_engine::get_columns;
-use nu_protocol::{ByteStream, ListStream, PipelineData, PipelineMetadata, Value, record};
+use nu_protocol::{
+    ByteStream, ListStream, PipelineData, PipelineMetadata, TryIntoValue, Value, record,
+};
 use std::collections::HashMap;
 
 pub fn collect_pipeline(input: PipelineData) -> Result<(Vec<String>, Vec<Vec<Value>>)> {
@@ -64,7 +66,7 @@ fn collect_byte_stream(
         },
         Err(stream) => {
             let value = stream
-                .try_into_value()
+                .try_into_value(span)
                 .unwrap_or_else(|err| Value::error(err, span));
 
             columns.push("".into());

--- a/crates/nu-plugin-engine/src/context.rs
+++ b/crates/nu-plugin-engine/src/context.rs
@@ -121,7 +121,7 @@ impl PluginExecutionContext for PluginExecutionCommandContext<'_> {
                     Value::Closure { val, .. } => {
                         ClosureEvalOnce::new(&self.engine_state, &self.stack, *val)
                             .run_with_input(PipelineData::empty())
-                            .and_then(|data| data.into_value(span))
+                            .and_then(|data| data.try_into_value(span))
                             .unwrap_or_else(|err| Value::error(err, self.call.head))
                     }
                     _ => value.clone(),

--- a/crates/nu-plugin-engine/src/context.rs
+++ b/crates/nu-plugin-engine/src/context.rs
@@ -3,7 +3,7 @@ use nu_engine::{ClosureEvalOnce, get_eval_block_with_early_return, get_full_help
 use nu_plugin_protocol::EvaluatedCall;
 use nu_protocol::{
     BlockId, Config, DeclId, IntoSpanned, OutDest, PipelineData, PluginIdentity, ShellError,
-    Signals, Span, Spanned, Value,
+    Signals, Span, Spanned, TryIntoValue, Value,
     engine::{Call, Closure, EngineState, Redirection, Stack},
     ir::{self, IrBlock},
     shell_error::generic::GenericError,

--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -12,8 +12,8 @@ use nu_plugin_protocol::{
 };
 use nu_protocol::{
     CustomValue, DynamicSuggestion, IntoSpanned, PipelineData, PluginMetadata, PluginSignature,
-    ShellError, SignalAction, Signals, Span, Spanned, Value, ast::Operator, casing::Casing,
-    engine::Sequence, shell_error::generic::GenericError,
+    ShellError, SignalAction, Signals, Span, Spanned, TryIntoValue, Value, ast::Operator,
+    casing::Casing, engine::Sequence, shell_error::generic::GenericError,
 };
 use nu_utils::SharedCow;
 use std::{

--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -1033,7 +1033,7 @@ impl PluginInterface {
 
         let call = PluginCall::CustomValueOp(value.map(|cv| cv.without_source()), op);
         match self.plugin_call(call, None)? {
-            PluginCallResponse::PipelineData(out_data) => out_data.into_value(span),
+            PluginCallResponse::PipelineData(out_data) => out_data.try_into_value(span),
             PluginCallResponse::Error(err) => Err(err),
             _ => Err(ShellError::PluginFailedToDecode {
                 msg: format!("Received unexpected response to custom value {op_name}() call"),

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -1092,7 +1092,7 @@ fn interface_run() -> Result<(), ShellError> {
 
     assert_eq!(
         Value::test_int(number),
-        result.into_value(Span::test_data())?,
+        result.try_into_value(Span::test_data())?,
     );
     assert!(test.has_unconsumed_write());
     Ok(())
@@ -1202,7 +1202,7 @@ fn interface_prepare_pipeline_data_accepts_normal_values() -> Result<(), ShellEr
         match interface.prepare_pipeline_data(PipelineData::value(value.clone(), None), &state) {
             Ok(data) => assert_eq!(
                 value.get_type(),
-                data.into_value(Span::test_data())?.get_type(),
+                data.try_into_value(Span::test_data())?.get_type(),
             ),
             Err(err) => panic!("failed to accept {value:?}: {err}"),
         }

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -17,7 +17,7 @@ use nu_plugin_protocol::{
 use nu_protocol::{
     BlockId, ByteStreamType, CustomValue, DynamicSuggestion, Id, IntoInterruptiblePipelineData,
     IntoSpanned, PipelineData, PipelineMetadata, PluginMetadata, PluginSignature, ShellError,
-    Signals, Span, Spanned, Value,
+    Signals, Span, Spanned, TryIntoValue, Value,
     ast::{Math, Operator},
     engine::Closure,
     shell_error,

--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -9,7 +9,7 @@ use nu_plugin_engine::{PluginCustomValueWithSource, PluginSource, WithSource};
 use nu_plugin_protocol::PluginCustomValue;
 use nu_protocol::{
     CustomValue, Example, IntoSpanned as _, LabeledError, PipelineData, ShellError, Signals, Span,
-    Value,
+    TryIntoValue, Value,
     debugger::WithoutDebug,
     engine::{EngineState, Stack, StateWorkingSet},
     report_shell_error,
@@ -235,10 +235,11 @@ impl PluginTest {
 
                         // Set all of the spans in the value to test_data() to avoid unnecessary
                         // differences when printing
-                        let _: Result<(), Infallible> = value.recurse_mut(&mut |here| {
-                            here.set_span(Span::test_data());
-                            Ok(())
-                        });
+                        let _: Result<(), Infallible> =
+                            value.recurse_mut(&mut |here: &mut Value| {
+                                here.set_span(Span::test_data());
+                                Ok(())
+                            });
 
                         // Check for equality with the result
                         if !self.value_eq(expectation, &value)? {

--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -231,7 +231,7 @@ impl PluginTest {
             if let Some(expectation) = &example.result {
                 match self.eval(example.example) {
                     Ok(data) => {
-                        let mut value = data.into_value(Span::test_data())?;
+                        let mut value = data.try_into_value(Span::test_data())?;
 
                         // Set all of the spans in the value to test_data() to avoid unnecessary
                         // differences when printing

--- a/crates/nu-plugin-test-support/tests/custom_value/mod.rs
+++ b/crates/nu-plugin-test-support/tests/custom_value/mod.rs
@@ -147,7 +147,7 @@ fn test_into_int_from_u32() -> Result<(), ShellError> {
             "into int from u32",
             PipelineData::value(CustomU32(42).into_value(Span::test_data()), None),
         )?
-        .into_value(Span::test_data())?;
+        .try_into_value(Span::test_data())?;
     assert_eq!(Value::test_int(42), result);
     Ok(())
 }

--- a/crates/nu-plugin-test-support/tests/custom_value/mod.rs
+++ b/crates/nu-plugin-test-support/tests/custom_value/mod.rs
@@ -3,7 +3,8 @@ use std::cmp::Ordering;
 use nu_plugin::{EngineInterface, EvaluatedCall, Plugin, SimplePluginCommand};
 use nu_plugin_test_support::PluginTest;
 use nu_protocol::{
-    CustomValue, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type, Value,
+    CustomValue, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+    Type, Value,
 };
 
 use serde::{Deserialize, Serialize};

--- a/crates/nu-plugin-test-support/tests/hello/mod.rs
+++ b/crates/nu-plugin-test-support/tests/hello/mod.rs
@@ -84,7 +84,7 @@ fn test_requiring_nu_cmd_lang_commands() -> Result<(), ShellError> {
 
     let result = PluginTest::new("hello", HelloPlugin.into())?
         .eval("do { let greeting = hello; $greeting }")?
-        .into_value(Span::test_data())?;
+        .try_into_value(Span::test_data())?;
 
     assert_eq!(Value::test_string("Hello, World!"), result);
 

--- a/crates/nu-plugin-test-support/tests/hello/mod.rs
+++ b/crates/nu-plugin-test-support/tests/hello/mod.rs
@@ -2,7 +2,7 @@
 
 use nu_plugin::*;
 use nu_plugin_test_support::PluginTest;
-use nu_protocol::{Example, LabeledError, ShellError, Signature, Type, Value};
+use nu_protocol::{Example, LabeledError, ShellError, Signature, TryIntoValue, Type, Value};
 
 struct HelloPlugin;
 struct Hello;

--- a/crates/nu-plugin-test-support/tests/lowercase/mod.rs
+++ b/crates/nu-plugin-test-support/tests/lowercase/mod.rs
@@ -78,7 +78,7 @@ fn test_lowercase_using_eval_with() -> Result<(), ShellError> {
 
     assert_eq!(
         Value::test_list(vec![Value::test_string("hello world")]),
-        result.into_value(Span::test_data())?
+        result.try_into_value(Span::test_data())?
     );
 
     Ok(())

--- a/crates/nu-plugin-test-support/tests/lowercase/mod.rs
+++ b/crates/nu-plugin-test-support/tests/lowercase/mod.rs
@@ -2,7 +2,7 @@ use nu_plugin::*;
 use nu_plugin_test_support::PluginTest;
 use nu_protocol::{
     Example, IntoInterruptiblePipelineData, LabeledError, PipelineData, ShellError, Signals,
-    Signature, Span, Type, Value,
+    Signature, Span, TryIntoValue, Type, Value,
 };
 
 struct LowercasePlugin;

--- a/crates/nu-plugin/src/plugin/command.rs
+++ b/crates/nu-plugin/src/plugin/command.rs
@@ -1,6 +1,6 @@
 use nu_protocol::{
     DynamicSuggestion, Example, IntoSpanned, LabeledError, PipelineData, PluginExample,
-    PluginSignature, ShellError, Signature, Value, engine::ArgType,
+    PluginSignature, ShellError, Signature, TryIntoValue, Value, engine::ArgType,
 };
 
 use crate::{DynamicCompletionCall, EngineInterface, EvaluatedCall, Plugin};

--- a/crates/nu-plugin/src/plugin/command.rs
+++ b/crates/nu-plugin/src/plugin/command.rs
@@ -363,7 +363,7 @@ where
         // Unwrap the PipelineData from input, consuming the potential stream, and pass it to the
         // simpler signature in Plugin
         let span = input.span().unwrap_or(call.head);
-        let input_value = input.into_value(span)?;
+        let input_value = input.try_into_value(span)?;
         // Wrap the output in PipelineData::value
         <Self as SimplePluginCommand>::run(self, plugin, engine, call, &input_value)
             .map(|value| PipelineData::value(value, None))

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -924,7 +924,7 @@ impl EngineInterface {
         let input = input.map_or_else(PipelineData::empty, |v| PipelineData::value(v, None));
         let output = self.eval_closure_with_stream(closure, positional, input, true, false)?;
         // Unwrap an error value
-        match output.into_value(closure.span)? {
+        match output.try_into_value(closure.span)? {
             Value::Error { error, .. } => Err(*error),
             value => Ok(value),
         }

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -14,7 +14,8 @@ use nu_plugin_protocol::{
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
     BlockId, Config, DeclId, DynamicSuggestion, Handler, HandlerGuard, Handlers, PipelineData,
-    PluginMetadata, PluginSignature, ShellError, SignalAction, Signals, Span, Spanned, Value,
+    PluginMetadata, PluginSignature, ShellError, SignalAction, Signals, Span, Spanned,
+    TryIntoValue, Value,
     engine::{Closure, Sequence},
     ir::IrBlock,
 };
@@ -981,7 +982,7 @@ impl EngineInterface {
     /// # Example
     ///
     /// ```rust,no_run
-    /// # use nu_protocol::{Value, ShellError, PipelineData};
+    /// # use nu_protocol::{Value, ShellError, PipelineData, TryIntoValue};
     /// # use nu_plugin::{EngineInterface, EvaluatedCall};
     /// # fn example(engine: &EngineInterface, call: &EvaluatedCall) -> Result<Value, ShellError> {
     /// if let Some(decl_id) = engine.find_decl("scope commands")? {
@@ -992,7 +993,7 @@ impl EngineInterface {
     ///         true,
     ///         false,
     ///     )?;
-    ///     commands.into_value(call.head)
+    ///     commands.try_into_value(call.head)
     /// } else {
     ///     Ok(Value::list(vec![], call.head))
     /// }

--- a/crates/nu-plugin/src/plugin/interface/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/tests.rs
@@ -11,7 +11,7 @@ use nu_plugin_protocol::{
 };
 use nu_protocol::{
     BlockId, ByteStreamType, Config, CustomValue, IntoInterruptiblePipelineData, LabeledError,
-    PipelineData, PluginSignature, ShellError, Signals, Span, Spanned, Value, VarId,
+    PipelineData, PluginSignature, ShellError, Signals, Span, Spanned, TryIntoValue, Value, VarId,
     engine::Closure, shell_error,
 };
 use std::{

--- a/crates/nu-plugin/src/plugin/interface/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/tests.rs
@@ -1055,7 +1055,7 @@ fn interface_eval_closure_with_stream() -> Result<(), ShellError> {
             true,
             false,
         )?
-        .into_value(Span::test_data())?;
+        .try_into_value(Span::test_data())?;
 
     assert_eq!(Value::test_int(2), result);
 

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -3,8 +3,8 @@
 //! This enables you to assign `const`-constants and execute parse-time code dependent on this.
 //! e.g. `source $my_const`
 use crate::{
-    BlockId, Config, HistoryFileFormat, HistoryPath, PipelineData, Record, ShellError, Span, Value,
-    VarId,
+    BlockId, Config, HistoryFileFormat, HistoryPath, PipelineData, Record, ShellError, Span,
+    TryIntoValue, Value, VarId,
     ast::{Assignment, Block, Call, Expr, Expression, ExternalArgument},
     debugger::{DebugContext, WithoutDebug},
     engine::{EngineState, StateWorkingSet},

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -467,7 +467,7 @@ impl Eval for EvalConst {
     ) -> Result<Value, ShellError> {
         // TODO: Allow debugging const eval
         // TODO: eval.rs uses call.head for the span rather than expr.span
-        eval_const_call(working_set, call, PipelineData::empty())?.into_value(span)
+        eval_const_call(working_set, call, PipelineData::empty())?.try_into_value(span)
     }
 
     fn eval_external_call(
@@ -506,7 +506,8 @@ impl Eval for EvalConst {
         }
         // TODO: Allow debugging const eval
         let block = working_set.get_block(block_id);
-        eval_const_subexpression(working_set, block, PipelineData::empty(), span)?.into_value(span)
+        eval_const_subexpression(working_set, block, PipelineData::empty(), span)?
+            .try_into_value(span)
     }
 
     fn regex_match(

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -5,7 +5,8 @@
 #[cfg(feature = "os")]
 use crate::process::{ChildPipe, ChildProcess};
 use crate::{
-    IntRange, PipelineData, ShellError, Signals, Span, TryIntoValue, Type, Value, shell_error::{bridge::ShellErrorBridge, io::IoError}
+    IntRange, PipelineData, ShellError, Signals, Span, TryIntoValue, Type, Value,
+    shell_error::{bridge::ShellErrorBridge, io::IoError},
 };
 use nu_utils::SplitRead as SplitReadInner;
 use serde::{Deserialize, Serialize};

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -5,8 +5,7 @@
 #[cfg(feature = "os")]
 use crate::process::{ChildPipe, ChildProcess};
 use crate::{
-    IntRange, PipelineData, ShellError, Signals, Span, Type, Value,
-    shell_error::{bridge::ShellErrorBridge, io::IoError},
+    IntRange, PipelineData, ShellError, Signals, Span, TryIntoValue, Type, Value, shell_error::{bridge::ShellErrorBridge, io::IoError}
 };
 use nu_utils::SplitRead as SplitReadInner;
 use serde::{Deserialize, Serialize};
@@ -646,39 +645,6 @@ impl ByteStream {
         }
     }
 
-    /// Collect all the bytes of the [`ByteStream`] into a [`Value`].
-    ///
-    /// If this is a `String` stream, the stream is decoded to UTF-8. If the stream came from an
-    /// external process or file, the trailing new line (`\n` or `\r\n`), if any, is removed from
-    /// the [`String`] prior to being returned.
-    ///
-    /// If this is a `Binary` stream, a [`Value::Binary`] is returned with any trailing new lines
-    /// preserved.
-    ///
-    /// If this is an `Unknown` stream, the behavior depends on whether the stream parses as valid
-    /// UTF-8 or not. If it does, this is uses the `String` behavior; if not, it uses the `Binary`
-    /// behavior.
-    pub fn try_into_value(self) -> Result<Value, ShellError> {
-        let span = self.span;
-        let trim = self.stream.is_external();
-        let value = match self.type_ {
-            // If the type is specified, then the stream should always become that type:
-            ByteStreamType::Binary => Value::binary(self.into_bytes()?, span),
-            ByteStreamType::String => Value::string(self.into_string()?, span),
-            // If the type is not specified, then it just depends on whether it parses or not:
-            ByteStreamType::Unknown => match String::from_utf8(self.into_bytes()?) {
-                Ok(mut str) => {
-                    if trim {
-                        trim_end_newline(&mut str);
-                    }
-                    Value::string(str, span)
-                }
-                Err(err) => Value::binary(err.into_bytes(), span),
-            },
-        };
-        Ok(value)
-    }
-
     /// Consume and drop all bytes of the [`ByteStream`].
     pub fn drain(self) -> Result<(), ShellError> {
         match self.stream {
@@ -733,6 +699,40 @@ impl ByteStream {
             }
         }
         Ok(())
+    }
+}
+
+impl TryIntoValue for ByteStream {
+    /// Collect all the bytes of the [`ByteStream`] into a [`Value`].
+    ///
+    /// If this is a `String` stream, the stream is decoded to UTF-8. If the stream came from an
+    /// external process or file, the trailing new line (`\n` or `\r\n`), if any, is removed from
+    /// the [`String`] prior to being returned.
+    ///
+    /// If this is a `Binary` stream, a [`Value::Binary`] is returned with any trailing new lines
+    /// preserved.
+    ///
+    /// If this is an `Unknown` stream, the behavior depends on whether the stream parses as valid
+    /// UTF-8 or not. If it does, this is uses the `String` behavior; if not, it uses the `Binary`
+    /// behavior.
+    fn try_into_value(self, span: Span) -> Result<Value, ShellError> {
+        let trim = self.stream.is_external();
+        let value = match self.type_ {
+            // If the type is specified, then the stream should always become that type:
+            ByteStreamType::Binary => Value::binary(self.into_bytes()?, span),
+            ByteStreamType::String => Value::string(self.into_string()?, span),
+            // If the type is not specified, then it just depends on whether it parses or not:
+            ByteStreamType::Unknown => match String::from_utf8(self.into_bytes()?) {
+                Ok(mut str) => {
+                    if trim {
+                        trim_end_newline(&mut str);
+                    }
+                    Value::string(str, span)
+                }
+                Err(err) => Value::binary(err.into_bytes(), span),
+            },
+        };
+        Ok(value)
     }
 }
 

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -175,7 +175,7 @@ impl From<ByteStreamType> for Type {
 /// Additionally, there are few methods to collect a [`ByteStream`] into memory:
 /// - [`into_bytes`](ByteStream::into_bytes): collects all bytes into a [`Vec<u8>`].
 /// - [`into_string`](ByteStream::into_string): collects all bytes into a [`String`], erroring if utf-8 decoding failed.
-/// - [`into_value`](ByteStream::into_value): collects all bytes into a value typed appropriately
+/// - [`try_into_value`](ByteStream::try_into_value): collects all bytes into a value typed appropriately
 ///   for the [type](.type_()) of this stream. If the type is [`Unknown`](ByteStreamType::Unknown),
 ///   it will produce a string value if the data is valid UTF-8, or a binary value otherwise.
 ///

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -658,7 +658,7 @@ impl ByteStream {
     /// If this is an `Unknown` stream, the behavior depends on whether the stream parses as valid
     /// UTF-8 or not. If it does, this is uses the `String` behavior; if not, it uses the `Binary`
     /// behavior.
-    pub fn into_value(self) -> Result<Value, ShellError> {
+    pub fn try_into_value(self) -> Result<Value, ShellError> {
         let span = self.span;
         let trim = self.stream.is_external();
         let value = match self.type_ {

--- a/crates/nu-protocol/src/pipeline/list_stream.rs
+++ b/crates/nu-protocol/src/pipeline/list_stream.rs
@@ -77,7 +77,7 @@ impl ListStream {
     /// Collect the values of a [`ListStream`] into a list [`Value`].
     ///
     /// If any of the values in the stream is a [Value::Error], its inner [ShellError] is returned.
-    pub fn into_value(self) -> Result<Value, ShellError> {
+    pub fn try_into_value(self) -> Result<Value, ShellError> {
         Ok(Value::list(
             self.stream
                 .map(Value::unwrap_error)

--- a/crates/nu-protocol/src/pipeline/list_stream.rs
+++ b/crates/nu-protocol/src/pipeline/list_stream.rs
@@ -2,7 +2,7 @@
 //! elements
 //!
 //! For more general infos regarding our pipelining model refer to [`PipelineData`]
-use crate::{Config, PipelineData, ShellError, Signals, Span, Value};
+use crate::{Config, PipelineData, ShellError, Signals, Span, TryIntoValue, Value};
 use std::fmt::Debug;
 
 pub type ValueIterator = Box<dyn Iterator<Item = Value> + Send + 'static>;
@@ -74,18 +74,6 @@ impl ListStream {
             .join(separator)
     }
 
-    /// Collect the values of a [`ListStream`] into a list [`Value`].
-    ///
-    /// If any of the values in the stream is a [Value::Error], its inner [ShellError] is returned.
-    pub fn try_into_value(self) -> Result<Value, ShellError> {
-        Ok(Value::list(
-            self.stream
-                .map(Value::unwrap_error)
-                .collect::<Result<_, _>>()?,
-            self.span,
-        ))
-    }
-
     /// Collect the values of a [`ListStream`] into a [`Value::List`], preserving [Value::Error]
     /// items for debugging purposes.
     pub fn into_debug_value(self) -> Value {
@@ -129,6 +117,20 @@ impl ListStream {
     /// to each of the values in the original [`ListStream`].
     pub fn map(self, mapping: impl FnMut(Value) -> Value + Send + 'static) -> Self {
         self.modify(|iter| iter.map(mapping))
+    }
+}
+
+impl TryIntoValue for ListStream {
+    /// Collect the values of a [`ListStream`] into a list [`Value`].
+    ///
+    /// If any of the values in the stream is a [Value::Error], its inner [ShellError] is returned.
+    fn try_into_value(self, span: Span) -> Result<Value, ShellError> {
+        Ok(Value::list(
+            self.stream
+                .map(Value::unwrap_error)
+                .collect::<Result<_, _>>()?,
+            span,
+        ))
     }
 }
 

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -160,7 +160,7 @@ impl PipelineData {
     ///
     /// The type returned here makes no effort to collect a stream, so it may be a different type
     /// than would be returned by [`Value::get_type()`] on the result of
-    /// [`.into_value()`](Self::into_value).
+    /// [`.try_into_value()`](Self::try_into_value).
     ///
     /// Specifically, a `ListStream` results in `list<any>` rather than
     /// the fully complete [`list`](Type::List) type (which would require knowing the contents),
@@ -179,12 +179,12 @@ impl PipelineData {
     ///
     /// This check makes no effort to collect a stream, so it may be a different result
     /// than would be returned by calling [`Value::is_subtype_of()`] on the result of
-    /// [`.into_value()`](Self::into_value).
+    /// [`.try_into_value()`](Self::try_into_value).
     ///
     /// A `ListStream` acts the same as an empty list type: it is a subtype of any [`list`](Type::List)
     /// or [`table`](Type::Table) type. After converting to a value, it may become a more specific type.
     /// For example, a `ListStream` is a subtype of `list<int>` and `list<string>`.
-    /// If calling [`.into_value()`](Self::into_value) results in a `list<int>`,
+    /// If calling [`.try_into_value()`](Self::try_into_value) results in a `list<int>`,
     /// then the value would not be a subtype of `list<string>`, in contrast to the original `ListStream`.
     ///
     /// A `ByteStream` is a subtype of [`string`](Type::String) if it is coercible into a string.
@@ -216,7 +216,7 @@ impl PipelineData {
         }
     }
 
-    pub fn into_value(self, span: Span) -> Result<Value, ShellError> {
+    pub fn try_into_value(self, span: Span) -> Result<Value, ShellError> {
         match self {
             PipelineData::Empty => Ok(Value::nothing(span)),
             PipelineData::Value(value, ..) => {
@@ -226,8 +226,8 @@ impl PipelineData {
                     Ok(value)
                 }
             }
-            PipelineData::ListStream(stream, ..) => stream.into_value(),
-            PipelineData::ByteStream(stream, ..) => stream.into_value(),
+            PipelineData::ListStream(stream, ..) => stream.try_into_value(),
+            PipelineData::ByteStream(stream, ..) => stream.try_into_value(),
         }
     }
 
@@ -354,7 +354,8 @@ impl PipelineData {
             OutDest::Value => {
                 let metadata = self.take_metadata();
                 let span = self.span().unwrap_or(Span::unknown());
-                self.into_value(span).map(|val| Self::Value(val, metadata))
+                self.try_into_value(span)
+                    .map(|val| Self::Value(val, metadata))
             }
             OutDest::File(file) => {
                 self.write_to(file.as_ref())?;
@@ -560,7 +561,7 @@ impl PipelineData {
                 Ok(PipelineData::list_stream(stream.map(f), metadata))
             }
             PipelineData::ByteStream(stream, metadata) => {
-                Ok(f(stream.into_value()?).into_pipeline_data_with_metadata(metadata))
+                Ok(f(stream.try_into_value()?).into_pipeline_data_with_metadata(metadata))
             }
         }
     }

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -2,7 +2,7 @@
 use crate::process::ExitStatusGuard;
 use crate::{
     ByteStream, ByteStreamSource, ByteStreamType, Config, ListStream, OutDest, PipelineMetadata,
-    Range, ShellError, Signals, Span, Type, Value,
+    Range, ShellError, Signals, Span, TryIntoValue, Type, Value,
     ast::{Call, PathMember},
     engine::{EngineState, Stack},
     shell_error::{generic::GenericError, io::IoError},
@@ -213,21 +213,6 @@ impl PipelineData {
             (PipelineData::Empty, _) => false,
             (PipelineData::ListStream(..), _) => false,
             (PipelineData::ByteStream(..), _) => false,
-        }
-    }
-
-    pub fn try_into_value(self, span: Span) -> Result<Value, ShellError> {
-        match self {
-            PipelineData::Empty => Ok(Value::nothing(span)),
-            PipelineData::Value(value, ..) => {
-                if value.span() == Span::unknown() {
-                    Ok(value.with_span(span))
-                } else {
-                    Ok(value)
-                }
-            }
-            PipelineData::ListStream(stream, ..) => stream.try_into_value(),
-            PipelineData::ByteStream(stream, ..) => stream.try_into_value(),
         }
     }
 
@@ -561,7 +546,8 @@ impl PipelineData {
                 Ok(PipelineData::list_stream(stream.map(f), metadata))
             }
             PipelineData::ByteStream(stream, metadata) => {
-                Ok(f(stream.try_into_value()?).into_pipeline_data_with_metadata(metadata))
+                let span = stream.span();
+                Ok(f(stream.try_into_value(span)?).into_pipeline_data_with_metadata(metadata))
             }
         }
     }
@@ -917,6 +903,29 @@ impl PipelineData {
                     Some(ExitStatusGuard::new(exit_future, ignore_error))
                 }
             },
+        }
+    }
+}
+
+impl TryIntoValue for PipelineData {
+    fn try_into_value(self, span: Span) -> Result<Value, ShellError> {
+        match self {
+            PipelineData::Empty => Ok(Value::nothing(span)),
+            PipelineData::Value(value, ..) => {
+                if value.span() == Span::unknown() {
+                    Ok(value.with_span(span))
+                } else {
+                    Ok(value)
+                }
+            }
+            PipelineData::ListStream(stream, ..) => {
+                let span = stream.span();
+                stream.try_into_value(span)
+            }
+            PipelineData::ByteStream(stream, ..) => {
+                let span = stream.span();
+                stream.try_into_value(span)
+            }
         }
     }
 }

--- a/crates/nu-protocol/tests/test_pipeline_data.rs
+++ b/crates/nu-protocol/tests/test_pipeline_data.rs
@@ -9,7 +9,7 @@ fn test_convert_pipeline_data_to_value() {
 
     // Test that conversion into Value is correct
     let new_span = Span::new(5, 6);
-    let converted_value = pipeline_data.into_value(new_span);
+    let converted_value = pipeline_data.try_into_value(new_span);
 
     assert_eq!(converted_value, Ok(Value::int(value_val, new_span)));
 }

--- a/crates/nu-protocol/tests/test_pipeline_data.rs
+++ b/crates/nu-protocol/tests/test_pipeline_data.rs
@@ -1,4 +1,4 @@
-use nu_protocol::{IntoPipelineData, Span, Value};
+use nu_protocol::{IntoPipelineData, Span, TryIntoValue, Value};
 
 #[test]
 fn test_convert_pipeline_data_to_value() {

--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -9,7 +9,7 @@ use std::{
 
 use nu_protocol::{
     CompileError, Config, FromValue, IntoValue, LabeledError, ParseError, PipelineData,
-    PipelineExecutionData, ShellError, Span, Value,
+    PipelineExecutionData, ShellError, Span, TryIntoValue, Value,
     ast::Block,
     debugger::WithoutDebug,
     engine::{Command, EngineState, Stack, StateDelta, StateWorkingSet},

--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -323,7 +323,7 @@ impl NuTester {
         pipeline_execution_data: PipelineExecutionData,
     ) -> Result<T, TestError> {
         let pipeline_data = pipeline_execution_data.body;
-        let value = pipeline_data.into_value(Span::test_data())?;
+        let value = pipeline_data.try_into_value(Span::test_data())?;
         let value = T::from_value(value)?;
         Ok(value)
     }

--- a/crates/nu_plugin_polars/src/cache/rm.rs
+++ b/crates/nu_plugin_polars/src/cache/rm.rs
@@ -83,7 +83,7 @@ fn as_uuid(s: &str, span: Span) -> Result<Uuid, ShellError> {
 mod test {
     use nu_command::{First, Get};
     use nu_plugin_test_support::PluginTest;
-    use nu_protocol::Span;
+    use nu_protocol::{Span, TryIntoValue};
 
     use super::*;
 

--- a/crates/nu_plugin_polars/src/cache/rm.rs
+++ b/crates/nu_plugin_polars/src/cache/rm.rs
@@ -94,7 +94,7 @@ mod test {
             .add_decl(Box::new(First))?
             .add_decl(Box::new(Get))?
             .eval("let df = ([[a b];[1 2] [3 4]] | polars into-df); polars store-ls | get key | first | polars store-rm $in")?;
-        let value = pipeline_data.into_value(Span::test_data())?;
+        let value = pipeline_data.try_into_value(Span::test_data())?;
         let msg = value
             .as_list()?
             .first()

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/agg_groups.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/agg_groups.rs
@@ -4,7 +4,9 @@ use crate::values::{
     CustomValueSupport, NuDataFrame, PolarsPluginObject, PolarsPluginType, cant_convert_err,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::df;
 use polars::series::Series;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/agg_groups.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/agg_groups.rs
@@ -66,7 +66,7 @@ impl PluginCommand for ExprAggGroups {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),
             PolarsPluginObject::NuSelector(selector) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/count.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/count.rs
@@ -4,7 +4,9 @@ use crate::values::{
     CustomValueSupport, NuDataFrame, PolarsPluginObject, PolarsPluginType, cant_convert_err,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::df;
 
 pub struct ExprCount;

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/count.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/count.rs
@@ -61,7 +61,7 @@ impl PluginCommand for ExprCount {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),
             PolarsPluginObject::NuSelector(selector) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/cumulative.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/cumulative.rs
@@ -164,7 +164,7 @@ impl PluginCommand for Cumulative {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         let cum_type: Spanned<String> = call.req(0)?;
         let cum_type = CumulativeType::from_str(&cum_type.item, cum_type.span)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/cumulative.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/cumulative.rs
@@ -7,7 +7,7 @@ use crate::values::{
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Value, shell_error::generic::GenericError,
+    SyntaxShape, TryIntoValue, Value, shell_error::generic::GenericError,
 };
 use polars::prelude::{DataType, IntoSeries, cum_max, cum_min, cum_sum};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/groupby.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/groupby.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::{df, prelude::Expr};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/groupby.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/groupby.rs
@@ -126,7 +126,7 @@ impl PluginCommand for ToLazyGroupBy {
         }
 
         let metadata = input.take_metadata();
-        let pipeline_value = input.into_value(call.head)?;
+        let pipeline_value = input.try_into_value(call.head)?;
         let lazy = NuLazyFrame::try_from_value_coerce(plugin, &pipeline_value)?;
         command(plugin, engine, call, lazy, expressions, maintain_order)
             .map_err(LabeledError::from)

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
@@ -55,7 +55,7 @@ impl PluginCommand for ExprImplode {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),
             _ => Err(cant_convert_err(&value, &[PolarsPluginType::NuExpression])),

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
@@ -4,7 +4,9 @@ use crate::values::{
     CustomValueSupport, NuDataFrame, PolarsPluginObject, PolarsPluginType, cant_convert_err,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::df;
 use polars::series::Series;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/max.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/max.rs
@@ -97,7 +97,7 @@ impl PluginCommand for ExprMax {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_lazy(plugin, engine, call, df.lazy()),
             PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/max.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/max.rs
@@ -6,7 +6,7 @@ use crate::values::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Value,
 };
 
 pub struct ExprMax;

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/mean.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/mean.rs
@@ -97,7 +97,7 @@ impl PluginCommand for ExprMean {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_lazy(plugin, engine, call, df.lazy()),
             PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/mean.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/mean.rs
@@ -6,7 +6,7 @@ use crate::values::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Value,
 };
 
 pub struct ExprMean;

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/median.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/median.rs
@@ -98,7 +98,7 @@ impl PluginCommand for LazyMedian {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command(plugin, engine, call, df.lazy()),
             PolarsPluginObject::NuLazyFrame(lazy) => command(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/median.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/median.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Value,
 };
 #[derive(Clone)]
 pub struct LazyMedian;

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/min.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/min.rs
@@ -6,7 +6,7 @@ use crate::values::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Value,
 };
 
 pub struct ExprMin;

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/min.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/min.rs
@@ -97,7 +97,7 @@ impl PluginCommand for ExprMin {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_lazy(plugin, engine, call, df.lazy()),
             PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/n_unique.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/n_unique.rs
@@ -6,8 +6,8 @@ use crate::{
 use crate::values::{Column, NuDataFrame, NuExpression};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
-    shell_error::generic::GenericError,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+    Value, shell_error::generic::GenericError,
 };
 
 #[derive(Clone)]

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/n_unique.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/n_unique.rs
@@ -77,7 +77,7 @@ impl PluginCommand for NUnique {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/over.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/over.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
-    shell_error::generic::GenericError,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value, shell_error::generic::GenericError,
 };
 use polars::df;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/over.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/over.rs
@@ -89,7 +89,7 @@ impl PluginCommand for Over {
         let expressions = NuExpression::extract_exprs(plugin, expr_value)?;
 
         let metadata = input.take_metadata();
-        let input_value = input.into_value(call.head)?;
+        let input_value = input.try_into_value(call.head)?;
 
         match PolarsPluginObject::try_from_value(plugin, &input_value)? {
             PolarsPluginObject::NuExpression(expr) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/quantile.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/quantile.rs
@@ -7,7 +7,8 @@ use crate::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::prelude::{QuantileMethod, lit};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/quantile.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/quantile.rs
@@ -105,7 +105,7 @@ impl PluginCommand for LazyQuantile {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         let quantile: f64 = call.req(0)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/std.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/std.rs
@@ -89,7 +89,7 @@ impl PluginCommand for ExprStd {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_lazy(plugin, engine, call, df.lazy()),
             PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/std.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/std.rs
@@ -5,7 +5,7 @@ use crate::values::{
 use crate::{dataframe::values::NuExpression, values::NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Value,
 };
 use polars::df;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/sum.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/sum.rs
@@ -6,7 +6,7 @@ use crate::values::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Value,
 };
 
 pub struct ExprSum;

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/sum.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/sum.rs
@@ -97,7 +97,7 @@ impl PluginCommand for ExprSum {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_lazy(plugin, engine, call, df.lazy()),
             PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/var.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/var.rs
@@ -6,7 +6,7 @@ use crate::values::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Value,
 };
 use polars::df;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/var.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/var.rs
@@ -90,7 +90,7 @@ impl PluginCommand for ExprVar {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_lazy(plugin, engine, call, df.lazy()),
             PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/expr_not.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/expr_not.rs
@@ -72,7 +72,7 @@ impl PluginCommand for ExprNot {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),
             PolarsPluginObject::NuSelector(selector) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/expr_not.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/expr_not.rs
@@ -4,7 +4,9 @@ use crate::values::{
     CustomValueSupport, NuDataFrame, PolarsPluginObject, PolarsPluginType, cant_convert_err,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::df;
 
 pub struct ExprNot;

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/is_in.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/is_in.rs
@@ -161,7 +161,7 @@ impl PluginCommand for ExprIsIn {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),
             PolarsPluginObject::NuSelector(selector) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/is_in.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/is_in.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::prelude::{DataType, Expr, lit};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/is_not_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/is_not_null.rs
@@ -84,7 +84,7 @@ impl PluginCommand for IsNotNull {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/is_not_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/is_not_null.rs
@@ -6,7 +6,7 @@ use crate::{
 use super::super::super::values::{Column, NuDataFrame, NuExpression};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Value,
 };
 use polars::prelude::IntoSeries;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/is_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/is_null.rs
@@ -8,7 +8,7 @@ use crate::{
 use super::super::super::values::{Column, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Value,
 };
 use polars::prelude::IntoSeries;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/is_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/is_null.rs
@@ -86,7 +86,7 @@ impl PluginCommand for IsNull {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/otherwise.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/otherwise.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, Signature, Span, SyntaxShape, Type, Value,
+    Category, Example, LabeledError, PipelineData, Signature, Span, SyntaxShape, TryIntoValue,
+    Type, Value,
 };
 
 #[derive(Clone)]

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/otherwise.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/otherwise.rs
@@ -100,7 +100,7 @@ impl PluginCommand for ExprOtherwise {
         let otherwise_predicate = NuExpression::try_from_value(plugin, &otherwise_predicate)?;
 
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         let complete: NuExpression = match NuWhen::try_from_value(plugin, &value)?.when_type {
             NuWhenType::Then(then) => then.otherwise(otherwise_predicate.into_polars()).into(),
             NuWhenType::ChainedThen(chained_when) => chained_when

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/when.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/when.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, Signature, Span, SyntaxShape, Type, Value,
+    Category, Example, LabeledError, PipelineData, Signature, Span, SyntaxShape, TryIntoValue,
+    Type, Value,
 };
 use polars::prelude::when;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/when.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/when.rs
@@ -119,7 +119,7 @@ impl PluginCommand for ExprWhen {
         let then_predicate = NuExpression::try_from_value(plugin, &then_predicate)?;
 
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         let when_then: NuWhen = match value {
             Value::Nothing { .. } => when(when_predicate.into_polars())
                 .then(then_predicate.into_polars())

--- a/crates/nu_plugin_polars/src/dataframe/command/computation/math.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/computation/math.rs
@@ -7,7 +7,7 @@ use crate::values::{
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Value, shell_error::generic::GenericError,
+    SyntaxShape, TryIntoValue, Value, shell_error::generic::GenericError,
 };
 use polars::prelude::{Expr, Literal, df};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/computation/math.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/computation/math.rs
@@ -180,7 +180,7 @@ impl PluginCommand for ExprMath {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         let func_type: Spanned<String> = call.req(0)?;
         let func_type = FunctionType::from_str(&func_type.item, func_type.span)?;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/core/profile.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/profile.rs
@@ -1,7 +1,7 @@
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Value, record,
-    shell_error::generic::GenericError,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, TryIntoValue, Value,
+    record, shell_error::generic::GenericError,
 };
 
 use crate::{

--- a/crates/nu_plugin_polars/src/dataframe/command/core/profile.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/profile.rs
@@ -71,7 +71,7 @@ The units of the timings are microseconds."#
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_lazy(plugin, engine, call, df.lazy()),
             PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
@@ -120,7 +120,7 @@ impl PluginCommand for SaveDF {
         debug!("file: {}", spanned_file.item);
 
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
 
         check_writing_into_source_file(
             metadata.as_ref(),

--- a/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/save/mod.rs
@@ -16,7 +16,7 @@ use log::debug;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, DataSource, Example, LabeledError, PipelineData, PipelineMetadata, ShellError,
-    Signature, Span, Spanned, SyntaxShape, Type,
+    Signature, Span, Spanned, SyntaxShape, TryIntoValue, Type,
     shell_error::{self, generic::GenericError, io::IoError},
 };
 use polars::error::PolarsError;

--- a/crates/nu_plugin_polars/src/dataframe/command/core/to_lazy.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/to_lazy.rs
@@ -108,7 +108,7 @@ mod tests {
         let plugin: Arc<PolarsPlugin> = PolarsPlugin::new_test_mode()?.into();
         let mut plugin_test = PluginTest::new("polars", Arc::clone(&plugin))?;
         let pipeline_data = plugin_test.eval("[[a b]; [6 2] [1 4] [4 1]] | polars into-lazy")?;
-        let value = pipeline_data.into_value(Span::test_data())?;
+        let value = pipeline_data.try_into_value(Span::test_data())?;
         let df = NuLazyFrame::try_from_value(&plugin, &value)?;
         assert!(!df.from_eager);
         Ok(())

--- a/crates/nu_plugin_polars/src/dataframe/command/core/to_lazy.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/to_lazy.rs
@@ -99,7 +99,7 @@ mod tests {
     use std::sync::Arc;
 
     use nu_plugin_test_support::PluginTest;
-    use nu_protocol::{ShellError, Span};
+    use nu_protocol::{ShellError, Span, TryIntoValue};
 
     use super::*;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/core/to_nu.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/to_nu.rs
@@ -1,7 +1,7 @@
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Type,
-    Value, record,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Type, Value, record,
 };
 
 use crate::{

--- a/crates/nu_plugin_polars/src/dataframe/command/core/to_nu.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/to_nu.rs
@@ -105,7 +105,7 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
     match PolarsPluginObject::try_from_value(plugin, &value)? {
         PolarsPluginObject::NuDataFrame(df) => dataframe_command(call, df),
         PolarsPluginObject::NuLazyFrame(lazy) => dataframe_command(call, lazy.collect(call.head)?),

--- a/crates/nu_plugin_polars/src/dataframe/command/core/to_repr.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/to_repr.rs
@@ -81,7 +81,7 @@ shape: (2, 2)
         call: &EvaluatedCall,
         input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         if NuDataFrame::can_downcast(&value) || NuLazyFrame::can_downcast(&value) {
             dataframe_command(plugin, call, value)
         } else {

--- a/crates/nu_plugin_polars/src/dataframe/command/core/to_repr.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/core/to_repr.rs
@@ -1,6 +1,7 @@
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Type,
+    Value,
 };
 
 use crate::{

--- a/crates/nu_plugin_polars/src/dataframe/command/data/alias.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/alias.rs
@@ -4,7 +4,8 @@ use crate::values::{NuExpression, PolarsPluginType};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, Signature, SyntaxShape, Value, record,
+    Category, Example, LabeledError, PipelineData, Signature, SyntaxShape, TryIntoValue, Value,
+    record,
 };
 
 #[derive(Clone)]

--- a/crates/nu_plugin_polars/src/dataframe/command/data/alias.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/alias.rs
@@ -74,7 +74,7 @@ impl PluginCommand for ExprAlias {
 
         let metadata = input.take_metadata();
         // Convert input to Value first to check type
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
 
         let expr = NuExpression::try_from_value(plugin, &value)?;
         let expr: NuExpression = expr.into_polars().alias(alias.as_str()).into();

--- a/crates/nu_plugin_polars/src/dataframe/command/data/cast.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/cast.rs
@@ -8,8 +8,8 @@ use crate::values::NuDataFrame;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
-    record,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value, record,
 };
 use polars::prelude::*;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/data/cast.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/cast.rs
@@ -96,7 +96,7 @@ impl PluginCommand for CastDF {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuLazyFrame(lazy) => {
                 let (dtype, column_nm) = df_args(call)?;

--- a/crates/nu_plugin_polars/src/dataframe/command/data/collect.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/collect.rs
@@ -71,7 +71,7 @@ impl PluginCommand for LazyCollect {
         call: &EvaluatedCall,
         input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuLazyFrame(lazy) => {
                 let mut eager = lazy.collect(call.head)?;

--- a/crates/nu_plugin_polars/src/dataframe/command/data/collect.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/collect.rs
@@ -7,7 +7,7 @@ use crate::{
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Value,
 };
 
 #[derive(Clone)]

--- a/crates/nu_plugin_polars/src/dataframe/command/data/entropy.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/entropy.rs
@@ -1,6 +1,7 @@
 use nu_plugin::PluginCommand;
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue,
 };
 use polars::df;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/data/entropy.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/entropy.rs
@@ -87,7 +87,7 @@ impl PluginCommand for Entropy {
         mut input: nu_protocol::PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),
             _ => Err(cant_convert_err(&value, &[PolarsPluginType::NuExpression])),

--- a/crates/nu_plugin_polars/src/dataframe/command/data/explode.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/explode.rs
@@ -6,7 +6,8 @@ use crate::values::{CustomValueSupport, NuSelector, PolarsPluginObject, PolarsPl
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::prelude::{ExplodeOptions, PlSmallStr, Selector};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/data/explode.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/explode.rs
@@ -142,7 +142,7 @@ pub(crate) fn explode(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
     let explode_options = ExplodeOptions {
         empty_as_null: call.has_flag("empty-as-null")?,
         keep_nulls: call.has_flag("keep-nulls")?,

--- a/crates/nu_plugin_polars/src/dataframe/command/data/fill_nan.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/fill_nan.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 
 #[derive(Clone)]

--- a/crates/nu_plugin_polars/src/dataframe/command/data/fill_nan.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/fill_nan.rs
@@ -100,7 +100,7 @@ impl PluginCommand for LazyFillNA {
     ) -> Result<PipelineData, LabeledError> {
         let fill: Value = call.req(0)?;
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
 
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/data/fill_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/fill_null.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 
 #[derive(Clone)]

--- a/crates/nu_plugin_polars/src/dataframe/command/data/fill_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/fill_null.rs
@@ -107,7 +107,7 @@ impl PluginCommand for LazyFillNull {
     ) -> Result<PipelineData, LabeledError> {
         let fill: Value = call.req(0)?;
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
 
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => cmd_lazy(plugin, engine, call, df.lazy(), fill),

--- a/crates/nu_plugin_polars/src/dataframe/command/data/filter.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/filter.rs
@@ -155,7 +155,7 @@ impl PluginCommand for LazyFilter {
         let expr_value: Value = call.req(0)?;
         let filter_expr = NuExpression::try_from_value(plugin, &expr_value)?;
         let metadata = input.take_metadata();
-        let pipeline_value = input.into_value(call.head)?;
+        let pipeline_value = input.try_into_value(call.head)?;
 
         match PolarsPluginObject::try_from_value(plugin, &pipeline_value)? {
             PolarsPluginObject::NuDataFrame(df) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/data/filter.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/filter.rs
@@ -6,7 +6,8 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 
 #[derive(Clone)]

--- a/crates/nu_plugin_polars/src/dataframe/command/data/filter_with.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/filter_with.rs
@@ -1,7 +1,8 @@
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::prelude::LazyFrame;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/data/filter_with.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/filter_with.rs
@@ -93,7 +93,7 @@ impl PluginCommand for FilterWith {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/data/first.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/first.rs
@@ -125,7 +125,7 @@ impl PluginCommand for FirstDF {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => {
                 command_eager(plugin, engine, call, df).map_err(|e| e.into())

--- a/crates/nu_plugin_polars/src/dataframe/command/data/first.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/first.rs
@@ -9,7 +9,8 @@ use crate::{
 use crate::values::{NuDataFrame, NuExpression};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::df;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/data/join.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/join.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::{
     df,

--- a/crates/nu_plugin_polars/src/dataframe/command/data/join.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/join.rs
@@ -425,7 +425,7 @@ impl PluginCommand for LazyJoin {
         let suffix = suffix.unwrap_or_else(|| "_x".into());
 
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         let lazy = NuLazyFrame::try_from_value_coerce(plugin, &value)?;
         let from_eager = lazy.from_eager;
         let lazy = lazy.to_polars();

--- a/crates/nu_plugin_polars/src/dataframe/command/data/join_where.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/join_where.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, Signature, Span, SyntaxShape, TryIntoValue,
+    Value,
 };
 
 #[derive(Clone)]

--- a/crates/nu_plugin_polars/src/dataframe/command/data/join_where.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/join_where.rs
@@ -97,7 +97,7 @@ impl PluginCommand for LazyJoinWhere {
         let condition = NuExpression::try_from_value(plugin, &condition)?;
         let condition = condition.into_polars();
 
-        let pipeline_value = input.into_value(call.head)?;
+        let pipeline_value = input.try_into_value(call.head)?;
         let lazy = NuLazyFrame::try_from_value_coerce(plugin, &pipeline_value)?;
         let from_eager = lazy.from_eager;
         let lazy = lazy.to_polars();

--- a/crates/nu_plugin_polars/src/dataframe/command/data/last.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/last.rs
@@ -101,7 +101,7 @@ impl PluginCommand for LastDF {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => {
                 command_eager(plugin, engine, call, df).map_err(|e| e.into())

--- a/crates/nu_plugin_polars/src/dataframe/command/data/last.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/last.rs
@@ -9,7 +9,8 @@ use crate::{
 use crate::values::{NuDataFrame, NuExpression};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::df;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/data/rename.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/rename.rs
@@ -129,7 +129,7 @@ impl PluginCommand for RenameDF {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value).map_err(LabeledError::from)? {
             PolarsPluginObject::NuDataFrame(df) => {
                 command_eager(plugin, engine, call, df).map_err(LabeledError::from)

--- a/crates/nu_plugin_polars/src/dataframe/command/data/rename.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/rename.rs
@@ -1,7 +1,8 @@
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 
 use crate::{

--- a/crates/nu_plugin_polars/src/dataframe/command/data/select.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/select.rs
@@ -6,7 +6,8 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, Signature, Span, SyntaxShape, TryIntoValue,
+    Value,
 };
 #[derive(Clone)]
 pub struct LazySelect;

--- a/crates/nu_plugin_polars/src/dataframe/command/data/select.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/select.rs
@@ -177,7 +177,7 @@ impl PluginCommand for LazySelect {
         let expressions = NuExpression::extract_exprs(plugin, expr_value)?;
 
         let metadata = input.take_metadata();
-        let pipeline_value = input.into_value(call.head)?;
+        let pipeline_value = input.try_into_value(call.head)?;
         let lazy = NuLazyFrame::try_from_value_coerce(plugin, &pipeline_value)?;
         let lazy: NuLazyFrame = lazy.to_polars().select(&expressions).into();
         lazy.to_pipeline_data(plugin, engine, call.head)

--- a/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs
@@ -141,7 +141,7 @@ impl PluginCommand for Shift {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
 
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),

--- a/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs
@@ -8,7 +8,8 @@ use crate::values::{Column, NuDataFrame};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 
 use polars_plan::prelude::lit;

--- a/crates/nu_plugin_polars/src/dataframe/command/data/slice.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/slice.rs
@@ -1,6 +1,7 @@
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 
 use crate::{PolarsPlugin, dataframe::values::Column, values::CustomValueSupport};

--- a/crates/nu_plugin_polars/src/dataframe/command/data/slice.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/slice.rs
@@ -72,7 +72,7 @@ impl PluginCommand for SliceDF {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuLazyFrame(lazy) => {
                 command_lazy(plugin, engine, call, lazy).map_err(|e| e.into())

--- a/crates/nu_plugin_polars/src/dataframe/command/data/sort_by_expr.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/sort_by_expr.rs
@@ -160,7 +160,7 @@ impl PluginCommand for LazySortBy {
         };
 
         let metadata = input.take_metadata();
-        let pipeline_value = input.into_value(call.head)?;
+        let pipeline_value = input.try_into_value(call.head)?;
         let lazy = NuLazyFrame::try_from_value_coerce(plugin, &pipeline_value)?;
         let lazy = NuLazyFrame::new(
             lazy.from_eager,

--- a/crates/nu_plugin_polars/src/dataframe/command/data/sort_by_expr.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/sort_by_expr.rs
@@ -7,7 +7,8 @@ use crate::{
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::chunked_array::ops::SortMultipleOptions;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/data/unique.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/unique.rs
@@ -183,7 +183,7 @@ impl PluginCommand for Unique {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
 
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),

--- a/crates/nu_plugin_polars/src/dataframe/command/data/unique.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/unique.rs
@@ -11,7 +11,8 @@ use crate::values::{Column, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::prelude::{IntoSeries, UniqueKeepStrategy, cols};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/data/with_column.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/with_column.rs
@@ -253,7 +253,7 @@ impl PluginCommand for WithColumn {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_eager(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/data/with_column.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/with_column.rs
@@ -8,7 +8,7 @@ use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Value,
+    SyntaxShape, TryIntoValue, Value,
 };
 
 #[derive(Clone)]

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/as_date.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/as_date.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
-    record,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value, record,
 };
 use polars::prelude::{DataType, Field, IntoSeries, Schema, StringMethods, StrptimeOptions, col};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/as_date.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/as_date.rs
@@ -206,7 +206,7 @@ fn command(
 ) -> Result<PipelineData, ShellError> {
     let format: String = call.req(0)?;
     let not_exact = call.has_flag("not-exact")?;
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     let options = StrptimeOptions {
         format: Some(format.into()),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/as_datetime.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/as_datetime.rs
@@ -15,7 +15,7 @@ use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Value,
+    SyntaxShape, TryIntoValue, Value,
 };
 use polars::prelude::{
     DataType, Expr, Field, IntoSeries, LiteralValue, PlSmallStr, Schema, StringMethods,

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/as_datetime.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/as_datetime.rs
@@ -274,7 +274,7 @@ fn command(
         .get_flag::<Spanned<String>>("time-zone")?
         .map(|s| timezone_from_str(&s.item, Some(s.span)))
         .transpose()?;
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     let options = StrptimeOptions {
         format: Some(format.into()),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/convert_time_zone.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/convert_time_zone.rs
@@ -151,7 +151,7 @@ impl PluginCommand for ConvertTimeZone {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
 
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/convert_time_zone.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/convert_time_zone.rs
@@ -8,7 +8,7 @@ use crate::{
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Value,
+    SyntaxShape, TryIntoValue, Value,
 };
 
 use chrono::DateTime;

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_day.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_day.rs
@@ -108,7 +108,7 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     match PolarsPluginObject::try_from_value(plugin, &value)? {
         PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_day.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_day.rs
@@ -8,7 +8,9 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::{
     prelude::{DatetimeMethods, IntoSeries, NamedFrom, col},
     series::Series,

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_hour.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_hour.rs
@@ -10,7 +10,9 @@ use super::super::super::values::NuDataFrame;
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::{
     prelude::{DatetimeMethods, IntoSeries, NamedFrom, col},
     series::Series,

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_hour.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_hour.rs
@@ -116,7 +116,7 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     match PolarsPluginObject::try_from_value(plugin, &value)? {
         PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_minute.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_minute.rs
@@ -8,7 +8,9 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::{
     prelude::{DatetimeMethods, IntoSeries, NamedFrom, col},
     series::Series,

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_minute.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_minute.rs
@@ -100,7 +100,7 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     match PolarsPluginObject::try_from_value(plugin, &value)? {
         PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_month.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_month.rs
@@ -8,7 +8,9 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::{
     prelude::{DatetimeMethods, IntoSeries, NamedFrom, col},
     series::Series,

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_month.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_month.rs
@@ -100,7 +100,7 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     match PolarsPluginObject::try_from_value(plugin, &value)? {
         PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_nanosecond.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_nanosecond.rs
@@ -8,7 +8,9 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::{
     prelude::{DatetimeMethods, IntoSeries, NamedFrom, col},
     series::Series,

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_nanosecond.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_nanosecond.rs
@@ -100,7 +100,7 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     match PolarsPluginObject::try_from_value(plugin, &value)? {
         PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_ordinal.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_ordinal.rs
@@ -8,7 +8,9 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::{
     prelude::{DatetimeMethods, IntoSeries, NamedFrom, col},
     series::Series,

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_ordinal.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_ordinal.rs
@@ -100,7 +100,7 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     match PolarsPluginObject::try_from_value(plugin, &value)? {
         PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_second.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_second.rs
@@ -8,7 +8,9 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::{
     prelude::{DatetimeMethods, IntoSeries, NamedFrom, col},
     series::Series,

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_second.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_second.rs
@@ -100,7 +100,7 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     match PolarsPluginObject::try_from_value(plugin, &value)? {
         PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_week.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_week.rs
@@ -8,7 +8,9 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::{
     prelude::{DatetimeMethods, IntoSeries, NamedFrom, col},
     series::Series,

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_week.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_week.rs
@@ -100,7 +100,7 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     match PolarsPluginObject::try_from_value(plugin, &value)? {
         PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs
@@ -8,7 +8,9 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::{
     prelude::{DatetimeMethods, IntoSeries, NamedFrom, col},
     series::Series,

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs
@@ -100,7 +100,7 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     match PolarsPluginObject::try_from_value(plugin, &value)? {
         PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs
@@ -8,7 +8,9 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{Category, Example, LabeledError, PipelineData, ShellError, Signature, Span};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+};
 use polars::{
     prelude::{DatetimeMethods, IntoSeries, NamedFrom, col},
     series::Series,

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs
@@ -100,7 +100,7 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     match PolarsPluginObject::try_from_value(plugin, &value)? {
         PolarsPluginObject::NuLazyFrame(lazy) => command_lazy(plugin, engine, call, lazy),

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/replace_time_zone.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/replace_time_zone.rs
@@ -9,7 +9,7 @@ use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Value,
+    SyntaxShape, TryIntoValue, Value,
 };
 
 use chrono::DateTime;

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/replace_time_zone.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/replace_time_zone.rs
@@ -233,7 +233,7 @@ impl PluginCommand for ReplaceTimeZone {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
 
         let ambiguous = match call.get_flag::<Value>("ambiguous")? {
             Some(v @ Value::String { .. }) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/strftime.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/strftime.rs
@@ -10,7 +10,8 @@ use super::super::super::values::{Column, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::prelude::IntoSeries;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/strftime.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/strftime.rs
@@ -101,7 +101,7 @@ impl PluginCommand for StrFTime {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_df(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/truncate.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/truncate.rs
@@ -180,7 +180,7 @@ fn command(
     call: &EvaluatedCall,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let value = input.into_value(call.head)?;
+    let value = input.try_into_value(call.head)?;
 
     let every = match call.req(0)? {
         // handle Value::Duration input for maximum compatibility

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/truncate.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/truncate.rs
@@ -9,7 +9,8 @@ use std::sync::Arc;
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 
 use chrono::DateTime;

--- a/crates/nu_plugin_polars/src/dataframe/command/integer/to_decimal.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/integer/to_decimal.rs
@@ -8,7 +8,8 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::prelude::DataType;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/integer/to_decimal.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/integer/to_decimal.rs
@@ -68,7 +68,7 @@ impl PluginCommand for ToDecimal {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command(plugin, engine, call, expr),
             _ => Err(cant_convert_err(&value, &[PolarsPluginType::NuExpression])),

--- a/crates/nu_plugin_polars/src/dataframe/command/integer/to_integer.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/integer/to_integer.rs
@@ -8,7 +8,8 @@ use crate::{
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::prelude::{DataType, Expr, lit};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/integer/to_integer.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/integer/to_integer.rs
@@ -74,7 +74,7 @@ impl PluginCommand for ToInteger {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command(plugin, engine, call, expr),
             _ => Err(cant_convert_err(&value, &[PolarsPluginType::NuExpression])),

--- a/crates/nu_plugin_polars/src/dataframe/command/list/contains.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/list/contains.rs
@@ -126,7 +126,7 @@ impl PluginCommand for ListContains {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),
             PolarsPluginObject::NuSelector(selector) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/list/contains.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/list/contains.rs
@@ -10,7 +10,8 @@ use super::super::super::values::{Column, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 
 #[derive(Clone)]

--- a/crates/nu_plugin_polars/src/dataframe/command/string/contains.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/contains.rs
@@ -10,7 +10,8 @@ use super::super::super::values::{Column, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::prelude::{IntoSeries, StringNameSpaceImpl, lit};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/string/contains.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/contains.rs
@@ -107,7 +107,7 @@ impl PluginCommand for Contains {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_df(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_join.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_join.rs
@@ -100,7 +100,7 @@ impl PluginCommand for StrJoin {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_df(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_join.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_join.rs
@@ -10,7 +10,8 @@ use super::super::super::values::{Column, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::{prelude::StringNameSpaceImpl, series::IntoSeries};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_lengths.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_lengths.rs
@@ -97,7 +97,7 @@ impl PluginCommand for StrLengths {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_df(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_lengths.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_lengths.rs
@@ -10,7 +10,7 @@ use super::super::super::values::{Column, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Value,
 };
 use polars::prelude::{IntoSeries, StringNameSpaceImpl};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_replace.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_replace.rs
@@ -107,7 +107,7 @@ impl PluginCommand for StrReplace {
         call: &EvaluatedCall,
         input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_df(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_replace.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_replace.rs
@@ -10,7 +10,8 @@ use super::super::super::values::{Column, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::prelude::{IntoSeries, StringNameSpaceImpl, lit};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_replace_all.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_replace_all.rs
@@ -111,7 +111,7 @@ impl PluginCommand for StrReplaceAll {
         call: &EvaluatedCall,
         input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_df(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_replace_all.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_replace_all.rs
@@ -10,7 +10,8 @@ use super::super::super::values::{Column, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::prelude::{IntoSeries, StringNameSpaceImpl, lit};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_slice.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_slice.rs
@@ -125,7 +125,7 @@ impl PluginCommand for StrSlice {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_df(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_slice.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_slice.rs
@@ -10,7 +10,8 @@ use super::super::super::values::{Column, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::{
     prelude::{Expr, IntoSeries, NamedFrom, Null, StringNameSpaceImpl, lit},

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_strip_chars.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_strip_chars.rs
@@ -9,7 +9,8 @@ use super::super::super::values::{Column, NuDataFrame};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    TryIntoValue, Value,
 };
 use polars::prelude::Expr;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_strip_chars.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_strip_chars.rs
@@ -142,7 +142,7 @@ impl PluginCommand for StrStripChars {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),
             PolarsPluginObject::NuSelector(selector) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/string/to_lowercase.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/to_lowercase.rs
@@ -96,7 +96,7 @@ impl PluginCommand for ToLowerCase {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_df(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/string/to_lowercase.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/to_lowercase.rs
@@ -10,7 +10,7 @@ use super::super::super::values::{Column, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue, Value,
 };
 use polars::prelude::{IntoSeries, StringNameSpaceImpl};
 

--- a/crates/nu_plugin_polars/src/dataframe/command/string/to_uppercase.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/to_uppercase.rs
@@ -100,7 +100,7 @@ impl PluginCommand for ToUpperCase {
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
         let metadata = input.take_metadata();
-        let value = input.into_value(call.head)?;
+        let value = input.try_into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuDataFrame(df) => command_df(plugin, engine, call, df),
             PolarsPluginObject::NuLazyFrame(lazy) => {

--- a/crates/nu_plugin_polars/src/dataframe/command/string/to_uppercase.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/to_uppercase.rs
@@ -9,8 +9,8 @@ use super::super::super::values::{Column, NuDataFrame};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
-    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Value,
-    shell_error::generic::GenericError,
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, TryIntoValue,
+    Value, shell_error::generic::GenericError,
 };
 use polars::prelude::{IntoSeries, StringNameSpaceImpl};
 

--- a/crates/nu_plugin_polars/src/dataframe/values/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/mod.rs
@@ -14,7 +14,7 @@ use nu_dtype::custom_value::NuDataTypeCustomValue;
 use nu_plugin::EngineInterface;
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    CustomValue, PipelineData, ShellError, Span, Spanned, Type, Value, ast::Operator,
+    CustomValue, PipelineData, ShellError, Span, Spanned, TryIntoValue, Type, Value, ast::Operator,
 };
 use nu_schema::custom_value::NuSchemaCustomValue;
 use std::{cmp::Ordering, fmt};

--- a/crates/nu_plugin_polars/src/dataframe/values/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/mod.rs
@@ -151,7 +151,7 @@ impl PolarsPluginObject {
         input: PipelineData,
         span: Span,
     ) -> Result<Self, ShellError> {
-        let value = input.into_value(span)?;
+        let value = input.try_into_value(span)?;
         Self::try_from_value(plugin, &value)
     }
 
@@ -414,7 +414,7 @@ pub trait CustomValueSupport: Cacheable {
         input: PipelineData,
         span: Span,
     ) -> Result<Self, ShellError> {
-        let value = input.into_value(span)?;
+        let value = input.try_into_value(span)?;
         Self::try_from_value(plugin, &value)
     }
 

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/mod.rs
@@ -8,7 +8,7 @@ pub use operations::Axis;
 
 use indexmap::map::IndexMap;
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{PipelineData, Record, ShellError, Span, Value, did_you_mean};
+use nu_protocol::{PipelineData, Record, ShellError, Span, TryIntoValue, Value, did_you_mean};
 use polars::prelude::{
     Column as PolarsColumn, DataFrame, DataType, IntoLazy, PolarsObject, Series,
 };

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/mod.rs
@@ -475,7 +475,7 @@ impl NuDataFrame {
         input: PipelineData,
         span: Span,
     ) -> Result<Self, ShellError> {
-        let value = input.into_value(span)?;
+        let value = input.try_into_value(span)?;
         Self::try_from_value_coerce(plugin, &value, span)
     }
 }

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/mod.rs
@@ -118,7 +118,7 @@ impl NuLazyFrame {
         input: PipelineData,
         span: Span,
     ) -> Result<Self, ShellError> {
-        let value = input.into_value(span)?;
+        let value = input.try_into_value(span)?;
         Self::try_from_value_coerce(plugin, &value)
     }
 }

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/mod.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use core::fmt;
 use nu_protocol::shell_error::generic::GenericError;
-use nu_protocol::{PipelineData, ShellError, Span, Value, record};
+use nu_protocol::{PipelineData, ShellError, Span, TryIntoValue, Value, record};
 use polars::prelude::{Expr, IntoLazy, LazyFrame};
 use std::sync::Arc;
 use uuid::Uuid;


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

`PipelineData` has the `into_value()` method which is separate from the `IntoValue` trait and is fallible too. For that reason the `TryIntoValue` trait exists. This PR replaces the old `into_value()` method of `PipelineData` with the `try_into_value` from `TryIntoValue`.

I'm not entirely sure if this is an improvement or not.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
n/a