### PR TITLE
Improved argument handling for untyped rest parameters

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1145,6 +1145,30 @@ fn command_wide_completion_custom(#[case] return_code: &str) {
     match_suggestions(&expected, &suggestions);
 }
 
+#[test]
+fn command_wide_completion_wrapped_untyped_equals_flag_value() {
+    let mut completer = custom_completer();
+
+    let sample = r#"
+        def "nu-complete wt" [spans: list<string>] {
+            let last = ($spans | last)
+            if ($last | str starts-with "--base=") {
+                [--base=releases/4.x.x --base=main]
+            } else {
+                [switch --base]
+            }
+        }
+
+        @complete "nu-complete wt"
+        def --wrapped "wt" [...args] {}
+
+        wt switch --base=rel"#;
+
+    let suggestions = completer.complete(sample, sample.len());
+    let expected = vec!["--base=releases/4.x.x", "--base=main"];
+    match_suggestions(&expected, &suggestions);
+}
+
 #[rstest]
 #[case::custom(
     r#"def "nu-complete foo" [spans: list] { null }

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -321,6 +321,45 @@ fn def_env_wrapped_no_help() {
 }
 
 #[test]
+fn def_wrapped_untyped_rest_strips_double_quoted_equals_value() {
+    let actual = nu!(r#"def --wrapped foo [...rest] { $rest.0 }; foo expression="releases/4.x.x""#);
+    assert_eq!(actual.out, "expression=releases/4.x.x");
+}
+
+#[test]
+fn def_wrapped_untyped_rest_strips_single_quoted_equals_value() {
+    let actual = nu!("def --wrapped foo [...rest] { $rest.0 }; foo expression='releases/4.x.x'");
+    assert_eq!(actual.out, "expression=releases/4.x.x");
+}
+
+#[test]
+fn def_wrapped_untyped_rest_expands_tilde() {
+    // When accessing $args directly (e.g. `$rest | get 0`), tilde should be expanded to the
+    // home dir. This is the core case from issue #17410.
+    let expected = nu!("'~' | path expand");
+    let actual = nu!("def --wrapped foo [...rest] { $rest | get 0 }; foo ~");
+    assert_eq!(actual.out, expected.out);
+
+    // Also works when forwarding to an external command
+    let expected_ext = nu!("^echo ~");
+    let actual_ext = nu!("def --wrapped foo [...rest] { ^echo ...$rest }; foo ~");
+    assert_eq!(actual_ext.out, expected_ext.out);
+}
+
+#[test]
+fn def_wrapped_explicit_string_rest_keeps_double_quoted_equals_value() {
+    let actual =
+        nu!(r#"def --wrapped foo [...rest: string] { $rest.0 }; foo --base="releases/4.x.x""#);
+    assert_eq!(actual.out, r#"--base="releases/4.x.x""#);
+}
+
+#[test]
+fn def_wrapped_explicit_string_rest_keeps_tilde_literal() {
+    let actual = nu!("def --wrapped foo [...rest: string] { $rest.0 }; foo ~");
+    assert_eq!(actual.out, "~");
+}
+
+#[test]
 fn def_recursive_func_should_work() {
     let actual = nu!("def bar [] { let x = 1; ($x | foo) }; def foo [] { foo }");
     assert!(actual.err.is_empty());

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, fs::File, sync::Arc};
 
-use nu_path::{expand_path, expand_path_with};
+use nu_path::{dots::expand_ndots_safe, expand_path, expand_path_with, expand_tilde};
 #[cfg(feature = "os")]
 use nu_protocol::process::check_exit_status_future;
 use nu_protocol::{
@@ -23,6 +23,29 @@ use nu_utils::IgnoreCaseExt;
 use crate::{
     ENV_CONVERSIONS, convert_env_vars, eval::is_automatic_env_var, eval_block_with_early_return,
 };
+
+/// For `def --wrapped` and `known extern` rest params (`SyntaxShape::ExternalArgument`), expand
+/// tilde and ndots in bare glob values that are not actual glob patterns. This mirrors what
+/// `run-external` does in `eval_external_arguments`, so that `$args | to nuon` returns expanded
+/// paths instead of the raw `~` / `...` tokens.
+fn expand_external_glob_arg(val: Value) -> Value {
+    if let Value::Glob {
+        val: ref s,
+        no_expand,
+        internal_span,
+        ..
+    } = val
+        && !no_expand
+        && !nu_glob::is_glob(s)
+    {
+        let expanded = expand_ndots_safe(expand_tilde(s.as_str()));
+        let expanded_str = expanded.to_string_lossy().into_owned();
+        if expanded_str != *s {
+            return Value::string(expanded_str, internal_span);
+        }
+    }
+    val
+}
 
 pub fn eval_ir_block<D: DebugContext>(
     engine_state: &EngineState,
@@ -1348,6 +1371,14 @@ fn gather_arguments(
     let mut rest = vec![];
     let mut rest_span: Option<Span> = None;
 
+    // If the rest param uses ExternalArgument shape (untyped `def --wrapped` or `known extern`),
+    // tilde and ndots in bare glob values should be expanded, matching `run-external` behavior so
+    // that `$args | to nuon` shows expanded paths (e.g. `/home/user`) rather than `~`.
+    // We detect this via `allows_unknown_args`, which is set for all `def --wrapped` and
+    // `known extern` commands, and only affects `Value::Glob` values (explicit `[...rest: string]`
+    // produces `Value::String`, not `Value::Glob`, so those are unaffected).
+    let expand_glob_args = block.signature.allows_unknown_args;
+
     // If we encounter a spread, all further positionals should go to rest
     let mut always_spread = false;
 
@@ -1367,6 +1398,11 @@ fn gather_arguments(
                     callee_stack.add_var(var_id, val);
                 } else {
                     rest_span = Some(rest_span.map_or(val.span(), |s| s.append(val.span())));
+                    let val = if expand_glob_args {
+                        expand_external_glob_arg(val)
+                    } else {
+                        val
+                    };
                     rest.push(val);
                 }
             }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -150,6 +150,33 @@ pub fn parse_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteComma
     }
 }
 
+fn rest_param_is_type_annotated(signature_source: &[u8], rest_name: &str) -> bool {
+    let mut needle = Vec::with_capacity(rest_name.len() + 3);
+    needle.extend_from_slice(b"...");
+    needle.extend_from_slice(rest_name.as_bytes());
+
+    if signature_source.len() < needle.len() {
+        return false;
+    }
+
+    for start in 0..=(signature_source.len() - needle.len()) {
+        if signature_source[start..start + needle.len()] != needle {
+            continue;
+        }
+
+        let mut idx = start + needle.len();
+        while idx < signature_source.len() && signature_source[idx].is_ascii_whitespace() {
+            idx += 1;
+        }
+
+        if idx < signature_source.len() && signature_source[idx] == b':' {
+            return true;
+        }
+    }
+
+    false
+}
+
 pub fn parse_def_predecl(working_set: &mut StateWorkingSet, spans: &[Span]) {
     let mut pos = 0;
 
@@ -250,6 +277,14 @@ pub fn parse_def_predecl(working_set: &mut StateWorkingSet, spans: &[Span]) {
     signature.name = name;
 
     if allow_unknown_args {
+        if let Some(rest) = &mut signature.rest_positional
+            && !rest_param_is_type_annotated(
+                working_set.get_span_contents(spans[signature_pos]),
+                &rest.name,
+            )
+        {
+            rest.shape = SyntaxShape::ExternalArgument;
+        }
         signature.allows_unknown_args = true;
     }
 
@@ -713,7 +748,14 @@ fn parse_def_inner(
 
     if let (Some(mut signature), Some(block_id)) = (sig.as_signature(), block.as_block()) {
         if has_wrapped {
-            if let Some(rest) = &signature.rest_positional {
+            if let Some(rest) = &mut signature.rest_positional {
+                if !rest_param_is_type_annotated(
+                    working_set.get_span_contents(sig.span),
+                    &rest.name,
+                ) {
+                    rest.shape = SyntaxShape::ExternalArgument;
+                }
+
                 if let Some(var_id) = rest.var_id {
                     let rest_var = &working_set.get_variable(var_id);
 


### PR DESCRIPTION
## Description
This PR improves argument handling for untyped wrapped rest parameters so behavior matches external-argument parsing more closely.

It addresses two regressions/consistency gaps:

1. Quote parity for `--key="value"` style args in `def --wrapped [...rest]`:
	- untyped wrapped rest now strips embedded quote wrappers in unknown args
	- example: `expression="releases/4.x.x"` is captured as `expression=releases/4.x.x`
	- same for single-quoted forms
2. Tilde expansion when reading wrapped args directly:
	- for wrapped/unknown-arg flows, bare non-glob `Value::Glob` args now get the same tilde/ndots expansion used by external forwarding

3. Explicitly typed string ...rests still provide literals
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
Fixed wrapped command argument handling in `def --wrapped [...rest]` for untyped rest params:

- Nushell now parses `--key="value"` and `--key='value'` in wrapped rest args like external args, removing quote wrappers around the value.
- Nushell now expands `~` in untyped wrapped rest args even when args are read directly (for example via `$args | to nuon`), not only when forwarding to an external command.
- Explicitly typed string rest params `[...rest: string]` keep prior literal behavior.


<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
closes #17410
closes #18128