### PR TITLE
Fix module description parsing with leading shebang

### DIFF
--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -228,7 +228,7 @@ export def foo [] {}
 }
 
 #[test]
-fn help_module_name() {
+fn help_module_name() -> Result {
     Playground::setup("help_module_name", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu, nu_repl_code, nu_with_std};
+use nu_test_support::prelude::*;
+use nu_test_support::{nu_repl_code, nu_with_std};
 
 // Note: These tests might slightly overlap with tests/scope/mod.rs
 
@@ -194,6 +195,33 @@ fn help_module_description_1() {
         assert!(actual.out.contains("line2"));
         assert!(actual.out.contains("line3"));
     })
+}
+
+#[test]
+fn help_module_description_ignores_leading_shebang() -> Result {
+    Playground::setup(
+        "help_module_description_ignores_leading_shebang",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContent(
+                "spam.nu",
+                "\
+#!/usr/bin/env nu
+
+# module_line1
+#
+# module_line2
+
+export def foo [] {}
+",
+            )]);
+
+            let mut tester = test().cwd(dirs.test());
+            let description: String = tester
+                .run("use spam.nu *; help modules | where name == spam | get 0.description")?;
+            assert_eq!(description, "module_line1");
+            Ok(())
+        },
+    )
 }
 
 #[test]

--- a/crates/nu-mcp/src/evaluation.rs
+++ b/crates/nu-mcp/src/evaluation.rs
@@ -774,14 +774,18 @@ mod tests {
     use nu_engine::eval_expression;
     use nu_protocol::{
         ShellError, Signature, SyntaxShape, Value,
-        engine::{Call, Command as NuCommand, StateWorkingSet},
+        engine::{Call, Command as NuCommand},
         shell_error::io::IoError,
     };
+    #[cfg(unix)]
+    use nu_protocol::engine::StateWorkingSet;
     use std::process::{Command as ProcessCommand, Stdio};
 
+    #[cfg(unix)]
     #[derive(Clone)]
     struct TestRunExternal;
 
+    #[cfg(unix)]
     impl NuCommand for TestRunExternal {
         fn name(&self) -> &str {
             "run-external"

--- a/crates/nu-mcp/src/evaluation.rs
+++ b/crates/nu-mcp/src/evaluation.rs
@@ -771,7 +771,9 @@ fn process_pipeline(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use nu_engine::eval_expression;
+    #[cfg(unix)]
     use nu_protocol::{
         ShellError, Signature, SyntaxShape, Value,
         engine::{Call, Command as NuCommand},
@@ -779,6 +781,7 @@ mod tests {
     };
     #[cfg(unix)]
     use nu_protocol::engine::StateWorkingSet;
+    #[cfg(unix)]
     use std::process::{Command as ProcessCommand, Stdio};
 
     #[cfg(unix)]

--- a/crates/nu-mcp/src/evaluation.rs
+++ b/crates/nu-mcp/src/evaluation.rs
@@ -774,13 +774,13 @@ mod tests {
     #[cfg(unix)]
     use nu_engine::eval_expression;
     #[cfg(unix)]
+    use nu_protocol::engine::StateWorkingSet;
+    #[cfg(unix)]
     use nu_protocol::{
         ShellError, Signature, SyntaxShape, Value,
         engine::{Call, Command as NuCommand},
         shell_error::io::IoError,
     };
-    #[cfg(unix)]
-    use nu_protocol::engine::StateWorkingSet;
     #[cfg(unix)]
     use std::process::{Command as ProcessCommand, Stdio};
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1819,13 +1819,19 @@ pub fn parse_export_env(
     (pipeline, Some(block_id))
 }
 
-fn collect_first_comments(tokens: &[Token]) -> Vec<Span> {
+fn collect_first_comments(working_set: &StateWorkingSet, tokens: &[Token]) -> Vec<Span> {
     let mut comments = vec![];
 
     let mut tokens_iter = tokens.iter().peekable();
     while let Some(token) = tokens_iter.next() {
         match token.contents {
             TokenContents::Comment => {
+                let comment = working_set.get_span_contents(token.span);
+
+                if comments.is_empty() && comment.starts_with(b"#!") {
+                    continue;
+                }
+
                 comments.push(token.span);
             }
             TokenContents::Eol => {
@@ -1862,7 +1868,7 @@ pub fn parse_module_block(
         working_set.error(err)
     }
 
-    let module_comments = collect_first_comments(&output);
+    let module_comments = collect_first_comments(working_set, &output);
 
     let (output, err) = lite_parse(&output, working_set);
     if let Some(err) = err {

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -1,6 +1,6 @@
 use nu_test_support::fs::Stub::FileWithContent;
-use nu_test_support::nu;
 use nu_test_support::playground::Playground;
+use nu_test_support::prelude::*;
 use pretty_assertions::assert_eq;
 
 // Note: These tests might slightly overlap with crates/nu-command/tests/commands/help.rs
@@ -184,7 +184,7 @@ fn correct_scope_modules_fields() {
 }
 
 #[test]
-fn scope_modules_ignores_leading_shebang_in_module_description() {
+fn scope_modules_ignores_leading_shebang_in_module_description() -> Result {
     Playground::setup(
         "scope_modules_ignores_leading_shebang_in_module_description",
         |dirs, sandbox| {
@@ -201,12 +201,11 @@ export def foo [] {}
 ",
             )]);
 
-            let inp = &[
-                "use spam.nu *",
-                "scope modules | where name == spam | get 0.description",
-            ];
-            let actual = nu!(cwd: dirs.test(), &inp.join("; "));
-            assert_eq!(actual.out, "module_line1");
+            let mut tester = test().cwd(dirs.test());
+            let description: String = tester
+                .run("use spam.nu *; scope modules | where name == spam | get 0.description")?;
+            assert_eq!(description, "module_line1");
+            Ok(())
         },
     )
 }

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -184,6 +184,34 @@ fn correct_scope_modules_fields() {
 }
 
 #[test]
+fn scope_modules_ignores_leading_shebang_in_module_description() {
+    Playground::setup(
+        "scope_modules_ignores_leading_shebang_in_module_description",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContent(
+                "spam.nu",
+                "\
+#!/usr/bin/env nu
+
+# module_line1
+#
+# module_line2
+
+export def foo [] {}
+",
+            )]);
+
+            let inp = &[
+                "use spam.nu *",
+                "scope modules | where name == spam | get 0.description",
+            ];
+            let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+            assert_eq!(actual.out, "module_line1");
+        },
+    )
+}
+
+#[test]
 fn correct_scope_aliases_fields() {
     let module_setup = "
         # nice alias


### PR DESCRIPTION
## Description

Fixes module description extraction so a leading shebang is not treated as part of the module docs.

Previously, if a module started with a shebang like `#!/usr/bin/env nu`, that line was collected with the initial comments used to build the module description. As a result, commands like `scope modules` could pick up the shebang instead of the actual doc comments at the top of the file. This change updates the module parser logic to ignore a leading shebang when collecting the first comment block for a module description, while preserving the existing handling for real documentation comments.

## User-facing changes (Release notes)

### Ignore Shebangs When Parsing Module Comments
- Shebangs are now ignored when extracting the `description` for a module. This affects the output in commands like `help <module name>` and `scope modules`.

## Additional notes

Fixes #18104

AI disclosure: I used Codex to identify the affected location and write the code to fix the issue. I reviewed the code before submitting the PR.