### PR TITLE
Refactor/update some old tests to the newer in process style

### DIFF
--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -1,42 +1,42 @@
+use nu_experimental::NATIVE_CLIP;
 use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu, nu_repl_code, nu_with_std};
+use nu_test_support::prelude::*;
 
 // Note: These tests might slightly overlap with tests/scope/mod.rs
 
 #[test]
-fn help_commands_length() {
-    let actual = nu!("help commands | length");
-
-    let output = actual.out;
-    let output_int: i32 = output.parse().unwrap();
-    let is_positive = output_int.is_positive();
-    assert!(is_positive);
+fn help_commands_length() -> Result {
+    test()
+        .run("help commands | length | $in > 0")
+        .expect_value_eq(true)
 }
 
 #[test]
-fn help_shows_signature() {
-    let actual = nu!("help str distance");
-    assert!(actual.out.contains("Input/output types"));
+fn help_shows_signature() -> Result {
+    let mut tester = test();
+
+    let outcome: String = tester.run("help str distance")?;
+    assert_contains("Input/output types", &outcome);
 
     // don't show signature for parser keyword
-    let actual = nu!("help alias");
-    assert!(!actual.out.contains("Input/output types"));
+    let outcome: String = tester.run("help alias")?;
+    assert!(!outcome.contains("Input/output types"));
+
+    Ok(())
 }
 
 #[test]
-fn help_aliases() {
-    let code = &[
-        "alias SPAM = print 'spam'",
-        "help aliases | where name == SPAM | length",
-    ];
-    let actual = nu!(nu_repl_code(code));
-
-    assert_eq!(actual.out, "1");
+fn help_aliases() -> Result {
+    let mut tester = test();
+    let () = tester.run("alias SPAM = print 'spam'")?;
+    tester
+        .run("help aliases | where name == SPAM | length")
+        .expect_value_eq(1)
 }
 
 #[test]
-fn help_alias_description_1() {
+fn help_alias_description_1() -> Result {
     Playground::setup("help_alias_description_1", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -46,29 +46,25 @@ fn help_alias_description_1() {
             ",
         )]);
 
-        let code = &[
-            "source spam.nu",
-            "help aliases | where name == SPAM | get 0.description",
-        ];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(code));
-
-        assert_eq!(actual.out, "line1");
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("source spam.nu")?;
+        tester
+            .run("help aliases | where name == SPAM | get 0.description")
+            .expect_value_eq("line1")
     })
 }
 
 #[test]
-fn help_alias_description_2() {
-    let code = &[
-        "alias SPAM = print 'spam'  # line2",
-        "help aliases | where name == SPAM | get 0.description",
-    ];
-    let actual = nu!(nu_repl_code(code));
-
-    assert_eq!(actual.out, "line2");
+fn help_alias_description_2() -> Result {
+    let mut tester = test();
+    let () = tester.run("alias SPAM = print 'spam'  # line2")?;
+    tester
+        .run("help aliases | where name == SPAM | get 0.description")
+        .expect_value_eq("line2")
 }
 
 #[test]
-fn help_alias_description_3() {
+fn help_alias_description_3() -> Result {
     Playground::setup("help_alias_description_3", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -78,19 +74,19 @@ fn help_alias_description_3() {
             ",
         )]);
 
-        let code = &[
-            "source spam.nu",
-            "help aliases | where name == SPAM | get 0.description",
-        ];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(code));
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("source spam.nu")?;
+        let outcome: String =
+            tester.run("help aliases | where name == SPAM | get 0.description")?;
 
-        assert!(actual.out.contains("line1"));
-        assert!(actual.out.contains("line2"));
+        assert_contains("line1", &outcome);
+        assert_contains("line2", &outcome);
+        Ok(())
     })
 }
 
 #[test]
-fn help_alias_name() {
+fn help_alias_name() -> Result {
     Playground::setup("help_alias_name", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -100,18 +96,20 @@ fn help_alias_name() {
             ",
         )]);
 
-        let code = &["source spam.nu", "help aliases SPAM"];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(code));
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("source spam.nu")?;
+        let outcome: String = tester.run("help aliases SPAM")?;
 
-        assert!(actual.out.contains("line1"));
-        assert!(actual.out.contains("line2"));
-        assert!(actual.out.contains("SPAM"));
-        assert!(actual.out.contains("print 'spam'"));
+        assert_contains("line1", &outcome);
+        assert_contains("line2", &outcome);
+        assert_contains("SPAM", &outcome);
+        assert_contains("print 'spam'", &outcome);
+        Ok(())
     })
 }
 
 #[test]
-fn help_alias_name_f() {
+fn help_alias_name_f() -> Result {
     Playground::setup("help_alias_name_f", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -121,16 +119,18 @@ fn help_alias_name_f() {
             ",
         )]);
 
-        let code = &["source spam.nu", "help aliases -f SPAM | get 0.description"];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(code));
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("source spam.nu")?;
+        let outcome: String = tester.run("help aliases -f SPAM | get 0.description")?;
 
-        assert!(actual.out.contains("line1"));
-        assert!(actual.out.contains("line2"));
+        assert_contains("line1", &outcome);
+        assert_contains("line2", &outcome);
+        Ok(())
     })
 }
 
 #[test]
-fn help_export_alias_name_single_word() {
+fn help_export_alias_name_single_word() -> Result {
     Playground::setup("help_export_alias_name_single_word", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -140,18 +140,20 @@ fn help_export_alias_name_single_word() {
             ",
         )]);
 
-        let code = &["use spam.nu SPAM", "help aliases SPAM"];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(code));
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("use spam.nu SPAM")?;
+        let outcome: String = tester.run("help aliases SPAM")?;
 
-        assert!(actual.out.contains("line1"));
-        assert!(actual.out.contains("line2"));
-        assert!(actual.out.contains("SPAM"));
-        assert!(actual.out.contains("print 'spam'"));
+        assert_contains("line1", &outcome);
+        assert_contains("line2", &outcome);
+        assert_contains("SPAM", &outcome);
+        assert_contains("print 'spam'", &outcome);
+        Ok(())
     })
 }
 
 #[test]
-fn help_export_alias_name_multi_word() {
+fn help_export_alias_name_multi_word() -> Result {
     Playground::setup("help_export_alias_name_multi_word", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -161,18 +163,20 @@ fn help_export_alias_name_multi_word() {
             ",
         )]);
 
-        let code = &["use spam.nu", "help aliases spam SPAM"];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(code));
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("use spam.nu")?;
+        let outcome: String = tester.run("help aliases spam SPAM")?;
 
-        assert!(actual.out.contains("line1"));
-        assert!(actual.out.contains("line2"));
-        assert!(actual.out.contains("SPAM"));
-        assert!(actual.out.contains("print 'spam'"));
+        assert_contains("line1", &outcome);
+        assert_contains("line2", &outcome);
+        assert_contains("SPAM", &outcome);
+        assert_contains("print 'spam'", &outcome);
+        Ok(())
     })
 }
 
 #[test]
-fn help_module_description_1() {
+fn help_module_description_1() -> Result {
     Playground::setup("help_module_description", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -184,20 +188,20 @@ fn help_module_description_1() {
             ",
         )]);
 
-        let code = &[
-            "source spam.nu",
-            "help modules | where name == SPAM | get 0.description",
-        ];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(code));
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("source spam.nu")?;
+        let outcome: String =
+            tester.run("help modules | where name == SPAM | get 0.description")?;
 
-        assert!(actual.out.contains("line1"));
-        assert!(actual.out.contains("line2"));
-        assert!(actual.out.contains("line3"));
+        assert_contains("line1", &outcome);
+        assert_contains("line2", &outcome);
+        assert_contains("line3", &outcome);
+        Ok(())
     })
 }
 
 #[test]
-fn help_module_name() {
+fn help_module_name() -> Result {
     Playground::setup("help_module_name", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -209,18 +213,20 @@ fn help_module_name() {
             ",
         )]);
 
-        let code = &["source spam.nu", "help modules SPAM"];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(code));
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("source spam.nu")?;
+        let outcome: String = tester.run("help modules SPAM")?;
 
-        assert!(actual.out.contains("line1"));
-        assert!(actual.out.contains("line2"));
-        assert!(actual.out.contains("line3"));
-        assert!(actual.out.contains("SPAM"));
+        assert_contains("line1", &outcome);
+        assert_contains("line2", &outcome);
+        assert_contains("line3", &outcome);
+        assert_contains("SPAM", &outcome);
+        Ok(())
     })
 }
 
 #[test]
-fn help_module_sorted_decls() {
+fn help_module_sorted_decls() -> Result {
     Playground::setup("help_module_sorted_decls", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -232,15 +238,17 @@ fn help_module_sorted_decls() {
             ",
         )]);
 
-        let code = &["source spam.nu", "help modules SPAM"];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(code));
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("source spam.nu")?;
+        let outcome: String = tester.run("help modules SPAM")?;
 
-        assert!(actual.out.contains("a, z"));
+        assert_contains("a, z", &outcome);
+        Ok(())
     })
 }
 
 #[test]
-fn help_module_sorted_aliases() {
+fn help_module_sorted_aliases() -> Result {
     Playground::setup("help_module_sorted_aliases", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -252,15 +260,17 @@ fn help_module_sorted_aliases() {
             ",
         )]);
 
-        let code = &["source spam.nu", "help modules SPAM"];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(code));
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("source spam.nu")?;
+        let outcome: String = tester.run("help modules SPAM")?;
 
-        assert!(actual.out.contains("a, z"));
+        assert_contains("a, z", &outcome);
+        Ok(())
     })
 }
 
 #[test]
-fn help_description_extra_description_command() {
+fn help_description_extra_description_command() -> Result {
     Playground::setup(
         "help_description_extra_description_command",
         |dirs, sandbox| {
@@ -277,30 +287,33 @@ fn help_description_extra_description_command() {
                 export def foo [] {}
             ",
             )]);
+            let mut tester = test().cwd(dirs.test());
+            let () = tester.run("use spam.nu *")?;
 
-            let actual = nu!(cwd: dirs.test(), "use spam.nu *; help modules spam");
-            assert!(actual.out.contains("module_line1"));
-            assert!(actual.out.contains("module_line2"));
+            let outcome: String = tester.run("help modules spam")?;
+            assert_contains("module_line1", &outcome);
+            assert_contains("module_line2", &outcome);
 
-            let actual = nu!(cwd: dirs.test(),
-            "use spam.nu *; help modules | where name == spam | get 0.description");
-            assert!(actual.out.contains("module_line1"));
-            assert!(!actual.out.contains("module_line2"));
+            let outcome: String =
+                tester.run("help modules | where name == spam | get 0.description")?;
+            assert_contains("module_line1", &outcome);
+            assert!(!outcome.contains("module_line2"));
 
-            let actual = nu!(cwd: dirs.test(), "use spam.nu *; help commands foo");
-            assert!(actual.out.contains("def_line1"));
-            assert!(actual.out.contains("def_line2"));
+            let outcome: String = tester.run("help commands foo")?;
+            assert_contains("def_line1", &outcome);
+            assert_contains("def_line2", &outcome);
 
-            let actual = nu!(cwd: dirs.test(),
-            "use spam.nu *; help commands | where name == foo | get 0.description");
-            assert!(actual.out.contains("def_line1"));
-            assert!(!actual.out.contains("def_line2"));
+            let outcome: String =
+                tester.run("help commands | where name == foo | get 0.description")?;
+            assert_contains("def_line1", &outcome);
+            assert!(!outcome.contains("def_line2"));
+            Ok(())
         },
     )
 }
 
 #[test]
-fn help_description_extra_description_alias() {
+fn help_description_extra_description_alias() -> Result {
     Playground::setup(
         "help_description_extra_description_alias",
         |dirs, sandbox| {
@@ -317,72 +330,71 @@ fn help_description_extra_description_alias() {
                 export alias bar = echo 'bar'
             ",
             )]);
+            let mut tester = test().cwd(dirs.test());
+            let () = tester.run("use spam.nu *")?;
 
-            let actual = nu!(cwd: dirs.test(), "use spam.nu *; help modules spam");
-            assert!(actual.out.contains("module_line1"));
-            assert!(actual.out.contains("module_line2"));
+            let outcome: String = tester.run("help modules spam")?;
+            assert_contains("module_line1", &outcome);
+            assert_contains("module_line2", &outcome);
 
-            let actual = nu!(cwd: dirs.test(),
-            "use spam.nu *; help modules | where name == spam | get 0.description");
-            assert!(actual.out.contains("module_line1"));
-            assert!(!actual.out.contains("module_line2"));
+            let outcome: String =
+                tester.run("help modules | where name == spam | get 0.description")?;
+            assert_contains("module_line1", &outcome);
+            assert!(!outcome.contains("module_line2"));
 
-            let actual = nu!(cwd: dirs.test(), "use spam.nu *; help aliases bar");
-            assert!(actual.out.contains("alias_line1"));
-            assert!(actual.out.contains("alias_line2"));
+            let outcome: String = tester.run("help aliases bar")?;
+            assert_contains("alias_line1", &outcome);
+            assert_contains("alias_line2", &outcome);
 
-            let actual = nu!(cwd: dirs.test(),
-            "use spam.nu *; help aliases | where name == bar | get 0.description");
-            assert!(actual.out.contains("alias_line1"));
-            assert!(!actual.out.contains("alias_line2"));
+            let outcome: String =
+                tester.run("help aliases | where name == bar | get 0.description")?;
+            assert_contains("alias_line1", &outcome);
+            assert!(!outcome.contains("alias_line2"));
+            Ok(())
         },
     )
 }
 
 #[test]
-fn help_modules_main_1() {
-    let inp = &[
+fn help_modules_main_1() -> Result {
+    let mut tester = test();
+    let () = tester.run(
         "module spam {
             export def main [] { 'foo' };
         }",
-        "help spam",
-    ];
-
-    let actual = nu!(&inp.join("; "));
-
-    assert!(actual.out.contains("  spam"));
+    )?;
+    let outcome: String = tester.run("help spam")?;
+    assert_contains("  spam", &outcome);
+    Ok(())
 }
 
 #[test]
-fn help_modules_main_2() {
-    let inp = &[
+fn help_modules_main_2() -> Result {
+    let mut tester = test();
+    let () = tester.run(
         "module spam {
             export def main [] { 'foo' };
         }",
-        "help modules | where name == spam | get 0.commands.0.name",
-    ];
-
-    let actual = nu!(&inp.join("; "));
-
-    assert_eq!(actual.out, "spam");
+    )?;
+    tester
+        .run("help modules | where name == spam | get 0.commands.0.name")
+        .expect_value_eq("spam")
 }
 
 #[test]
-fn help_shows_module_qualified_usage() {
-    let inp = &[
-        "module spam { export def prefix [p:string] { $p } }",
-        "use spam",
-        "help spam prefix",
-    ];
-
-    let actual = nu!(&inp.join("; "));
+fn help_shows_module_qualified_usage() -> Result {
+    let mut tester = test();
+    let () = tester.run("module spam { export def prefix [p:string] { $p } }")?;
+    let () = tester.run("use spam")?;
+    let outcome: String = tester.run("help spam prefix")?;
 
     // Usage line should show the module-qualified command name
-    assert!(actual.out.contains("> spam prefix"));
+    assert_contains("> spam prefix", &outcome);
+    Ok(())
 }
 
 #[test]
-fn help_commands_shows_overlay_name_for_module_decls() {
+fn help_commands_shows_overlay_name_for_module_decls() -> Result {
     Playground::setup("help_overlay_name", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -392,33 +404,27 @@ fn help_commands_shows_overlay_name_for_module_decls() {
             ",
         )]);
 
-        let code = &[
-            "use spam.nu",
-            "help commands | where name == \"spam prefix\" | length",
-        ];
-
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(code));
-
-        assert_eq!(actual.out, "1");
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("use spam.nu")?;
+        tester
+            .run(r#"help commands | where name == "spam prefix" | length"#)
+            .expect_value_eq(1)
     })
 }
 
 #[test]
-#[ignore = "run this test only when experimental option native-clip is set"]
-fn clip_command_shows_module_qualified_decls_after_use() {
+#[exp(NATIVE_CLIP)]
+fn clip_command_shows_module_qualified_decls_after_use() -> Result {
     // Ensure running `clip` shows module-qualified subcommands like `clip prefix` after `use std/clip`.
-    let actual = nu_with_std!("use std/clip; clip");
-    assert!(
-        actual.out.contains("clip prefix"),
-        "help for `clip` must include `clip prefix`, got:\n{}",
-        actual.out
-    );
+    let outcome: String = test().run("use std/clip; clip")?;
+    assert_contains("clip prefix", &outcome);
+    Ok(())
 }
 #[test]
-fn nothing_type_annotation() {
-    let actual = nu!("
-    def foo []: nothing -> nothing {};
-    help commands | where name == foo | get input_output.0.output.0
-        ");
-    assert_eq!(actual.out, "nothing");
+fn nothing_type_annotation() -> Result {
+    let mut tester = test();
+    let () = tester.run("def foo []: nothing -> nothing {}")?;
+    tester
+        .run("help commands | where name == foo | get input_output.0.output.0")
+        .expect_value_eq("nothing")
 }

--- a/crates/nu-protocol/tests/into_config.rs
+++ b/crates/nu-protocol/tests/into_config.rs
@@ -1,108 +1,136 @@
-use nu_test_support::{nu, nu_repl_code};
+use nu_protocol::{ConfigError, Record, Type};
+use nu_test_support::prelude::*;
 
-#[test]
-fn config_is_mutable() {
-    let actual = nu!(nu_repl_code(&[
-        "$env.config = { ls: { clickable_links: true } }",
-        "$env.config.ls.clickable_links = false;",
-        "$env.config.ls.clickable_links"
-    ]));
+const DEFAULT_FILES_DIR: &str = "crates/nu-utils/src/default_files";
 
-    assert_eq!(actual.out, "false");
+#[track_caller]
+fn config_error<const N: usize>(err: &ShellError) -> Result<&[ConfigError; N]> {
+    match err {
+        ShellError::InvalidConfig { errors } => match errors.as_slice().try_into() {
+            Ok(errs) => Ok(errs),
+            _ => panic!("expected {N} config error, got {}", errors.len()),
+        },
+        _ => Err(err.clone().into()),
+    }
 }
 
 #[test]
-fn config_preserved_after_do() {
-    let actual = nu!(nu_repl_code(&[
-        "$env.config = { ls: { clickable_links: true } }",
-        "do -i { $env.config.ls.clickable_links = false }",
-        "$env.config.ls.clickable_links"
-    ]));
-
-    assert_eq!(actual.out, "true");
+fn config_is_mutable() -> Result {
+    let mut tester = test();
+    let () = tester.run("$env.config = { ls: { clickable_links: true } }")?;
+    let () = tester.run("$env.config.ls.clickable_links = false")?;
+    tester
+        .run("$env.config.ls.clickable_links")
+        .expect_value_eq(false)
 }
 
 #[test]
-fn config_affected_when_mutated() {
-    let actual = nu!(nu_repl_code(&[
-        "$env.config = { filesize: { unit: binary } }",
-        "$env.config = { filesize: { unit: metric } }",
-        "20MB | into string"
-    ]));
-
-    assert_eq!(actual.out, "20.0 MB");
+fn config_preserved_after_do() -> Result {
+    let mut tester = test();
+    let () = tester.run("$env.config = { ls: { clickable_links: true } }")?;
+    let () = tester.run("do -i { $env.config.ls.clickable_links = false }")?;
+    tester
+        .run("$env.config.ls.clickable_links")
+        .expect_value_eq(true)
 }
 
 #[test]
-fn config_affected_when_deep_mutated() {
-    let actual = nu!(cwd: "crates/nu-utils/src/default_files", nu_repl_code(&[
-        "source default_config.nu",
-        "$env.config.filesize.unit = 'binary'",
-        "20MiB | into string"]));
-
-    assert_eq!(actual.out, "20.0 MiB");
+fn config_affected_when_mutated() -> Result {
+    let mut tester = test();
+    let () = tester.run("$env.config = { filesize: { unit: binary } }")?;
+    let () = tester.run("$env.config = { filesize: { unit: metric } }")?;
+    tester.run("20MB | into string").expect_value_eq("20.0 MB")
 }
 
 #[test]
-fn config_add_unsupported_key() {
-    let actual = nu!(cwd: "crates/nu-utils/src/default_files", nu_repl_code(&[
-        "source default_config.nu",
-        "$env.config.foo = 2",
-        ";"]));
-
-    assert!(
-        actual
-            .err
-            .contains("Unknown config option: $env.config.foo")
-    );
+fn config_affected_when_deep_mutated() -> Result {
+    let mut tester = test().cwd(DEFAULT_FILES_DIR);
+    let () = tester.run("source default_config.nu")?;
+    let () = tester.run("$env.config.filesize.unit = 'binary'")?;
+    tester
+        .run("20MiB | into string")
+        .expect_value_eq("20.0 MiB")
 }
 
 #[test]
-fn config_add_unsupported_type() {
-    let actual = nu!(cwd: "crates/nu-utils/src/default_files", nu_repl_code(&["source default_config.nu",
-        "$env.config.ls = '' ",
-        ";"]));
+fn config_add_unsupported_key() -> Result {
+    let mut tester = test().cwd(DEFAULT_FILES_DIR);
+    let () = tester.run("source default_config.nu")?;
+    let shell_error = tester.run("$env.config.foo = 2").expect_shell_error()?;
+    let [err] = config_error(&shell_error)?;
 
-    assert!(actual.err.contains("Type mismatch"));
+    match err {
+        ConfigError::UnknownOption { path, .. } if path == "$env.config.foo" => Ok(()),
+        _ => Err(shell_error.into()),
+    }
 }
 
 #[test]
-fn config_add_unsupported_value() {
-    let actual = nu!(cwd: "crates/nu-utils/src/default_files", nu_repl_code(&["source default_config.nu",
-        "$env.config.history.file_format = ''",
-        ";"]));
+fn config_add_unsupported_type() -> Result {
+    let mut tester = test().cwd(DEFAULT_FILES_DIR);
+    let () = tester.run("source default_config.nu")?;
+    let shell_error = tester.run("$env.config.ls = '' ").expect_shell_error()?;
+    let [err] = config_error(&shell_error)?;
 
-    assert!(actual.err.contains("Invalid value"));
-    assert!(actual.err.contains("expected 'sqlite' or 'plaintext'"));
+    match err {
+        ConfigError::TypeMismatch {
+            expected: Type::Record(_),
+            actual: Type::String,
+            ..
+        } => Ok(()),
+        _ => Err(shell_error.into()),
+    }
 }
 
 #[test]
-#[ignore = "Figure out how to make test_bins::nu_repl() continue execution after shell errors"]
-fn config_unsupported_key_reverted() {
-    let actual = nu!(cwd: "crates/nu-utils/src/default_files", nu_repl_code(&["source default_config.nu",
-        "$env.config.foo = 1",
-        "'foo' in $env.config"]));
+fn config_add_unsupported_value() -> Result {
+    let mut tester = test().cwd(DEFAULT_FILES_DIR);
+    let () = tester.run("source default_config.nu")?;
+    let shell_error = tester
+        .run("$env.config.history.file_format = ''")
+        .expect_shell_error()?;
+    let [err] = config_error(&shell_error)?;
 
-    assert_eq!(actual.out, "false");
+    match err {
+        ConfigError::InvalidValue { valid, actual, .. } => {
+            #[cfg(feature = "sqlite")]
+            assert_eq!(valid, "'sqlite' or 'plaintext'");
+            #[cfg(not(feature = "sqlite"))]
+            assert_eq!(valid, "'plaintext'");
+
+            assert_eq!(actual, "''");
+            Ok(())
+        }
+        _ => Err(shell_error.into()),
+    }
 }
 
 #[test]
-#[ignore = "Figure out how to make test_bins::nu_repl() continue execution after shell errors"]
-fn config_unsupported_type_reverted() {
-    let actual = nu!(cwd: "crates/nu-utils/src/default_files", nu_repl_code(&[" source default_config.nu",
-        "$env.config.ls = ''",
-        "$env.config.ls | describe"]));
-
-    assert_eq!(actual.out, "record");
+fn config_unsupported_key_reverted() -> Result {
+    let mut tester = test().cwd(DEFAULT_FILES_DIR);
+    let () = tester.run("source default_config.nu")?;
+    let _ = tester.run("$env.config.foo = 1").expect_shell_error()?;
+    tester.run("'foo' in $env.config").expect_value_eq(false)
 }
 
 #[test]
-#[ignore = "Figure out how to make test_bins::nu_repl() continue execution after errors"]
-fn config_unsupported_value_reverted() {
-    let actual = nu!(cwd: "crates/nu-utils/src/default_files", nu_repl_code(&[" source default_config.nu",
-        "$env.config.history.file_format = 'plaintext'",
-        "$env.config.history.file_format = ''",
-        "$env.config.history.file_format | to json"]));
+fn config_unsupported_type_reverted() -> Result {
+    let mut tester = test().cwd(DEFAULT_FILES_DIR);
+    let () = tester.run(" source default_config.nu")?;
+    let _ = tester.run("$env.config.ls = ''").expect_shell_error()?;
+    let _: Record = tester.run("$env.config.ls")?;
+    Ok(())
+}
 
-    assert_eq!(actual.out, "\"plaintext\"");
+#[test]
+fn config_unsupported_value_reverted() -> Result {
+    let mut tester = test().cwd(DEFAULT_FILES_DIR);
+    let () = tester.run(" source default_config.nu")?;
+    let () = tester.run("$env.config.history.file_format = 'plaintext'")?;
+    let _ = tester
+        .run("$env.config.history.file_format = ''")
+        .expect_shell_error()?;
+    tester
+        .run("$env.config.history.file_format")
+        .expect_value_eq("plaintext")
 }

--- a/crates/nu-protocol/tests/test_config.rs
+++ b/crates/nu-protocol/tests/test_config.rs
@@ -1,47 +1,32 @@
-use nu_test_support::{nu, nu_repl_code};
+use nu_protocol::test_record;
+use nu_test_support::{nu, nu_repl_code, prelude::*};
+use rstest::rstest;
 
-#[test]
-fn filesize_mb() {
-    let code = &[
-        "$env.config = { filesize: { unit: MB } }",
-        "20MB | into string",
-    ];
-    let actual = nu!(nu_repl_code(code));
-    assert_eq!(actual.out, "20.0 MB");
+#[rstest]
+#[case::mb("MB")]
+#[case::mib("MiB")]
+fn filesize(#[case] unit: &str) -> Result {
+    let mut tester = test();
+    let () = tester.run_with_data("$env.config.filesize.unit = $in", unit)?;
+    tester
+        .run(format!("20{unit} | into string"))
+        .expect_value_eq(format!("20.0 {unit}"))
+}
+
+#[rstest]
+#[case::metric("metric", "[2MB, 2GB, 2TB]", &["2.0 MB", "2.0 GB", "2.0 TB"])]
+#[case::binary("binary", "[2MiB, 2GiB, 2TiB]", &["2.0 MiB", "2.0 GiB", "2.0 TiB"])]
+fn filesize_format(#[case] unit: &str, #[case] input: &str, #[case] expected: &[&str]) -> Result {
+    let mut tester = test();
+    let () = tester.run_with_data("$env.config.filesize.unit = $in", unit)?;
+    let val: Value = tester.run(input)?;
+    tester
+        .run_with_data("into string", val)
+        .expect_value_eq(expected.to_vec())
 }
 
 #[test]
-fn filesize_mib() {
-    let code = &[
-        "$env.config = { filesize: { unit: MiB } }",
-        "20MiB | into string",
-    ];
-    let actual = nu!(nu_repl_code(code));
-    assert_eq!(actual.out, "20.0 MiB");
-}
-
-#[test]
-fn filesize_format_decimal() {
-    let code = &[
-        "$env.config = { filesize: { unit: metric } }",
-        "[2MB 2GB 2TB] | into string | to nuon",
-    ];
-    let actual = nu!(nu_repl_code(code));
-    assert_eq!(actual.out, r#"["2.0 MB", "2.0 GB", "2.0 TB"]"#);
-}
-
-#[test]
-fn filesize_format_binary() {
-    let code = &[
-        "$env.config = { filesize: { unit: binary } }",
-        "[2MiB 2GiB 2TiB] | into string | to nuon",
-    ];
-    let actual = nu!(nu_repl_code(code));
-    assert_eq!(actual.out, r#"["2.0 MiB", "2.0 GiB", "2.0 TiB"]"#);
-}
-
-#[test]
-fn fancy_default_errors() {
+fn fancy_default_errors() -> Result {
     let code = nu_repl_code(&[
         "$env.config.use_ansi_coloring = true",
         r#"def force_error [x] {
@@ -62,10 +47,12 @@ fn fancy_default_errors() {
         actual.err,
         "Error: \u{1b}[31mnu::shell::error\u{1b}[0m\n\n  \u{1b}[31m×\u{1b}[0m oh no!\n   ╭─[\u{1b}[36;1;4mline2:1:13\u{1b}[0m]\n \u{1b}[2m1\u{1b}[0m │ force_error \"My error\"\n   · \u{1b}[35;1m            ─────┬────\u{1b}[0m\n   ·                  \u{1b}[35;1m╰── \u{1b}[35;1mhere's the error\u{1b}[0m\u{1b}[0m\n   ╰────\n\n"
     );
+
+    Ok(())
 }
 
 #[test]
-fn narratable_errors() {
+fn narratable_errors() -> Result {
     let code = nu_repl_code(&[
         r#"$env.config = { error_style: "plain" }"#,
         r#"def force_error [x] {
@@ -95,14 +82,19 @@ diagnostic code: nu::shell::error
 
 "#,
     );
+
+    Ok(())
 }
 
 #[test]
-fn plugins() {
-    let code = &[
-        "$env.config = { plugins: { nu_plugin_config: { key: value } } }",
-        "$env.config.plugins",
-    ];
-    let actual = nu!(nu_repl_code(code));
-    assert_eq!(actual.out, "{nu_plugin_config: {key: value}}");
+fn plugins() -> Result {
+    let mut tester = test();
+    let () = tester.run("$env.config = { plugins: { nu_plugin_config: { key: value } } }")?;
+    tester
+        .run("$env.config.plugins")
+        .expect_value_eq(test_record! {
+            "nu_plugin_config" => test_record! {
+                "key" => "value"
+            }
+        })
 }

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -1,4 +1,5 @@
-use nu_test_support::nu;
+use nu_protocol::{Type, record};
+use nu_test_support::prelude::*;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 
@@ -16,441 +17,513 @@ const MODULE_SETUP: &str = "
 ";
 
 #[test]
-fn const_bool() {
-    let inp = &["const x = false", "$x"];
+fn const_bool() -> Result {
+    let code = "
+        const x = false
+        $x
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert_eq!(actual.out, "false");
+    test().run(code).expect_value_eq(false)
 }
 
 #[test]
-fn const_int() {
-    let inp = &["const x = 10", "$x"];
+fn const_int() -> Result {
+    let code = "
+        const x = 10
+        $x
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert_eq!(actual.out, "10");
+    test().run(code).expect_value_eq(10)
 }
 
 #[test]
-fn const_float() {
-    let inp = &["const x = 1.234", "$x"];
+fn const_float() -> Result {
+    let code = "
+        const x = 1.234
+        $x
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert_eq!(actual.out, "1.234");
+    test().run(code).expect_value_eq(1.234)
 }
 
 #[test]
-fn const_binary() {
-    let inp = &["const x = 0x[12]", "$x"];
+fn const_binary() -> Result {
+    let code = "
+        const x = 0x[12]
+        $x
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert!(actual.out.contains("12"));
+    test().run(code).expect_value_eq(Value::test_binary([0x12]))
 }
 
 #[test]
-fn const_datetime() {
-    let inp = &["const x = 2021-02-27T13:55:40+00:00", "$x"];
+fn const_datetime() -> Result {
+    let code = "
+        const x = 2021-02-27T13:55:40+00:00
+        $x
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert!(actual.out.contains("Sat, 27 Feb 2021 13:55:40"));
+    let outcome: Value = test().run(code)?;
+    let date = outcome.as_date()?.to_rfc3339();
+    assert_eq!(date, "2021-02-27T13:55:40+00:00");
+    Ok(())
 }
 
 #[test]
-fn const_list() {
-    let inp = &["const x = [ a b c ]", "$x | describe"];
+fn const_list() -> Result {
+    let code = "
+        const x = [ a b c ]
+        $x
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert_eq!(actual.out, "list<string>");
+    test().run(code).expect_value_eq(["a", "b", "c"])
 }
 
 #[test]
-fn const_record() {
-    let inp = &["const x = { a: 10, b: 20, c: 30 }", "$x | describe"];
+fn const_record() -> Result {
+    let code = "
+        const x = { a: 10, b: 20, c: 30 }
+        $x
+    ";
 
-    let actual = nu!(&inp.join("; "));
+    let expected = record! {
+        "a" => Value::test_int(10),
+        "b" => Value::test_int(20),
+        "c" => Value::test_int(30),
+    };
 
-    assert_eq!(actual.out, "record<a: int, b: int, c: int>");
+    test().run(code).expect_value_eq(expected)
 }
 
 #[test]
-fn const_table() {
-    let inp = &[
-        "const x = [[a b c]; [10 20 30] [100 200 300]]",
-        "$x | describe",
-    ];
+fn const_table() -> Result {
+    let code = "
+        const x = [[a b c]; [10 20 30] [100 200 300]]
+        $x | describe
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert_eq!(actual.out, "table<a: int, b: int, c: int>");
+    test()
+        .run(code)
+        .expect_value_eq("table<a: int, b: int, c: int>")
 }
 
 #[test]
-fn const_invalid_table() {
-    let inp = &["const x = [[a b a]; [10 20 30] [100 200 300]]"];
+fn const_invalid_table() -> Result {
+    let code = "
+        const x = [[a b a]; [10 20 30] [100 200 300]]
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert!(actual.err.contains("column_defined_twice"));
+    let err = test().run(code).expect_parse_error()?.to_string();
+    assert_contains("Record field or table column used twice: a", err);
+    Ok(())
 }
 
 #[test]
-fn const_string() {
-    let inp = &[r#"const x = "abc""#, "$x"];
+fn const_string() -> Result {
+    let code = r#"
+        const x = "abc"
+        $x
+    "#;
 
-    let actual = nu!(&inp.join("; "));
-
-    assert_eq!(actual.out, "abc");
+    test().run(code).expect_value_eq("abc")
 }
 
 #[test]
-fn const_string_interpolation_var() {
-    let actual = nu!(r#"const x = 2; const s = $"($x)"; $s"#);
-    assert_eq!(actual.out, "2");
+fn const_string_interpolation_var() -> Result {
+    let code = r#"
+        const x = 2
+        const s = $"($x)"
+        $s
+    "#;
+
+    test().run(code).expect_value_eq("2")
 }
 
 #[test]
-fn const_string_interpolation_date() {
-    let actual = nu!(r#"const s = $"(2021-02-27T13:55:40+00:00)"; $s"#);
-    assert!(actual.out.contains("Sat, 27 Feb 2021 13:55:40 +0000"));
+fn const_string_interpolation_date() -> Result {
+    let code = r#"
+        const s = $"(2021-02-27T13:55:40+00:00)"
+        $s
+    "#;
+
+    let outcome: String = test().locale_en().run(code)?;
+    assert_contains("Sat, 27 Feb 2021 13:55:40 +0000", outcome);
+    Ok(())
 }
 
 #[test]
-fn const_string_interpolation_filesize() {
-    let actual = nu!(r#"const s = $"(2kB)"; $s"#);
-    assert_eq!(actual.out, "2.0 kB");
+fn const_string_interpolation_filesize() -> Result {
+    let code = r#"
+        const s = $"(2kB)"
+        $s
+    "#;
+
+    test().locale_en().run(code).expect_value_eq("2.0 kB")
 }
 
 #[test]
-fn const_nothing() {
-    let inp = &["const x = null", "$x | describe"];
+fn const_nothing() -> Result {
+    let code = "
+      const x = null
+      $x | describe
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert_eq!(actual.out, "nothing");
+    test().run(code).expect_value_eq("nothing")
 }
 
 #[rstest]
-#[case(&["const x = not false", "$x"], "true")]
-#[case(&["const x = false", "const y = not $x", "$y"], "true")]
-#[case(&["const x = not false", "const y = not $x", "$y"], "false")]
-fn const_unary_operator(#[case] inp: &[&str], #[case] expect: &str) {
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, expect);
+#[case("const x = not false; $x", true)]
+#[case("const x = false; const y = not $x; $y", true)]
+#[case("const x = not false; const y = not $x; $y", false)]
+fn const_unary_operator(#[case] code: &str, #[case] expect: bool) -> Result {
+    test().run(code).expect_value_eq(expect)
 }
 
 #[rstest]
-#[case(&["const x = 1 + 2", "$x"], "3")]
-#[case(&["const x = 1 * 2", "$x"], "2")]
-#[case(&["const x = 4 / 2", "$x"], "2.0")]
-#[case(&["const x = 4 mod 3", "$x"], "1")]
-#[case(&["const x = 5.0 / 2.0", "$x"], "2.5")]
-#[case(&[r#"const x = "a" + "b" "#, "$x"], "ab")]
-#[case(&[r#"const x = "a" ++ "b" "#, "$x"], "ab")]
-#[case(&["const x = [1,2] ++ [3]", "$x | describe"], "list<int>")]
-#[case(&["const x = 0x[1,2] ++ 0x[3]", "$x | describe"], "binary")]
-#[case(&["const x = 1 < 2", "$x"], "true")]
-#[case(&["const x = (3 * 200) > (2 * 100)", "$x"], "true")]
-#[case(&["const x = (3 * 200) < (2 * 100)", "$x"], "false")]
-#[case(&["const x = (3 * 200) == (2 * 300)", "$x"], "true")]
-fn const_binary_operator(#[case] inp: &[&str], #[case] expect: &str) {
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, expect);
+#[case("const x = 1 + 2; $x", 3)]
+#[case("const x = 1 * 2; $x", 2)]
+#[case("const x = 4 / 2; $x", 2.0)]
+#[case("const x = 4 mod 3; $x", 1)]
+#[case("const x = 5.0 / 2.0; $x", 2.5)]
+#[case(r#"const x = "a" + "b"; $x"#, "ab")]
+#[case(r#"const x = "a" ++ "b"; $x"#, "ab")]
+#[case("const x = [1,2] ++ [3]; $x", [1_i64, 2, 3])]
+#[case("const x = 0x[1,2] ++ 0x[3]; $x", Value::test_binary([0x12_u8, 0x03]))]
+#[case("const x = 1 < 2; $x", true)]
+#[case("const x = (3 * 200) > (2 * 100); $x", true)]
+#[case("const x = (3 * 200) < (2 * 100); $x", false)]
+#[case("const x = (3 * 200) == (2 * 300); $x", true)]
+fn const_binary_operator(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    test().run(code).expect_value_eq(expect)
 }
 
 #[rstest]
-#[case(&["const x = 1 / 0", "$x"], "division by zero")]
-#[case(&["const x = 10 ** 10000000", "$x"], "pow operation overflowed")]
-#[case(&["const x = 2 ** 62 * 2", "$x"], "multiply operation overflowed")]
-#[case(&["const x = 1 ++ 0", "$x"], "nu::parser::operator_unsupported_type")]
-fn const_operator_error(#[case] inp: &[&str], #[case] expect: &str) {
-    let actual = nu!(&inp.join("; "));
-    assert!(actual.err.contains(expect));
+#[case("const x = 1 / 0; $x", "division by zero")]
+#[case("const x = 10 ** 10000000; $x", "pow operation overflowed")]
+#[case("const x = 2 ** 62 * 2; $x", "multiply operation overflowed")]
+#[case("const x = 1 ++ 0; $x", "operator does not work on values of type")]
+fn const_operator_error(#[case] code: &str, #[case] expect: &str) -> Result {
+    let err = test().run(code).expect_parse_error()?.to_string();
+    assert_contains(expect, err);
+    Ok(())
 }
 
 #[rstest]
-#[case(&["const x = (1..3)", "$x | math sum"], "6")]
-#[case(&["const x = (1..3)", "$x | describe"], "range")]
-fn const_range(#[case] inp: &[&str], #[case] expect: &str) {
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, expect);
+#[case("const x = (1..3); $x | math sum", 6)]
+#[case("const x = (1..3); $x | describe", "range")]
+fn const_range(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    test().run(code).expect_value_eq(expect)
 }
 
 #[test]
-fn const_subexpression_supported() {
-    let inp = &["const x = ('spam')", "$x"];
+fn const_subexpression_supported() -> Result {
+    let code = "
+        const x = ('spam')
+        $x
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert_eq!(actual.out, "spam");
+    test().run(code).expect_value_eq("spam")
 }
 
 #[test]
-fn const_command_supported() {
-    let inp = &["const x = ('spam' | str length)", "$x"];
+fn const_command_supported() -> Result {
+    let code = "
+      const x = ('spam' | str length)
+      $x
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert_eq!(actual.out, "4");
+    test().run(code).expect_value_eq(4)
 }
 
 #[test]
-fn const_command_unsupported() {
-    let inp = &["const x = (loop { break })"];
+fn const_command_unsupported() -> Result {
+    let code = "
+      const x = (loop { break })
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert!(actual.err.contains("not_a_const_command"));
+    let outcome = test().run(code).expect_parse_error()?.to_string();
+    assert_contains("not_a_const_command", outcome);
+    Ok(())
 }
 
 #[test]
-fn const_in_scope() {
-    let inp = &["do { const x = 'x'; $x }"];
+fn const_in_scope() -> Result {
+    let code = "
+      do { const x = 'x'; $x }
+    ";
 
-    let actual = nu!(&inp.join("; "));
-
-    assert_eq!(actual.out, "x");
+    test().run(code).expect_value_eq("x")
 }
 
 #[test]
-fn not_a_const_help() {
-    let actual = nu!("const x = ('abc' | str length -h)");
-    assert!(actual.err.contains("not_a_const_help"));
+fn not_a_const_help() -> Result {
+    let code = "const x = ('abc' | str length -h)";
+
+    let outcome = test().run(code).expect_parse_error()?.to_string();
+    assert_contains("not_a_const_help", outcome);
+    Ok(())
+}
+
+#[rstest]
+#[case("$spam.X", "x")]
+#[case("$spam.eggs.E", "e")]
+#[case("$spam.eggs.bacon.viking", "eats")]
+#[case("'none' in $spam.eggs.bacon", false)]
+fn complex_const_export(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    let mut tester = test();
+
+    let () = tester.run(MODULE_SETUP)?;
+    let () = tester.run("use spam")?;
+    tester.run(code).expect_value_eq(expect)
+}
+
+#[rstest]
+#[case("$X", "x")]
+#[case("$eggs.E", "e")]
+#[case("$eggs.bacon.viking", "eats")]
+#[case("'none' in $eggs.bacon", false)]
+fn complex_const_glob_export(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    let mut tester = test();
+
+    let () = tester.run(MODULE_SETUP)?;
+    let () = tester.run("use spam *")?;
+    tester.run(code).expect_value_eq(expect)
 }
 
 #[test]
-fn complex_const_export() {
-    let inp = &[MODULE_SETUP, "use spam", "$spam.X"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "x");
+fn complex_const_drill_export() -> Result {
+    let mut tester = test();
 
-    let inp = &[MODULE_SETUP, "use spam", "$spam.eggs.E"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "e");
-
-    let inp = &[MODULE_SETUP, "use spam", "$spam.eggs.bacon.viking"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "eats");
-
-    let inp = &[MODULE_SETUP, "use spam", "'none' in $spam.eggs.bacon"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "false");
+    let () = tester.run(MODULE_SETUP)?;
+    let () = tester.run("use spam eggs bacon none")?;
+    let err = tester.run("$none").expect_parse_error()?.to_string();
+    assert_contains("Variable not found", err);
+    Ok(())
 }
 
 #[test]
-fn only_nested_module_have_const() {
-    let setup = "
+fn complex_const_list_export() -> Result {
+    let mut tester = test();
+
+    let () = tester.run(MODULE_SETUP)?;
+    let () = tester.run("use spam [X eggs]")?;
+    tester
+        .run("[$X $eggs.E] | str join ''")
+        .expect_value_eq("xe")
+}
+
+#[test]
+fn exported_const_is_const() -> Result {
+    let code = "
+        module foo {
+            export def main [] { 'foo' }
+        }
         module spam {
-            export module eggs {
-                export module bacon {
-                    export const viking = 'eats'
-                    export module none {}
-                }
-            }
+            export const MOD_NAME = 'foo'
+        }
+
+        use spam
+        use $spam.MOD_NAME
+
+        foo
+    ";
+
+    test().run(code).expect_value_eq("foo")
+}
+
+#[rstest]
+#[case("$env.SPAM", "xy")]
+#[case("spam", "xy")]
+fn const_captures_work(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    let module = "
+        module spam {
+            export const X = 'x'
+            const Y = 'y'
+
+            export-env { $env.SPAM = $X + $Y }
+            export def main [] { $X + $Y }
         }
     ";
-    let inp = &[setup, "use spam", "$spam.eggs.bacon.viking"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "eats");
 
-    let inp = &[setup, "use spam", "'none' in $spam.eggs.bacon"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "false");
+    let mut tester = test();
+
+    let () = tester.run(module)?;
+    let () = tester.run("use spam")?;
+    tester.run(code).expect_value_eq(expect)
 }
 
 #[test]
-fn complex_const_glob_export() {
-    let inp = &[MODULE_SETUP, "use spam *", "$X"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "x");
-
-    let inp = &[MODULE_SETUP, "use spam *", "$eggs.E"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "e");
-
-    let inp = &[MODULE_SETUP, "use spam *", "$eggs.bacon.viking"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "eats");
-
-    let inp = &[MODULE_SETUP, "use spam *", "'none' in $eggs.bacon"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "false");
-}
-
-#[test]
-fn complex_const_drill_export() {
-    let inp = &[MODULE_SETUP, "use spam eggs bacon none", "$none"];
-    let actual = nu!(&inp.join("; "));
-    assert!(actual.err.contains("variable not found"));
-}
-
-#[test]
-fn complex_const_list_export() {
-    let inp = &[
-        MODULE_SETUP,
-        "use spam [X eggs]",
-        "[$X $eggs.E] | str join ''",
-    ];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "xe");
-}
-
-#[test]
-fn exported_const_is_const() {
-    let module1 = "module foo {
-        export def main [] { 'foo' }
-    }";
-
-    let module2 = "module spam {
-        export const MOD_NAME = 'foo'
-    }";
-
-    let inp = &[module1, module2, "use spam", "use $spam.MOD_NAME", "foo"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "foo");
-}
-
-#[test]
-fn const_captures_work() {
-    let module = "module spam {
-        export const X = 'x'
-        const Y = 'y'
-
-        export-env { $env.SPAM = $X + $Y }
-        export def main [] { $X + $Y }
-    }";
-
-    let inp = &[module, "use spam", "$env.SPAM"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "xy");
-
-    let inp = &[module, "use spam", "spam"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "xy");
-}
-
-#[test]
-fn const_captures_in_closures_work() {
-    let module = "module foo {
-        const a = 'world'
-        export def bar [] {
-            'hello ' + $a
+fn const_captures_in_closures_work() -> Result {
+    let code = "
+        module foo {
+            const a = 'world'
+            export def bar [] {
+                'hello ' + $a
+            }
         }
-    }";
-    let inp = &[module, "use foo", "do { foo bar }"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "hello world");
+
+        use foo
+
+        do { foo bar }
+    ";
+
+    test().run(code).expect_value_eq("hello world")
 }
 
-#[test]
-fn complex_const_overlay_use() {
-    let inp = &[MODULE_SETUP, "overlay use spam", "$X"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "x");
+#[rstest]
+#[case("$X", "x")]
+#[case("$eggs.E", "e")]
+#[case("$eggs.bacon.viking", "eats")]
+#[case("($eggs.bacon not-has 'none')", true)]
+fn complex_const_overlay_use(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    let mut tester = test();
 
-    let inp = &[MODULE_SETUP, "overlay use spam", "$eggs.E"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "e");
-
-    let inp = &[MODULE_SETUP, "overlay use spam", "$eggs.bacon.viking"];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "eats");
-
-    let inp = &[
-        MODULE_SETUP,
-        "overlay use spam",
-        "($eggs.bacon not-has 'none')",
-    ];
-    let actual = nu!(&inp.join("; "));
-    assert_eq!(actual.out, "true");
+    let () = tester.run(MODULE_SETUP)?;
+    let () = tester.run("use spam *")?;
+    tester.run(code).expect_value_eq(expect)
 }
 
 #[ignore = "TODO: `overlay hide` should be possible to use after `overlay use` in the same source unit."]
 #[test]
-fn overlay_use_hide_in_single_source_unit() {
+fn overlay_use_hide_in_single_source_unit() -> Result {
     let inp = &[MODULE_SETUP, "overlay use spam", "overlay hide", "$eggs"];
     let actual = nu!(&inp.join("; "));
     assert!(actual.err.contains("nu::parser::variable_not_found"));
+    Ok(())
 }
 
 // const implementations of commands without dedicated tests
 #[test]
-fn describe_const() {
-    let actual = nu!("const x = ('abc' | describe); $x");
-    assert_eq!(actual.out, "string");
+fn describe_const() -> Result {
+    let code = "
+        const x = 'abc' | describe
+        $x
+    ";
+
+    test().run(code).expect_value_eq("string")
 }
 
 #[test]
-fn ignore_const() {
-    let actual = nu!(r#"const x = ("spam" | ignore); $x == null"#);
-    assert_eq!(actual.out, "true");
+fn ignore_const() -> Result {
+    let code = r#"
+        const x = "spam" | ignore
+        $x
+    "#;
+
+    test().run(code).expect_value_eq(())
 }
 
 #[test]
-fn version_const() {
-    let actual = nu!("const x = (version); $x");
-    assert!(actual.err.is_empty());
-}
+fn version_const() -> Result {
+    let code = "
+        const x = version
+        $x
+    ";
 
-#[test]
-fn if_const() {
-    let actual = nu!("const x = (if 2 < 3 { 'yes!' }); $x");
-    assert_eq!(actual.out, "yes!");
-
-    let actual = nu!("const x = (if 5 < 3 { 'yes!' } else { 'no!' }); $x");
-    assert_eq!(actual.out, "no!");
-
-    let actual =
-        nu!("const x = (if 5 < 3 { 'yes!' } else if 4 < 5 { 'no!' } else { 'okay!' }); $x");
-    assert_eq!(actual.out, "no!");
+    let _: Value = test().run(code)?;
+    Ok(())
 }
 
 #[rstest]
-#[case(&"const x = if true ()", "expected block, found nothing")]
-#[case(&"const x = if true {foo: bar}", "expected block, found record")]
-#[case(&"const x = if true {1: 2}", "expected block")]
-fn if_const_error(#[case] inp: &str, #[case] expect: &str) {
-    let actual = nu!(inp);
-    assert!(actual.err.contains(expect));
+#[case("const x = (if 2 < 3 { 'yes!' }); $x", "yes!")]
+#[case("const x = (if 5 < 3 { 'yes!' } else { 'no!' }); $x", "no!")]
+#[case(
+    "const x = (if 5 < 3 { 'yes!' } else if 4 < 5 { 'no!' } else { 'okay!' }); $x",
+    "no!"
+)]
+fn if_const(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    test().run(code).expect_value_eq(expect)
 }
 
 #[test]
-fn const_glob_type() {
-    let actual = nu!("const x: glob = 'aa'; $x | describe");
-    assert_eq!(actual.out, "glob");
+fn if_const_error() -> Result {
+    let err = test().run("const x = if true ()").expect_parse_error()?;
+    assert!(matches!(
+        err,
+        ParseError::TypeMismatch(Type::Block, Type::Nothing, _)
+            | ParseError::TypeMismatchHelp(Type::Block, Type::Nothing, _, _)
+    ));
+
+    let err = test()
+        .run("const x = if true {foo: bar}")
+        .expect_parse_error()?;
+    assert!(matches!(
+        err,
+        ParseError::TypeMismatch(Type::Block, Type::Record(_), _)
+            | ParseError::TypeMismatchHelp(Type::Block, Type::Record(_), _, _)
+    ));
+
+    let err = test()
+        .run("const x = if true {1: 2}")
+        .expect_parse_error()?;
+    assert!(matches!(
+        err,
+        ParseError::TypeMismatch(Type::Block, Type::Record(_), _)
+            | ParseError::TypeMismatchHelp(Type::Block, Type::Record(_), _, _)
+    ));
+
+    Ok(())
 }
 
 #[test]
-fn const_raw_string() {
-    let actual = nu!(r#"const x = r#'abcde""fghi"''''jkl'#; $x"#);
-    assert_eq!(actual.out, r#"abcde""fghi"''''jkl"#);
+fn const_glob_type() -> Result {
+    let code = "
+        const x: glob = 'aa'
+        $x | describe
+    ";
 
-    let actual = nu!(r#"const x = r##'abcde""fghi"''''#jkl'##; $x"#);
-    assert_eq!(actual.out, r#"abcde""fghi"''''#jkl"#);
+    test().run(code).expect_value_eq("glob")
+}
 
-    let actual = nu!(r#"const x = r###'abcde""fghi"'''##'#jkl'###; $x"#);
-    assert_eq!(actual.out, r#"abcde""fghi"'''##'#jkl"#);
-
-    let actual = nu!("const x = r#'abc'#; $x");
-    assert_eq!(actual.out, "abc");
+#[rstest]
+#[case(
+    r####"const x = r#'abcde""fghi"''''jkl'#; $x"####,
+    r####"abcde""fghi"''''jkl"####
+)]
+#[case(
+    r####"const x = r##'abcde""fghi"''''#jkl'##; $x"####,
+    r####"abcde""fghi"''''#jkl"####
+)]
+#[case(
+    r####"const x = r###'abcde""fghi"'''##'#jkl'###; $x"####,
+    r####"abcde""fghi"'''##'#jkl"####
+)]
+#[case("const x = r#'abc'#; $x", "abc")]
+fn const_raw_string(#[case] code: &str, #[case] expect: &str) -> Result {
+    test().run(code).expect_value_eq(expect)
 }
 
 #[test]
-fn const_takes_pipeline() {
-    let actual = nu!("const list = 'bar_baz_quux' | split row '_'; $list | length");
-    assert_eq!(actual.out, "3");
+fn const_takes_pipeline() -> Result {
+    let code = "
+        const list = 'bar_baz_quux' | split row '_'
+        $list | length
+    ";
+
+    test().run(code).expect_value_eq(3)
 }
 
 #[test]
-fn const_const() {
-    let actual = nu!(r#"const y = (const x = "foo"; $x + $x); $y"#);
-    assert_eq!(actual.out, "foofoo");
+fn const_const() -> Result {
+    let code = r#"
+        const y = (
+            const x = "foo";
+            $x + $x
+        )
+        $y
+    "#;
 
-    let actual = nu!(r#"const y = (const x = "foo"; $x + $x); $x"#);
-    assert!(actual.err.contains("nu::parser::variable_not_found"));
+    test().run(code).expect_value_eq("foofoo")?;
+
+    let code = r#"
+        const y = (
+            const x = "foo";
+            $x + $x
+        )
+        $x
+    "#;
+    let err = test().run(code).expect_parse_error()?;
+    assert!(matches!(err, ParseError::VariableNotFound(..)));
+
+    Ok(())
 }


### PR DESCRIPTION
## Description
- Moved from `nu!(...)` to `test().run(...)`
- Parameterize tests with `rstest` where applicable
- Enable some ignored tests that didn't work with the older style.

## User-facing changes (Release notes)
N/A