### PR TITLE
Removed implicit line splitting of byte streams in `parse`

### DIFF
--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -46,7 +46,7 @@ impl Command for Parse {
         vec![
             Example {
                 description: "Parse a string into two named columns.",
-                example: "\"hi there\" | parse \"{foo} {bar}\"",
+                example: r#""hi there" | parse "{foo} {bar}""#,
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "foo" => Value::test_string("hi"),
                     "bar" => Value::test_string("there"),
@@ -54,14 +54,14 @@ impl Command for Parse {
             },
             Example {
                 description: "Parse a string, ignoring a column with _.",
-                example: "\"hello world\" | parse \"{foo} {_}\"",
+                example: r#""hello world" | parse "{foo} {_}""#,
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "foo" => Value::test_string("hello"),
                 })])),
             },
             Example {
                 description: "This is how the first example is interpreted in the source code.",
-                example: "\"hi there\" | parse --regex '(?s)\\A(?P<foo>.*?) (?P<bar>.*?)\\z'",
+                example: r#""hi there" | parse --regex '(?s)\A(?P<foo>.*?) (?P<bar>.*?)\z'"#,
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "foo" => Value::test_string("hi"),
                     "bar" => Value::test_string("there"),
@@ -69,14 +69,14 @@ impl Command for Parse {
             },
             Example {
                 description: "Parse a string using fancy-regex named capture group pattern.",
-                example: "\"foo bar.\" | parse --regex '\\s*(?<name>\\w+)(?=\\.)'",
+                example: r#""foo bar." | parse --regex '\s*(?<name>\w+)(?=\.)'"#,
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "name" => Value::test_string("bar"),
                 })])),
             },
             Example {
                 description: "Parse a string using fancy-regex capture group pattern.",
-                example: "\"foo! bar.\" | parse --regex '(\\w+)(?=\\.)|(\\w+)(?=!)'",
+                example: r#""foo! bar." | parse --regex '(\w+)(?=\.)|(\w+)(?=!)'"#,
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
                         "capture0" => Value::test_nothing(),
@@ -90,7 +90,7 @@ impl Command for Parse {
             },
             Example {
                 description: "Parse a string using fancy-regex look behind pattern.",
-                example: "\" @another(foo bar)   \" | parse --regex '\\s*(?<=[() ])(@\\w+)(\\([^)]*\\))?\\s*'",
+                example: r#"" @another(foo bar)   " | parse --regex '\s*(?<=[() ])(@\w+)(\([^)]*\))?\s*'"#,
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "capture0" => Value::test_string("@another"),
                     "capture1" => Value::test_string("(foo bar)"),
@@ -98,14 +98,14 @@ impl Command for Parse {
             },
             Example {
                 description: "Parse a string using fancy-regex look ahead atomic group pattern.",
-                example: "\"abcd\" | parse --regex '^a(bc(?=d)|b)cd$'",
+                example: r#""abcd" | parse --regex '^a(bc(?=d)|b)cd$'"#,
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "capture0" => Value::test_string("b"),
                 })])),
             },
             Example {
                 description: "Parse a string with a manually set fancy-regex backtrack limit.",
-                example: "\"hi there\" | parse --backtrack 1500000 \"{foo} {bar}\"",
+                example: r#""hi there" | parse --backtrack 1500000 "{foo} {bar}""#,
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "foo" => Value::test_string("hi"),
                     "bar" => Value::test_string("there"),
@@ -278,7 +278,7 @@ fn operate(
 }
 
 fn build_regex(input: &str, span: Span) -> Result<String, ShellError> {
-    let mut output = "(?s)\\A".to_string();
+    let mut output = r#"(?s)\A"#.to_string();
 
     // Single-pass scanner keeps parsing state explicit and avoids byte-offset bookkeeping.
     let mut loop_input = input.char_indices().peekable();
@@ -352,7 +352,7 @@ fn build_regex(input: &str, span: Span) -> Result<String, ShellError> {
         output.push_str(&fancy_regex::escape(&before));
     }
 
-    output.push_str("\\z");
+    output.push_str(r#"\z"#);
     Ok(output)
 }
 

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -259,20 +259,14 @@ fn operate(
             })
             .into()),
         PipelineData::ByteStream(stream, ..) => {
-            if let Some(lines) = stream.lines() {
-                let iter = ParseIter {
-                    captures: VecDeque::new(),
-                    regex,
-                    columns,
-                    iter: lines,
-                    span: head,
-                    signals: engine_state.signals().clone(),
-                };
+            let val = stream.into_string()?;
 
-                Ok(ListStream::new(iter, head, Signals::empty()).into())
-            } else {
-                Ok(PipelineData::empty())
-            }
+            let captures = regex
+                .captures_iter(&val)
+                .map(|captures| captures_to_value(captures, &columns, head))
+                .collect::<Result<_, _>>()?;
+
+            Ok(Value::list(captures, head).into_pipeline_data())
         }
     }
 }

--- a/crates/nu-command/tests/commands/parse.rs
+++ b/crates/nu-command/tests/commands/parse.rs
@@ -1,6 +1,5 @@
-use nu_test_support::fs::Stub;
-use nu_test_support::nu;
-use nu_test_support::playground::Playground;
+use nu_protocol::{ByteStream, ByteStreamType, PipelineData, Signals, Span, test_table};
+use nu_test_support::{fs::Stub, prelude::*};
 
 mod simple {
     use super::*;
@@ -237,5 +236,43 @@ mod regex {
 
             assert_eq!(actual.out, "1000");
         })
+    }
+
+    #[test]
+    fn multiline_regex() -> Result {
+        let mut tester = test();
+
+        let pattern = r#"(?ms)^(?<n>\d+)\. (?<text>.*?)(?=$\s^\d|\Z)"#;
+        let () = tester.run_with_data("let pattern = $in", pattern)?;
+
+        let input = [
+            "1. one\n",
+            "2. two and\n",
+            "   a half\n",
+            "3. three\n",
+            "4. four and\n",
+            "   some more\n",
+        ];
+        let byte_stream = PipelineData::ByteStream(
+            ByteStream::from_iter(
+                input,
+                Span::test_data(),
+                Signals::empty(),
+                ByteStreamType::Unknown,
+            ),
+            None,
+        );
+
+        let code = "parse -r $pattern";
+        tester
+            .run_raw_with_data(code, byte_stream)
+            .and_then(|x| x.body.into_value(Span::test_data()).map_err(Error::from))
+            .expect_value_eq(test_table![
+              ["n", "text"];
+              ["1", "one"],
+              ["2", "two and\n   a half"],
+              ["3", "three"],
+              ["4", "four and\n   some more"]
+            ])
     }
 }


### PR DESCRIPTION
## Description

Related:
- #16057
- #18122

## User-facing changes (Release notes)

`parse` command, when receiving byte or string stream input (i.e. from an external process or file), used to implicitly split the input into lines. With this release it will collect such streams before processing them.

While the line-by-line behavior is closer to how tools like `sed`, `grep` and `awk` operate, it was confusing as `parse` worked differently between working with a string _stream_ input and working with a string _value_ input.


<table><tbody>
<tr><td>Input</td><td width=1000>

<table><tbody>
<tr><td><code>file.txt</code></td></tr>
<tr><td width=500>

```
1. one
2. two and
   a half
3. three
4. four and
   some more
```

</td></tr>
</tbody></table>

</td></tr>
<tr><td>Code</td><td width=500>

```nushell
open file.txt
| parse -r r#'(?ms)^(?<n>\d+)\. (?<text>.*?)(?=$\s^\d|\Z)'#
```

</td></tr>
<tr><td>Output</td><td>


<table><tbody>
<tr><td>Before</td><td>After</td></tr>
<tr>
<td width=300>

```
╭───┬───┬──────────╮
│ # │ n │   text   │
├───┼───┼──────────┤
│ 0 │ 1 │ one      │
│ 1 │ 2 │ two and  │
│ 2 │ 3 │ three    │
│ 3 │ 4 │ four and │
╰───┴───┴──────────╯
```

</td><td width=300>

```
╭───┬───┬──────────────╮
│ # │ n │     text     │
├───┼───┼──────────────┤
│ 0 │ 1 │ one          │
│ 1 │ 2 │ two and      │
│   │   │    a half    │
│ 2 │ 3 │ three        │
│ 3 │ 4 │ four and     │
│   │   │    some more │
╰───┴───┴──────────────╯
```

</td>
</tr>
</tbody></table>

</td></tr>
</tbody></table>


To process the input line-by-line all you need to do is run the stream through `lines`:

```nushell
.. | lines | parse -r '...'
```