### PR TITLE
nu-mcp: raise default promote-after to 2m and add `timeout_secs` param

### DIFF
--- a/crates/nu-mcp/src/evaluate_tool.md
+++ b/crates/nu-mcp/src/evaluate_tool.md
@@ -8,6 +8,12 @@ Avoid commands that produce a large amount of output, and consider piping those 
 If you need to run a long lived command, background it - e.g. `job spawn { uvicorn main:app }` so that
 this tool does not run indefinitely.
 
+Calls that run longer than the promote-after timeout are auto-promoted to a background job; the
+tool then errors with a job id and you must `job recv` to collect the result. Precedence: the
+`timeout_secs` parameter (seconds) wins over `$env.NU_MCP_PROMOTE_AFTER`, which wins over the
+built-in default (120s). Pass a larger `timeout_secs` for known long-running commands so they stay
+synchronous.
+
 Command Equivalents to Bash:
 
 | Bash Command | Nushell Command | Description |

--- a/crates/nu-mcp/src/evaluation.rs
+++ b/crates/nu-mcp/src/evaluation.rs
@@ -176,9 +176,15 @@ pub(crate) fn shell_error_to_mcp_error(
 /// Maximum length for job descriptions shown in `job list`.
 const JOB_DESCRIPTION_MAX_LEN: usize = 40;
 
-/// How long an evaluation can run before being auto-promoted to a background job.
-/// Overridden via `NU_MCP_PROMOTE_AFTER` env var (e.g. `30sec`, `5sec`).
-const DEFAULT_PROMOTE_AFTER: Duration = Duration::from_secs(10);
+/// How long an evaluation can run before being auto-promoted to a background
+/// job. Overridden per-call via the `timeout_secs` tool param or globally via
+/// the `NU_MCP_PROMOTE_AFTER` env var.
+///
+/// 2 minutes is deliberate: a shorter default (we had 10s) made Claude Opus 4.7
+/// give up on nushell because everyday commands kept getting shoved into the
+/// background. Keep the happy path synchronous; callers who know a command is
+/// long-running can still widen the window per-call.
+const DEFAULT_PROMOTE_AFTER: Duration = Duration::from_secs(120);
 
 /// Evaluates Nushell code in a persistent REPL-style context for MCP.
 ///
@@ -281,15 +287,22 @@ impl Evaluator {
     }
 
     /// Evaluates nushell source code, promoting to a background job on
-    /// cancellation or if the evaluation exceeds `NU_MCP_PROMOTE_AFTER` (default 10s).
+    /// cancellation or if the evaluation exceeds its promote-after timeout.
+    ///
+    /// Timeout precedence (first wins):
+    /// 1. `timeout_override` — per-call value from the MCP tool parameter.
+    /// 2. `NU_MCP_PROMOTE_AFTER` env var on the persistent stack.
+    /// 3. [`DEFAULT_PROMOTE_AFTER`] (2 minutes).
     pub async fn eval_async(
         &self,
         nu_source: &str,
         ct: CancellationToken,
+        timeout_override: Option<Duration>,
     ) -> Result<String, rmcp::ErrorData> {
         let (forked_state, interrupt, promote_after) = {
             let state = self.state.lock().await;
-            let timeout = promote_timeout(&state.engine_state, &state.stack);
+            let timeout = timeout_override
+                .unwrap_or_else(|| promote_timeout(&state.engine_state, &state.stack));
             let (forked, interrupt) = state.fork();
             (forked, interrupt, timeout)
         };
@@ -342,7 +355,7 @@ impl Evaluator {
                 None,
             )
         })?;
-        rt.block_on(self.eval_async(nu_source, CancellationToken::new()))
+        rt.block_on(self.eval_async(nu_source, CancellationToken::new(), None))
     }
 
     pub async fn list_available_commands(&self, find: Option<String>) -> Result<String, String> {
@@ -654,7 +667,9 @@ fn eval_on_state(
 /// Returns the duration after which a running evaluation is auto-promoted
 /// to a background job.
 ///
-/// Defaults to 10s. Can be overridden via `NU_MCP_PROMOTE_AFTER` env var.
+/// Defaults to [`DEFAULT_PROMOTE_AFTER`] (2 minutes). Can be overridden via
+/// `NU_MCP_PROMOTE_AFTER` env var, or per-call via the tool's `timeout_secs`
+/// parameter (which wins over the env var).
 fn promote_timeout(engine_state: &EngineState, stack: &Stack) -> Duration {
     stack
         .get_env_var(engine_state, "NU_MCP_PROMOTE_AFTER")
@@ -1170,6 +1185,7 @@ mod tests {
             .eval_async(
                 "$env.NU_MCP_PROMOTE_AFTER = 100ms",
                 CancellationToken::new(),
+                None,
             )
             .await
             .expect("setting promotion timeout should succeed");
@@ -1178,6 +1194,7 @@ mod tests {
             .eval_async(
                 "sh -c 'sleep 0.2; printf stdout; printf stderr >&2; exit 7'",
                 CancellationToken::new(),
+                None,
             )
             .await;
 
@@ -1233,7 +1250,7 @@ mod tests {
 
         // Set a variable first
         evaluator
-            .eval_async("let x = 1", CancellationToken::new())
+            .eval_async("let x = 1", CancellationToken::new(), None)
             .await
             .unwrap();
 
@@ -1245,7 +1262,7 @@ mod tests {
         ct_clone.cancel();
 
         // Should be promoted to a background job, not just discarded
-        let result = evaluator.eval_async("let x = 999", ct).await;
+        let result = evaluator.eval_async("let x = 999", ct, None).await;
         assert!(result.is_err(), "Cancelled evaluation should error");
         let err_msg = result.unwrap_err().message.to_string();
         assert!(
@@ -1255,7 +1272,7 @@ mod tests {
 
         // Original variable should still be 1 (forked state not committed)
         let result = evaluator
-            .eval_async("$x", CancellationToken::new())
+            .eval_async("$x", CancellationToken::new(), None)
             .await
             .unwrap();
         assert!(

--- a/crates/nu-mcp/src/instructions.md
+++ b/crates/nu-mcp/src/instructions.md
@@ -262,7 +262,7 @@ job spawn { let my_id = job id; ... }
 
 **Auto-promoted jobs:**
 
-Evaluations that run longer than 10 seconds (or when the client cancels) are automatically promoted to background jobs. The evaluation continues running and the **full** (non-truncated) output is delivered to the main thread's mailbox when complete. The timeout is configurable via `$env.NU_MCP_PROMOTE_AFTER` (e.g., `30sec`, `5sec`).
+Evaluations that run longer than the promote-after threshold (or when the client cancels) are automatically promoted to background jobs; full (non-truncated) output is delivered to the main thread's mailbox on completion. See the `evaluate` tool description for the default and how to override it.
 
 ```nu
 # After promotion, the server returns an error like:
@@ -276,9 +276,6 @@ job recv
 
 # Or with a timeout
 job recv --timeout 60sec
-
-# Change the auto-promote threshold
-$env.NU_MCP_PROMOTE_AFTER = 30sec
 ```
 
 Promoted jobs appear in `job list` with a description like `mcp: <command>`. They share the jobs table with manually spawned jobs, so `job kill <id>` works to cancel them.

--- a/crates/nu-mcp/src/server.rs
+++ b/crates/nu-mcp/src/server.rs
@@ -10,6 +10,7 @@ use rmcp::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
 
 pub struct NushellMcpServer {
     tool_router: ToolRouter<Self>,
@@ -56,10 +57,16 @@ By default all available commands will be returned. To find a specific command b
     async fn evaluate(
         &self,
         ctx: RequestContext<RoleServer>,
-        Parameters(NuSourceRequest { input }): Parameters<NuSourceRequest>,
+        Parameters(NuSourceRequest {
+            input,
+            timeout_secs,
+        }): Parameters<NuSourceRequest>,
     ) -> Result<String, String> {
+        let timeout_override = timeout_secs
+            .filter(|secs| secs.is_finite() && *secs > 0.0)
+            .map(Duration::from_secs_f64);
         self.evaluator
-            .eval_async(&input, ctx.ct)
+            .eval_async(&input, ctx.ct, timeout_override)
             .await
             .map_err(|err| err.message.to_string())
     }
@@ -81,6 +88,13 @@ struct CommandNameRequest {
 struct NuSourceRequest {
     #[schemars(description = "The Nushell source code to evaluate")]
     input: String,
+    /// Seconds before this call is promoted to a background job. See the tool
+    /// description for details and precedence rules.
+    #[schemars(
+        description = "Seconds before this call is promoted to a background job (default 120). Set higher for long builds/tests."
+    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timeout_secs: Option<f64>,
 }
 
 #[tool_handler]
@@ -244,6 +258,7 @@ mod tests {
                 ctx,
                 Parameters(NuSourceRequest {
                     input: "5 + 2".to_string(),
+                    timeout_secs: None,
                 }),
             )
             .await
@@ -269,6 +284,7 @@ mod tests {
                 make_request_context(3),
                 Parameters(NuSourceRequest {
                     input: "1".to_string(),
+                    timeout_secs: None,
                 }),
             )
             .await
@@ -283,6 +299,7 @@ mod tests {
                 make_request_context(4),
                 Parameters(NuSourceRequest {
                     input: "2".to_string(),
+                    timeout_secs: None,
                 }),
             )
             .await


### PR DESCRIPTION
# Description

Two related tweaks to the `nu-mcp` `evaluate` tool:

1. Bumps the default auto-promote-to-background threshold from **10s to 120s**. The 10s default was aggressive enough that everyday commands (builds, test runs, longer pipelines) kept getting shoved into the background, which made Claude Opus give up on the tool. Two minutes keeps the happy path synchronous while still catching genuine hangs.
2. Adds a new per-call `timeout_secs` parameter to the `evaluate` tool so callers that know a command is long-running can widen the window without mutating `$env.NU_MCP_PROMOTE_AFTER` on the persistent stack.

Precedence (first wins):

1. `timeout_secs` tool parameter
2. `$env.NU_MCP_PROMOTE_AFTER` env var
3. Built-in default (now `120s`)

Docs in `evaluate_tool.md` and `instructions.md` are updated to match.

# User-Facing Changes

`nu-mcp` only. Default promotion timeout changes from 10s to 120s, and the `evaluate` MCP tool gains an optional `timeout_secs` field.

# Tests + Formatting

- `nu -c "use toolkit.nu; toolkit fmt"`
- `nu -c "use toolkit.nu; toolkit clippy"`

Existing `nu-mcp` tests updated for the new `timeout_override` parameter; the test that relies on promotion still passes by setting `$env.NU_MCP_PROMOTE_AFTER = 100ms`.

## Release notes summary - What our users need to know

- `nu-mcp`: default auto-promote-to-background threshold raised from 10s to 120s.
- `nu-mcp`: the `evaluate` tool accepts a new optional `timeout_secs` parameter to override the promotion threshold per call.

## Tasks after submitting

- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)