### PR TITLE
feat(`std-rfc`): add progressbar osc 9;4 wrapper

### DIFF
--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -138,6 +138,7 @@ pub fn load_standard_library(
             "std-rfc/xml",
             include_str!("../std-rfc/xml/mod.nu"),
         ),
+        ("mod.nu", "std-rfc/pb", include_str!("../std-rfc/pb/mod.nu")),
     ];
 
     for (filename, std_rfc_subdir_name, content) in std_rfc_submodules.drain(..) {

--- a/crates/nu-std/std-rfc/mod.nu
+++ b/crates/nu-std/std-rfc/mod.nu
@@ -5,6 +5,7 @@ export module str
 export module iter
 export module random
 export module xml
+export module pb
 
 # kv module depends on sqlite feature, which may not be available in some builds
 const kv_module = if ("sqlite" in (version).features) { "std-rfc/kv" } else { null }

--- a/crates/nu-std/std-rfc/pb/mod.nu
+++ b/crates/nu-std/std-rfc/pb/mod.nu
@@ -1,0 +1,41 @@
+# Wrapper over the terminal OSC 9;4 for progress bars. Your terminal application may not support any/some of the commands.
+
+# Set progress bar with a percentage
+export def set [
+    percentage: int # percentage to set, must be between 0 and 100
+] {
+    print -n $"(ansi osc)9;4;1;($percentage)(ansi st)"
+}
+
+# Set progress bar with an index and a maximum value
+export def set-idx [
+    index: int # the current index
+    total: int # the total value
+] {
+    print -n $"(ansi osc)9;4;1;($index / $total * 100 | into int)(ansi st)"
+}
+
+# Set progress bar to indeterminate
+export def indeterminate [
+] {
+    print -n $"(ansi osc)9;4;3(ansi st)"
+}
+
+# Clear progress bar
+export def clear [
+] {
+    print -n $"(ansi osc)9;4;0(ansi st)"
+}
+
+# Pause progress bar
+export def pause [
+] {
+    print -n $"(ansi osc)9;4;4(ansi st)"
+}
+
+# Error progress bar
+export def error [
+    error_code: int = 0 # Error code to set in the progress bar
+] {
+    print -n $"(ansi osc)9;4;2;($error_code)(ansi st)"
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
Not a lot going on but I think it's nice having a proper nushell interface instead of using prints with `ansi osc` directly.

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
### Terminal emulator progress bars via `std-rfc/pb`
Added a new module to std-rfc `use std-rfc/pb` that wraps the `OSC 9;4` escape sequences for setting progress bars in the terminal (some terminals don't support any/some of the commands).

Example:
```nushell
use std-rfc/pb

try {
	0..<10 | each {|x| sleep 200ms ; pb set-idx $x 10 }
} catch {
	pb error
} finally {
	pb clear
}
```

<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->