### PR TITLE
feat: add basic support msgpack extension types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4367,6 +4367,7 @@ dependencies = [
  "toml 1.1.0+spec-1.1.0",
  "toml_edit",
  "trash",
+ "typetag",
  "umask",
  "unicode-segmentation",
  "unicode-width 0.2.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,6 +208,7 @@ tokio = { version = "1.51.0" }
 toml = "1.0.7"
 toml_edit = "0.25.8"
 trash = "=5.2.4"
+typetag = "0.2"
 update-informer = { version = "1.3.0", default-features = false, features = ["github", "ureq"] }
 umask = "2.1"
 unicode-segmentation = "1.13"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -118,6 +118,7 @@ tabled = { workspace = true, features = ["ansi"], default-features = false }
 titlecase = { workspace = true }
 toml = { workspace = true, features = ["preserve_order"] }
 toml_edit = { workspace = true }
+typetag = { workspace = true }
 unicode-segmentation = { workspace = true }
 update-informer = { workspace = true, optional = true }
 ureq = { workspace = true, default-features = false, features = [

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -309,6 +309,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             FromJson,
             FromMd,
             FromMsgpack,
+            MsgpackExt,
             FromMsgpackz,
             FromNuon,
             FromOds,

--- a/crates/nu-command/src/formats/from/msgpack.rs
+++ b/crates/nu-command/src/formats/from/msgpack.rs
@@ -13,6 +13,8 @@ use nu_engine::command_prelude::*;
 use nu_protocol::{Signals, shell_error::generic::GenericError};
 use rmp::decode::{self as mp, ValueReadError};
 
+use crate::formats::msgpack_ext_type::MsgpackExtensionType;
+
 /// Max recursion depth
 const MAX_DEPTH: usize = 50;
 
@@ -453,15 +455,14 @@ fn read_ext(input: &mut impl io::Read, len: usize, span: Span) -> Result<Value, 
             let secs = input.read_i64::<BigEndian>().err_span(span)?;
             make_date(secs, nanos, span)
         }
-        _ => Err(ShellError::Generic(
-            GenericError::new(
-                "Unknown MessagePack extension",
-                format!("encountered extension type {ty}, length {len}"),
+        (ty, len) => {
+            let mut data = vec![0; len];
+            input.read_exact(&mut data).err_span(span)?;
+            Ok(Value::custom(
+                Box::new(MsgpackExtensionType { ty, data }),
                 span,
-            )
-            .with_help("only the timestamp extension (-1) is supported"),
-        )
-        .into()),
+            ))
+        }
     }
 }
 

--- a/crates/nu-command/src/formats/mod.rs
+++ b/crates/nu-command/src/formats/mod.rs
@@ -1,9 +1,11 @@
 mod from;
+pub mod msgpack_ext_type;
 mod nu_xml_format;
 mod to;
 mod toml_utils;
 
 pub use from::*;
+pub use msgpack_ext_type::MsgpackExt;
 pub use to::*;
 
 pub(crate) use toml_utils::{preserve_toml_document, read_toml_source_from_metadata};

--- a/crates/nu-command/src/formats/mod.rs
+++ b/crates/nu-command/src/formats/mod.rs
@@ -1,11 +1,11 @@
 mod from;
-pub mod msgpack_ext_type;
+mod msgpack_ext_type;
 mod nu_xml_format;
 mod to;
 mod toml_utils;
 
 pub use from::*;
-pub use msgpack_ext_type::MsgpackExt;
+pub use msgpack_ext_type::*;
 pub use to::*;
 
 pub(crate) use toml_utils::{preserve_toml_document, read_toml_source_from_metadata};

--- a/crates/nu-command/src/formats/msgpack_ext_type.rs
+++ b/crates/nu-command/src/formats/msgpack_ext_type.rs
@@ -1,0 +1,129 @@
+use nu_engine::CallExt;
+use nu_protocol::{
+    Category, CustomValue, Example, IntoPipelineData, PipelineData, Record, ShellError, Signature,
+    Span, SyntaxShape, Type, Value,
+    casing::Casing,
+    engine::{Call, Command, EngineState, Stack},
+};
+use nu_utils::IgnoreCaseExt;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct MsgpackExtensionType {
+    pub ty: i8,
+    pub data: Vec<u8>,
+}
+
+impl MsgpackExtensionType {
+    fn ty(&self, span: Span) -> Value {
+        Value::int(self.ty.into(), span)
+    }
+
+    fn data(&self, span: Span) -> Value {
+        Value::binary(self.data.clone(), span)
+    }
+}
+
+#[typetag::serde]
+impl CustomValue for MsgpackExtensionType {
+    fn clone_value(&self, span: Span) -> Value {
+        Value::custom(Box::new(self.clone()), span)
+    }
+
+    fn type_name(&self) -> String {
+        std::any::type_name::<Self>().to_owned()
+    }
+
+    fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
+        Ok(Value::record(
+            Record::from_iter([
+                ("ty".to_owned(), self.ty(span)),
+                ("data".to_owned(), self.data(span)),
+            ]),
+            span,
+        ))
+    }
+
+    fn follow_path_string(
+        &self,
+        self_span: Span,
+        column_name: String,
+        path_span: Span,
+        optional: bool,
+        casing: Casing,
+    ) -> Result<Value, ShellError> {
+        match (&*column_name, casing) {
+            ("ty", _) => Ok(self.ty(self_span)),
+            ("data", _) => Ok(self.data(self_span)),
+
+            (str, Casing::Insensitive) if str.eq_ignore_case("ty") => Ok(self.ty(self_span)),
+            (str, Casing::Insensitive) if str.eq_ignore_case("data") => Ok(self.data(self_span)),
+
+            _ if optional => Ok(Value::nothing(path_span)),
+            _ => Err(ShellError::IncompatiblePathAccess {
+                type_name: self.type_name(),
+                span: path_span,
+            }),
+        }
+    }
+
+    fn memory_size(&self) -> usize {
+        std::mem::size_of::<Self>() + self.data.len()
+    }
+
+    /// Any representation used to downcast object to its original type
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    /// Any representation used to downcast object to its original type (mutable reference)
+    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+#[derive(Clone)]
+pub struct MsgpackExt;
+
+impl Command for MsgpackExt {
+    fn name(&self) -> &str {
+        "msgpack ext"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("msgpack ext")
+            .input_output_types(vec![(
+                Type::Binary,
+                Type::Custom(std::any::type_name::<MsgpackExtensionType>().into()),
+            )])
+            .required("type", SyntaxShape::Int, "Extension type to use")
+            .category(Category::Formats)
+    }
+
+    fn description(&self) -> &str {
+        "Create msgpack extension type.\nSee <https://github.com/msgpack/msgpack/blob/master/spec.md#extension-types>"
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        // TODO: add some examples
+        vec![]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let metadata = input.take_metadata().unwrap_or_default();
+        let input_span = input.span().unwrap_or(call.head);
+        let data = input.into_value(input_span)?.into_binary()?;
+
+        let ty = call.req(engine_state, stack, 0)?;
+        Ok(
+            Value::custom(Box::new(MsgpackExtensionType { ty, data }), call.head)
+                .into_pipeline_data_with_metadata(metadata),
+        )
+    }
+}

--- a/crates/nu-command/src/formats/to/msgpack.rs
+++ b/crates/nu-command/src/formats/to/msgpack.rs
@@ -3,6 +3,7 @@
 
 use std::io;
 
+use crate::formats::msgpack_ext_type::MsgpackExtensionType;
 use byteorder::{BigEndian, WriteBytesExt};
 use nu_engine::command_prelude::*;
 use nu_protocol::{
@@ -283,14 +284,26 @@ pub(crate) fn write_value(
             mp::write_bin(out, val).err_span(span)?;
         }
         Value::Custom { val, .. } => {
-            write_value(
-                out,
-                &val.to_base_value(span)?,
-                depth,
-                engine_state,
-                call_span,
-                serialize_types,
-            )?;
+            if let Some(MsgpackExtensionType { ty, data }) =
+                val.as_any().downcast_ref::<MsgpackExtensionType>()
+            {
+                let len = data
+                    .len()
+                    .try_into()
+                    .map_err(io::Error::other)
+                    .err_span(span)?;
+                mp::write_ext_meta(out, len, *ty).err_span(span)?;
+                out.write_all(&data[..len as usize]).err_span(span)?;
+            } else {
+                write_value(
+                    out,
+                    &val.to_base_value(span)?,
+                    depth,
+                    engine_state,
+                    call_span,
+                    serialize_types,
+                )?;
+            }
         }
     }
     Ok(())

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
-typetag = "0.2"
+typetag = { workspace = true }
 os_pipe = { workspace = true, optional = true, features = ["io_safety"] }
 log = { workspace = true }
 web-time = { workspace = true }


### PR DESCRIPTION
<!--
Thank you for improving Nushell!
Please, read our contributing guide: https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md
-->

Rough implementation for supporting serializing and deserializing to support
arbitrary extension types (as they are used for example for `nvim`'s msgpack-rpc).

## Release notes summary - What our users need to know
<!--
This section will be included as part of our release notes. See the contributing guide for more details.
Please include only details relevant for users here. Motivation and technical details can be added above or below this section.

You may leave this section blank until your PR is finalized. Ask a core team member if you need help filling this section.
-->

## Tasks after submitting
<!-- Remove any tasks which aren't relevant for your PR, or add your own -->
- [ ] Update the [documentation](https://github.com/nushell/nushell.github.io)
