### PR TITLE
feat(streaming): stream CSV/TSV output through 'save' and fail fast on schema drift implements #14338

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -88,111 +88,25 @@ impl Command for Save {
             });
 
         let from_io_error = IoError::factory(span, path.item.as_path());
+        let save_byte_stream = |stream, metadata| {
+            stream_byte_stream_to_file(
+                stream,
+                ByteStreamSaveContext {
+                    metadata,
+                    path: &path,
+                    stderr_path: stderr_path.as_ref(),
+                    engine_state,
+                    append,
+                    force,
+                    span,
+                    progress,
+                },
+            )
+        };
+
         match input {
             PipelineData::ByteStream(stream, metadata) => {
-                check_saving_to_source_file(metadata.as_ref(), &path, stderr_path.as_ref())?;
-
-                let (file, stderr_file) =
-                    get_files(engine_state, &path, stderr_path.as_ref(), append, force)?;
-
-                let size = stream.known_size();
-                let signals = engine_state.signals();
-
-                match stream.into_source() {
-                    ByteStreamSource::Read(read) => {
-                        stream_to_file(read, size, signals, file, span, progress)?;
-                    }
-                    ByteStreamSource::File(source) => {
-                        stream_to_file(source, size, signals, file, span, progress)?;
-                    }
-                    #[cfg(feature = "os")]
-                    ByteStreamSource::Child(mut child) => {
-                        fn write_or_consume_stderr(
-                            stderr: ChildPipe,
-                            file: Option<File>,
-                            span: Span,
-                            signals: &Signals,
-                            progress: bool,
-                        ) -> Result<(), ShellError> {
-                            if let Some(file) = file {
-                                match stderr {
-                                    ChildPipe::Pipe(pipe) => {
-                                        stream_to_file(pipe, None, signals, file, span, progress)
-                                    }
-                                    ChildPipe::Tee(tee) => {
-                                        stream_to_file(tee, None, signals, file, span, progress)
-                                    }
-                                }?
-                            } else {
-                                match stderr {
-                                    ChildPipe::Pipe(mut pipe) => {
-                                        io::copy(&mut pipe, &mut io::stderr())
-                                    }
-                                    ChildPipe::Tee(mut tee) => {
-                                        io::copy(&mut tee, &mut io::stderr())
-                                    }
-                                }
-                                .map_err(|err| IoError::new(err, span, None))?;
-                            }
-                            Ok(())
-                        }
-
-                        match (child.stdout.take(), child.stderr.take()) {
-                            (Some(stdout), stderr) => {
-                                // delegate a thread to redirect stderr to result.
-                                let handler = stderr
-                                    .map(|stderr| {
-                                        let signals = signals.clone();
-                                        thread::Builder::new().name("stderr saver".into()).spawn(
-                                            move || {
-                                                write_or_consume_stderr(
-                                                    stderr,
-                                                    stderr_file,
-                                                    span,
-                                                    &signals,
-                                                    progress,
-                                                )
-                                            },
-                                        )
-                                    })
-                                    .transpose()
-                                    .map_err(&from_io_error)?;
-
-                                let res = match stdout {
-                                    ChildPipe::Pipe(pipe) => {
-                                        stream_to_file(pipe, None, signals, file, span, progress)
-                                    }
-                                    ChildPipe::Tee(tee) => {
-                                        stream_to_file(tee, None, signals, file, span, progress)
-                                    }
-                                };
-                                if let Some(h) = handler {
-                                    h.join().map_err(|err| ShellError::ExternalCommand {
-                                        label: "Fail to receive external commands stderr message"
-                                            .to_string(),
-                                        help: format!("{err:?}"),
-                                        span,
-                                    })??;
-                                }
-                                res?;
-                            }
-                            (None, Some(stderr)) => {
-                                write_or_consume_stderr(
-                                    stderr,
-                                    stderr_file,
-                                    span,
-                                    signals,
-                                    progress,
-                                )?;
-                            }
-                            (None, None) => {}
-                        };
-
-                        child.wait()?;
-                    }
-                }
-
-                Ok(PipelineData::empty())
+                save_byte_stream(stream, metadata.as_ref())
             }
             PipelineData::ListStream(ls, pipeline_metadata)
                 if raw || prepare_path(&path, append, force)?.0.extension().is_none() =>
@@ -242,6 +156,12 @@ impl Command for Save {
                             span,
                         )
                         .map(|()| PipelineData::empty());
+                }
+
+                // If convert_to_extension returned a ByteStream (e.g., from `to csv`), stream it directly
+                // instead of collecting into memory with into_value()
+                if let PipelineData::ByteStream(stream, metadata) = converted {
+                    return save_byte_stream(stream, metadata.as_ref());
                 }
 
                 let bytes = value_to_bytes(converted.into_value(span)?)?;
@@ -521,6 +441,119 @@ fn get_files(
         .transpose()?;
 
     Ok((file, stderr_file))
+}
+
+fn write_or_consume_stderr(
+    stderr: ChildPipe,
+    file: Option<File>,
+    span: Span,
+    signals: &Signals,
+    progress: bool,
+) -> Result<(), ShellError> {
+    if let Some(file) = file {
+        match stderr {
+            ChildPipe::Pipe(pipe) => stream_to_file(pipe, None, signals, file, span, progress),
+            ChildPipe::Tee(tee) => stream_to_file(tee, None, signals, file, span, progress),
+        }?
+    } else {
+        match stderr {
+            ChildPipe::Pipe(mut pipe) => io::copy(&mut pipe, &mut io::stderr()),
+            ChildPipe::Tee(mut tee) => io::copy(&mut tee, &mut io::stderr()),
+        }
+        .map_err(|err| IoError::new(err, span, None))?;
+    }
+    Ok(())
+}
+
+struct ByteStreamSaveContext<'a> {
+    metadata: Option<&'a PipelineMetadata>,
+    path: &'a Spanned<PathBuf>,
+    stderr_path: Option<&'a Spanned<PathBuf>>,
+    engine_state: &'a EngineState,
+    append: bool,
+    force: bool,
+    span: Span,
+    progress: bool,
+}
+
+fn stream_byte_stream_to_file(
+    stream: ByteStream,
+    context: ByteStreamSaveContext<'_>,
+) -> Result<PipelineData, ShellError> {
+    let from_io_error = IoError::factory(context.span, context.path.item.as_path());
+    let span = context.span;
+    let progress = context.progress;
+
+    check_saving_to_source_file(context.metadata, context.path, context.stderr_path)?;
+
+    let (file, stderr_file) = get_files(
+        context.engine_state,
+        context.path,
+        context.stderr_path,
+        context.append,
+        context.force,
+    )?;
+
+    let size = stream.known_size();
+    let signals = context.engine_state.signals();
+
+    match stream.into_source() {
+        ByteStreamSource::Read(read) => {
+            stream_to_file(read, size, signals, file, span, progress)?;
+        }
+        ByteStreamSource::File(source) => {
+            stream_to_file(source, size, signals, file, span, progress)?;
+        }
+        #[cfg(feature = "os")]
+        ByteStreamSource::Child(mut child) => {
+            match (child.stdout.take(), child.stderr.take()) {
+                (Some(stdout), stderr) => {
+                    let handler = stderr
+                        .map(|stderr| {
+                            let signals = signals.clone();
+                            thread::Builder::new()
+                                .name("stderr saver".into())
+                                .spawn(move || {
+                                    write_or_consume_stderr(
+                                        stderr,
+                                        stderr_file,
+                                        span,
+                                        &signals,
+                                        progress,
+                                    )
+                                })
+                        })
+                        .transpose()
+                        .map_err(&from_io_error)?;
+
+                    let res = match stdout {
+                        ChildPipe::Pipe(pipe) => {
+                            stream_to_file(pipe, None, signals, file, span, progress)
+                        }
+                        ChildPipe::Tee(tee) => {
+                            stream_to_file(tee, None, signals, file, span, progress)
+                        }
+                    };
+                    if let Some(h) = handler {
+                        h.join().map_err(|err| ShellError::ExternalCommand {
+                            label: "Fail to receive external commands stderr message".to_string(),
+                            help: format!("{err:?}"),
+                            span,
+                        })??;
+                    }
+                    res?;
+                }
+                (None, Some(stderr)) => {
+                    write_or_consume_stderr(stderr, stderr_file, span, signals, progress)?;
+                }
+                (None, None) => {}
+            };
+
+            child.wait()?;
+        }
+    }
+
+    Ok(PipelineData::empty())
 }
 
 fn stream_to_file(

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -65,6 +65,25 @@ fn make_cant_convert_error(value: &Value, format_name: &'static str) -> ShellErr
     }
 }
 
+fn make_schema_drift_error(format_name: &str, new_column: &str, head: Span) -> ShellError {
+    let command_name = format_name.to_ascii_lowercase();
+
+    ShellError::Generic(
+        GenericError::new(
+            format!(
+                "streamed {command_name} schema changed: new column '{new_column}' appeared after output started"
+            ),
+            format!(
+                "{format_name} output started with a specific set of columns, but a later row contains an unexpected column."
+            ),
+            head,
+        )
+        .with_help(format!(
+            "use `to {command_name} --columns [...]` or `collect` before `to {command_name}`"
+        )),
+    )
+}
+
 pub struct ToDelimitedDataArgs {
     pub noheaders: bool,
     pub separator: Spanned<char>,
@@ -75,19 +94,74 @@ pub struct ToDelimitedDataArgs {
     pub content_type: Option<String>,
 }
 
+/// Helper function to extract column names from a Value
+fn extract_columns(value: &Value) -> Result<Vec<String>, ShellError> {
+    match value {
+        Value::Record { val, .. } => Ok(val.columns().cloned().collect()),
+        Value::List { vals, .. } => Ok(merge_descriptors(vals)),
+        Value::Error { error, .. } => Err(*error.clone()),
+        other => Err(make_unsupported_input_error(
+            other.get_type(),
+            other.span(),
+            other.span(),
+        )),
+    }
+}
+
+fn current_stream_columns<'a>(
+    explicit_columns: bool,
+    columns: &'a [String],
+    detected_columns: Option<&'a [String]>,
+    format_name: &'static str,
+    head: Span,
+) -> Result<&'a [String], ShellError> {
+    if explicit_columns {
+        Ok(columns)
+    } else {
+        detected_columns.ok_or_else(|| {
+            ShellError::Generic(GenericError::new(
+                format!("failed to initialize streamed {format_name} columns"),
+                "the input stream ended before Nushell could determine its schema".to_string(),
+                head,
+            ))
+        })
+    }
+}
+
+/// Helper function to write a single row to CSV
+fn write_csv_row(
+    wtr: &mut csv::Writer<&mut Vec<u8>>,
+    record: &nu_protocol::Record,
+    columns: &[String],
+    config: &Config,
+    format_name: &'static str,
+    head: Span,
+) -> Result<(), ShellError> {
+    for column in columns {
+        let field = record
+            .get(column)
+            .map(|v| to_string_tagged_value(v, config, format_name))
+            .unwrap_or(Ok(String::new()))?;
+        wtr.write_field(field)
+            .map_err(|err| make_csv_error(err, format_name, head))?;
+    }
+    wtr.write_record(iter::empty::<String>())
+        .map_err(|err| make_csv_error(err, format_name, head))?;
+    Ok(())
+}
+
 pub fn to_delimited_data(
     ToDelimitedDataArgs {
         noheaders,
         separator,
         columns,
         format_name,
-        input,
+        mut input,
         head,
         content_type,
     }: ToDelimitedDataArgs,
     config: Arc<Config>,
 ) -> Result<PipelineData, ShellError> {
-    let mut input = input;
     let span = input.span().unwrap_or(head);
     let metadata = Some(
         input
@@ -117,30 +191,58 @@ pub fn to_delimited_data(
         PipelineData::Empty => (),
     }
 
-    // Determine the columns we'll use. This is necessary even if we don't write the header row,
-    // because we need to write consistent columns.
-    let columns = match columns {
-        Some(columns) => columns,
-        None => {
-            // The columns were not provided. We need to detect them, and in order to do so, we have
-            // to convert the input into a value first, so that we can find all of them
-            let value = input.into_value(span)?;
-            let columns = match &value {
-                Value::List { vals, .. } => merge_descriptors(vals),
-                Value::Record { val, .. } => val.columns().cloned().collect(),
-                _ => return Err(make_unsupported_input_error(value.get_type(), head, span)),
-            };
-            input = PipelineData::value(value, None);
-            columns
-        }
-    };
+    // When the input is already materialized (Value::List or Value::Record), we can inspect all
+    // rows upfront to compute the union of all columns via merge_descriptors. This preserves the
+    // existing behavior where heterogeneous tables get all columns filled in.
+    if let PipelineData::Value(ref value @ (Value::List { .. } | Value::Record { .. }), _) = input {
+        let columns = match columns {
+            Some(cols) => cols,
+            None => extract_columns(value)?,
+        };
+        let mut iter = input.into_iter();
+        let mut header_written = noheaders; // If noheaders is true, consider it already written
 
-    // Generate a byte stream of all of the values in the pipeline iterator, with a non-strict
-    // iterator so we can still accept plain records.
+        let stream = ByteStream::from_fn(
+            head,
+            Signals::empty(),
+            ByteStreamType::String,
+            move |buffer| {
+                let mut wtr = WriterBuilder::new()
+                    .delimiter(separator)
+                    .from_writer(buffer);
+
+                // Write header once if not already written
+                if !header_written {
+                    wtr.write_record(&columns)
+                        .map_err(|err| make_csv_error(err, format_name, head))?;
+                    header_written = true;
+                }
+
+                if let Some(row) = iter.next() {
+                    if let Value::Error { error, .. } = &row {
+                        return Err(*error.clone());
+                    }
+                    let record = row.into_record()?;
+                    write_csv_row(&mut wtr, &record, &columns, &config, format_name, head)?;
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            },
+        );
+        return Ok(PipelineData::byte_stream(stream, metadata));
+    }
+
+    // For streaming input (ListStream), we cannot look ahead to compute the column union.
+    // Instead, columns are either provided explicitly via --columns or detected from the first
+    // row. Subsequent rows with new columns produce a schema drift error.
+    let explicit_columns = columns.is_some();
+    let columns = columns.unwrap_or_default();
+
     let mut iter = input.into_iter();
-
-    // If we're configured to generate a header, we generate it first, then set this false
-    let mut is_header = !noheaders;
+    let mut detected_columns: Option<Vec<String>> = None;
+    let mut first_row_processed = false;
+    let mut header_written = noheaders;
 
     let stream = ByteStream::from_fn(
         head,
@@ -151,30 +253,81 @@ pub fn to_delimited_data(
                 .delimiter(separator)
                 .from_writer(buffer);
 
-            if is_header {
-                // Unless we are configured not to write a header, we write the header row now, once,
-                // before everything else.
+            if explicit_columns && !header_written {
                 wtr.write_record(&columns)
                     .map_err(|err| make_csv_error(err, format_name, head))?;
-                is_header = false;
-                Ok(true)
-            } else if let Some(row) = iter.next() {
-                // Write each column of a normal row, in order
-                let record = row.into_record()?;
-                for column in &columns {
-                    let field = record
-                        .get(column)
-                        .map(|v| to_string_tagged_value(v, &config, format_name))
-                        .unwrap_or(Ok(String::new()))?;
-                    wtr.write_field(field)
-                        .map_err(|err| make_csv_error(err, format_name, head))?;
+                header_written = true;
+            }
+
+            if !first_row_processed {
+                match iter.next() {
+                    Some(row) => {
+                        if let Value::Error { error, .. } = &row {
+                            return Err(*error.clone());
+                        }
+
+                        // Detect columns from first row if not explicitly provided
+                        if !explicit_columns && detected_columns.is_none() {
+                            detected_columns = Some(extract_columns(&row)?);
+                        }
+
+                        let cols = current_stream_columns(
+                            explicit_columns,
+                            &columns,
+                            detected_columns.as_deref(),
+                            format_name,
+                            head,
+                        )?;
+
+                        if !header_written {
+                            wtr.write_record(cols)
+                                .map_err(|err| make_csv_error(err, format_name, head))?;
+                            header_written = true;
+                        }
+
+                        let record = row.into_record()?;
+                        write_csv_row(&mut wtr, &record, cols, &config, format_name, head)?;
+
+                        first_row_processed = true;
+                        Ok(true)
+                    }
+                    None => Ok(false),
                 }
-                // End the row
-                wtr.write_record(iter::empty::<String>())
-                    .map_err(|err| make_csv_error(err, format_name, head))?;
-                Ok(true)
             } else {
-                Ok(false)
+                match iter.next() {
+                    Some(row) => {
+                        if let Value::Error { error, .. } = &row {
+                            return Err(*error.clone());
+                        }
+
+                        let cols = current_stream_columns(
+                            explicit_columns,
+                            &columns,
+                            detected_columns.as_deref(),
+                            format_name,
+                            head,
+                        )?;
+
+                        let record = row.into_record()?;
+
+                        // Schema drift detection: error on new columns in streaming mode
+                        // without explicit columns. Missing columns are intentionally allowed
+                        // and filled with empty strings by write_csv_row, matching the
+                        // explicit-columns behavior.
+                        if !explicit_columns {
+                            for col in record.columns() {
+                                if !cols.iter().any(|c| c.as_str() == col) {
+                                    return Err(make_schema_drift_error(format_name, col, head));
+                                }
+                            }
+                        }
+
+                        write_csv_row(&mut wtr, &record, cols, &config, format_name, head)?;
+
+                        Ok(true)
+                    }
+                    None => Ok(false),
+                }
             }
         },
     );

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -555,3 +555,99 @@ fn force_save_to_dir() {
 
     assert!(actual.err.contains("nu::shell::io::is_a_directory"));
 }
+
+#[test]
+fn save_table_to_csv_with_explicit_columns() {
+    Playground::setup("save_table_csv", |dirs, sandbox| {
+        sandbox.with_files(&[]);
+
+        let expected_file = dirs.test().join("test.csv");
+
+        nu!(
+            cwd: dirs.root(),
+            "[[a b]; [1 2] [3 4]] | to csv --columns [a b] | save -f save_table_csv/test.csv",
+        );
+
+        let actual = file_contents(expected_file);
+        assert!(actual.contains("a,b"));
+        assert!(actual.contains("1,2"));
+        assert!(actual.contains("3,4"));
+    })
+}
+
+#[test]
+fn save_table_to_csv_without_explicit_columns() {
+    Playground::setup("save_table_csv_auto", |dirs, sandbox| {
+        sandbox.with_files(&[]);
+
+        let expected_file = dirs.test().join("test.csv");
+
+        nu!(
+            cwd: dirs.root(),
+            "[[a b]; [1 2] [3 4]] | to csv | save -f save_table_csv_auto/test.csv",
+        );
+
+        let actual = file_contents(expected_file);
+        assert!(actual.contains("a,b"));
+        assert!(actual.contains("1,2"));
+        assert!(actual.contains("3,4"));
+    })
+}
+
+#[test]
+fn save_record_to_csv() {
+    Playground::setup("save_record_csv", |dirs, sandbox| {
+        sandbox.with_files(&[]);
+
+        let expected_file = dirs.test().join("test.csv");
+
+        nu!(
+            cwd: dirs.root(),
+            "{a: 1, b: 2} | to csv | save -f save_record_csv/test.csv",
+        );
+
+        let actual = file_contents(expected_file);
+        assert!(actual.contains("a,b"));
+        assert!(actual.contains("1,2"));
+    })
+}
+
+#[test]
+fn save_table_to_tsv() {
+    Playground::setup("save_table_tsv", |dirs, sandbox| {
+        sandbox.with_files(&[]);
+
+        let expected_file = dirs.test().join("test.tsv");
+
+        nu!(
+            cwd: dirs.root(),
+            "[[a b]; [1 2] [3 4]] | to tsv | save -f save_table_tsv/test.tsv",
+        );
+
+        let actual = file_contents(expected_file);
+        assert!(actual.contains("a\tb"));
+        assert!(actual.contains("1\t2"));
+        assert!(actual.contains("3\t4"));
+    })
+}
+
+#[test]
+fn save_streaming_list_stream_to_csv() {
+    // Exercises the streaming path (ListStream -> ByteStream -> save) rather than
+    // the materialized table path, ensuring rows are streamed to disk progressively.
+    Playground::setup("save_streaming_csv", |dirs, sandbox| {
+        sandbox.with_files(&[]);
+
+        let expected_file = dirs.test().join("test.csv");
+
+        nu!(
+            cwd: dirs.root(),
+            "1..5 | each { |i| {a: $i, b: ($i * 10)} } | to csv | save -f save_streaming_csv/test.csv",
+        );
+
+        let actual = file_contents(expected_file);
+        assert!(actual.contains("a,b"));
+        assert!(actual.contains("1,10"));
+        assert!(actual.contains("5,50"));
+    })
+}

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -474,3 +474,73 @@ fn from_csv_test_flexible_missing_vals() -> Result {
 
     test().run(code).expect_value_eq("[1]")
 }
+
+#[test]
+fn streaming_heterogeneous_table_fails_with_explicit_error() -> Result {
+    // Heterogeneous tables streamed without explicit columns should fail with a clear error
+    // instead of silently dropping columns
+    let code = "
+        1..3 | each {|i|
+            if $i == 1 {
+                {a: $i}
+            } else {
+                {a: $i b: ($i * 10)}
+            }
+        } | to csv
+    ";
+
+    let outcome = test().run(code).expect_shell_error()?;
+    assert!(
+        outcome.to_string().contains("streamed csv schema changed"),
+        "Expected schema drift error, got: {}",
+        outcome
+    );
+    Ok(())
+}
+
+#[test]
+fn streaming_heterogeneous_table_with_explicit_columns_works() -> Result {
+    // Heterogeneous tables with explicit columns should work correctly (fill missing with empty)
+    let code = "
+        1..3 | each {|i|
+            if $i == 1 {
+                {a: $i}
+            } else {
+                {a: $i b: ($i * 10)}
+            }
+        } | to csv --columns [a b]
+    ";
+
+    test().run(code).expect_value_eq("a,b\n1,\n2,20\n3,30\n")
+}
+
+#[test]
+fn materialized_heterogeneous_table_preserved() -> Result {
+    // Materialized (collected) heterogeneous tables should still use old merge_descriptors semantics
+    // which computes union of all columns
+    let code = "
+        1..3 | each {|i|
+            if $i == 1 {
+                {a: $i}
+            } else {
+                {a: $i b: ($i * 10)}
+            }
+        } | collect | to csv
+    ";
+
+    test().run(code).expect_value_eq("a,b\n1,\n2,20\n3,30\n")
+}
+
+#[test]
+fn empty_stream_with_explicit_columns_still_writes_header() -> Result {
+    let code = "
+        1..3
+        | where {|i| $i > 10 }
+        | wrap a
+        | to csv --columns [a]
+        | lines
+        | to nuon
+    ";
+
+    test().run(code).expect_value_eq("[a]")
+}

--- a/crates/nu-command/tests/format_conversions/tsv.rs
+++ b/crates/nu-command/tests/format_conversions/tsv.rs
@@ -285,3 +285,22 @@ fn from_tsv_text_with_wrong_type_comment() -> Result {
         Ok(())
     })
 }
+
+#[test]
+fn streaming_heterogeneous_table_reports_tsv_specific_error() -> Result {
+    let code = "
+        1..3 | each {|i|
+            if $i == 1 {
+                {a: $i}
+            } else {
+                {a: $i b: ($i * 10)}
+            }
+        } | to tsv
+    ";
+
+    let outcome = test().run(code).expect_shell_error()?;
+    let message = outcome.to_string();
+    assert_contains("streamed tsv schema changed", message.as_str());
+    assert!(!message.contains("csv"));
+    Ok(())
+}


### PR DESCRIPTION
## Description

This is trying to implement idea for #14338 - I would like to enable saving streaming table data to `.csv` and `.tsv` where rows are written to disk progressively instead of buffering the full output first. This applies both to `to csv`/`to tsv` pipelines saved with `save` and to table data saved directly to `.csv`/`.tsv` files.

Streaming CSV/TSV export now also fails with a clear schema-drift error if later rows introduce new columns after output has started. If your input has varying columns, use `to csv --columns [...]` / `to tsv --columns [...]` or `collect` first.

## User-facing changes (Release notes)
### `to csv` and `to tsv` stream now to `save`
Saving streaming table data to `.csv` and `.tsv` now writes rows to disk as they arrive instead of buffering the full output first.

Streaming CSV/TSV export now fails with a clear schema-drift error if later rows introduce new columns after output has started. If your input has varying columns, use `to csv --columns [...]` / `to tsv --columns [...]` or `collect` first.

## Additional notes

Fixes #14338.
