### PR TITLE
Add `--pretty` flag and align table columns in `to nuon`

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -13,7 +13,7 @@ impl Command for ToNuon {
             .input_output_types(vec![(Type::Any, Type::String)])
             .switch(
                 "raw",
-                "Remove all of the whitespace (overwrites -i and -t).",
+                "Remove all of the whitespace (overwrites -i, -t, and -p).",
                 Some('r'),
             )
             .named(
@@ -48,6 +48,11 @@ impl Command for ToNuon {
                 "Do not use commas between items in tables and lists.",
                 Some('c'),
             )
+            .switch(
+                "pretty",
+                "Format output with indentation and aligned table columns.",
+                Some('p'),
+            )
             .category(Category::Formats)
     }
 
@@ -66,12 +71,15 @@ impl Command for ToNuon {
         let raw_strings = call.has_flag(engine_state, stack, "raw-strings")?;
         let list_of_records = call.has_flag(engine_state, stack, "list-of-records")?;
         let no_commas = call.has_flag(engine_state, stack, "no-commas")?;
+        let pretty = call.has_flag(engine_state, stack, "pretty")?;
         let style = if call.has_flag(engine_state, stack, "raw")? {
             nuon::ToStyle::Raw
         } else if let Some(t) = call.get_flag(engine_state, stack, "tabs")? {
             nuon::ToStyle::Tabs(t)
         } else if let Some(i) = call.get_flag(engine_state, stack, "indent")? {
             nuon::ToStyle::Spaces(i)
+        } else if pretty {
+            nuon::ToStyle::Spaces(2)
         } else {
             nuon::ToStyle::Default
         };
@@ -156,6 +164,13 @@ impl Command for ToNuon {
                 description: "Output a record without commas between fields.",
                 example: "{a: 1, b: 2} | to nuon --no-commas",
                 result: Some(Value::test_string("{a: 1 b: 2}")),
+            },
+            Example {
+                description: "Format output with pretty indentation and aligned table columns.",
+                example: "[[name, age]; [Alice, 30], [Bob, 25]] | to nuon --pretty",
+                result: Some(Value::test_string(
+                    "[\n  [name,  age];\n  [Alice, 30],\n  [Bob,   25]\n]",
+                )),
             },
         ]
     }

--- a/crates/nuon/src/lib.rs
+++ b/crates/nuon/src/lib.rs
@@ -669,4 +669,38 @@ version = "1.0.0"
             Value::test_string("# example.toml\nname = \"my-app\"\nversion = \"1.0.0\"\n")
         );
     }
+
+    #[test]
+    fn table_column_alignment_with_indent() {
+        let engine_state = EngineState::new();
+        let val = Value::test_list(vec![
+            Value::test_record(record!(
+                "name" => Value::test_string("alice"),
+                "age" => Value::test_int(22),
+                "active" => Value::test_bool(true)
+            )),
+            Value::test_record(record!(
+                "name" => Value::test_string("bob"),
+                "age" => Value::test_int(20),
+                "active" => Value::test_bool(false)
+            )),
+            Value::test_record(record!(
+                "name" => Value::test_string("charlie"),
+                "age" => Value::test_int(20),
+                "active" => Value::test_bool(false)
+            )),
+        ]);
+        let result = to_nuon(
+            &engine_state,
+            &val,
+            ToNuonConfig::default().style(ToStyle::Spaces(2)),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            "[\n  [name,    age, active];\n  [alice,   22,  true],\n  [bob,     20,  false],\n  [charlie, 20,  false]\n]"
+        );
+        // roundtrip: aligned output parses back to the same value
+        assert_eq!(val, from_nuon(&result, None).unwrap());
+    }
 }

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -295,14 +295,78 @@ fn value_to_string(
                 };
 
                 if indent.is_some_and(|i| !i.is_empty()) {
-                    let header_row = format!("[{}];", headers.join(c));
+                    // Recompute headers without idt prefix for proper alignment
+                    let col_names: Vec<String> = get_columns(vals)
+                        .iter()
+                        .map(|s| {
+                            if needs_quoting(s) {
+                                escape_quote_string(s)
+                            } else {
+                                s.clone()
+                            }
+                        })
+                        .collect();
 
-                    let value_rows = record_rows(&|row| format!("[{}]", row.join(c)))?
-                        .join(&format!(",{nl}{idt_po}"));
+                    // Pre-render all cell values for column width computation
+                    let num_cols = col_names.len();
+                    let mut all_rows: Vec<Vec<String>> = Vec::new();
+                    for val in vals {
+                        let Value::Record { val, .. } = val else {
+                            continue;
+                        };
+                        let row: Vec<String> = val
+                            .values()
+                            .map(|v| {
+                                value_to_string_without_quotes(
+                                    engine_state,
+                                    v,
+                                    span,
+                                    depth + 2,
+                                    indent,
+                                    options,
+                                )
+                            })
+                            .collect::<Result<Vec<_>, _>>()?;
+                        all_rows.push(row);
+                    }
+
+                    // Column widths = max of header and cell widths per column
+                    let mut widths: Vec<usize> = col_names.iter().map(|h| h.len()).collect();
+                    for row in &all_rows {
+                        for (i, cell) in row.iter().enumerate() {
+                            widths[i] = widths[i].max(cell.len());
+                        }
+                    }
+
+                    // Per-cell trailing separator: comma (if enabled) plus padding to column
+                    // width + 2 keeps columns aligned in both `--pretty` and
+                    // `--pretty --no-commas` modes.
+                    let pad_row = |items: &[String]| -> String {
+                        let mut out = String::new();
+                        for (i, item) in items.iter().enumerate() {
+                            if i < num_cols - 1 {
+                                let _ = write!(
+                                    out,
+                                    "{:<width$}",
+                                    format!("{item}{c}"),
+                                    width = widths[i] + 2
+                                );
+                            } else {
+                                out.push_str(item);
+                            }
+                        }
+                        out
+                    };
+
+                    let header_row = format!("[{}];", pad_row(&col_names));
+                    let value_rows: Vec<String> = all_rows
+                        .iter()
+                        .map(|row| format!("[{}]", pad_row(row)))
+                        .collect();
+                    let value_rows_str = value_rows.join(&format!("{c}{nl}{idt_po}"));
 
                     Ok(format!(
-                        "[{nl}{idt_po}{}{sep}{nl}{idt_po}{}{nl}{idt}]",
-                        header_row, value_rows
+                        "[{nl}{idt_po}{header_row}{sep}{nl}{idt_po}{value_rows_str}{nl}{idt}]"
                     ))
                 } else {
                     let headers_output = headers.join(&format!("{c}{sep}{nl}{idt_pt}"));


### PR DESCRIPTION
Why: make aligned tables in "to nuon" format look nicer


## Description

This PR makes two related changes to `to nuon`:

1. **Aligned table columns in indented output**: When `to nuon` renders tables with indentation (`--indent` or `--tabs`), columns are now padded so values align vertically across rows.

2. **New `--pretty` (`-p`) flag**: Convenience shorthand for `--indent 2`, providing readable aligned output without remembering the indent width.

Before (`--indent 2`):
```nushell
> [[name, age, active]; [alice, 22, true], [bob, 20, false]] | to nuon --indent 2
[
  [name, age, active];
  [alice, 22, true],
  [bob, 20, false]
]
```

After (`--indent 2` or `--pretty`):
```nushell
> [[name, age, active]; [alice, 22, true], [bob, 20, false]] | to nuon --pretty
[
  [name,  age, active];
  [alice, 22,  true],
  [bob,   20,  false]
]
```

The alignment is computed by pre-rendering all cell values, finding the max width per column, and padding with spaces. The compact (default) and raw paths are unchanged. `--raw` overrides `--pretty`.

The aligned output remains valid NUON and roundtrips correctly through `from nuon`.

## User-facing changes (Release notes)

`to nuon` now aligns table columns when using `--indent`, `--tabs`, or the new `--pretty` (`-p`) flag, making output easier to read. `--pretty` is shorthand for `--indent 2`.

```nushell
> [[name, age]; [Alice, 30], [Bob, 25]] | to nuon --pretty
[
  [name,  age];
  [Alice, 30],
  [Bob,   25]
]
```

## Additional notes

Note: this changes the whitespace in `--indent`/`--tabs` table output (columns are now padded). The output is still valid NUON and parses back identically.
