### PR TITLE
fix(completion): allow explicit return in command-wide completer

### DIFF
--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -407,7 +407,7 @@ impl<'a> Completer for CommandWideCompletion<'a> {
         let mut engine_state = working_set.permanent_state.clone();
         let _ = engine_state.merge_delta(working_set.delta.clone());
 
-        let result = nu_engine::eval_block::<WithoutDebug>(
+        let result = nu_engine::eval_block_with_early_return::<WithoutDebug>(
             &engine_state,
             &mut callee_stack,
             &block,

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1123,21 +1123,24 @@ fn command_wide_completion_external() {
     match_suggestions(&expected, &suggestions);
 }
 
-#[test]
-fn command_wide_completion_custom() {
+#[rstest]
+// https://github.com/nushell/nushell/issues/18007
+#[case::explicit_return("return")]
+#[case::implicit_return("")]
+fn command_wide_completion_custom(#[case] return_code: &str) {
     let mut completer = custom_completer();
 
-    let sample = /* lang=nu */ r#"
-        def "nu-complete foo" [spans: list] {
-            $spans ++ [some more]
-        }
+    let sample = /* lang=nu */ format!(r#"
+        def "nu-complete foo" [spans: list] {{
+            {return_code} ($spans ++ [some more])
+        }}
 
         @complete "nu-complete foo"
-        def --wrapped "foo" [...rest] {}
+        def --wrapped "foo" [...rest] {{}}
 
-        foo bar baz"#;
+        foo bar baz"#);
 
-    let suggestions = completer.complete(sample, sample.len());
+    let suggestions = completer.complete(&sample, sample.len());
     let expected = vec!["foo", "bar", "baz", "some", "more"];
     match_suggestions(&expected, &suggestions);
 }


### PR DESCRIPTION
Fixes #18007 

## Release notes summary - What our users need to know

Fixed a bug of command-wide completer where explicit `return` expressions in the completer commands disrupt the functionality.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
