### PR TITLE
Even more polars selectors

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(awk '{print $2}')",
+      "Bash(cargo build *)",
+      "Bash(cargo test *)",
+      "Bash(wait)",
+      "Bash(nu -c \"use toolkit.nu; toolkit fmt\")",
+      "Bash(nu -c \"use toolkit.nu; toolkit clippy\")",
+      "Bash(git *)"
+    ]
+  }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/mod.rs
@@ -1,19 +1,39 @@
 mod selector_all;
 mod selector_alpha;
 mod selector_alphanumeric;
+mod selector_array;
+mod selector_binary;
+mod selector_boolean;
 mod selector_by_dtype;
+mod selector_by_index;
 mod selector_by_name;
+mod selector_categorical;
+mod selector_contains;
+mod selector_date;
+mod selector_datetime;
+mod selector_decimal;
+mod selector_digit;
+mod selector_duration;
+mod selector_empty;
 mod selector_ends_with;
+mod selector_exclude;
 mod selector_first;
 mod selector_float;
 mod selector_integer;
 mod selector_last;
+mod selector_list;
 mod selector_matches;
+mod selector_nested;
 mod selector_not;
 mod selector_numeric;
+mod selector_object;
+mod selector_polars_enum;
+mod selector_polars_struct;
 mod selector_signed_integer;
 mod selector_starts_with;
+mod selector_string;
 mod selector_stub;
+mod selector_temporal;
 mod selector_unsigned_integer;
 
 use nu_plugin::PluginCommand;
@@ -25,19 +45,39 @@ pub(crate) fn selector_commands() -> Vec<Box<dyn PluginCommand<Plugin = PolarsPl
         Box::new(selector_all::SelectorAll),
         Box::new(selector_alpha::SelectorAlpha),
         Box::new(selector_alphanumeric::SelectorAlphanumeric),
+        Box::new(selector_array::SelectorArray),
+        Box::new(selector_binary::SelectorBinary),
+        Box::new(selector_boolean::SelectorBoolean),
         Box::new(selector_by_dtype::SelectorByDtype),
+        Box::new(selector_by_index::SelectorByIndex),
         Box::new(selector_by_name::SelectorByName),
+        Box::new(selector_categorical::SelectorCategorical),
+        Box::new(selector_contains::SelectorContains),
+        Box::new(selector_date::SelectorDate),
+        Box::new(selector_datetime::SelectorDatetime),
+        Box::new(selector_decimal::SelectorDecimal),
+        Box::new(selector_digit::SelectorDigit),
+        Box::new(selector_duration::SelectorDuration),
+        Box::new(selector_empty::SelectorEmpty),
         Box::new(selector_ends_with::SelectorEndsWith),
+        Box::new(selector_exclude::SelectorExclude),
         Box::new(selector_first::SelectorFirst),
         Box::new(selector_float::SelectorFloat),
         Box::new(selector_integer::SelectorInteger),
         Box::new(selector_last::SelectorLast),
+        Box::new(selector_list::SelectorList),
         Box::new(selector_matches::SelectorMatches),
+        Box::new(selector_nested::SelectorNested),
         Box::new(selector_not::SelectorNot),
         Box::new(selector_numeric::SelectorNumeric),
+        Box::new(selector_object::SelectorObject),
+        Box::new(selector_polars_enum::SelectorPolarsEnum),
+        Box::new(selector_polars_struct::SelectorPolarsStruct),
         Box::new(selector_signed_integer::SelectorSignedInteger),
         Box::new(selector_starts_with::SelectorStartsWith),
+        Box::new(selector_string::SelectorString),
         Box::new(selector_stub::SelectorCmd),
+        Box::new(selector_temporal::SelectorTemporal),
         Box::new(selector_unsigned_integer::SelectorUnsignedInteger),
     ]
 }

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_array.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_array.rs
@@ -1,0 +1,85 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, SyntaxShape, Type};
+use polars::prelude::{DataTypeSelector, Selector};
+
+#[derive(Clone)]
+pub struct SelectorArray;
+
+impl PluginCommand for SelectorArray {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector array"
+    }
+
+    fn description(&self) -> &str {
+        "Select all array columns. Optionally filter by fixed width."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .named(
+                "width",
+                SyntaxShape::Int,
+                "Only select arrays with this fixed width.",
+                None,
+            )
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                example: "polars selector array",
+                description: "Create a selector for all array columns",
+                result: None,
+            },
+            Example {
+                example: "polars selector array --width 3",
+                description: "Create a selector for fixed-width arrays of size 3",
+                result: None,
+            },
+        ]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "array", "fixed"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+        let width: Option<i64> = call.get_flag("width")?;
+        let width_usize = width.map(|w| w as usize);
+
+        let selector = Selector::ByDType(DataTypeSelector::Array(None, width_usize));
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorArray)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_binary.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_binary.rs
@@ -1,0 +1,70 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Type};
+use polars::prelude::{DataType, DataTypeSelector, Selector};
+
+#[derive(Clone)]
+pub struct SelectorBinary;
+
+impl PluginCommand for SelectorBinary {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector binary"
+    }
+
+    fn description(&self) -> &str {
+        "Select all binary columns."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: "polars selector binary",
+            description: "Create a selector for binary columns",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "binary", "bytes"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let selector = Selector::ByDType(DataTypeSelector::AnyOf(vec![DataType::Binary].into()));
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorBinary)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_boolean.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_boolean.rs
@@ -1,0 +1,87 @@
+use crate::values::NuDataFrame;
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Span, Type};
+use polars::df;
+use polars::prelude::{DataType, DataTypeSelector, Selector};
+
+#[derive(Clone)]
+pub struct SelectorBoolean;
+
+impl PluginCommand for SelectorBoolean {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector boolean"
+    }
+
+    fn description(&self) -> &str {
+        "Select all boolean columns."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: r#"{
+    "name": ["Alice", "Bob"],
+    "active": [true, false],
+    "score": [1, 2],
+} |
+polars into-df --as-columns |
+polars select (polars selector boolean) |
+polars collect"#,
+            description: "Select all boolean columns",
+            result: Some(
+                NuDataFrame::from(
+                    df!(
+                        "active" => [true, false],
+                    )
+                    .expect("simple df for test should not fail"),
+                )
+                .into_value(Span::test_data()),
+            ),
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "boolean", "bool"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let selector = Selector::ByDType(DataTypeSelector::AnyOf(vec![DataType::Boolean].into()));
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorBoolean)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_by_index.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_by_index.rs
@@ -1,0 +1,129 @@
+use crate::values::{Column, NuDataFrame};
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, Signature, Span, SyntaxShape, Type, Value,
+};
+use polars::prelude::Selector;
+
+#[derive(Clone)]
+pub struct SelectorByIndex;
+
+impl PluginCommand for SelectorByIndex {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector by-index"
+    }
+
+    fn description(&self) -> &str {
+        "Select columns by their index position. Supports negative indices (e.g., -1 for the last column)."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .rest(
+                "index",
+                SyntaxShape::Int,
+                "Column index positions to select (negative indices count from the end).",
+            )
+            .switch(
+                "not-strict",
+                "Allow out-of-range indices without error.",
+                None,
+            )
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                example: r#"[[a b c]; [1 2 3] [4 5 6]]
+    | polars into-df
+    | polars select (polars selector by-index 0 2)
+    | polars collect"#,
+                description: "Select first and third columns by index",
+                result: Some(
+                    NuDataFrame::try_from_columns(
+                        vec![
+                            Column::new(
+                                "a".to_string(),
+                                vec![Value::test_int(1), Value::test_int(4)],
+                            ),
+                            Column::new(
+                                "c".to_string(),
+                                vec![Value::test_int(3), Value::test_int(6)],
+                            ),
+                        ],
+                        None,
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                example: r#"[[a b c]; [1 2 3] [4 5 6]]
+    | polars into-df
+    | polars select (polars selector by-index -1)
+    | polars collect"#,
+                description: "Select the last column using a negative index",
+                result: Some(
+                    NuDataFrame::try_from_columns(
+                        vec![Column::new(
+                            "c".to_string(),
+                            vec![Value::test_int(3), Value::test_int(6)],
+                        )],
+                        None,
+                        Span::test_data(),
+                    )
+                    .expect("simple df for test should not fail")
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "index", "position"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+        let indices: Vec<i64> = call.rest(0)?;
+        let strict = !call.has_flag("not-strict")?;
+
+        let selector = Selector::ByIndex {
+            indices: indices.into(),
+            strict,
+        };
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorByIndex)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_categorical.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_categorical.rs
@@ -1,0 +1,70 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Type};
+use polars::prelude::{DataTypeSelector, Selector};
+
+#[derive(Clone)]
+pub struct SelectorCategorical;
+
+impl PluginCommand for SelectorCategorical {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector categorical"
+    }
+
+    fn description(&self) -> &str {
+        "Select all categorical columns."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: "polars selector categorical",
+            description: "Create a selector for categorical columns",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "categorical", "category", "cat"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let selector = Selector::ByDType(DataTypeSelector::Categorical);
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorCategorical)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_contains.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_contains.rs
@@ -1,0 +1,127 @@
+use crate::values::NuDataFrame;
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Type,
+};
+use polars::df;
+use polars::prelude::Selector;
+
+#[derive(Clone)]
+pub struct SelectorContains;
+
+impl PluginCommand for SelectorContains {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector contains"
+    }
+
+    fn description(&self) -> &str {
+        "Select columns whose names contain the given literal substring(s)."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .rest(
+                "substring",
+                SyntaxShape::String,
+                "Literal substring(s) to search for in column names.",
+            )
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                example: r#"{
+    "foo_bar": [1.0, 2.0],
+    "foo_baz": [3.0, 4.0],
+    "qux": [5, 6],
+} |
+polars into-df --as-columns |
+polars select (polars selector contains foo) |
+polars sort-by foo_bar foo_baz |
+polars collect"#,
+                description: "Select columns whose names contain 'foo'",
+                result: Some(
+                    NuDataFrame::from(
+                        df!(
+                            "foo_bar" => [1.0, 2.0],
+                            "foo_baz" => [3.0, 4.0],
+                        )
+                        .expect("simple df for test should not fail"),
+                    )
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                example: r#"{
+    "foo_x": [1, 2],
+    "bar_x": [3, 4],
+    "baz": [5, 6],
+} |
+polars into-df --as-columns |
+polars select (polars selector contains foo bar) |
+polars sort-by foo_x bar_x |
+polars collect"#,
+                description: "Select columns whose names contain 'foo' or 'bar'",
+                result: Some(
+                    NuDataFrame::from(
+                        df!(
+                            "foo_x" => [1i64, 2i64],
+                            "bar_x" => [3i64, 4i64],
+                        )
+                        .expect("simple df for test should not fail"),
+                    )
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "contains", "substring"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+        let substrings: Result<Vec<String>, ShellError> =
+            call.positional.iter().try_fold(Vec::new(), |mut acc, arg| {
+                let s = arg.as_str()?;
+                acc.push(fancy_regex::escape(s).to_string());
+                Ok(acc)
+            });
+
+        let pattern = substrings?.join("|");
+        let selector = Selector::Matches(pattern.into());
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorContains)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_date.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_date.rs
@@ -1,0 +1,70 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Type};
+use polars::prelude::{DataType, DataTypeSelector, Selector};
+
+#[derive(Clone)]
+pub struct SelectorDate;
+
+impl PluginCommand for SelectorDate {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector date"
+    }
+
+    fn description(&self) -> &str {
+        "Select all date columns."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: "polars selector date",
+            description: "Create a selector for date columns",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "date"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let selector = Selector::ByDType(DataTypeSelector::AnyOf(vec![DataType::Date].into()));
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorDate)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_datetime.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_datetime.rs
@@ -1,0 +1,159 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, SyntaxShape, Type};
+use polars::prelude::TimeZone;
+use polars_plan::prelude::{DataTypeSelector, Selector, TimeUnitSet, TimeZoneSet};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct SelectorDatetime;
+
+impl PluginCommand for SelectorDatetime {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector datetime"
+    }
+
+    fn description(&self) -> &str {
+        r#"Select all datetime columns. Optionally filter by time unit (ns, us, ms) and/or timezone."#
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .named(
+                "time-unit",
+                SyntaxShape::List(Box::new(SyntaxShape::String)),
+                "Filter by time unit(s): ns (nanoseconds), us (microseconds), ms (milliseconds).",
+                None,
+            )
+            .named(
+                "time-zone",
+                SyntaxShape::List(Box::new(SyntaxShape::String)),
+                r#"Filter by timezone(s). Use "*" to match any set timezone, or "unset" to match columns without a timezone."#,
+                None,
+            )
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                example: "polars selector datetime",
+                description: "Create a selector for all datetime columns",
+                result: None,
+            },
+            Example {
+                example: "polars selector datetime --time-unit [ns us]",
+                description: "Create a selector for nanosecond or microsecond datetime columns",
+                result: None,
+            },
+            Example {
+                example: r#"polars selector datetime --time-unit [ns] --time-zone [UTC]"#,
+                description: "Create a selector for nanosecond datetime columns with UTC timezone",
+                result: None,
+            },
+        ]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "datetime", "timestamp", "time"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let time_units: Vec<String> = call
+            .get_flag::<Vec<String>>("time-unit")?
+            .unwrap_or_default();
+        let time_zones: Vec<String> = call
+            .get_flag::<Vec<String>>("time-zone")?
+            .unwrap_or_default();
+
+        let tu_set = parse_time_unit_set(&time_units, call)?;
+        let tz_set = parse_time_zone_set(&time_zones, call)?;
+
+        let selector = Selector::ByDType(DataTypeSelector::Datetime(tu_set, tz_set));
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+fn parse_time_unit_set(
+    time_units: &[String],
+    call: &EvaluatedCall,
+) -> Result<TimeUnitSet, LabeledError> {
+    if time_units.is_empty() {
+        return Ok(TimeUnitSet::all());
+    }
+    let mut set = TimeUnitSet::empty();
+    for tu in time_units {
+        let flag = match tu.as_str() {
+            "ns" => TimeUnitSet::NANO_SECONDS,
+            "us" => TimeUnitSet::MICRO_SECONDS,
+            "ms" => TimeUnitSet::MILLI_SECONDS,
+            other => {
+                return Err(LabeledError::new(format!("Invalid time unit: '{other}'"))
+                    .with_label("expected 'ns', 'us', or 'ms'", call.head));
+            }
+        };
+        set |= flag;
+    }
+    Ok(set)
+}
+
+fn parse_time_zone_set(
+    time_zones: &[String],
+    call: &EvaluatedCall,
+) -> Result<TimeZoneSet, LabeledError> {
+    if time_zones.is_empty() {
+        return Ok(TimeZoneSet::Any);
+    }
+    if time_zones.len() == 1 && time_zones[0] == "*" {
+        return Ok(TimeZoneSet::Any);
+    }
+    if time_zones.len() == 1 && time_zones[0] == "unset" {
+        return Ok(TimeZoneSet::Unset);
+    }
+    let mut parsed: Vec<TimeZone> = Vec::with_capacity(time_zones.len());
+    for tz_str in time_zones {
+        let tz = TimeZone::opt_try_new(Some(tz_str.as_str()))
+            .map_err(|e| {
+                LabeledError::new(format!("Invalid timezone '{tz_str}': {e}"))
+                    .with_label("invalid timezone string", call.head)
+            })?
+            .ok_or_else(|| {
+                LabeledError::new("Empty timezone string")
+                    .with_label("timezone cannot be empty", call.head)
+            })?;
+        parsed.push(tz);
+    }
+    let arc: Arc<[TimeZone]> = parsed.into();
+    Ok(TimeZoneSet::AnyOf(arc))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorDatetime)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_decimal.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_decimal.rs
@@ -1,0 +1,70 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Type};
+use polars::prelude::{DataTypeSelector, Selector};
+
+#[derive(Clone)]
+pub struct SelectorDecimal;
+
+impl PluginCommand for SelectorDecimal {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector decimal"
+    }
+
+    fn description(&self) -> &str {
+        "Select all decimal columns."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: "polars selector decimal",
+            description: "Create a selector for decimal columns",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "decimal"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let selector = Selector::ByDType(DataTypeSelector::Decimal);
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorDecimal)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_digit.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_digit.rs
@@ -1,0 +1,123 @@
+use crate::values::NuDataFrame;
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use log::debug;
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Span, Type};
+use polars::df;
+use polars::prelude::Selector;
+
+#[derive(Clone)]
+pub struct SelectorDigit;
+
+impl PluginCommand for SelectorDigit {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector digit"
+    }
+
+    fn description(&self) -> &str {
+        r#"Select columns whose names consist entirely of digit characters. By default uses Unicode decimal digits; use `--ascii-only` to restrict to ASCII 0-9."#
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .switch(
+                "ascii-only",
+                "Restrict to ASCII digit characters (0-9) only.",
+                Some('a'),
+            )
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                example: r#"{
+    "123": [1, 2],
+    "abc": [3, 4],
+    "4": [5, 6],
+} |
+polars into-df --as-columns |
+polars select (polars selector digit) |
+polars sort-by "123" "4" |
+polars collect"#,
+                description: "Select columns whose names consist entirely of digits",
+                result: Some(
+                    NuDataFrame::from(
+                        df!(
+                            "123" => [1i64, 2i64],
+                            "4" => [5i64, 6i64],
+                        )
+                        .expect("simple df for test should not fail"),
+                    )
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                example: r#"{
+    "123": [1, 2],
+    "abc": [3, 4],
+} |
+polars into-df --as-columns |
+polars select (polars selector digit --ascii-only) |
+polars collect"#,
+                description: "Select digit-named columns using ASCII digits only",
+                result: Some(
+                    NuDataFrame::from(
+                        df!(
+                            "123" => [1i64, 2i64],
+                        )
+                        .expect("simple df for test should not fail"),
+                    )
+                    .into_value(Span::test_data()),
+                ),
+            },
+        ]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "digit", "numeric", "number"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let ascii_only = call.has_flag("ascii-only")?;
+        let pattern = if ascii_only {
+            "^[0-9]+$".to_string()
+        } else {
+            r"^\p{Nd}+$".to_string()
+        };
+        debug!("SelectorDigit: pattern = {pattern}");
+        let selector = Selector::Matches(pattern.into());
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorDigit)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_duration.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_duration.rs
@@ -1,0 +1,112 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, SyntaxShape, Type};
+use polars_plan::prelude::{DataTypeSelector, Selector, TimeUnitSet};
+
+#[derive(Clone)]
+pub struct SelectorDuration;
+
+impl PluginCommand for SelectorDuration {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector duration"
+    }
+
+    fn description(&self) -> &str {
+        "Select all duration columns. Optionally filter by time unit (ns, us, ms)."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .named(
+                "time-unit",
+                SyntaxShape::List(Box::new(SyntaxShape::String)),
+                "Filter by time unit(s): ns (nanoseconds), us (microseconds), ms (milliseconds).",
+                None,
+            )
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                example: "polars selector duration",
+                description: "Create a selector for all duration columns",
+                result: None,
+            },
+            Example {
+                example: "polars selector duration --time-unit [ns us]",
+                description: "Create a selector for nanosecond or microsecond duration columns",
+                result: None,
+            },
+        ]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "duration", "interval", "time"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let time_units: Vec<String> = call
+            .get_flag::<Vec<String>>("time-unit")?
+            .unwrap_or_default();
+
+        let tu_set = parse_time_unit_set(&time_units, call)?;
+
+        let selector = Selector::ByDType(DataTypeSelector::Duration(tu_set));
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+fn parse_time_unit_set(
+    time_units: &[String],
+    call: &EvaluatedCall,
+) -> Result<TimeUnitSet, LabeledError> {
+    if time_units.is_empty() {
+        return Ok(TimeUnitSet::all());
+    }
+    let mut set = TimeUnitSet::empty();
+    for tu in time_units {
+        let flag = match tu.as_str() {
+            "ns" => TimeUnitSet::NANO_SECONDS,
+            "us" => TimeUnitSet::MICRO_SECONDS,
+            "ms" => TimeUnitSet::MILLI_SECONDS,
+            other => {
+                return Err(LabeledError::new(format!("Invalid time unit: '{other}'"))
+                    .with_label("expected 'ns', 'us', or 'ms'", call.head));
+            }
+        };
+        set |= flag;
+    }
+    Ok(set)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorDuration)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_empty.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_empty.rs
@@ -1,0 +1,70 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Type};
+use polars::prelude::Selector;
+
+#[derive(Clone)]
+pub struct SelectorEmpty;
+
+impl PluginCommand for SelectorEmpty {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector empty"
+    }
+
+    fn description(&self) -> &str {
+        "Create an empty selector that matches no columns. Useful as a base for selector composition."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: "polars selector empty",
+            description: "Create an empty selector that matches no columns",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "empty", "none"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let selector = Selector::Empty;
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorEmpty)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_exclude.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_exclude.rs
@@ -1,0 +1,121 @@
+use crate::values::NuDataFrame;
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{
+    Category, Example, LabeledError, PipelineData, Signature, Span, SyntaxShape, Type,
+};
+use polars::df;
+use polars::prelude::{PlSmallStr, Selector};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct SelectorExclude;
+
+impl PluginCommand for SelectorExclude {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector exclude"
+    }
+
+    fn description(&self) -> &str {
+        "Select all columns except those with the given name(s). This is the inverse of `polars selector by-name`."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .rest(
+                "column",
+                SyntaxShape::String,
+                "Column name(s) to exclude from the selection.",
+            )
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                example: r#"{
+    "a": [1.0, 2.0],
+    "b": [3.0, 4.0],
+    "c": [5, 6],
+} |
+polars into-df --as-columns |
+polars select (polars selector exclude a b) |
+polars collect"#,
+                description: "Select all columns except 'a' and 'b'",
+                result: Some(
+                    NuDataFrame::from(
+                        df!(
+                            "c" => [5i64, 6i64],
+                        )
+                        .expect("simple df for test should not fail"),
+                    )
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                example: r#"[[a b c]; [1 2 3] [4 5 6]]
+    | polars into-df
+    | polars select (polars selector exclude c)
+    | polars collect"#,
+                description: "Select all columns except 'c'",
+                result: None,
+            },
+        ]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "exclude", "except", "drop"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+        let columns: Vec<String> = call.rest(0)?;
+
+        if columns.is_empty() {
+            return Err(LabeledError::new("Missing column names")
+                .with_label("At least one column name is required", call.head));
+        }
+
+        let names: Arc<[PlSmallStr]> = columns
+            .into_iter()
+            .map(PlSmallStr::from)
+            .collect::<Vec<_>>()
+            .into();
+
+        let excluded = Selector::ByName {
+            names,
+            strict: false,
+        };
+        let selector = Selector::Difference(Arc::new(Selector::Wildcard), Arc::new(excluded));
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorExclude)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_list.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_list.rs
@@ -1,0 +1,70 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Type};
+use polars::prelude::{DataTypeSelector, Selector};
+
+#[derive(Clone)]
+pub struct SelectorList;
+
+impl PluginCommand for SelectorList {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector list"
+    }
+
+    fn description(&self) -> &str {
+        "Select all list columns."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: "polars selector list",
+            description: "Create a selector for list columns",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "list", "array"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let selector = Selector::ByDType(DataTypeSelector::List(None));
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorList)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_nested.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_nested.rs
@@ -1,0 +1,70 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Type};
+use polars::prelude::{DataTypeSelector, Selector};
+
+#[derive(Clone)]
+pub struct SelectorNested;
+
+impl PluginCommand for SelectorNested {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector nested"
+    }
+
+    fn description(&self) -> &str {
+        "Select all nested columns (list, array, or struct)."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: "polars selector nested",
+            description: "Create a selector for nested columns (list, array, or struct)",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "nested", "list", "array", "struct"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let selector = Selector::ByDType(DataTypeSelector::Nested);
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorNested)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_object.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_object.rs
@@ -1,0 +1,70 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Type};
+use polars::prelude::{DataTypeSelector, Selector};
+
+#[derive(Clone)]
+pub struct SelectorObject;
+
+impl PluginCommand for SelectorObject {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector object"
+    }
+
+    fn description(&self) -> &str {
+        "Select all object columns."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: "polars selector object",
+            description: "Create a selector for object columns",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "object"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let selector = Selector::ByDType(DataTypeSelector::Object);
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorObject)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_polars_enum.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_polars_enum.rs
@@ -1,0 +1,70 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Type};
+use polars::prelude::{DataTypeSelector, Selector};
+
+#[derive(Clone)]
+pub struct SelectorPolarsEnum;
+
+impl PluginCommand for SelectorPolarsEnum {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector enum"
+    }
+
+    fn description(&self) -> &str {
+        "Select all enum columns."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: "polars selector enum",
+            description: "Create a selector for enum columns",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "enum"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let selector = Selector::ByDType(DataTypeSelector::Enum);
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorPolarsEnum)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_polars_struct.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_polars_struct.rs
@@ -1,0 +1,70 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Type};
+use polars::prelude::{DataTypeSelector, Selector};
+
+#[derive(Clone)]
+pub struct SelectorPolarsStruct;
+
+impl PluginCommand for SelectorPolarsStruct {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector struct"
+    }
+
+    fn description(&self) -> &str {
+        "Select all struct columns."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: "polars selector struct",
+            description: "Create a selector for struct columns",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "struct"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let selector = Selector::ByDType(DataTypeSelector::Struct);
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorPolarsStruct)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_string.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_string.rs
@@ -1,0 +1,108 @@
+use crate::values::NuDataFrame;
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Span, Type};
+use polars::df;
+use polars::prelude::{DataType, DataTypeSelector, Selector};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct SelectorString;
+
+impl PluginCommand for SelectorString {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector string"
+    }
+
+    fn description(&self) -> &str {
+        "Select all string columns. Use `--include-categorical` to also select categorical columns."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .switch(
+                "include-categorical",
+                "Also include categorical columns in the selection.",
+                Some('c'),
+            )
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                example: r#"{
+    "name": ["Alice", "Bob"],
+    "age": [30, 25],
+    "active": [true, false],
+} |
+polars into-df --as-columns |
+polars select (polars selector string) |
+polars collect"#,
+                description: "Select all string columns",
+                result: Some(
+                    NuDataFrame::from(
+                        df!(
+                            "name" => ["Alice", "Bob"],
+                        )
+                        .expect("simple df for test should not fail"),
+                    )
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                example: "polars selector string --include-categorical",
+                description: "Create a selector for string and categorical columns",
+                result: None,
+            },
+        ]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["columns", "select", "string", "text", "str"]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+        let include_categorical = call.has_flag("include-categorical")?;
+
+        let selector = if include_categorical {
+            Selector::ByDType(DataTypeSelector::Union(
+                Arc::new(DataTypeSelector::AnyOf(vec![DataType::String].into())),
+                Arc::new(DataTypeSelector::Categorical),
+            ))
+        } else {
+            Selector::ByDType(DataTypeSelector::AnyOf(vec![DataType::String].into()))
+        };
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorString)
+    }
+}

--- a/crates/nu_plugin_polars/src/dataframe/command/selector/selector_temporal.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/selector/selector_temporal.rs
@@ -1,0 +1,72 @@
+use crate::{
+    PolarsPlugin,
+    dataframe::values::NuSelector,
+    values::{CustomValueSupport, PolarsPluginType},
+};
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Type};
+use polars::prelude::{DataTypeSelector, Selector};
+
+#[derive(Clone)]
+pub struct SelectorTemporal;
+
+impl PluginCommand for SelectorTemporal {
+    type Plugin = PolarsPlugin;
+
+    fn name(&self) -> &str {
+        "polars selector temporal"
+    }
+
+    fn description(&self) -> &str {
+        "Select all temporal columns (date, datetime, duration, and time)."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Any, PolarsPluginType::NuSelector.into())
+            .category(Category::Custom("expression".into()))
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: "polars selector temporal",
+            description: "Create a selector for temporal columns (date, datetime, duration, time)",
+            result: None,
+        }]
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec![
+            "columns", "select", "temporal", "date", "datetime", "duration", "time",
+        ]
+    }
+
+    fn run(
+        &self,
+        plugin: &Self::Plugin,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+        mut input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let metadata = input.take_metadata();
+
+        let selector = Selector::ByDType(DataTypeSelector::Temporal);
+        let nu_selector = NuSelector::from(selector);
+
+        nu_selector
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
+            .map(|pd| pd.set_metadata(metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::test_polars_plugin_command;
+
+    #[test]
+    fn test_examples() -> Result<(), nu_protocol::ShellError> {
+        test_polars_plugin_command(&SelectorTemporal)
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description

Added the rest of the selectors that are part of the Python library but not in the polars plugin.
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)

Added 20 additional polars selectors:

- `polars selector array` - Select all array columns. Optionally filter by fixed width.
- `polars selector binary` - Select all binary columns.
- `polars selector boolean` - Select all boolean columns.
- `polars selector by-index` - Select columns by their index position. Supports negative indices (e.g., `-1` for the last column).
- `polars selector categorical` - Select all categorical columns.
- `polars selector contains` - Select columns whose names contain the given literal substring(s).
- `polars selector date` - Select all date columns.
- `polars selector datetime` - Select all datetime columns. Optionally filter by time unit (`ns`, `us`, `ms`) and/or timezone.
- `polars selector decimal` - Select all decimal columns.
- `polars selector digit` - Select columns whose names consist entirely of digit characters. By default uses Unicode decimal digits; use `--ascii-only` to restrict to ASCII `0-9`.
- `polars selector duration` - Select all duration columns. Optionally filter by time unit (`ns`, `us`, `ms`).
- `polars selector empty` - Create an empty selector that matches no columns. Useful as a base for selector composition.
- `polars selector ends-with` - Select columns that end with the given substring(s).
- `polars selector enum` - Select all enum columns.
- `polars selector exclude` - Select all columns except those with the given name(s). This is the inverse of `polars selector by-name`.
- `polars selector list` - Select all list columns.
- `polars selector nested` - Select all nested columns (`list`, `array`, or `struct`).
- `polars selector object` - Select all object columns.
- `polars selector starts-with` - Select columns that start with the given substring(s).
- `polars selector string` - Select all string columns. Use `--include-categorical` to also select categorical columns.
- `polars selector struct` - Select all struct columns.
- `polars selector temporal` - Select all temporal columns (`date`, `datetime`, `duration`, and `time`).