### PR TITLE
(#17448) Update label and help text on CantFindCol error

### DIFF
--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -191,7 +191,7 @@ fn quoted_column_access() {
 fn get_does_not_delve_too_deep_in_nested_lists() {
     let actual = nu!("[[{foo: bar}]] | get foo");
 
-    assert!(actual.err.contains("cannot find column"));
+    assert!(actual.err.contains("column 'foo' is missing"));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -51,7 +51,7 @@ fn errors_if_given_unknown_column_name() {
             | group-by {{|| get nu.releases.missing_column }}
         "
     ));
-    assert!(actual.err.contains("cannot find column"));
+    assert!(actual.err.contains("column 'missing_column' is missing"));
 }
 
 #[test]

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -606,10 +606,13 @@ pub enum ShellError {
     ///
     /// Check the spelling of your column name. Did you forget to rename a column somewhere?
     #[error("Cannot find column '{col_name}'")]
-    #[diagnostic(code(nu::shell::column_not_found))]
+    #[diagnostic(
+        code(nu::shell::column_not_found),
+        help = "If some rows have this column, try using '{col_name}?' for optional access, or pre-fill using the `default` command"
+    )]
     CantFindColumn {
         col_name: String,
-        #[label = "cannot find column '{col_name}'"]
+        #[label = "column '{col_name}' is missing in one or more values"]
         span: Option<Span>,
         #[label = "value originates here"]
         src_span: Span,

--- a/tests/repl/test_cell_path.rs
+++ b/tests/repl/test_cell_path.rs
@@ -110,8 +110,8 @@ fn list_single_field_failure() -> TestResult {
 // Test the scenario where the requested column is not present in all rows
 #[test]
 fn jagged_list_access_fails() -> TestResult {
-    fail_test("[{foo: 'bar'}, {}].foo", "cannot find column")?;
-    fail_test("[{}, {foo: 'bar'}].foo", "cannot find column")
+    fail_test("[{foo: 'bar'}, {}].foo", "column 'foo' is missing")?;
+    fail_test("[{}, {foo: 'bar'}].foo", "column 'foo' is missing")
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn list_row_optional_access_succeeds() -> TestResult {
 // regression test for an old bug
 #[test]
 fn do_not_delve_too_deep_in_nested_lists() -> TestResult {
-    fail_test("[[{foo: bar}]].foo", "cannot find column")
+    fail_test("[[{foo: bar}]].foo", "column 'foo' is missing")
 }
 
 #[test]

--- a/tests/repl/test_modules.rs
+++ b/tests/repl/test_modules.rs
@@ -173,7 +173,7 @@ fn use_module_with_invalid_var_name(#[case] name: &str) -> TestResult {
 fn cannot_export_private_const() -> TestResult {
     fail_test(
         "module spam { const b = 3; export const c = 4 }; use spam; $spam.b + $spam.c",
-        "cannot find column 'b'",
+        "column 'b' is missing in one or more values",
     )
 }
 

--- a/tests/repl/test_table_operations.rs
+++ b/tests/repl/test_table_operations.rs
@@ -177,7 +177,7 @@ fn update_cell_path_1() -> TestResult {
 fn missing_column_errors() -> TestResult {
     fail_test(
         "[ { name: ABC, size: 20 }, { name: HIJ } ].size.1 == null",
-        "cannot find column",
+        "column 'size' is missing in one or more values",
     )
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

This PR addresses [issue #17448](https://github.com/nushell/nushell/issues/17448). It improves the `CantFindColumn` error by being more precise about missing data and suggesting workarounds with optional access and the `default` command.

Please review the language, it may be too verbose or too specific to table-style access.

Example:
```
$ [{b: 2}, {a: 0, b: 1}] | select a
Error: nu::shell::column_not_found

  × Cannot find column 'a'
   ╭─[source:1:2]
 1 │ [{b: 2}, {b: 3}, {a: 0, b: 1}] | select a
   ·  ───┬──                                 ┬
   ·     │                                   ╰── column 'a' is missing in one or more values
   ·     ╰── value originates here
   ╰────
  help: If some rows have this column, try using 'a?' for optional access, or pre-fill using
        the `default` command
```

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
- Improved language for the "Cannot find column ..." shell error to be more precise about missing data and suggest user actions to fix.