### PR TITLE
refactor some commands and add tests

### DIFF
--- a/crates/nu-mcp/src/evaluation.rs
+++ b/crates/nu-mcp/src/evaluation.rs
@@ -6,6 +6,7 @@ use nu_protocol::{
     engine::{EngineState, Job, Jobs, Mail, Stack, StateWorkingSet, ThreadJob},
 };
 use std::{
+    fmt::Write,
     sync::{Arc, Mutex as SyncMutex, atomic::AtomicBool, mpsc, mpsc::Sender},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -343,6 +344,115 @@ impl Evaluator {
         })?;
         rt.block_on(self.eval_async(nu_source, CancellationToken::new()))
     }
+
+    pub async fn list_available_commands(&self, find: Option<String>) -> Result<String, String> {
+        let state = self.state.lock().await;
+        let commands: Vec<String> = state
+            .engine_state
+            .get_signatures_and_declids(false)
+            .into_iter()
+            .filter(|(sig, _)| {
+                if let Some(find) = &find {
+                    let find = find.to_lowercase();
+                    let name = sig.name.to_lowercase();
+                    let description = sig.description.to_lowercase();
+                    let search_terms = sig
+                        .search_terms
+                        .iter()
+                        .any(|term| term.to_lowercase().contains(&find));
+
+                    name.contains(&find) || description.contains(&find) || search_terms
+                } else {
+                    true
+                }
+            })
+            .map(|(sig, _)| format!("{} - {}", sig.call_signature(), sig.description))
+            .collect();
+
+        if commands.is_empty() {
+            return Err("No matching commands found".to_string());
+        }
+
+        Ok(commands.join("\n"))
+    }
+
+    pub async fn command_help(&self, command_name: &str) -> Result<String, String> {
+        let state = self.state.lock().await;
+
+        let signature = state
+            .engine_state
+            .get_signatures_and_declids(false)
+            .into_iter()
+            .find_map(|(sig, _)| {
+                if sig.name == command_name {
+                    Some(sig)
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(|| format!("command `{}` not found", command_name))?;
+
+        Ok(format_command_help(&signature))
+    }
+}
+
+fn format_command_help(signature: &nu_protocol::Signature) -> String {
+    let mut output = String::new();
+    let usage = signature.call_signature();
+
+    writeln!(output, "Command: {}", signature.name).ok();
+    writeln!(output, "Usage: {}", usage).ok();
+
+    if !signature.description.is_empty() {
+        writeln!(output, "\nDescription: {}", signature.description).ok();
+    }
+
+    if !signature.extra_description.is_empty() {
+        writeln!(output, "\nDetails: {}", signature.extra_description).ok();
+    }
+
+    if !signature.search_terms.is_empty() {
+        writeln!(
+            output,
+            "\nSearch terms: {}",
+            signature.search_terms.join(", ")
+        )
+        .ok();
+    }
+
+    if !signature.named.is_empty() {
+        writeln!(output, "\nFlags:").ok();
+        for flag in &signature.named {
+            let short = flag.short.map(|s| format!("-{}, ", s)).unwrap_or_default();
+            let arg = flag
+                .arg
+                .as_ref()
+                .map(|shape| format!(" <{shape}>", shape = shape))
+                .unwrap_or_default();
+            writeln!(output, "  {}--{}{}: {}", short, flag.long, arg, flag.desc).ok();
+        }
+    }
+
+    if !signature.required_positional.is_empty()
+        || !signature.optional_positional.is_empty()
+        || signature.rest_positional.is_some()
+    {
+        writeln!(output, "\nParameters:").ok();
+
+        for positional in &signature.required_positional {
+            writeln!(output, "  {}: {}", positional.name, positional.desc).ok();
+        }
+
+        for positional in &signature.optional_positional {
+            writeln!(output, "  [{}]: {}", positional.name, positional.desc).ok();
+        }
+
+        if let Some(rest) = &signature.rest_positional {
+            writeln!(output, "  ...{}: {}", rest.name, rest.desc).ok();
+        }
+    }
+
+    output.trim_end().to_string()
 }
 
 /// Registers a [`ThreadJob`] for a still-running evaluation and spawns a task

--- a/crates/nu-mcp/src/lib.rs
+++ b/crates/nu-mcp/src/lib.rs
@@ -1,6 +1,3 @@
-use std::sync::Arc;
-use std::time::Duration;
-
 use hyper_util::{
     rt::{TokioExecutor, TokioIo},
     server::conn::auto::Builder,
@@ -18,6 +15,8 @@ use rmcp::{
     },
 };
 use server::NushellMcpServer;
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::runtime::Runtime;
 use tokio_util::sync::CancellationToken;
 use tracing_subscriber::EnvFilter;

--- a/crates/nu-mcp/src/server.rs
+++ b/crates/nu-mcp/src/server.rs
@@ -1,5 +1,4 @@
-use std::sync::Arc;
-
+use crate::evaluation::Evaluator;
 use nu_protocol::{UseAnsiColoring, engine::EngineState};
 use rmcp::{
     RoleServer, ServerHandler,
@@ -10,8 +9,7 @@ use rmcp::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-use crate::evaluation::Evaluator;
+use std::sync::Arc;
 
 pub struct NushellMcpServer {
     tool_router: ToolRouter<Self>,
@@ -36,19 +34,10 @@ impl NushellMcpServer {
 By default all available commands will be returned. To find a specific command by searching command names, descriptions and search terms, use the find parameter."#)]
     async fn list_commands(
         &self,
-        ctx: RequestContext<RoleServer>,
+        _ctx: RequestContext<RoleServer>,
         Parameters(ListCommandsRequest { find }): Parameters<ListCommandsRequest>,
     ) -> Result<String, String> {
-        let cmd = if let Some(f) = find {
-            format!("help commands --find {f}")
-        } else {
-            "help commands".to_string()
-        };
-
-        self.evaluator
-            .eval_async(&cmd, ctx.ct)
-            .await
-            .map_err(|err| err.message.to_string())
+        self.evaluator.list_available_commands(find).await
     }
 
     #[tool(
@@ -56,14 +45,10 @@ By default all available commands will be returned. To find a specific command b
     )]
     async fn command_help(
         &self,
-        ctx: RequestContext<RoleServer>,
+        _ctx: RequestContext<RoleServer>,
         Parameters(CommandNameRequest { name }): Parameters<CommandNameRequest>,
     ) -> Result<String, String> {
-        let cmd = format!("help {name}");
-        self.evaluator
-            .eval_async(&cmd, ctx.ct)
-            .await
-            .map_err(|err| err.message.to_string())
+        self.evaluator.command_help(&name).await
     }
 
     #[doc = include_str!("evaluate_tool.md")]
@@ -108,5 +93,228 @@ impl ServerHandler for NushellMcpServer {
                     .with_website_url("https://www.nushell.sh"),
             )
             .with_instructions(include_str!("instructions.md"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::channel::mpsc;
+    use nu_cmd_lang::create_default_context;
+    use rmcp::model::RequestId;
+    use rmcp::service::{RxJsonRpcMessage, TxJsonRpcMessage, serve_directly};
+    use serde_json::Value as JsonValue;
+
+    fn make_request_context(request_id: i64) -> RequestContext<RoleServer> {
+        let engine_state = create_default_context();
+        let server = NushellMcpServer::new(engine_state);
+
+        let (tx, _rx_sink) = mpsc::unbounded::<TxJsonRpcMessage<RoleServer>>();
+        let (_tx_stream, rx_stream) = mpsc::unbounded::<RxJsonRpcMessage<RoleServer>>();
+        let transport = (tx, rx_stream);
+
+        let running = serve_directly(server, transport, None);
+        let peer = running.peer().clone();
+        drop(running);
+
+        RequestContext::new(RequestId::Number(request_id), peer)
+    }
+
+    #[test]
+    fn server_info_serializes_expected_mcp_metadata() {
+        let engine_state = create_default_context();
+        let server = NushellMcpServer::new(engine_state);
+        let info = server.get_info();
+        let json = serde_json::to_value(&info).expect("ServerInfo should serialize to JSON");
+
+        let capabilities = json
+            .get("capabilities")
+            .expect("ServerInfo JSON should include capabilities");
+        let tools = capabilities
+            .get("tools")
+            .and_then(JsonValue::as_object)
+            .expect("Server capabilities should include tools");
+        assert!(
+            tools.is_empty(),
+            "tools capability should be present as an empty object"
+        );
+
+        let instructions = json
+            .get("instructions")
+            .expect("ServerInfo JSON should include instructions")
+            .as_str()
+            .expect("instructions should be a string");
+        assert!(
+            instructions.contains("Nushell native commands"),
+            "instructions should document command discovery"
+        );
+
+        let server_info = json
+            .get("serverInfo")
+            .or_else(|| json.get("server_info"))
+            .expect("ServerInfo JSON should include serverInfo");
+        assert_eq!(
+            server_info.get("name").and_then(JsonValue::as_str),
+            Some("nushell-mcp-server")
+        );
+        assert_eq!(
+            server_info.get("title").and_then(JsonValue::as_str),
+            Some("Nushell MCP Server")
+        );
+        assert_eq!(
+            server_info.get("version").and_then(JsonValue::as_str),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+        assert_eq!(
+            server_info
+                .get("websiteUrl")
+                .or_else(|| server_info.get("website_url"))
+                .and_then(JsonValue::as_str),
+            Some("https://www.nushell.sh")
+        );
+    }
+
+    #[test]
+    fn tool_router_exposes_expected_mcp_tools() {
+        let router = NushellMcpServer::tool_router();
+        let tool_names: Vec<_> = router
+            .list_all()
+            .iter()
+            .map(|tool| tool.name.clone())
+            .collect();
+        assert_eq!(
+            tool_names,
+            vec![
+                "command_help".to_string(),
+                "evaluate".to_string(),
+                "list_commands".to_string()
+            ]
+        );
+
+        let list_commands_tool = router
+            .get("list_commands")
+            .expect("list_commands tool should be registered");
+        assert!(
+            list_commands_tool
+                .description
+                .as_deref()
+                .unwrap_or("")
+                .contains("List available Nushell native commands"),
+            "list_commands tool description should mention native command discovery"
+        );
+    }
+
+    fn create_mcp_server() -> NushellMcpServer {
+        let engine_state = create_default_context();
+        NushellMcpServer::new(engine_state)
+    }
+
+    #[tokio::test]
+    async fn list_commands_tool_returns_non_empty_help() {
+        let server = create_mcp_server();
+        let ctx = make_request_context(0);
+
+        let result = server
+            .list_commands(
+                ctx,
+                Parameters(ListCommandsRequest {
+                    find: Some("version".to_string()),
+                }),
+            )
+            .await
+            .expect("list_commands should succeed");
+
+        assert!(
+            result.len() > 20,
+            "list_commands output should not be empty"
+        );
+        assert!(
+            result.to_lowercase().contains("version"),
+            "list_commands output should mention version"
+        );
+    }
+
+    #[tokio::test]
+    async fn evaluate_tool_computes_basic_expression() {
+        let server = create_mcp_server();
+        let ctx = make_request_context(1);
+
+        let result = server
+            .evaluate(
+                ctx,
+                Parameters(NuSourceRequest {
+                    input: "5 + 2".to_string(),
+                }),
+            )
+            .await
+            .expect("evaluate should succeed");
+
+        assert!(
+            result.contains("output"),
+            "evaluate output should include output metadata"
+        );
+        assert!(
+            result.contains('7'),
+            "evaluate output should include the computed result"
+        );
+    }
+
+    #[tokio::test]
+    async fn evaluate_tool_history_index_increments() {
+        let engine_state = nu_cmd_lang::create_default_context();
+        let server = NushellMcpServer::new(engine_state);
+
+        let result1 = server
+            .evaluate(
+                make_request_context(3),
+                Parameters(NuSourceRequest {
+                    input: "1".to_string(),
+                }),
+            )
+            .await
+            .expect("first evaluate should succeed");
+        assert!(
+            result1.contains("history_index:0") || result1.contains("history_index: 0"),
+            "first evaluation should have history_index 0"
+        );
+
+        let result2 = server
+            .evaluate(
+                make_request_context(4),
+                Parameters(NuSourceRequest {
+                    input: "2".to_string(),
+                }),
+            )
+            .await
+            .expect("second evaluate should succeed");
+        assert!(
+            result2.contains("history_index:1") || result2.contains("history_index: 1"),
+            "second evaluation should have history_index 1"
+        );
+    }
+
+    #[tokio::test]
+    async fn command_help_tool_returns_help_for_version_command() {
+        let server = create_mcp_server();
+        let ctx = make_request_context(2);
+
+        let result = server
+            .command_help(
+                ctx,
+                Parameters(CommandNameRequest {
+                    name: "version".to_string(),
+                }),
+            )
+            .await
+            .expect("command_help should succeed");
+
+        assert!(
+            result.to_lowercase().contains("version"),
+            "command_help output should mention the command name"
+        );
+        assert!(
+            result.to_lowercase().contains("usage") || result.contains("Usage"),
+            "command_help output should include usage information"
+        );
     }
 }


### PR DESCRIPTION
This PR refactors some of the MCP by making list_commands and command_help use engine introspection instead of relying on `help commands`. It also adds more tests to help prove that the mcp is working and keep us from breaking it.

## Release notes summary - What our users need to know
Refactor nu-mcp to allow for engine introspection and add more thorough testing.

## Tasks after submitting
N/A