### PR TITLE
fix(toml): Preserve TOML comments when saving files #4296

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4349,6 +4349,7 @@ dependencies = [
  "tempfile",
  "titlecase",
  "toml 1.1.0+spec-1.1.0",
+ "toml_edit",
  "trash",
  "umask",
  "unicode-segmentation",
@@ -8469,6 +8470,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.8+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.0",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10032,6 +10046,9 @@ name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,7 @@ thiserror = "2.0.18"
 titlecase = "3.6"
 tokio = { version = "1.51.0" }
 toml = "1.0.7"
+toml_edit = "0.25.8"
 trash = "=5.2.4"
 update-informer = { version = "1.3.0", default-features = false, features = ["github", "ureq"] }
 umask = "2.1"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -117,6 +117,7 @@ sysinfo = { workspace = true }
 tabled = { workspace = true, features = ["ansi"], default-features = false }
 titlecase = { workspace = true }
 toml = { workspace = true, features = ["preserve_order"] }
+toml_edit = { workspace = true }
 unicode-segmentation = { workspace = true }
 update-informer = { workspace = true, optional = true }
 ureq = { workspace = true, default-features = false, features = [

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -1,3 +1,4 @@
+use crate::formats::{preserve_toml_document, read_toml_source_from_metadata};
 use crate::progress_bar;
 use nu_engine::{command_prelude::*, get_eval_block};
 use nu_path::{expand_path_with, is_windows_device_path};
@@ -221,6 +222,18 @@ impl Command for Save {
                     check_saving_to_source_file(input.metadata_ref(), &path, stderr_path.as_ref())?;
                 }
 
+                if let Some(bytes) =
+                    preserve_toml_output(engine_state, &input, &path.item, raw, append, span)?
+                {
+                    let (mut file, _) =
+                        get_files(engine_state, &path, stderr_path.as_ref(), append, force)?;
+
+                    file.write_all(&bytes).map_err(&from_io_error)?;
+                    file.flush().map_err(&from_io_error)?;
+
+                    return Ok(PipelineData::empty());
+                }
+
                 // Try to convert the input pipeline into another type if we know the extension
                 let ext = extract_extension(&input, &path.item, raw);
                 let converted = match ext {
@@ -339,6 +352,37 @@ fn check_saving_to_source_file(
     }
 
     Ok(())
+}
+
+fn preserve_toml_output(
+    engine_state: &EngineState,
+    input: &PipelineData,
+    path: &Path,
+    raw: bool,
+    append: bool,
+    span: Span,
+) -> Result<Option<Vec<u8>>, ShellError> {
+    if raw
+        || append
+        || path
+            .extension()
+            .is_none_or(|extension| extension.to_string_lossy() != "toml")
+    {
+        return Ok(None);
+    }
+
+    let PipelineData::Value(value, metadata) = input else {
+        return Ok(None);
+    };
+    let Some(original_source) = read_toml_source_from_metadata(metadata.as_ref()) else {
+        return Ok(None);
+    };
+
+    match value {
+        Value::Record { .. } => preserve_toml_document(engine_state, value, &original_source, span)
+            .map(|document| Some(document.into_bytes())),
+        _ => Ok(None),
+    }
 }
 
 /// Extract extension for conversion.

--- a/crates/nu-command/src/formats/from/mod.rs
+++ b/crates/nu-command/src/formats/from/mod.rs
@@ -30,3 +30,4 @@ pub use xml::FromXml;
 pub use yaml::{FROM_YAML, FROM_YML, FromYamlLike};
 
 pub(crate) use json::try_str_to_value as try_json_str_to_value;
+pub(crate) use toml::convert_toml_datetime_to_value as toml_datetime_to_value;

--- a/crates/nu-command/src/formats/from/toml.rs
+++ b/crates/nu-command/src/formats/from/toml.rs
@@ -57,7 +57,7 @@ b = [1, 2]' | from toml",
     }
 }
 
-fn convert_toml_datetime_to_value(dt: &Datetime, span: Span) -> Value {
+pub(crate) fn convert_toml_datetime_to_value(dt: &Datetime, span: Span) -> Value {
     match &dt.clone() {
         toml::value::Datetime {
             date: Some(_),
@@ -129,7 +129,10 @@ fn convert_toml_to_value(value: &toml::Value, span: Span) -> Value {
     }
 }
 
-pub fn convert_string_to_value(string_input: String, span: Span) -> Result<Value, ShellError> {
+pub(crate) fn convert_string_to_value(
+    string_input: String,
+    span: Span,
+) -> Result<Value, ShellError> {
     let result: Result<toml::Value, toml::de::Error> = toml::from_str(&string_input);
     match result {
         Ok(value) => Ok(convert_toml_to_value(&value, span)),

--- a/crates/nu-command/src/formats/mod.rs
+++ b/crates/nu-command/src/formats/mod.rs
@@ -1,6 +1,9 @@
 mod from;
 mod nu_xml_format;
 mod to;
+mod toml_utils;
 
 pub use from::*;
 pub use to::*;
+
+pub(crate) use toml_utils::{preserve_toml_document, read_toml_source_from_metadata};

--- a/crates/nu-command/src/formats/to/mod.rs
+++ b/crates/nu-command/src/formats/to/mod.rs
@@ -27,3 +27,4 @@ pub use yaml::{TO_YAML, TO_YML, ToYamlLike};
 
 #[cfg_attr(not(feature = "network"), expect(unused))]
 pub(crate) use json::value_to_json_value;
+pub(crate) use toml::nu_value_to_toml_value;

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -1,3 +1,4 @@
+use crate::formats::{preserve_toml_document, read_toml_source_from_metadata};
 use chrono::{DateTime, Datelike, FixedOffset, Timelike};
 use nu_engine::command_prelude::*;
 use nu_protocol::{PipelineMetadata, ast::PathMember};
@@ -49,7 +50,7 @@ impl Command for ToToml {
 
 // Helper method to recursively convert nu_protocol::Value -> toml::Value
 // This shouldn't be called at the top-level
-fn helper(
+pub(crate) fn nu_value_to_toml_value(
     engine_state: &EngineState,
     v: &Value,
     serialize_types: bool,
@@ -66,7 +67,10 @@ fn helper(
         Value::Record { val, .. } => {
             let mut m = toml::map::Map::new();
             for (k, v) in &**val {
-                m.insert(k.clone(), helper(engine_state, v, serialize_types)?);
+                m.insert(
+                    k.clone(),
+                    nu_value_to_toml_value(engine_state, v, serialize_types)?,
+                );
             }
             toml::Value::Table(m)
         }
@@ -118,7 +122,11 @@ fn toml_list(
     let mut out = vec![];
 
     for value in input {
-        out.push(helper(engine_state, value, serialize_types)?);
+        out.push(nu_value_to_toml_value(
+            engine_state,
+            value,
+            serialize_types,
+        )?);
     }
 
     Ok(out)
@@ -160,7 +168,9 @@ fn value_to_toml_value(
     serialize_types: bool,
 ) -> Result<toml::Value, ShellError> {
     match v {
-        Value::Record { .. } | Value::Closure { .. } => helper(engine_state, v, serialize_types),
+        Value::Record { .. } | Value::Closure { .. } => {
+            nu_value_to_toml_value(engine_state, v, serialize_types)
+        }
         // Propagate existing errors
         Value::Error { error, .. } => Err(*error.clone()),
         _ => Err(ShellError::UnsupportedInput {
@@ -180,6 +190,19 @@ fn to_toml(
 ) -> Result<PipelineData, ShellError> {
     let metadata = input.take_metadata();
     let value = input.into_value(span)?;
+
+    if !serialize_types
+        && let Some(original_source) = read_toml_source_from_metadata(metadata.as_ref())
+        && let Value::Record { .. } = &value
+        && let Ok(preserved) = preserve_toml_document(engine_state, &value, &original_source, span)
+    {
+        let new_md = Some(
+            metadata
+                .unwrap_or_default()
+                .with_content_type(Some("text/x-toml".into())),
+        );
+        return Ok(Value::string(preserved, span).into_pipeline_data_with_metadata(new_md));
+    }
 
     let toml_value = value_to_toml_value(engine_state, &value, span, serialize_types)?;
     match toml_value {
@@ -271,7 +294,7 @@ mod tests {
             offset: Some(toml::value::Offset::Custom { minutes: 120 }),
         });
 
-        let result = helper(&engine_state, &test_date, serialize_types);
+        let result = nu_value_to_toml_value(&engine_state, &test_date, serialize_types);
 
         assert!(result.is_ok_and(|res| res == reference_date));
     }

--- a/crates/nu-command/src/formats/toml_utils.rs
+++ b/crates/nu-command/src/formats/toml_utils.rs
@@ -1,0 +1,478 @@
+use crate::formats::nu_value_to_toml_value;
+use nu_engine::command_prelude::*;
+use nu_protocol::{DataSource, PipelineMetadata};
+use toml_edit::{DocumentMut, Item, TableLike};
+
+#[derive(Clone, Copy)]
+enum ContainerKind {
+    Table,
+    InlineTable,
+}
+
+/// Reads the original TOML source from the file referenced in pipeline metadata.
+/// Returns `None` if the metadata doesn't point to a `.toml` file or the file can't be read.
+pub(crate) fn read_toml_source_from_metadata(
+    metadata: Option<&PipelineMetadata>,
+) -> Option<String> {
+    let path = match &metadata?.data_source {
+        DataSource::FilePath(p) => p,
+        _ => return None,
+    };
+    // Use to_str() for case-insensitive comparison, returns None for non-UTF8 paths
+    let extension = path.extension()?.to_str()?;
+    if !extension.eq_ignore_ascii_case("toml") {
+        return None;
+    }
+    // Silently return None on read errors (permissions, etc.) - preservation is best-effort
+    std::fs::read_to_string(path).ok()
+}
+
+pub(crate) fn preserve_toml_document(
+    engine_state: &EngineState,
+    current_value: &Value,
+    original_source: &str,
+    span: Span,
+) -> Result<String, ShellError> {
+    let Value::Record {
+        val: current_record,
+        ..
+    } = current_value
+    else {
+        return Err(ShellError::UnsupportedInput {
+            msg: format!("{} is not valid top-level TOML", current_value.get_type()),
+            input: "value originates from here".into(),
+            msg_span: span,
+            input_span: current_value.span(),
+        });
+    };
+
+    let mut document = original_source
+        .parse::<DocumentMut>()
+        .map_err(|err| toml_preservation_error("string", "TOML document", span, err))?;
+
+    let original_value = toml_edit_table_to_nu_value(document.as_table(), span);
+    let Value::Record {
+        val: original_record,
+        ..
+    } = original_value
+    else {
+        return Err(ShellError::UnsupportedInput {
+            msg: "top-level TOML must deserialize to a record".into(),
+            input: "original TOML source originates from here".into(),
+            msg_span: span,
+            input_span: span,
+        });
+    };
+
+    apply_record_diff(
+        engine_state,
+        &original_record,
+        current_record,
+        document.as_table_mut(),
+        ContainerKind::Table,
+    )?;
+
+    Ok(document.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// toml_edit -> nushell Value conversion (used to derive original values from
+// the parsed document, avoiding a second parse via the `toml` crate)
+// ---------------------------------------------------------------------------
+
+fn toml_edit_table_to_nu_value(table: &toml_edit::Table, span: Span) -> Value {
+    let record: Record = table
+        .iter()
+        .map(|(key, item)| (key.to_string(), toml_edit_item_to_nu_value(item, span)))
+        .collect();
+    Value::record(record, span)
+}
+
+fn toml_edit_item_to_nu_value(item: &toml_edit::Item, span: Span) -> Value {
+    match item {
+        Item::Value(v) => toml_edit_value_to_nu_value(v, span),
+        Item::Table(t) => toml_edit_table_to_nu_value(t, span),
+        Item::ArrayOfTables(arr) => {
+            let vals: Vec<Value> = arr
+                .iter()
+                .map(|t| toml_edit_table_to_nu_value(t, span))
+                .collect();
+            Value::list(vals, span)
+        }
+        Item::None => Value::nothing(span),
+    }
+}
+
+fn toml_edit_value_to_nu_value(v: &toml_edit::Value, span: Span) -> Value {
+    match v {
+        toml_edit::Value::String(s) => Value::string(s.value().clone(), span),
+        toml_edit::Value::Integer(i) => Value::int(*i.value(), span),
+        toml_edit::Value::Float(f) => Value::float(*f.value(), span),
+        toml_edit::Value::Boolean(b) => Value::bool(*b.value(), span),
+        toml_edit::Value::Datetime(dt) => {
+            crate::formats::from::toml_datetime_to_value(dt.value(), span)
+        }
+        toml_edit::Value::Array(arr) => {
+            let vals: Vec<Value> = arr
+                .iter()
+                .map(|v| toml_edit_value_to_nu_value(v, span))
+                .collect();
+            Value::list(vals, span)
+        }
+        toml_edit::Value::InlineTable(t) => {
+            let record: Record = t
+                .iter()
+                .map(|(k, v)| (k.to_string(), toml_edit_value_to_nu_value(v, span)))
+                .collect();
+            Value::record(record, span)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Diffing: walk original vs current nushell Values and apply minimal edits
+// to the toml_edit document so that comments and formatting are preserved.
+// ---------------------------------------------------------------------------
+
+fn apply_record_diff<Container: TableLike>(
+    engine_state: &EngineState,
+    original: &Record,
+    current: &Record,
+    container: &mut Container,
+    container_kind: ContainerKind,
+) -> Result<(), ShellError> {
+    for (key, _) in original {
+        if !current.contains(key) {
+            container.remove(key);
+        }
+    }
+
+    for (key, current_value) in current {
+        match (original.get(key), container.get_mut(key)) {
+            (Some(original_value), Some(item)) => {
+                apply_value_diff(
+                    engine_state,
+                    original_value,
+                    current_value,
+                    item,
+                    container_kind,
+                )?;
+            }
+            _ => {
+                container.insert(
+                    key,
+                    item_from_value(engine_state, current_value, container_kind)?,
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn apply_value_diff(
+    engine_state: &EngineState,
+    original: &Value,
+    current: &Value,
+    item: &mut Item,
+    container_kind: ContainerKind,
+) -> Result<(), ShellError> {
+    if original == current {
+        return Ok(());
+    }
+
+    if let (
+        Value::Record {
+            val: original_record,
+            ..
+        },
+        Value::Record {
+            val: current_record,
+            ..
+        },
+    ) = (original, current)
+    {
+        if let Some(table) = item.as_table_mut() {
+            return apply_record_diff(
+                engine_state,
+                original_record,
+                current_record,
+                table,
+                ContainerKind::Table,
+            );
+        }
+
+        if let Some(inline_table) = item.as_inline_table_mut() {
+            return apply_record_diff(
+                engine_state,
+                original_record,
+                current_record,
+                inline_table,
+                ContainerKind::InlineTable,
+            );
+        }
+    }
+
+    if let (
+        Value::List {
+            vals: orig_list, ..
+        },
+        Value::List {
+            vals: curr_list, ..
+        },
+    ) = (original, current)
+        && let Some(arr) = item.as_array_of_tables_mut()
+    {
+        return apply_array_of_tables_diff(engine_state, orig_list, curr_list, arr);
+    }
+
+    *item = item_from_value(engine_state, current, container_kind)?;
+    Ok(())
+}
+
+/// Element-wise diff for `[[array_of_tables]]` sections.
+/// Matching indices are recursively diffed so that per-table comments and
+/// formatting are preserved. Trailing removals and appended entries are handled
+/// by shrinking / growing the array.
+fn apply_array_of_tables_diff(
+    engine_state: &EngineState,
+    original: &[Value],
+    current: &[Value],
+    arr: &mut toml_edit::ArrayOfTables,
+) -> Result<(), ShellError> {
+    let common = original.len().min(current.len());
+
+    for i in 0..common {
+        if let (Value::Record { val: orig_rec, .. }, Value::Record { val: curr_rec, .. }) =
+            (&original[i], &current[i])
+            && let Some(table) = arr.get_mut(i)
+        {
+            apply_record_diff(
+                engine_state,
+                orig_rec,
+                curr_rec,
+                table,
+                ContainerKind::Table,
+            )?;
+        }
+    }
+
+    // Remove trailing entries when the current list is shorter.
+    while arr.len() > current.len() {
+        arr.remove(arr.len() - 1);
+    }
+
+    // Append new entries when the current list is longer.
+    for value in &current[common..] {
+        let toml_value = nu_value_to_toml_value(engine_state, value, false)?;
+        if let toml::Value::Table(map) = toml_value {
+            let mut table = toml_edit::Table::new();
+            for (k, v) in &map {
+                table.insert(k, toml_value_to_edit_item(v, ContainerKind::Table));
+            }
+            arr.push(table);
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// nushell Value -> toml_edit Item/Value construction (replaces the former
+// serialize-to-string-and-reparse wrapper approach)
+// ---------------------------------------------------------------------------
+
+fn item_from_value(
+    engine_state: &EngineState,
+    value: &Value,
+    container_kind: ContainerKind,
+) -> Result<Item, ShellError> {
+    let toml_value = nu_value_to_toml_value(engine_state, value, false)?;
+    Ok(toml_value_to_edit_item(&toml_value, container_kind))
+}
+
+/// Convert a `toml::Value` into a `toml_edit::Item`, respecting the
+/// surrounding container kind so that tables inside inline tables stay inline
+/// and top-level tables use the `[header]` syntax.
+fn toml_value_to_edit_item(value: &toml::Value, container_kind: ContainerKind) -> Item {
+    match value {
+        toml::Value::Table(map) => match container_kind {
+            ContainerKind::InlineTable => {
+                let mut t = toml_edit::InlineTable::new();
+                for (k, v) in map {
+                    t.insert(k, toml_value_to_edit_value(v));
+                }
+                Item::Value(toml_edit::Value::InlineTable(t))
+            }
+            ContainerKind::Table => {
+                let mut t = toml_edit::Table::new();
+                for (k, v) in map {
+                    t.insert(k, toml_value_to_edit_item(v, ContainerKind::Table));
+                }
+                Item::Table(t)
+            }
+        },
+        toml::Value::Array(arr)
+            if matches!(container_kind, ContainerKind::Table)
+                && !arr.is_empty()
+                && arr.iter().all(|v| matches!(v, toml::Value::Table(_))) =>
+        {
+            let mut aot = toml_edit::ArrayOfTables::new();
+            for v in arr {
+                if let toml::Value::Table(map) = v {
+                    let mut table = toml_edit::Table::new();
+                    for (k, v) in map {
+                        table.insert(k, toml_value_to_edit_item(v, ContainerKind::Table));
+                    }
+                    aot.push(table);
+                }
+            }
+            Item::ArrayOfTables(aot)
+        }
+        other => Item::Value(toml_value_to_edit_value(other)),
+    }
+}
+
+/// Convert a `toml::Value` into a `toml_edit::Value` (always inline form).
+fn toml_value_to_edit_value(value: &toml::Value) -> toml_edit::Value {
+    match value {
+        toml::Value::String(s) => toml_edit::Value::from(s.as_str()),
+        toml::Value::Integer(i) => toml_edit::Value::from(*i),
+        toml::Value::Float(f) => toml_edit::Value::from(*f),
+        toml::Value::Boolean(b) => toml_edit::Value::from(*b),
+        toml::Value::Datetime(dt) => toml_edit::Value::from(*dt),
+        toml::Value::Array(arr) => {
+            let mut edit_arr = toml_edit::Array::new();
+            for v in arr {
+                edit_arr.push(toml_value_to_edit_value(v));
+            }
+            toml_edit::Value::Array(edit_arr)
+        }
+        toml::Value::Table(map) => {
+            let mut t = toml_edit::InlineTable::new();
+            for (k, v) in map {
+                t.insert(k, toml_value_to_edit_value(v));
+            }
+            toml_edit::Value::InlineTable(t)
+        }
+    }
+}
+
+fn toml_preservation_error(
+    from_type: &str,
+    to_type: &str,
+    span: Span,
+    err: impl ToString,
+) -> ShellError {
+    ShellError::CantConvert {
+        to_type: to_type.into(),
+        from_type: from_type.into(),
+        span,
+        help: Some(err.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserve_array_of_tables_comments() {
+        let engine_state = EngineState::new();
+        let span = Span::test_data();
+
+        let source = "\
+# top comment
+[settings]
+verbose = true
+
+# first item
+[[items]]
+name = \"alpha\"
+value = 1
+
+# second item
+[[items]]
+name = \"beta\"
+value = 2
+";
+
+        let current = Value::test_record(record! {
+            "settings" => Value::test_record(record! {
+                "verbose" => Value::test_bool(true),
+            }),
+            "items" => Value::test_list(vec![
+                Value::test_record(record! {
+                    "name" => Value::test_string("alpha"),
+                    "value" => Value::test_int(99),
+                }),
+                Value::test_record(record! {
+                    "name" => Value::test_string("beta"),
+                    "value" => Value::test_int(2),
+                }),
+            ]),
+        });
+
+        let result = preserve_toml_document(&engine_state, &current, source, span).unwrap();
+        eprintln!("--- RESULT ---\n{result}--- END ---");
+        assert!(result.contains("# top comment"), "top comment preserved");
+        assert!(
+            result.contains("# first item"),
+            "first item comment preserved"
+        );
+        assert!(
+            result.contains("# second item"),
+            "second item comment preserved"
+        );
+        assert!(result.contains("value = 99"), "value updated");
+        assert!(result.contains("value = 2"), "unchanged value preserved");
+    }
+
+    #[test]
+    fn extension_case_insensitive() {
+        // Test that .TOML (uppercase) extension is recognized
+        let metadata = PipelineMetadata {
+            data_source: DataSource::FilePath(std::path::PathBuf::from("config.TOML")),
+            ..Default::default()
+        };
+
+        // This will return None because the file doesn't exist,
+        // but we can verify it attempts to read the file (not rejected early)
+        let result = read_toml_source_from_metadata(Some(&metadata));
+        // File doesn't exist, so we expect None from .ok() conversion
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn non_toml_extension_returns_none() {
+        let metadata = PipelineMetadata {
+            data_source: DataSource::FilePath(std::path::PathBuf::from("config.json")),
+            ..Default::default()
+        };
+
+        let result = read_toml_source_from_metadata(Some(&metadata));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn no_extension_returns_none() {
+        let metadata = PipelineMetadata {
+            data_source: DataSource::FilePath(std::path::PathBuf::from("config")),
+            ..Default::default()
+        };
+
+        let result = read_toml_source_from_metadata(Some(&metadata));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn non_file_data_source_returns_none() {
+        let metadata = PipelineMetadata {
+            data_source: DataSource::None,
+            ..Default::default()
+        };
+
+        let result = read_toml_source_from_metadata(Some(&metadata));
+        assert!(result.is_none());
+    }
+}

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -195,6 +195,88 @@ fn save_failure_not_overrides() {
 }
 
 #[test]
+fn save_preserves_toml_comment_and_inline_table_after_update() {
+    Playground::setup("save_test_10_toml_preservation", |dirs, sandbox| {
+        sandbox.with_files(&[Stub::FileWithContent(
+            "sample.toml",
+            r#"# keep this comment
+[package]
+name = "demo"
+version = "0.1.0"
+metadata = { repo = "https://example.com", keywords = ["alpha", "beta"] }
+"#,
+        )]);
+
+        let expected_file = dirs.test().join("out.toml");
+
+        nu!(
+            cwd: dirs.test(),
+            "open sample.toml | update package.version '0.2.0' | save -f out.toml",
+        );
+
+        let actual = file_contents(expected_file);
+        assert_eq!(
+            actual,
+            r#"# keep this comment
+[package]
+name = "demo"
+version = "0.2.0"
+metadata = { repo = "https://example.com", keywords = ["alpha", "beta"] }
+"#
+        );
+    })
+}
+
+#[test]
+fn save_preserves_toml_array_of_tables_comments() {
+    Playground::setup("save_test_toml_aot_preservation", |dirs, sandbox| {
+        sandbox.with_files(&[Stub::FileWithContent(
+            "sample.toml",
+            r#"# project config
+[settings]
+verbose = true
+
+# first item
+[[items]]
+name = "alpha"
+value = 1
+
+# second item
+[[items]]
+name = "beta"
+value = 2
+"#,
+        )]);
+
+        let expected_file = dirs.test().join("out.toml");
+
+        nu!(
+            cwd: dirs.test(),
+            "open sample.toml | update items.0.value 99 | save -f out.toml",
+        );
+
+        let actual = file_contents(expected_file);
+        assert_eq!(
+            actual,
+            r#"# project config
+[settings]
+verbose = true
+
+# first item
+[[items]]
+name = "alpha"
+value = 99
+
+# second item
+[[items]]
+name = "beta"
+value = 2
+"#
+        );
+    })
+}
+
+#[test]
 fn save_append_works_on_stderr() {
     Playground::setup("save_test_11", |dirs, sandbox| {
         sandbox.with_files(&[


### PR DESCRIPTION
This PR is proposal for fixing #4296 - by implementing proposed there usage of `toml_edit` package. 

## Release notes summary - What our users need to know
### Preserve TOML comments when saving files
TOML files now preserve comments, formatting, and inline tables when modified and saved. 
Example: 
```
open Cargo.toml | update version "1.1.0" | save Cargo.toml
```
should keep all comments intact.

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
