### PR TITLE
Deprecated `watch` command's optional closure argument

### DIFF
--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -93,21 +93,22 @@ impl Command for Watch {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let cwd = engine_state.cwd_as_string(Some(stack))?;
-        let path_arg: Spanned<String> = call.req(engine_state, stack, 0)?;
 
-        let path_no_whitespace = path_arg
-            .item
-            .trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
+        let path = {
+            let cwd = engine_state.cwd_as_string(Some(stack))?;
+            let path_arg: Spanned<String> = call.req(engine_state, stack, 0)?;
+            let path_no_whitespace = path_arg
+                .item
+                .trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
 
-        let path = nu_path::absolute_with(path_no_whitespace, cwd).map_err(|err| {
-            ShellError::Io(IoError::new(
-                err,
-                path_arg.span,
-                PathBuf::from(path_no_whitespace),
-            ))
-        })?;
-
+            nu_path::absolute_with(path_no_whitespace, cwd).map_err(|err| {
+                ShellError::Io(IoError::new(
+                    err,
+                    path_arg.span,
+                    PathBuf::from(path_no_whitespace),
+                ))
+            })?
+        };
         let closure: Option<Closure> = call.opt(engine_state, stack, 1)?;
         let verbose = call.has_flag(engine_state, stack, "verbose")?;
         let quiet = call.has_flag(engine_state, stack, "quiet")?;

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -143,31 +143,28 @@ impl Command for Watch {
             }
         };
 
-        let (tx, rx) = channel();
-
-        let mut debouncer = new_debouncer(debounce_duration, None, tx).map_err(|err| {
-            ShellError::Generic(GenericError::new(
-                "Failed to create watcher",
-                err.to_string(),
-                call.head,
-            ))
-        })?;
-
-        if let Err(err) = debouncer.watcher().watch(&path, recursive_mode) {
-            return Err(ShellError::Generic(GenericError::new(
-                "Failed to create watcher",
-                err.to_string(),
-                call.head,
-            )));
-        }
-        // need to cache to make sure that rename event works.
-        debouncer.cache().add_root(&path, recursive_mode);
+        let iter = {
+            let (tx, rx) = channel();
+            let mut debouncer = new_debouncer(debounce_duration, None, tx)
+                .and_then(|mut debouncer| {
+                    debouncer.watcher().watch(&path, recursive_mode)?;
+                    Ok(debouncer)
+                })
+                .map_err(|err| {
+                    ShellError::Generic(GenericError::new(
+                        "Failed to create watcher",
+                        err.to_string(),
+                        call.head,
+                    ))
+                })?;
+            // need to cache to make sure that rename event works.
+            debouncer.cache().add_root(&path, recursive_mode);
+            WatchIterator::new(debouncer, rx, engine_state.signals().clone())
+        };
 
         if !quiet {
             eprintln!("Now watching files at {path:?}. Press ctrl+c to abort.");
         }
-
-        let iter = WatchIterator::new(debouncer, rx, engine_state.signals().clone());
 
         fn glob_filter(glob: Option<&nu_glob::Pattern>, ev: &WatchEvent) -> bool {
             let Some(glob) = glob else { return true };

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -1,5 +1,5 @@
 use std::{
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::mpsc::{Receiver, RecvTimeoutError, channel},
     time::Duration,
 };
@@ -93,7 +93,6 @@ impl Command for Watch {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-
         let path = {
             let cwd = engine_state.cwd_as_string(Some(stack))?;
             let path_arg: Spanned<String> = call.req(engine_state, stack, 0)?;
@@ -109,7 +108,7 @@ impl Command for Watch {
                 ))
             })?
         };
-        let closure: Option<Closure> = call.opt(engine_state, stack, 1)?;
+        let closure: Option<Spanned<Closure>> = call.opt(engine_state, stack, 1)?;
         let verbose = call.has_flag(engine_state, stack, "verbose")?;
         let quiet = call.has_flag(engine_state, stack, "quiet")?;
         let debounce_duration: Duration = call
@@ -162,37 +161,18 @@ impl Command for Watch {
             WatchIterator::new(debouncer, rx, engine_state.signals().clone())
         };
 
-        if !quiet {
-            eprintln!("Now watching files at {path:?}. Press ctrl+c to abort.");
-        }
-
         if let Some(closure) = closure {
-            let mut closure = ClosureEval::new(engine_state, stack, closure);
-
-            for events in iter {
-                for event in events? {
-                    let matches_glob = glob_filter(glob_pattern.as_ref(), &event);
-
-                    if verbose && glob_pattern.is_some() {
-                        eprintln!("Matches glob: {matches_glob}");
-                    }
-
-                    if matches_glob {
-                        let result = closure
-                            .add_arg(event.operation.into_value(head))?
-                            .add_arg(event.path.into_value(head))?
-                            .add_arg(event.new_path.into_value(head))?
-                            .run_with_input(PipelineData::empty());
-
-                        match result {
-                            Ok(val) => val.print_table(engine_state, stack, false, false)?,
-                            Err(err) => report_shell_error(Some(stack), engine_state, &err),
-                        };
-                    }
-                }
-            }
-
-            Ok(PipelineData::empty())
+            run_closure(
+                engine_state,
+                stack,
+                head,
+                quiet,
+                verbose,
+                &path,
+                glob_pattern,
+                iter,
+                closure.item,
+            )
         } else {
             let out = iter
                 .flat_map(|e| match e {
@@ -253,6 +233,50 @@ fn glob_filter(glob: Option<&nu_glob::Pattern>, ev: &WatchEvent) -> bool {
         .or(ev.new_path.as_deref())
         .expect("at least one of path or new_path should be present");
     glob.matches_path(path)
+}
+
+#[allow(clippy::too_many_arguments)]
+#[inline]
+fn run_closure(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    head: Span,
+    quiet: bool,
+    verbose: bool,
+    path: &Path,
+    glob_pattern: Option<nu_glob::Pattern>,
+    iter: WatchIterator,
+    closure: Closure,
+) -> Result<PipelineData, ShellError> {
+    if !quiet {
+        eprintln!("Now watching files at {path:?}. Press ctrl+c to abort.");
+    }
+
+    let mut closure = ClosureEval::new(engine_state, stack, closure);
+    for events in iter {
+        for event in events? {
+            let matches_glob = glob_filter(glob_pattern.as_ref(), &event);
+
+            if verbose && glob_pattern.is_some() {
+                eprintln!("Matches glob: {matches_glob}");
+            }
+
+            if matches_glob {
+                let result = closure
+                    .add_arg(event.operation.into_value(head))?
+                    .add_arg(event.path.into_value(head))?
+                    .add_arg(event.new_path.into_value(head))?
+                    .run_with_input(PipelineData::empty());
+
+                match result {
+                    Ok(val) => val.print_table(engine_state, stack, false, false)?,
+                    Err(err) => report_shell_error(Some(stack), engine_state, &err),
+                };
+            }
+        }
+    }
+
+    Ok(PipelineData::empty())
 }
 
 #[derive(IntoValue)]

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -133,17 +133,14 @@ impl Command for Watch {
             })
             .transpose()?;
 
-        let recursive_flag: Option<Spanned<bool>> =
-            call.get_flag(engine_state, stack, "recursive")?;
-        let recursive_mode = match recursive_flag {
-            Some(recursive) => {
-                if recursive.item {
-                    RecursiveMode::Recursive
-                } else {
-                    RecursiveMode::NonRecursive
-                }
+        let recursive_mode = {
+            let recursive_flag = call
+                .get_flag::<bool>(engine_state, stack, "recursive")?
+                .unwrap_or(true);
+            match recursive_flag {
+                true => RecursiveMode::Recursive,
+                false => RecursiveMode::NonRecursive,
             }
-            None => RecursiveMode::Recursive,
         };
 
         let (tx, rx) = channel();

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -62,7 +62,7 @@ impl Command for Watch {
             .optional(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::String, SyntaxShape::String, SyntaxShape::String])),
-                "Some Nu code to run whenever a file changes. The closure will be passed `operation`, `path`, and `new_path` (for renames only) arguments in that order. (deprecated)",
+                "Some Nu code to run whenever a file changes. The closure will be passed `operation`, `path`, and `new_path` (for renames only) arguments in that order (deprecated).",
             )
             .named(
                 "debounce",
@@ -180,6 +180,7 @@ impl Command for Watch {
                 },
             );
 
+            #[allow(deprecated)]
             run_closure(
                 engine_state,
                 stack,

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -15,8 +15,10 @@ use notify_debouncer_full::{
 
 use nu_engine::{ClosureEval, command_prelude::*};
 use nu_protocol::{
-    Signals, engine::Closure, report_shell_error, shell_error::generic::GenericError,
-    shell_error::io::IoError,
+    Signals,
+    engine::Closure,
+    report_shell_error, report_shell_warning,
+    shell_error::{generic::GenericError, io::IoError},
 };
 
 // durations chosen mostly arbitrarily
@@ -60,7 +62,7 @@ impl Command for Watch {
             .optional(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::String, SyntaxShape::String, SyntaxShape::String])),
-                "Some Nu code to run whenever a file changes. The closure will be passed `operation`, `path`, and `new_path` (for renames only) arguments in that order.",
+                "Some Nu code to run whenever a file changes. The closure will be passed `operation`, `path`, and `new_path` (for renames only) arguments in that order (deprecated).",
             )
             .named(
                 "debounce",
@@ -162,6 +164,21 @@ impl Command for Watch {
         };
 
         if let Some(closure) = closure {
+            report_shell_warning(
+                Some(stack),
+                engine_state,
+                &ShellWarning::Deprecated {
+                    dep_type: "Argument".into(),
+                    label: "remove this".into(),
+                    span: closure.span,
+                    help: "Since 0.113.0, running a closure with `watch` is deprecated. \
+                            Instead, use `watch` as the source of a `for` loop."
+                        .to_string()
+                        .into(),
+                    report_mode: nu_protocol::ReportMode::FirstUse,
+                },
+            );
+
             run_closure(
                 engine_state,
                 stack,

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -51,39 +51,69 @@ impl Command for Watch {
                 (Type::Nothing, Type::Nothing),
                 (
                     Type::Nothing,
-                    Type::Table(vec![
-                        ("operation".into(), Type::String),
-                        ("path".into(), Type::OneOf([Type::String, Type::Nothing].into())),
-                        ("new_path".into(), Type::OneOf([Type::String, Type::Nothing].into())),
-                    ].into_boxed_slice())
+                    Type::Table(
+                        vec![
+                            ("operation".into(), Type::String),
+                            (
+                                "path".into(),
+                                Type::OneOf([Type::String, Type::Nothing].into()),
+                            ),
+                            (
+                                "new_path".into(),
+                                Type::OneOf([Type::String, Type::Nothing].into()),
+                            ),
+                        ]
+                        .into_boxed_slice(),
+                    ),
                 ),
             ])
-            .required("path", SyntaxShape::Filepath, "The path to watch. Can be a file or directory.")
+            .required(
+                "path",
+                SyntaxShape::Filepath,
+                "The path to watch. Can be a file or directory.",
+            )
             .optional(
                 "closure",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::String, SyntaxShape::String, SyntaxShape::String])),
-                "Some Nu code to run whenever a file changes. The closure will be passed `operation`, `path`, and `new_path` (for renames only) arguments in that order (deprecated).",
+                SyntaxShape::Closure(Some(vec![
+                    SyntaxShape::String,
+                    SyntaxShape::String,
+                    SyntaxShape::String,
+                ])),
+                "Some Nu code to run whenever a file changes. \
+                    The closure will be passed `operation`, `path`, \
+                    and `new_path` (for renames only) arguments in that order (deprecated).",
             )
             .named(
                 "debounce",
                 SyntaxShape::Duration,
-                "Debounce changes for this duration (default: 100ms). Adjust if you find that single writes are reported as multiple events.",
+                "Debounce changes for this duration (default: 100ms). \
+                    Adjust if you find that single writes are reported as multiple events.",
                 Some('d'),
             )
             .named(
                 "glob",
-                SyntaxShape::String, // SyntaxShape::GlobPattern gets interpreted relative to cwd, so use String instead
+                // SyntaxShape::GlobPattern gets interpreted relative to cwd, so use String instead
+                SyntaxShape::String,
                 "Only report changes for files that match this glob pattern (default: all files)",
                 Some('g'),
             )
             .named(
                 "recursive",
                 SyntaxShape::Boolean,
-                "Watch all directories under `<path>` recursively. Will be ignored if `<path>` is a file (default: true).",
+                "Watch all directories under `<path>` recursively. \
+                    Will be ignored if `<path>` is a file (default: true).",
                 Some('r'),
             )
-            .switch("quiet", "Hide the initial status message (default: false).", Some('q'))
-            .switch("verbose", "Operate in verbose mode (default: false).", Some('v'))
+            .switch(
+                "quiet",
+                "Hide the initial status message (default: false).",
+                Some('q'),
+            )
+            .switch(
+                "verbose",
+                "Operate in verbose mode (default: false).",
+                Some('v'),
+            )
             .category(Category::FileSystem)
     }
 

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -116,8 +116,8 @@ impl Command for Watch {
             .get_flag(engine_state, stack, "debounce")?
             .unwrap_or(DEFAULT_WATCH_DEBOUNCE_DURATION);
 
-        let glob_flag: Option<Spanned<String>> = call.get_flag(engine_state, stack, "glob")?;
-        let glob_pattern = glob_flag
+        let glob_pattern = call
+            .get_flag::<Spanned<String>>(engine_state, stack, "glob")?
             .map(|glob| {
                 let absolute_path = path.join(glob.item);
                 if verbose {

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -210,16 +210,16 @@ impl Command for Watch {
         vec![
             Example {
                 description: "Run `cargo test` whenever a Rust file changes.",
-                example: "watch . --glob=**/*.rs {|| cargo test }",
+                example: "for _ in (watch . --glob=**/*.rs) { cargo test }",
                 result: None,
             },
             Example {
                 description: "Watch all changes in the current directory.",
-                example: r#"watch . { |op, path, new_path| $"($op) ($path) ($new_path)"}"#,
+                example: "watch . | each { print }",
                 result: None,
             },
             Example {
-                description: "`watch` (when run without a closure) can also emit a stream of events it detects.",
+                description: "Filter, limit and modify `watch`'s output by using it as part of a pipeline.",
                 example: r#"watch /foo/bar
     | where operation == Create
     | first 5
@@ -230,12 +230,17 @@ impl Command for Watch {
             },
             Example {
                 description: "Print file changes with a debounce time of 5 minutes.",
-                example: r#"watch /foo/bar --debounce 5min { |op, path| $"Registered ($op) on ($path)" | print }"#,
+                example: r#"watch /foo/bar --debounce 5min | each {|e| $"Registered ($e.operation) on ($e.path)" | print }"#,
                 result: None,
             },
             Example {
                 description: "Note: if you are looking to run a command every N units of time, this can be accomplished with a loop and sleep.",
                 example: "loop { command; sleep duration }",
+                result: None,
+            },
+            Example {
+                description: "Run `cargo test` whenever a Rust file changes (with the deprecated closure argument).",
+                example: "watch . --glob=**/*.rs {|| cargo test }",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -62,7 +62,7 @@ impl Command for Watch {
             .optional(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::String, SyntaxShape::String, SyntaxShape::String])),
-                "Some Nu code to run whenever a file changes. The closure will be passed `operation`, `path`, and `new_path` (for renames only) arguments in that order (deprecated).",
+                "Some Nu code to run whenever a file changes. The closure will be passed `operation`, `path`, and `new_path` (for renames only) arguments in that order. (deprecated)",
             )
             .named(
                 "debounce",
@@ -172,7 +172,8 @@ impl Command for Watch {
                     label: "remove this".into(),
                     span: closure.span,
                     help: "Since 0.113.0, running a closure with `watch` is deprecated. \
-                            Instead, use `watch` as the source of a `for` loop."
+                            Instead, use `watch` by piping its output to `each` \
+                            or as the source of a `for` loop."
                         .to_string()
                         .into(),
                     report_mode: nu_protocol::ReportMode::FirstUse,
@@ -259,6 +260,7 @@ fn glob_filter(glob: Option<&nu_glob::Pattern>, ev: &WatchEvent) -> bool {
 
 #[allow(clippy::too_many_arguments)]
 #[inline]
+#[deprecated(since = "0.113.0")]
 fn run_closure(
     engine_state: &EngineState,
     stack: &mut Stack,

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -166,16 +166,6 @@ impl Command for Watch {
             eprintln!("Now watching files at {path:?}. Press ctrl+c to abort.");
         }
 
-        fn glob_filter(glob: Option<&nu_glob::Pattern>, ev: &WatchEvent) -> bool {
-            let Some(glob) = glob else { return true };
-            let path = ev
-                .path
-                .as_deref()
-                .or(ev.new_path.as_deref())
-                .expect("at least one of path or new_path should be present");
-            glob.matches_path(path)
-        }
-
         if let Some(closure) = closure {
             let mut closure = ClosureEval::new(engine_state, stack, closure);
 
@@ -253,6 +243,16 @@ impl Command for Watch {
             },
         ]
     }
+}
+
+fn glob_filter(glob: Option<&nu_glob::Pattern>, ev: &WatchEvent) -> bool {
+    let Some(glob) = glob else { return true };
+    let path = ev
+        .path
+        .as_deref()
+        .or(ev.new_path.as_deref())
+        .expect("at least one of path or new_path should be present");
+    glob.matches_path(path)
 }
 
 #[derive(IntoValue)]


### PR DESCRIPTION
## Description

> We should think about deprecating the optional closure parameter and only supporting the streaming version. The closure form
> - does not compose with other commands
> - can't be stopped without user intervention...
> - ...which also makes it harder to test

The closure argument was previously left in to preserve backwards compatibility with the intention of deprecating it later. This PR does that

- #16428

## User-facing changes (Release notes)

`watch` command's optional closure argument is deprecated and will be removed in a future release. Update your scripts to use a for-loop or `each` instead:

```nushell
for event in (watch . --glob=**/*.rs) {
	cargo test
}
# or
watch . --glob=**/*.rs | each { cargo test }
```

As a reminder, using this streaming approach allows you to combine `watch` with other commands as well:
```nushell
watch .
| where operation == Write and path like "*.md"
| each { md-lint $in.path }
```

## Additional notes

Should we consider deprecating/removing the `--glob` flag as well? It is applied as a filter _after_ receiving the events so it doesn't really "limit" which files are watched.

It could easily be replaced by just piping `watch` through `where` but I don't think we can make the change yet because we don't have a command or operator to check if a given path/string matches a glob.

If we had glob literal syntax, and `in` or `like` could be used to check if a path matches a glob, we could do something like this instead:

```nushell
for _ in (watch . --glob=**/*.rs) {
	cargo test
}
#vs
for _ in (watch . | where path in `**/*.rs`) {
	cargo test
}
```