### PR TITLE
Do not use `version` for nu dev dependencies

### DIFF
--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -19,10 +19,10 @@ path = "tests/main.rs"
 harness = false
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.112.0" }
-nu-command = { path = "../nu-command", version = "0.112.0" }
-nu-std = { path = "../nu-std", version = "0.112.0" }
-nu-test-support = { path = "../nu-test-support", version = "0.112.0" }
+nu-cmd-lang = { path = "../nu-cmd-lang" }
+nu-command = { path = "../nu-command" }
+nu-std = { path = "../nu-std" }
+nu-test-support = { path = "../nu-test-support" }
 rstest = { workspace = true, default-features = false }
 tempfile = { workspace = true }
 

--- a/crates/nu-cmd-base/Cargo.toml
+++ b/crates/nu-cmd-base/Cargo.toml
@@ -21,5 +21,3 @@ nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features =
 
 indexmap = { workspace = true }
 miette = { workspace = true }
-
-[dev-dependencies]

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -44,9 +44,9 @@ itertools = { workspace = true }
 mime = { workspace = true }
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.112.0" }
-nu-command = { path = "../nu-command", version = "0.112.0" }
-nu-test-support = { path = "../nu-test-support", version = "0.112.0" }
+nu-cmd-lang = { path = "../nu-cmd-lang" }
+nu-command = { path = "../nu-command" }
+nu-test-support = { path = "../nu-test-support" }
 
 [build-dependencies]
 nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false }

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -31,6 +31,7 @@ shadow-rs = { version = "1.7", default-features = false, features = ["build"] }
 
 [dev-dependencies]
 nu-test-support = { path = "../nu-test-support"}
+
 quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
 miette = { workspace = true }

--- a/crates/nu-cmd-plugin/Cargo.toml
+++ b/crates/nu-cmd-plugin/Cargo.toml
@@ -20,5 +20,3 @@ nu-protocol = { path = "../nu-protocol", version = "0.112.0", features = ["plugi
 nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.112.0" }
 
 itertools = { workspace = true }
-
-[dev-dependencies]

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -24,4 +24,4 @@ nu-ansi-term = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.112.0" }
+nu-test-support = { path = "../nu-test-support" }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -247,8 +247,8 @@ sqlite = ["rusqlite"]
 trash-support = ["trash"]
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.112.0" }
-nu-test-support = { path = "../nu-test-support", version = "0.112.0" }
+nu-cmd-lang = { path = "../nu-cmd-lang" }
+nu-test-support = { path = "../nu-test-support" }
 
 dirs = { workspace = true }
 mockito = { workspace = true, default-features = false }

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -30,8 +30,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.112.0" }
-nu-path = { path = "../nu-path", version = "0.112.0" }
+nu-test-support = { path = "../nu-test-support" }
+nu-path = { path = "../nu-path" }
+
 serde_json = "1.0"
 fancy-regex = "0.17.0"
 pretty_assertions = { workspace = true }

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -28,11 +28,11 @@ serde_json = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.112.0" }
-nu-command = { path = "../nu-command", version = "0.112.0" }
-nu-engine = { path = "../nu-engine", version = "0.112.0" }
-nu-std = { path = "../nu-std", version = "0.112.0" }
-nu-test-support = { path = "../nu-test-support", version = "0.112.0" }
+nu-cmd-lang = { path = "../nu-cmd-lang" }
+nu-command = { path = "../nu-command" }
+nu-engine = { path = "../nu-engine" }
+nu-std = { path = "../nu-std" }
+nu-test-support = { path = "../nu-test-support" }
 
 assert-json-diff = "2.0"
 rstest = { workspace = true, default-features = false }

--- a/crates/nu-mcp/Cargo.toml
+++ b/crates/nu-mcp/Cargo.toml
@@ -41,4 +41,4 @@ mcp = []
 workspace = true
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.112.0" }
+nu-cmd-lang = { path = "../nu-cmd-lang" }

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -78,9 +78,10 @@ plugin = [
 sqlite = []
 
 [dev-dependencies]
+nu-test-support = { path = "../nu-test-support", features = ["os"] }
+nu-utils = { path = "../nu-utils" }
+
 serde_json = { workspace = true }
-nu-test-support = { path = "../nu-test-support", version = "0.112.0", features = ["os"] }
-nu-utils = { path = "../nu-utils", version = "0.112.0" }
 pretty_assertions = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -22,6 +22,3 @@ nu-color-config = { path = "../nu-color-config", version = "0.112.0" }
 nu-ansi-term = { workspace = true }
 fancy-regex = { workspace = true }
 tabled = { workspace = true, features = ["ansi"], default-features = false }
-
-[dev-dependencies]
-# nu-test-support = { path="../nu-test-support", version = "0.112.0"  }

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -53,8 +53,8 @@ which = { workspace = true }
 
 [dev-dependencies]
 # doc tests use the "os" feature of `nu-command`
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.112.0", features = ["default"] }
-nu-command = { path = "../nu-command", version = "0.112.0", features = ["default"] }
+nu-cmd-lang = { path = "../nu-cmd-lang", features = ["default"] }
+nu-command = { path = "../nu-command", features = ["default"] }
 
 bytes = { workspace = true }
 rstest = { workspace = true }

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -21,4 +21,4 @@ serde = { workspace = true }
 typetag = "0.2"
 
 [dev-dependencies]
-nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.112.0" }
+nu-plugin-test-support = { path = "../nu-plugin-test-support" }

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -24,5 +24,5 @@ nu-plugin = { path = "../nu-plugin", version = "0.112.0" }
 nu-protocol = { path = "../nu-protocol", version = "0.112.0", features = ["plugin"] }
 
 [dev-dependencies]
-nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.112.0" }
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.112.0" }
+nu-plugin-test-support = { path = "../nu-plugin-test-support" }
+nu-cmd-lang = { path = "../nu-cmd-lang" }

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -24,4 +24,4 @@ plist = "1.8"
 chrono = "0.4.41" # polars is requiring <= 0.4.41
 
 [dev-dependencies]
-nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.112.0" }
+nu-plugin-test-support = { path = "../nu-plugin-test-support" }

--- a/crates/nu_plugin_polars/Cargo.toml
+++ b/crates/nu_plugin_polars/Cargo.toml
@@ -106,9 +106,10 @@ optional = false
 version = "=0.53.0"
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.112.0" }
-nu-engine = { path = "../nu-engine", version = "0.112.0" }
-nu-parser = { path = "../nu-parser", version = "0.112.0" }
-nu-command = { path = "../nu-command", version = "0.112.0" }
-nu-plugin-test-support = { path = "../nu-plugin-test-support", version = "0.112.0" }
+nu-cmd-lang = { path = "../nu-cmd-lang" }
+nu-engine = { path = "../nu-engine" }
+nu-parser = { path = "../nu-parser" }
+nu-command = { path = "../nu-command" }
+nu-plugin-test-support = { path = "../nu-plugin-test-support" }
+
 tempfile.workspace = true


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

We have some cyclic depencencies if you respect the `dev-dependencies`. This is allowed as compiling works but cannot be published without issues as `cargo` would try to find a dependency tree to publish. But for publishing dev dependencies may be excluded which can be done by removing the `version` field in a dev dependency. So I did that for all our crates. This seems to allow publishing.

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
n/a
