### PR TITLE
Add `path_columns` metadata to `which` and history command

### DIFF
--- a/crates/nu-cli/src/commands/history/history_.rs
+++ b/crates/nu-cli/src/commands/history/history_.rs
@@ -3,7 +3,7 @@ use nu_engine::command_prelude::*;
 #[cfg(not(feature = "sqlite"))]
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{
-    HistoryFileFormat,
+    HistoryFileFormat, PipelineMetadata,
     shell_error::{self, io::IoError},
 };
 #[cfg(feature = "sqlite")]
@@ -174,9 +174,10 @@ impl Command for History {
                     .with_order_by("rowid ASC".to_string())
                     .with_unix_millis_datetime_column(fields::START_TIMESTAMP.to_string())
                     .with_millis_duration_column(fields::DURATION.to_string());
+
                 Ok(PipelineData::Value(
                     Value::custom(Box::new(table), head),
-                    None,
+                    Some(PipelineMetadata::default().with_path_columns(vec!["cwd".into()])),
                 ))
             }
         }

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -1,4 +1,5 @@
 use nu_engine::{command_prelude::*, env};
+use nu_protocol::PipelineMetadata;
 use nu_protocol::engine::CommandType;
 use std::collections::HashSet;
 use std::fs;
@@ -332,11 +333,14 @@ fn which(
     // known externals; we just won't find any PATH-based binaries.
     let paths = env::path_str(engine_state, stack, head).unwrap_or_default();
 
+    let metadata = PipelineMetadata::default().with_path_columns(vec!["path".into()]);
+
     if which_args.applications.is_empty() {
         return Ok(
             list_all_executables(engine_state, &paths, which_args.all, head)
                 .into_iter()
-                .into_pipeline_data(head, engine_state.signals().clone()),
+                .into_pipeline_data(head, engine_state.signals().clone())
+                .set_metadata(Some(metadata)),
         );
     }
 
@@ -347,7 +351,8 @@ fn which(
 
     Ok(output
         .into_iter()
-        .into_pipeline_data(head, engine_state.signals().clone()))
+        .into_pipeline_data(head, engine_state.signals().clone())
+        .set_metadata(Some(metadata)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION

## Release notes summary - What our users need to know
`which` and `history` command now also have `path_columns` metadata in their output. So the paths will render like it does for `ls` command.

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
