### PR TITLE
Fix typo

### DIFF
--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -1,4 +1,4 @@
-# std.nu, `use`d to load all standard library components
+# std.nu, used to load all standard library components
 
 # Top-level commands: ellie, repeat, null-device, and "path add"
 export use std/util *


### PR DESCRIPTION
## Release notes summary - What our users need to know
Fixed a typo in `nu-std` crate.

## Tasks after submitting