### PR TITLE
`metadata access` can modify `$env`

### DIFF
--- a/crates/nu-command/src/debug/metadata_access.rs
+++ b/crates/nu-command/src/debug/metadata_access.rs
@@ -1,4 +1,4 @@
-use nu_engine::{command_prelude::*, get_eval_block_with_early_return};
+use nu_engine::{command_prelude::*, get_eval_block_with_early_return, redirect_env};
 use nu_protocol::{
     PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
     engine::{Call, Closure, Command, EngineState, Stack},
@@ -49,7 +49,12 @@ impl Command for MetadataAccess {
         }
 
         let eval = get_eval_block_with_early_return(engine_state);
-        eval(engine_state, &mut callee_stack, block, input).map(|p| p.body)
+        let result = eval(engine_state, &mut callee_stack, block, input).map(|p| p.body);
+
+        // Merge the block's environment to the current stack
+        redirect_env(engine_state, caller_stack, &callee_stack);
+
+        result
     }
 
     fn examples(&self) -> Vec<Example<'_>> {

--- a/crates/nu-command/tests/commands/debug/metadata_access.rs
+++ b/crates/nu-command/tests/commands/debug/metadata_access.rs
@@ -1,0 +1,47 @@
+use nu_protocol::PipelineData;
+use nu_test_support::prelude::*;
+
+#[test]
+fn metadata_access_is_streaming() -> Result {
+    let code = "
+        let id = job id
+
+        for i in (
+            seq 1 3 | metadata access {|md|
+                each { job send $id; $in }
+            }
+        ) {
+            $i | job send $id
+        }
+
+        generate {|x=null|
+            try {{next: null, out: ( job recv --timeout 0sec )}}
+        }
+    ";
+
+    test().run(code).expect_value_eq([1, 1, 2, 2, 3, 3])
+}
+
+#[test]
+fn metadata_access_affect_caller_env() -> Result {
+    let mut tester = test();
+    tester.run("$env.FOO?").expect_value_eq(())?;
+
+    let code = "
+        seq 0 9
+        | metadata access {|md|
+            match ($env.FOO = true) { _ => {} }
+        }
+    ";
+
+    let output = tester.run_raw(code)?;
+    let PipelineData::ListStream(stream, _) = output.body else {
+        panic!("Output must be a stream")
+    };
+    stream
+        .into_value()
+        .map_err(Error::from)
+        .expect_value_eq((0..10).collect::<Vec<i64>>())?;
+
+    tester.run("$env.FOO").expect_value_eq(true)
+}

--- a/crates/nu-command/tests/commands/debug/mod.rs
+++ b/crates/nu-command/tests/commands/debug/mod.rs
@@ -1,3 +1,4 @@
+mod metadata_access;
 mod metadata_set;
 mod timeit;
 mod view_source;


### PR DESCRIPTION
## Description

Pretty straightforward change. Also added a test for asserting streaming behavior.

## User-facing changes (Release notes)

`metadata access`'s closure can now modify the caller's environment, as if run with `do --env`

## Additional notes

- Follow up to #17796