### PR TITLE
feat(polars): pivot: provide default --on-cols value if not specified

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/data/pivot.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/pivot.rs
@@ -40,7 +40,7 @@ impl PluginCommand for PivotDF {
                 "Column names for pivoting.",
                 Some('o'),
             )
-            .required_named(
+            .named(
                 "on-cols",
                 SyntaxShape::Any,
                 "column names used as value columns",
@@ -112,6 +112,30 @@ impl PluginCommand for PivotDF {
     polars sort-by name maths physics |
     polars collect"#,
                 description: "Given a set of test scores, reshape so we have one row per student, with different subjects as columns, and their `test_1` scores as values",
+                result: Some(
+                    NuDataFrame::from(
+                        df!(
+                            "name" => ["Cady", "Karen"],
+                            "maths" => [98, 61],
+                            "physics" => [99, 58],
+                        )
+                        .expect("Could not create test datafarme"),
+                    )
+                    .into_value(Span::test_data()),
+                ),
+            },
+            Example {
+                example: r#"{
+        "name": ["Cady", "Cady", "Karen", "Karen"],
+        "subject": ["maths", "physics", "maths", "physics"],
+        "test_1": [98, 99, 61, 58],
+        "test_2": [100, 100, 60, 60],
+    } | 
+    polars into-df --as-columns | 
+    polars pivot --on subject --index name --values test_1 |
+    polars sort-by name maths physics |
+    polars collect"#,
+                description: "Given a set of test scores, reshape so we have one row per student, with different subjects as columns, and their `test_1` scores as values, without specifying --on-cols",
                 result: Some(
                     NuDataFrame::from(
                         df!(
@@ -211,8 +235,19 @@ fn command_lazy(
         .get_flag::<Value>("on-cols")?
         .map(|ref v| NuDataFrame::try_from_value(plugin, v))
         .transpose()?
-        .ok_or(required_flag("on-cols", call.head))?
-        .to_polars();
+        .map(|df| df.to_polars())
+        .or_else(|| {
+            lazy.to_polars()
+                .select([on.clone().as_expr()])
+                .unique_stable(None, polars::frame::UniqueKeepStrategy::Any)
+                .collect()
+                .ok()
+        })
+        .ok_or(ShellError::Generic(GenericError::new(
+            "Pivot columns cannot be deduced, `--on-cols` must be specified",
+            "",
+            call.head,
+        )))?;
 
     let index: Option<Selector> = call
         .get_flag::<Value>("index")?


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
This PR removes the requirement in `polars pivot` that `--on-cols` must be specified. Mirroring the behavior in Python polars.pivot (https://github.com/pola-rs/polars/blob/py-1.40.1/py-polars/src/polars/dataframe/frame.py#L9456-L9683), `polars pivot` now supplies default values for `--on-cols` by selecting unique values from the columns specified by `--on`. 

See examples below
```nu
# Given a set of test scores, reshape so we have one row per student, with different subjects as columns, and their test_1 scores as values
  > {
        "name": ["Cady", "Cady", "Karen", "Karen"],
        "subject": ["maths", "physics", "maths", "physics"],
        "test_1": [98, 99, 61, 58],
        "test_2": [100, 100, 60, 60],
    } |
    polars into-df --as-columns |
    polars pivot --on subject --on-cols [maths physics] --index name --values test_1 |
    polars sort-by name maths physics |
    polars collect
  ╭───┬───────┬───────┬─────────╮
  │ # │ name  │ maths │ physics │
  ├───┼───────┼───────┼─────────┤
  │ 0 │ Cady  │    98 │      99 │
  │ 1 │ Karen │    61 │      58 │
  ╰───┴───────┴───────┴─────────╯

 # Given a set of test scores, reshape so we have one row per student, with different subjects as columns, and their test_1 scores as values, without specifying --on-cols
  > {
        "name": ["Cady", "Cady", "Karen", "Karen"],
        "subject": ["maths", "physics", "maths", "physics"],
        "test_1": [98, 99, 61, 58],
        "test_2": [100, 100, 60, 60],
    } |
    polars into-df --as-columns |
    polars pivot --on subject --index name --values test_1 |
    polars sort-by name maths physics |
    polars collect
  ╭───┬───────┬───────┬─────────╮
  │ # │ name  │ maths │ physics │
  ├───┼───────┼───────┼─────────┤
  │ 0 │ Cady  │    98 │      99 │
  │ 1 │ Karen │    61 │      58 │
  ╰───┴───────┴───────┴─────────╯
```


## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
Refactor `--on-cols` in `polars pivot` from required to optional parameter; supply default values based on unique values of `--on` columns

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->