### PR TITLE
Overhaul nu-mcp instructions sent to MCP clients

### DIFF
--- a/crates/nu-mcp/src/instructions.md
+++ b/crates/nu-mcp/src/instructions.md
@@ -1,294 +1,254 @@
-The nushell extension gives you run nushell specific commands and other shell commands.
-This extension should be preferred over other tools for running shell commands as it can run both nushell commands and other shell commands.
+The nushell extension runs nushell and external shell commands. Prefer it over
+any other shell tool — nushell's structured pipelines let you filter results
+without re-running the command.
+
+## THE RULE
+
+**Never cap output inside a pipeline you are running for the first time.** No
+`head`, `tail`, `first N`, `last N`, `take N`, `head -c`, `-n 5`, or any other
+size-limiter in the pipe. This rule is unconditional. `where` does not license
+capping. "I'm already filtering" does not license capping. "The output might be
+huge" does not license capping.
+
+Every evaluation's full result is captured in `$history` automatically. The
+tool response you see may be truncated to fit the inline size limit, but
+nothing is lost — you always get a `history_index` you can use to slice the
+full result afterwards. You cannot flood context by running a large command.
+Stop trying to help.
+
+```nu
+# BAD — all of these cap the live pipeline
+ls **/*.rs | first 20
+cargo build o+e>| tail -50
+curl https://api.example.com/huge.json | head -c 500
+rg foo crates/ | lines | where $it =~ "err" | first 30   # where is fine, first 30 is not
+
+# GOOD — run once, slice afterwards
+cargo build o+e>| complete
+# response: { history_index: 7, ... }
+$history.7 | lines | where $it =~ '^error'
+$history.7 | lines | where $it =~ '^error' | skip 30 | first 30   # paging a saved result is fine
+```
+
+The only time you should cap inside the command is when **generation itself**
+costs something real — a remote API that bills per byte, a paid model call,
+etc. Local commands: just run them.
 
 ## Response Format
 
-Every evaluation returns a structured record with:
-- `cwd`: The current working directory after the command executes
-- `history_index`: The 0-based index of this result in the history
-- `timestamp`: When the command was executed (datetime)
-- `output`: The command output (when not truncated)
-- `note`: Present instead of `output` when truncated, indicates where to find full result
+Every evaluation returns a NUON record:
+- `cwd` — current working directory after the command
+- `history_index` — 0-based index into `$history` for this result. **This is
+  your handle for re-slicing later.** Read it out of the response.
+- `timestamp` — datetime when executed
+- `output` — the command output (when it fits under the limit)
+- `note` — present **instead of** `output` when truncated; tells you the history index
 
-## History Variable
+When you see `note`, the response is truncated but `$history.<that_index>` has
+the full, untruncated result.
 
-The `$history` variable is a `list<any>` storing all previous command outputs. Access previous results by index:
-- `$history.0` - first command output
-- `$history.1` - second command output
-- `$history | last` - most recent output
+## `$history` — the ring buffer
 
-**Ring Buffer Behavior**: History is limited to 100 entries by default. When the limit is reached,
-oldest entries are evicted. Configure via `$env.NU_MCP_HISTORY_LIMIT` (e.g., `$env.NU_MCP_HISTORY_LIMIT = 50`).
+`$history: list<any>` stores every prior evaluation's output. **Use the stable
+index from the response, not `| last`** — each new evaluation pushes its own
+entry, so `$history | last` on a second call refers to itself, not to the
+command you originally ran.
 
-Large outputs are stored in `$history` but may be truncated in the response.
-To enable truncation, set `$env.NU_MCP_OUTPUT_LIMIT` to a filesize (e.g., `$env.NU_MCP_OUTPUT_LIMIT = 10kb`).
-
-Example workflow:
 ```nu
-# First command returns large table
-ls **/*
-# Response: {cwd: "/path", history_index: 0, timestamp: 2025-01-01T12:00:00, note: "output truncated, full result in $history.0"}
+$history.7           # full result of the evaluation whose response had history_index: 7
+$history.0           # first command's output
+$history | length    # number of entries currently held
 
-# Access and filter the full result
-$history.0 | where name =~ ".rs"
+# `$history | last` is only correct *before* you run anything else. As a habit
+# it teaches the wrong reflex. Always re-index by the explicit history_index.
 ```
 
-## Structured Output
+Limits (configurable via env):
+- `NU_MCP_HISTORY_LIMIT` — max entries, default `100`. When exceeded the oldest
+  entry is evicted (ring-buffer semantics — indices do not shift, older ones
+  simply become unavailable).
+- `NU_MCP_OUTPUT_LIMIT` — response truncation threshold, default `10kb`. Set to
+  `0b` to disable truncation entirely. The full value is always in `$history`
+  regardless of this setting.
 
-Native nushell commands return structured content in NUON format (no need to pipe to `| to json`).
-Native nushell commands can be discovered by using the list_commands tool.
-Prefer nushell native commands where possible as they provide structured data in a pipeline, versus text output.
-To discover the input (stdin) and output (stdout) types of a command, flags, and positional arguments use the command_help tool.
-
-Nushell native commands will return structured content. Piping of commands that return a table, list, or record to `to text` will return plain text.
-In order to find out what columns are available use the `columns` command. For example `ps | columns` will return the columns available from the `ps` command.
-
-**String interpolation:** Use `$"...(expr)..."` syntax. Variables/expressions must be in parentheses inside `$"..."` strings.
 ```nu
-# BAD - regular strings don't interpolate variables
-let name = "world"; echo "hello $name"   # Prints literal: hello $name
-
-# GOOD - use $"..." with parentheses around expressions
-let name = "world"; echo $"hello ($name)"       # Prints: hello world
-ls $"($env.HOME)/Documents"                     # Expands path correctly
-cargo build $"--jobs=(sys cpu | length)"        # Dynamic flag value
+$env.NU_MCP_OUTPUT_LIMIT = 50kb     # bigger inline responses
+$env.NU_MCP_OUTPUT_LIMIT = 0b       # never truncate
+$env.NU_MCP_HISTORY_LIMIT = 200     # remember more entries
 ```
 
-**Command-line flags with variables:** When building flags that include variable values, the entire flag must be an interpolated string.
+## Structured Output — prefer native commands
+
+Native nushell commands return structured NUON (records/tables/lists) — do NOT
+pipe them to `| to json`, they already are structured. Use `list_commands` to
+discover commands and `command_help` to see flags / input / output types.
+
 ```nu
-# BAD - mixing bash-style and nushell syntax
-mysql -p"$env.DATABASE_PASSWORD" mydb           # ERROR: $env not expanded
-mysql -p $env.DATABASE_PASSWORD mydb            # ERROR: password becomes separate arg
-
-# GOOD - entire flag as interpolated string
-mysql $"-p($env.DATABASE_PASSWORD)" mydb        # Password correctly embedded
-curl -H $"Authorization: Bearer ($token)"       # Header with variable
-
-# GOOD - alternative: use flag=value syntax if supported
-mysql $"--password=($env.DATABASE_PASSWORD)" mydb
+ps | columns                    # see what columns are available
+ls | where size > 1mb | get name
+sys cpu | length                # record has a length like any other
 ```
 
-**String types:** Nushell has several string formats. Inside any quoted string, `*` and other special characters are literal.
+External commands return a `string`. Parse with `from json` / `from yaml` /
+`from csv` / `lines` / `split column` as needed.
 
-| Format | Syntax | Escapes | Use case |
-|--------|--------|---------|----------|
-| Single-quoted | `'hello'` | None | Simple strings, Windows paths |
-| Double-quoted | `"hello\n"` | `\n \t \" \\` etc. | Strings needing escape sequences |
-| Raw string | `r#'hello'#` | None | Strings with `'` or `"`, multi-line |
-| Bare word | `hello` | None | Command arguments (word chars only) |
-| Backtick | `` `hello world` `` | None | Paths/args with spaces, globs |
-| Interpolated | `$"($var)"` | Depends on quotes | Embedding variables/expressions |
+## String literals
+
+| Form                | Example                | Escapes | Use case |
+|---------------------|------------------------|---------|----------|
+| Single-quoted       | `'hello'`              | none    | literal, Windows paths, SQL |
+| Double-quoted       | `"a\nb"`               | `\n \t \" \\` | strings needing escapes |
+| Raw                 | `r#'he said "hi"'#`    | none    | mixed quotes, multi-line |
+| Bare word           | `hello`                | none    | command args (word chars only) |
+| Backtick            | `` `my file.txt` ``    | none    | paths/globs with spaces |
+| Interpolated        | `$"x=($var)"`          | per-quote | embedding variables |
+
+Interpolation requires `$"..."` (or `$'...'`) **and** parentheses around the
+expression:
 
 ```nu
-# Single-quoted: completely literal
-'C:\path\to\file'                               # Backslashes literal
-'SELECT * FROM users'                           # * is literal
-
-# Double-quoted: C-style escapes
-"Line one\nLine two"                            # \n = newline
-"Say \"hello\""                                 # \" = literal quote
-
-# Raw strings: literal, can contain single quotes
-r#'It's a "test"'#                              # No escaping needed
-r##'Contains r#'nested'#'##                     # Add more # to nest
-
-# Bare words: unquoted, only "word" characters
-print hello                                     # hello is a string
-[foo bar baz]                                   # list of strings
-
-# Backtick strings: bare words with spaces, useful for paths/globs
-ls `./my directory`                             # Path with space
-ls `**/*.rs`                                    # Glob pattern
-
-# Interpolation: $"..." (with escapes) or $'...' (literal)
 let name = "world"
-$"Hello ($name)!"                               # => Hello world!
-$'Path: ($env.HOME)'                            # Single-quoted interpolation
-$"2 + 2 = (2 + 2)"                              # Expressions work too
+"hello $name"          # literal: "hello $name"   ← WRONG
+$"hello ($name)"       # "hello world"            ← RIGHT
 ```
 
-**Prefer raw strings** (`r#'...'#`) for multi-line content or when mixing quote styles to avoid escaping.
+Flags with embedded variables — the **whole** flag must be one interpolated
+string, or use `--key=value`:
 
-**ANSI escape codes:** Use `ansi strip` to remove ANSI color/formatting codes from output. Do NOT use `\u001b` or similar unicode escapes - nushell doesn't support that syntax.
 ```nu
-# BAD - nushell doesn't support \uXXXX unicode escapes
-$output | str replace -a "\u001b" ""        # ERROR: invalid unicode escape
-
-# GOOD - use ansi strip to remove ANSI codes
-$output | ansi strip                         # Removes all ANSI escape sequences
-^rg pattern | ansi strip                     # Strip colors from external command output
-
-# To produce special characters, use the char command
-char escape                                  # ESC character (0x1b)
-char newline                                 # Newline
-char tab                                     # Tab
+# BAD
+mysql -p $env.PASSWORD db       # becomes two separate args
+# GOOD
+mysql $"-p($env.PASSWORD)" db
+mysql $"--password=($env.PASSWORD)" db
 ```
 
-**Stderr redirection:** Use `o+e>` or `out+err>` instead of bash-style `2>&1`.
-```nu
-# BAD - bash syntax doesn't work in nushell
-command 2>&1                                    # ERROR: use 'out+err>' instead
-command 2>/dev/null                             # ERROR: not valid nushell
+Use `char escape` / `char newline` / `char tab` for control characters — nushell
+does **not** support `\uXXXX` escapes in strings. Strip ANSI color codes with
+`ansi strip`, not regex replacement.
 
-# GOOD - nushell redirection syntax
-command o+e>| other_command                     # Redirect stderr to stdout, pipe
-command o+e>| ignore                            # Discard both stdout and stderr
+## Redirection — no `2>&1`
+
+Nushell uses its own redirection syntax:
+
+| Bash                       | Nushell                    |
+|----------------------------|----------------------------|
+| `cmd > file`               | `cmd o> file`              |
+| `cmd >> file`              | `cmd o>> file`             |
+| `cmd > /dev/null`          | `cmd \| ignore`            |
+| `cmd 2>&1`                 | `cmd o+e>\| next_cmd`      |
+| `cmd > /dev/null 2>&1`     | `cmd o+e>\| ignore`        |
+| `cmd \| tee log \| other`  | `cmd \| tee { save log } \| other` |
+
+## Bash → Nushell quick reference
+
+| Bash                               | Nushell                                      |
+|------------------------------------|----------------------------------------------|
+| `mkdir -p path`                    | `mkdir path`                                 |
+| `rm -rf path`                      | `rm -r path`                                 |
+| `cat file`                         | `open --raw file`                            |
+| `grep pat`                         | `where $it =~ pat` / `find pat`              |
+| `sed 's/a/b/'`                     | `str replace a b`                            |
+| `head -5` / `tail -5`              | `first 5` / `last 5`  *(only on a saved `$history.N` — never on the live pipeline)* |
+| `for f in *.md; do ...; done`      | `ls *.md \| each { \|r\| ... }`              |
+| `$(cmd)`                           | `(cmd)` in expressions, `...(cmd)` to splat  |
+| `echo $PATH`                       | `$env.PATH` (Unix) / `$env.Path` (Windows)   |
+| `echo $?`                          | `$env.LAST_EXIT_CODE`                        |
+| `FOO=bar ./bin`                    | `FOO=bar ./bin`                              |
+| `type foo`                         | `which foo`                                  |
+| `cmd1 && cmd2`                     | `cmd1; cmd2`                                 |
+| line continuation `\`              | wrap in `( ... )`                            |
+
+## HTTP — already parsed
+
+`http get|post|put|...` auto-parses JSON responses based on `Content-Type`. Do
+NOT pipe to `from json`.
+
+```nu
+http get https://api.example.com/users | get 0.name    # just works
+http get -H {Authorization: $"Bearer ($token)"} $url
+http post -t application/json $url {key: "value"}
+http post -H {X-API-Key: $key} $url (bytes build)      # empty body
+http get --raw $url | from json                        # opt out of auto-parse
 ```
 
-## HTTP Requests
+Note: `-t json` does **not** work — pass the full MIME type (`application/json`).
 
-**Automatic JSON parsing:** HTTP commands (`http get`, `http post`, etc.) automatically parse JSON responses into structured Nushell data based on the `Content-Type` header. Do NOT pipe to `from json` - the data is already parsed.
+## Parallelism
+
+`par-each` runs closures across threads; use it whenever order doesn't matter
+and the work is non-trivial.
 
 ```nu
-# BAD - redundant, will error because input is already structured
-http get https://api.example.com/data | from json
-
-# GOOD - returns structured data directly
-http get https://api.example.com/data
-
-# GOOD - access fields immediately
-http get https://api.example.com/users | get name
-
-# Use --raw (-r) to disable auto-parsing and get raw string
-http get --raw https://api.example.com/data | from json  # Manual parsing
+ls **/*.rs | par-each { |f| open $f.name | lines | length }
+ls **/*.log | par-each --threads 8 { |f| $f | ... }
 ```
 
-**Common flags:**
-- `-H {key: value}` or `--headers {key: value}`: Custom headers as a record
-- `-t application/json` or `--content-type application/json`: Set Content-Type for request body. Note: `-t json` does NOT work — the full MIME type is required.
-- `(bytes build)`: Empty body (required for POST/PUT when you have no data to send)
+Use plain `each` when order must be preserved or side effects must be serial.
 
-**Pipeline content-type:** Commands like `to json` set content-type metadata that `http` commands use automatically:
+## Globs and file discovery
+
+Prefer `glob` over `find` / `ls -r`: nushell's `ls **/*` traverses hidden
+directories too, which blows up output. Use `command_help glob` for details.
+
+## Polars (if loaded)
+
+For parquet/jsonl/ndjson/csv/avro, `polars` is dramatically faster than native
+nushell or external tools. Start with `plugin use polars`.
+
 ```nu
-# Pipeline approach - content-type is set automatically by `to json`
-{foo: "bar", baz: 123} | to json | http post https://api.example.com/endpoint
+polars open data.parquet | polars select name status | polars save out.parquet
+ps | polars into-df | polars collect
+polars open x.parquet | polars into-nu            # back to nushell table
 ```
 
-```nu
-# GET request
-http get https://api.example.com/data
+## Long-running commands and background jobs
 
-# GET with auth header
-http get -H {Authorization: "Bearer token"} https://api.example.com/data
-
-# POST with JSON body
-http post -t application/json https://api.example.com/endpoint {foo: "bar", baz: 123}
-
-# POST with headers but empty body (bytes build creates empty body)
-http post -H {X-API-Key: "secret"} https://api.example.com/sync (bytes build)
-
-# POST with both headers and JSON body
-http post -t application/json -H {Authorization: "Bearer token"} https://api.example.com/data {key: "value"}
-```
-
-**Parallel iteration:** Prefer `par-each` over `each` for better performance. `par-each` runs closures in parallel across multiple threads.
-```nu
-# BAD - sequential processing
-ls **/*.rs | each { |f| wc -l $f.name }
-
-# GOOD - parallel processing (much faster for I/O or CPU-bound work)
-ls **/*.rs | par-each { |f| wc -l $f.name }
-
-# GOOD - with thread count control
-ls **/*.rs | par-each --threads 8 { |f| wc -l $f.name }
-```
-
-**When to use `each` instead:**
-- Order must be preserved exactly (par-each returns results in completion order)
-- Side effects must happen sequentially
-- Very small lists where parallelization overhead exceeds benefit
-
-## Background Jobs
-
-Use `job spawn` to run commands in the background. This is the idiomatic nushell replacement for bash's `command &`.
+Evaluations that run longer than the promote-after threshold (or are cancelled
+by the client) are auto-promoted to background jobs. The full (non-truncated)
+output is delivered to the main thread's mailbox on completion. See the
+`evaluate` tool description for the default and how to override it.
 
 ```nu
-# Spawn a background job (returns job ID immediately)
-job spawn { sleep 5sec; echo "done" }
-
-# Spawn with a descriptive tag
-job spawn --tag "web-server" { uvicorn main:app }
-
-# List all running background jobs
-job list
-
-# Kill a background job by ID
-job kill 1
-```
-
-**Getting output from background jobs:** Use the mailbox system with `job send` and `job recv`.
-`job recv` reads from the *current job's mailbox* only. It does not take a job ID.
-The main thread always has job ID `0`, so background jobs should `job send 0`.
-
-```nu
-# Spawn job that sends result back to main thread
-job spawn { ls | job send 0 }
-
-# Wait and receive the result
-job recv
-
-# One-liner version
-job spawn { ls | job send 0 }; job recv
-
-# With timeout (to avoid blocking forever)
-job spawn { some-command | job send 0 }; job recv --timeout 5sec
-
-# Capture stderr too (external command)
-job spawn { ^nc -vz -w 5 51.81.221.204 5432 o+e>| job send 0 }; job recv --timeout 10sec
-```
-
-**Inter-job communication and tags:** Jobs can send messages to each other using tags as filters.
-Tags are integers. `job send --tag N` attaches a tag to the message.
-`job recv --tag N` only receives messages with that exact tag.
-Untagged messages are only received by `job recv` without a `--tag` filter.
-
-```nu
-# Send with a tag for filtering
-job spawn { "result" | job send 0 --tag 1 }
-job recv --tag 1    # Only receives messages with tag 1
-
-# Get current job's ID from within a job
-job spawn { let my_id = job id; ... }
-```
-
-**Job management commands:**
-- `job spawn { ... }` - Start a background job, returns job ID
-- `job list` - List all running jobs
-- `job kill <id>` - Terminate a job
-- `job send <id>` - Send data to a job's mailbox
-- `job recv` - Receive data from mailbox (blocks until message arrives)
-- `job id` - Get current job's ID
-- `job tag <id> <tag>` - Add/change a job's description tag
-
-**Auto-promoted jobs:**
-
-Evaluations that run longer than the promote-after threshold (or when the client cancels) are automatically promoted to background jobs; full (non-truncated) output is delivered to the main thread's mailbox on completion. See the `evaluate` tool description for the default and how to override it.
-
-```nu
-# After promotion, the server returns an error like:
+# You'll see an error like:
 # "Operation promoted to background job (id: 1). Use `job list` to see it and `job recv` to get the result."
 
-# Check if the promoted job is still running
-job list
-
-# Retrieve the result (blocks until available) — always full output, never truncated
-job recv
-
-# Or with a timeout
-job recv --timeout 60sec
+job list                         # check if still running
+job recv                         # blocks until the result arrives (FULL output)
+job recv --timeout 60sec         # bounded wait
+job kill 1                       # cancel
 ```
 
-Promoted jobs appear in `job list` with a description like `mcp: <command>`. They share the jobs table with manually spawned jobs, so `job kill <id>` works to cancel them.
+Promoted jobs bypass `$history` — their full output arrives via `job recv`, not
+as a history entry.
 
-**Important:** Promoted jobs deliver output directly through the mailbox, bypassing `$history`. The `$history` variable is only populated for non-promoted evaluations.
+For manual backgrounding:
 
-**Common gotchas:**
-- There is no `job ls`. Use `job list`.
-- `job recv` does not accept a job id or `--id`. It only reads from the current job's mailbox.
- - `job send` always takes a target job id. The main thread id is `0`.
- - `job recv --tag N` will ignore untagged messages and messages with other tags.
+```nu
+job spawn { uvicorn main:app }
+job spawn --tag web-server { ... }
 
-To find a nushell command or to see all available commands use the list_commands tool.
-To learn more about how to use a command, use the command_help tool.
-You can use the eval tool to run any command that would work on the relevant operating system.
-Use the eval tool as needed to locate files or interact with the project.
+# get a result back to the main thread (id 0)
+job spawn { ls | job send 0 }; job recv
+job spawn { some-cmd | job send 0 }; job recv --timeout 5sec
+job spawn { ^nc -vz -w5 host 5432 o+e>| job send 0 }; job recv --timeout 10sec
+
+# tagged messages — only received when you filter by the same tag
+job spawn { "done" | job send 0 --tag 1 }
+job recv --tag 1
+```
+
+Gotchas: there is no `job ls` (use `job list`). `job recv` reads only the
+current job's mailbox and takes no id. `job send` always takes a target id;
+the main thread is `0`.
+
+## Other quick tips
+
+- Use `detect columns` to structure columnar CLI output (e.g.
+  `launchctl list | detect columns`, `df | detect columns`) instead of hand-rolled
+  `parse` patterns.
+- Variables and env changes persist across tool calls (REPL semantics). Set
+  `let x = ...` or `$env.FOO = ...` in one call, read it in the next.
+- External processes do **not** inherit `let`-bound variables — only
+  environment variables.
+- `use list_commands` to search and `command_help <name>` for signatures.

--- a/crates/nu-mcp/src/server.rs
+++ b/crates/nu-mcp/src/server.rs
@@ -159,8 +159,8 @@ mod tests {
             .as_str()
             .expect("instructions should be a string");
         assert!(
-            instructions.contains("Nushell native commands"),
-            "instructions should document command discovery"
+            instructions.contains("list_commands") && instructions.contains("command_help"),
+            "instructions should point at the command discovery tools (list_commands / command_help)"
         );
 
         let server_info = json


### PR DESCRIPTION
Overhauls the instructions the `nu-mcp` server sends to MCP clients. The server already truncates inline output and retains the full, untruncated result in `$history`, but the old instructions didn't lean on that — clients would routinely pre-slice with `head` / `tail` / `first N` / `last N`, throwing away data they'd want to filter moments later. The new instructions lead with an explicit rule against capping live pipelines, then tighten the rest of the guidance: response format and `$history` ring-buffer semantics (incl. `NU_MCP_HISTORY_LIMIT` / `NU_MCP_OUTPUT_LIMIT`), preference for structured native output over `| to json`, string-literal forms and interpolation pitfalls, nushell redirection (`o>`, `o+e>|`), a trimmed bash→nu reference, auto-parsed `http` responses, `par-each`, glob vs `ls **/*`, polars, and background-job mechanics (`job list` / `job recv` / `job send` with the id-0 mailbox).

No behavior changes — this is documentation surfaced through the MCP protocol. The one code tweak is loosening a `server_info` test to assert on the tool names (`list_commands`, `command_help`) instead of a specific prose phrase that no longer appears.

## Release notes summary - What our users need to know
n/a

## Tasks after submitting
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io) if relevant