### PR TITLE
Fix `input list` when stdin is redirected in Unix TTY environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,6 +1499,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more 2.1.1",
  "document-features",
+ "filedescriptor",
  "mio 1.1.1",
  "parking_lot",
  "rustix 1.1.3",
@@ -2141,6 +2142,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
 dependencies = [
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -56,7 +56,7 @@ chrono = { workspace = true, features = [
 ], default-features = false }
 chrono-humanize = { workspace = true }
 chrono-tz = { workspace = true }
-crossterm = { workspace = true, optional = true }
+crossterm = { workspace = true, optional = true, features = ["use-dev-tty"] }
 csv = { workspace = true }
 devicons = { workspace = true }
 digest = { workspace = true, default-features = false }


### PR DESCRIPTION
Enable `crossterm`'s `use-dev-tty` feature for `nu-command`. 

This fixes `input list` in Unix environments where Nushell is still attached to a real terminal, but `stdin` is redirected or proxied by an outer tool such as a git hook runner.
 
Currently, `input list` can fail with an interact/I/O error in hook-runner style environments even though the user is still interacting from a real terminal. A concrete example is running Nushell-based commit hooks through a wrapper that changes `stdin` handling. In that setup, interactive selection should still work, but event reading fails.

This switches `crossterm` to its `use-dev-tty` Unix backend, so terminal event handling uses the controlling TTY path  instead of relying on the redirected `stdin` path.

BTW: This feature works before but fails recently

## Release notes summary
Fixed `input list` when stdin is redirected in Unix TTY environments.