### PR TITLE
deps: update git2 minimum to 0.20.4

### DIFF
--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -20,4 +20,4 @@ bench = false
 nu-plugin = { path = "../nu-plugin", version = "0.111.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.111.1" }
 
-git2 = "0.20"
+git2 = "0.20.4"


### PR DESCRIPTION
```log
Crate:     git2
Version:   0.20.2
Warning:   unsound
Title:     Potential undefined behavior when dereferencing Buf struct
Date:      2026-02-02
ID:        RUSTSEC-2026-0008
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0008
```