### PR TITLE
fix: operator precedence bug: `&` has higher precedence than `|` in Rust

### DIFF
--- a/crates/nu-utils/src/utils.rs
+++ b/crates/nu-utils/src/utils.rs
@@ -43,9 +43,9 @@ fn enable_vt_processing_input(console_in_mode: ConsoleMode, mode: u32) -> Result
 
     console_in_mode.set_mode(
         mode | ENABLE_VIRTUAL_TERMINAL_INPUT
-            & ENABLE_ECHO_INPUT
-            & ENABLE_LINE_INPUT
-            & ENABLE_PROCESSED_INPUT,
+            | ENABLE_ECHO_INPUT
+            | ENABLE_LINE_INPUT
+            | ENABLE_PROCESSED_INPUT,
     )
 }
 


### PR DESCRIPTION
## Description

In this PR, I fixed a section where nothing was actually executed due to operator precedence.
This should now set VT input as intended, added in #13961.

## User-facing changes (Release notes)

VT input is now enabled at startup on Windows (previously a no-op due to the bug).

## Additional notes

Nushell currently uses crossterm, which does not support VT input, so merging this could break existing behavior.
See crossterm-rs/crossterm#1030 for crossterm issue.