### PR TITLE
refactor: Prefer borrowed strings

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -51,7 +51,7 @@ pub fn evaluate_file(
     let file = std::fs::read(&file_path).map_err(|err| {
         let cmdline = format!("nu {path} {}", args.join(" "));
         let mut working_set = StateWorkingSet::new(engine_state);
-        let file_id = working_set.add_file("<commandline>".into(), cmdline.as_bytes());
+        let file_id = working_set.add_file("<commandline>", cmdline.as_bytes());
         let span = working_set
             .get_span_for_file(file_id)
             .subspan(3, path.len() + 3)

--- a/crates/nu-cmd-lang/src/parse_const_test.rs
+++ b/crates/nu-cmd-lang/src/parse_const_test.rs
@@ -9,7 +9,7 @@ fn quickcheck_parse(data: String) -> bool {
         let context = crate::create_default_context();
         {
             let mut working_set = StateWorkingSet::new(&context);
-            let _ = working_set.add_file("quickcheck".into(), data.as_bytes());
+            let _ = working_set.add_file("quickcheck", data.as_bytes());
 
             let _ =
                 nu_parser::parse_block(&mut working_set, &tokens, Span::new(0, 0), false, false);

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -623,7 +623,7 @@ fn stream_to_file(
 
         let res = loop {
             if let Err(err) = signals.check(&span) {
-                bar.abandoned_msg("# Cancelled #".to_owned());
+                bar.abandoned_msg("# Cancelled #");
                 return Err(err);
             }
 
@@ -647,7 +647,7 @@ fn stream_to_file(
         // If the process failed, stop the progress bar with an error message.
         if let Err(err) = res {
             let _ = file.flush();
-            bar.abandoned_msg("# Error while saving #".to_owned());
+            bar.abandoned_msg("# Error while saving #");
             Err(from_io_error(err).into())
         } else {
             file.flush().map_err(&from_io_error)?;

--- a/crates/nu-command/src/progress_bar.rs
+++ b/crates/nu-command/src/progress_bar.rs
@@ -1,5 +1,5 @@
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 // This module includes the progress bar used to show the progress when using the command `save`
 // Eventually it would be nice to find a better place for it.
@@ -47,7 +47,7 @@ impl NuProgressBar {
         self.pb.set_position(bytes_processed);
     }
 
-    pub fn abandoned_msg(&self, msg: String) {
+    pub fn abandoned_msg(&self, msg: impl Into<Cow<'static, str>>) {
         self.pb.abandon_with_message(msg);
     }
 }

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -181,7 +181,7 @@ fn parse_module(
 ) -> Result<PipelineData, ShellError> {
     let filename = filename.unwrap_or_else(|| "empty".to_string());
 
-    let file_id = working_set.add_file(filename.clone(), contents);
+    let file_id = working_set.add_file(&filename, contents);
     let new_span = working_set.get_span_for_file(file_id);
 
     let starting_error_count = working_set.parse_errors.len();

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2119,7 +2119,7 @@ fn parse_module_file(
         return None;
     };
 
-    let file_id = working_set.add_file(path.path().to_string_lossy().to_string(), &contents);
+    let file_id = working_set.add_file(&path.path().to_string_lossy(), &contents);
     let new_span = working_set.get_span_for_file(file_id);
 
     // Check if we've parsed the module before.

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -7503,17 +7503,14 @@ pub fn parse(
     scoped: bool,
 ) -> Arc<Block> {
     trace!("parse");
-    let name = match fname {
-        Some(fname) => {
-            // use the canonical name for this filename
-            nu_path::expand_to_real_path(fname)
-                .to_string_lossy()
-                .to_string()
-        }
-        None => "source".to_string(),
+
+    let file_id = {
+        let fname = fname.map(nu_path::expand_to_real_path);
+        let fname = fname.as_deref().map(|p| p.to_string_lossy());
+        let name = fname.as_deref().unwrap_or("source");
+        working_set.add_file(name, contents)
     };
 
-    let file_id = working_set.add_file(name, contents);
     let new_span = working_set.get_span_for_file(file_id);
 
     let previously_parsed_block = working_set.find_block_by_span(new_span);

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1140,7 +1140,7 @@ mod engine_state_tests {
     fn add_file_gives_id() {
         let engine_state = EngineState::new();
         let mut engine_state = StateWorkingSet::new(&engine_state);
-        let id = engine_state.add_file("test.nu".into(), &[]);
+        let id = engine_state.add_file("test.nu", &[]);
 
         assert_eq!(id, FileId::new(0));
     }
@@ -1151,7 +1151,7 @@ mod engine_state_tests {
         let parent_id = engine_state.add_file("test.nu".into(), Arc::new([]));
 
         let mut working_set = StateWorkingSet::new(&engine_state);
-        let working_set_id = working_set.add_file("child.nu".into(), &[]);
+        let working_set_id = working_set.add_file("child.nu", &[]);
 
         assert_eq!(parent_id, FileId::new(0));
         assert_eq!(working_set_id, FileId::new(1));
@@ -1164,7 +1164,7 @@ mod engine_state_tests {
 
         let delta = {
             let mut working_set = StateWorkingSet::new(&engine_state);
-            let _ = working_set.add_file("child.nu".into(), &[]);
+            let _ = working_set.add_file("child.nu", &[]);
             working_set.render()
         };
 

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -336,10 +336,10 @@ impl<'a> StateWorkingSet<'a> {
     }
 
     #[must_use]
-    pub fn add_file(&mut self, filename: String, contents: &[u8]) -> FileId {
+    pub fn add_file(&mut self, filename: &str, contents: &[u8]) -> FileId {
         // First, look for the file to see if we already have it
         for (idx, cached_file) in self.files().enumerate() {
-            if *cached_file.name == filename && &*cached_file.content == contents {
+            if &*cached_file.name == filename && &*cached_file.content == contents {
                 return FileId::new(idx);
             }
         }

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 
 fn create_virt_file(working_set: &mut StateWorkingSet, name: &str, content: &str) -> VirtualPathId {
     let sanitized_name = PathBuf::from(name).to_string_lossy().to_string();
-    let file_id = working_set.add_file(sanitized_name.clone(), content.as_bytes());
+    let file_id = working_set.add_file(&sanitized_name, content.as_bytes());
 
     working_set.add_virtual_path(sanitized_name, VirtualPath::File(file_id))
 }

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -24,7 +24,7 @@ fn find_id(
     file: &[u8],
     location: &Value,
 ) -> Option<(Id, usize, Span)> {
-    let file_id = working_set.add_file(file_path.to_string(), file);
+    let file_id = working_set.add_file(file_path, file);
     let file_span = working_set.get_span_for_file(file_id);
     let offset = file_span.start;
     let _ = working_set.files.push(file_path.into(), file_span);


### PR DESCRIPTION
## Description
Remove unnecessary allocations by replacing owned `String`s with borrowed ones.

## User-facing changes (Release notes)
N/A