### PR TITLE
refactor!: remove deprecated `DataSource::Ls`

### DIFF
--- a/crates/nu-command/src/debug/metadata_set.rs
+++ b/crates/nu-command/src/debug/metadata_set.rs
@@ -1,9 +1,6 @@
 use super::util::{extend_record_with_metadata, parse_metadata_from_record};
 use nu_engine::{ClosureEvalOnce, command_prelude::*};
-use nu_protocol::{
-    DataSource, DeprecationEntry, DeprecationType, ReportMode, engine::Closure,
-    shell_error::generic::GenericError,
-};
+use nu_protocol::{DataSource, engine::Closure, shell_error::generic::GenericError};
 
 #[derive(Clone)]
 pub struct MetadataSet;
@@ -24,11 +21,6 @@ impl Command for MetadataSet {
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Record(vec![])])),
                 "A closure that receives the current metadata and returns a new metadata record. Cannot be used with other flags.",
-            )
-            .switch(
-                "datasource-ls",
-                "(DEPRECATED) Assign the DataSource::Ls metadata to the input.",
-                Some('l'),
             )
             .named(
                 "datasource-filepath",
@@ -52,18 +44,6 @@ impl Command for MetadataSet {
             .category(Category::Debug)
     }
 
-    fn deprecation_info(&self) -> Vec<DeprecationEntry> {
-        vec![DeprecationEntry {
-            ty: DeprecationType::Flag("datasource-ls".into()),
-            report_mode: ReportMode::FirstUse,
-            since: Some("0.111.0".into()),
-            expected_removal: Some("0.113.0".into()),
-            help: Some(
-                "Use the path-columns flag instead: `metadata set --path-columns [name]`".into(),
-            ),
-        }]
-    }
-
     fn run(
         &self,
         engine_state: &EngineState,
@@ -74,7 +54,6 @@ impl Command for MetadataSet {
         let head = call.head;
         let closure: Option<Closure> = call.opt(engine_state, stack, 0)?;
         let ds_fp: Option<String> = call.get_flag(engine_state, stack, "datasource-filepath")?;
-        let ds_ls = call.has_flag(engine_state, stack, "datasource-ls")?;
         let path_columns: Option<Vec<String>> =
             call.get_flag(engine_state, stack, "path-columns")?;
         let content_type: Option<Option<String>> =
@@ -89,7 +68,7 @@ impl Command for MetadataSet {
 
         // Handle closure parameter - mutually exclusive with flags
         if let Some(closure) = closure {
-            if ds_fp.is_some() || ds_ls || path_columns.is_some() || content_type.is_some() {
+            if ds_fp.is_some() || path_columns.is_some() || content_type.is_some() {
                 return Err(ShellError::Generic(
                     GenericError::new(
                         "Incompatible parameters",
@@ -132,26 +111,8 @@ impl Command for MetadataSet {
             metadata.content_type = content_type;
         }
 
-        match (ds_fp, ds_ls) {
-            (Some(path), false) => metadata.data_source = DataSource::FilePath(path.into()),
-            #[allow(deprecated)]
-            (None, true) => {
-                metadata.data_source = DataSource::Ls;
-                metadata.path_columns.push("name".to_string());
-            }
-            (Some(_), true) => {
-                return Err(ShellError::IncompatibleParameters {
-                    left_message: "cannot use `--datasource-filepath`".into(),
-                    left_span: call
-                        .get_flag_span(stack, "datasource-filepath")
-                        .expect("has flag"),
-                    right_message: "with `--datasource-ls`".into(),
-                    right_span: call
-                        .get_flag_span(stack, "datasource-ls")
-                        .expect("has flag"),
-                });
-            }
-            (None, false) => (),
+        if let Some(path) = ds_fp {
+            metadata.data_source = DataSource::FilePath(path.into());
         }
 
         Ok(input.set_metadata(Some(metadata)))

--- a/crates/nu-command/src/debug/util.rs
+++ b/crates/nu-command/src/debug/util.rs
@@ -14,8 +14,6 @@ pub fn extend_record_with_metadata(
     }) = metadata
     {
         match data_source {
-            #[allow(deprecated)]
-            DataSource::Ls => record.push("source", Value::string("ls", head)),
             DataSource::HtmlThemes => {
                 record.push("source", Value::string("into html --list", head))
             }
@@ -52,8 +50,6 @@ pub fn parse_metadata_from_record(record: &Record) -> PipelineMetadata {
             "source" => {
                 if let Ok(s) = value.as_str() {
                     metadata.data_source = match s {
-                        #[allow(deprecated)]
-                        "ls" => DataSource::Ls,
                         "into html --list" => DataSource::HtmlThemes,
                         _ => DataSource::FilePath(PathBuf::from(s)),
                     };

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -4,7 +4,7 @@ use nu_engine::{command_prelude::*, glob_from};
 use nu_glob::MatchOptions;
 use nu_path::{expand_path_with, expand_to_real_path};
 use nu_protocol::{
-    DataSource, NuGlob, PipelineMetadata, Signals,
+    NuGlob, PipelineMetadata, Signals,
     shell_error::{self, generic::GenericError, io::IoError},
 };
 use pathdiff::diff_paths;
@@ -231,8 +231,6 @@ impl Command for Ls {
                         call_span,
                         engine_state.signals().clone(),
                         PipelineMetadata {
-                            #[allow(deprecated)]
-                            data_source: DataSource::Ls,
                             path_columns: vec!["name".to_string()],
                             ..Default::default()
                         },
@@ -258,8 +256,6 @@ impl Command for Ls {
                         call_span,
                         engine_state.signals().clone(),
                         PipelineMetadata {
-                            #[allow(deprecated)]
-                            data_source: DataSource::Ls,
                             path_columns: vec!["name".to_string()],
                             ..Default::default()
                         },

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
 
 use nu_engine::command_prelude::*;
-use nu_protocol::{
-    DataSource, DeprecationEntry, DeprecationType, ReportMode, Signals, ast::PathMember,
-};
+use nu_protocol::{DeprecationEntry, DeprecationType, ReportMode, Signals, ast::PathMember};
 
 #[derive(Clone)]
 pub struct Get;
@@ -241,10 +239,6 @@ fn action(
         follow_cell_path_into_stream(input, signals, cell_path.members, span).map(|data| {
             if !cell_path_is_index && let Some(metadata) = &mut metadata {
                 metadata.path_columns.clear();
-                #[allow(deprecated)]
-                if metadata.data_source == DataSource::Ls {
-                    metadata.data_source = DataSource::None
-                }
             }
             data.set_metadata(metadata)
         })
@@ -264,10 +258,6 @@ fn action(
 
         if !any_cell_path_is_index && let Some(metadata) = &mut metadata {
             metadata.path_columns.clear();
-            #[allow(deprecated)]
-            if metadata.data_source == DataSource::Ls {
-                metadata.data_source = DataSource::None
-            }
         }
 
         Ok(output

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -601,15 +601,9 @@ fn handle_record(
     let config = input.get_config();
 
     if let Some(PipelineMetadata {
-        data_source,
-        mut path_columns,
-        ..
+        mut path_columns, ..
     }) = metadata
     {
-        #[allow(deprecated)]
-        if data_source == DataSource::Ls {
-            path_columns.push(String::from("name"));
-        }
         // Remove duplicates
         path_columns.sort_unstable();
         path_columns.dedup();
@@ -796,15 +790,9 @@ fn handle_row_stream(
         };
 
         let PipelineMetadata {
-            data_source,
-            mut path_columns,
-            ..
+            mut path_columns, ..
         } = metadata;
 
-        #[allow(deprecated)]
-        if data_source == DataSource::Ls {
-            path_columns.push(String::from("name"));
-        }
         // Remove duplicates
         path_columns.sort_unstable();
         path_columns.dedup();

--- a/crates/nu-command/tests/commands/debug/metadata_set.rs
+++ b/crates/nu-command/tests/commands/debug/metadata_set.rs
@@ -3,28 +3,6 @@ use std::collections::HashMap;
 use nu_test_support::prelude::*;
 
 #[test]
-fn errors_on_conflicting_metadata_flags() -> Result {
-    let code = r#"
-        echo "foo" 
-        | metadata set --datasource-filepath foo.txt --datasource-ls
-    "#;
-
-    let err = test().run(code).expect_error()?;
-    match err {
-        ShellError::IncompatibleParameters {
-            left_message,
-            right_message,
-            ..
-        } => {
-            assert_eq!(left_message, "cannot use `--datasource-filepath`");
-            assert_eq!(right_message, "with `--datasource-ls`");
-            Ok(())
-        }
-        _ => Err(err.into()),
-    }
-}
-
-#[test]
 fn works_with_datasource_filepath() -> Result {
     let code = r#"
     echo "foo"
@@ -34,19 +12,6 @@ fn works_with_datasource_filepath() -> Result {
 
     let outcome: HashMap<String, Value> = test().run(code)?;
     assert_eq!(outcome["source"].as_str()?, "foo.txt");
-    Ok(())
-}
-
-#[test]
-fn works_with_datasource_ls() -> Result {
-    let code = r#"
-        echo "foo"
-        | metadata set --datasource-ls
-        | metadata
-    "#;
-
-    let outcome: HashMap<String, Value> = test().run(code)?;
-    assert_eq!(outcome["source"].as_str()?, "ls");
     Ok(())
 }
 

--- a/crates/nu-protocol/src/pipeline/metadata.rs
+++ b/crates/nu-protocol/src/pipeline/metadata.rs
@@ -86,15 +86,10 @@ impl PipelineMetadata {
 
 /// Describes where the particular [`PipelineMetadata`] originates.
 ///
-/// This can either be a particular family of commands (useful so downstream commands can adjust
-/// the presentation e.g. `Ls`) or the opened file to protect against overwrite-attempts properly.
+/// This can either be a particular family of commands or the opened file to protect against
+/// overwrite-attempts properly.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub enum DataSource {
-    #[deprecated(
-        since = "0.111.0",
-        note = "Use `PipelineMetadata { path_columns: vec![\"name\".to_string()], .. }` instead."
-    )]
-    Ls,
     HtmlThemes,
     FilePath(PathBuf),
     #[default]


### PR DESCRIPTION


## Release notes summary - What our users need to know
### Removed deprecated flag `--datasource-ls` of `metadata set`
The deprecated flag of metadata `--datasource-ls` has been removed. Use `metadata set --path-columns [name]` instead.
The `ls` command will no longer set the `source` metadata to `ls`.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
