### PR TITLE
 fix: properly quote special characters in script arguments

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -1,7 +1,7 @@
 use crate::util::{eval_source, print_pipeline};
 use log::{info, trace};
 use nu_engine::eval_block;
-use nu_parser::{escape_for_script_arg, parse};
+use nu_parser::parse;
 use nu_path::absolute_with;
 use nu_protocol::{
     PipelineData, ShellError, Span, Value,
@@ -190,18 +190,13 @@ pub fn evaluate_file(
         // Invoke the main command with arguments. Keep using `main` as the internal command name
         // so the parser reliably resolves it; the block's signature was already rewritten to the
         // script filename above, so help messages will show the correct `script.nu`-qualified name.
-        // Newline/CR/tab characters are escaped to preserve them inside the string.
-        let args = format!(
-            "main {}",
-            args.iter()
-                .map(|arg| escape_for_script_arg(arg))
-                .collect::<Vec<_>>()
-                .join(" ")
-        );
+        // The CLI parser has already escaped script arguments via `args_to_script`, so we must not
+        // escape them again here or we would double-quote values like `"arg 2"`.
+        let command_line = format!("main {}", args.join(" "));
         eval_source(
             engine_state,
             stack,
-            args.as_bytes(),
+            command_line.as_bytes(),
             "<commandline>",
             input,
             true,
@@ -226,18 +221,49 @@ mod tests {
     use nu_test_support::prelude::*;
 
     #[test]
-    fn evaluate_file_arg_with_newline_does_not_split_commands() -> Result {
+    fn evaluate_file_arg_with_newline_does_not_split_commands2() -> Result {
         Playground::setup("evaluate_file_newline_arg", |dirs, sandbox| {
             sandbox.with_files(&[FileWithContent(
                 "test.nu",
-                "def main [...args: string] { print ...($args) }",
+                r#"def main [...args: string] {
+  let token3 = $args | get 2
+
+  if $token3 starts-with '"' or $token3 ends-with '"' {
+    "error"
+  } else {
+    "ok"
+  }
+}"#,
             )]);
 
-            // If newline escaping regresses, command parsing fails before returning "ok".
             test()
                 .cwd(dirs.test())
                 .add_nu_to_path()
-                .run("nu test.nu a b \"c\\nd\"; 'ok'")
+                .run(r#"nu test.nu a b "c\nd"; 'ok'"#)
+                .expect_value_eq("ok")
+        })
+    }
+
+    #[test]
+    fn evaluate_file_quoted_space_arg_is_passed_without_extra_quotes() -> Result {
+        Playground::setup("evaluate_file_quoted_space_arg", |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContent(
+                "test.nu",
+                r#"def main [...args: string] {
+  let token3 = $args | get 1
+
+  if $token3 starts-with '"' or $token3 ends-with '"' {
+    "error"
+  } else {
+    "ok"
+  }
+}"#,
+            )]);
+
+            test()
+                .cwd(dirs.test())
+                .add_nu_to_path()
+                .run(r#"nu test.nu arg1 "arg 2"; 'ok'"#)
                 .expect_value_eq("ok")
         })
     }

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -269,8 +269,8 @@ mod tests {
     }
 
     #[test]
-    fn evaluate_file_arg_with_various_character_escape_properly() -> Result {
-        Playground::setup("evaluate_file_newline_arg", |dirs, sandbox| {
+    fn evaluate_file_arg_with_various_characters_escape_properly() -> Result {
+        Playground::setup("evaluate_file_various_characters", |dirs, sandbox| {
             sandbox.with_files(&[FileWithContent(
                 "test.nu",
                 "def main [...args: string] { $args | to json }",

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -221,54 +221,6 @@ mod tests {
     use nu_test_support::prelude::*;
 
     #[test]
-    fn evaluate_file_arg_with_newline_does_not_split_commands2() -> Result {
-        Playground::setup("evaluate_file_newline_arg", |dirs, sandbox| {
-            sandbox.with_files(&[FileWithContent(
-                "test.nu",
-                r#"def main [...args: string] {
-  let token3 = $args | get 2
-
-  if $token3 starts-with '"' or $token3 ends-with '"' {
-    "error"
-  } else {
-    "ok"
-  }
-}"#,
-            )]);
-
-            test()
-                .cwd(dirs.test())
-                .add_nu_to_path()
-                .run(r#"nu test.nu a b "c\nd"; 'ok'"#)
-                .expect_value_eq("ok")
-        })
-    }
-
-    #[test]
-    fn evaluate_file_quoted_space_arg_is_passed_without_extra_quotes() -> Result {
-        Playground::setup("evaluate_file_quoted_space_arg", |dirs, sandbox| {
-            sandbox.with_files(&[FileWithContent(
-                "test.nu",
-                r#"def main [...args: string] {
-  let token3 = $args | get 1
-
-  if $token3 starts-with '"' or $token3 ends-with '"' {
-    "error"
-  } else {
-    "ok"
-  }
-}"#,
-            )]);
-
-            test()
-                .cwd(dirs.test())
-                .add_nu_to_path()
-                .run(r#"nu test.nu arg1 "arg 2"; 'ok'"#)
-                .expect_value_eq("ok")
-        })
-    }
-
-    #[test]
     fn evaluate_file_arg_with_various_characters_escape_properly() -> Result {
         Playground::setup("evaluate_file_various_characters", |dirs, sandbox| {
             sandbox.with_files(&[FileWithContent(

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -267,4 +267,20 @@ mod tests {
                 .expect_value_eq("ok")
         })
     }
+
+    #[test]
+    fn evaluate_file_arg_with_various_character_escape_properly() -> Result {
+        Playground::setup("evaluate_file_newline_arg", |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContent(
+                "test.nu",
+                "def main [...args: string] { $args | to json }",
+            )]);
+
+            test()
+                .cwd(dirs.test())
+                .add_nu_to_path()
+                .run(r#"nu test.nu a "" b "c\nd" "e f" "[" "}" | from json"#)
+                .expect_value_eq(["a", "", "b", "c\nd", "e f", "[", "}"])
+        })
+    }
 }

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -228,11 +228,14 @@ mod tests {
                 "def main [...args: string] { $args | to json }",
             )]);
 
+            let args = r#"a "" b "c\nd" "e f" "[" "}" "\"" '"'"#;
+            let expected = ["a", "", "b", "c\nd", "e f", "[", "}", "\"", "\""];
+
             test()
                 .cwd(dirs.test())
                 .add_nu_to_path()
-                .run(r#"nu test.nu a "" b "c\nd" "e f" "[" "}" | from json"#)
-                .expect_value_eq(["a", "", "b", "c\nd", "e f", "[", "}"])
+                .run(format!("nu test.nu {args} | from json"))
+                .expect_value_eq(expected)
         })
     }
 }

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -228,8 +228,8 @@ mod tests {
                 "def main [...args: string] { $args | to json }",
             )]);
 
-            let args = r#"a "" b "c\nd" "e f" "[" "}" "\"" '"'"#;
-            let expected = ["a", "", "b", "c\nd", "e f", "[", "}", "\"", "\""];
+            let args = r#"a "" b "c\nd" "e f" ] "[" "}" "{" "\"" '"'"#;
+            let expected = ["a", "", "b", "c\nd", "e f", "]", "[", "}", "{", "\"", "\""];
 
             test()
                 .cwd(dirs.test())

--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -1,10 +1,14 @@
 use nu_utils::escape_quote_string;
 
 fn string_should_be_quoted(input: &str) -> bool {
-    input.starts_with('$')
+    input.is_empty()
+        || input.starts_with('$')
         || input.chars().any(|c| {
             c.is_whitespace()
                 || c == '('
+                || c == '['
+                || c == '{'
+                || c == '}'
                 || c == '\''
                 || c == '`'
                 || c == '"'


### PR DESCRIPTION
Ensures that empty strings and strings containing `[`, `{`, or `}` are properly quoted during deparsing.

Follow up to https://github.com/nushell/nushell/pull/18030

## Release notes summary - What our users need to know
When nu is run from a script, empty strings and strings containing `[`, `{`, or `}` in the arguments are now properly quoted.
