### PR TITLE
Fix backtabbing in `--multi` mode in `input list`

### DIFF
--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -1538,8 +1538,8 @@ impl<'a> SelectWidget<'a> {
                 KeyAction::Continue
             }
             KeyCode::BackTab => {
-                self.toggle_current();
                 self.navigate_up();
+                self.toggle_current();
                 KeyAction::Continue
             }
             _ => KeyAction::Continue,
@@ -1790,8 +1790,8 @@ impl<'a> SelectWidget<'a> {
 
             // Shift-Tab: Toggle selection and move up
             KeyCode::BackTab => {
-                self.toggle_current_fuzzy();
                 self.navigate_up();
+                self.toggle_current_fuzzy();
                 KeyAction::Continue
             }
 


### PR DESCRIPTION
# Description
It turns out there's one more oddity about the new implementation of `input list`, so I'm going to put this fix on my account :D

When pressing backtab it selects the current position instead of undoing the previous one:

After 4 tabs:
```
~> 0..10 | collect | input list --multi 
  [x] 0
  [x] 1
  [x] 2
  [x] 3
> [ ] 4
```

After one backtab:
```
  [x] 0
  [x] 1
  [x] 2
> [x] 3
  [x] 4
```

And another one:
```
  [x] 0
  [x] 1
> [x] 2
  [ ] 3
  [x] 4
```

Same happens if one backtabs and then tabs once:

```
  [x] 0
  [ ] 1
  [ ] 2
> [ ] 3
  [x] 4
  [x] 5
---------------
  [x] 0
  [ ] 1
  [ ] 2
  [x] 3
> [x] 4
  [x] 5
---------------
  [x] 0
  [ ] 1
  [ ] 2
  [x] 3
  [ ] 4
> [x] 5
```

This PR fixes that by swapping the navigation and toggling around

## User-facing changes (Release notes)

Fixes `input list` backtab functionality by undoing previous selection before navigation.