### PR TITLE
refactor: replace FindMapResult with ControlFlow

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -29,9 +29,10 @@ fn find_pipeline_element_by_position<'a>(
 ) -> FindMapResult<&'a Expression> {
     // skip the entire expression if the position is not in it
     if !expr.span.contains(pos) {
-        return FindMapResult::Stop;
+        return FindMapResult::Break(None);
     }
     let closure = |expr: &'a Expression| find_pipeline_element_by_position(expr, working_set, pos);
+    let found = |x| FindMapResult::Break(Some(x));
     match &expr.expr {
         Expr::RowCondition(block_id)
         | Expr::Subexpression(block_id)
@@ -40,17 +41,15 @@ fn find_pipeline_element_by_position<'a>(
             let block = working_set.get_block(*block_id);
             // check redirection target for sub blocks before diving recursively into them
             check_redirection_in_block(block.as_ref(), pos)
-                .map(FindMapResult::Found)
-                .unwrap_or_default()
+                .map(found)
+                .unwrap_or(FindMapResult::Continue(()))
         }
         Expr::Call(call) => call
             .arguments
             .iter()
             .find_map(|arg| arg.expr().and_then(|e| e.find_map(working_set, &closure)))
-            // if no inner call/external_call found, then this is the inner-most one
-            .or(Some(expr))
-            .map(FindMapResult::Found)
-            .unwrap_or_default(),
+            .map(found)
+            .unwrap_or(found(expr)),
         Expr::ExternalCall(head, arguments) => arguments
             .iter()
             .find_map(|arg| arg.expr().find_map(working_set, &closure))
@@ -66,38 +65,34 @@ fn find_pipeline_element_by_position<'a>(
                     None
                 }
             })
-            .or(Some(expr))
-            .map(FindMapResult::Found)
-            .unwrap_or_default(),
+            .map(found)
+            .unwrap_or(found(expr)),
         // complete the operator
         Expr::BinaryOp(lhs, _, rhs) => lhs
             .find_map(working_set, &closure)
             .or_else(|| rhs.find_map(working_set, &closure))
-            .or(Some(expr))
-            .map(FindMapResult::Found)
-            .unwrap_or_default(),
+            .map(found)
+            .unwrap_or(found(expr)),
         Expr::FullCellPath(fcp) => fcp
             .head
             .find_map(working_set, &closure)
-            .map(FindMapResult::Found)
+            .map(found)
             // e.g. use std/util [<tab>
             .or_else(|| {
                 (fcp.head.span.contains(pos) && matches!(fcp.head.expr, Expr::List(_)))
-                    .then_some(FindMapResult::Continue)
+                    .then_some(FindMapResult::Continue(()))
             })
-            .or(Some(FindMapResult::Found(expr)))
-            .unwrap_or_default(),
-        Expr::Var(_) => FindMapResult::Found(expr),
+            .unwrap_or(found(expr)),
+        Expr::Var(_) => found(expr),
         Expr::AttributeBlock(ab) => ab
             .attributes
             .iter()
             .map(|attr| &attr.expr)
             .chain(Some(ab.item.as_ref()))
             .find_map(|expr| expr.find_map(working_set, &closure))
-            .or(Some(expr))
-            .map(FindMapResult::Found)
-            .unwrap_or_default(),
-        _ => FindMapResult::Continue,
+            .map(found)
+            .unwrap_or(found(expr)),
+        _ => FindMapResult::Continue(()),
     }
 }
 

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -6,15 +6,12 @@ use crate::completions::{
 use nu_parser::parse;
 use nu_protocol::{
     CommandWideCompleter, Completion, GetSpan, Signature, Span,
-    ast::{
-        Argument, Block, Expr, Expression, FindMapResult, PipelineRedirection, RedirectionTarget,
-        Traverse,
-    },
+    ast::{Argument, Block, Expr, Expression, PipelineRedirection, RedirectionTarget, Traverse},
     engine::{ArgType, EngineState, Stack, StateWorkingSet},
 };
 use reedline::{Completer as ReedlineCompleter, Suggestion};
-use std::borrow::Cow;
 use std::sync::Arc;
+use std::{borrow::Cow, ops::ControlFlow};
 
 use super::{StaticCompletion, custom_completions::CommandWideCompletion};
 
@@ -26,13 +23,13 @@ fn find_pipeline_element_by_position<'a>(
     expr: &'a Expression,
     working_set: &'a StateWorkingSet,
     pos: usize,
-) -> FindMapResult<&'a Expression> {
+) -> ControlFlow<Option<&'a Expression>> {
     // skip the entire expression if the position is not in it
     if !expr.span.contains(pos) {
-        return FindMapResult::Break(None);
+        return ControlFlow::Break(None);
     }
     let closure = |expr: &'a Expression| find_pipeline_element_by_position(expr, working_set, pos);
-    let found = |x| FindMapResult::Break(Some(x));
+    let found = |x| ControlFlow::Break(Some(x));
     match &expr.expr {
         Expr::RowCondition(block_id)
         | Expr::Subexpression(block_id)
@@ -42,7 +39,7 @@ fn find_pipeline_element_by_position<'a>(
             // check redirection target for sub blocks before diving recursively into them
             check_redirection_in_block(block.as_ref(), pos)
                 .map(found)
-                .unwrap_or(FindMapResult::Continue(()))
+                .unwrap_or(ControlFlow::Continue(()))
         }
         Expr::Call(call) => call
             .arguments
@@ -80,7 +77,7 @@ fn find_pipeline_element_by_position<'a>(
             // e.g. use std/util [<tab>
             .or_else(|| {
                 (fcp.head.span.contains(pos) && matches!(fcp.head.expr, Expr::List(_)))
-                    .then_some(FindMapResult::Continue(()))
+                    .then_some(ControlFlow::Continue(()))
             })
             .unwrap_or(found(expr)),
         Expr::Var(_) => found(expr),
@@ -92,7 +89,7 @@ fn find_pipeline_element_by_position<'a>(
             .find_map(|expr| expr.find_map(working_set, &closure))
             .map(found)
             .unwrap_or(found(expr)),
-        _ => FindMapResult::Continue(()),
+        _ => ControlFlow::Continue(()),
     }
 }
 

--- a/crates/nu-lsp/src/ast.rs
+++ b/crates/nu-lsp/src/ast.rs
@@ -432,42 +432,43 @@ fn find_id_in_expr(
 ) -> FindMapResult<(Id, Span)> {
     // skip the entire expression if the location is not in it
     if !expr.span.contains(*location) {
-        return FindMapResult::Stop;
+        return FindMapResult::Break(None);
     }
     let span = expr.span;
     match &expr.expr {
         Expr::VarDecl(var_id) | Expr::Var(var_id) => {
             let (name, clean_span) = strip_dollar_sign(span, working_set);
-            FindMapResult::Found((Id::Variable(*var_id, name), clean_span))
+            FindMapResult::Break(Some((Id::Variable(*var_id, name), clean_span)))
         }
         Expr::Call(call) => {
             if call.head.contains(*location) {
                 let span = command_name_span_from_call_head(working_set, call.decl_id, call.head);
-                FindMapResult::Found((Id::Declaration(call.decl_id), span))
+                FindMapResult::Break(Some((Id::Declaration(call.decl_id), span)))
             } else {
                 try_find_id_in_misc(call, working_set, Some(location), None)
-                    .map(FindMapResult::Found)
-                    .unwrap_or_default()
+                    .map(Some)
+                    .map(FindMapResult::Break)
+                    .unwrap_or(FindMapResult::Continue(()))
             }
         }
         Expr::ExternalCall(head, _) => {
             if head.span.contains(*location)
                 && let Expr::GlobPattern(cmd, _) = &head.expr
             {
-                return FindMapResult::Found((Id::External(cmd.clone()), head.span));
+                return FindMapResult::Break(Some((Id::External(cmd.clone()), head.span)));
             }
-            FindMapResult::Continue
+            FindMapResult::Continue(())
         }
         Expr::FullCellPath(fcp) => {
             if fcp.head.span.contains(*location) {
-                FindMapResult::Continue
+                FindMapResult::Continue(())
             } else {
                 let Expression {
                     expr: Expr::Var(var_id),
                     ..
                 } = fcp.head
                 else {
-                    return FindMapResult::Continue;
+                    return FindMapResult::Continue(());
                 };
                 let tail: Vec<PathMember> = fcp
                     .tail
@@ -476,13 +477,13 @@ fn find_id_in_expr(
                     .take_while(|pm| pm.span().start <= *location)
                     .collect();
                 let Some(span) = tail.last().map(|pm| pm.span()) else {
-                    return FindMapResult::Stop;
+                    return FindMapResult::Break(None);
                 };
-                FindMapResult::Found((Id::CellPath(var_id, tail), span))
+                FindMapResult::Break(Some((Id::CellPath(var_id, tail), span)))
             }
         }
         Expr::Overlay(Some(module_id)) => {
-            FindMapResult::Found((Id::Module(*module_id, [].into()), span))
+            FindMapResult::Break(Some((Id::Module(*module_id, [].into()), span)))
         }
         // terminal value expressions
         Expr::Bool(_)
@@ -497,8 +498,8 @@ fn find_id_in_expr(
         | Expr::Nothing
         | Expr::RawString(_)
         | Expr::Signature(_)
-        | Expr::String(_) => FindMapResult::Found((Id::Value(expr.ty.clone()), span)),
-        _ => FindMapResult::Continue,
+        | Expr::String(_) => FindMapResult::Break(Some((Id::Value(expr.ty.clone()), span))),
+        _ => FindMapResult::Continue(()),
     }
 }
 

--- a/crates/nu-lsp/src/ast.rs
+++ b/crates/nu-lsp/src/ast.rs
@@ -1,10 +1,10 @@
 use crate::Id;
 use nu_protocol::{
     DeclId, ModuleId, Span,
-    ast::{Argument, Block, Call, Expr, Expression, FindMapResult, ListItem, PathMember, Traverse},
+    ast::{Argument, Block, Call, Expr, Expression, ListItem, PathMember, Traverse},
     engine::StateWorkingSet,
 };
-use std::sync::Arc;
+use std::{ops::ControlFlow, sync::Arc};
 
 /// Adjust span if quoted
 fn strip_quotes(span: Span, working_set: &StateWorkingSet) -> (Box<[u8]>, Span) {
@@ -429,46 +429,46 @@ fn find_id_in_expr(
     expr: &Expression,
     working_set: &StateWorkingSet,
     location: &usize,
-) -> FindMapResult<(Id, Span)> {
+) -> ControlFlow<Option<(Id, Span)>> {
     // skip the entire expression if the location is not in it
     if !expr.span.contains(*location) {
-        return FindMapResult::Break(None);
+        return ControlFlow::Break(None);
     }
     let span = expr.span;
     match &expr.expr {
         Expr::VarDecl(var_id) | Expr::Var(var_id) => {
             let (name, clean_span) = strip_dollar_sign(span, working_set);
-            FindMapResult::Break(Some((Id::Variable(*var_id, name), clean_span)))
+            ControlFlow::Break(Some((Id::Variable(*var_id, name), clean_span)))
         }
         Expr::Call(call) => {
             if call.head.contains(*location) {
                 let span = command_name_span_from_call_head(working_set, call.decl_id, call.head);
-                FindMapResult::Break(Some((Id::Declaration(call.decl_id), span)))
+                ControlFlow::Break(Some((Id::Declaration(call.decl_id), span)))
             } else {
                 try_find_id_in_misc(call, working_set, Some(location), None)
                     .map(Some)
-                    .map(FindMapResult::Break)
-                    .unwrap_or(FindMapResult::Continue(()))
+                    .map(ControlFlow::Break)
+                    .unwrap_or(ControlFlow::Continue(()))
             }
         }
         Expr::ExternalCall(head, _) => {
             if head.span.contains(*location)
                 && let Expr::GlobPattern(cmd, _) = &head.expr
             {
-                return FindMapResult::Break(Some((Id::External(cmd.clone()), head.span)));
+                return ControlFlow::Break(Some((Id::External(cmd.clone()), head.span)));
             }
-            FindMapResult::Continue(())
+            ControlFlow::Continue(())
         }
         Expr::FullCellPath(fcp) => {
             if fcp.head.span.contains(*location) {
-                FindMapResult::Continue(())
+                ControlFlow::Continue(())
             } else {
                 let Expression {
                     expr: Expr::Var(var_id),
                     ..
                 } = fcp.head
                 else {
-                    return FindMapResult::Continue(());
+                    return ControlFlow::Continue(());
                 };
                 let tail: Vec<PathMember> = fcp
                     .tail
@@ -477,13 +477,13 @@ fn find_id_in_expr(
                     .take_while(|pm| pm.span().start <= *location)
                     .collect();
                 let Some(span) = tail.last().map(|pm| pm.span()) else {
-                    return FindMapResult::Break(None);
+                    return ControlFlow::Break(None);
                 };
-                FindMapResult::Break(Some((Id::CellPath(var_id, tail), span)))
+                ControlFlow::Break(Some((Id::CellPath(var_id, tail), span)))
             }
         }
         Expr::Overlay(Some(module_id)) => {
-            FindMapResult::Break(Some((Id::Module(*module_id, [].into()), span)))
+            ControlFlow::Break(Some((Id::Module(*module_id, [].into()), span)))
         }
         // terminal value expressions
         Expr::Bool(_)
@@ -498,8 +498,8 @@ fn find_id_in_expr(
         | Expr::Nothing
         | Expr::RawString(_)
         | Expr::Signature(_)
-        | Expr::String(_) => FindMapResult::Break(Some((Id::Value(expr.ty.clone()), span))),
-        _ => FindMapResult::Continue(()),
+        | Expr::String(_) => ControlFlow::Break(Some((Id::Value(expr.ty.clone()), span))),
+        _ => ControlFlow::Continue(()),
     }
 }
 

--- a/crates/nu-lsp/src/signature.rs
+++ b/crates/nu-lsp/src/signature.rs
@@ -4,36 +4,36 @@ use lsp_types::{
 };
 use nu_protocol::{
     Flag, PositionalArg, Signature, SyntaxShape, Value,
-    ast::{Argument, Call, Expr, Expression, FindMapResult, Traverse},
+    ast::{Argument, Call, Expr, Expression, Traverse},
     engine::StateWorkingSet,
 };
 
 use crate::{LanguageServer, uri_to_path};
-use std::fmt::Write;
+use std::{fmt::Write, ops::ControlFlow};
 
 fn find_active_internal_call<'a>(
     expr: &'a Expression,
     working_set: &'a StateWorkingSet,
     pos: usize,
-) -> FindMapResult<&'a Call> {
+) -> ControlFlow<Option<&'a Call>> {
     if !expr.span.contains(pos) {
-        return FindMapResult::Break(None);
+        return ControlFlow::Break(None);
     }
     let closure = |e| find_active_internal_call(e, working_set, pos);
     match &expr.expr {
         Expr::Call(call) => {
             if call.head.contains(pos) {
-                return FindMapResult::Break(None);
+                return ControlFlow::Break(None);
             }
             call.arguments
                 .iter()
                 .find_map(|arg| arg.expr().and_then(|e| e.find_map(working_set, &closure)))
                 .or(Some(call.as_ref()))
                 .map(Some)
-                .map(FindMapResult::Break)
-                .unwrap_or(FindMapResult::Continue(()))
+                .map(ControlFlow::Break)
+                .unwrap_or(ControlFlow::Continue(()))
         }
-        _ => FindMapResult::Continue(()),
+        _ => ControlFlow::Continue(()),
     }
 }
 

--- a/crates/nu-lsp/src/signature.rs
+++ b/crates/nu-lsp/src/signature.rs
@@ -17,22 +17,23 @@ fn find_active_internal_call<'a>(
     pos: usize,
 ) -> FindMapResult<&'a Call> {
     if !expr.span.contains(pos) {
-        return FindMapResult::Stop;
+        return FindMapResult::Break(None);
     }
     let closure = |e| find_active_internal_call(e, working_set, pos);
     match &expr.expr {
         Expr::Call(call) => {
             if call.head.contains(pos) {
-                return FindMapResult::Stop;
+                return FindMapResult::Break(None);
             }
             call.arguments
                 .iter()
                 .find_map(|arg| arg.expr().and_then(|e| e.find_map(working_set, &closure)))
                 .or(Some(call.as_ref()))
-                .map(FindMapResult::Found)
-                .unwrap_or_default()
+                .map(Some)
+                .map(FindMapResult::Break)
+                .unwrap_or(FindMapResult::Continue(()))
         }
-        _ => FindMapResult::Continue,
+        _ => FindMapResult::Continue(()),
     }
 }
 

--- a/crates/nu-protocol/src/ast/traverse.rs
+++ b/crates/nu-protocol/src/ast/traverse.rs
@@ -5,13 +5,12 @@ use super::{
 };
 
 /// Result of find_map closure
-#[derive(Default)]
 pub enum FindMapResult<T> {
-    Found(T),
-    #[default]
-    Continue,
-    Stop,
+    Break(Option<T>),
+    Continue(()),
 }
+
+// pub type FindMapResult<T> = std::ops::ControlFlow<Option<T>>;
 
 /// Trait for traversing the AST
 pub trait Traverse {
@@ -196,9 +195,9 @@ impl Traverse for Expression {
     {
         // behavior overridden by f
         match f(self) {
-            FindMapResult::Found(t) => Some(t),
-            FindMapResult::Stop => None,
-            FindMapResult::Continue => {
+            FindMapResult::Break(Some(t)) => Some(t),
+            FindMapResult::Break(None) => None,
+            FindMapResult::Continue(()) => {
                 let recur = |expr: &'a Expression| expr.find_map(working_set, f);
                 match &self.expr {
                     Expr::RowCondition(block_id)

--- a/crates/nu-protocol/src/ast/traverse.rs
+++ b/crates/nu-protocol/src/ast/traverse.rs
@@ -1,16 +1,10 @@
+use std::ops::ControlFlow;
+
 use crate::engine::StateWorkingSet;
 
 use super::{
     Block, Expr, Expression, ListItem, MatchPattern, Pattern, PipelineRedirection, RecordItem,
 };
-
-/// Result of find_map closure
-pub enum FindMapResult<T> {
-    Break(Option<T>),
-    Continue(()),
-}
-
-// pub type FindMapResult<T> = std::ops::ControlFlow<Option<T>>;
 
 /// Trait for traversing the AST
 pub trait Traverse {
@@ -32,7 +26,7 @@ pub trait Traverse {
     /// * `f` - function that overrides the default behavior
     fn find_map<'a, T, F>(&'a self, working_set: &'a StateWorkingSet, f: &F) -> Option<T>
     where
-        F: Fn(&'a Expression) -> FindMapResult<T>;
+        F: Fn(&'a Expression) -> ControlFlow<Option<T>>;
 }
 
 impl Traverse for Block {
@@ -52,7 +46,7 @@ impl Traverse for Block {
 
     fn find_map<'a, T, F>(&'a self, working_set: &'a StateWorkingSet, f: &F) -> Option<T>
     where
-        F: Fn(&'a Expression) -> FindMapResult<T>,
+        F: Fn(&'a Expression) -> ControlFlow<Option<T>>,
     {
         self.pipelines.iter().find_map(|pipeline| {
             pipeline.elements.iter().find_map(|element| {
@@ -83,7 +77,7 @@ impl Traverse for PipelineRedirection {
 
     fn find_map<'a, T, F>(&'a self, working_set: &'a StateWorkingSet, f: &F) -> Option<T>
     where
-        F: Fn(&'a Expression) -> FindMapResult<T>,
+        F: Fn(&'a Expression) -> ControlFlow<Option<T>>,
     {
         let recur = |expr: &'a Expression| expr.find_map(working_set, f);
         match self {
@@ -191,13 +185,13 @@ impl Traverse for Expression {
 
     fn find_map<'a, T, F>(&'a self, working_set: &'a StateWorkingSet, f: &F) -> Option<T>
     where
-        F: Fn(&'a Expression) -> FindMapResult<T>,
+        F: Fn(&'a Expression) -> ControlFlow<Option<T>>,
     {
         // behavior overridden by f
         match f(self) {
-            FindMapResult::Break(Some(t)) => Some(t),
-            FindMapResult::Break(None) => None,
-            FindMapResult::Continue(()) => {
+            ControlFlow::Break(Some(t)) => Some(t),
+            ControlFlow::Break(None) => None,
+            ControlFlow::Continue(()) => {
                 let recur = |expr: &'a Expression| expr.find_map(working_set, f);
                 match &self.expr {
                     Expr::RowCondition(block_id)
@@ -283,7 +277,7 @@ impl Traverse for MatchPattern {
 
     fn find_map<'a, T, F>(&'a self, working_set: &'a StateWorkingSet, f: &F) -> Option<T>
     where
-        F: Fn(&'a Expression) -> FindMapResult<T>,
+        F: Fn(&'a Expression) -> ControlFlow<Option<T>>,
     {
         let recur = |expr: &'a Expression| expr.find_map(working_set, f);
         let recur_pattern = |pattern: &'a MatchPattern| pattern.find_map(working_set, f);


### PR DESCRIPTION
## Description
Replace `nu_protocol::ast:FindMapResult<T>` with `std::ops::ControlFlow<Option<T>>`.

## User-facing changes (Release notes)
N/A

## Additional notes
cc: @blindFS 