### PR TITLE
feat: `for` loops can work with pipeline input

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -15,7 +15,10 @@ impl Command for For {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("for")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![
+                (Type::Nothing, Type::Nothing),
+                (Type::Any, Type::Nothing),
+            ])
             .allow_variants_without_examples(true)
             .required(
                 "var_name",

--- a/crates/nu-command/tests/commands/for_.rs
+++ b/crates/nu-command/tests/commands/for_.rs
@@ -1,4 +1,4 @@
-use nu_test_support::nu;
+use nu_test_support::prelude::*;
 
 #[test]
 fn for_doesnt_auto_print_in_each_iteration() {
@@ -50,4 +50,58 @@ fn for_loops_dont_collect_source() {
         }
     ");
     assert_eq!(actual.out, "1122334455");
+}
+
+#[test]
+fn for_loops_accept_pipeline_input() -> Result {
+    let code = r#"
+        mut out = []
+
+        seq 1 5 | if true {
+            for i in () {
+                $out ++= [$"item: ($i)"];
+            }
+        }
+
+        $out
+    "#;
+    test()
+        .run(code)
+        .expect_value_eq(["item: 1", "item: 2", "item: 3", "item: 4", "item: 5"])
+}
+
+#[test]
+fn for_loop_in_pipeline() -> Result {
+    let code = r#"
+        mut out = []
+
+        seq 1 5 | for i in () {
+            $out ++= [$"item: ($i)"];
+        }
+
+        $out
+    "#;
+    test()
+        .run(code)
+        .expect_value_eq(["item: 1", "item: 2", "item: 3", "item: 4", "item: 5"])
+}
+
+#[test]
+fn for_loop_input_piped_to_iter_source() -> Result {
+    let code = r#"
+        mut out = []
+
+        seq char a e | for e in (enumerate) {
+            $out ++= [$"index: ($e.index), item: ($e.item)"];
+        }
+
+        $out
+    "#;
+    test().run(code).expect_value_eq([
+        "index: 0, item: a",
+        "index: 1, item: b",
+        "index: 2, item: c",
+        "index: 3, item: d",
+        "index: 4, item: e",
+    ])
 }

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -925,17 +925,24 @@ pub(crate) fn compile_for(
     let block_id = block_arg.as_block().ok_or_else(invalid)?;
     let block = working_set.get_block(block_id);
 
+    let stream_reg = builder.next_register()?;
+    builder.push(
+        Instruction::Move {
+            dst: stream_reg,
+            src: io_reg,
+        }
+        .into_spanned(call.head),
+    )?;
+
     // Ensure io_reg is marked so we don't use it
     builder.load_empty(io_reg)?;
-
-    let stream_reg = builder.next_register()?;
 
     compile_expression(
         working_set,
         builder,
         in_expr,
         RedirectModes::caller(in_expr.span),
-        None,
+        Some(stream_reg),
         stream_reg,
     )?;
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6339,7 +6339,7 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
 
         // For now, check for special parses of certain keywords
         match bytes.as_slice() {
-            b"def" | b"extern" | b"for" | b"module" | b"use" | b"source" | b"alias" | b"export"
+            b"def" | b"extern" | b"module" | b"use" | b"source" | b"alias" | b"export"
             | b"export-env" | b"hide" => {
                 working_set.error(ParseError::BuiltinCommandInPipeline(
                     String::from_utf8(bytes)


### PR DESCRIPTION
## Description
- closes #18038
 
## User-facing changes (Release notes)

### `for` loops can now iterate over pipeline input

`for` loops can now be used at the end of a pipeline, the pipeline input to the `for` loop is piped into the for loop's "source" expression. This makes the following examples valid:
```nushell
# `ls` is piped into `enumerate`
ls | for e in (enumerate) { .. }

# `ls` is "piped" into `()`, which does nothing
# and passes it through to the for loop to iterate over
ls | for e in () { .. }
```

## Additional notes

- There are some issues with type checking, specifically with `for e in ()` when used by itself in a block like `do { for e in () { .. } }` where `$e` is typed `nothing`.