### PR TITLE
nu-mcp: remove timeout_secs param, rely on NU_MCP_PROMOTE_AFTER

### DIFF
--- a/crates/nu-mcp/src/evaluate_tool.md
+++ b/crates/nu-mcp/src/evaluate_tool.md
@@ -9,10 +9,10 @@ If you need to run a long lived command, background it - e.g. `job spawn { uvico
 this tool does not run indefinitely.
 
 Calls that run longer than the promote-after timeout are auto-promoted to a background job; the
-tool then errors with a job id and you must `job recv` to collect the result. Precedence: the
-`timeout_secs` parameter (seconds) wins over `$env.NU_MCP_PROMOTE_AFTER`, which wins over the
-built-in default (120s). Pass a larger `timeout_secs` for known long-running commands so they stay
-synchronous.
+tool then errors with a job id and you must `job recv` to collect the result. The timeout defaults
+to 120s and can be overridden by setting `$env.NU_MCP_PROMOTE_AFTER` (a duration, e.g. `10min`) on
+the persistent stack. Bump it before a known long-running command so it stays synchronous; the
+setting persists across subsequent calls until you change it again.
 
 Command Equivalents to Bash:
 

--- a/crates/nu-mcp/src/evaluation.rs
+++ b/crates/nu-mcp/src/evaluation.rs
@@ -177,13 +177,13 @@ pub(crate) fn shell_error_to_mcp_error(
 const JOB_DESCRIPTION_MAX_LEN: usize = 40;
 
 /// How long an evaluation can run before being auto-promoted to a background
-/// job. Overridden per-call via the `timeout_secs` tool param or globally via
-/// the `NU_MCP_PROMOTE_AFTER` env var.
+/// job. Overridden via the `NU_MCP_PROMOTE_AFTER` env var on the persistent
+/// stack.
 ///
 /// 2 minutes is deliberate: a shorter default (we had 10s) made Claude Opus 4.7
 /// give up on nushell because everyday commands kept getting shoved into the
 /// background. Keep the happy path synchronous; callers who know a command is
-/// long-running can still widen the window per-call.
+/// long-running can widen the window by setting `$env.NU_MCP_PROMOTE_AFTER`.
 const DEFAULT_PROMOTE_AFTER: Duration = Duration::from_secs(120);
 
 /// Evaluates Nushell code in a persistent REPL-style context for MCP.
@@ -289,20 +289,17 @@ impl Evaluator {
     /// Evaluates nushell source code, promoting to a background job on
     /// cancellation or if the evaluation exceeds its promote-after timeout.
     ///
-    /// Timeout precedence (first wins):
-    /// 1. `timeout_override` — per-call value from the MCP tool parameter.
-    /// 2. `NU_MCP_PROMOTE_AFTER` env var on the persistent stack.
-    /// 3. [`DEFAULT_PROMOTE_AFTER`] (2 minutes).
+    /// Timeout resolution:
+    /// 1. `NU_MCP_PROMOTE_AFTER` env var on the persistent stack.
+    /// 2. [`DEFAULT_PROMOTE_AFTER`] (2 minutes).
     pub async fn eval_async(
         &self,
         nu_source: &str,
         ct: CancellationToken,
-        timeout_override: Option<Duration>,
     ) -> Result<String, rmcp::ErrorData> {
         let (forked_state, interrupt, promote_after) = {
             let state = self.state.lock().await;
-            let timeout = timeout_override
-                .unwrap_or_else(|| promote_timeout(&state.engine_state, &state.stack));
+            let timeout = promote_timeout(&state.engine_state, &state.stack);
             let (forked, interrupt) = state.fork();
             (forked, interrupt, timeout)
         };
@@ -355,7 +352,7 @@ impl Evaluator {
                 None,
             )
         })?;
-        rt.block_on(self.eval_async(nu_source, CancellationToken::new(), None))
+        rt.block_on(self.eval_async(nu_source, CancellationToken::new()))
     }
 
     pub async fn list_available_commands(&self, find: Option<String>) -> Result<String, String> {
@@ -668,8 +665,7 @@ fn eval_on_state(
 /// to a background job.
 ///
 /// Defaults to [`DEFAULT_PROMOTE_AFTER`] (2 minutes). Can be overridden via
-/// `NU_MCP_PROMOTE_AFTER` env var, or per-call via the tool's `timeout_secs`
-/// parameter (which wins over the env var).
+/// `NU_MCP_PROMOTE_AFTER` env var on the persistent stack.
 fn promote_timeout(engine_state: &EngineState, stack: &Stack) -> Duration {
     stack
         .get_env_var(engine_state, "NU_MCP_PROMOTE_AFTER")
@@ -1175,6 +1171,63 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn promote_timeout_defaults_when_env_var_unset() {
+        let engine_state = nu_cmd_lang::create_default_context();
+        let evaluator = Evaluator::new(engine_state);
+
+        let state = evaluator.state.lock().await;
+        assert_eq!(
+            promote_timeout(&state.engine_state, &state.stack),
+            DEFAULT_PROMOTE_AFTER,
+            "without NU_MCP_PROMOTE_AFTER the default 2-minute timeout should apply"
+        );
+    }
+
+    #[tokio::test]
+    async fn promote_timeout_reads_nu_mcp_promote_after_env_var() {
+        let engine_state = nu_cmd_lang::create_default_context();
+        let evaluator = Evaluator::new(engine_state);
+
+        evaluator
+            .eval_async(
+                "$env.NU_MCP_PROMOTE_AFTER = 750ms",
+                CancellationToken::new(),
+            )
+            .await
+            .expect("setting NU_MCP_PROMOTE_AFTER should succeed");
+
+        let state = evaluator.state.lock().await;
+        assert_eq!(
+            promote_timeout(&state.engine_state, &state.stack),
+            Duration::from_millis(750),
+            "promote_timeout should honor NU_MCP_PROMOTE_AFTER on the persistent stack"
+        );
+    }
+
+    #[tokio::test]
+    async fn promote_timeout_ignores_malformed_env_var() {
+        let engine_state = nu_cmd_lang::create_default_context();
+        let evaluator = Evaluator::new(engine_state);
+
+        // A non-duration value must not override the default; otherwise a typo
+        // could silently disable promotion entirely.
+        evaluator
+            .eval_async(
+                "$env.NU_MCP_PROMOTE_AFTER = 'not-a-duration'",
+                CancellationToken::new(),
+            )
+            .await
+            .expect("setting NU_MCP_PROMOTE_AFTER to a string should succeed");
+
+        let state = evaluator.state.lock().await;
+        assert_eq!(
+            promote_timeout(&state.engine_state, &state.stack),
+            DEFAULT_PROMOTE_AFTER,
+            "malformed NU_MCP_PROMOTE_AFTER should fall back to the default"
+        );
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn test_external_command_promotion_respects_promote_after_env() {
@@ -1185,7 +1238,6 @@ mod tests {
             .eval_async(
                 "$env.NU_MCP_PROMOTE_AFTER = 100ms",
                 CancellationToken::new(),
-                None,
             )
             .await
             .expect("setting promotion timeout should succeed");
@@ -1194,7 +1246,6 @@ mod tests {
             .eval_async(
                 "sh -c 'sleep 0.2; printf stdout; printf stderr >&2; exit 7'",
                 CancellationToken::new(),
-                None,
             )
             .await;
 
@@ -1250,7 +1301,7 @@ mod tests {
 
         // Set a variable first
         evaluator
-            .eval_async("let x = 1", CancellationToken::new(), None)
+            .eval_async("let x = 1", CancellationToken::new())
             .await
             .unwrap();
 
@@ -1262,7 +1313,7 @@ mod tests {
         ct_clone.cancel();
 
         // Should be promoted to a background job, not just discarded
-        let result = evaluator.eval_async("let x = 999", ct, None).await;
+        let result = evaluator.eval_async("let x = 999", ct).await;
         assert!(result.is_err(), "Cancelled evaluation should error");
         let err_msg = result.unwrap_err().message.to_string();
         assert!(
@@ -1272,7 +1323,7 @@ mod tests {
 
         // Original variable should still be 1 (forked state not committed)
         let result = evaluator
-            .eval_async("$x", CancellationToken::new(), None)
+            .eval_async("$x", CancellationToken::new())
             .await
             .unwrap();
         assert!(

--- a/crates/nu-mcp/src/instructions.md
+++ b/crates/nu-mcp/src/instructions.md
@@ -70,11 +70,15 @@ Limits (configurable via env):
 - `NU_MCP_OUTPUT_LIMIT` — response truncation threshold, default `10kb`. Set to
   `0b` to disable truncation entirely. The full value is always in `$history`
   regardless of this setting.
+- `NU_MCP_PROMOTE_AFTER` — how long a call may run before being auto-promoted to
+  a background job, default `120sec`. Bump it before a known long-running
+  command to keep it synchronous.
 
 ```nu
 $env.NU_MCP_OUTPUT_LIMIT = 50kb     # bigger inline responses
 $env.NU_MCP_OUTPUT_LIMIT = 0b       # never truncate
 $env.NU_MCP_HISTORY_LIMIT = 200     # remember more entries
+$env.NU_MCP_PROMOTE_AFTER = 10min   # don't promote this session's long builds
 ```
 
 ## Structured Output — prefer native commands

--- a/crates/nu-mcp/src/server.rs
+++ b/crates/nu-mcp/src/server.rs
@@ -10,7 +10,6 @@ use rmcp::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use std::time::Duration;
 
 pub struct NushellMcpServer {
     #[allow(dead_code)]
@@ -58,16 +57,10 @@ By default all available commands will be returned. To find a specific command b
     async fn evaluate(
         &self,
         ctx: RequestContext<RoleServer>,
-        Parameters(NuSourceRequest {
-            input,
-            timeout_secs,
-        }): Parameters<NuSourceRequest>,
+        Parameters(NuSourceRequest { input }): Parameters<NuSourceRequest>,
     ) -> Result<String, String> {
-        let timeout_override = timeout_secs
-            .filter(|secs| secs.is_finite() && *secs > 0.0)
-            .map(Duration::from_secs_f64);
         self.evaluator
-            .eval_async(&input, ctx.ct, timeout_override)
+            .eval_async(&input, ctx.ct)
             .await
             .map_err(|err| err.message.to_string())
     }
@@ -89,13 +82,6 @@ struct CommandNameRequest {
 struct NuSourceRequest {
     #[schemars(description = "The Nushell source code to evaluate")]
     input: String,
-    /// Seconds before this call is promoted to a background job. See the tool
-    /// description for details and precedence rules.
-    #[schemars(
-        description = "Seconds before this call is promoted to a background job (default 120). Set higher for long builds/tests."
-    )]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    timeout_secs: Option<f64>,
 }
 
 #[tool_handler]
@@ -219,6 +205,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn evaluate_tool_input_schema_exposes_only_input_property() {
+        let router = NushellMcpServer::tool_router();
+        let evaluate_tool = router
+            .get("evaluate")
+            .expect("evaluate tool should be registered");
+
+        let properties = evaluate_tool
+            .input_schema
+            .get("properties")
+            .and_then(JsonValue::as_object)
+            .expect("evaluate input schema should expose a properties object");
+
+        let mut property_names: Vec<_> = properties.keys().cloned().collect();
+        property_names.sort();
+        assert_eq!(
+            property_names,
+            vec!["input".to_string()],
+            "evaluate tool should accept only `input`; per-call timeout must be \
+             controlled exclusively via the NU_MCP_PROMOTE_AFTER env var"
+        );
+    }
+
     fn create_mcp_server() -> NushellMcpServer {
         let engine_state = create_default_context();
         NushellMcpServer::new(engine_state)
@@ -259,7 +268,6 @@ mod tests {
                 ctx,
                 Parameters(NuSourceRequest {
                     input: "5 + 2".to_string(),
-                    timeout_secs: None,
                 }),
             )
             .await
@@ -285,7 +293,6 @@ mod tests {
                 make_request_context(3),
                 Parameters(NuSourceRequest {
                     input: "1".to_string(),
-                    timeout_secs: None,
                 }),
             )
             .await
@@ -300,7 +307,6 @@ mod tests {
                 make_request_context(4),
                 Parameters(NuSourceRequest {
                     input: "2".to_string(),
-                    timeout_secs: None,
                 }),
             )
             .await


### PR DESCRIPTION
## Description

The `evaluate` MCP tool had two overlapping override paths for the promote-after timeout: a per-call `timeout_secs` tool parameter and the `$env.NU_MCP_PROMOTE_AFTER` env var. This PR drops the tool parameter and keeps the env var as the sole override so the knob shape matches `NU_MCP_HISTORY_LIMIT` and `NU_MCP_OUTPUT_LIMIT`, shrinks the tool schema, and removes the precedence rule clients had to remember. The 120-second default is unchanged; callers bumping the window for a known long-running command set `$env.NU_MCP_PROMOTE_AFTER = 10min` once and it persists across subsequent evaluations via the REPL-style stack.

Also adds three regression tests: one locking in that the `evaluate` tool's input schema exposes only `input`, plus two unit tests for `promote_timeout` that exercise the env-var-present, env-var-absent, and malformed-value paths so a typo in `NU_MCP_PROMOTE_AFTER` silently falls back to the default rather than disabling promotion entirely.

Instructions (\`instructions.md\`) now list \`NU_MCP_PROMOTE_AFTER\` alongside the other two env vars so MCP clients discover it without digging into the tool description.

## User-facing changes (Release notes)

The \`evaluate\` MCP tool no longer accepts a \`timeout_secs\` parameter. To override the promote-after timeout, set \`\$env.NU_MCP_PROMOTE_AFTER\` (e.g. \`\$env.NU_MCP_PROMOTE_AFTER = 10min\`) — the setting is REPL-sticky and applies to subsequent calls until changed.

## Additional notes

Follow-up to #18059, which introduced both knobs at once.