### PR TITLE
Fix grammatical "an" -> "a" in doc comments

### DIFF
--- a/crates/nu-experimental/src/options/reorder_cell_paths.rs
+++ b/crates/nu-experimental/src/options/reorder_cell_paths.rs
@@ -4,7 +4,7 @@ use crate::*;
 ///
 /// - Accessing a field in a record is cheap, just a simple search and you get a reference to the
 ///   value.
-/// - Accessing an row in a list is even cheaper, just an array access and you get a reference to
+/// - Accessing a row in a list is even cheaper, just an array access and you get a reference to
 ///   the value.
 /// - Accessing a **column** in a table is expensive, it requires accessing the relevant field in
 ///   all rows, and creating a new list to store those value. This uses more computation and more

--- a/crates/nu-protocol/src/ir/mod.rs
+++ b/crates/nu-protocol/src/ir/mod.rs
@@ -256,15 +256,15 @@ pub enum Instruction {
     /// Push an error handler, capturing the error value into `dst`. If the error handler is not
     /// called, the register should be freed manually.
     OnErrorInto { index: usize, dst: RegId },
-    /// Push an finally handler, without capturing the error value
+    /// Push a finally handler, without capturing the error value
     Finally { index: usize },
-    /// Push an finally handler, capturing the error value into `dst`. If the finally handler is not
+    /// Push a finally handler, capturing the error value into `dst`. If the finally handler is not
     /// called, the register should be freed manually.
     FinallyInto { index: usize, dst: RegId },
     /// Pop an error handler. This is not necessary when control flow is directed to the error
     /// handler due to an error.
     PopErrorHandler,
-    /// Pop an finally handler.
+    /// Pop a finally handler.
     PopFinallyRun,
     /// Return early from the block, raising a `ShellError::Return` instead.
     ///


### PR DESCRIPTION

**Repo:** nushell/nushell (⭐ 35000)
**Type:** docs
**Files changed:** 2
**Lines:** +4/-4

## What
Corrects incorrect use of the indefinite article "an" before consonant-sounded words ("an row", "an finally handler") in doc comments within `crates/nu-experimental/src/options/reorder_cell_paths.rs` and `crates/nu-protocol/src/ir/mod.rs`. Pure doc-comment fixes with no code or behavior impact.

## Why
These rustdoc comments appear in generated API docs and developer-facing source. The use of "an" before consonant sounds reads awkwardly. A small, targeted cleanup improves documentation quality at near-zero risk.

## Testing
No behavior change — doc comments only. `cargo doc` would render the corrected text; `cargo check` would pass since only `///` content changed.

## Risk
Low — comment-only edit, zero compiled-code changes.
