### PR TITLE
refactor tests to avoid format!

### DIFF
--- a/crates/nu-command/tests/commands/base/base32.rs
+++ b/crates/nu-command/tests/commands/base/base32.rs
@@ -19,8 +19,9 @@ fn encode() -> Result {
     let text = "Ș̗͙̂̏o̲̲̗͗̌͊m̝̊̓́͂ë̡̦̞̤́̌̈́̀ ̥̝̪̎̿ͅf̧̪̻͉͗̈́̍̆u̮̝͌̈́ͅn̹̞̈́̊k̮͇̟͎̂͘y̧̲̠̾̆̕ͅ ̙͖̭͔̂̐t̞́́͘e̢̨͕̽x̥͋t͍̑̔͝";
     let encoded = "KPGIFTEPZSTMZF6NTFX43F6MRTGYVTFSZSZMZF3NZSFMZE6MQHGYFTE5MXGYJTEMZWCMZAGMU3GKDTE6ZSSCBTEOZS743BOMUXGJ3TFKM3GZPTMEZSG4ZBWMVLGLXTFHZWEXLTMMZWCMZLWMTXGYK3WNQTGIVTFZZSPGXTMYZSBMZLWNQ7GJ7TMOPHGL5TEVZSDM3BOMWLGKPTFAEDGIFTEQZSM43FWMVXGZI5GMQHGZRTEBZSPGLTF5ZSRM3FOMVB4M3C6MUV2MZEOMSTGZ3TMN";
 
-    let code = format!("'{text}' | encode base32 --nopad");
-    test().run(code).expect_value_eq(encoded)
+    test()
+        .run_with_data("encode base32 --nopad", text)
+        .expect_value_eq(encoded)
 }
 
 #[test]
@@ -28,8 +29,9 @@ fn decode_string() -> Result {
     let text = "Very important data";
     let encoded = "KZSXE6JANFWXA33SORQW45BAMRQXIYI=";
 
-    let code = format!("'{encoded}' | decode base32 | decode");
-    test().run(code).expect_value_eq(text)
+    test()
+        .run_with_data("decode base32 | decode", encoded)
+        .expect_value_eq(text)
 }
 
 #[test]
@@ -38,11 +40,13 @@ fn decode_pad_nopad() -> Result {
     let encoded_pad = "YKXGY3TOIXBL5S4GYOVQ====";
     let encoded_nopad = "YKXGY3TOIXBL5S4GYOVQ";
 
-    let code = format!("'{encoded_pad}' | decode base32 | decode");
-    test().run(code).expect_value_eq(text)?;
+    test()
+        .run_with_data("decode base32 | decode", encoded_pad)
+        .expect_value_eq(text)?;
 
-    let code = format!("'{encoded_nopad}' | decode base32 --nopad | decode");
-    test().run(code).expect_value_eq(text)
+    test()
+        .run_with_data("decode base32 --nopad | decode", encoded_nopad)
+        .expect_value_eq(text)
 }
 
 #[test]
@@ -50,12 +54,14 @@ fn reject_pad_nopad() -> Result {
     let encoded_nopad = "ME";
     let encoded_pad = "ME======";
 
-    let code = format!("'{encoded_nopad}' | decode base32");
-    let err = test().run(code).expect_error()?;
+    let err = test()
+        .run_with_data("decode base32", encoded_nopad)
+        .expect_error()?;
     assert!(!err.to_string().is_empty());
 
-    let code = format!("'{encoded_pad}' | decode base32 --nopad");
-    let err = test().run(code).expect_error()?;
+    let err = test()
+        .run_with_data("decode base32 --nopad", encoded_pad)
+        .expect_error()?;
     assert!(!err.to_string().is_empty());
     Ok(())
 }

--- a/crates/nu-command/tests/commands/base/base32hex.rs
+++ b/crates/nu-command/tests/commands/base/base32hex.rs
@@ -19,8 +19,9 @@ fn encode() -> Result {
     let text = "Ș̗͙̂̏o̲̲̗͗̌͊m̝̊̓́͂ë̡̦̞̤́̌̈́̀ ̥̝̪̎̿ͅf̧̪̻͉͗̈́̍̆u̮̝͌̈́ͅn̹̞̈́̊k̮͇̟͎̂͘y̧̲̠̾̆̕ͅ ̙͖̭͔̂̐t̞́́͘e̢̨͕̽x̥͋t͍̑̔͝";
     let encoded = "AF685J4FPIJCP5UDJ5NSR5UCHJ6OLJ5IPIPCP5RDPI5CP4UCG76O5J4TCN6O9J4CPM2CP06CKR6A3J4UPII21J4EPIVSR1ECKN69RJ5ACR6PFJC4PI6SP1MCLB6BNJ57PM4NBJCCPM2CPBMCJN6OARMDGJ68LJ5PPIF6NJCOPI1CPBMDGV69VJCEF76BTJ4LPI3CR1ECMB6AFJ5043685J4GPICSR5MCLN6P8T6CG76PHJ41PIF6BJ5TPIHCR5ECL1SCR2UCKLQCP4ECIJ6PRJCD";
 
-    let code = format!("'{text}' | encode base32hex --nopad");
-    test().run(code).expect_value_eq(encoded)
+    test()
+        .run_with_data("encode base32hex --nopad", text)
+        .expect_value_eq(encoded)
 }
 
 #[test]
@@ -28,8 +29,9 @@ fn decode_string() -> Result {
     let text = "Very important data";
     let encoded = "APIN4U90D5MN0RRIEHGMST10CHGN8O8=";
 
-    let code = format!("'{encoded}' | decode base32hex | decode");
-    test().run(code).expect_value_eq(text)
+    test()
+        .run_with_data("decode base32hex | decode", encoded)
+        .expect_value_eq(text)
 }
 
 #[test]
@@ -38,11 +40,13 @@ fn decode_pad_nopad() -> Result {
     let encoded_pad = "OAN6ORJE8N1BTIS6OELG====";
     let encoded_nopad = "OAN6ORJE8N1BTIS6OELG";
 
-    let code = format!("'{encoded_pad}' | decode base32hex | decode");
-    test().run(code).expect_value_eq(text)?;
+    test()
+        .run_with_data("decode base32hex | decode", encoded_pad)
+        .expect_value_eq(text)?;
 
-    let code = format!("'{encoded_nopad}' | decode base32hex --nopad | decode");
-    test().run(code).expect_value_eq(text)
+    test()
+        .run_with_data("decode base32hex --nopad | decode", encoded_nopad)
+        .expect_value_eq(text)
 }
 
 #[test]
@@ -50,12 +54,14 @@ fn reject_pad_nopad() -> Result {
     let encoded_nopad = "D1KG";
     let encoded_pad = "D1KG====";
 
-    let code = format!("'{encoded_nopad}' | decode base32hex");
-    let err = test().run(code).expect_error()?;
+    let err = test()
+        .run_with_data("decode base32hex", encoded_nopad)
+        .expect_error()?;
     assert!(!err.to_string().is_empty());
 
-    let code = format!("'{encoded_pad}' | decode base32hex --nopad");
-    let err = test().run(code).expect_error()?;
+    let err = test()
+        .run_with_data("decode base32hex --nopad", encoded_pad)
+        .expect_error()?;
     assert!(!err.to_string().is_empty());
     Ok(())
 }

--- a/crates/nu-command/tests/commands/base/base64.rs
+++ b/crates/nu-command/tests/commands/base/base64.rs
@@ -23,8 +23,9 @@ fn encode() -> Result {
     let text = "Ș̗͙̂̏o̲̲̗͗̌͊m̝̊̓́͂ë̡̦̞̤́̌̈́̀ ̥̝̪̎̿ͅf̧̪̻͉͗̈́̍̆u̮̝͌̈́ͅn̹̞̈́̊k̮͇̟͎̂͘y̧̲̠̾̆̕ͅ ̙͖̭͔̂̐t̞́́͘e̢̨͕̽x̥͋t͍̑̔͝";
     let encoded = "U8yCzI/MpsyXzZlvzZfMjM2KzLLMssyXbcyKzJPMgc2CzJ1lzYTMjM2EzIDMpsyhzJ7MpCDMjsy/zYXMpcydzKpmzZfNhMyNzIbMqsy7zKfNiXXNjM2EzK7Mnc2Fbs2EzIrMucyea82YzILMrs2HzJ/NjnnMvsyVzIbNhcyyzKfMoCDMgsyQzJnNlsytzZR0zIHNmMyBzJ5lzL3Mos2VzKh4zYvMpXTMkcyUzZ3NjQ==";
 
-    let code = format!("'{text}' | encode base64");
-    test().run(code).expect_value_eq(encoded)
+    test()
+        .run_with_data("encode base64", text)
+        .expect_value_eq(encoded)
 }
 
 #[test]
@@ -32,8 +33,9 @@ fn decode_string() -> Result {
     let text = "Very important data";
     let encoded = "VmVyeSBpbXBvcnRhbnQgZGF0YQ==";
 
-    let code = format!("'{encoded}' | decode base64 | decode");
-    test().run(code).expect_value_eq(text)
+    test()
+        .run_with_data("decode base64 | decode", encoded)
+        .expect_value_eq(text)
 }
 
 #[test]
@@ -42,11 +44,13 @@ fn decode_pad_nopad() -> Result {
     let encoded_pad = "4oCdwqUuw6RAwrBiWsO2wqI=";
     let encoded_nopad = "4oCdwqUuw6RAwrBiWsO2wqI";
 
-    let code = format!("'{encoded_pad}' | decode base64 | decode");
-    test().run(code).expect_value_eq(text)?;
+    test()
+        .run_with_data("decode base64 | decode", encoded_pad)
+        .expect_value_eq(text)?;
 
-    let code = format!("'{encoded_nopad}' | decode base64 --nopad | decode");
-    test().run(code).expect_value_eq(text)
+    test()
+        .run_with_data("decode base64 --nopad | decode", encoded_nopad)
+        .expect_value_eq(text)
 }
 
 #[test]
@@ -55,11 +59,13 @@ fn decode_url() -> Result {
     let encoded = "cDpn15jdvt+rdCs/";
     let encoded_url = "cDpn15jdvt-rdCs_";
 
-    let code = format!("'{encoded}' | decode base64 | decode");
-    test().run(code).expect_value_eq(text)?;
+    test()
+        .run_with_data("decode base64 | decode", encoded)
+        .expect_value_eq(text)?;
 
-    let code = format!("'{encoded_url}' | decode base64 --url | decode");
-    test().run(code).expect_value_eq(text)
+    test()
+        .run_with_data("decode base64 --url | decode", encoded_url)
+        .expect_value_eq(text)
 }
 
 #[test]
@@ -67,12 +73,14 @@ fn reject_pad_nopad() -> Result {
     let encoded_nopad = "YQ";
     let encoded_pad = "YQ==";
 
-    let code = format!("'{encoded_nopad}' | decode base64");
-    let err = test().run(code).expect_error()?;
+    let err = test()
+        .run_with_data("decode base64", encoded_nopad)
+        .expect_error()?;
     assert!(!err.to_string().is_empty());
 
-    let code = format!("'{encoded_pad}' | decode base64 --nopad");
-    let err = test().run(code).expect_error()?;
+    let err = test()
+        .run_with_data("decode base64 --nopad", encoded_pad)
+        .expect_error()?;
     assert!(!err.to_string().is_empty());
     Ok(())
 }

--- a/crates/nu-command/tests/commands/base/hex.rs
+++ b/crates/nu-command/tests/commands/base/hex.rs
@@ -17,8 +17,9 @@ fn encode() -> Result {
     let text = "Ș̗͙̂̏o̲̲̗͗̌͊m̝̊̓́͂ë̡̦̞̤́̌̈́̀ ̥̝̪̎̿ͅf̧̪̻͉͗̈́̍̆u̮̝͌̈́ͅn̹̞̈́̊k̮͇̟͎̂͘y̧̲̠̾̆̕ͅ ̙͖̭͔̂̐t̞́́͘e̢̨͕̽x̥͋t͍̑̔͝";
     let encoded = "53CC82CC8FCCA6CC97CD996FCD97CC8CCD8ACCB2CCB2CC976DCC8ACC93CC81CD82CC9D65CD84CC8CCD84CC80CCA6CCA1CC9ECCA420CC8ECCBFCD85CCA5CC9DCCAA66CD97CD84CC8DCC86CCAACCBBCCA7CD8975CD8CCD84CCAECC9DCD856ECD84CC8ACCB9CC9E6BCD98CC82CCAECD87CC9FCD8E79CCBECC95CC86CD85CCB2CCA7CCA020CC82CC90CC99CD96CCADCD9474CC81CD98CC81CC9E65CCBDCCA2CD95CCA878CD8BCCA574CC91CC94CD9DCD8D";
 
-    let code = format!("'{text}' | encode hex");
-    test().run(code).expect_value_eq(encoded)
+    test()
+        .run_with_data("encode hex", text)
+        .expect_value_eq(encoded)
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/bytes/at.rs
+++ b/crates/nu-command/tests/commands/bytes/at.rs
@@ -1,3 +1,4 @@
+use nu_protocol::{IntoPipelineData, Span};
 use nu_test_support::prelude::*;
 
 #[test]
@@ -73,10 +74,14 @@ pub fn test_string_returns_correct_slice_for_max_end() -> Result {
 
 #[test]
 pub fn test_drops_content_type() -> Result {
-    test()
-        .run_with_data(
-            "open $in | bytes at 3..5 | metadata | get content_type? | describe",
-            file!(),
-        )
-        .expect_value_eq("nothing")
+    let content_type = test()
+        .run_raw_with_data(
+            "open $in | bytes at 3..5",
+            (file!()).into_value(Span::test_data()).into_pipeline_data(),
+        )?
+        .take_metadata()
+        .and_then(|md| md.content_type);
+
+    assert!(content_type.is_none());
+    Ok(())
 }

--- a/crates/nu-command/tests/commands/bytes/at.rs
+++ b/crates/nu-command/tests/commands/bytes/at.rs
@@ -73,9 +73,10 @@ pub fn test_string_returns_correct_slice_for_max_end() -> Result {
 
 #[test]
 pub fn test_drops_content_type() -> Result {
-    let code = format!(
-        "open {} | bytes at 3..5 | metadata | get content_type? | describe",
-        file!(),
-    );
-    test().run(code).expect_value_eq("nothing")
+    test()
+        .run_with_data(
+            "open $in | bytes at 3..5 | metadata | get content_type? | describe",
+            file!(),
+        )
+        .expect_value_eq("nothing")
 }

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -1,3 +1,5 @@
+use std::os::unix::ffi::OsStrExt;
+
 use nu_protocol::{shell_error, test_record};
 use nu_test_support::{fs::Stub::EmptyFile, prelude::*};
 
@@ -44,7 +46,7 @@ fn filesystem_change_from_current_directory_using_absolute_path() -> Result {
     Playground::setup("cd_test_2", |dirs, _| {
         test()
             .cwd(dirs.test())
-            .run_with_data("cd $in; $env.PWD", dirs.formats().display().to_string())
+            .run_with_data("cd $in; $env.PWD", dirs.formats())
             .expect_value_eq(dirs.formats())
     })
 }
@@ -52,15 +54,18 @@ fn filesystem_change_from_current_directory_using_absolute_path() -> Result {
 #[test]
 fn filesystem_change_from_current_directory_using_absolute_path_with_trailing_slash() -> Result {
     Playground::setup("cd_test_2", |dirs, _| {
-        let path = format!(
-            "{}{}",
-            dirs.formats().display(),
-            std::path::MAIN_SEPARATOR_STR
-        );
+        let dir = {
+            let mut dir = dirs.formats();
+            // It works and is unlikely to break, but is not explicitly documented behavior
+            // Also Path::with_trailing_sep is unstable
+            dir.push("");
+            assert!(dir.as_os_str().as_bytes().ends_with(b"/"));
+            dir
+        };
 
         test()
             .cwd(dirs.test())
-            .run_with_data("cd $in; $env.PWD", path)
+            .run_with_data("cd $in; $env.PWD", dir)
             .expect_value_eq(dirs.formats())
     })
 }

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -1,4 +1,4 @@
-use nu_protocol::shell_error;
+use nu_protocol::{shell_error, test_record};
 use nu_test_support::{fs::Stub::EmptyFile, prelude::*};
 
 #[test]
@@ -42,10 +42,9 @@ fn filesystem_change_from_current_directory_using_relative_path_with_trailing_sl
 #[test]
 fn filesystem_change_from_current_directory_using_absolute_path() -> Result {
     Playground::setup("cd_test_2", |dirs, _| {
-        let code = format!("cd '{}'; $env.PWD", dirs.formats().display());
         test()
             .cwd(dirs.test())
-            .run(code)
+            .run_with_data("cd $in; $env.PWD", dirs.formats().display().to_string())
             .expect_value_eq(dirs.formats())
     })
 }
@@ -53,15 +52,15 @@ fn filesystem_change_from_current_directory_using_absolute_path() -> Result {
 #[test]
 fn filesystem_change_from_current_directory_using_absolute_path_with_trailing_slash() -> Result {
     Playground::setup("cd_test_2", |dirs, _| {
-        let code = format!(
-            "cd '{}{}'; $env.PWD",
+        let path = format!(
+            "{}{}",
             dirs.formats().display(),
-            std::path::MAIN_SEPARATOR_STR,
+            std::path::MAIN_SEPARATOR_STR
         );
 
         test()
             .cwd(dirs.test())
-            .run(code)
+            .run_with_data("cd $in; $env.PWD", path)
             .expect_value_eq(dirs.formats())
     })
 }
@@ -72,9 +71,10 @@ fn filesystem_switch_back_to_previous_working_directory() -> Result {
         sandbox.mkdir("odin");
         let odin_path = dirs.test().join("odin");
 
-        let code = format!("cd {}; cd -; $env.PWD", dirs.test().display());
-
-        test().cwd(&odin_path).run(code).expect_value_eq(odin_path)
+        test()
+            .cwd(&odin_path)
+            .run_with_data("cd $in; cd -; $env.PWD", dirs.test())
+            .expect_value_eq(odin_path)
     })
 }
 
@@ -279,9 +279,21 @@ fn pwd_recovery() -> Result {
         .display()
         .to_string();
 
+    let ctx = test_record! {
+        "tmpdir" => tmpdir,
+        "nu" => nu,
+    };
     // We `cd` into a temporary directory, then spawn another `nu` process to
     // delete that directory. Then we attempt to recover by running `cd /`.
-    let cmd =
-        format!("mkdir '{tmpdir}'; cd '{tmpdir}'; {nu} -c \"cd /; rm -r '{tmpdir}'\"; cd /; pwd");
-    test().run(cmd).expect_value_eq("/")
+    let code = r#"
+        let ctx = $in
+
+        mkdir $ctx.tmpdir
+        cd $ctx.tmpdir
+        ^$ctx.nu -c $"cd /; rm -r '($ctx.tmpdir)'"
+        cd /
+        pwd
+    "#;
+
+    test().run_with_data(code, ctx).expect_value_eq("/")
 }

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -1,5 +1,5 @@
 use nu_protocol::test_record;
-use nu_test_support::prelude::*;
+use nu_test_support::{fs::fixtures, prelude::*};
 
 #[test]
 fn all() -> Result {
@@ -30,7 +30,7 @@ fn compute_sum_of_individual_row() -> Result {
         ("mem", 3032375296.),
         ("virtual", 102579965952.),
     ];
-    let mut tester = test().cwd("tests/fixtures/formats");
+    let mut tester = test().cwd(fixtures().join("formats"));
     for (column_name, expected_value) in answers_for_columns {
         let () = tester.run_with_data("let column = into cell-path", [column_name])?;
         let code = "
@@ -61,7 +61,7 @@ fn compute_sum_of_table() -> Result {
     };
 
     test()
-        .cwd("tests/fixtures/formats")
+        .cwd(fixtures().join("formats"))
         .run(code)
         .expect_value_eq(expected)
 }
@@ -69,7 +69,7 @@ fn compute_sum_of_table() -> Result {
 #[test]
 fn sum_of_a_row_containing_a_table_is_an_error() -> Result {
     let outcome = test()
-        .cwd("tests/fixtures/formats")
+        .cwd(fixtures().join("formats"))
         .run("open sample-sys-output.json | math sum")
         .expect_shell_error()?;
     match outcome {

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -1,3 +1,4 @@
+use nu_protocol::test_record;
 use nu_test_support::prelude::*;
 
 #[test]
@@ -10,16 +11,14 @@ fn all() -> Result {
         ]
     }"#;
 
-    let code = format!(
-        "
-            {sample}
-            | get meals
-            | get calories
-            | math sum
-        "
-    );
+    let code = "
+        from nuon
+        | get meals
+        | get calories
+        | math sum
+    ";
 
-    test().run(&code).expect_value_eq(448)
+    test().run_with_data(code, sample).expect_value_eq(448)
 }
 
 #[test]
@@ -33,10 +32,14 @@ fn compute_sum_of_individual_row() -> Result {
     ];
     let mut tester = test().cwd("tests/fixtures/formats");
     for (column_name, expected_value) in answers_for_columns {
-        let code = format!(
-            "open sample-ps-output.json | select {column_name} | math sum | get {column_name}"
-        );
-        tester.run(&code).expect_value_eq(expected_value)?;
+        let () = tester.run_with_data("let column = into cell-path", [column_name])?;
+        let code = "
+            open sample-ps-output.json
+            | select $column
+            | math sum
+            | get $column
+        ";
+        tester.run(code).expect_value_eq(expected_value)?;
     }
     Ok(())
 }
@@ -45,19 +48,22 @@ fn compute_sum_of_individual_row() -> Result {
 #[allow(clippy::unreadable_literal)]
 #[allow(clippy::float_cmp)]
 fn compute_sum_of_table() -> Result {
-    let answers_for_columns = [
-        ("cpu", 88.257434),
-        ("mem", 3032375296.),
-        ("virtual", 102579965952.),
-    ];
-    let mut tester = test().cwd("tests/fixtures/formats");
-    for (column_name, expected_value) in answers_for_columns {
-        let code = format!(
-            "open sample-ps-output.json | select cpu mem virtual | math sum | get {column_name}"
-        );
-        tester.run(&code).expect_value_eq(expected_value)?;
-    }
-    Ok(())
+    let code = "
+        open sample-ps-output.json
+        | select cpu mem virtual
+        | math sum
+    ";
+
+    let expected = test_record! {
+        "cpu" => 88.257434,
+        "mem" => 3032375296.,
+        "virtual" => 102579965952.,
+    };
+
+    test()
+        .cwd("tests/fixtures/formats")
+        .run(code)
+        .expect_value_eq(expected)
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/merge.rs
+++ b/crates/nu-command/tests/commands/merge.rs
@@ -1,68 +1,106 @@
+use nu_protocol::test_record;
 use nu_test_support::prelude::*;
 
 #[test]
 fn row() -> Result {
-    let left_sample = "[[name, country, luck];
-        [Andrés, Ecuador, 0],
-        [JT, USA, 0],
-        [Jason, Canada, 0],
-        [Yehuda, USA, 0]]";
+    let mut tester = test();
 
-    let right_sample = r#"[[name, country, luck];
+    let left_sample = "
+        [[name, country, luck];
+         [Andrés, Ecuador, 0],
+         [JT, USA, 0],
+         [Jason, Canada, 0],
+         [Yehuda, USA, 0]]";
+    let () = tester.run_with_data("let left = from nuon", left_sample)?;
+
+    let right_sample = r#"
+        [[name, country, luck];
          ["Andrés Robalino", "Guayaquil Ecuador", 1],
          ["JT Turner", "New Zealand", 1]]"#;
+    let () = tester.run_with_data("let right = from nuon", right_sample)?;
 
-    let code = format!(
-        r#"
-            ({left_sample})
-            | merge ({right_sample})
-            | where country in ["Guayaquil Ecuador" "New Zealand"]
-            | get luck
-            | math sum
-        "#
-    );
+    let code = r#"
+        $left
+        | merge $right
+        | where country in ["Guayaquil Ecuador" "New Zealand"]
+        | get luck
+        | math sum
+    "#;
 
-    test().run(code).expect_value_eq(2)
+    tester.run(code).expect_value_eq(2)
 }
 
 #[test]
 fn single_record_no_overwrite() -> Result {
     test()
-        .run("{a: 1, b: 5} | merge {c: 2} | to nuon")
-        .expect_value_eq("{a: 1, b: 5, c: 2}")
+        .run("{a: 1, b: 5} | merge {c: 2}")
+        .expect_value_eq(test_record! { "a" => 1, "b" => 5, "c" => 2 })
 }
 
 #[test]
 fn single_record_overwrite() -> Result {
     test()
-        .run("{a: 1, b: 2} | merge {a: 2} | to nuon")
-        .expect_value_eq("{a: 2, b: 2}")
+        .run("{a: 1, b: 2} | merge {a: 2}")
+        .expect_value_eq(test_record! {"a" => 2, "b" => 2})
 }
 
 #[test]
 fn single_row_table_overwrite() -> Result {
     test()
-        .run("[[a b]; [1 4]] | merge [[a b]; [2 4]] | to nuon")
-        .expect_value_eq("[[a, b]; [2, 4]]")
+        .run("[[a b]; [1 4]] | merge [[a b]; [2 4]]")
+        .expect_value_eq([test_record! {"a" => 2, "b" => 4}])
 }
 
 #[test]
 fn single_row_table_no_overwrite() -> Result {
     test()
-        .run("[[a b]; [1 4]] | merge [[c d]; [2 4]] | to nuon")
-        .expect_value_eq("[[a, b, c, d]; [1, 4, 2, 4]]")
+        .run("[[a b]; [1 4]] | merge [[c d]; [2 4]]")
+        .expect_value_eq([test_record! {
+          "a" => 1,
+          "b" => 4,
+          "c" => 2,
+          "d" => 4
+        }])
 }
 
 #[test]
 fn multi_row_table_no_overwrite() -> Result {
     test()
-        .run("[[a b]; [1 4] [8 9] [9 9]] | merge [[c d]; [2 4]]  | to nuon")
-        .expect_value_eq("[{a: 1, b: 4, c: 2, d: 4}, {a: 8, b: 9}, {a: 9, b: 9}]")
+        .run("[[a b]; [1 4] [8 9] [9 9]] | merge [[c d]; [2 4]]")
+        .expect_value_eq([
+            test_record! {
+              "a" => 1,
+              "b" => 4,
+              "c" => 2,
+              "d" => 4
+            },
+            test_record! {
+              "a" => 8,
+              "b" => 9
+            },
+            test_record! {
+              "a" => 9,
+              "b" => 9
+            },
+        ])
 }
 
 #[test]
 fn multi_row_table_overwrite() -> Result {
     test()
-        .run("[[a b]; [1 4] [8 9] [9 9]] | merge  [[a b]; [7 7]]  | to nuon")
-        .expect_value_eq("[[a, b]; [7, 7], [8, 9], [9, 9]]")
+        .run("[[a b]; [1 4] [8 9] [9 9]] | merge  [[a b]; [7 7]]")
+        .expect_value_eq([
+            test_record! {
+              "a" => 7,
+              "b" => 7
+            },
+            test_record! {
+              "a" => 8,
+              "b" => 9
+            },
+            test_record! {
+              "a" => 9,
+              "b" => 9
+            },
+        ])
 }

--- a/crates/nu-command/tests/commands/merge.rs
+++ b/crates/nu-command/tests/commands/merge.rs
@@ -1,23 +1,25 @@
-use nu_protocol::test_record;
+use nu_protocol::{test_record, test_table};
 use nu_test_support::prelude::*;
 
 #[test]
 fn row() -> Result {
     let mut tester = test();
 
-    let left_sample = "
-        [[name, country, luck];
-         [Andrés, Ecuador, 0],
-         [JT, USA, 0],
-         [Jason, Canada, 0],
-         [Yehuda, USA, 0]]";
-    let () = tester.run_with_data("let left = from nuon", left_sample)?;
+    let left_sample = test_table![
+        ["name", "country", "luck"];
+        ["Andrés", "Ecuador", 0],
+        ["JT", "USA", 0],
+        ["Jason", "Canada", 0],
+        ["Yehuda", "USA", 0]
+    ];
+    let right_sample = test_table![
+        ["name", "country", "luck"];
+        ["Andrés Robalino", "Guayaquil Ecuador", 1],
+        ["JT Turner", "New Zealand", 1]
+    ];
 
-    let right_sample = r#"
-        [[name, country, luck];
-         ["Andrés Robalino", "Guayaquil Ecuador", 1],
-         ["JT Turner", "New Zealand", 1]]"#;
-    let () = tester.run_with_data("let right = from nuon", right_sample)?;
+    let () = tester.run_with_data("let left = $in", left_sample)?;
+    let () = tester.run_with_data("let right = $in", right_sample)?;
 
     let code = r#"
         $left
@@ -48,19 +50,14 @@ fn single_record_overwrite() -> Result {
 fn single_row_table_overwrite() -> Result {
     test()
         .run("[[a b]; [1 4]] | merge [[a b]; [2 4]]")
-        .expect_value_eq([test_record! {"a" => 2, "b" => 4}])
+        .expect_value_eq(test_table![["a", "b"]; [2, 4]])
 }
 
 #[test]
 fn single_row_table_no_overwrite() -> Result {
     test()
         .run("[[a b]; [1 4]] | merge [[c d]; [2 4]]")
-        .expect_value_eq([test_record! {
-          "a" => 1,
-          "b" => 4,
-          "c" => 2,
-          "d" => 4
-        }])
+        .expect_value_eq(test_table! [["a", "b", "c", "d"]; [1, 4, 2, 4]])
 }
 
 #[test]
@@ -89,18 +86,10 @@ fn multi_row_table_no_overwrite() -> Result {
 fn multi_row_table_overwrite() -> Result {
     test()
         .run("[[a b]; [1 4] [8 9] [9 9]] | merge  [[a b]; [7 7]]")
-        .expect_value_eq([
-            test_record! {
-              "a" => 7,
-              "b" => 7
-            },
-            test_record! {
-              "a" => 8,
-              "b" => 9
-            },
-            test_record! {
-              "a" => 9,
-              "b" => 9
-            },
+        .expect_value_eq(test_table![
+            ["a", "b"];
+            [7, 7],
+            [8, 9],
+            [9, 9],
         ])
 }

--- a/crates/nu-command/tests/commands/merge_deep.rs
+++ b/crates/nu-command/tests/commands/merge_deep.rs
@@ -1,63 +1,101 @@
 use nu_test_support::prelude::*;
 use rstest::rstest;
-use std::fmt::Display;
 
-struct Strategy<'a>(Option<&'a str>);
-
-impl<'a> Display for Strategy<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0
-            .map(|s| write!(f, "--strategy={s}"))
-            .unwrap_or(Ok(()))
-    }
+#[derive(Debug, IntoValue)]
+enum Strategy {
+    Table,
+    Append,
+    Prepend,
+    Overwrite,
 }
 
-const TABLE_LEFT: &str = "{inner: [{a: 1}, {b: 2}]}";
-const TABLE_RIGHT: &str = "{inner: [{c: 3}]}";
+mod table {
+    pub const LEFT: &str = "{ inner: [
+        {a: 1},
+        {b: 2},
+    ]}";
+    pub const RIGHT: &str = "{ inner: [
+        {c: 3},
+    ]}";
 
-const LIST_LEFT: &str = "{a: [1, 2, 3]}";
-const LIST_RIGHT: &str = "{a: [4, 5, 6]}";
+    pub const TABLE: &str = "{ inner: [
+        {a: 1      c: 3}
+        {     b: 2     }
+    ]}";
+    pub const APPEND: &str = "{ inner: [
+        {a: 1}
+        {b: 2}
+        {c: 3}
+    ]}";
+    pub const PREPEND: &str = "{ inner: [
+        {c: 3}
+        {a: 1}
+        {b: 2}
+    ]}";
+    pub const OVERWRITE: &str = "{ inner: [
+        {c: 3}
+    ]}";
+}
+
+mod list {
+    pub const LEFT: &str = "{a: [1, 2, 3]}";
+    pub const RIGHT: &str = "{a: [4, 5, 6]}";
+
+    pub const TABLE: &str = "{a: [4, 5, 6]}";
+    pub const APPEND: &str = "{a: [1, 2, 3, 4, 5, 6]}";
+    pub const PREPEND: &str = "{a: [4, 5, 6, 1, 2, 3]}";
+    pub const OVERWRITE: &str = "{a: [4, 5, 6]}";
+}
 
 #[rstest]
-#[case::s_table_table(None, TABLE_LEFT, TABLE_RIGHT, "{inner: [{a: 1, c: 3}, {b: 2}]}")]
-#[case::s_table_list(None, LIST_LEFT, LIST_RIGHT, "{a: [4, 5, 6]}")]
-#[case::s_overwrite_table("overwrite", TABLE_LEFT, TABLE_RIGHT, "{inner: [[c]; [3]]}")]
-#[case::s_overwrite_list("overwrite", LIST_LEFT, LIST_RIGHT, "{a: [4, 5, 6]}")]
-#[case::s_append_table("append", TABLE_LEFT, TABLE_RIGHT, "{inner: [{a: 1}, {b: 2}, {c: 3}]}")]
-#[case::s_append_list("append", LIST_LEFT, LIST_RIGHT, "{a: [1, 2, 3, 4, 5, 6]}")]
-#[case::s_prepend_table(
-    "prepend",
-    TABLE_LEFT,
-    TABLE_RIGHT,
-    "{inner: [{c: 3}, {a: 1}, {b: 2}]}"
-)]
-#[case::s_prepend_list("prepend", LIST_LEFT, LIST_RIGHT, "{a: [4, 5, 6, 1, 2, 3]}")]
+#[case::s_table_table(table::LEFT, table::RIGHT, None, table::TABLE)]
+#[case::s_table_table(table::LEFT, table::RIGHT, Strategy::Table, table::TABLE)]
+#[case::s_overwrite_table(table::LEFT, table::RIGHT, Strategy::Overwrite, table::OVERWRITE)]
+#[case::s_append_table(table::LEFT, table::RIGHT, Strategy::Append, table::APPEND)]
+#[case::s_prepend_table(table::LEFT, table::RIGHT, Strategy::Prepend, table::PREPEND)]
+#[case::s_table_list(list::LEFT, list::RIGHT, None, list::TABLE)]
+#[case::s_table_list(list::LEFT, list::RIGHT, Strategy::Table, list::TABLE)]
+#[case::s_overwrite_list(list::LEFT, list::RIGHT, Strategy::Overwrite, list::OVERWRITE)]
+#[case::s_append_list(list::LEFT, list::RIGHT, Strategy::Append, list::APPEND)]
+#[case::s_prepend_list(list::LEFT, list::RIGHT, Strategy::Prepend, list::PREPEND)]
 #[case::record_nested_with_overwrite(
-    None,
     "{a: {b: {c: {d: 123, e: 456}}}}",
     "{a: {b: {c: {e: 654, f: 789}}}}",
+    None,
     "{a: {b: {c: {d: 123, e: 654, f: 789}}}}"
 )]
 #[case::single_row_table(
-    None,
     "[[a]; [{foo: [1, 2, 3]}]]",
     "[[a]; [{bar: [4, 5, 6]}]]",
+    None,
     "[[a]; [{foo: [1, 2, 3], bar: [4, 5, 6]}]]"
 )]
 #[case::multi_row_table(
-    None,
     "[[a b]; [{inner: {foo: abc}} {inner: {baz: ghi}}]]",
     "[[a b]; [{inner: {bar: def}} {inner: {qux: jkl}}]]",
+    None,
     "[[a, b]; [{inner: {foo: abc, bar: def}}, {inner: {baz: ghi, qux: jkl}}]]"
 )]
-fn merge_deep_tests<'a>(
-    #[case] strategy: impl Into<Option<&'a str>>,
+fn merge_deep_tests(
     #[case] left: &str,
     #[case] right: &str,
+    #[case] strategy: impl Into<Option<Strategy>>,
     #[case] expected: &str,
 ) -> Result {
-    let strategy = Strategy(strategy.into());
-    test()
-        .run(format!("{left} | merge deep {strategy} {right} | to nuon"))
-        .expect_value_eq(expected)
+    let mut tester = test();
+    let strategy = strategy.into();
+    let strategy_is_some = strategy.is_some();
+
+    let () = tester.run_with_data("let left = from nuon", left)?;
+    let () = tester.run_with_data("let right = from nuon", right)?;
+    let () = tester.run_with_data("let strategy = $in", strategy)?;
+    let expected_val: Value = tester.run_with_data("from nuon", expected)?;
+
+    let code = if strategy_is_some {
+        "$left | merge deep --strategy=$strategy $right"
+    } else {
+        "$left | merge deep $right"
+    };
+
+    tester.run(code).expect_value_eq(expected_val)
 }

--- a/crates/nu-command/tests/commands/move_/column.rs
+++ b/crates/nu-command/tests/commands/move_/column.rs
@@ -12,18 +12,16 @@ fn moves_a_column_before() -> Result {
         [------- ------- ------- --- -------- "   S    " ---------]
     ]"#;
 
-    let code = format!(
-        "
-            {sample}
-            | move column99 --before column1
-            | rename chars
-            | get chars
-            | str trim
-            | str join
-        "
-    );
+    let code = "
+        from nuon
+        | move column99 --before column1
+        | rename chars
+        | get chars
+        | str trim
+        | str join
+    ";
 
-    let actual: String = test().run(code)?;
+    let actual: String = test().run_with_data(code, sample)?;
     assert_contains("ANDRES", actual);
     Ok(())
 }
@@ -39,19 +37,17 @@ fn moves_columns_before() -> Result {
         [------- ------- "   J   " --- -------- "   T    " ---------]
     ]"#;
 
-    let code = format!(
-        "
-            {sample}
-            | move column99 column3 --before column2
-            | rename _ chars_1 chars_2
-            | select chars_2 chars_1
-            | upsert new_col {{|f| $f | transpose | get column1 | str trim | str join}}
-            | get new_col
-            | str join
-        "
-    );
+    let code = "
+        from nuon
+        | move column99 column3 --before column2
+        | rename _ chars_1 chars_2
+        | select chars_2 chars_1
+        | upsert new_col {|f| $f | transpose | get column1 | str trim | str join}
+        | get new_col
+        | str join
+    ";
 
-    let actual: String = test().run(code)?;
+    let actual: String = test().run_with_data(code, sample)?;
     assert_contains("ANDRES::JT", actual);
     Ok(())
 }
@@ -67,27 +63,25 @@ fn moves_a_column_after() -> Result {
         [------- ------- "   J   " --- -------- "   T    " ---------]
     ]"#;
 
-    let code = format!(
-        "
-            {sample}
-            | move letters --after and_more
-            | move letters and_more --before column2
-            | rename _ chars_1 chars_2
-            | select chars_1 chars_2
-            | upsert new_col {{|f| $f | transpose | get column1 | str trim | str join}}
-            | get new_col
-            | str join
-        "
-    );
+    let code = "
+        from nuon
+        | move letters --after and_more
+        | move letters and_more --before column2
+        | rename _ chars_1 chars_2
+        | select chars_1 chars_2
+        | upsert new_col {|f| $f | transpose | get column1 | str trim | str join}
+        | get new_col
+        | str join
+    ";
 
-    let actual: String = test().run(code)?;
+    let actual: String = test().run_with_data(code, sample)?;
     assert_contains("ANDRES::JT", actual);
     Ok(())
 }
 
 #[test]
 fn moves_columns_after() -> Result {
-    let content = r#"[
+    let sample = r#"[
         [column1 column2   letters ... column98  and_more  column100];
         [------- ------- "   A   " --- -------- "   N    " ---------]
         [------- ------- "   D   " --- -------- "   R    " ---------]
@@ -96,17 +90,15 @@ fn moves_columns_after() -> Result {
         [------- ------- "   J   " --- -------- "   T    " ---------]
     ]"#;
 
-    let code = format!(
-        "
-            {content}
-            | move letters and_more --after column1
-            | columns
-            | select 1 2
-            | str join
-        "
-    );
+    let code = "
+        from nuon
+        | move letters and_more --after column1
+        | columns
+        | select 1 2
+        | str join
+    ";
 
-    let actual: String = test().run(code)?;
+    let actual: String = test().run_with_data(code, sample)?;
     assert_contains("lettersand_more", actual);
     Ok(())
 }

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -8,7 +8,7 @@ fn http_get_is_success() -> Result {
     let mut server = Server::new();
     let _mock = server.mock("GET", "/").with_body("foo").create();
     test()
-        .run_with_data("let url = $in; http get $url", server.url())
+        .run_with_data("http get $in", server.url())
         .expect_value_eq("foo")
 }
 
@@ -17,7 +17,7 @@ fn http_get_failed_due_to_server_error() -> Result {
     let mut server = Server::new();
     let _mock = server.mock("GET", "/").with_status(400).create();
     let err = test()
-        .run_with_data("let url = $in; http get $url", server.url())
+        .run_with_data("http get $in", server.url())
         .expect_shell_error()?;
     match err {
         ShellError::NetworkFailure { msg, .. } => {
@@ -39,7 +39,7 @@ fn http_get_with_accept_errors() -> Result {
         .create();
 
     test()
-        .run_with_data("let url = $in; http get -e $url", server.url())
+        .run_with_data("http get -e $in", server.url())
         .expect_value_eq("error body")
 }
 
@@ -59,8 +59,7 @@ fn http_get_with_accept_errors_and_full_raw_response() -> Result {
         body: String,
     }
 
-    let response: Response =
-        test().run_with_data("let url = $in; http get -e -f $url", server.url())?;
+    let response: Response = test().run_with_data("http get -e -f $in", server.url())?;
     assert_eq!(response.status, 400);
     assert_eq!(response.body, "error body");
     Ok(())
@@ -88,8 +87,7 @@ fn http_get_with_accept_errors_and_full_json_response() -> Result {
         msg: String,
     }
 
-    let response: Response =
-        test().run_with_data("let url = $in; http get -e -f $url", server.url())?;
+    let response: Response = test().run_with_data("http get -e -f $in", server.url())?;
     assert_eq!(response.status, 400);
     assert_eq!(response.body.msg, "error body");
     Ok(())
@@ -112,13 +110,11 @@ fn http_get_with_custom_headers_as_records() -> Result {
         .create();
 
     let _: String = test().run_with_data(
-        "let url = $in; http get -H {content-type: application/json} $url",
+        "http get -H {content-type: application/json} $in",
         server.url(),
     )?;
-    let _: String = test().run_with_data(
-        "let url = $in; http get -H {content-type: text/plain} $url",
-        server.url(),
-    )?;
+    let _: String =
+        test().run_with_data("http get -H {content-type: text/plain} $in", server.url())?;
 
     mock1.assert();
     mock2.assert();
@@ -132,7 +128,7 @@ fn http_get_full_response() -> Result {
     let _mock = server.mock("GET", "/").with_body("foo").create();
 
     let outcome: String = test().run_with_data(
-        "let url = $in; http get --full $url --headers [foo bar] | to json",
+        "http get --full $in --headers [foo bar] | to json",
         server.url(),
     )?;
     let output: serde_json::Value =

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -7,16 +7,18 @@ use std::{thread, time::Duration};
 fn http_get_is_success() -> Result {
     let mut server = Server::new();
     let _mock = server.mock("GET", "/").with_body("foo").create();
-    let code = format!("http get {url}", url = server.url());
-    test().run(code).expect_value_eq("foo")
+    test()
+        .run_with_data("let url = $in; http get $url", server.url())
+        .expect_value_eq("foo")
 }
 
 #[test]
 fn http_get_failed_due_to_server_error() -> Result {
     let mut server = Server::new();
     let _mock = server.mock("GET", "/").with_status(400).create();
-    let code = format!("http get {url}", url = server.url());
-    let err = test().run(code).expect_shell_error()?;
+    let err = test()
+        .run_with_data("let url = $in; http get $url", server.url())
+        .expect_shell_error()?;
     match err {
         ShellError::NetworkFailure { msg, .. } => {
             assert_contains("Bad request (400)", msg);
@@ -36,8 +38,9 @@ fn http_get_with_accept_errors() -> Result {
         .with_body("error body")
         .create();
 
-    let code = format!("http get -e {url}", url = server.url());
-    test().run(code).expect_value_eq("error body")
+    test()
+        .run_with_data("let url = $in; http get -e $url", server.url())
+        .expect_value_eq("error body")
 }
 
 #[test]
@@ -56,8 +59,8 @@ fn http_get_with_accept_errors_and_full_raw_response() -> Result {
         body: String,
     }
 
-    let code = format!("http get -e -f {url}", url = server.url());
-    let response: Response = test().run(code)?;
+    let response: Response =
+        test().run_with_data("let url = $in; http get -e -f $url", server.url())?;
     assert_eq!(response.status, 400);
     assert_eq!(response.body, "error body");
     Ok(())
@@ -85,8 +88,8 @@ fn http_get_with_accept_errors_and_full_json_response() -> Result {
         msg: String,
     }
 
-    let code = format!("http get -e -f {url}", url = server.url());
-    let response: Response = test().run(code)?;
+    let response: Response =
+        test().run_with_data("let url = $in; http get -e -f $url", server.url())?;
     assert_eq!(response.status, 400);
     assert_eq!(response.body.msg, "error body");
     Ok(())
@@ -108,18 +111,14 @@ fn http_get_with_custom_headers_as_records() -> Result {
         .with_body("world")
         .create();
 
-    let json_code = format!(
-        "http get -H {{content-type: application/json}} {url}",
-        url = server.url()
-    );
-
-    let text_code = format!(
-        "http get -H {{content-type: text/plain}} {url}",
-        url = server.url()
-    );
-
-    let _: String = test().run(json_code)?;
-    let _: String = test().run(text_code)?;
+    let _: String = test().run_with_data(
+        "let url = $in; http get -H {content-type: application/json} $url",
+        server.url(),
+    )?;
+    let _: String = test().run_with_data(
+        "let url = $in; http get -H {content-type: text/plain} $url",
+        server.url(),
+    )?;
 
     mock1.assert();
     mock2.assert();
@@ -132,12 +131,10 @@ fn http_get_full_response() -> Result {
 
     let _mock = server.mock("GET", "/").with_body("foo").create();
 
-    let code = format!(
-        "http get --full {url} --headers [foo bar] | to json",
-        url = server.url()
-    );
-
-    let outcome: String = test().run(code)?;
+    let outcome: String = test().run_with_data(
+        "let url = $in; http get --full $url --headers [foo bar] | to json",
+        server.url(),
+    )?;
     let output: serde_json::Value =
         serde_json::from_str(&outcome).expect("full response should be valid JSON");
 
@@ -170,8 +167,9 @@ fn http_get_follows_redirect() -> Result {
         .with_header("Location", "/bar")
         .create();
 
-    let code = format!("http get {url}/foo", url = server.url());
-    test().run(code).expect_value_eq("bar")
+    test()
+        .run_with_data("let url = $in; http get $'($url)/foo'", server.url())
+        .expect_value_eq("bar")
 }
 
 #[test]
@@ -185,12 +183,12 @@ fn http_get_redirect_mode_manual() -> Result {
         .with_header("Location", "/bar")
         .create();
 
-    let code = format!(
-        "http get --redirect-mode manual {url}/foo",
-        url = server.url()
-    );
-
-    test().run(code).expect_value_eq("foo")
+    test()
+        .run_with_data(
+            "let url = $in; http get --redirect-mode manual $'($url)/foo'",
+            server.url(),
+        )
+        .expect_value_eq("foo")
 }
 
 #[test]
@@ -204,12 +202,13 @@ fn http_get_redirect_mode_error() -> Result {
         .with_header("Location", "/bar")
         .create();
 
-    let code = format!(
-        "http get --redirect-mode error {url}/foo",
-        url = server.url()
-    );
+    let err = test()
+        .run_with_data(
+            "let url = $in; http get --redirect-mode error $'($url)/foo'",
+            server.url(),
+        )
+        .expect_shell_error()?;
 
-    let err = test().run(code).expect_shell_error()?;
     match err {
         ShellError::NetworkFailure { msg, .. } => {
             assert_eq!(
@@ -276,9 +275,9 @@ fn http_get_with_invalid_mime_type() -> Result {
         .create();
 
     // but `from nuon` is a known command in nu, so we take `foo.{ext}` and pass it to `from {ext}`
-    let code = format!("http get {url}/foo.nuon", url = server.url());
-
-    test().run(code).expect_value_eq([1, 2, 3])
+    test()
+        .run_with_data("let url = $in; http get $'($url)/foo.nuon'", server.url())
+        .expect_value_eq([1, 2, 3])
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/network/http/options.rs
+++ b/crates/nu-command/tests/commands/network/http/options.rs
@@ -13,12 +13,16 @@ fn http_options_default_shows_response_headers() -> Result {
         .with_header("Allow", "OPTIONS, GET")
         .create();
 
-    let code = format!(
-        "http options {url} | where name == allow | get value.0",
-        url = server.url()
-    );
+    let code = "
+        let url = $in
+        http options $url
+        | where name == allow
+        | get value.0
+    ";
 
-    test().run(code).expect_value_eq("OPTIONS, GET")
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("OPTIONS, GET")
 }
 
 #[test]
@@ -30,12 +34,14 @@ fn http_options_full_response_includes_response_headers() -> Result {
         .with_header("Allow", "OPTIONS, GET")
         .create();
 
-    let code = format!(
-        "http options --full {url} | get headers.response | length",
-        url = server.url()
-    );
+    let code = "
+        let url = $in
+        http options --full $url
+        | get headers.response
+        | length
+    ";
 
-    let outcome: i64 = test().run(code)?;
+    let outcome: i64 = test().run_with_data(code, server.url())?;
     assert!(outcome > 0);
     Ok(())
 }
@@ -50,12 +56,15 @@ fn http_options_with_allow_errors() -> Result {
         .with_header("x-error-header", "present")
         .create();
 
-    let code = format!(
-        "http options -e {url} | where name == x-error-header | get value.0",
-        url = server.url()
-    );
+    let code = "
+        let url = $in
+        http options -e $url
+        | where name == x-error-header
+        | get value.0";
 
-    test().run(code).expect_value_eq("present")
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("present")
 }
 
 #[test]
@@ -64,8 +73,10 @@ fn http_options_failed_due_to_server_error() -> Result {
 
     let _mock = server.mock("OPTIONS", "/").with_status(400).create();
 
-    let code = format!("http options {url}", url = server.url());
-    let err = test().run(code).expect_shell_error()?;
+    let code = "let url = $in; http options $url";
+    let err = test()
+        .run_with_data(code, server.url())
+        .expect_shell_error()?;
 
     match err {
         ShellError::NetworkFailure { msg, .. } => {
@@ -87,8 +98,8 @@ fn http_options_timeout() -> Result {
         })
         .create();
 
-    let code = format!("http options --max-time 100ms {url}", url = server.url());
-    let err = test().run(code).expect_io_error()?;
+    let code = "let url = $in; http options --max-time 100ms $url";
+    let err = test().run_with_data(code, server.url()).expect_io_error()?;
     assert!(matches!(
         err.kind,
         shell_error::io::ErrorKind::Std(std::io::ErrorKind::TimedOut, ..)

--- a/crates/nu-command/tests/commands/network/http/patch.rs
+++ b/crates/nu-command/tests/commands/network/http/patch.rs
@@ -8,16 +8,16 @@ use nu_test_support::prelude::*;
 fn http_patch_is_success() -> Result {
     let mut server = Server::new();
     let _mock = server.mock("PATCH", "/").match_body("foo").create();
-    let code = format!(r#"http patch {url} "foo""#, url = server.url());
-    test().run(code).expect_value_eq("")
+    let code = r#"let url = $in; http patch $url "foo""#;
+    test().run_with_data(code, server.url()).expect_value_eq("")
 }
 
 #[test]
 fn http_patch_is_success_pipeline() -> Result {
     let mut server = Server::new();
     let _mock = server.mock("PATCH", "/").match_body("foo").create();
-    let code = format!(r#""foo" | http patch {url}"#, url = server.url());
-    test().run(code).expect_value_eq("")
+    let code = r#"let url = $in; "foo" | http patch $url"#;
+    test().run_with_data(code, server.url()).expect_value_eq("")
 }
 
 #[test]
@@ -26,8 +26,10 @@ fn http_patch_failed_due_to_server_error() -> Result {
 
     let _mock = server.mock("PATCH", "/").with_status(400).create();
 
-    let code = format!(r#"http patch {url} "body""#, url = server.url());
-    let err = test().run(code).expect_shell_error()?;
+    let code = r#"let url = $in; http patch $url "body""#;
+    let err = test()
+        .run_with_data(code, server.url())
+        .expect_shell_error()?;
     match err {
         ShellError::NetworkFailure { msg, .. } => {
             assert_contains("Bad request (400)", msg);
@@ -43,8 +45,11 @@ fn http_patch_failed_due_to_missing_body() -> Result {
 
     let _mock = server.mock("PATCH", "/").create();
 
-    let code = format!("http patch {url}", url = server.url());
-    let err = test().run(code).expect_shell_error()?.generic_error()?;
+    let code = "let url = $in; http patch $url";
+    let err = test()
+        .run_with_data(code, server.url())
+        .expect_shell_error()?
+        .generic_error()?;
     assert_eq!(
         err,
         "Data must be provided either through pipeline or positional argument"
@@ -58,8 +63,10 @@ fn http_patch_failed_due_to_unexpected_body() -> Result {
 
     let _mock = server.mock("PATCH", "/").match_body("foo").create();
 
-    let code = format!(r#"http patch {url} "bar""#, url = server.url());
-    let err = test().run(code).expect_shell_error()?;
+    let code = r#"let url = $in; http patch $url "bar""#;
+    let err = test()
+        .run_with_data(code, server.url())
+        .expect_shell_error()?;
 
     match err {
         ShellError::NetworkFailure { msg, .. } => {
@@ -81,8 +88,10 @@ fn http_patch_follows_redirect() -> Result {
         .with_header("Location", "/bar")
         .create();
 
-    let code = format!("http patch {url}/foo patchbody", url = server.url());
-    test().run(code).expect_value_eq("bar")
+    let code = "let url = $in; http patch $'($url)/foo' patchbody";
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("bar")
 }
 
 #[test]
@@ -96,12 +105,10 @@ fn http_patch_redirect_mode_manual() -> Result {
         .with_header("Location", "/bar")
         .create();
 
-    let code = format!(
-        "http patch --redirect-mode manual {url}/foo patchbody",
-        url = server.url()
-    );
-
-    test().run(code).expect_value_eq("foo")
+    let code = "let url = $in; http patch --redirect-mode manual $'($url)/foo' patchbody";
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("foo")
 }
 
 #[test]
@@ -115,12 +122,11 @@ fn http_patch_redirect_mode_error() -> Result {
         .with_header("Location", "/bar")
         .create();
 
-    let code = format!(
-        "http patch --redirect-mode error {url}/foo patchbody",
-        url = server.url()
-    );
+    let code = "let url = $in; http patch --redirect-mode error $'($url)/foo' patchbody";
 
-    let err = test().run(code).expect_shell_error()?;
+    let err = test()
+        .run_with_data(code, server.url())
+        .expect_shell_error()?;
     match err {
         ShellError::NetworkFailure { msg, .. } => {
             assert_eq!(
@@ -144,11 +150,8 @@ fn http_patch_timeout() -> Result {
         })
         .create();
 
-    let code = format!(
-        "http patch --max-time 100ms {url} patchbody",
-        url = server.url()
-    );
-    let err = test().run(code).expect_io_error()?;
+    let code = "let url = $in; http patch --max-time 100ms $url patchbody";
+    let err = test().run_with_data(code, server.url()).expect_io_error()?;
     assert!(matches!(
         err.kind,
         shell_error::io::ErrorKind::Std(std::io::ErrorKind::TimedOut, ..)

--- a/crates/nu-command/tests/commands/network/http/post.rs
+++ b/crates/nu-command/tests/commands/network/http/post.rs
@@ -8,15 +8,15 @@ use nu_test_support::prelude::*;
 fn http_post_is_success() -> Result {
     let mut server = Server::new();
     let _mock = server.mock("POST", "/").match_body("foo").create();
-    let code = format!(r#"http post {url} "foo""#, url = server.url());
-    test().run(code).expect_value_eq("")
+    let code = r#"let url = $in; http post $url "foo""#;
+    test().run_with_data(code, server.url()).expect_value_eq("")
 }
 #[test]
 fn http_post_is_success_pipeline() -> Result {
     let mut server = Server::new();
     let _mock = server.mock("POST", "/").match_body("foo").create();
-    let code = format!(r#""foo" | http post {url}"#, url = server.url());
-    test().run(code).expect_value_eq("")
+    let code = r#"let url = $in; "foo" | http post $url"#;
+    test().run_with_data(code, server.url()).expect_value_eq("")
 }
 
 #[test]
@@ -25,8 +25,10 @@ fn http_post_failed_due_to_server_error() -> Result {
 
     let _mock = server.mock("POST", "/").with_status(400).create();
 
-    let code = format!(r#"http post {url} "body""#, url = server.url());
-    let err = test().run(code).expect_shell_error()?;
+    let code = r#"let url = $in; http post $url "body""#;
+    let err = test()
+        .run_with_data(code, server.url())
+        .expect_shell_error()?;
     match err {
         ShellError::NetworkFailure { msg, .. } => {
             assert_contains("Bad request (400)", msg);
@@ -42,8 +44,11 @@ fn http_post_failed_due_to_missing_body() -> Result {
 
     let _mock = server.mock("POST", "/").create();
 
-    let code = format!("http post {url}", url = server.url());
-    let err = test().run(code).expect_shell_error()?.generic_error()?;
+    let code = "let url = $in; http post $url";
+    let err = test()
+        .run_with_data(code, server.url())
+        .expect_shell_error()?
+        .generic_error()?;
     assert_eq!(
         err,
         "Data must be provided either through pipeline or positional argument"
@@ -57,8 +62,10 @@ fn http_post_failed_due_to_unexpected_body() -> Result {
 
     let _mock = server.mock("POST", "/").match_body("foo").create();
 
-    let code = format!(r#"http post {url} "bar""#, url = server.url());
-    let err = test().run(code).expect_shell_error()?;
+    let code = r#"let url = $in; http post $url "bar""#;
+    let err = test()
+        .run_with_data(code, server.url())
+        .expect_shell_error()?;
 
     match err {
         ShellError::NetworkFailure { msg, .. } => {
@@ -79,12 +86,11 @@ fn http_post_json_is_success() -> Result {
 
     let mock = server.mock("POST", "/").match_body(JSON).create();
 
-    let code = format!(
-        "http post -t 'application/json' {url} {{foo: 'bar'}}",
-        url = server.url()
-    );
+    let code = "let url = $in; http post -t 'application/json' $url {foo: 'bar'}";
 
-    test().run(code).expect_value_eq("")?;
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("")?;
     mock.assert();
     Ok(())
 }
@@ -95,12 +101,11 @@ fn http_post_json_string_is_success() -> Result {
 
     let mock = server.mock("POST", "/").match_body(JSON).create();
 
-    let code = format!(
-        r#"http post -t 'application/json' {url} '{{"foo":"bar"}}'"#,
-        url = server.url()
-    );
+    let code = r#"let url = $in; http post -t 'application/json' $url '{"foo":"bar"}'"#;
 
-    test().run(code).expect_value_eq("")?;
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("")?;
     mock.assert();
     Ok(())
 }
@@ -117,12 +122,11 @@ fn http_post_json_list_is_success() -> Result {
 
     let mock = server.mock("POST", "/").match_body(JSON_LIST).create();
 
-    let code = format!(
-        r#"http post -t 'application/json' {url} [{{foo: "bar"}}]"#,
-        url = server.url()
-    );
+    let code = r#"let url = $in; http post -t 'application/json' $url [{foo: "bar"}]"#;
 
-    test().run(code).expect_value_eq("")?;
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("")?;
     mock.assert();
     Ok(())
 }
@@ -133,12 +137,11 @@ fn http_post_json_int_is_success() -> Result {
 
     let mock = server.mock("POST", "/").match_body("50").create();
 
-    let code = format!(
-        "http post -t 'application/json' {url} 50",
-        url = server.url()
-    );
+    let code = "let url = $in; http post -t 'application/json' $url 50";
 
-    test().run(code).expect_value_eq("")?;
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("")?;
     mock.assert();
     Ok(())
 }
@@ -149,12 +152,11 @@ fn http_post_json_raw_string_is_success() -> Result {
 
     let mock = server.mock("POST", "/").match_body(r#""test""#).create();
 
-    let code = format!(
-        r#"http post -t 'application/json' {url} "test""#,
-        url = server.url()
-    );
+    let code = r#"let url = $in; http post -t 'application/json' $url "test""#;
 
-    test().run(code).expect_value_eq("")?;
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("")?;
     mock.assert();
     Ok(())
 }
@@ -170,8 +172,10 @@ fn http_post_follows_redirect() -> Result {
         .with_header("Location", "/bar")
         .create();
 
-    let code = format!("http post {url}/foo postbody", url = server.url());
-    test().run(code).expect_value_eq("bar")
+    let code = "let url = $in; http post $'($url)/foo' postbody";
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("bar")
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/network/http/put.rs
+++ b/crates/nu-command/tests/commands/network/http/put.rs
@@ -8,16 +8,16 @@ use nu_test_support::prelude::*;
 fn http_put_is_success() -> Result {
     let mut server = Server::new();
     let _mock = server.mock("PUT", "/").match_body("foo").create();
-    let code = format!(r#"http put {url} "foo""#, url = server.url());
-    test().run(code).expect_value_eq("")
+    let code = r#"let url = $in; http put $url "foo""#;
+    test().run_with_data(code, server.url()).expect_value_eq("")
 }
 
 #[test]
 fn http_put_is_success_pipeline() -> Result {
     let mut server = Server::new();
     let _mock = server.mock("PUT", "/").match_body("foo").create();
-    let code = format!(r#""foo" | http put {url} "#, url = server.url());
-    test().run(code).expect_value_eq("")
+    let code = r#"let url = $in; "foo" | http put $url "#;
+    test().run_with_data(code, server.url()).expect_value_eq("")
 }
 
 #[test]
@@ -26,8 +26,10 @@ fn http_put_failed_due_to_server_error() -> Result {
 
     let _mock = server.mock("PUT", "/").with_status(400).create();
 
-    let code = format!(r#"http put {url} "body""#, url = server.url());
-    let err = test().run(code).expect_shell_error()?;
+    let code = r#"let url = $in; http put $url "body""#;
+    let err = test()
+        .run_with_data(code, server.url())
+        .expect_shell_error()?;
     match err {
         ShellError::NetworkFailure { msg, .. } => {
             assert_contains("Bad request (400)", msg);
@@ -43,8 +45,11 @@ fn http_put_failed_due_to_missing_body() -> Result {
 
     let _mock = server.mock("PUT", "/").create();
 
-    let code = format!("http put {url}", url = server.url());
-    let err = test().run(code).expect_shell_error()?.generic_error()?;
+    let code = "let url = $in; http put $url";
+    let err = test()
+        .run_with_data(code, server.url())
+        .expect_shell_error()?
+        .generic_error()?;
     assert_eq!(
         err,
         "Data must be provided either through pipeline or positional argument"
@@ -58,8 +63,10 @@ fn http_put_failed_due_to_unexpected_body() -> Result {
 
     let _mock = server.mock("PUT", "/").match_body("foo").create();
 
-    let code = format!(r#"http put {url} "bar""#, url = server.url());
-    let err = test().run(code).expect_shell_error()?;
+    let code = r#"let url = $in; http put $url "bar""#;
+    let err = test()
+        .run_with_data(code, server.url())
+        .expect_shell_error()?;
 
     match err {
         ShellError::NetworkFailure { msg, .. } => {
@@ -81,8 +88,10 @@ fn http_put_follows_redirect() -> Result {
         .with_header("Location", "/bar")
         .create();
 
-    let code = format!("http put {url}/foo putbody", url = server.url());
-    test().run(code).expect_value_eq("bar")
+    let code = "let url = $in; http put $'($url)/foo' putbody";
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("bar")
 }
 
 #[test]
@@ -96,11 +105,10 @@ fn http_put_redirect_mode_manual() -> Result {
         .with_header("Location", "/bar")
         .create();
 
-    let code = format!(
-        "http put --redirect-mode manual {url}/foo putbody",
-        url = server.url()
-    );
-    test().run(code).expect_value_eq("foo")
+    let code = "let url = $in; http put --redirect-mode manual $'($url)/foo' putbody";
+    test()
+        .run_with_data(code, server.url())
+        .expect_value_eq("foo")
 }
 
 #[test]
@@ -114,12 +122,11 @@ fn http_put_redirect_mode_error() -> Result {
         .with_header("Location", "/bar")
         .create();
 
-    let code = format!(
-        "http put --redirect-mode error {url}/foo putbody",
-        url = server.url()
-    );
+    let code = "let url = $in; http put --redirect-mode error $'($url)/foo' putbody";
 
-    let err = test().run(code).expect_shell_error()?;
+    let err = test()
+        .run_with_data(code, server.url())
+        .expect_shell_error()?;
     match err {
         ShellError::NetworkFailure { msg, .. } => {
             assert_eq!(
@@ -143,11 +150,8 @@ fn http_put_timeout() -> Result {
         })
         .create();
 
-    let code = format!(
-        "http put --max-time 100ms {url} putbody",
-        url = server.url()
-    );
-    let err = test().run(code).expect_io_error()?;
+    let code = "let url = $in; http put --max-time 100ms $url putbody";
+    let err = test().run_with_data(code, server.url()).expect_io_error()?;
     assert!(matches!(
         err.kind,
         shell_error::io::ErrorKind::Std(std::io::ErrorKind::TimedOut, ..)

--- a/crates/nu-command/tests/commands/network/port.rs
+++ b/crates/nu-command/tests/commands/network/port.rs
@@ -14,7 +14,7 @@ fn port_with_already_usage() -> Result {
     let port = nu_utils::net::reserve_local_addr().unwrap().port();
     let _listener = TcpListener::bind((Ipv4Addr::LOCALHOST, port)).unwrap();
     let err = test()
-        .run(format!("port {port} {port}"))
+        .run_with_data("let port = $in; port $port $port", port)
         .expect_io_error()?;
     assert!(matches!(
         err.kind,

--- a/crates/nu-command/tests/commands/platform/kill.rs
+++ b/crates/nu-command/tests/commands/platform/kill.rs
@@ -2,8 +2,9 @@ use nu_test_support::prelude::*;
 
 #[test]
 fn test_kill_invalid_pid() -> Result {
-    let pid = i32::MAX;
-    let err = test().run(format!("kill {pid}")).expect_shell_error()?;
+    let err = test()
+        .run_with_data("kill $in", i32::MAX)
+        .expect_shell_error()?;
 
     assert_contains("process didn't terminate successfully", err.to_string());
     Ok(())

--- a/crates/nu-command/tests/commands/skip/skip_.rs
+++ b/crates/nu-command/tests/commands/skip/skip_.rs
@@ -1,4 +1,4 @@
-use nu_protocol::{IntoPipelineData, PipelineMetadata};
+use nu_protocol::{IntoPipelineData, PipelineMetadata, Span};
 use nu_test_support::prelude::*;
 use rstest::rstest;
 
@@ -24,12 +24,16 @@ fn fail_on_non_iterator() -> Result {
 
 #[test]
 fn skips_bytes_and_drops_content_type() -> Result {
-    test()
-        .run_with_data(
-            "open $in | skip 3 | metadata | get content_type? | describe",
-            file!(),
-        )
-        .expect_value_eq("nothing")
+    let content_type = test()
+        .run_raw_with_data(
+            "open $in | skip 3",
+            (file!()).into_value(Span::test_data()).into_pipeline_data(),
+        )?
+        .take_metadata()
+        .and_then(|md| md.content_type);
+
+    assert!(content_type.is_none());
+    Ok(())
 }
 
 enum InputType {

--- a/crates/nu-command/tests/commands/skip/skip_.rs
+++ b/crates/nu-command/tests/commands/skip/skip_.rs
@@ -24,11 +24,12 @@ fn fail_on_non_iterator() -> Result {
 
 #[test]
 fn skips_bytes_and_drops_content_type() -> Result {
-    let code = format!(
-        "open {} | skip 3 | metadata | get content_type? | describe",
-        file!(),
-    );
-    test().run(code).expect_value_eq("nothing")
+    test()
+        .run_with_data(
+            "open $in | skip 3 | metadata | get content_type? | describe",
+            file!(),
+        )
+        .expect_value_eq("nothing")
 }
 
 enum InputType {

--- a/crates/nu-command/tests/commands/skip/until.rs
+++ b/crates/nu-command/tests/commands/skip/until.rs
@@ -21,18 +21,16 @@ fn condition_is_met() -> Result {
         [Yehuda, 0, 0, 3]
     ]"#;
 
-    let code = format!(
-        r#"
-            {sample}
-            | skip until {{|row| $row."Chicken Collection" == "Red Chickens" }}
-            | skip 1
-            | into int "31/04/2020"
-            | get "31/04/2020"
-            | math sum
-        "#
-    );
+    let code = r#"
+        from nuon
+        | skip until {|row| $row."Chicken Collection" == "Red Chickens" }
+        | skip 1
+        | into int "31/04/2020"
+        | get "31/04/2020"
+        | math sum
+    "#;
 
-    test().run(code).expect_value_eq(6)
+    test().run_with_data(code, sample).expect_value_eq(6)
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/skip/while_.rs
+++ b/crates/nu-command/tests/commands/skip/while_.rs
@@ -21,18 +21,16 @@ fn condition_is_met() -> Result {
         [Yehuda, 0, 0, 3]
     ]"#;
 
-    let code = format!(
-        r#"
-            {sample}
-            | skip while {{|row| $row."Chicken Collection" != "Red Chickens" }}
-            | skip 1
-            | into int "31/04/2020"
-            | get "31/04/2020"
-            | math sum
-        "#
-    );
+    let code = r#"
+        from nuon
+        | skip while {|row| $row."Chicken Collection" != "Red Chickens" }
+        | skip 1
+        | into int "31/04/2020"
+        | get "31/04/2020"
+        | math sum
+    "#;
 
-    test().run(code).expect_value_eq(6)
+    test().run_with_data(code, sample).expect_value_eq(6)
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -1,7 +1,10 @@
 mod into_string;
 mod join;
 
-use nu_test_support::{fs::Stub::FileWithContent, prelude::*};
+use nu_test_support::{
+    fs::{Stub::FileWithContent, fixtures},
+    prelude::*,
+};
 
 #[test]
 fn trims() -> Result {
@@ -423,11 +426,13 @@ fn substring_of_empty_string() -> Result {
 
 #[test]
 fn substring_drops_content_type() -> Result {
-    let code = format!(
-        "open {} | str substring 0..2 | metadata | get content_type? | describe",
-        file!(),
-    );
-    test().run(code).expect_value_eq("nothing")
+    let code = "
+        open --raw formats/cargo_sample.toml
+        | str substring 0..2
+        | metadata
+        | $in.content_type?
+    ";
+    test().cwd(fixtures()).run(code).expect_value_eq(())
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/take/rows.rs
+++ b/crates/nu-command/tests/commands/take/rows.rs
@@ -1,3 +1,4 @@
+use nu_protocol::{IntoPipelineData, Span};
 use nu_test_support::prelude::*;
 
 #[test]
@@ -59,10 +60,14 @@ fn works_with_binary_list() -> Result {
 
 #[test]
 fn takes_bytes_and_drops_content_type() -> Result {
-    test()
-        .run_with_data(
-            "open $in | take 3 | metadata | get content_type? | describe",
-            file!(),
-        )
-        .expect_value_eq("nothing")
+    let content_type = test()
+        .run_raw_with_data(
+            "open $in | take 3",
+            (file!()).into_value(Span::test_data()).into_pipeline_data(),
+        )?
+        .take_metadata()
+        .and_then(|md| md.content_type);
+
+    assert!(content_type.is_none());
+    Ok(())
 }

--- a/crates/nu-command/tests/commands/take/rows.rs
+++ b/crates/nu-command/tests/commands/take/rows.rs
@@ -9,16 +9,14 @@ fn rows() -> Result {
          [Jason , 2],
          [Yehuda, 1]]";
 
-    let code = format!(
-        "
-            {sample}
-            | take 3
-            | get lucky_code
-            | math sum
-        "
-    );
+    let code = "
+        from nuon
+        | take 3
+        | get lucky_code
+        | math sum
+    ";
 
-    test().run(code).expect_value_eq(4)
+    test().run_with_data(code, sample).expect_value_eq(4)
 }
 
 #[test]
@@ -61,10 +59,10 @@ fn works_with_binary_list() -> Result {
 
 #[test]
 fn takes_bytes_and_drops_content_type() -> Result {
-    let code = format!(
-        "open {} | take 3 | metadata | get content_type? | describe",
-        file!(),
-    );
-
-    test().run(code).expect_value_eq("nothing")
+    test()
+        .run_with_data(
+            "open $in | take 3 | metadata | get content_type? | describe",
+            file!(),
+        )
+        .expect_value_eq("nothing")
 }

--- a/crates/nu-command/tests/commands/take/until.rs
+++ b/crates/nu-command/tests/commands/take/until.rs
@@ -21,19 +21,17 @@ fn condition_is_met() -> Result {
         [Yehuda, 1, 1, 3]
     ]"#;
 
-    let code = format!(
-        r#"
-            {sample}
-            | skip while {{|row| $row."Chicken Collection" != "Blue Chickens" }}
-            | take until {{|row| $row."Chicken Collection" == "Red Chickens" }}
-            | skip 1
-            | into int "31/04/2020"
-            | get "31/04/2020"
-            | math sum
-        "#
-    );
+    let code = r#"
+        from nuon
+        | skip while {|row| $row."Chicken Collection" != "Blue Chickens" }
+        | take until {|row| $row."Chicken Collection" == "Red Chickens" }
+        | skip 1
+        | into int "31/04/2020"
+        | get "31/04/2020"
+        | math sum
+    "#;
 
-    test().run(code).expect_value_eq(8)
+    test().run_with_data(code, sample).expect_value_eq(8)
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/take/while_.rs
+++ b/crates/nu-command/tests/commands/take/while_.rs
@@ -21,18 +21,16 @@ fn condition_is_met() -> Result {
         [Yehuda, 1, 1, 3]
     ]"#;
 
-    let code = format!(
-        r#"
-            {sample}
-            | skip 1
-            | take while {{|row| $row."Chicken Collection" != "Blue Chickens"}}
-            | into int "31/04/2020"
-            | get "31/04/2020"
-            | math sum
-        "#
-    );
+    let code = r#"
+        from nuon
+        | skip 1
+        | take while {|row| $row."Chicken Collection" != "Blue Chickens"}
+        | into int "31/04/2020"
+        | get "31/04/2020"
+        | math sum
+    "#;
 
-    test().run(code).expect_value_eq(4)
+    test().run_with_data(code, sample).expect_value_eq(4)
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -106,17 +106,19 @@ fn uniq_when_keys_out_of_order() -> Result {
 #[case::a("B", 1)]
 fn uniq_counting(#[case] item: &str, #[case] value: u32) -> Result {
     #[rustfmt::skip]
-    let code = format!(r#"
+    let code = r#"
+        let item = $in
+
         ["A", "B", "A"]
         | wrap item
         | uniq --count
         | flatten
-        | where item == {item}
+        | where item == $item
         | get count
         | get 0
-    "#);
+    "#;
 
-    test().run(code).expect_value_eq(value)
+    test().run_with_data(code, item).expect_value_eq(value)
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/uniq_by.rs
+++ b/crates/nu-command/tests/commands/uniq_by.rs
@@ -13,8 +13,8 @@ fn removes_duplicate_rows() -> Result {
         [JT        , Turner,    "11/12/2011", O   ]
     ]"#;
 
-    let code = format!("{sample} | uniq-by last_name | length");
-    test().run(code).expect_value_eq(3)
+    let code = "from nuon | uniq-by last_name | length";
+    test().run_with_data(code, sample).expect_value_eq(3)
 }
 
 #[test]
@@ -31,17 +31,19 @@ fn uniq_when_keys_out_of_order() -> Result {
 #[case::b("B", 1)]
 fn uniq_counting(#[case] item: &str, #[case] count: u32) -> Result {
     #[rustfmt::skip]
-    let code = format!(r#"
+    let code = r#"
+        let item = $in
+
         ["A", "B", "A"]
         | wrap item
         | uniq-by item --count
         | flatten
-        | where item == {item}
+        | where item == $item
         | get count
         | get 0
-    "#);
+    "#;
 
-    test().run(code).expect_value_eq(count)
+    test().run_with_data(code, item).expect_value_eq(count)
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/wrap.rs
+++ b/crates/nu-command/tests/commands/wrap.rs
@@ -9,30 +9,28 @@ const SAMPLE: &str = "[
 
 #[test]
 fn wrap_rows_into_a_row() -> Result {
-    let code = format!(
-        "
-            {SAMPLE}
-            | wrap caballeros
-            | get caballeros
-            | get 0
-            | get last_name
-        "
-    );
+    let code = "
+        from nuon
+        | wrap caballeros
+        | get caballeros
+        | get 0
+        | get last_name
+    ";
 
-    test().run(code).expect_value_eq("Robalino")
+    test()
+        .run_with_data(code, SAMPLE)
+        .expect_value_eq("Robalino")
 }
 
 #[test]
 fn wrap_rows_into_a_table() -> Result {
-    let code = format!(
-        "
-            {SAMPLE}
-            | get last_name
-            | wrap caballero
-            | get 2
-            | get caballero
-        "
-    );
+    let code = "
+        from nuon
+        | get last_name
+        | wrap caballero
+        | get 2
+        | get caballero
+    ";
 
-    test().run(code).expect_value_eq("Katz")
+    test().run_with_data(code, SAMPLE).expect_value_eq("Katz")
 }

--- a/crates/nu-command/tests/format_conversions/json.rs
+++ b/crates/nu-command/tests/format_conversions/json.rs
@@ -1,5 +1,6 @@
 use nu_protocol::test_record;
 use nu_test_support::{fs::Stub::FileWithContentToBeTrimmed, prelude::*};
+use rstest::rstest;
 
 #[test]
 fn table_to_json_text_and_from_json_text_back_into_table() -> Result {
@@ -119,13 +120,14 @@ fn from_json_text_objects_is_stream() -> Result {
             "#,
         )]);
 
-        let code = "
-            open katz.txt
-            | from json -o
-            | describe -n
-        ";
+        let code = "open katz.txt | from json -o";
+        let nu_protocol::PipelineData::ListStream(_, _) =
+            test().cwd(dirs.test()).run_raw(code)?.body
+        else {
+            panic!("Output must be a stream");
+        };
 
-        test().cwd(dirs.test()).run(code).expect_value_eq("stream")
+        Ok(())
     })
 }
 
@@ -211,32 +213,27 @@ fn table_to_json_text_strict() -> Result {
     })
 }
 
-#[test]
-fn top_level_values_from_json() -> Result {
-    let mut tester = test();
-    for (value, type_name) in [("null", "nothing"), ("true", "bool"), ("false", "bool")] {
-        tester
-            .run_with_data("from json | to json", value)
-            .expect_value_eq(value)?;
-        tester
-            .run_with_data("from json | describe", value)
-            .expect_value_eq(type_name)?;
-    }
-    Ok(())
+#[rstest]
+#[case("null", ())]
+#[case("true", true)]
+#[case("false", false)]
+fn top_level_values_from_json(#[case] json: &str, #[case] expected: impl IntoValue) -> Result {
+    test()
+        .run_with_data("from json", json)
+        .expect_value_eq(expected)
 }
 
-#[test]
-fn top_level_values_from_json_strict() -> Result {
-    let mut tester = test();
-    for (value, type_name) in [("null", "nothing"), ("true", "bool"), ("false", "bool")] {
-        tester
-            .run_with_data("from json -s | to json", value)
-            .expect_value_eq(value)?;
-        tester
-            .run_with_data("from json -s | describe", value)
-            .expect_value_eq(type_name)?;
-    }
-    Ok(())
+#[rstest]
+#[case("null", ())]
+#[case("true", true)]
+#[case("false", false)]
+fn top_level_values_from_json_strict(
+    #[case] json: &str,
+    #[case] expected: impl IntoValue,
+) -> Result {
+    test()
+        .run_with_data("from json --strict", json)
+        .expect_value_eq(expected)
 }
 
 #[test]

--- a/crates/nu-command/tests/format_conversions/json.rs
+++ b/crates/nu-command/tests/format_conversions/json.rs
@@ -213,24 +213,28 @@ fn table_to_json_text_strict() -> Result {
 
 #[test]
 fn top_level_values_from_json() -> Result {
+    let mut tester = test();
     for (value, type_name) in [("null", "nothing"), ("true", "bool"), ("false", "bool")] {
-        let code = format!(r#""{value}" | from json | to json"#);
-        test().run(&code).expect_value_eq(value)?;
-
-        let code = format!(r#""{value}" | from json | describe"#);
-        test().run(&code).expect_value_eq(type_name)?;
+        tester
+            .run_with_data("from json | to json", value)
+            .expect_value_eq(value)?;
+        tester
+            .run_with_data("from json | describe", value)
+            .expect_value_eq(type_name)?;
     }
     Ok(())
 }
 
 #[test]
 fn top_level_values_from_json_strict() -> Result {
+    let mut tester = test();
     for (value, type_name) in [("null", "nothing"), ("true", "bool"), ("false", "bool")] {
-        let code = format!(r#""{value}" | from json -s | to json"#);
-        test().run(&code).expect_value_eq(value)?;
-
-        let code = format!(r#""{value}" | from json -s | describe"#);
-        test().run(&code).expect_value_eq(type_name)?;
+        tester
+            .run_with_data("from json -s | to json", value)
+            .expect_value_eq(value)?;
+        tester
+            .run_with_data("from json -s | describe", value)
+            .expect_value_eq(type_name)?;
     }
     Ok(())
 }

--- a/crates/nu-command/tests/format_conversions/msgpackz.rs
+++ b/crates/nu-command/tests/format_conversions/msgpackz.rs
@@ -11,12 +11,9 @@ fn sample_roundtrip() -> Result {
     let sample_nuon =
         std::fs::read_to_string(&path_to_sample_nuon).expect("failed to open sample.nuon");
 
-    let code = format!(
-        "open '{}' | to msgpackz | from msgpackz | to nuon --indent 4",
-        path_to_sample_nuon.display()
-    );
+    let code = "open $in | to msgpackz | from msgpackz | to nuon --indent 4";
 
-    let outcome: String = test().run(code)?;
+    let outcome: String = test().run_with_data(code, path_to_sample_nuon)?;
     assert_eq!(
         outcome.replace("\r\n", "\n").trim(),
         sample_nuon.replace("\r\n", "\n").trim()


### PR DESCRIPTION
## Description

Refactored some test that used `format!` to inject data into nu code.
It's a rather brittle approach, and thanks our current in-process testing infra we can easily inject actual values.

## User-facing changes (Release notes)
N/A