### PR TITLE
fix: allow pre_prompt and env_change hooks to modify the commandline

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -529,6 +529,8 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
 
     perf!("update_prompt", start_time, use_color);
 
+    line_editor = flush_engine_state_repl_buffer(engine_state, line_editor);
+
     *entry_num += 1;
 
     start_time = Instant::now();


### PR DESCRIPTION

## Description
Previously, the `pre_prompt` and `env_change` hooks couldn't modify the commandline. Now they can.

As a consequence, commands executed by keybindings (ExecuteHostCommand) also reset the commandline. I will probably wait for https://github.com/nushell/nushell/pull/18018 to fix that as that PR separates the `Signal::HostCommand` from the `Signal::Success` arm, so we can make the hooks work only if its not an `ExecuteHostCommand`.


## User-facing changes (Release notes)
### The `pre_prompt` and `env_change` hooks may now modify the commandline
The `pre_prompt` and `env_change` hooks can now modify the commandline using the `commandline edit` command.

Example:
```nushell
$env.config.hooks.pre_prompt ++= [{ commandline edit "test" }]
```

## Additional notes
N/A