### PR TITLE
Fix failing test for `grid` command

### DIFF
--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -283,7 +283,7 @@ fn convert_to_list(
     let has_name_header = headers.iter().any(|&str| str == NAME_COLUMN);
 
     if !headers.is_empty() && !has_name_header {
-        return Ok(None);
+        return Ok(Some(vec![]));
     }
 
     iter.map(|item| {


### PR DESCRIPTION
`commands::griddle::test_output::case_8_list_whose_first_element_is_record_without_name_columns` was the test that was failing

Consequence of merging #18021 before #18022 

/cc @fdncred 

## Release notes summary - What our users need to know
N/A