### PR TITLE
docs(nu-mcp): prefer `| complete` over `o+e>| complete`

### DIFF
--- a/crates/nu-mcp/src/instructions.md
+++ b/crates/nu-mcp/src/instructions.md
@@ -24,11 +24,19 @@ curl https://api.example.com/huge.json | head -c 500
 rg foo crates/ | lines | where $it =~ "err" | first 30   # where is fine, first 30 is not
 
 # GOOD — run once, slice afterwards
-cargo build o+e>| complete
+cargo build | complete
 # response: { history_index: 7, ... }
-$history.7 | lines | where $it =~ '^error'
-$history.7 | lines | where $it =~ '^error' | skip 30 | first 30   # paging a saved result is fine
+# `complete` captures { stdout, stderr, exit_code } as separate columns —
+# don't merge streams unless you have a reason to.
+$history.7.stderr | lines | where $it =~ '^error'
+$history.7.stderr | lines | where $it =~ '^error' | skip 30 | first 30   # paging a saved result is fine
 ```
+
+`complete` already gives you `stdout` and `stderr` as distinct columns. Reach
+for `o+e>| complete` only when you specifically want the interleaved ordering
+(e.g. a build log where the stderr warnings need to stay adjacent to the
+stdout lines they precede). Default to plain `| complete` and keep the streams
+separate — it's almost always what you want.
 
 The only time you should cap inside the command is when **generation itself**
 costs something real — a remote API that bills per byte, a paid model call,


### PR DESCRIPTION
## Description

Small docs tweak to `crates/nu-mcp/src/instructions.md`. The "GOOD" example in the "never cap output" section used `cargo build o+e>| complete`, which biases MCP clients (LLM agents) toward always merging stderr into stdout before `complete` sees it.

In practice this confuses agents. `complete` on its own returns a record with `{stdout, stderr, exit_code}` as separate columns, and `o+e>|` collapses that to `{stdout, exit_code}`. An agent that learned the merged form from the docs then tries to read `.stderr` off the result, hits a "column not found" error, and has to fall back to `columns` to rediscover the shape. I ran into exactly this while using the MCP server.

For most commands (builds, linters, tests), keeping stdout and stderr separate is what you actually want, and the interleaved stream ordering that `o+e>|` preserves almost never matters. This change flips the default example to plain `| complete` and narrows `o+e>| complete` to the specific case where interleaved ordering genuinely does matter (e.g. reading a build log where stderr warnings need to stay adjacent to the stdout lines they precede).

Changes: flipped the GOOD example in `THE RULE` from `cargo build o+e>| complete` to `cargo build | complete`, and updated the follow-up slicing examples to use `.stderr` to show off the record shape. Added a short paragraph right after the example explaining when (rarely) to reach for `o+e>| complete` instead. Docs-only, no code changes.

## User-facing changes (Release notes)

n/a (docs-only change to MCP server instructions)