### PR TITLE
fix(`parser`): parse default values of type glob correcly

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4723,31 +4723,11 @@ pub fn parse_signature_helper(
                                         flag.arg.clone().unwrap_or(SyntaxShape::Any)
                                     }
                                 };
-                                let mut expression = parse_value(working_set, span, &SyntaxShape::Any);
-
-                                let var_id = match last {
-                                    Arg::Positional { arg, .. } => arg.var_id,
-                                    Arg::RestPositional(arg) => arg.var_id,
-                                    Arg::Flag { flag, .. } => flag.var_id,
+                                let expression = if shape == SyntaxShape::GlobPattern {
+                                    parse_value(working_set, span, &SyntaxShape::GlobPattern)
+                                } else {
+                                    parse_value(working_set, span, &SyntaxShape::Any)
                                 };
-
-                                let mut type_is_compatible = true;
-                                if let Some(var_id) = var_id {
-                                    let var_type = &working_set.get_variable(var_id).ty;
-                                    if !matches!(var_type, Type::Any) && !type_compatible(var_type, &expression.ty) {
-                                        type_is_compatible = false;
-                                    }
-                                }
-
-                                if type_is_compatible {
-                                    let error_count_before_reparse = working_set.parse_errors.len();
-                                    let coerced_expression = parse_value(working_set, span, &shape);
-                                    if working_set.parse_errors.len() == error_count_before_reparse {
-                                        expression = coerced_expression;
-                                    } else {
-                                        working_set.parse_errors.truncate(error_count_before_reparse);
-                                    }
-                                }
 
                                 //TODO check if we're replacing a custom parameter already
                                 match last {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4716,7 +4716,38 @@ pub fn parse_signature_helper(
                         }
                         ParseMode::DefaultValue => {
                             if !is_external && let Some(last) = args.last_mut() {
-                                let expression = parse_value(working_set, span, &SyntaxShape::Any);
+                                let shape = match last {
+                                    Arg::Positional { arg, .. } => arg.shape.clone(),
+                                    Arg::RestPositional(arg) => arg.shape.clone(),
+                                    Arg::Flag { flag, .. } => {
+                                        flag.arg.clone().unwrap_or(SyntaxShape::Any)
+                                    }
+                                };
+                                let mut expression = parse_value(working_set, span, &SyntaxShape::Any);
+
+                                let var_id = match last {
+                                    Arg::Positional { arg, .. } => arg.var_id,
+                                    Arg::RestPositional(arg) => arg.var_id,
+                                    Arg::Flag { flag, .. } => flag.var_id,
+                                };
+
+                                let mut type_is_compatible = true;
+                                if let Some(var_id) = var_id {
+                                    let var_type = &working_set.get_variable(var_id).ty;
+                                    if !matches!(var_type, Type::Any) && !type_compatible(var_type, &expression.ty) {
+                                        type_is_compatible = false;
+                                    }
+                                }
+
+                                if type_is_compatible {
+                                    let error_count_before_reparse = working_set.parse_errors.len();
+                                    let coerced_expression = parse_value(working_set, span, &shape);
+                                    if working_set.parse_errors.len() == error_count_before_reparse {
+                                        expression = coerced_expression;
+                                    } else {
+                                        working_set.parse_errors.truncate(error_count_before_reparse);
+                                    }
+                                }
 
                                 //TODO check if we're replacing a custom parameter already
                                 match last {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4723,11 +4723,8 @@ pub fn parse_signature_helper(
                                         flag.arg.clone().unwrap_or(SyntaxShape::Any)
                                     }
                                 };
-                                let expression = if shape == SyntaxShape::GlobPattern {
-                                    parse_value(working_set, span, &SyntaxShape::GlobPattern)
-                                } else {
-                                    parse_value(working_set, span, &SyntaxShape::Any)
-                                };
+
+                                let expression = parse_value(working_set, span, &shape);
 
                                 //TODO check if we're replacing a custom parameter already
                                 match last {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4741,7 +4741,7 @@ pub fn parse_signature_helper(
                                     } => {
                                         let var_id = var_id.expect("internal error: all custom parameters must have var_ids");
                                         let var_type = &working_set.get_variable(var_id).ty;
-                                        if matches!(var_type, Type::Any) && !*type_annotated {
+                                        if var_type == &Type::Any && !*type_annotated {
                                             working_set
                                                 .set_variable_type(var_id, expression.ty.clone());
                                         }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4741,28 +4741,9 @@ pub fn parse_signature_helper(
                                     } => {
                                         let var_id = var_id.expect("internal error: all custom parameters must have var_ids");
                                         let var_type = &working_set.get_variable(var_id).ty;
-                                        match var_type {
-                                            Type::Any => {
-                                                if !*type_annotated {
-                                                    working_set.set_variable_type(
-                                                        var_id,
-                                                        expression.ty.clone(),
-                                                    );
-                                                }
-                                            }
-                                            _ => {
-                                                if !type_compatible(var_type, &expression.ty) {
-                                                    working_set.error(
-                                                        ParseError::AssignmentMismatch(
-                                                            "Default value wrong type".into(),
-                                                            format!(
-                                                            "expected default value to be `{var_type}`"
-                                                        ),
-                                                            expression.span,
-                                                        ),
-                                                    )
-                                                }
-                                            }
+                                        if matches!(var_type, Type::Any) && !*type_annotated {
+                                            working_set
+                                                .set_variable_type(var_id, expression.ty.clone());
                                         }
 
                                         *default_value = if let Ok(constant) =
@@ -4812,7 +4793,6 @@ pub fn parse_signature_helper(
                                         };
 
                                         let var_id = var_id.expect("internal error: all custom parameters must have var_ids");
-                                        let var_type = &working_set.get_variable(var_id).ty;
                                         let expression_ty = expression.ty.clone();
 
                                         // Flags without type annotations are present/not-present
@@ -4822,14 +4802,6 @@ pub fn parse_signature_helper(
                                         if !*type_annotated {
                                             *arg = Some(expression_ty.to_shape());
                                             working_set.set_variable_type(var_id, expression_ty);
-                                        } else if !type_compatible(var_type, &expression_ty) {
-                                            working_set.error(ParseError::AssignmentMismatch(
-                                                "Default value is the wrong type".into(),
-                                                format!(
-                                                    "expected default value to be `{var_type}`"
-                                                ),
-                                                expression_span,
-                                            ))
                                         }
                                     }
                                 }

--- a/tests/repl/test_engine.rs
+++ b/tests/repl/test_engine.rs
@@ -408,10 +408,7 @@ fn default_value12() -> TestResult {
 
 #[test]
 fn default_value_glob() -> TestResult {
-    run_test(
-        r#"def foo [--x:glob = *.nu] { $x | describe }; foo"#,
-        "glob",
-    )
+    run_test("def foo [--x:glob = *.nu] { $x | describe }; foo", "glob")
 }
 
 #[test]

--- a/tests/repl/test_engine.rs
+++ b/tests/repl/test_engine.rs
@@ -407,6 +407,14 @@ fn default_value12() -> TestResult {
 }
 
 #[test]
+fn default_value_glob() -> TestResult {
+    run_test(
+        r#"def foo [--x:glob = **/*.nu] { $x | describe }; foo"#,
+        "glob",
+    )
+}
+
+#[test]
 fn default_value_constant1() -> TestResult {
     run_test(r#"def foo [x = "foo"] { $x }; foo"#, "foo")
 }

--- a/tests/repl/test_engine.rs
+++ b/tests/repl/test_engine.rs
@@ -409,7 +409,7 @@ fn default_value12() -> TestResult {
 #[test]
 fn default_value_glob() -> TestResult {
     run_test(
-        r#"def foo [--x:glob = **/*.nu] { $x | describe }; foo"#,
+        r#"def foo [--x:glob = *.nu] { $x | describe }; foo"#,
         "glob",
     )
 }

--- a/tests/repl/test_engine.rs
+++ b/tests/repl/test_engine.rs
@@ -400,10 +400,7 @@ fn default_value11() -> TestResult {
 
 #[test]
 fn default_value12() -> TestResult {
-    fail_test(
-        r#"def foo [--x:int = "a"] { $x }"#,
-        "expected default value to be `int`",
-    )
+    fail_test(r#"def foo [--x:int = "a"] { $x }"#, "expected int")
 }
 
 #[test]

--- a/tests/repl/test_signatures.rs
+++ b/tests/repl/test_signatures.rs
@@ -123,8 +123,8 @@ fn list_annotations_with_default_val_1() -> TestResult {
 #[test]
 fn list_annotations_with_default_val_2() -> TestResult {
     let input = "def run [list: list<string> = [2 5 4]] {$list | length}; run";
-    let expected = "Default value wrong type";
-    fail_test(input, expected)
+    let expected = "3";
+    run_test(input, expected)
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
I discovered that even when using `: glob` in a command argument, the default value was being passed as a string, not expanded by `ls` and causing an error.

## User-facing changes (Release notes)
### Annotated default values typed as `glob` are now properly handled 
Default values in commands will now be correctly parsed as `glob` type instead of `string` when annotated.
- Before
```nushell
def foo [--x: glob = *.x] {
	$x | describe
}
→ foo
# string
```
- After
```nushell
def foo [--x: glob = *.x] {
	$x | describe
}
→ foo
# glob
```

## Additional notes
- [x] Added test