### PR TITLE
fix: losing string quoting for YAML  values (Fixes #16072)

### DIFF
--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -1,5 +1,17 @@
 use nu_engine::command_prelude::*;
 use nu_protocol::ast::PathMember;
+use std::fmt::Write as _;
+
+/// YAML 1.1 boolean-like strings that need quoting when used as record keys.
+const YAML_11_BOOLEANS: &[&str] = &[
+    "y", "Y", "yes", "Yes", "YES", "n", "N", "no", "No", "NO", "on", "On", "ON", "off", "Off",
+    "OFF",
+];
+
+/// YAML special float and numeric strings that need quoting to preserve them as strings.
+const YAML_SPECIAL_NUMERICS: &[&str] = &[
+    ".inf", ".Inf", ".INF", "-.inf", "-.Inf", "-.INF", ".nan", ".NaN", ".NAN",
+];
 
 #[derive(Clone)]
 pub struct ToYamlLike(&'static str);
@@ -129,6 +141,218 @@ pub fn value_to_yaml_value(
     })
 }
 
+fn render_yaml_string(value: &str) -> String {
+    if value.chars().any(char::is_control) {
+        let mut escaped = String::with_capacity(value.len() + 2);
+        escaped.push('"');
+
+        for ch in value.chars() {
+            match ch {
+                '"' => escaped.push_str("\\\""),
+                '\\' => escaped.push_str("\\\\"),
+                '\u{08}' => escaped.push_str("\\b"),
+                '\u{0C}' => escaped.push_str("\\f"),
+                '\n' => escaped.push_str("\\n"),
+                '\r' => escaped.push_str("\\r"),
+                '\t' => escaped.push_str("\\t"),
+                c if c.is_control() => {
+                    let _ = write!(escaped, "\\u{:04X}", c as u32);
+                }
+                c => escaped.push(c),
+            }
+        }
+
+        escaped.push('"');
+        escaped
+    } else {
+        format!("'{}'", value.replace('\'', "''"))
+    }
+}
+
+fn should_quote_yaml_key(key: &str) -> bool {
+    if key.is_empty() {
+        return true;
+    }
+    if key.chars().any(char::is_control) {
+        return true;
+    }
+    if key.starts_with(char::is_whitespace) || key.ends_with(char::is_whitespace) {
+        return true;
+    }
+    if YAML_11_BOOLEANS.contains(&key) {
+        return true;
+    }
+    if matches!(
+        key,
+        "~" | "null" | "Null" | "NULL" | "true" | "True" | "TRUE" | "false" | "False" | "FALSE"
+    ) {
+        return true;
+    }
+    // Check for YAML special numeric values (.inf, .nan) and hex/octal notation
+    if YAML_SPECIAL_NUMERICS.contains(&key) {
+        return true;
+    }
+    if key.starts_with("0x") || key.starts_with("0X") {
+        return true;
+    }
+    if key.starts_with("0o") || key.starts_with("0O") {
+        return true;
+    }
+    if key.parse::<i64>().is_ok() {
+        return true;
+    }
+    if key.parse::<u64>().is_ok() {
+        return true;
+    }
+    if key.parse::<f64>().is_ok() {
+        return true;
+    }
+    if !key
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/'))
+    {
+        return true;
+    }
+    false
+}
+
+fn render_yaml_key(key: &serde_yaml::Value) -> String {
+    match key {
+        serde_yaml::Value::String(key) if should_quote_yaml_key(key) => render_yaml_string(key),
+        serde_yaml::Value::String(key) => key.clone(),
+        _ => render_inline_yaml_value(key),
+    }
+}
+
+fn render_inline_yaml_value(value: &serde_yaml::Value) -> String {
+    match value {
+        serde_yaml::Value::Null => "null".to_string(),
+        serde_yaml::Value::Bool(value) => value.to_string(),
+        serde_yaml::Value::Number(value) => value.to_string(),
+        serde_yaml::Value::String(value) => render_yaml_string(value),
+        serde_yaml::Value::Sequence(values) => {
+            let values = values
+                .iter()
+                .map(render_inline_yaml_value)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("[{values}]")
+        }
+        serde_yaml::Value::Mapping(entries) => {
+            let entries = entries
+                .iter()
+                .map(|(key, value)| {
+                    format!(
+                        "{}: {}",
+                        render_yaml_key(key),
+                        render_inline_yaml_value(value)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{{{entries}}}")
+        }
+        serde_yaml::Value::Tagged(tagged) => {
+            format!("{} {}", tagged.tag, render_inline_yaml_value(&tagged.value))
+        }
+    }
+}
+
+fn is_inline_yaml_value(value: &serde_yaml::Value) -> bool {
+    match value {
+        serde_yaml::Value::Sequence(values) => values.is_empty(),
+        serde_yaml::Value::Mapping(entries) => entries.is_empty(),
+        serde_yaml::Value::Tagged(tagged) => is_inline_yaml_value(&tagged.value),
+        _ => true,
+    }
+}
+
+fn write_yaml_indent(output: &mut String, indent: usize) {
+    for _ in 0..indent {
+        output.push(' ');
+    }
+}
+
+fn write_yaml_value(output: &mut String, value: &serde_yaml::Value, indent: usize) {
+    match value {
+        serde_yaml::Value::Sequence(values) if !values.is_empty() => {
+            write_yaml_sequence(output, values, indent);
+        }
+        serde_yaml::Value::Mapping(entries) if !entries.is_empty() => {
+            write_yaml_mapping(output, entries, indent, "");
+        }
+        serde_yaml::Value::Tagged(tagged) => write_yaml_value(output, &tagged.value, indent),
+        _ => {
+            write_yaml_indent(output, indent);
+            output.push_str(&render_inline_yaml_value(value));
+            output.push('\n');
+        }
+    }
+}
+
+fn write_yaml_sequence(output: &mut String, values: &[serde_yaml::Value], indent: usize) {
+    for value in values {
+        match value {
+            serde_yaml::Value::Mapping(entries) if !entries.is_empty() => {
+                write_yaml_mapping(output, entries, indent, "- ");
+            }
+            value if is_inline_yaml_value(value) => {
+                write_yaml_indent(output, indent);
+                output.push_str("- ");
+                output.push_str(&render_inline_yaml_value(value));
+                output.push('\n');
+            }
+            _ => {
+                write_yaml_indent(output, indent);
+                output.push_str("-\n");
+                write_yaml_value(output, value, indent + 2);
+            }
+        }
+    }
+}
+
+fn write_yaml_mapping(
+    output: &mut String,
+    entries: &serde_yaml::Mapping,
+    indent: usize,
+    first_prefix: &str,
+) {
+    let first_prefix_len = first_prefix.len();
+
+    for (index, (key, value)) in entries.iter().enumerate() {
+        let is_first = index == 0;
+        // For the first entry, the prefix is written at the current indent level.
+        // For subsequent entries, we need to account for the prefix's length
+        // to maintain proper alignment with the first entry.
+        let line_indent = indent + if is_first { 0 } else { first_prefix_len };
+        // The key starts after the prefix (already written for first entry,
+        // will be written as part of indent for subsequent entries).
+        let key_indent = line_indent + if is_first { first_prefix_len } else { 0 };
+
+        write_yaml_indent(output, line_indent);
+        if is_first {
+            output.push_str(first_prefix);
+        }
+
+        output.push_str(&render_yaml_key(key));
+
+        if is_inline_yaml_value(value) {
+            output.push_str(": ");
+            output.push_str(&render_inline_yaml_value(value));
+            output.push('\n');
+        } else {
+            output.push_str(":\n");
+            write_yaml_value(output, value, key_indent + 2);
+        }
+    }
+}
+
+fn yaml_value_to_string(value: &serde_yaml::Value) -> String {
+    let mut output = String::new();
+    write_yaml_value(&mut output, value, 0);
+    output
+}
+
 fn to_yaml(
     engine_state: &EngineState,
     mut input: PipelineData,
@@ -143,22 +367,8 @@ fn to_yaml(
     let value = input.into_value(head)?;
 
     let yaml_value = value_to_yaml_value(engine_state, &value, serialize_types)?;
-    match serde_yaml::to_string(&yaml_value) {
-        Ok(serde_yaml_string) => {
-            Ok(Value::string(serde_yaml_string, head)
-                .into_pipeline_data_with_metadata(Some(metadata)))
-        }
-        _ => Ok(Value::error(
-            ShellError::CantConvert {
-                to_type: "YAML".into(),
-                from_type: value.get_type().to_string(),
-                span: head,
-                help: None,
-            },
-            head,
-        )
-        .into_pipeline_data_with_metadata(Some(metadata))),
-    }
+    let yaml_string = yaml_value_to_string(&yaml_value);
+    Ok(Value::string(yaml_string, head).into_pipeline_data_with_metadata(Some(metadata)))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/tests/format_conversions/yaml.rs
+++ b/crates/nu-command/tests/format_conversions/yaml.rs
@@ -59,11 +59,34 @@ fn convert_dict_to_yaml_with_integer_floats_key() -> Result {
 }
 
 #[test]
-#[ignore]
-fn convert_bool_to_yaml_in_yaml_spec_1_2() -> Result {
-    let code = "[y n no On OFF True true false] | to yaml";
+fn convert_yaml_11_booleans_are_quoted_in_output() -> Result {
+    let code = "[y n no On OFF] | to yaml";
 
     test()
         .run(code)
-        .expect_value_eq("- 'y'- 'n'- 'no'- 'On'- 'OFF'- 'True'- true- false")
+        .expect_value_eq("- 'y'\n- 'n'\n- 'no'\n- 'On'\n- 'OFF'\n")
+}
+
+#[test]
+fn convert_issue_16072_strings_are_quoted_in_output() -> Result {
+    let code = r#"
+        '{
+            "value": "off",
+            "path": "/dev/stdout",
+            "listen": "0.0.0.0:8444,0.0.0.0:8445 ssl"
+        }'
+        | from json
+        | to yaml
+    "#;
+
+    test().run(code).expect_value_eq(
+        "value: 'off'\npath: '/dev/stdout'\nlisten: '0.0.0.0:8444,0.0.0.0:8445 ssl'\n",
+    )
+}
+
+#[test]
+fn convert_strings_with_colons_are_not_corrupted() -> Result {
+    let code = "{addr: 'on:80'} | to yaml";
+
+    test().run(code).expect_value_eq("addr: 'on:80'\n")
 }


### PR DESCRIPTION
This should fix #16072

## Release notes summary - What our users need to know

### `to yaml` now correctly quotes string values

Before:
```nu
'{"value": "off", "listen": "0.0.0.0:8444"}' | from json | to yaml                                                                                    
value: off
listen: 0.0.0.0:8444                                                                                                                                  
```
                  
After:
```nu
'{"value": "off", "listen": "0.0.0.0:8444"}' | from json | to yaml                                                                                    
value: 'off'
listen: '0.0.0.0:8444'     
```

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
