### PR TITLE
`finally` should not affect return value

### DIFF
--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -268,14 +268,17 @@ fn try_catch_finally() {
         nu!("try { 1 / 0 } catch { 1 / 0; print 'inside catch' } finally { print 'this finally' }");
     assert!(actual.out.contains("this finally"));
     assert!(!actual.out.contains("inside catch"));
-    assert!(!actual.err.contains("division by zero"));
+    assert!(actual.err.contains("division by zero"));
 }
 
 #[test]
 fn try_finally() {
+    let actual = nu!("try { 0 } finally { 3 }");
+    assert_eq!(actual.out, "0");
+
     let actual = nu!("try { 1 / 0 } finally { print 'this finally' }");
     assert!(actual.out.contains("this finally"));
-    assert!(!actual.err.contains("division by zero"));
+    assert!(actual.err.contains("division by zero"));
 
     let actual = nu!("try { print 'inside try' } finally { print 'this finally' }");
     assert!(actual.out.contains("inside try"));
@@ -307,11 +310,12 @@ fn return_statement_in_finally_should_be_used() {
 #[test]
 fn try_finally_with_variable() {
     // try failed with finally
-    let actual = nu!("try { 1 / 0 } finally {|x| $x.msg }");
+    let actual = nu!("try { 1 / 0 } finally {|x| print $x.msg }");
     assert_eq!(actual.out, "Division by zero.");
 
-    let actual = nu!("try { 3 } finally {|x| $x == 3 }");
-    assert_eq!(actual.out, "true");
+    let actual = nu!("try { 3 } finally {|x| print ($x == 3) }");
+    assert!(actual.out.contains("true"));
+    assert!(actual.out.ends_with('3'));
 }
 
 #[test]
@@ -345,11 +349,12 @@ fn try_abort_not_run_finally() {
 #[test]
 fn catch_finally_with_variable() {
     // try catch with finally
-    let actual = nu!("try { 1 / 0 } catch { 33 } finally {|x| $x == 33}");
-    assert_eq!(actual.out, "true");
+    let actual = nu!("try { 1 / 0 } catch { 33 } finally {|x| print ($x == 33) }");
+    assert!(actual.out.contains("true"));
+    assert!(actual.out.ends_with("33"));
 
     let actual = nu!(
-        "try { 1 / 0 } catch { 33; error make 'err in catch' } finally {|x| $x.msg == 'err in catch'}"
+        "try { 1 / 0 } catch { 33; error make 'err in catch' } finally {|x| print ($x.msg == 'err in catch')}"
     );
     assert_eq!(actual.out, "true");
 }

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -677,15 +677,11 @@ pub(crate) fn compile_try(
 
     // This is the finally part.
     if let Some(finally_part) = finally_type {
+        // Preserve the value produced by `try`/`catch`: `finally` can observe it
+        // but its own pipeline result should not replace the overall `try` expression result.
+        let preserved_result_reg = builder.clone_reg(io_reg, call.head)?;
         if let Some(var_id) = finally_part.var_id {
-            let value_reg = builder.next_register()?;
-            builder.push(
-                Instruction::Clone {
-                    dst: value_reg,
-                    src: io_reg,
-                }
-                .into_spanned(call.head),
-            )?;
+            let value_reg = builder.clone_reg(io_reg, call.head)?;
             builder.push(
                 Instruction::StoreVariable {
                     var_id,
@@ -701,6 +697,13 @@ pub(crate) fn compile_try(
             redirect_modes,
             Some(io_reg),
             io_reg,
+        )?;
+        builder.push(
+            Instruction::Move {
+                dst: io_reg,
+                src: preserved_result_reg,
+            }
+            .into_spanned(call.head),
         )?;
     }
 

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -281,8 +281,13 @@ fn eval_ir_block_impl<D: DebugContext>(
                 } else if let Some(always_run_handler) =
                     ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
                 {
-                    prepare_error_handler(ctx, always_run_handler, Some(err.into_spanned(*span)));
+                    prepare_error_handler(
+                        ctx,
+                        always_run_handler,
+                        Some(err.clone().into_spanned(*span)),
+                    );
                     pc = always_run_handler.handler_index;
+                    ret_val = Some(err);
                 } else if need_backtrace {
                     let err = ShellError::into_chained(err, *span);
                     return Err(err);


### PR DESCRIPTION
## Description
This pr changes the semantic of finally, in detail:
1. finally should not suppresses error message from try / catch (if any), this is achieved by keeping error value while detecting errors and running finally block.
2. the return value of `try .. catch .. finally` block will always be the return value of `try` block or return value of `catch` block, this is achieved by additional `Instruction::Move` instruction after compiling finally block.

## User-facing changes (Release notes)
### Finally no longer suppresses error messages
For example:

```nushell
> try { 1 / 0 } finally { print 'this finally' }
```
It prints 'this finally' and throws out the error.

### The return value of finally is the return value of `try` or `catch`
```nushell
> let x = try { 13 } finally { print 'this finally'; 1 }
this finally
> $x == 3
true
> let x = try { 1 / 0 } catch { "xx" } finally { print 'this finally' }
this finally
> $x == "xx"
true
```

## Additional notes
Fixes: #18050
Fixes: #17970