### PR TITLE
Implement `Debug` for `EngineState` and derive more `Debug` impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4767,6 +4767,7 @@ name = "nu-test-support"
 version = "0.112.3"
 dependencies = [
  "bytes",
+ "derive_more 2.1.1",
  "gatekeeper",
  "itertools 0.14.0",
  "kitest",
@@ -4812,6 +4813,7 @@ dependencies = [
  "byteyarn",
  "crossterm",
  "crossterm_winapi",
+ "derive_more 2.1.1",
  "fancy-regex",
  "lean_string",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,6 +1717,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4674,6 +4675,7 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-humanize",
+ "derive_more 2.1.1",
  "dirs",
  "dirs-sys",
  "fancy-regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ crossbeam-channel = "0.5.15"
 crossterm = "0.29.0"
 csv = "1.4"
 ctrlc = "3.5"
+derive_more = "2.1.1"
 devicons = "0.6.12"
 digest = { default-features = false, version = "0.10" }
 dirs = "6.0"

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -22,12 +22,13 @@ pub enum ComputableStyle {
 
 // An alias for the mapping used internally by StyleComputer.
 pub type StyleMapping = HashMap<String, ComputableStyle>;
-//
+
 // A StyleComputer is an all-in-one way to compute styles. A nu command can
 // simply create it with from_config(), and then use it with compute().
 // It stores the engine state and stack needed to run closures that
 // may be defined as a user style.
-//
+
+#[derive(Debug)]
 pub struct StyleComputer<'a> {
     engine_state: &'a EngineState,
     stack: &'a Stack,
@@ -170,16 +171,6 @@ impl<'a> StyleComputer<'a> {
             }
         }
         StyleComputer::new(engine_state, stack, map)
-    }
-}
-
-// Because EngineState doesn't have Debug (Dec 2022),
-// this incomplete representation must be used.
-impl Debug for StyleComputer<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        f.debug_struct("StyleComputer")
-            .field("map", &self.map)
-            .finish()
     }
 }
 

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -8,7 +8,7 @@ use nu_protocol::{
 };
 use std::{
     collections::HashMap,
-    fmt::{Debug, Formatter, Result},
+    fmt::Debug,
 };
 
 // ComputableStyle represents the valid user style types: a single color value, or a closure which

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -6,10 +6,7 @@ use nu_protocol::{
     engine::{Closure, EngineState, Stack},
     report_shell_error,
 };
-use std::{
-    collections::HashMap,
-    fmt::Debug,
-};
+use std::{collections::HashMap, fmt::Debug};
 
 // ComputableStyle represents the valid user style types: a single color value, or a closure which
 // takes an input value and produces a color value. The latter represents a value which

--- a/crates/nu-experimental/src/lib.rs
+++ b/crates/nu-experimental/src/lib.rs
@@ -203,7 +203,7 @@ impl Debug for ExperimentalOption {
         let mut debug_struct = f.debug_struct("ExperimentalOption");
         debug_struct.field("identifier", &self.identifier());
         debug_struct.field("value", &self.get());
-        debug_struct.field("stability", &self.status());
+        debug_struct.field("status", &self.status());
         if add_description {
             debug_struct.field("description", &self.description());
         }

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -36,6 +36,7 @@ bytes = { workspace = true }
 chrono = { workspace = true, features = ["serde", "std", "unstable-locales"], default-features = false }
 chrono-humanize = { workspace = true }
 dirs = { workspace = true }
+derive_more = { workspace = true, features = ["debug"] }
 fancy-regex = { workspace = true }
 heck = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/nu-protocol/src/engine/cached_file.rs
+++ b/crates/nu-protocol/src/engine/cached_file.rs
@@ -2,13 +2,14 @@ use crate::Span;
 use std::sync::Arc;
 
 /// Unit of cached source code
-#[derive(Clone)]
+#[derive(Clone, derive_more::Debug)]
 pub struct CachedFile {
     // Use Arcs of slice types for more compact representation (capacity less)
     // Could possibly become an `Arc<PathBuf>`
     /// The file name with which the code is associated (also includes REPL input)
     pub name: Arc<str>,
     /// Source code as raw bytes
+    #[debug("[...]")]
     pub content: Arc<[u8]>,
     /// global span coordinates that are covered by this [`CachedFile`]
     pub covered_span: Span,

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -8,7 +8,7 @@ use crate::{
 use std::{
     any::Any,
     borrow::Cow,
-    fmt::{self, Debug, Display},
+    fmt::{Debug, Display},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -5,7 +5,11 @@ use crate::{
     Alias, BlockId, DeprecationEntry, DynamicCompletionCallRef, DynamicSuggestion, Example,
     OutDest, PipelineData, ShellError, Signature, Span, Value, engine::Call,
 };
-use std::{any::Any, borrow::Cow, fmt::Display};
+use std::{
+    any::Any,
+    borrow::Cow,
+    fmt::{self, Debug, Display},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ArgType<'a> {

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -41,6 +41,7 @@ pub enum VirtualPath {
     Dir(Vec<VirtualPathId>),
 }
 
+#[derive(Debug)]
 pub struct ReplState {
     pub buffer: String,
     // A byte position, as `EditCommand::MoveToPosition` is also a byte position
@@ -49,6 +50,7 @@ pub struct ReplState {
     pub accept: bool,
 }
 
+#[derive(Debug)]
 pub struct IsDebugging(AtomicBool);
 
 impl IsDebugging {
@@ -80,16 +82,19 @@ impl Clone for IsDebugging {
 ///
 /// Note that the runtime stack is not part of this global state. Runtime stacks are handled differently,
 /// but they also rely on using IDs rather than full definitions.
-#[derive(Clone)]
+#[derive(Clone, derive_more::Debug)]
 pub struct EngineState {
     files: Vec<CachedFile>,
     pub(super) virtual_paths: Vec<(String, VirtualPath)>,
     vars: Vec<Variable>,
+    #[debug("{:?}", decls.iter().map(|c| c.name()).collect::<Vec<_>>())]
     decls: Arc<Vec<Box<dyn Command + 'static>>>,
     // The Vec is wrapped in Arc so that if we don't need to modify the list, we can just clone
     // the reference and not have to clone each individual Arc inside. These lists can be
     // especially long, so it helps
+    #[debug("{:?}", blocks.iter().map(|b| &b.signature.name))]
     pub(super) blocks: Arc<Vec<Arc<Block>>>,
+    #[debug("{:?}", modules.iter().map(|m| String::from_utf8_lossy(&m.name)))]
     pub(super) modules: Arc<Vec<Arc<Module>>>,
     pub spans: Vec<Span>,
     doccomments: Doccomments,
@@ -105,6 +110,7 @@ pub struct EngineState {
     #[cfg(feature = "plugin")]
     pub plugin_path: Option<PathBuf>,
     #[cfg(feature = "plugin")]
+    #[debug("{:?}", plugins.iter().map(|rp| rp.identity().name()).collect::<Vec<_>>())]
     plugins: Vec<Arc<dyn RegisteredPlugin>>,
     config_path: HashMap<String, PathBuf>,
     pub history_enabled: bool,

--- a/crates/nu-protocol/src/engine/env_name.rs
+++ b/crates/nu-protocol/src/engine/env_name.rs
@@ -15,19 +15,12 @@
 //! - Case is preserved when storing the variable name
 //! - Existing scripts may need updates if they relied on case sensitivity
 
-use std::fmt;
-use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 
 /// A `String` that's case-insensitive for all environment variable names, used for environment variable names.
-#[derive(Clone)]
+#[derive(Clone, derive_more::Debug)]
+#[debug("{_0:?}")]
 pub struct EnvName(pub(crate) String);
-
-impl Debug for EnvName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
 
 impl<T: Into<String>> From<T> for EnvName {
     fn from(name: T) -> Self {

--- a/crates/nu-protocol/src/engine/jobs.rs
+++ b/crates/nu-protocol/src/engine/jobs.rs
@@ -17,6 +17,7 @@ use crate::{PipelineData, Signals, shell_error};
 
 use crate::JobId;
 
+#[derive(Debug)]
 pub struct Jobs {
     next_job_id: usize,
 
@@ -129,6 +130,7 @@ impl Jobs {
     }
 }
 
+#[derive(Debug)]
 pub enum Job {
     Thread(ThreadJob),
     Frozen(FrozenJob),
@@ -142,7 +144,7 @@ pub enum Job {
 // is a direct undocumentented requirement of its soundness, and is thus assumed by this
 // implementaation.
 // see issue https://github.com/rust-lang/rust/issues/126239.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ThreadJob {
     signals: Signals,
     pids: Arc<Mutex<HashSet<u32>>>,
@@ -229,6 +231,7 @@ impl Job {
     }
 }
 
+#[derive(Debug)]
 pub struct FrozenJob {
     pub unfreeze: UnfreezeHandle,
     pub description: Option<String>,
@@ -250,7 +253,7 @@ impl FrozenJob {
 }
 
 /// Stores the information about the background job currently being executed by this thread, if any
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CurrentJob {
     pub id: JobId,
 
@@ -268,6 +271,7 @@ pub struct CurrentJob {
 // Messages are initially sent over a mpsc channel,
 // and may then be stored in a IgnoredMail struct when
 // filtered out by a message tag.
+#[derive(Debug)]
 pub struct Mailbox {
     receiver: Receiver<Mail>,
     ignored_mail: IgnoredMail,
@@ -341,7 +345,7 @@ impl Mailbox {
 
 // A data structure used to store messages which were received, but currently ignored by a tag filter
 // messages are added and popped in a first-in-first-out matter.
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct IgnoredMail {
     next_id: usize,
     messages: BTreeMap<usize, Mail>,

--- a/crates/nu-protocol/src/errors/report_error.rs
+++ b/crates/nu-protocol/src/errors/report_error.rs
@@ -47,7 +47,8 @@ impl<'src> CliError<'src> {
 /// A bloom-filter like structure to store the hashes of warnings,
 /// without actually permanently storing the entire warning in memory.
 /// May rarely result in warnings incorrectly being unreported upon hash collision.
-#[derive(Default)]
+#[derive(Default, derive_more::Debug)]
+#[debug("ReportLog([...])")]
 pub struct ReportLog(Vec<u64>);
 
 /// How a warning/error should be reported

--- a/crates/nu-protocol/src/pipeline/handlers.rs
+++ b/crates/nu-protocol/src/pipeline/handlers.rs
@@ -1,4 +1,5 @@
-use std::fmt::Debug;
+use core::fmt;
+use std::fmt::Display;
 use std::sync::{Arc, Mutex};
 
 use crate::{ShellError, SignalAction, engine::Sequence};
@@ -7,28 +8,22 @@ use crate::{ShellError, SignalAction, engine::Sequence};
 pub type Handler = Box<dyn Fn(SignalAction) + Send + Sync>;
 
 /// Manages a collection of handlers.
-#[derive(Clone)]
+#[derive(Clone, derive_more::Debug, Default)]
 pub struct Handlers {
     /// List of handler tuples containing an ID and the handler itself.
+    #[debug("{}", debug_fmt_handlers(&self.handlers))]
     handlers: Arc<Mutex<Vec<(usize, Handler)>>>,
     /// Sequence generator for unique IDs.
     next_id: Arc<Sequence>,
 }
 
-impl Debug for Handlers {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Handlers")
-            .field("next_id", &self.next_id)
-            .finish()
-    }
-}
-
 /// HandlerGuard that unregisters a handler when dropped.
-#[derive(Clone)]
+#[derive(Clone, derive_more::Debug)]
 pub struct HandlerGuard {
     /// Unique ID of the handler.
     id: usize,
     /// Reference to the handlers list.
+    #[debug("{}", debug_fmt_handlers(&self.handlers))]
     handlers: Arc<Mutex<Vec<(usize, Handler)>>>,
 }
 
@@ -41,17 +36,9 @@ impl Drop for HandlerGuard {
     }
 }
 
-impl Debug for HandlerGuard {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Guard").field("id", &self.id).finish()
-    }
-}
-
 impl Handlers {
     pub fn new() -> Handlers {
-        let handlers = Arc::new(Mutex::new(vec![]));
-        let next_id = Arc::new(Sequence::default());
-        Handlers { handlers, next_id }
+        Self::default()
     }
 
     /// Registers a new handler and returns an RAII guard which will unregister the handler when
@@ -91,10 +78,16 @@ impl Handlers {
     }
 }
 
-impl Default for Handlers {
-    fn default() -> Self {
-        Self::new()
-    }
+#[inline]
+#[expect(unused, reason = "used in `Debug` impls")]
+fn debug_fmt_handlers(handlers: &Mutex<Vec<(usize, Handler)>>) -> impl Display {
+    fmt::from_fn(|f| match handlers.try_lock() {
+        Err(err) => write!(f, "{err:?}"),
+        Ok(handlers) => {
+            let ids: Vec<_> = handlers.iter().map(|(id, _)| id).collect();
+            write!(f, "{ids:?}")
+        }
+    })
 }
 
 #[cfg(test)]

--- a/crates/nu-protocol/src/pipeline/list_stream.rs
+++ b/crates/nu-protocol/src/pipeline/list_stream.rs
@@ -3,7 +3,6 @@
 //!
 //! For more general infos regarding our pipelining model refer to [`PipelineData`]
 use crate::{Config, PipelineData, ShellError, Signals, Span, Value};
-use std::fmt::Debug;
 
 pub type ValueIterator = Box<dyn Iterator<Item = Value> + Send + 'static>;
 
@@ -12,6 +11,8 @@ pub type ValueIterator = Box<dyn Iterator<Item = Value> + Send + 'static>;
 /// In practice, a "stream" here means anything which can be iterated and produces Values.
 /// Like other iterators in Rust, observing values from this stream will drain the items
 /// as you view them and the stream cannot be replayed.
+#[derive(derive_more::Debug)]
+#[debug("ListStream")]
 pub struct ListStream {
     stream: ValueIterator,
     span: Span,
@@ -129,12 +130,6 @@ impl ListStream {
     /// to each of the values in the original [`ListStream`].
     pub fn map(self, mapping: impl FnMut(Value) -> Value + Send + 'static) -> Self {
         self.modify(|iter| iter.map(mapping))
-    }
-}
-
-impl Debug for ListStream {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ListStream").finish()
     }
 }
 

--- a/crates/nu-protocol/src/process/child.rs
+++ b/crates/nu-protocol/src/process/child.rs
@@ -194,15 +194,13 @@ impl ExitStatusFuture {
     }
 }
 
+#[derive(derive_more::Debug)]
 pub enum ChildPipe {
+    #[debug("ChildPipe::Pipe")]
     Pipe(PipeReader),
-    Tee(Box<dyn Read + Send + 'static>),
-}
 
-impl Debug for ChildPipe {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ChildPipe").finish()
-    }
+    #[debug("ChildPipe::Tee")]
+    Tee(Box<dyn Read + Send + 'static>),
 }
 
 impl From<PipeReader> for ChildPipe {
@@ -230,6 +228,8 @@ pub struct ChildProcess {
 }
 
 /// A wrapper for a closure that runs once the shell finishes waiting on the process.
+#[derive(derive_more::Debug)]
+#[debug("<wait_callback>")]
 pub struct PostWaitCallback(pub Box<dyn FnOnce(ForegroundWaitStatus) + Send>);
 
 impl PostWaitCallback {
@@ -274,12 +274,6 @@ impl PostWaitCallback {
                 }
             }
         })
-    }
-}
-
-impl Debug for PostWaitCallback {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "<wait_callback>")
     }
 }
 

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -40,6 +40,7 @@ nu-std = { path = "../nu-std", version = "0.112.3", default-features = false }
 nu-test-support-macros = { path = "../nu-test-support-macros", version = "0.112.3", default-features = false }
 nu-utils = { path = "../nu-utils", version = "0.112.3", default-features = false }
 
+derive_more = { workspace = true }
 itertools = { workspace = true }
 kitest = { workspace = true }
 lexopt = { workspace = true }

--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -373,14 +373,9 @@ pub struct TestError {
     kind: TestErrorKind,
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, derive_more::Debug)]
+#[debug("{_0}")]
 pub struct TestLocation(&'static Location<'static>);
-
-impl Debug for TestLocation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 /// Errors emitted by `NuTester` when parsing, compiling, or evaluating code.
 ///

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -20,6 +20,7 @@ bench = false
 [dependencies]
 byteyarn.workspace = true
 crossterm = { workspace = true, optional = true }
+derive_more = { workspace = true }
 fancy-regex = { workspace = true }
 lean_string.workspace = true
 log = { workspace = true }

--- a/crates/nu-utils/src/strings/shared.rs
+++ b/crates/nu-utils/src/strings/shared.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Borrow,
-    fmt::{Arguments, Debug, Display},
+    fmt::{Arguments, Display},
     hash::Hash,
     ops::Deref,
 };

--- a/crates/nu-utils/src/strings/shared.rs
+++ b/crates/nu-utils/src/strings/shared.rs
@@ -37,6 +37,8 @@ use serde::{Deserialize, Serialize};
 ///   
 /// Internally, `SharedString` is powered by [`lean_string::LeanString`], which provides the
 /// underlying implementation for these optimizations.
+#[derive(derive_more::Debug, Clone, Default)]
+#[debug("{_0:?}")]
 pub struct SharedString(lean_string::LeanString);
 
 const _: () = const {
@@ -109,27 +111,6 @@ impl Borrow<str> for SharedString {
     #[inline]
     fn borrow(&self) -> &str {
         self.as_str()
-    }
-}
-
-impl Clone for SharedString {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
-impl Debug for SharedString {
-    #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(&self.0, f)
-    }
-}
-
-impl Default for SharedString {
-    #[inline]
-    fn default() -> Self {
-        Self(Default::default())
     }
 }
 

--- a/crates/nu-utils/src/strings/unique.rs
+++ b/crates/nu-utils/src/strings/unique.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Borrow,
-    fmt::{Arguments, Debug, Display},
+    fmt::{Arguments, Display},
     hash::Hash,
     ops::Deref,
 };

--- a/crates/nu-utils/src/strings/unique.rs
+++ b/crates/nu-utils/src/strings/unique.rs
@@ -37,6 +37,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// Internally, `UniqueString` is powered by [`byteyarn::Yarn`], which provides the
 /// underlying implementation for these optimizations.
+#[derive(derive_more::Debug, Clone, Default)]
+#[debug("{_0:?}")]
 pub struct UniqueString(byteyarn::Yarn);
 
 const _: () = const {
@@ -106,27 +108,6 @@ impl Borrow<str> for UniqueString {
     #[inline]
     fn borrow(&self) -> &str {
         self.as_str()
-    }
-}
-
-impl Clone for UniqueString {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
-impl Debug for UniqueString {
-    #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(&self.0, f)
-    }
-}
-
-impl Default for UniqueString {
-    #[inline]
-    fn default() -> Self {
-        Self(Default::default())
     }
 }
 


### PR DESCRIPTION
## Description

<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

Right now `EngineState` does not implement `Debug`, which becomes annoying once it is part of a struct where you want to just derive `Debug`. Some places worked around this by adding manual `Debug` impls and simply leaving out the `EngineState` field, but that is not great.

Those manual impls also tend to look very close to what `#[derive(Debug)]` would generate, which makes them easy to forget when the struct changes. That can lead to them drifting out of sync over time, which is exactly what deriving is supposed to avoid.

To clean this up, I added `Debug` for `EngineState` and switched a bunch of structs from manual impls to derived ones. To make this easier with more complex types, I pulled in the `derive_more` crate (already present in `Cargo.lock`) and used it where needed.

For some `EngineState` fields, the debug output is intentionally reduced to very minimal info to avoid flooding the output with large or non-human-readable data.

## User-facing changes (Release notes)

<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

n/a
