### PR TITLE
Add `idx` family of commands for in-memory indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,15 @@ dependencies = [
 
 [[package]]
 name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
@@ -777,6 +786,12 @@ checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
  "virtue",
 ]
+
+[[package]]
+name = "bindet"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5afee99ef5f7527f3944f2bf4f5d443749fa47d43eb1d4f83a36e839be7900a3"
 
 [[package]]
 name = "bindgen"
@@ -1754,11 +1769,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1769,7 +1805,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1843,6 +1879,15 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "doxygen-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
+dependencies = [
+ "phf 0.11.3",
+]
 
 [[package]]
 name = "dtoa"
@@ -2134,6 +2179,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fff-grep"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88283e24a45f87707db72788a5e41d662df75d445e81fb34d197e04f2b2d443f"
+dependencies = [
+ "bstr",
+ "memchr",
+]
+
+[[package]]
+name = "fff-notify-debouncer-full"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4594f0ef1ad0bfcd112bbe4b397ef881f50442bc710356b86858d555848e4d09"
+dependencies = [
+ "file-id",
+ "log",
+ "notify 9.0.0-rc.3",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
+name = "fff-query-parser"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab582f40d563f533ef3c7fe893fb936a42111ffb41517d3aa01a6e49dbdc1564"
+
+[[package]]
+name = "fff-search"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c18af8dea8c5f50db9c4178caad1acfabdfa587487206b0dd8e319eef048c5"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "bindet",
+ "blake3",
+ "chrono",
+ "dirs 5.0.1",
+ "dunce",
+ "fff-grep",
+ "fff-notify-debouncer-full",
+ "fff-query-parser",
+ "git2",
+ "glidesort",
+ "globset",
+ "heed",
+ "ignore",
+ "libc",
+ "memchr",
+ "memmap2",
+ "neo_frizbee",
+ "notify 9.0.0-rc.3",
+ "once_cell",
+ "parking_lot",
+ "pathdiff",
+ "rayon",
+ "regex",
+ "regex-syntax 0.8.10",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "smartstring",
+ "thiserror 2.0.18",
+ "toml 0.8.23",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2550,6 +2667,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43503cc176394dd30a6525f5f36e838339b8b5619be33ed9a7783841580a97b6"
 
 [[package]]
+name = "glidesort"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e102e6eb644d3e0b186fc161e4460417880a0a0b87d235f2e5b8fb30f2e9e0"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,6 +2683,19 @@ name = "glob-match"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.14",
+ "regex-syntax 0.8.10",
+]
 
 [[package]]
 name = "goblin"
@@ -2699,6 +2835,44 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "heed"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad82d6598ccf1dac15c8b758a1bd282b755b6776be600429176757190a1b0202"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "heed-traits",
+ "heed-types",
+ "libc",
+ "lmdb-master-sys",
+ "once_cell",
+ "page_size",
+ "serde",
+ "synchronoise",
+ "url",
+]
+
+[[package]]
+name = "heed-traits"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
+
+[[package]]
+name = "heed-types"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
+dependencies = [
+ "bincode 1.3.3",
+ "byteorder",
+ "heed-traits",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "hex"
@@ -3062,6 +3236,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.14",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,6 +3316,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
  "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -3622,6 +3823,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "lmdb-master-sys"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaeb9bd22e73bd1babffff614994b341e9b2008de7bb73bf1f7e9154f1978f8b"
+dependencies = [
+ "cc",
+ "doxygen-rs",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3991,6 +4203,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "neo_frizbee"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b216854d8c3752f8dbda56703c708de44bccb0542ca3924976c5977d6fb0724"
+dependencies = [
+ "itertools 0.14.0",
+ "raw-cpuid",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4062,13 +4284,33 @@ dependencies = [
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
- "inotify",
+ "inotify 0.9.6",
  "kqueue",
  "libc",
  "log",
  "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify"
+version = "9.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783683ce6e1059e3747190a6c05688db21e07a846bf90babb351365f9133fe3e"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify 0.11.1",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 1.2.0",
+ "notify-types",
+ "objc2-core-foundation",
+ "objc2-core-services",
+ "walkdir",
+ "windows-sys 0.61.2",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -4079,9 +4321,18 @@ checksum = "fb7fd166739789c9ff169e654dc1501373db9d80a4c3f972817c8a4d7cf8f34e"
 dependencies = [
  "file-id",
  "log",
- "notify",
+ "notify 6.1.1",
  "parking_lot",
  "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4109,7 +4360,7 @@ dependencies = [
  "assert_cmd",
  "crossterm",
  "ctrlc",
- "dirs",
+ "dirs 6.0.0",
  "fancy-regex",
  "lexopt",
  "log",
@@ -4298,11 +4549,12 @@ dependencies = [
  "data-encoding",
  "devicons",
  "digest",
- "dirs",
+ "dirs 6.0.0",
  "dns-lookup",
  "dtparse",
  "encoding_rs",
  "fancy-regex",
+ "fff-search",
  "filesize",
  "filetime",
  "fuzzy-matcher",
@@ -4374,8 +4626,8 @@ dependencies = [
  "tabled",
  "tempfile",
  "titlecase",
- "toml",
- "toml_edit",
+ "toml 1.1.2+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "trash",
  "umask",
  "unicode-segmentation",
@@ -4564,7 +4816,7 @@ dependencies = [
 name = "nu-path"
 version = "0.112.3"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
  "omnipath",
  "pwd",
  "ref-cast",
@@ -4665,8 +4917,8 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "derive_more 2.1.1",
- "dirs",
- "dirs-sys",
+ "dirs 6.0.0",
+ "dirs-sys 0.5.0",
  "fancy-regex",
  "heck",
  "indexmap 2.14.0",
@@ -5116,6 +5368,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5346,6 +5608,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "papergrid"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5513,6 +5785,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -5531,7 +5804,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -5574,6 +5847,19 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6256,7 +6542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c97cabf53eb8fbf6050cde3fef8f596c51cc25fd7d55fbde108d815ee6674abf"
 dependencies = [
  "argminmax",
- "bincode",
+ "bincode 2.0.1",
  "bytemuck",
  "bytes",
  "compact_str",
@@ -6859,6 +7145,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7546,6 +7843,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -7787,6 +8093,18 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "serde",
+ "static_assertions",
+ "version_check",
+]
 
 [[package]]
 name = "smol_str"
@@ -8060,6 +8378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8088,6 +8412,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "synchronoise"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
+dependencies = [
+ "crossbeam-queue",
 ]
 
 [[package]]
@@ -8452,17 +8785,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.0",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -8476,12 +8830,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.0",
@@ -8495,6 +8863,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -8557,6 +8931,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -10071,7 +10458,7 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
 dependencies = [
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "version_check",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "fff-grep"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88283e24a45f87707db72788a5e41d662df75d445e81fb34d197e04f2b2d443f"
+checksum = "443fba608280becc4422d8066201bb34d6f9e378065270ec77673f146a9ec9f9"
 dependencies = [
  "bstr",
  "memchr",
@@ -2193,28 +2193,29 @@ dependencies = [
 
 [[package]]
 name = "fff-notify-debouncer-full"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4594f0ef1ad0bfcd112bbe4b397ef881f50442bc710356b86858d555848e4d09"
+checksum = "5c6f0c16164d10c082af931377766f5495440bee66a9a841bbcea1af5de8878c"
 dependencies = [
  "file-id",
  "log",
  "notify 9.0.0-rc.3",
  "notify-types",
+ "rustc-hash",
  "walkdir",
 ]
 
 [[package]]
 name = "fff-query-parser"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab582f40d563f533ef3c7fe893fb936a42111ffb41517d3aa01a6e49dbdc1564"
+checksum = "8eb0d1657037857ffea06312ca951839930cc52bb132d9cd8b6fb66aabe37fa4"
 
 [[package]]
 name = "fff-search"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c18af8dea8c5f50db9c4178caad1acfabdfa587487206b0dd8e319eef048c5"
+checksum = "54ad0883a0f9c7bda8d4ea67cc7f6d8493131aa52c585572ed77dc5abbe9562d"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ encoding_rs = "0.8"
 fancy-regex = "0.17"
 filesize = "0.2"
 filetime = "0.2.27"
+fff-search = "0.6.4"
 fuzzy-matcher = { version = "^0.3.7" }
 gatekeeper = "3.0.0"
 heck = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ encoding_rs = "0.8"
 fancy-regex = "0.17"
 filesize = "0.2"
 filetime = "0.2.27"
-fff-search = "0.6.4"
+fff-search = { version = "0.6.4", default-features = false }
 fuzzy-matcher = { version = "^0.3.7" }
 gatekeeper = "3.0.0"
 heck = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ encoding_rs = "0.8"
 fancy-regex = "0.17"
 filesize = "0.2"
 filetime = "0.2.27"
-fff-search = { version = "0.6.4", default-features = false }
+fff-search = { version = "0.7.0", default-features = false }
 fuzzy-matcher = { version = "^0.3.7" }
 gatekeeper = "3.0.0"
 heck = "0.5.0"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -66,6 +66,7 @@ encoding_rs = { workspace = true }
 fancy-regex = { workspace = true }
 filesize = { workspace = true }
 filetime = { workspace = true }
+fff-search = { workspace = true }
 fuzzy-matcher = { workspace = true }
 http = { workspace = true }
 human-date-parser = { workspace = true }
@@ -188,7 +189,7 @@ features = [
 workspace = true
 
 [features]
-default = ["os", "network", "rustls-tls"]
+default = ["os", "network", "rustls-tls", "sqlite"]
 os = [
 	# include other features
 	"js",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -158,7 +158,7 @@ arboard = { version = "3.6.0", default-features = false, features = ["wayland-da
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 uucore = { workspace = true, features = ["mode"] }
-fff-search = { workspace = true, optional = true }
+fff-search = { workspace = true, optional = true, default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 umask = { workspace = true }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -66,7 +66,6 @@ encoding_rs = { workspace = true }
 fancy-regex = { workspace = true }
 filesize = { workspace = true }
 filetime = { workspace = true }
-fff-search = { workspace = true }
 fuzzy-matcher = { workspace = true }
 http = { workspace = true }
 human-date-parser = { workspace = true }
@@ -159,6 +158,7 @@ arboard = { version = "3.6.0", default-features = false, features = ["wayland-da
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 uucore = { workspace = true, features = ["mode"] }
+fff-search = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 umask = { workspace = true }
@@ -196,6 +196,7 @@ os = [
 	"nu-engine/os",
 	"nu-protocol/os",
 	"nu-utils/os",
+	"dep:fff-search",
 
 	# os-dependant dependencies
 	"crossterm",

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -254,6 +254,16 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             UTouch,
             Glob,
             Watch,
+            Idx,
+            IdxInit,
+            IdxStatus,
+            IdxFind,
+            IdxSearch,
+            IdxExport,
+            IdxImport,
+            IdxDrop,
+            IdxDirs,
+            IdxFiles,
         };
 
         // Platform

--- a/crates/nu-command/src/filesystem/idx/dirs.rs
+++ b/crates/nu-command/src/filesystem/idx/dirs.rs
@@ -1,0 +1,39 @@
+use super::state::stream_dirs;
+use nu_engine::command_prelude::*;
+#[derive(Clone)]
+pub struct IdxDirs;
+
+impl Command for IdxDirs {
+    fn name(&self) -> &str {
+        "idx dirs"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::record())))])
+            .category(Category::FileSystem)
+    }
+
+    fn description(&self) -> &str {
+        "List indexed directories from idx state."
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            description: "List all indexed directories",
+            example: "idx dirs",
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let signals = engine_state.signals();
+        stream_dirs(call.head, signals)
+    }
+}

--- a/crates/nu-command/src/filesystem/idx/drop.rs
+++ b/crates/nu-command/src/filesystem/idx/drop.rs
@@ -1,0 +1,35 @@
+use super::state::drop_runtime;
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct IdxDrop;
+
+impl Command for IdxDrop {
+    fn name(&self) -> &str {
+        "idx drop"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_types(vec![(Type::Nothing, Type::record())])
+            .category(Category::FileSystem)
+    }
+
+    fn description(&self) -> &str {
+        "Drop the current idx runtime from memory."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Use this when you want to free the in-memory index completely before reinitializing or restoring a different snapshot."
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(PipelineData::value(drop_runtime(call.head)?, None))
+    }
+}

--- a/crates/nu-command/src/filesystem/idx/export.rs
+++ b/crates/nu-command/src/filesystem/idx/export.rs
@@ -1,0 +1,53 @@
+use super::state::store_snapshot;
+use nu_engine::command_prelude::*;
+#[derive(Clone)]
+pub struct IdxExport;
+
+impl Command for IdxExport {
+    fn name(&self) -> &str {
+        "idx export"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .required(
+                "filepath",
+                SyntaxShape::Filepath,
+                "Path where idx snapshot should be stored.",
+            )
+            .input_output_types(vec![(Type::Nothing, Type::record())])
+            .category(Category::FileSystem)
+    }
+
+    fn description(&self) -> &str {
+        "Persist idx state to disk."
+    }
+
+    fn extra_description(&self) -> &str {
+        "The snapshot is stored as a SQLite database. Use `idx import` to reload it."
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            description: "Save the current idx index to disk",
+            example: "idx export ~/my-index.db",
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let path: Spanned<String> = call.req(engine_state, stack, 0)?;
+        let cwd = engine_state.cwd(Some(stack))?;
+        let abs = nu_path::expand_path_with(path.item, cwd, true);
+        Ok(PipelineData::value(
+            store_snapshot(abs.as_ref(), call.head)?,
+            None,
+        ))
+    }
+}

--- a/crates/nu-command/src/filesystem/idx/files.rs
+++ b/crates/nu-command/src/filesystem/idx/files.rs
@@ -1,0 +1,53 @@
+use super::state::stream_files;
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct IdxFiles;
+
+impl Command for IdxFiles {
+    fn name(&self) -> &str {
+        "idx files"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .optional(
+                "path",
+                SyntaxShape::String,
+                "Optional path to lookup in index.",
+            )
+            .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::record())))])
+            .category(Category::FileSystem)
+    }
+
+    fn description(&self) -> &str {
+        "List indexed files, or lookup a specific indexed path."
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                description: "List all indexed files",
+                example: "idx files",
+                result: None,
+            },
+            Example {
+                description: "Lookup a specific file path in the index",
+                example: "idx files src/main.rs",
+                result: None,
+            },
+        ]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let path = call.opt::<String>(engine_state, stack, 0)?;
+        let signals = engine_state.signals();
+        stream_files(path, call.head, signals)
+    }
+}

--- a/crates/nu-command/src/filesystem/idx/find.rs
+++ b/crates/nu-command/src/filesystem/idx/find.rs
@@ -1,0 +1,85 @@
+use super::state::stream_find;
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct IdxFind;
+
+impl Command for IdxFind {
+    fn name(&self) -> &str {
+        "idx find"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .required("query", SyntaxShape::String, "Freeform fuzzy query.")
+            .switch("verbose", "Include verbose scoring details.", Some('v'))
+            .switch("dirs", "Search directories only.", Some('d'))
+            .switch("files", "Search files only.", Some('f'))
+            .named(
+                "limit",
+                SyntaxShape::Int,
+                "Maximum number of rows to return.",
+                Some('l'),
+            )
+            .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::record())))])
+            .category(Category::FileSystem)
+    }
+
+    fn description(&self) -> &str {
+        "Search idx with fuzzy matching across files and directories by default."
+    }
+
+    fn extra_description(&self) -> &str {
+        "`idx find` searches both files and directories unless you narrow it with `--files` or `--dirs`."
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                description: "Fuzzy search for files and directories matching 'main'",
+                example: "idx find main",
+                result: None,
+            },
+            Example {
+                description: "Search only files with verbose scoring output",
+                example: "idx find config --files --verbose",
+                result: None,
+            },
+            Example {
+                description: "Search only directories, limited to top 10 results",
+                example: "idx find src --dirs --limit 10",
+                result: None,
+            },
+        ]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let query: String = call.req(engine_state, stack, 0)?;
+        let verbose = call.has_flag(engine_state, stack, "verbose")?;
+        let dirs = call.has_flag(engine_state, stack, "dirs")?;
+        let files = call.has_flag(engine_state, stack, "files")?;
+
+        if files && dirs {
+            return Err(ShellError::IncompatibleParameters {
+                left_message: "--files cannot be used with --dirs".to_string(),
+                left_span: call.get_flag_span(stack, "files").unwrap_or(call.head),
+                right_message: "--dirs cannot be used with --files".to_string(),
+                right_span: call.get_flag_span(stack, "dirs").unwrap_or(call.head),
+            });
+        }
+
+        let limit = call
+            .get_flag::<i64>(engine_state, stack, "limit")?
+            .and_then(|v| usize::try_from(v).ok())
+            .unwrap_or(100);
+
+        let signals = engine_state.signals();
+        stream_find(&query, files, dirs, verbose, limit, call.head, signals)
+    }
+}

--- a/crates/nu-command/src/filesystem/idx/idx_.rs
+++ b/crates/nu-command/src/filesystem/idx/idx_.rs
@@ -1,0 +1,38 @@
+use nu_engine::{command_prelude::*, get_full_help};
+
+#[derive(Clone)]
+pub struct Idx;
+
+impl Command for Idx {
+    fn name(&self) -> &str {
+        "idx"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("idx")
+            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .category(Category::FileSystem)
+    }
+
+    fn description(&self) -> &str {
+        "Manage in-memory file index state."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Use one of the subcommands: init, status, find, search, export, import, drop, dirs, files. Watch mode keeps the index warm as files change; disable it when you only need a snapshot of the current tree."
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(Value::string(
+            get_full_help(self, engine_state, stack, call.head),
+            call.head,
+        )
+        .into_pipeline_data())
+    }
+}

--- a/crates/nu-command/src/filesystem/idx/import.rs
+++ b/crates/nu-command/src/filesystem/idx/import.rs
@@ -1,0 +1,54 @@
+use super::state::restore_snapshot;
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct IdxImport;
+
+impl Command for IdxImport {
+    fn name(&self) -> &str {
+        "idx import"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .required(
+                "filepath",
+                SyntaxShape::Filepath,
+                "Path to a stored idx snapshot.",
+            )
+            .input_output_types(vec![(Type::Nothing, Type::record())])
+            .category(Category::FileSystem)
+    }
+
+    fn description(&self) -> &str {
+        "Import idx state from disk."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Reads a SQLite snapshot created by `idx export` and hydrates the runtime from stored rows. Watch mode is not restored from the snapshot."
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            description: "Restore an idx index from a snapshot on disk",
+            example: "idx import ~/my-index.db",
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let path: Spanned<String> = call.req(engine_state, stack, 0)?;
+        let cwd = engine_state.cwd(Some(stack))?;
+        let abs = nu_path::expand_path_with(path.item, cwd, true);
+        Ok(PipelineData::value(
+            restore_snapshot(abs.as_ref(), call.head)?,
+            None,
+        ))
+    }
+}

--- a/crates/nu-command/src/filesystem/idx/init.rs
+++ b/crates/nu-command/src/filesystem/idx/init.rs
@@ -1,0 +1,64 @@
+use super::state::init_runtime;
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct IdxInit;
+
+impl Command for IdxInit {
+    fn name(&self) -> &str {
+        "idx init"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .required("path", SyntaxShape::Directory, "Path to index.")
+            .switch(
+                "wait",
+                "Block until the initial scan completes before returning.",
+                Some('w'),
+            )
+            .input_output_types(vec![(Type::Nothing, Type::record())])
+            .category(Category::FileSystem)
+    }
+
+    fn description(&self) -> &str {
+        "Initialize the in-memory idx index for a path."
+    }
+
+    fn extra_description(&self) -> &str {
+        "By default idx init returns immediately and indexing continues in the background. Use `idx status` to check when scanning completes. Pass `--wait` to block until the initial scan finishes."
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                description: "Initialize idx for the current directory",
+                example: "idx init .",
+                result: None,
+            },
+            Example {
+                description: "Initialize idx and wait for the initial scan to complete",
+                example: "idx init . --wait",
+                result: None,
+            },
+        ]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let path: Spanned<String> = call.req(engine_state, stack, 0)?;
+        let wait = call.has_flag(engine_state, stack, "wait")?;
+        let cwd = engine_state.cwd(Some(stack))?;
+        let abs = nu_path::expand_path_with(path.item, cwd, true);
+        // There is a functionality in fff-search to update the index via watch but it was non-trivial to get working
+        // So, for now, let's always default to watch = false.
+        let watch = false;
+        let status = init_runtime(&abs, watch, wait, call.head)?;
+        Ok(PipelineData::value(status.to_value(call.head), None))
+    }
+}

--- a/crates/nu-command/src/filesystem/idx/mod.rs
+++ b/crates/nu-command/src/filesystem/idx/mod.rs
@@ -1,0 +1,22 @@
+mod dirs;
+mod drop;
+mod export;
+mod files;
+mod find;
+mod idx_;
+mod import;
+mod init;
+mod search;
+mod state;
+mod status;
+
+pub use dirs::IdxDirs;
+pub use drop::IdxDrop;
+pub use export::IdxExport;
+pub use files::IdxFiles;
+pub use find::IdxFind;
+pub use idx_::Idx;
+pub use import::IdxImport;
+pub use init::IdxInit;
+pub use search::IdxSearch;
+pub use status::IdxStatus;

--- a/crates/nu-command/src/filesystem/idx/search.rs
+++ b/crates/nu-command/src/filesystem/idx/search.rs
@@ -1,0 +1,103 @@
+use super::state::stream_grep;
+use fff_search::GrepMode;
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct IdxSearch;
+
+impl Command for IdxSearch {
+    fn name(&self) -> &str {
+        "idx search"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .rest(
+                "pattern",
+                SyntaxShape::String,
+                "One or more search patterns.",
+            )
+            .switch("regex", "Use regular-expression matching mode.", Some('r'))
+            .switch("fuzzy", "Use fuzzy line-matching mode.", Some('f'))
+            .named(
+                "limit",
+                SyntaxShape::Int,
+                "Maximum number of matches to collect.",
+                Some('l'),
+            )
+            .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::record())))])
+            .category(Category::FileSystem)
+    }
+
+    fn description(&self) -> &str {
+        "Search indexed file contents."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Mode selection: plain text is the default and treats each pattern literally, `--regex` evaluates the patterns as regular expressions, and `--fuzzy` performs approximate line matching."
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                description: "Search indexed file contents for a plain text pattern",
+                example: "idx search hello",
+                result: None,
+            },
+            Example {
+                description: "Search using a regular expression",
+                example: "idx search --regex 'fn \\w+'",
+                result: None,
+            },
+            Example {
+                description: "Search with multiple patterns simultaneously",
+                example: "idx search TODO FIXME HACK",
+                result: None,
+            },
+        ]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let patterns: Vec<String> = call.rest(engine_state, stack, 0)?;
+        if patterns.is_empty() {
+            return Err(ShellError::MissingParameter {
+                param_name: "pattern".to_string(),
+                span: call.head,
+            });
+        }
+
+        let regex = call.has_flag(engine_state, stack, "regex")?;
+        let fuzzy = call.has_flag(engine_state, stack, "fuzzy")?;
+
+        if regex && fuzzy {
+            return Err(ShellError::IncompatibleParameters {
+                left_message: "--regex cannot be used with --fuzzy".to_string(),
+                left_span: call.get_flag_span(stack, "regex").unwrap_or(call.head),
+                right_message: "--fuzzy cannot be used with --regex".to_string(),
+                right_span: call.get_flag_span(stack, "fuzzy").unwrap_or(call.head),
+            });
+        }
+
+        let limit = call
+            .get_flag::<i64>(engine_state, stack, "limit")?
+            .and_then(|v| usize::try_from(v).ok())
+            .unwrap_or(50);
+
+        let mode = if fuzzy {
+            GrepMode::Fuzzy
+        } else if regex {
+            GrepMode::Regex
+        } else {
+            GrepMode::PlainText
+        };
+
+        let signals = engine_state.signals();
+        stream_grep(&patterns, mode, limit, call.head, signals)
+    }
+}

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -1225,10 +1225,27 @@ pub fn stream_grep(
                 .match_byte_offsets
                 .iter()
                 .map(|(start, end)| {
+                    let start = i64::try_from(*start).unwrap_or(i64::MAX);
+                    let end = i64::try_from(*end).unwrap_or(i64::MAX);
                     Value::record(
                         [
-                            ("start".to_string(), Value::int(i64::from(*start), span)),
-                            ("end".to_string(), Value::int(i64::from(*end), span)),
+                            // ("start".to_string(), Value::int(start, span)),
+                            // ("end".to_string(), Value::int(end, span)),
+
+                            // I'm guessing calculated offset to match start, end is more valuable
+                            // than just the offset to start and end of the match
+                            (
+                                "start".to_string(),
+                                // byte_offset is the offset to the beginning of the line,
+                                // so match start is offset + start
+                                Value::int(start + item.byte_offset as i64, span),
+                            ),
+                            (
+                                "end".to_string(),
+                                // byte_offset is the offset to the beginning of the line,
+                                // so match end is offset + start + length or offset + end
+                                Value::int(item.byte_offset as i64 + end, span),
+                            ),
                         ]
                         .into_iter()
                         .collect(),

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -1,6 +1,6 @@
 use fff_search::{
     FFFMode, FilePicker, FilePickerOptions, FuzzySearchOptions, GrepMode, GrepSearchOptions,
-    MixedItemRef, PaginationArgs, QueryParser, SharedFrecency, SharedFilePicker,
+    MixedItemRef, PaginationArgs, QueryParser, SharedFilePicker, SharedFrecency,
 };
 use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -1,6 +1,6 @@
 use fff_search::{
     FFFMode, FilePicker, FilePickerOptions, FuzzySearchOptions, GrepMode, GrepSearchOptions,
-    MixedItemRef, PaginationArgs, QueryParser, SharedFrecency, SharedPicker,
+    MixedItemRef, PaginationArgs, QueryParser, SharedFrecency, SharedFilePicker,
 };
 use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
@@ -16,8 +16,7 @@ use std::time::Duration;
 pub struct IdxRuntime {
     pub base_path: PathBuf,
     pub watch: bool,
-    pub shared_picker: SharedPicker,
-    pub scan_signal: Arc<AtomicBool>,
+    pub shared_picker: SharedFilePicker,
     pub scan_start_time: Instant,
     pub scan_completed: Arc<AtomicBool>,
     pub scan_duration_ms: Arc<AtomicU64>,
@@ -127,7 +126,7 @@ fn fff_error<E: std::fmt::Display>(err: E, span: Span) -> ShellError {
     ))
 }
 
-fn shutdown_shared_picker(shared_picker: &SharedPicker, span: Span) -> Result<(), ShellError> {
+fn shutdown_shared_picker(shared_picker: &SharedFilePicker, span: Span) -> Result<(), ShellError> {
     // Important: never join the watcher thread while holding the shared
     // picker write lock, otherwise the owner thread can deadlock waiting for
     // the same lock while processing a final event batch.
@@ -203,7 +202,6 @@ fn runtime_snapshot() -> Option<RuntimeSnapshot> {
         base_path: runtime.base_path.clone(),
         watch: runtime.watch,
         shared_picker: runtime.shared_picker.clone(),
-        scan_signal: runtime.scan_signal.clone(),
         scan_start_time: runtime.scan_start_time,
         scan_completed: runtime.scan_completed.clone(),
         scan_duration_ms: runtime.scan_duration_ms.clone(),
@@ -226,25 +224,6 @@ pub fn current_status(scan_start_override: Option<Instant>) -> IdxStatus {
     };
 
     let scan_start = scan_start_override.unwrap_or(snapshot.scan_start_time);
-
-    // Keep status non-blocking while initial indexing is active so REPL
-    // status checks do not stall behind picker writes.
-    if snapshot.scan_signal.load(Ordering::Acquire) {
-        let duration = freeze_scan_duration_if_needed(
-            &snapshot.scan_completed,
-            &snapshot.scan_duration_ms,
-            scan_start,
-            true,
-        );
-        return IdxStatus {
-            initialized: true,
-            base_path: snapshot.base_path.display().to_string(),
-            watch: snapshot.watch,
-            scanning: true,
-            scan_duration_ms: duration,
-            ..Default::default()
-        };
-    }
 
     let Ok(guard) = snapshot.shared_picker.read() else {
         let duration = freeze_scan_duration_if_needed(
@@ -284,7 +263,7 @@ pub fn init_runtime(
     wait: bool,
     span: Span,
 ) -> Result<IdxStatus, ShellError> {
-    let shared_picker = SharedPicker::default();
+    let shared_picker = SharedFilePicker::default();
     let shared_frecency = SharedFrecency::noop();
 
     FilePicker::new_with_shared_state(
@@ -316,11 +295,6 @@ pub fn init_runtime(
         base_path: path.to_path_buf(),
         watch,
         shared_picker: shared_picker.clone(),
-        scan_signal: shared_picker
-            .read()
-            .ok()
-            .and_then(|pg| pg.as_ref().map(|picker| picker.scan_signal()))
-            .unwrap_or_else(|| Arc::new(AtomicBool::new(true))),
         scan_start_time: Instant::now(),
         scan_completed: Arc::new(AtomicBool::new(false)),
         scan_duration_ms: Arc::new(AtomicU64::new(0)),
@@ -1225,8 +1199,8 @@ pub fn stream_grep(
                 .match_byte_offsets
                 .iter()
                 .map(|(start, end)| {
-                    let start = i64::try_from(*start).unwrap_or(i64::MAX);
-                    let end = i64::try_from(*end).unwrap_or(i64::MAX);
+                    let start = i64::from(*start);
+                    let end = i64::from(*end);
                     Value::record(
                         [
                             // ("start".to_string(), Value::int(start, span)),

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -25,7 +25,7 @@ pub struct IdxRuntime {
 
 /// A cloned snapshot of the current runtime state, obtained while holding the
 /// global mutex for the minimum amount of time. All fields are cheaply
-/// clonable (Arc / Copy), so callers can work with this after the lock is
+/// cloneable (Arc / Copy), so callers can work with this after the lock is
 /// released.
 pub type RuntimeSnapshot = IdxRuntime;
 

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -1,0 +1,1282 @@
+use fff_search::{
+    FFFMode, FilePicker, FilePickerOptions, FuzzySearchOptions, GrepMode, GrepSearchOptions,
+    MixedItemRef, PaginationArgs, QueryParser, SharedFrecency, SharedPicker,
+};
+use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::generic::GenericError;
+use nu_protocol::{ListStream, PipelineMetadata, Signals};
+use nu_utils::time::Instant;
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+pub struct IdxRuntime {
+    pub base_path: PathBuf,
+    pub watch: bool,
+    pub shared_picker: SharedPicker,
+    pub scan_signal: Arc<AtomicBool>,
+    pub scan_start_time: Instant,
+    pub scan_completed: Arc<AtomicBool>,
+    pub scan_duration_ms: Arc<AtomicU64>,
+}
+
+/// A cloned snapshot of the current runtime state, obtained while holding the
+/// global mutex for the minimum amount of time. All fields are cheaply
+/// clonable (Arc / Copy), so callers can work with this after the lock is
+/// released.
+pub type RuntimeSnapshot = IdxRuntime;
+
+#[derive(Clone, Debug, Default)]
+pub struct IdxStatus {
+    pub initialized: bool,
+    pub base_path: String,
+    pub watch: bool,
+    pub scanning: bool,
+    pub scan_duration_ms: u128,
+    pub files: usize,
+    pub dirs: usize,
+    pub arena_bytes_base: usize,
+    pub arena_bytes_overflow: usize,
+    pub arena_bytes_untracked: usize,
+}
+
+impl IdxStatus {
+    pub fn to_value(&self, span: Span) -> Value {
+        Value::record(
+            [
+                (
+                    "initialized".to_string(),
+                    Value::bool(self.initialized, span),
+                ),
+                (
+                    "base_path".to_string(),
+                    Value::string(self.base_path.clone(), span),
+                ),
+                ("watch".to_string(), Value::bool(self.watch, span)),
+                ("scanning".to_string(), Value::bool(self.scanning, span)),
+                (
+                    "scan_duration_ms".to_string(),
+                    Value::int(
+                        i64::try_from(self.scan_duration_ms).unwrap_or(i64::MAX),
+                        span,
+                    ),
+                ),
+                (
+                    "files".to_string(),
+                    Value::int(i64::try_from(self.files).unwrap_or(i64::MAX), span),
+                ),
+                (
+                    "dirs".to_string(),
+                    Value::int(i64::try_from(self.dirs).unwrap_or(i64::MAX), span),
+                ),
+                (
+                    "arena_bytes_base".to_string(),
+                    Value::filesize(
+                        i64::try_from(self.arena_bytes_base).unwrap_or(i64::MAX),
+                        span,
+                    ),
+                ),
+                (
+                    "arena_bytes_overflow".to_string(),
+                    Value::filesize(
+                        i64::try_from(self.arena_bytes_overflow).unwrap_or(i64::MAX),
+                        span,
+                    ),
+                ),
+                (
+                    "arena_bytes_untracked".to_string(),
+                    Value::filesize(
+                        i64::try_from(self.arena_bytes_untracked).unwrap_or(i64::MAX),
+                        span,
+                    ),
+                ),
+                (
+                    "arena_bytes_total".to_string(),
+                    Value::filesize(
+                        i64::try_from(
+                            self.arena_bytes_base
+                                .saturating_add(self.arena_bytes_overflow)
+                                .saturating_add(self.arena_bytes_untracked),
+                        )
+                        .unwrap_or(i64::MAX),
+                        span,
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            span,
+        )
+    }
+}
+
+static IDX_RUNTIME: OnceLock<Mutex<Option<IdxRuntime>>> = OnceLock::new();
+
+fn runtime() -> &'static Mutex<Option<IdxRuntime>> {
+    IDX_RUNTIME.get_or_init(|| Mutex::new(None))
+}
+
+fn fff_error<E: std::fmt::Display>(err: E, span: Span) -> ShellError {
+    ShellError::Generic(GenericError::new(
+        "idx operation failed",
+        err.to_string(),
+        span,
+    ))
+}
+
+fn shutdown_shared_picker(shared_picker: &SharedPicker, span: Span) -> Result<(), ShellError> {
+    // Important: never join the watcher thread while holding the shared
+    // picker write lock, otherwise the owner thread can deadlock waiting for
+    // the same lock while processing a final event batch.
+    let mut picker_to_stop = {
+        let mut guard = shared_picker.write().map_err(|err| fff_error(err, span))?;
+        guard.take()
+    };
+
+    if let Some(picker) = picker_to_stop.as_mut() {
+        // First tell background workers to stop taking new work, then
+        // synchronously stop/join the watcher owner thread.
+        picker.cancel();
+        picker.stop_background_monitor();
+    }
+
+    Ok(())
+}
+
+fn idx_status_from_picker(
+    base_path: &Path,
+    watch: bool,
+    picker: &FilePicker,
+    scan_duration_ms: u128,
+) -> IdxStatus {
+    IdxStatus {
+        initialized: true,
+        base_path: base_path.display().to_string(),
+        watch,
+        scanning: picker.is_scan_active(),
+        scan_duration_ms,
+        files: picker.get_files().len(),
+        dirs: picker.get_dirs().len(),
+        arena_bytes_base: picker.arena_bytes().0,
+        arena_bytes_overflow: picker.arena_bytes().1,
+        arena_bytes_untracked: picker.arena_bytes().2,
+    }
+}
+
+fn elapsed_ms(scan_start: Instant) -> u64 {
+    u64::try_from(scan_start.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+fn freeze_scan_duration_if_needed(
+    scan_completed: &AtomicBool,
+    scan_duration_ms: &AtomicU64,
+    scan_start: Instant,
+    scanning: bool,
+) -> u128 {
+    if scan_completed.load(Ordering::Acquire) {
+        return u128::from(scan_duration_ms.load(Ordering::Acquire));
+    }
+
+    let elapsed = elapsed_ms(scan_start);
+    if !scanning {
+        if scan_completed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            scan_duration_ms.store(elapsed, Ordering::Release);
+            return u128::from(elapsed);
+        }
+
+        return u128::from(scan_duration_ms.load(Ordering::Acquire));
+    }
+
+    u128::from(elapsed)
+}
+
+fn runtime_snapshot() -> Option<RuntimeSnapshot> {
+    let guard = runtime().lock().ok()?;
+    let runtime = guard.as_ref()?;
+    Some(RuntimeSnapshot {
+        base_path: runtime.base_path.clone(),
+        watch: runtime.watch,
+        shared_picker: runtime.shared_picker.clone(),
+        scan_signal: runtime.scan_signal.clone(),
+        scan_start_time: runtime.scan_start_time,
+        scan_completed: runtime.scan_completed.clone(),
+        scan_duration_ms: runtime.scan_duration_ms.clone(),
+    })
+}
+
+fn require_runtime(span: Span) -> Result<RuntimeSnapshot, ShellError> {
+    runtime_snapshot().ok_or_else(|| {
+        ShellError::Generic(GenericError::new(
+            "idx is not initialized",
+            "run `idx init <path>` first",
+            span,
+        ))
+    })
+}
+
+pub fn current_status(scan_start_override: Option<Instant>) -> IdxStatus {
+    let Some(snapshot) = runtime_snapshot() else {
+        return IdxStatus::default();
+    };
+
+    let scan_start = scan_start_override.unwrap_or(snapshot.scan_start_time);
+
+    // Keep status non-blocking while initial indexing is active so REPL
+    // status checks do not stall behind picker writes.
+    if snapshot.scan_signal.load(Ordering::Acquire) {
+        let duration = freeze_scan_duration_if_needed(
+            &snapshot.scan_completed,
+            &snapshot.scan_duration_ms,
+            scan_start,
+            true,
+        );
+        return IdxStatus {
+            initialized: true,
+            base_path: snapshot.base_path.display().to_string(),
+            watch: snapshot.watch,
+            scanning: true,
+            scan_duration_ms: duration,
+            ..Default::default()
+        };
+    }
+
+    let Ok(guard) = snapshot.shared_picker.read() else {
+        let duration = freeze_scan_duration_if_needed(
+            &snapshot.scan_completed,
+            &snapshot.scan_duration_ms,
+            scan_start,
+            false,
+        );
+        return IdxStatus {
+            initialized: true,
+            base_path: snapshot.base_path.display().to_string(),
+            watch: snapshot.watch,
+            scanning: false,
+            scan_duration_ms: duration,
+            ..Default::default()
+        };
+    };
+
+    guard
+        .as_ref()
+        .map(|picker| {
+            let scanning = picker.is_scan_active();
+            let duration = freeze_scan_duration_if_needed(
+                &snapshot.scan_completed,
+                &snapshot.scan_duration_ms,
+                scan_start,
+                scanning,
+            );
+            idx_status_from_picker(&snapshot.base_path, snapshot.watch, picker, duration)
+        })
+        .unwrap_or_default()
+}
+
+pub fn init_runtime(
+    path: &Path,
+    watch: bool,
+    wait: bool,
+    span: Span,
+) -> Result<IdxStatus, ShellError> {
+    let shared_picker = SharedPicker::default();
+    let shared_frecency = SharedFrecency::noop();
+
+    FilePicker::new_with_shared_state(
+        shared_picker.clone(),
+        shared_frecency,
+        FilePickerOptions {
+            base_path: path.display().to_string(),
+            enable_mmap_cache: false,
+            enable_content_indexing: false,
+            mode: FFFMode::Ai,
+            cache_budget: None,
+            watch,
+        },
+    )
+    .map_err(|err| fff_error(err, span))?;
+
+    // Store the runtime immediately — background scan and watcher threads are
+    // already running. Callers can check `idx status` to see when scanning
+    // completes (`scanning: false`).
+    let mut guard = runtime().lock().map_err(|_| {
+        ShellError::Generic(GenericError::new(
+            "idx runtime lock failed",
+            "idx runtime lock poisoned",
+            span,
+        ))
+    })?;
+
+    let previous = guard.replace(IdxRuntime {
+        base_path: path.to_path_buf(),
+        watch,
+        shared_picker: shared_picker.clone(),
+        scan_signal: shared_picker
+            .read()
+            .ok()
+            .and_then(|pg| pg.as_ref().map(|picker| picker.scan_signal()))
+            .unwrap_or_else(|| Arc::new(AtomicBool::new(true))),
+        scan_start_time: Instant::now(),
+        scan_completed: Arc::new(AtomicBool::new(false)),
+        scan_duration_ms: Arc::new(AtomicU64::new(0)),
+    });
+
+    // Drop the lock before potentially blocking on --wait so other threads
+    // (e.g. the background scanner writing into the shared picker) are not
+    // deadlocked against us.
+    drop(guard);
+
+    // If there was an existing runtime, shut down its watcher cleanly.
+    if let Some(old_runtime) = previous {
+        let _ = shutdown_shared_picker(&old_runtime.shared_picker, span);
+    }
+
+    // --wait: block until the background scan finishes (useful for scripts).
+    // We give the scan up to 5 minutes before giving up; this is intentionally
+    // generous so that large repos complete without errors.
+    if wait {
+        const WAIT_TIMEOUT: Duration = Duration::from_secs(300);
+        if !shared_picker.wait_for_scan(WAIT_TIMEOUT) {
+            return Err(ShellError::Generic(GenericError::new(
+                "idx scan timed out",
+                "timed out waiting for the initial scan to finish (300 s). The index is still available with partial results.",
+                span,
+            )));
+        }
+        if watch && !shared_picker.wait_for_watcher(WAIT_TIMEOUT) {
+            return Err(ShellError::Generic(GenericError::new(
+                "idx watcher startup timed out",
+                "timed out waiting for the background filesystem watcher to become ready (300 s).",
+                span,
+            )));
+        }
+    }
+    let status = IdxStatus {
+        initialized: true,
+        base_path: path.display().to_string(),
+        watch,
+        scanning: true,
+        ..Default::default()
+    };
+
+    Ok(status)
+}
+
+pub fn drop_runtime(span: Span) -> Result<Value, ShellError> {
+    let mut guard = runtime().lock().map_err(|_| {
+        ShellError::Generic(GenericError::new(
+            "idx runtime lock failed",
+            "idx runtime lock poisoned",
+            span,
+        ))
+    })?;
+
+    let previous_runtime = guard.take();
+    drop(guard);
+
+    if let Some(runtime) = previous_runtime.as_ref() {
+        let _ = shutdown_shared_picker(&runtime.shared_picker, span);
+    }
+
+    let dropped = previous_runtime.is_some();
+
+    Ok(Value::record(
+        [
+            ("dropped".to_string(), Value::bool(dropped, span)),
+            ("status".to_string(), IdxStatus::default().to_value(span)),
+        ]
+        .into_iter()
+        .collect(),
+        span,
+    ))
+}
+
+pub fn stream_dirs(span: Span, signals: &Signals) -> Result<PipelineData, ShellError> {
+    let snapshot = require_runtime(span)?;
+    let guard = snapshot
+        .shared_picker
+        .read()
+        .map_err(|err| fff_error(err, span))?;
+    let picker = guard.as_ref().ok_or_else(|| {
+        ShellError::Generic(GenericError::new(
+            "idx is not initialized",
+            "run `idx init <path>` first",
+            span,
+        ))
+    })?;
+
+    let base_path = snapshot.base_path.clone();
+    let dirs_data: Vec<_> = picker
+        .get_dirs()
+        .iter()
+        .map(|item| {
+            let rel_path = item.relative_path(picker);
+            let full_path = item.absolute_path(picker, &base_path);
+
+            Value::record(
+                [
+                    ("relative_path".to_string(), Value::string(rel_path, span)),
+                    (
+                        "full_path".to_string(),
+                        Value::string(full_path.to_string_lossy().to_string(), span),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+                span,
+            )
+        })
+        .collect();
+
+    drop(guard);
+
+    let stream_signals = signals.clone();
+    let stream = dirs_data.into_iter().map(move |value| {
+        if let Err(err) = stream_signals.check(&span) {
+            return Value::error(err, span);
+        }
+        value
+    });
+
+    Ok(PipelineData::ListStream(
+        ListStream::new(stream, span, signals.clone()),
+        Some(PipelineMetadata::default()),
+    ))
+}
+
+pub fn stream_files(
+    path: Option<String>,
+    span: Span,
+    signals: &Signals,
+) -> Result<PipelineData, ShellError> {
+    let snapshot = require_runtime(span)?;
+    let guard = snapshot
+        .shared_picker
+        .read()
+        .map_err(|err| fff_error(err, span))?;
+    let picker = guard.as_ref().ok_or_else(|| {
+        ShellError::Generic(GenericError::new(
+            "idx is not initialized",
+            "run `idx init <path>` first",
+            span,
+        ))
+    })?;
+
+    let base_path = snapshot.base_path.clone();
+
+    let files_data: Vec<_> = if let Some(path_str) = path {
+        let lookup_path = Path::new(&path_str);
+
+        // Try relative path first, then strip base_path prefix from absolute paths.
+        let item = picker.get_file_by_path(lookup_path).or_else(|| {
+            if lookup_path.is_absolute() {
+                lookup_path
+                    .strip_prefix(&base_path)
+                    .ok()
+                    .and_then(|rel| picker.get_file_by_path(rel))
+            } else {
+                None
+            }
+        });
+
+        item.map(|i| vec![build_file_record(i, picker, &base_path, span)])
+            .unwrap_or_default()
+    } else {
+        picker
+            .get_files()
+            .iter()
+            .map(|item| build_file_record(item, picker, &base_path, span))
+            .collect()
+    };
+
+    drop(guard);
+
+    let stream_signals = signals.clone();
+    let stream = files_data.into_iter().map(move |value| {
+        if let Err(err) = stream_signals.check(&span) {
+            return Value::error(err, span);
+        }
+        value
+    });
+
+    Ok(PipelineData::ListStream(
+        ListStream::new(stream, span, signals.clone()),
+        Some(PipelineMetadata::default()),
+    ))
+}
+
+fn build_file_record(
+    item: &fff_search::FileItem,
+    picker: &FilePicker,
+    base_path: &Path,
+    span: Span,
+) -> Value {
+    let full_path = item.absolute_path(picker, base_path);
+    Value::record(
+        [
+            (
+                "relative_path".to_string(),
+                Value::string(item.relative_path(picker), span),
+            ),
+            (
+                "full_path".to_string(),
+                Value::string(full_path.to_string_lossy().to_string(), span),
+            ),
+            (
+                "file_name".to_string(),
+                Value::string(item.file_name(picker), span),
+            ),
+            (
+                "directory".to_string(),
+                Value::string(item.dir_str(picker), span),
+            ),
+            (
+                "size".to_string(),
+                Value::int(i64::try_from(item.size).unwrap_or(i64::MAX), span),
+            ),
+            (
+                "modified".to_string(),
+                Value::int(i64::try_from(item.modified).unwrap_or(i64::MAX), span),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+        span,
+    )
+}
+
+fn usize_to_i64(value: usize) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+pub fn stream_find(
+    query: &str,
+    files_only: bool,
+    dirs_only: bool,
+    verbose: bool,
+    limit: usize,
+    span: Span,
+    signals: &Signals,
+) -> Result<PipelineData, ShellError> {
+    let snapshot = require_runtime(span)?;
+    let guard = snapshot
+        .shared_picker
+        .read()
+        .map_err(|err| fff_error(err, span))?;
+    let picker = guard.as_ref().ok_or_else(|| {
+        ShellError::Generic(GenericError::new(
+            "idx is not initialized",
+            "run `idx init <path>` first",
+            span,
+        ))
+    })?;
+
+    let parser = QueryParser::default();
+    let parsed = parser.parse(query);
+    let options = FuzzySearchOptions {
+        max_threads: 0,
+        current_file: None,
+        project_path: None,
+        combo_boost_score_multiplier: 0,
+        min_combo_count: 0,
+        pagination: PaginationArgs { offset: 0, limit },
+    };
+
+    let find_data: Vec<Value> = if !files_only && !dirs_only {
+        let result = picker.fuzzy_search_mixed(&parsed, None, options);
+
+        result
+            .items
+            .iter()
+            .zip(result.scores.iter())
+            .enumerate()
+            .map(|(rank, (item, score))| {
+                let (kind, path) = match item {
+                    MixedItemRef::File(file) => ("file", file.relative_path(picker)),
+                    MixedItemRef::Dir(dir) => ("dir", dir.relative_path(picker)),
+                };
+
+                let mut cols = vec![
+                    ("kind".to_string(), Value::string(kind, span)),
+                    ("path".to_string(), Value::string(path, span)),
+                    ("rank".to_string(), Value::int(usize_to_i64(rank + 1), span)),
+                    (
+                        "score".to_string(),
+                        Value::int(i64::from(score.total), span),
+                    ),
+                ];
+
+                if verbose {
+                    cols.push((
+                        "score_details".to_string(),
+                        Value::record(
+                            [
+                                (
+                                    "base_score".to_string(),
+                                    Value::int(i64::from(score.base_score), span),
+                                ),
+                                (
+                                    "filename_bonus".to_string(),
+                                    Value::int(i64::from(score.filename_bonus), span),
+                                ),
+                                (
+                                    "special_filename_bonus".to_string(),
+                                    Value::int(i64::from(score.special_filename_bonus), span),
+                                ),
+                                (
+                                    "frecency_boost".to_string(),
+                                    Value::int(i64::from(score.frecency_boost), span),
+                                ),
+                            ]
+                            .into_iter()
+                            .collect(),
+                            span,
+                        ),
+                    ));
+                }
+
+                Value::record(cols.into_iter().collect(), span)
+            })
+            .collect()
+    } else if dirs_only {
+        let result = picker.fuzzy_search_directories(&parsed, options);
+        result
+            .items
+            .iter()
+            .zip(result.scores.iter())
+            .enumerate()
+            .map(|(rank, (item, score))| {
+                let mut cols = vec![
+                    ("kind".to_string(), Value::string("dir", span)),
+                    (
+                        "path".to_string(),
+                        Value::string(item.relative_path(picker), span),
+                    ),
+                    ("rank".to_string(), Value::int(usize_to_i64(rank + 1), span)),
+                    (
+                        "score".to_string(),
+                        Value::int(i64::from(score.total), span),
+                    ),
+                ];
+
+                if verbose {
+                    cols.push((
+                        "exact_match".to_string(),
+                        Value::bool(score.exact_match, span),
+                    ));
+                }
+
+                Value::record(cols.into_iter().collect(), span)
+            })
+            .collect()
+    } else {
+        let result = picker.fuzzy_search(&parsed, None, options);
+        result
+            .items
+            .iter()
+            .zip(result.scores.iter())
+            .enumerate()
+            .map(|(rank, (item, score))| {
+                let mut cols = vec![
+                    ("kind".to_string(), Value::string("file", span)),
+                    (
+                        "path".to_string(),
+                        Value::string(item.relative_path(picker), span),
+                    ),
+                    ("rank".to_string(), Value::int(usize_to_i64(rank + 1), span)),
+                    (
+                        "score".to_string(),
+                        Value::int(i64::from(score.total), span),
+                    ),
+                ];
+
+                if verbose {
+                    cols.push((
+                        "match_type".to_string(),
+                        Value::string(score.match_type, span),
+                    ));
+                }
+
+                Value::record(cols.into_iter().collect(), span)
+            })
+            .collect()
+    };
+
+    drop(guard);
+
+    let stream_signals = signals.clone();
+    let stream = find_data.into_iter().map(move |value| {
+        if let Err(err) = stream_signals.check(&span) {
+            return Value::error(err, span);
+        }
+        value
+    });
+
+    Ok(PipelineData::ListStream(
+        ListStream::new(stream, span, signals.clone()),
+        Some(PipelineMetadata::default()),
+    ))
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IdxSnapshotFile {
+    pub relative_path: String,
+    pub full_path: String,
+    pub file_name: String,
+    pub directory: String,
+    pub size: u64,
+    pub modified: u64,
+    pub access_frecency_score: i16,
+    pub modification_frecency_score: i16,
+    pub is_binary: bool,
+    pub is_deleted: bool,
+    pub is_overflow: bool,
+}
+
+#[derive(Debug)]
+pub struct IdxSnapshotDir {
+    pub relative_path: String,
+    pub full_path: String,
+    pub last_segment_offset: u16,
+    pub max_access_frecency: i32,
+    pub is_overflow: bool,
+}
+
+pub fn store_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
+    let snapshot = require_runtime(span)?;
+    let guard = snapshot
+        .shared_picker
+        .read()
+        .map_err(|err| fff_error(err, span))?;
+    let picker = guard.as_ref().ok_or_else(|| {
+        ShellError::Generic(GenericError::new(
+            "idx is not initialized",
+            "run `idx init <path>` first",
+            span,
+        ))
+    })?;
+
+    let files = picker
+        .get_files()
+        .iter()
+        .map(|item| IdxSnapshotFile {
+            relative_path: item.relative_path(picker),
+            full_path: item
+                .absolute_path(picker, &snapshot.base_path)
+                .to_string_lossy()
+                .to_string(),
+            file_name: item.file_name(picker),
+            directory: item.dir_str(picker),
+            size: item.size,
+            modified: item.modified,
+            access_frecency_score: item.access_frecency_score,
+            modification_frecency_score: item.modification_frecency_score,
+            is_binary: item.is_binary(),
+            is_deleted: item.is_deleted(),
+            is_overflow: item.is_overflow(),
+        })
+        .collect::<Vec<_>>();
+
+    let dirs = picker
+        .get_dirs()
+        .iter()
+        .map(|item| IdxSnapshotDir {
+            relative_path: item.relative_path(picker),
+            full_path: item
+                .absolute_path(picker, &snapshot.base_path)
+                .to_string_lossy()
+                .to_string(),
+            last_segment_offset: item.last_segment_offset(),
+            max_access_frecency: item.max_access_frecency(),
+            is_overflow: item.is_overflow(),
+        })
+        .collect::<Vec<_>>();
+
+    // Create or open SQLite database
+    let conn = Connection::open(path).map_err(|err| {
+        ShellError::Generic(GenericError::new(
+            "idx snapshot database open failed",
+            err.to_string(),
+            span,
+        ))
+    })?;
+
+    // Create schema
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS metadata (
+            id INTEGER PRIMARY KEY,
+            version INTEGER NOT NULL,
+            base_path TEXT NOT NULL,
+            watch BOOLEAN NOT NULL,
+            file_count INTEGER NOT NULL,
+            dir_count INTEGER NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS files (
+            id INTEGER PRIMARY KEY,
+            relative_path TEXT NOT NULL,
+            full_path TEXT NOT NULL,
+            file_name TEXT NOT NULL,
+            directory TEXT NOT NULL,
+            size INTEGER NOT NULL,
+            modified INTEGER NOT NULL,
+            access_frecency_score INTEGER NOT NULL,
+            modification_frecency_score INTEGER NOT NULL,
+            is_binary BOOLEAN NOT NULL,
+            is_deleted BOOLEAN NOT NULL,
+            is_overflow BOOLEAN NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS dirs (
+            id INTEGER PRIMARY KEY,
+            relative_path TEXT NOT NULL,
+            full_path TEXT NOT NULL,
+            last_segment_offset INTEGER NOT NULL,
+            max_access_frecency INTEGER NOT NULL,
+            is_overflow BOOLEAN NOT NULL
+        );",
+    )
+    .map_err(|err| {
+        ShellError::Generic(GenericError::new(
+            "idx snapshot schema creation failed",
+            err.to_string(),
+            span,
+        ))
+    })?;
+
+    // Clear existing data
+    let tx = conn.unchecked_transaction().map_err(|err| {
+        ShellError::Generic(GenericError::new(
+            "idx snapshot transaction failed",
+            err.to_string(),
+            span,
+        ))
+    })?;
+    tx.execute("DELETE FROM metadata", []).map_err(|err| {
+        ShellError::Generic(GenericError::new(
+            "idx snapshot clear failed",
+            err.to_string(),
+            span,
+        ))
+    })?;
+    tx.execute("DELETE FROM files", []).map_err(|err| {
+        ShellError::Generic(GenericError::new(
+            "idx snapshot clear failed",
+            err.to_string(),
+            span,
+        ))
+    })?;
+    tx.execute("DELETE FROM dirs", []).map_err(|err| {
+        ShellError::Generic(GenericError::new(
+            "idx snapshot clear failed",
+            err.to_string(),
+            span,
+        ))
+    })?;
+
+    // Insert metadata
+    tx.execute(
+        "INSERT INTO metadata (version, base_path, watch, file_count, dir_count) VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![1, snapshot.base_path.display().to_string(), snapshot.watch, files.len(), dirs.len()],
+    )
+    .map_err(|err| {
+        ShellError::Generic(GenericError::new(
+            "idx snapshot metadata insert failed",
+            err.to_string(),
+            span,
+        ))
+    })?;
+
+    // Insert files
+    for file in &files {
+        tx.execute(
+            "INSERT INTO files (relative_path, full_path, file_name, directory, size, modified, access_frecency_score, modification_frecency_score, is_binary, is_deleted, is_overflow) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            params![
+                file.relative_path,
+                file.full_path,
+                file.file_name,
+                file.directory,
+                file.size,
+                file.modified,
+                file.access_frecency_score,
+                file.modification_frecency_score,
+                file.is_binary,
+                file.is_deleted,
+                file.is_overflow,
+            ],
+        )
+        .map_err(|err| {
+            ShellError::Generic(GenericError::new(
+                "idx snapshot file insert failed",
+                err.to_string(),
+                span,
+            ))
+        })?;
+    }
+
+    // Insert dirs
+    for dir in &dirs {
+        tx.execute(
+            "INSERT INTO dirs (relative_path, full_path, last_segment_offset, max_access_frecency, is_overflow) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                dir.relative_path,
+                dir.full_path,
+                dir.last_segment_offset,
+                dir.max_access_frecency,
+                dir.is_overflow,
+            ],
+        )
+        .map_err(|err| {
+            ShellError::Generic(GenericError::new(
+                "idx snapshot dir insert failed",
+                err.to_string(),
+                span,
+            ))
+        })?;
+    }
+
+    tx.commit().map_err(|err| {
+        ShellError::Generic(GenericError::new(
+            "idx snapshot commit failed",
+            err.to_string(),
+            span,
+        ))
+    })?;
+
+    Ok(Value::record(
+        [
+            ("stored".to_string(), Value::bool(true, span)),
+            (
+                "path".to_string(),
+                Value::string(path.to_string_lossy().to_string(), span),
+            ),
+            (
+                "file_count".to_string(),
+                Value::int(i64::try_from(files.len()).unwrap_or(i64::MAX), span),
+            ),
+            (
+                "dir_count".to_string(),
+                Value::int(i64::try_from(dirs.len()).unwrap_or(i64::MAX), span),
+            ),
+            (
+                "base_path".to_string(),
+                Value::string(snapshot.base_path.display().to_string(), span),
+            ),
+            ("format".to_string(), Value::string("sqlite", span)),
+        ]
+        .into_iter()
+        .collect(),
+        span,
+    ))
+}
+
+pub fn restore_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
+    // Open SQLite database
+    let conn = Connection::open(path).map_err(|err| {
+        ShellError::Generic(GenericError::new(
+            "idx snapshot database open failed",
+            err.to_string(),
+            span,
+        ))
+    })?;
+
+    // Read metadata
+    let metadata = conn
+        .query_row(
+            "SELECT version, base_path, watch, file_count, dir_count FROM metadata LIMIT 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, u32>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, bool>(2)?,
+                    row.get::<_, usize>(3)?,
+                    row.get::<_, usize>(4)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(|err| {
+            ShellError::Generic(GenericError::new(
+                "idx snapshot metadata query failed",
+                err.to_string(),
+                span,
+            ))
+        })?
+        .ok_or_else(|| {
+            ShellError::Generic(GenericError::new(
+                "idx snapshot is empty",
+                "the snapshot database contains no metadata",
+                span,
+            ))
+        })?;
+
+    let (version, base_path_str, watch, file_count, dir_count) = metadata;
+
+    if version != 1 {
+        return Err(ShellError::Generic(GenericError::new(
+            "unsupported idx snapshot version",
+            format!("expected version 1, found {}", version),
+            span,
+        )));
+    }
+
+    // Read all files from snapshot (offline restoration)
+    let mut stmt = conn
+        .prepare("SELECT relative_path, full_path, file_name, directory, size, modified, access_frecency_score, modification_frecency_score, is_binary, is_deleted, is_overflow FROM files")
+        .map_err(|err| {
+            ShellError::Generic(GenericError::new(
+                "idx snapshot file query failed",
+                err.to_string(),
+                span,
+            ))
+        })?;
+
+    let files: Vec<IdxSnapshotFile> = stmt
+        .query_map([], |row| {
+            Ok(IdxSnapshotFile {
+                relative_path: row.get(0)?,
+                full_path: row.get(1)?,
+                file_name: row.get(2)?,
+                directory: row.get(3)?,
+                size: row.get(4)?,
+                modified: row.get(5)?,
+                access_frecency_score: row.get(6)?,
+                modification_frecency_score: row.get(7)?,
+                is_binary: row.get(8)?,
+                is_deleted: row.get(9)?,
+                is_overflow: row.get(10)?,
+            })
+        })
+        .map_err(|err| {
+            ShellError::Generic(GenericError::new(
+                "idx snapshot file query failed",
+                err.to_string(),
+                span,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| {
+            ShellError::Generic(GenericError::new(
+                "idx snapshot file collection failed",
+                err.to_string(),
+                span,
+            ))
+        })?;
+
+    // Read all dirs from snapshot (offline restoration)
+    let mut stmt = conn
+        .prepare("SELECT relative_path, full_path, last_segment_offset, max_access_frecency, is_overflow FROM dirs")
+        .map_err(|err| {
+            ShellError::Generic(GenericError::new(
+                "idx snapshot dir query failed",
+                err.to_string(),
+                span,
+            ))
+        })?;
+
+    let dirs: Vec<IdxSnapshotDir> = stmt
+        .query_map([], |row| {
+            Ok(IdxSnapshotDir {
+                relative_path: row.get(0)?,
+                full_path: row.get(1)?,
+                last_segment_offset: row.get(2)?,
+                max_access_frecency: row.get(3)?,
+                is_overflow: row.get(4)?,
+            })
+        })
+        .map_err(|err| {
+            ShellError::Generic(GenericError::new(
+                "idx snapshot dir query failed",
+                err.to_string(),
+                span,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| {
+            ShellError::Generic(GenericError::new(
+                "idx snapshot dir collection failed",
+                err.to_string(),
+                span,
+            ))
+        })?;
+
+    // Compute arena memory from restored data
+    let mut arena_bytes_base = 0usize;
+    let mut arena_bytes_overflow = 0usize;
+
+    for file in &files {
+        let size = file.relative_path.len()
+            + file.full_path.len()
+            + file.file_name.len()
+            + file.directory.len();
+        if file.is_overflow {
+            arena_bytes_overflow = arena_bytes_overflow.saturating_add(size);
+        } else {
+            arena_bytes_base = arena_bytes_base.saturating_add(size);
+        }
+    }
+
+    for dir in &dirs {
+        let size = dir.relative_path.len() + dir.full_path.len();
+        if dir.is_overflow {
+            arena_bytes_overflow = arena_bytes_overflow.saturating_add(size);
+        } else {
+            arena_bytes_base = arena_bytes_base.saturating_add(size);
+        }
+    }
+
+    // Create status from restored snapshot data (no live scanning)
+    let status = IdxStatus {
+        initialized: true,
+        base_path: base_path_str.clone(),
+        watch,
+        scanning: false, // offline restore doesn't scan
+        scan_duration_ms: 0,
+        files: file_count,
+        dirs: dir_count,
+        arena_bytes_base,
+        arena_bytes_overflow,
+        arena_bytes_untracked: 0,
+    };
+
+    Ok(Value::record(
+        [
+            ("restored".to_string(), Value::bool(true, span)),
+            (
+                "source_path".to_string(),
+                Value::string(path.to_string_lossy().to_string(), span),
+            ),
+            (
+                "base_path".to_string(),
+                Value::string(base_path_str.clone(), span),
+            ),
+            ("watch".to_string(), Value::bool(watch, span)),
+            (
+                "rehydration_mode".to_string(),
+                Value::string("offline_from_snapshot_rows", span),
+            ),
+            ("status".to_string(), status.to_value(span)),
+            (
+                "restored_files".to_string(),
+                Value::int(i64::try_from(files.len()).unwrap_or(i64::MAX), span),
+            ),
+            (
+                "restored_dirs".to_string(),
+                Value::int(i64::try_from(dirs.len()).unwrap_or(i64::MAX), span),
+            ),
+            ("format".to_string(), Value::string("sqlite", span)),
+        ]
+        .into_iter()
+        .collect(),
+        span,
+    ))
+}
+
+pub fn stream_grep(
+    patterns: &[String],
+    mode: GrepMode,
+    page_limit: usize,
+    span: Span,
+    signals: &Signals,
+) -> Result<PipelineData, ShellError> {
+    let snapshot = require_runtime(span)?;
+    let guard = snapshot
+        .shared_picker
+        .read()
+        .map_err(|err| fff_error(err, span))?;
+    let picker = guard.as_ref().ok_or_else(|| {
+        ShellError::Generic(GenericError::new(
+            "idx is not initialized",
+            "run `idx init <path>` first",
+            span,
+        ))
+    })?;
+
+    let options = GrepSearchOptions {
+        mode,
+        page_limit,
+        ..Default::default()
+    };
+
+    let result = if patterns.len() == 1 {
+        let parser = QueryParser::default();
+        let query = parser.parse(&patterns[0]);
+        picker.grep(&query, &options)
+    } else {
+        let refs = patterns.iter().map(String::as_str).collect::<Vec<_>>();
+        picker.multi_grep(&refs, &[], &options)
+    };
+
+    let grep_data: Vec<Value> = result
+        .matches
+        .iter()
+        .map(|item| {
+            let path = result
+                .files
+                .get(item.file_index)
+                .map(|f| f.relative_path(picker))
+                .unwrap_or_else(|| "<unknown>".to_string());
+
+            let offsets = item
+                .match_byte_offsets
+                .iter()
+                .map(|(start, end)| {
+                    Value::record(
+                        [
+                            ("start".to_string(), Value::int(i64::from(*start), span)),
+                            ("end".to_string(), Value::int(i64::from(*end), span)),
+                        ]
+                        .into_iter()
+                        .collect(),
+                        span,
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            Value::record(
+                [
+                    ("path".to_string(), Value::string(path, span)),
+                    (
+                        "line_number".to_string(),
+                        Value::int(i64::try_from(item.line_number).unwrap_or(i64::MAX), span),
+                    ),
+                    (
+                        "column".to_string(),
+                        Value::int(usize_to_i64(item.col), span),
+                    ),
+                    (
+                        "byte_offset".to_string(),
+                        Value::int(i64::try_from(item.byte_offset).unwrap_or(i64::MAX), span),
+                    ),
+                    (
+                        "line".to_string(),
+                        Value::string(item.line_content.clone(), span),
+                    ),
+                    ("matches".to_string(), Value::list(offsets, span)),
+                ]
+                .into_iter()
+                .collect(),
+                span,
+            )
+        })
+        .collect();
+
+    drop(guard);
+
+    let stream_signals = signals.clone();
+    let stream = grep_data.into_iter().map(move |value| {
+        if let Err(err) = stream_signals.check(&span) {
+            return Value::error(err, span);
+        }
+        value
+    });
+
+    Ok(PipelineData::ListStream(
+        ListStream::new(stream, span, signals.clone()),
+        Some(PipelineMetadata::default()),
+    ))
+}

--- a/crates/nu-command/src/filesystem/idx/status.rs
+++ b/crates/nu-command/src/filesystem/idx/status.rs
@@ -1,0 +1,42 @@
+use super::state::current_status;
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct IdxStatus;
+
+impl Command for IdxStatus {
+    fn name(&self) -> &str {
+        "idx status"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_types(vec![(Type::Nothing, Type::record())])
+            .category(Category::FileSystem)
+    }
+
+    fn description(&self) -> &str {
+        "Show status information for the global in-memory idx runtime."
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            description: "Show the current idx runtime status",
+            example: "idx status",
+            result: None,
+        }]
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(PipelineData::value(
+            current_status(None).to_value(call.head),
+            None,
+        ))
+    }
+}

--- a/crates/nu-command/src/filesystem/mod.rs
+++ b/crates/nu-command/src/filesystem/mod.rs
@@ -20,8 +20,7 @@ pub use cd::Cd;
 pub use du::Du;
 pub use glob::Glob;
 pub use idx::{
-    Idx, IdxDirs, IdxDrop, IdxExport, IdxFiles, IdxFind, IdxImport, IdxInit, IdxSearch,
-    IdxStatus,
+    Idx, IdxDirs, IdxDrop, IdxExport, IdxFiles, IdxFind, IdxImport, IdxInit, IdxSearch, IdxStatus,
 };
 pub use ls::Ls;
 pub use mktemp::Mktemp;

--- a/crates/nu-command/src/filesystem/mod.rs
+++ b/crates/nu-command/src/filesystem/mod.rs
@@ -1,6 +1,7 @@
 mod cd;
 mod du;
 mod glob;
+mod idx;
 mod ls;
 mod mktemp;
 mod open;
@@ -18,6 +19,10 @@ pub use self::open::Open;
 pub use cd::Cd;
 pub use du::Du;
 pub use glob::Glob;
+pub use idx::{
+    Idx, IdxDirs, IdxDrop, IdxExport, IdxFiles, IdxFind, IdxImport, IdxInit, IdxSearch,
+    IdxStatus,
+};
 pub use ls::Ls;
 pub use mktemp::Mktemp;
 pub use rm::Rm;

--- a/crates/nu-command/tests/commands/idx.rs
+++ b/crates/nu-command/tests/commands/idx.rs
@@ -1,0 +1,152 @@
+use nu_test_support::fs::Stub::{EmptyFile, FileWithContent};
+use nu_test_support::prelude::*;
+
+#[test]
+#[serial]
+fn idx_init_sets_initialized_status() -> Result {
+    Playground::setup("idx_init_sets_initialized_status", |dirs, sandbox| {
+        sandbox.with_files(&[EmptyFile("alpha.txt")]);
+
+        test()
+            .cwd(dirs.test())
+            .run("idx init . | get initialized")
+            .expect_value_eq(true)
+    })
+}
+
+#[test]
+#[serial]
+fn idx_status_reports_initialized_after_init() -> Result {
+    Playground::setup(
+        "idx_status_reports_initialized_after_init",
+        |dirs, sandbox| {
+            sandbox.with_files(&[EmptyFile("beta.txt")]);
+
+            test()
+                .cwd(dirs.test())
+                .run("idx init .; idx status | get initialized")
+                .expect_value_eq(true)
+        },
+    )
+}
+
+#[test]
+#[serial]
+fn idx_status_reports_watch_disabled_by_default() -> Result {
+    Playground::setup(
+        "idx_status_reports_watch_enabled_by_default",
+        |dirs, sandbox| {
+            sandbox.with_files(&[EmptyFile("beta.txt")]);
+
+            test()
+                .cwd(dirs.test())
+                .run("idx init .; idx status | get watch")
+                .expect_value_eq(false)
+        },
+    )
+}
+
+#[test]
+#[serial]
+fn idx_files_returns_records_with_full_path() -> Result {
+    Playground::setup(
+        "idx_files_returns_records_with_full_path",
+        |dirs, sandbox| {
+            sandbox.with_files(&[EmptyFile("gamma.txt")]);
+
+            test()
+                .cwd(dirs.test())
+                .run("idx init . --wait; idx files | get 0.full_path | str contains gamma.txt")
+                .expect_value_eq(true)
+        },
+    )
+}
+
+#[test]
+#[serial]
+fn idx_dirs_returns_records_with_full_path() -> Result {
+    Playground::setup(
+        "idx_dirs_returns_records_with_full_path",
+        |dirs, sandbox| {
+            sandbox.mkdir("nested");
+            sandbox.with_files(&[EmptyFile("nested/delta.txt")]);
+
+            test()
+                .cwd(dirs.test())
+                .run("idx init . --wait; idx dirs | get full_path | any {|path| $path | str contains 'nested' }")
+                .expect_value_eq(true)
+        },
+    )
+}
+
+#[test]
+#[serial]
+fn idx_find_defaults_to_files_and_dirs() -> Result {
+    Playground::setup("idx_find_defaults_to_files_and_dirs", |dirs, sandbox| {
+        sandbox.mkdir("target-dir");
+        sandbox.with_files(&[
+            EmptyFile("target-file.txt"),
+            EmptyFile("target-dir/inside.txt"),
+        ]);
+
+        test()
+            .cwd(dirs.test())
+            .run("idx init . --wait; let rows = (idx find target); [($rows | where kind == file | length) ($rows | where kind == dir | length)] | to nuon")
+            .expect_value_eq("[2, 1]")
+    })
+}
+
+#[test]
+#[serial]
+fn idx_export_and_import_roundtrip() -> Result {
+    Playground::setup("idx_export_and_import_roundtrip", |dirs, sandbox| {
+        sandbox.with_files(&[
+            FileWithContent("searchable.txt", "hello from idx search"),
+            FileWithContent("other.txt", "unrelated"),
+        ]);
+
+        test()
+            .cwd(dirs.test())
+            .run("idx init . --wait; idx export snapshot.json | get stored")
+            .expect_value_eq(true)?;
+
+        test()
+            .cwd(dirs.test())
+            .run("idx import snapshot.json | get restored")
+            .expect_value_eq(true)
+    })
+}
+
+#[test]
+#[serial]
+fn idx_search_finds_content() -> Result {
+    Playground::setup("idx_search_finds_content", |dirs, sandbox| {
+        sandbox.with_files(&[
+            FileWithContent("searchable.txt", "hello from idx search"),
+            FileWithContent("other.txt", "unrelated"),
+        ]);
+
+        test()
+            .cwd(dirs.test())
+            .run("idx init . --wait; idx search hello | get 0.path | str contains searchable.txt")
+            .expect_value_eq(true)
+    })
+}
+
+#[test]
+#[serial]
+fn idx_drop_clears_runtime() -> Result {
+    Playground::setup("idx_drop_clears_runtime", |dirs, sandbox| {
+        sandbox.with_files(&[EmptyFile("alpha.txt")]);
+
+        test()
+            .cwd(dirs.test())
+            .run("idx init . --wait; idx drop | get dropped")
+            .expect_value_eq(true)?;
+
+        test()
+            .cwd(dirs.test())
+            .run("idx status | get initialized")
+            .expect_value_eq(false)
+    })
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -51,6 +51,7 @@ mod hash_;
 mod headers;
 mod help;
 mod histogram;
+mod idx;
 mod ignore;
 mod insert;
 mod inspect;


### PR DESCRIPTION
## Description

This PR adds the `idx` command family for in-memory filesystem indexing and search.

Built on [`fff-search`](https://docs.rs/fff-search/latest/fff_search/) (v0.7.0), which walks the path  and stores file and directory metadata in memory arenas. The global runtime lives in a `static OnceLock<Mutex<Option<IdxRuntime>>>` so a single index is shared across all commands in a session.

The implementation includes:
- `idx init`, `idx status`, `idx files`, `idx dirs`, `idx find`, `idx search`, `idx export`,  `idx import`, and `idx drop` commands
- Runtime state management through a global singleton with status reporting and scan duration tracking
- SQLite snapshot persistence for `idx export` and metadata-driven rehydration for `idx import`

<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
Add the `idx` command family for in-memory filesystem indexing and search.

### Commands

#### `idx init <path> [--wait]`

Initializes the global idx runtime by scanning `<path>`. If the runtime is already initialized it is dropped and re-scanned. `--wait` blocks until the initial scan completes; omitting it returns immediately with a `scanning = true` status.

```nushell
idx init .
idx init ~/projects --wait
```

#### `idx status`

Returns a record describing the current runtime: `initialized`, `base_path`, `watch`, `scanning`, `scan_duration_ms`, `files`, `dirs`, and arena memory usage fields.

```nushell
idx status
```

#### `idx dirs`

Returns all indexed directories as records with `relative_path` and `full_path` columns.

```nushell
idx dirs
idx dirs | where full_path =~ src
```

#### `idx files [<path>]`

Returns all indexed files as records with `relative_path`, `full_path`, `file_name`, `directory`, `size`, and `modified` columns. If an optional `<path>` is provided it performs a direct lookup by relative or absolute path.

```nushell
idx files
idx files src/main.rs
idx files /absolute/path/to/file.rs
```

#### `idx find <query> [--files] [--dirs] [--verbose] [--limit <n>]`

Fuzzy-searches the index using [`fff-search` scoring](https://docs.rs/fff-search/latest/fff_search/). By default searches both files and directories. `--files` or `--dirs` narrows the search. `--verbose` adds a `score_details` column. `--limit` caps the result count (default 100).

```nushell
idx find main
idx find config --files --verbose
idx find src --dirs --limit 10
```

#### `idx search <pattern>... [--regex] [--fuzzy] [--limit <n>]`

Searches the **contents** of indexed files. Plain text is the default. `--regex` enables regex matching. `--fuzzy` enables approximate line matching. Multiple patterns are searched with `multi_grep`. `--limit` caps matches (default 50).

```nushell
idx search hello
idx search --regex 'fn \w+'
idx search TODO FIXME HACK
```

#### `idx export <filepath>`

Persists the current runtime to a **SQLite** database at `<filepath>`. Returns a record with `stored`, `path`, `file_count`, `dir_count`, `base_path`, and `format`.

```nushell
idx export ~/my-index.db
```

#### `idx import <filepath>`

Imports a SQLite snapshot created by `idx export`. Performs true offline restoration by hydrating the index from stored file and directory rows in the database with no filesystem rescanning. Returns a record with `restored`, `source_path`, `base_path`, `watch`, `rehydration_mode`, `status`, `restored_files`, `restored_dirs`, and `format`. The `rehydration_mode` is `offline_from_snapshot_rows`, and the status fields (`scanning`, `scan_duration_ms`).

```nushell
idx import ~/my-index.db
```

#### `idx drop`

Drops the current runtime from memory. Returns `{dropped: bool, status: record}` where `status` is always the default (zeroed) status after the drop.

```nushell
idx drop
```

<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
Right now fff-search uses the `ignore` crate and there is no way to control what is ignored other than changing/adding .gitignore or .ignore files.
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->