### PR TITLE
Select specific version for `getrandom` and bump minor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,11 +2512,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4280,7 +4282,7 @@ dependencies = [
  "filesize",
  "filetime",
  "fuzzy-matcher",
- "getrandom 0.2.17",
+ "getrandom 0.4.2",
  "http 1.4.0",
  "human-date-parser",
  "indexmap 2.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4080,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "nu"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "assert_cmd",
  "crossterm",
@@ -4137,7 +4137,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cli"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "chrono",
  "crossterm",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-base"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "indexmap 2.13.0",
  "miette",
@@ -4187,7 +4187,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-extra"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "fancy-regex",
  "heck",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-lang"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "itertools 0.14.0",
  "miette",
@@ -4232,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-plugin"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "itertools 0.14.0",
  "nu-engine",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "nu-color-config"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "nu-ansi-term",
  "nu-engine",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "nu-command"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "alphanumeric-sort",
  "arboard",
@@ -4379,7 +4379,7 @@ dependencies = [
 
 [[package]]
 name = "nu-derive-value"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "heck",
  "proc-macro-error2",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "fancy-regex",
  "log",
@@ -4403,7 +4403,7 @@ dependencies = [
 
 [[package]]
 name = "nu-experimental"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "itertools 0.14.0",
  "thiserror 2.0.18",
@@ -4411,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "nu-explore"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "ansi-str",
  "anyhow",
@@ -4440,14 +4440,14 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "doc-comment",
 ]
 
 [[package]]
 name = "nu-json"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "fancy-regex",
  "linked-hash-map",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "nu-lsp"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "assert-json-diff",
  "crossbeam-channel",
@@ -4493,7 +4493,7 @@ dependencies = [
 
 [[package]]
 name = "nu-mcp"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "nu-parser"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "bytesize",
  "chrono",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "dirs",
  "omnipath",
@@ -4547,7 +4547,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "log",
  "nix 0.31.2",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-core"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "interprocess",
  "log",
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-engine"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "log",
  "nu-engine",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-protocol"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "nu-protocol",
  "nu-utils",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-test-support"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "nu-ansi-term",
  "nu-cmd-lang",
@@ -4624,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "nu-pretty-hex"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "heapless",
  "nu-ansi-term",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "brotli",
  "bytes",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "nu-std"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "log",
  "miette",
@@ -4686,7 +4686,7 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "chrono",
  "itertools 0.14.0",
@@ -4706,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "nu-table"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "fancy-regex",
  "nu-ansi-term",
@@ -4719,7 +4719,7 @@ dependencies = [
 
 [[package]]
 name = "nu-term-grid"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "nu-utils",
  "unicode-width 0.2.2",
@@ -4727,7 +4727,7 @@ dependencies = [
 
 [[package]]
 name = "nu-test-support"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "bytes",
  "gatekeeper",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "nu-test-support-macros"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "heck",
  "nu-experimental",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "byteyarn",
  "crossterm",
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_example"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "nu-cmd-lang",
  "nu-plugin",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_formats"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "chrono",
  "eml-parser",
@@ -4829,7 +4829,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_gstat"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "git2",
  "nu-plugin",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_inc"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -4847,7 +4847,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_polars"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4889,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_query"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "gjson",
  "nu-plugin",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_stress_internals"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "interprocess",
  "serde",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "nuon"
-version = "0.112.0"
+version = "0.112.1"
 dependencies = [
  "chrono",
  "nu-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 autotests = false
 
 [workspace.package]
@@ -35,8 +35,8 @@ pkg-fmt = "zip"
 [package.metadata.winresource]
 LegalCopyright = "Copyright © 2019-2026 The Nushell Project Developers"
 FileDescription = "A new type of shell"
-FileVersion = "0.112.0"
-ProductVersion = "0.112.0"
+FileVersion = "0.112.1"
+ProductVersion = "0.112.1"
 ProductName = "Nushell"
 
 [workspace]
@@ -247,24 +247,24 @@ used_underscore_binding = "warn"
 workspace = true
 
 [dependencies]
-nu-cli = { path = "./crates/nu-cli", version = "0.112.0" }
-nu-cmd-base = { path = "./crates/nu-cmd-base", version = "0.112.0" }
-nu-cmd-extra = { path = "./crates/nu-cmd-extra", version = "0.112.0" }
-nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.112.0" }
-nu-cmd-plugin = { path = "./crates/nu-cmd-plugin", version = "0.112.0", optional = true }
-nu-command = { path = "./crates/nu-command", version = "0.112.0", default-features = false, features = ["os"] }
-nu-engine = { path = "./crates/nu-engine", version = "0.112.0" }
-nu-experimental = { path = "./crates/nu-experimental", version = "0.112.0" }
-nu-explore = { path = "./crates/nu-explore", version = "0.112.0" }
-nu-lsp = { path = "./crates/nu-lsp/", version = "0.112.0" }
-nu-parser = { path = "./crates/nu-parser", version = "0.112.0" }
-nu-path = { path = "./crates/nu-path", version = "0.112.0" }
-nu-plugin-engine = { path = "./crates/nu-plugin-engine", optional = true, version = "0.112.0" }
-nu-protocol = { path = "./crates/nu-protocol", version = "0.112.0" }
-nu-std = { path = "./crates/nu-std", version = "0.112.0" }
-nu-system = { path = "./crates/nu-system", version = "0.112.0" }
-nu-utils = { path = "./crates/nu-utils", version = "0.112.0" }
-nu-mcp = { path = "./crates/nu-mcp", version = "0.112.0", optional = true }
+nu-cli = { path = "./crates/nu-cli", version = "0.112.1" }
+nu-cmd-base = { path = "./crates/nu-cmd-base", version = "0.112.1" }
+nu-cmd-extra = { path = "./crates/nu-cmd-extra", version = "0.112.1" }
+nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.112.1" }
+nu-cmd-plugin = { path = "./crates/nu-cmd-plugin", version = "0.112.1", optional = true }
+nu-command = { path = "./crates/nu-command", version = "0.112.1", default-features = false, features = ["os"] }
+nu-engine = { path = "./crates/nu-engine", version = "0.112.1" }
+nu-experimental = { path = "./crates/nu-experimental", version = "0.112.1" }
+nu-explore = { path = "./crates/nu-explore", version = "0.112.1" }
+nu-lsp = { path = "./crates/nu-lsp/", version = "0.112.1" }
+nu-parser = { path = "./crates/nu-parser", version = "0.112.1" }
+nu-path = { path = "./crates/nu-path", version = "0.112.1" }
+nu-plugin-engine = { path = "./crates/nu-plugin-engine", optional = true, version = "0.112.1" }
+nu-protocol = { path = "./crates/nu-protocol", version = "0.112.1" }
+nu-std = { path = "./crates/nu-std", version = "0.112.1" }
+nu-system = { path = "./crates/nu-system", version = "0.112.1" }
+nu-utils = { path = "./crates/nu-utils", version = "0.112.1" }
+nu-mcp = { path = "./crates/nu-mcp", version = "0.112.1", optional = true }
 reedline = { workspace = true, features = ["bashisms"] }
 
 crossterm = { workspace = true }
@@ -295,9 +295,9 @@ nix = { workspace = true, default-features = false, features = [
 ] }
 
 [dev-dependencies]
-nu-test-support = { path = "./crates/nu-test-support", version = "0.112.0", features = ["os"] }
-nu-plugin-protocol = { path = "./crates/nu-plugin-protocol", version = "0.112.0" }
-nu-plugin-core = { path = "./crates/nu-plugin-core", version = "0.112.0" }
+nu-test-support = { path = "./crates/nu-test-support", version = "0.112.1", features = ["os"] }
+nu-plugin-protocol = { path = "./crates/nu-plugin-protocol", version = "0.112.1" }
+nu-plugin-core = { path = "./crates/nu-plugin-core", version = "0.112.1" }
 assert_cmd = "2.2.0"
 dirs = { workspace = true }
 tango-bench = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ quickcheck = "1.1"
 quickcheck_macros = "1.2"
 quote = "1.0.45"
 rand = "0.10"
-getrandom = "*" # pick same version that rand requires
+getrandom = "0.4.2" # pick same version that rand requires
 rand_chacha = "0.10"
 ratatui = { version = "0.30", default-features = false, features = [
   "all-widgets",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 license = "MIT"
 name = "nu-cli"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 autotests = false
 
 [lib]
@@ -27,17 +27,17 @@ rstest = { workspace = true, default-features = false }
 tempfile = { workspace = true }
 
 [dependencies]
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.112.0" }
-nu-command = { path = "../nu-command", version = "0.112.0", features = ["os"], default-features = false }
-nu-engine = { path = "../nu-engine", version = "0.112.0", features = ["os"] }
-nu-glob = { path = "../nu-glob", version = "0.112.0" }
-nu-path = { path = "../nu-path", version = "0.112.0" }
-nu-parser = { path = "../nu-parser", version = "0.112.0" }
-nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.112.0", optional = true }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", features = ["os"] }
-nu-utils = { path = "../nu-utils", version = "0.112.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.112.0" }
-nu-experimental = { path = "../nu-experimental", version = "0.112.0" }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.112.1" }
+nu-command = { path = "../nu-command", version = "0.112.1", features = ["os"], default-features = false }
+nu-engine = { path = "../nu-engine", version = "0.112.1", features = ["os"] }
+nu-glob = { path = "../nu-glob", version = "0.112.1" }
+nu-path = { path = "../nu-path", version = "0.112.1" }
+nu-parser = { path = "../nu-parser", version = "0.112.1" }
+nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.112.1", optional = true }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", features = ["os"] }
+nu-utils = { path = "../nu-utils", version = "0.112.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.112.1" }
+nu-experimental = { path = "../nu-experimental", version = "0.112.1" }
 nu-ansi-term = { workspace = true }
 reedline = { workspace = true, features = ["bashisms"] }
 

--- a/crates/nu-cmd-base/Cargo.toml
+++ b/crates/nu-cmd-base/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "nu-cmd-base"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-base"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,10 +14,10 @@ version = "0.112.0"
 workspace = true
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.112.0", default-features = false }
-nu-parser = { path = "../nu-parser", version = "0.112.0" }
-nu-path = { path = "../nu-path", version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false }
+nu-engine = { path = "../nu-engine", version = "0.112.1", default-features = false }
+nu-parser = { path = "../nu-parser", version = "0.112.1" }
+nu-path = { path = "../nu-path", version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", default-features = false }
 
 indexmap = { workspace = true }
 miette = { workspace = true }

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "nu-cmd-extra"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-extra"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 autotests = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -24,13 +24,13 @@ path = "tests/main.rs"
 harness = false
 
 [dependencies]
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.112.0" }
-nu-engine = { path = "../nu-engine", version = "0.112.0", default-features = false }
-nu-json = { version = "0.112.0", path = "../nu-json" }
-nu-parser = { path = "../nu-parser", version = "0.112.0" }
-nu-pretty-hex = { version = "0.112.0", path = "../nu-pretty-hex" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false }
-nu-utils = { path = "../nu-utils", version = "0.112.0", default-features = false }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.112.1" }
+nu-engine = { path = "../nu-engine", version = "0.112.1", default-features = false }
+nu-json = { version = "0.112.1", path = "../nu-json" }
+nu-parser = { path = "../nu-parser", version = "0.112.1" }
+nu-pretty-hex = { version = "0.112.1", path = "../nu-pretty-hex" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", default-features = false }
+nu-utils = { path = "../nu-utils", version = "0.112.1", default-features = false }
 
 # Potential dependencies for extras
 heck = { workspace = true }
@@ -49,7 +49,7 @@ nu-command = { path = "../nu-command" }
 nu-test-support = { path = "../nu-test-support" }
 
 [build-dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", default-features = false }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 license = "MIT"
 name = "nu-cmd-lang"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 bench = false
@@ -16,12 +16,12 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.112.0", default-features = false }
-nu-experimental = { path = "../nu-experimental", version = "0.112.0" }
-nu-parser = { path = "../nu-parser", version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false }
-nu-utils = { path = "../nu-utils", version = "0.112.0", default-features = false }
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.112.0" }
+nu-engine = { path = "../nu-engine", version = "0.112.1", default-features = false }
+nu-experimental = { path = "../nu-experimental", version = "0.112.1" }
+nu-parser = { path = "../nu-parser", version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", default-features = false }
+nu-utils = { path = "../nu-utils", version = "0.112.1", default-features = false }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.112.1" }
 
 itertools = { workspace = true }
 shadow-rs = { version = "1.7", default-features = false }

--- a/crates/nu-cmd-plugin/Cargo.toml
+++ b/crates/nu-cmd-plugin/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "nu-cmd-plugin"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-plugin"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,9 +14,9 @@ version = "0.112.0"
 workspace = true
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.112.0" }
-nu-path = { path = "../nu-path", version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", features = ["plugin"] }
-nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.112.0" }
+nu-engine = { path = "../nu-engine", version = "0.112.1" }
+nu-path = { path = "../nu-path", version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", features = ["plugin"] }
+nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.112.1" }
 
 itertools = { workspace = true }

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 license = "MIT"
 name = "nu-color-config"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 bench = false
@@ -16,9 +16,9 @@ harness = false
 workspace = true
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false }
-nu-engine = { path = "../nu-engine", version = "0.112.0", default-features = false }
-nu-json = { path = "../nu-json", version = "0.112.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", default-features = false }
+nu-engine = { path = "../nu-engine", version = "0.112.1", default-features = false }
+nu-json = { path = "../nu-json", version = "0.112.1" }
 nu-ansi-term = { workspace = true }
 
 serde = { workspace = true, features = ["derive"] }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -214,7 +214,7 @@ os = [
 # The dependencies listed below need 'getrandom'.
 # They work with JS (usually with wasm-bindgen) or regular OS support.
 # Hence they are also put under the 'os' feature to avoid repetition.
-js = ["getrandom", "getrandom/js", "rand", "uuid"]
+js = ["getrandom", "getrandom/wasm_js", "rand", "uuid"]
 
 # These dependencies require networking capabilities, especially the http
 # interface requires openssl which is not easy to embed into wasm,

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "nu-command"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-command"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 autotests = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -25,21 +25,21 @@ workspace = true
 
 [dependencies]
 nu-ansi-term = { workspace = true }
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.112.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.112.0" }
-nu-engine = { path = "../nu-engine", version = "0.112.0", default-features = false }
-nu-experimental = { path = "../nu-experimental", version = "0.112.0" }
-nu-glob = { path = "../nu-glob", version = "0.112.0" }
-nu-json = { path = "../nu-json", version = "0.112.0", features = ["nu-protocol"] }
-nu-parser = { path = "../nu-parser", version = "0.112.0" }
-nu-path = { path = "../nu-path", version = "0.112.0" }
-nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false }
-nu-system = { path = "../nu-system", version = "0.112.0" }
-nu-table = { path = "../nu-table", version = "0.112.0" }
-nu-term-grid = { path = "../nu-term-grid", version = "0.112.0" }
-nu-utils = { path = "../nu-utils", version = "0.112.0", default-features = false }
-nuon = { path = "../nuon", version = "0.112.0" }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.112.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.112.1" }
+nu-engine = { path = "../nu-engine", version = "0.112.1", default-features = false }
+nu-experimental = { path = "../nu-experimental", version = "0.112.1" }
+nu-glob = { path = "../nu-glob", version = "0.112.1" }
+nu-json = { path = "../nu-json", version = "0.112.1", features = ["nu-protocol"] }
+nu-parser = { path = "../nu-parser", version = "0.112.1" }
+nu-path = { path = "../nu-path", version = "0.112.1" }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", default-features = false }
+nu-system = { path = "../nu-system", version = "0.112.1" }
+nu-table = { path = "../nu-table", version = "0.112.1" }
+nu-term-grid = { path = "../nu-term-grid", version = "0.112.1" }
+nu-utils = { path = "../nu-utils", version = "0.112.1", default-features = false }
+nuon = { path = "../nuon", version = "0.112.1" }
 
 alphanumeric-sort = { workspace = true }
 base64 = { workspace = true }

--- a/crates/nu-derive-value/Cargo.toml
+++ b/crates/nu-derive-value/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "nu-derive-value"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-derive-value"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 proc-macro = true

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 license = "MIT"
 name = "nu-engine"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 bench = false
@@ -15,11 +15,11 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false }
-nu-experimental = { path = "../nu-experimental", version = "0.112.0" }
-nu-path = { path = "../nu-path", version = "0.112.0" }
-nu-glob = { path = "../nu-glob", version = "0.112.0" }
-nu-utils = { path = "../nu-utils", version = "0.112.0", default-features = false }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", default-features = false }
+nu-experimental = { path = "../nu-experimental", version = "0.112.1" }
+nu-path = { path = "../nu-path", version = "0.112.1" }
+nu-glob = { path = "../nu-glob", version = "0.112.1" }
+nu-utils = { path = "../nu-utils", version = "0.112.1", default-features = false }
 fancy-regex = { workspace = true }
 log = { workspace = true }
 

--- a/crates/nu-experimental/Cargo.toml
+++ b/crates/nu-experimental/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "nu-experimental"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-experimental"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 
 [dependencies]
 itertools.workspace = true

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 license = "MIT"
 name = "nu-explore"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 bench = false
@@ -15,16 +15,16 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.112.0" }
-nu-parser = { path = "../nu-parser", version = "0.112.0" }
-nu-path = { path = "../nu-path", version = "0.112.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.112.0" }
-nu-engine = { path = "../nu-engine", version = "0.112.0" }
-nu-table = { path = "../nu-table", version = "0.112.0" }
-nu-json = { path = "../nu-json", version = "0.112.0" }
-nu-utils = { path = "../nu-utils", version = "0.112.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1" }
+nu-parser = { path = "../nu-parser", version = "0.112.1" }
+nu-path = { path = "../nu-path", version = "0.112.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.112.1" }
+nu-engine = { path = "../nu-engine", version = "0.112.1" }
+nu-table = { path = "../nu-table", version = "0.112.1" }
+nu-json = { path = "../nu-json", version = "0.112.1" }
+nu-utils = { path = "../nu-utils", version = "0.112.1" }
 nu-ansi-term = { workspace = true }
-nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.112.0" }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.112.1" }
 
 ansi-str = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-glob"
-version = "0.112.0"
+version = "0.112.1"
 authors = ["The Nushell Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 description = """

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-json"
-version = "0.112.0"
+version = "0.112.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,8 +21,8 @@ preserve_order = ["linked-hash-map", "linked-hash-map/serde_impl"]
 default = ["preserve_order"]
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.112.0", default-features = false }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false, optional = true }
+nu-utils = { path = "../nu-utils", version = "0.112.1", default-features = false }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", default-features = false, optional = true }
 
 linked-hash-map = { version = "0.5", optional = true }
 num-traits = { workspace = true }

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -3,17 +3,17 @@ authors = ["The Nushell Project Developers"]
 description = "Nushell's integrated LSP server"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-lsp"
 name = "nu-lsp"
-version = "0.112.0"
+version = "0.112.1"
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 
 [dependencies]
-nu-cli = { path = "../nu-cli", version = "0.112.0" }
-nu-glob = { path = "../nu-glob", version = "0.112.0" }
-nu-parser = { path = "../nu-parser", version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0" }
-nu-utils = { path = "../nu-utils", version = "0.112.0" }
+nu-cli = { path = "../nu-cli", version = "0.112.1" }
+nu-glob = { path = "../nu-glob", version = "0.112.1" }
+nu-parser = { path = "../nu-parser", version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1" }
+nu-utils = { path = "../nu-utils", version = "0.112.1" }
 
 crossbeam-channel = { workspace = true }
 fancy-regex = { workspace = true }

--- a/crates/nu-mcp/Cargo.toml
+++ b/crates/nu-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-mcp"
-version = "0.112.0"
+version = "0.112.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["The Nushell Project Developers"]
@@ -15,9 +15,9 @@ nix = { workspace = true, features = ["process"] }
 [dependencies]
 futures = "0.3.31"
 miette = { workspace = true }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", features = ["plugin"] }
-nu-engine = { path = "../nu-engine", version = "0.112.0" }
-nu-parser = { path = "../nu-parser", version = "0.112.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", features = ["plugin"] }
+nu-engine = { path = "../nu-engine", version = "0.112.1" }
+nu-parser = { path = "../nu-parser", version = "0.112.1" }
 
 rmcp = { version = "1.3.0", features = ["server", "transport-io", "schemars", "transport-streamable-http-server"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "service"] }
@@ -30,7 +30,7 @@ tracing = { version = "0.1.44", features = ["log"] }
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 bytes = { workspace = true }
 indoc = "2.0.7"
-nuon = { path = "../nuon", version = "0.112.0" }
+nuon = { path = "../nuon", version = "0.112.1" }
 chrono = { workspace = true }
 
 [features]

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-parser"
-version = "0.112.0"
+version = "0.112.1"
 exclude = ["/fuzz"]
 
 [lib]
@@ -16,12 +16,12 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.112.0", default-features = false }
-nu-path = { path = "../nu-path", version = "0.112.0" }
-nu-plugin-engine = { path = "../nu-plugin-engine", optional = true, version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false }
-nu-utils = { path = "../nu-utils", version = "0.112.0", default-features = false }
-nu-experimental = { path = "../nu-experimental", version = "0.112.0" }
+nu-engine = { path = "../nu-engine", version = "0.112.1", default-features = false }
+nu-path = { path = "../nu-path", version = "0.112.1" }
+nu-plugin-engine = { path = "../nu-plugin-engine", optional = true, version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", default-features = false }
+nu-utils = { path = "../nu-utils", version = "0.112.1", default-features = false }
+nu-experimental = { path = "../nu-experimental", version = "0.112.1" }
 
 bytesize = { workspace = true }
 chrono = { default-features = false, features = ['std'], workspace = true }

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-path"
-version = "0.112.0"
+version = "0.112.1"
 exclude = ["/fuzz"]
 
 [lib]

--- a/crates/nu-plugin-core/Cargo.toml
+++ b/crates/nu-plugin-core/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-plugin-core"
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 bench = false
@@ -15,9 +15,9 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.112.0", default-features = false }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0" }
-nu-utils = { path = "../nu-utils", version = "0.112.0" }
+nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.112.1", default-features = false }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1" }
+nu-utils = { path = "../nu-utils", version = "0.112.1" }
 
 rmp-serde = { workspace = true }
 serde = { workspace = true }

--- a/crates/nu-plugin-engine/Cargo.toml
+++ b/crates/nu-plugin-engine/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-plugin-engine"
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 bench = false
@@ -15,12 +15,12 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0" }
-nu-system = { path = "../nu-system", version = "0.112.0" }
-nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.112.0" }
-nu-plugin-core = { path = "../nu-plugin-core", version = "0.112.0", default-features = false }
-nu-utils = { path = "../nu-utils", version = "0.112.0" }
+nu-engine = { path = "../nu-engine", version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1" }
+nu-system = { path = "../nu-system", version = "0.112.1" }
+nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.112.1" }
+nu-plugin-core = { path = "../nu-plugin-core", version = "0.112.1", default-features = false }
+nu-utils = { path = "../nu-utils", version = "0.112.1" }
 
 serde = { workspace = true }
 log = { workspace = true }

--- a/crates/nu-plugin-protocol/Cargo.toml
+++ b/crates/nu-plugin-protocol/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-plugin-protocol"
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 bench = false
@@ -15,8 +15,8 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", features = ["plugin"] }
-nu-utils = { path = "../nu-utils", version = "0.112.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", features = ["plugin"] }
+nu-utils = { path = "../nu-utils", version = "0.112.1" }
 
 rmp-serde = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/nu-plugin-test-support/Cargo.toml
+++ b/crates/nu-plugin-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-plugin-test-support"
-version = "0.112.0"
+version = "0.112.1"
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
@@ -16,14 +16,14 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.112.0", features = ["plugin"] }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", features = ["plugin"] }
-nu-parser = { path = "../nu-parser", version = "0.112.0", features = ["plugin"] }
-nu-plugin = { path = "../nu-plugin", version = "0.112.0" }
-nu-plugin-core = { path = "../nu-plugin-core", version = "0.112.0" }
-nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.112.0" }
-nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.112.0" }
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.112.0" }
+nu-engine = { path = "../nu-engine", version = "0.112.1", features = ["plugin"] }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", features = ["plugin"] }
+nu-parser = { path = "../nu-parser", version = "0.112.1", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.112.1" }
+nu-plugin-core = { path = "../nu-plugin-core", version = "0.112.1" }
+nu-plugin-engine = { path = "../nu-plugin-engine", version = "0.112.1" }
+nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.112.1" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.112.1" }
 nu-ansi-term = { workspace = true }
 similar = "3.0"
 

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-plugin"
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 bench = false
@@ -15,11 +15,11 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.112.0", features = ["plugin"] }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", features = ["plugin"] }
-nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.112.0" }
-nu-plugin-core = { path = "../nu-plugin-core", version = "0.112.0", default-features = false }
-nu-utils = { path = "../nu-utils", version = "0.112.0" }
+nu-engine = { path = "../nu-engine", version = "0.112.1", features = ["plugin"] }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", features = ["plugin"] }
+nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.112.1" }
+nu-plugin-core = { path = "../nu-plugin-core", version = "0.112.1", default-features = false }
+nu-utils = { path = "../nu-utils", version = "0.112.1" }
 
 log = { workspace = true }
 thiserror = "2.0.18"

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-pretty-hex"
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 doctest = false

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-protocol"
-version = "0.112.0"
+version = "0.112.1"
 autotests = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -24,12 +24,12 @@ harness = false
 workspace = true
 
 [dependencies]
-nu-derive-value = { path = "../nu-derive-value", version = "0.112.0" }
-nu-glob = { path = "../nu-glob", version = "0.112.0" }
-nu-path = { path = "../nu-path", version = "0.112.0" }
-nu-system = { path = "../nu-system", version = "0.112.0" }
-nu-utils = { path = "../nu-utils", version = "0.112.0", default-features = false }
-nu-experimental = { path = "../nu-experimental", version = "0.112.0" }
+nu-derive-value = { path = "../nu-derive-value", version = "0.112.1" }
+nu-glob = { path = "../nu-glob", version = "0.112.1" }
+nu-path = { path = "../nu-path", version = "0.112.1" }
+nu-system = { path = "../nu-system", version = "0.112.1" }
+nu-utils = { path = "../nu-utils", version = "0.112.1", default-features = false }
+nu-experimental = { path = "../nu-experimental", version = "0.112.1" }
 
 brotli = { workspace = true, optional = true }
 bytes = { workspace = true }

--- a/crates/nu-std/Cargo.toml
+++ b/crates/nu-std/Cargo.toml
@@ -6,12 +6,12 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-std"
-version = "0.112.0"
+version = "0.112.1"
 
 [dependencies]
-nu-parser = { version = "0.112.0", path = "../nu-parser" }
-nu-protocol = { version = "0.112.0", path = "../nu-protocol", default-features = false }
-nu-engine = { version = "0.112.0", path = "../nu-engine", default-features = false }
+nu-parser = { version = "0.112.1", path = "../nu-parser" }
+nu-protocol = { version = "0.112.1", path = "../nu-protocol", default-features = false }
+nu-engine = { version = "0.112.1", path = "../nu-engine", default-features = false }
 miette = { workspace = true, features = ["fancy-no-backtrace"] }
 
 log = "0.4"

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["The Nushell Project Developers", "procs creators"]
 description = "Nushell system querying"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-system"
 name = "nu-system"
-version = "0.112.0"
+version = "0.112.1"
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
@@ -17,7 +17,7 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.112.0", default-features = false }
+nu-utils = { path = "../nu-utils", version = "0.112.1", default-features = false }
 
 libc = { workspace = true }
 log = { workspace = true }

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-table"
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 bench = false
@@ -15,10 +15,10 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false }
-nu-utils = { path = "../nu-utils", version = "0.112.0", default-features = false }
-nu-engine = { path = "../nu-engine", version = "0.112.0", default-features = false }
-nu-color-config = { path = "../nu-color-config", version = "0.112.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", default-features = false }
+nu-utils = { path = "../nu-utils", version = "0.112.1", default-features = false }
+nu-engine = { path = "../nu-engine", version = "0.112.1", default-features = false }
+nu-color-config = { path = "../nu-color-config", version = "0.112.1" }
 nu-ansi-term = { workspace = true }
 fancy-regex = { workspace = true }
 tabled = { workspace = true, features = ["ansi"], default-features = false }

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-term-grid"
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 bench = false
@@ -15,6 +15,6 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.112.0", default-features = false }
+nu-utils = { path = "../nu-utils", version = "0.112.1", default-features = false }
 
 unicode-width = { workspace = true }

--- a/crates/nu-test-support-macros/Cargo.toml
+++ b/crates/nu-test-support-macros/Cargo.toml
@@ -6,13 +6,13 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-test-support-macros"
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-nu-experimental = { path = "../nu-experimental", version = "0.112.0" }
+nu-experimental = { path = "../nu-experimental", version = "0.112.1" }
 
 heck = { workspace = true }
 proc-macro-error2 = { workspace = true }

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu-test-support"
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 doctest = false
@@ -27,18 +27,18 @@ network = ["nu-command/network"]
 rustls-tls = ["nu-command/rustls-tls"]
 
 [dependencies]
-nu-cmd-extra = { path = "../nu-cmd-extra", version = "0.112.0", default-features = false }
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.112.0", default-features = false }
-nu-command = { path = "../nu-command", version = "0.112.0", default-features = false }
-nu-engine = { path = "../nu-engine", version = "0.112.0", default-features = false }
-nu-experimental = { path = "../nu-experimental", version = "0.112.0", default-features = false }
-nu-glob = { path = "../nu-glob", version = "0.112.0", default-features = false }
-nu-parser = { path = "../nu-parser", version = "0.112.0", default-features = false }
-nu-path = { path = "../nu-path", version = "0.112.0", default-features = false }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false }
-nu-std = { path = "../nu-std", version = "0.112.0", default-features = false }
-nu-test-support-macros = { path = "../nu-test-support-macros", version = "0.112.0", default-features = false }
-nu-utils = { path = "../nu-utils", version = "0.112.0", default-features = false }
+nu-cmd-extra = { path = "../nu-cmd-extra", version = "0.112.1", default-features = false }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.112.1", default-features = false }
+nu-command = { path = "../nu-command", version = "0.112.1", default-features = false }
+nu-engine = { path = "../nu-engine", version = "0.112.1", default-features = false }
+nu-experimental = { path = "../nu-experimental", version = "0.112.1", default-features = false }
+nu-glob = { path = "../nu-glob", version = "0.112.1", default-features = false }
+nu-parser = { path = "../nu-parser", version = "0.112.1", default-features = false }
+nu-path = { path = "../nu-path", version = "0.112.1", default-features = false }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", default-features = false }
+nu-std = { path = "../nu-std", version = "0.112.1", default-features = false }
+nu-test-support-macros = { path = "../nu-test-support-macros", version = "0.112.1", default-features = false }
+nu-utils = { path = "../nu-utils", version = "0.112.1", default-features = false }
 
 itertools = { workspace = true }
 kitest = { workspace = true }

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "nu-utils"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-utils"
 rust-version.workspace = true
-version = "0.112.0"
+version = "0.112.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/nu-utils/src/default_files/default_config.nu
+++ b/crates/nu-utils/src/default_files/default_config.nu
@@ -1,6 +1,6 @@
 # Nushell Config File
 #
-# version = "0.112.0"
+# version = "0.112.1"
 $env.config.color_config = {
     separator: default
     leading_trailing_space_bg: { attr: n }

--- a/crates/nu-utils/src/default_files/default_env.nu
+++ b/crates/nu-utils/src/default_files/default_env.nu
@@ -1,7 +1,7 @@
 # Default Nushell Environment Config File
 # These "sensible defaults" are set before the user's `env.nu` is loaded
 #
-# version = "0.112.0"
+# version = "0.112.1"
 
 $env.PROMPT_COMMAND = {||
     let dir = match (do -i { $env.PWD | path relative-to $nu.home-dir }) {

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -3,7 +3,7 @@
 # Warning: This file is intended for documentation purposes only and
 # is not intended to be used as an actual configuration file as-is.
 #
-# version = "0.112.0"
+# version = "0.112.1"
 #
 # A `config.nu` file is used to override default Nushell settings,
 # define (or import) custom commands, or run any other startup tasks.

--- a/crates/nu-utils/src/default_files/doc_env.nu
+++ b/crates/nu-utils/src/default_files/doc_env.nu
@@ -1,6 +1,6 @@
 # Nushell Environment Config File Documentation
 #
-# version = "0.112.0"
+# version = "0.112.1"
 #
 # Previously, environment variables were typically configured in `env.nu`.
 # In general, most configuration can and should be performed in `config.nu`

--- a/crates/nu-utils/src/default_files/scaffold_config.nu
+++ b/crates/nu-utils/src/default_files/scaffold_config.nu
@@ -1,7 +1,7 @@
 # config.nu
 #
 # Installed by:
-# version = "0.112.0"
+# version = "0.112.1"
 #
 # This file is used to override default Nushell settings, define
 # (or import) custom commands, or run any other startup tasks.

--- a/crates/nu-utils/src/default_files/scaffold_env.nu
+++ b/crates/nu-utils/src/default_files/scaffold_env.nu
@@ -1,7 +1,7 @@
 # env.nu
 #
 # Installed by:
-# version = "0.112.0"
+# version = "0.112.1"
 #
 # Previously, environment variables were typically configured in `env.nu`.
 # In general, most configuration can and should be performed in `config.nu`

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -15,8 +15,8 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.112.0", features = [] }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.112.1", features = [] }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", features = ["plugin"] }
 serde = { workspace = true }
 typetag = "0.2"
 

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu_plugin_example"
-version = "0.112.0"
+version = "0.112.1"
 publish = false
 
 [[bin]]
@@ -20,8 +20,8 @@ bench = false
 workspace = true
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", features = ["plugin"] }
 
 [dev-dependencies]
 nu-plugin-test-support = { path = "../nu-plugin-test-support" }

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -6,15 +6,15 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu_plugin_formats"
-version = "0.112.0"
+version = "0.112.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lints]
 workspace = true
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", features = ["plugin"] }
 
 indexmap = { workspace = true }
 eml-parser = "0.1"

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu_plugin_gstat"
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 doctest = false
@@ -17,7 +17,7 @@ name = "nu_plugin_gstat"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0" }
+nu-plugin = { path = "../nu-plugin", version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1" }
 
 git2 = "0.20.4"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu_plugin_inc"
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 doctest = false
@@ -17,7 +17,7 @@ name = "nu_plugin_inc"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", features = ["plugin"] }
 
 semver = "1.0"

--- a/crates/nu_plugin_nu_example/nu_plugin_nu_example.nu
+++ b/crates/nu_plugin_nu_example/nu_plugin_nu_example.nu
@@ -6,7 +6,7 @@
 # it also allows us to test the plugin interface with something manually implemented in a scripting
 # language without adding any extra dependencies to our tests.
 
-const NUSHELL_VERSION = "0.112.0"
+const NUSHELL_VERSION = "0.112.1"
 const PLUGIN_VERSION = "0.1.1" # bump if you change commands!
 
 def main [--stdio] {

--- a/crates/nu_plugin_polars/Cargo.toml
+++ b/crates/nu_plugin_polars/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license = "MIT"
 name = "nu_plugin_polars"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_polars"
-version = "0.112.0"
+version = "0.112.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,10 +18,10 @@ bench = false
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.112.0" }
-nu-plugin = { path = "../nu-plugin", version = "0.112.0" }
-nu-path = { path = "../nu-path", version = "0.112.0" }
-nu-utils = { path = "../nu-utils", version = "0.112.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1" }
+nu-plugin = { path = "../nu-plugin", version = "0.112.1" }
+nu-path = { path = "../nu-path", version = "0.112.1" }
+nu-utils = { path = "../nu-utils", version = "0.112.1" }
 
 # Potential dependencies for extras
 chrono = { workspace = true, features = [

--- a/crates/nu_plugin_python/nu_plugin_python_example.py
+++ b/crates/nu_plugin_python/nu_plugin_python_example.py
@@ -27,7 +27,7 @@ import sys
 import json
 
 
-NUSHELL_VERSION = "0.112.0"
+NUSHELL_VERSION = "0.112.1"
 PLUGIN_VERSION = "0.1.1"  # bump if you change commands!
 
 

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu_plugin_query"
-version = "0.112.0"
+version = "0.112.1"
 
 [lib]
 doctest = false
@@ -17,8 +17,8 @@ name = "nu_plugin_query"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0" }
+nu-plugin = { path = "../nu-plugin", version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1" }
 
 gjson = "0.8.1"
 scraper = { default-features = false, version = "0.26" }

--- a/crates/nu_plugin_stress_internals/Cargo.toml
+++ b/crates/nu_plugin_stress_internals/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nu_plugin_stress_internals"
-version = "0.112.0"
+version = "0.112.1"
 publish = false
 
 [[bin]]

--- a/crates/nuon/Cargo.toml
+++ b/crates/nuon/Cargo.toml
@@ -6,15 +6,15 @@ edition.workspace = true
 rust-version.workspace = true
 license = "MIT"
 name = "nuon"
-version = "0.112.0"
+version = "0.112.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-parser = { path = "../nu-parser", version = "0.112.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.112.0", default-features = false }
-nu-engine = { path = "../nu-engine", version = "0.112.0", default-features = false }
-nu-utils = { path = "../nu-utils", version = "0.112.0", default-features = false }
+nu-parser = { path = "../nu-parser", version = "0.112.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.112.1", default-features = false }
+nu-engine = { path = "../nu-engine", version = "0.112.1", default-features = false }
+nu-utils = { path = "../nu-utils", version = "0.112.1", default-features = false }
 
 [dev-dependencies]
 chrono = { workspace = true }


### PR DESCRIPTION
crates.io sent me a 400 response when I tried to publish 0.112.0 because we had `getrandom = "*"`. This is ok for `cargo` but not for crates.io. So just to be save, we release 0.112.1.