### PR TITLE
Fixed `Rename` events in `watch`

### DIFF
--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -1,3 +1,10 @@
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+    sync::mpsc::{Receiver, RecvTimeoutError, channel},
+    time::Duration,
+};
+
 use itertools::{Either, Itertools};
 use notify_debouncer_full::{
     DebouncedEvent, Debouncer, FileIdMap, new_debouncer,
@@ -6,17 +13,11 @@ use notify_debouncer_full::{
         event::{DataChange, ModifyKind, RenameMode},
     },
 };
+
 use nu_engine::{ClosureEval, command_prelude::*};
 use nu_protocol::{
     Signals, engine::Closure, report_shell_error, shell_error::generic::GenericError,
     shell_error::io::IoError,
-};
-
-use std::{
-    borrow::Cow,
-    path::{Path, PathBuf},
-    sync::mpsc::{Receiver, RecvTimeoutError, channel},
-    time::Duration,
 };
 
 // durations chosen mostly arbitrarily

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -262,9 +262,36 @@ impl Command for Watch {
 
 #[derive(IntoValue)]
 struct WatchEvent {
-    operation: &'static str,
+    operation: WatchEventKind,
     path: Option<PathBuf>,
     new_path: Option<PathBuf>,
+}
+
+#[derive(IntoValue)]
+#[nu_value(rename_all = "UpperCamelCase")]
+enum WatchEventKind {
+    Create,
+    Write,
+    Rename,
+    Remove,
+}
+
+impl TryFrom<EventKind> for WatchEventKind {
+    type Error = ();
+
+    fn try_from(value: EventKind) -> Result<Self, Self::Error> {
+        Ok(match value {
+            EventKind::Create(_) => Self::Create,
+            EventKind::Remove(_) => Self::Remove,
+            EventKind::Modify(
+                ModifyKind::Data(DataChange::Content | DataChange::Any) | ModifyKind::Any,
+            ) => Self::Write,
+            EventKind::Modify(ModifyKind::Name(
+                RenameMode::Both | RenameMode::From | RenameMode::To,
+            )) => Self::Rename,
+            _ => return Err(()),
+        })
+    }
 }
 
 impl TryFrom<DebouncedEvent> for WatchEvent {
@@ -285,28 +312,19 @@ impl TryFrom<DebouncedEvent> for WatchEvent {
             _ => return Err(()),
         };
 
-        let operation = match kind {
-            EventKind::Create(_) => "Create",
-            EventKind::Remove(_) => "Remove",
-            EventKind::Modify(
-                ModifyKind::Data(DataChange::Content | DataChange::Any) | ModifyKind::Any,
-            ) => "Write",
-            EventKind::Modify(ModifyKind::Name(RenameMode::Both | RenameMode::From)) => "Rename",
-            EventKind::Modify(ModifyKind::Name(RenameMode::To)) => {
-                return Ok(WatchEvent {
-                    operation: "Rename",
-                    path: None,
-                    new_path: Some(path),
-                });
-            }
-            _ => return Err(()),
-        };
-
-        Ok(WatchEvent {
-            operation,
-            path: Some(path),
-            new_path,
-        })
+        if let EventKind::Modify(ModifyKind::Name(RenameMode::To)) = kind {
+            Ok(WatchEvent {
+                operation: WatchEventKind::Rename,
+                path: None,
+                new_path: Some(path),
+            })
+        } else {
+            Ok(WatchEvent {
+                operation: kind.try_into()?,
+                path: Some(path),
+                new_path,
+            })
+        }
     }
 }
 

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use itertools::{Either, Itertools};
+use itertools::Either;
 use notify_debouncer_full::{
     DebouncedEvent, Debouncer, FileIdMap, new_debouncer,
     notify::{
@@ -275,39 +275,36 @@ struct WatchEvent {
 impl TryFrom<DebouncedEvent> for WatchEvent {
     type Error = ();
 
-    fn try_from(mut ev: DebouncedEvent) -> Result<Self, Self::Error> {
+    fn try_from(ev: DebouncedEvent) -> Result<Self, Self::Error> {
         // TODO: Maybe we should handle all event kinds?
-        match ev.event.kind {
-            EventKind::Create(_) => ev.paths.pop().map(|p| WatchEvent {
-                operation: "Create",
-                path: p,
-                new_path: None,
-            }),
-            EventKind::Remove(_) => ev.paths.pop().map(|p| WatchEvent {
-                operation: "Remove",
-                path: p,
-                new_path: None,
-            }),
+        let DebouncedEvent {
+            event: notify::Event {
+                kind, mut paths, ..
+            },
+            ..
+        } = ev;
+
+        let (path, new_path) = match paths.as_mut_slice() {
+            [path] => (std::mem::take(path), None),
+            [path, new_path] => (std::mem::take(path), Some(std::mem::take(new_path))),
+            _ => return Err(()),
+        };
+
+        let operation = match kind {
+            EventKind::Create(_) => "Create",
+            EventKind::Remove(_) => "Remove",
             EventKind::Modify(
                 ModifyKind::Data(DataChange::Content | DataChange::Any) | ModifyKind::Any,
-            ) => ev.paths.pop().map(|p| WatchEvent {
-                operation: "Write",
-                path: p,
-                new_path: None,
-            }),
-            EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => ev
-                .paths
-                .drain(..)
-                .rev()
-                .next_array()
-                .map(|[from, to]| WatchEvent {
-                    operation: "Rename",
-                    path: from,
-                    new_path: Some(to),
-                }),
-            _ => None,
-        }
-        .ok_or(())
+            ) => "Write",
+            EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => "Rename",
+            _ => return Err(()),
+        };
+
+        Ok(WatchEvent {
+            operation,
+            path,
+            new_path,
+        })
     }
 }
 

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -1,5 +1,5 @@
 use std::{
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::mpsc::{Receiver, RecvTimeoutError, channel},
     time::Duration,
 };
@@ -51,8 +51,8 @@ impl Command for Watch {
                     Type::Nothing,
                     Type::Table(vec![
                         ("operation".into(), Type::String),
-                        ("path".into(), Type::String),
-                        ("new_path".into(), Type::String),
+                        ("path".into(), Type::OneOf([Type::String, Type::Nothing].into())),
+                        ("new_path".into(), Type::OneOf([Type::String, Type::Nothing].into())),
                     ].into_boxed_slice())
                 ),
             ])
@@ -171,15 +171,23 @@ impl Command for Watch {
 
         let iter = WatchIterator::new(debouncer, rx, engine_state.signals().clone());
 
+        fn glob_filter(glob: Option<&nu_glob::Pattern>, ev: &WatchEvent) -> bool {
+            let Some(glob) = glob else { return true };
+            let path = ev
+                .path
+                .as_deref()
+                .or(ev.new_path.as_deref())
+                .expect("at least one of path or new_path should be present");
+            glob.matches_path(path)
+        }
+
         if let Some(closure) = closure {
             let mut closure = ClosureEval::new(engine_state, stack, closure);
 
             for events in iter {
                 for event in events? {
-                    let matches_glob = match &glob_pattern {
-                        Some(glob) => glob.matches_path(&event.path),
-                        None => true,
-                    };
+                    let matches_glob = glob_filter(glob_pattern.as_ref(), &event);
+
                     if verbose && glob_pattern.is_some() {
                         eprintln!("Matches glob: {matches_glob}");
                     }
@@ -187,14 +195,8 @@ impl Command for Watch {
                     if matches_glob {
                         let result = closure
                             .add_arg(event.operation.into_value(head))?
-                            .add_arg(event.path.to_string_lossy().into_value(head))?
-                            .add_arg(
-                                event
-                                    .new_path
-                                    .as_deref()
-                                    .map(Path::to_string_lossy)
-                                    .into_value(head),
-                            )?
+                            .add_arg(event.path.into_value(head))?
+                            .add_arg(event.new_path.into_value(head))?
                             .run_with_input(PipelineData::empty());
 
                         match result {
@@ -207,20 +209,13 @@ impl Command for Watch {
 
             Ok(PipelineData::empty())
         } else {
-            fn glob_filter(glob: Option<&nu_glob::Pattern>, path: &Path) -> bool {
-                let Some(glob) = glob else { return true };
-                glob.matches_path(path)
-            }
-
             let out = iter
                 .flat_map(|e| match e {
                     Ok(events) => Either::Right(events.into_iter().map(Ok)),
                     Err(err) => Either::Left(std::iter::once(Err(err))),
                 })
                 .filter_map(move |e| match e {
-                    Ok(ev) if glob_filter(glob_pattern.as_ref(), &ev.path) => {
-                        Some(ev.into_value(head))
-                    }
+                    Ok(ev) if glob_filter(glob_pattern.as_ref(), &ev) => Some(ev.into_value(head)),
                     Ok(_) => None,
                     Err(err) => Some(Value::error(err, head)),
                 })
@@ -268,7 +263,7 @@ impl Command for Watch {
 #[derive(IntoValue)]
 struct WatchEvent {
     operation: &'static str,
-    path: PathBuf,
+    path: Option<PathBuf>,
     new_path: Option<PathBuf>,
 }
 
@@ -296,13 +291,20 @@ impl TryFrom<DebouncedEvent> for WatchEvent {
             EventKind::Modify(
                 ModifyKind::Data(DataChange::Content | DataChange::Any) | ModifyKind::Any,
             ) => "Write",
-            EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => "Rename",
+            EventKind::Modify(ModifyKind::Name(RenameMode::Both | RenameMode::From)) => "Rename",
+            EventKind::Modify(ModifyKind::Name(RenameMode::To)) => {
+                return Ok(WatchEvent {
+                    operation: "Rename",
+                    path: None,
+                    new_path: Some(path),
+                });
+            }
             _ => return Err(()),
         };
 
         Ok(WatchEvent {
             operation,
-            path,
+            path: Some(path),
             new_path,
         })
     }

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     path::{Path, PathBuf},
     sync::mpsc::{Receiver, RecvTimeoutError, channel},
     time::Duration,
@@ -219,8 +218,10 @@ impl Command for Watch {
                     Err(err) => Either::Left(std::iter::once(Err(err))),
                 })
                 .filter_map(move |e| match e {
-                    Ok(ev) => glob_filter(glob_pattern.as_ref(), &ev.path)
-                        .then(|| WatchEventRecord::from(&ev).into_value(head)),
+                    Ok(ev) if glob_filter(glob_pattern.as_ref(), &ev.path) => {
+                        Some(ev.into_value(head))
+                    }
+                    Ok(_) => None,
                     Err(err) => Some(Value::error(err, head)),
                 })
                 .into_pipeline_data(head, engine_state.signals().clone());
@@ -264,27 +265,11 @@ impl Command for Watch {
     }
 }
 
+#[derive(IntoValue)]
 struct WatchEvent {
     operation: &'static str,
     path: PathBuf,
     new_path: Option<PathBuf>,
-}
-
-#[derive(IntoValue)]
-struct WatchEventRecord<'a> {
-    operation: &'static str,
-    path: Cow<'a, str>,
-    new_path: Option<Cow<'a, str>>,
-}
-
-impl<'a> From<&'a WatchEvent> for WatchEventRecord<'a> {
-    fn from(value: &'a WatchEvent) -> Self {
-        Self {
-            operation: value.operation,
-            path: value.path.to_string_lossy(),
-            new_path: value.new_path.as_deref().map(Path::to_string_lossy),
-        }
-    }
 }
 
 impl TryFrom<DebouncedEvent> for WatchEvent {

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -137,6 +137,7 @@ mod upsert;
 mod url;
 mod use_;
 mod utouch;
+mod watch;
 mod where_;
 mod which;
 mod while_;

--- a/crates/nu-command/tests/commands/watch.rs
+++ b/crates/nu-command/tests/commands/watch.rs
@@ -23,7 +23,7 @@ const STREAM_TIMEOUT: &str = r#"
 
 #[rstest]
 #[case::within_time(Duration::ZERO, [0, 1, 2, 3, 4])]
-#[case::timed_out(Duration::from_millis(10), [0, 1])]
+#[case::timed_out(Duration::from_millis(100), [0, 1])]
 fn stream_timeout(#[case] delay: Duration, #[case] expected: impl IntoValue) -> Result {
     let mut tester = test();
     let () = tester.run(STREAM_TIMEOUT)?;
@@ -32,7 +32,7 @@ fn stream_timeout(#[case] delay: Duration, #[case] expected: impl IntoValue) -> 
     let code = "
         0..<5
         | each { sleep $delay; $in }
-        | stream-timeout 25ms
+        | stream-timeout 250ms
     ";
     tester.run(code).expect_value_eq(expected)
 }
@@ -51,7 +51,7 @@ fn watch_stream() -> Result {
                 {|| rm bar.txt }
             ]
             | each {|fn| null; do $fn; {}}
-            | zip { watch . --quiet | stream-timeout 2sec }
+            | zip { watch . --debounce 200ms --quiet | stream-timeout 5sec }
             | each { into record }
         "#;
 
@@ -87,7 +87,7 @@ fn watch_stream_outside() -> Result {
                 {|| mv foo.txt ../ }
             ]
             | each {|fn| null; do $fn; {}}
-            | zip { watch . --quiet | stream-timeout 2sec }
+            | zip { watch . --debounce 200ms --quiet | stream-timeout 5sec }
             | each { into record }
         ";
 

--- a/crates/nu-command/tests/commands/watch.rs
+++ b/crates/nu-command/tests/commands/watch.rs
@@ -1,5 +1,41 @@
+use std::time::Duration;
+
+use rstest::rstest;
+
 use nu_protocol::test_table;
 use nu_test_support::{fs::Stub, prelude::*};
+
+const STREAM_TIMEOUT: &str = r#"
+    # cut off the input stream after `$duration`
+    def stream-timeout [wait: duration]: list -> list {
+        wrap item
+        | append {stop: true}
+        | interleave {
+            generate {|d|
+                sleep $d
+                {out: {stop: true}}
+            } $wait
+        }
+        | take while { $in has "item" }
+        | get item
+    }
+"#;
+
+#[rstest]
+#[case::within_time(Duration::ZERO, [0, 1, 2, 3, 4])]
+#[case::timed_out(Duration::from_millis(10), [0, 1])]
+fn stream_timeout(#[case] delay: Duration, #[case] expected: impl IntoValue) -> Result {
+    let mut tester = test();
+    let () = tester.run(STREAM_TIMEOUT)?;
+    let () = tester.run_with_data("let delay = $in", delay)?;
+
+    let code = "
+        0..<5
+        | each { sleep $delay; $in }
+        | stream-timeout 25ms
+    ";
+    tester.run(code).expect_value_eq(expected)
+}
 
 #[test]
 fn watch_stream() -> Result {
@@ -15,7 +51,7 @@ fn watch_stream() -> Result {
                 {|| rm bar.txt }
             ]
             | each {|fn| null; do $fn; {}}
-            | zip { watch . --quiet }
+            | zip { watch . --quiet | stream-timeout 2sec }
             | each { into record }
         "#;
 
@@ -27,7 +63,9 @@ fn watch_stream() -> Result {
             [   "Remove", bar_txt,         ()],
         ];
 
-        test().cwd(dirs.test()).run(code).expect_value_eq(expected)
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run(STREAM_TIMEOUT)?;
+        tester.run(code).expect_value_eq(expected)
     })
 }
 
@@ -49,7 +87,7 @@ fn watch_stream_outside() -> Result {
                 {|| mv foo.txt ../ }
             ]
             | each {|fn| null; do $fn; {}}
-            | zip { watch . --quiet }
+            | zip { watch . --quiet | stream-timeout 2sec }
             | each { into record }
         ";
 
@@ -59,9 +97,8 @@ fn watch_stream_outside() -> Result {
             [   "Rename", foo_txt,         ()],
         ];
 
-        test()
-            .cwd(dirs.test().join("watched_dir"))
-            .run(code)
-            .expect_value_eq(expected)
+        let mut tester = test().cwd(dirs.test().join("watched_dir"));
+        let () = tester.run(STREAM_TIMEOUT)?;
+        tester.run(code).expect_value_eq(expected)
     })
 }

--- a/crates/nu-command/tests/commands/watch.rs
+++ b/crates/nu-command/tests/commands/watch.rs
@@ -24,6 +24,10 @@ const STREAM_TIMEOUT: &str = r#"
 #[rstest]
 #[case::within_time(Duration::ZERO, [0, 1, 2, 3, 4])]
 #[case::timed_out(Duration::from_millis(100), [0, 1])]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "anything involving timing is unreliable on macos in CI"
+)]
 fn stream_timeout(#[case] delay: Duration, #[case] expected: impl IntoValue) -> Result {
     let mut tester = test();
     let () = tester.run(STREAM_TIMEOUT)?;
@@ -38,6 +42,10 @@ fn stream_timeout(#[case] delay: Duration, #[case] expected: impl IntoValue) -> 
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "file operations or anything involving timing is unreliable on macos in CI"
+)]
 fn watch_stream() -> Result {
     Playground::setup("streaming_watch_fs", |dirs, _| {
         let foo_txt = &*dirs.test().join("foo.txt");
@@ -55,11 +63,22 @@ fn watch_stream() -> Result {
             | each { into record }
         "#;
 
+        #[cfg(not(target_os = "macos"))]
         let expected = test_table![
             ["operation",  "path", "new_path"];
             [   "Create", foo_txt,         ()],
             [    "Write", foo_txt,         ()],
             [   "Rename", foo_txt,    bar_txt],
+            [   "Remove", bar_txt,         ()],
+        ];
+
+        // https://github.com/notify-rs/notify/issues/900
+        #[cfg(target_os = "macos")]
+        let expected = test_table![
+            ["operation",  "path", "new_path"];
+            [   "Create", foo_txt,         ()],
+            [   "Create", foo_txt,         ()],
+            [   "Create", bar_txt,         ()],
             [   "Remove", bar_txt,         ()],
         ];
 
@@ -70,8 +89,12 @@ fn watch_stream() -> Result {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "file operations that involve paths outside the watched directory do not work properly on macos"
+)]
 fn watch_stream_outside() -> Result {
-    Playground::setup("streaming_watch_fs", |dirs, sandbox| {
+    Playground::setup("streaming_watch_fs_outside_watched_dir", |dirs, sandbox| {
         sandbox
             .mkdir("watched_dir")
             .with_files(&[Stub::EmptyFile("foo.txt")]);

--- a/crates/nu-command/tests/commands/watch.rs
+++ b/crates/nu-command/tests/commands/watch.rs
@@ -1,5 +1,5 @@
 use nu_protocol::test_table;
-use nu_test_support::prelude::*;
+use nu_test_support::{fs::Stub, prelude::*};
 
 #[test]
 fn watch_stream() -> Result {
@@ -28,5 +28,40 @@ fn watch_stream() -> Result {
         ];
 
         test().cwd(dirs.test()).run(code).expect_value_eq(expected)
+    })
+}
+
+#[test]
+fn watch_stream_outside() -> Result {
+    Playground::setup("streaming_watch_fs", |dirs, sandbox| {
+        sandbox
+            .mkdir("watched_dir")
+            .with_files(&[Stub::EmptyFile("foo.txt")]);
+
+        let mut foo_txt = dirs.test().to_owned();
+        foo_txt.push("watched_dir");
+        foo_txt.push("foo.txt");
+        let foo_txt = &*foo_txt;
+
+        let code = "
+            [
+                {|| mv ../foo.txt ./ }
+                {|| mv foo.txt ../ }
+            ]
+            | each {|fn| null; do $fn; {}}
+            | zip { watch . --quiet }
+            | each { into record }
+        ";
+
+        let expected = test_table![
+            ["operation",  "path", "new_path"];
+            [   "Rename",      (),    foo_txt],
+            [   "Rename", foo_txt,         ()],
+        ];
+
+        test()
+            .cwd(dirs.test().join("watched_dir"))
+            .run(code)
+            .expect_value_eq(expected)
     })
 }

--- a/crates/nu-command/tests/commands/watch.rs
+++ b/crates/nu-command/tests/commands/watch.rs
@@ -1,0 +1,32 @@
+use nu_protocol::test_table;
+use nu_test_support::prelude::*;
+
+#[test]
+fn watch_stream() -> Result {
+    Playground::setup("streaming_watch_fs", |dirs, _| {
+        let foo_txt = &*dirs.test().join("foo.txt");
+        let bar_txt = &*dirs.test().join("bar.txt");
+
+        let code = r#"
+            [
+                {|| touch foo.txt }
+                {|| "meow" | save -f foo.txt }
+                {|| mv foo.txt bar.txt }
+                {|| rm bar.txt }
+            ]
+            | each {|fn| null; do $fn; {}}
+            | zip { watch . --quiet }
+            | each { into record }
+        "#;
+
+        let expected = test_table![
+            ["operation",  "path", "new_path"];
+            [   "Create", foo_txt,         ()],
+            [    "Write", foo_txt,         ()],
+            [   "Rename", foo_txt,    bar_txt],
+            [   "Remove", bar_txt,         ()],
+        ];
+
+        test().cwd(dirs.test()).run(code).expect_value_eq(expected)
+    })
+}


### PR DESCRIPTION
## Description

- Added tests, which we couldn't do cleanly before streaming `watch`
- Remove the intermediate `WatchEventRecord` type previously used for easier conversion to `Value`.
  > `IntoValue` was not widely implemented for std types at the time of initial implementation, and an intermediate type was necessary.
- Simplify `TryFrom<DebouncedEvent> for WatchEvent` and fix the order of paths in `Rename` events.
- Detect `Rename` events where the source or destination path is outside of the watched directory.

## User-facing changes (Release notes)

Order of the paths reported for `Rename` events are now correct, whereas previously they were reported as if `$new_path` was renamed to `$path`.

Additionally if one of these paths happened to be outside of the watched directory, previously the event was not reported at all, now they are reported with the path outside of the watched directory as `null`.

## Additional notes

We should think about deprecating the optional closure parameter and only supporting the streaming version. The closure form
- does not compose with other commands
- can't be stopped without user intervention...
- ...which also makes it harder to test

Removing the closure parameter would also make it possible to have a rest parameter which could be used to watch multiple paths.