### PR TITLE
Add `--include-ignored` flag to custom test harness

### DIFF
--- a/crates/nu-test-support/src/harness/args.rs
+++ b/crates/nu-test-support/src/harness/args.rs
@@ -10,6 +10,7 @@ pub struct Args {
     pub format: Format,
     pub help: bool,
     pub ignored: bool,
+    pub include_ignored: bool,
     pub list: bool,
     pub no_capture: bool,
     pub skip: Vec<String>,
@@ -31,6 +32,7 @@ impl Default for Args {
             format: Format::Pretty,
             help: false,
             ignored: false,
+            include_ignored: false,
             list: false,
             no_capture: false,
             skip: Vec::new(),
@@ -77,6 +79,7 @@ impl Args {
                 }
                 Long("help") => parse_flag(&mut parser, &mut args.help)?,
                 Long("ignored") => parse_flag(&mut parser, &mut args.ignored)?,
+                Long("include-ignored") => parse_flag(&mut parser, &mut args.include_ignored)?,
                 Long("list") => parse_flag(&mut parser, &mut args.list)?,
                 Long("nocapture" | "no-capture") => parse_flag(&mut parser, &mut args.no_capture)?,
                 Long("skip") => args.skip.push(parser.value()?.parse()?),
@@ -114,6 +117,7 @@ impl Args {
         line!("  --format <pretty|terse>      Choose output style");
         line!("  --help                       Show this help text");
         line!("  --ignored                    Run only ignored tests");
+        line!("  --include-ignored            Include ignored tests");
         line!("  --list                       List tests without running them");
         line!("  --nocapture                  Print test output directly");
         line!("  --skip <FILTER>              Skip matching tests, can be used multiple times");

--- a/crates/nu-test-support/src/harness/group.rs
+++ b/crates/nu-test-support/src/harness/group.rs
@@ -55,6 +55,7 @@ impl From<&Extra> for GroupKey {
     }
 }
 
+#[derive(Debug)]
 pub struct GroupCtx {
     pub run_in_serial: bool,
     pub experimental_options: BTreeMap<&'static ExperimentalOption, bool>,
@@ -99,7 +100,7 @@ impl Display for GroupCtx {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Grouper(HashMap<GroupKey, GroupCtx>);
 
 impl TestGrouper<Extra, GroupKey, GroupCtx> for Grouper {
@@ -128,7 +129,7 @@ impl TestGrouper<Extra, GroupKey, GroupCtx> for Grouper {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct GroupRunner(SimpleGroupRunner);
 
 impl<'t> TestGroupRunner<'t, Extra, GroupKey, GroupCtx> for GroupRunner {

--- a/crates/nu-test-support/src/harness/mod.rs
+++ b/crates/nu-test-support/src/harness/mod.rs
@@ -18,6 +18,7 @@ use kitest::{
     filter::DefaultFilter,
     formatter::{pretty::PrettyFormatter, terse::TerseFormatter},
     group::TestGroupBTreeMap,
+    ignore::DefaultIgnore,
 };
 use nu_ansi_term::Color;
 
@@ -85,12 +86,18 @@ pub fn main() -> ExitCode {
         .with_skip(args.skip)
         .with_only_ignored(args.ignored);
 
+    let ignore = match args.include_ignored {
+        false => DefaultIgnore::Default,
+        true => DefaultIgnore::IncludeIgnored,
+    };
+
     let harness = kitest::harness(TESTS.deref())
         .with_grouper(Grouper::default())
         .with_group_runner(GroupRunner::default())
         .with_groups(TestGroupBTreeMap::default())
         .with_runner(runner)
-        .with_filter(filter);
+        .with_filter(filter)
+        .with_ignore(ignore);
 
     let pretty_formatter = PrettyFormatter::default()
         .with_color_setting(args.color)

--- a/crates/nu-test-support/src/harness/test.rs
+++ b/crates/nu-test-support/src/harness/test.rs
@@ -12,6 +12,7 @@ use nu_utils::downcast;
 
 use crate::{harness::group::RUN_TEST_GROUP_IN_SERIAL, tester::TestError};
 
+#[derive(Debug)]
 pub struct Extra {
     pub run_in_serial: bool,
     pub experimental_options: &'static [(&'static ExperimentalOption, bool)],


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

This PR adds the `--include-ignored` flag to the custom test harness in `nu-test-support`. With this flag it is possible to include ignored tests in the test run.

closes #18028

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->
n/a