### PR TITLE
assortment of small refactors

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/attr/example.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/example.rs
@@ -86,13 +86,12 @@ impl Command for AttrExample {
         let result: Option<Value> = call.get_flag_const(working_set, "result")?;
 
         let example_string: Result<String, _> = call.req_const(working_set, 1);
-        let example_expr =
-            call.assert_ast_call()?
-                .positional_nth(1)
-                .ok_or(ShellError::MissingParameter {
-                    param_name: "example".into(),
-                    span: call.head,
-                })?;
+        let example_expr = call.assert_ast_call()?.positional_iter().nth(1).ok_or(
+            ShellError::MissingParameter {
+                param_name: "example".into(),
+                span: call.head,
+            },
+        )?;
 
         attr_example_impl(
             example_expr,

--- a/crates/nu-cmd-lang/src/core_commands/if_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/if_.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use nu_engine::command_prelude::*;
 use nu_protocol::{
     engine::{CommandType, StateWorkingSet},
@@ -59,15 +60,21 @@ impl Command for If {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let call = call.assert_ast_call()?;
-        let cond = call.positional_nth(0).expect("checked through parser");
-        let then_expr = call.positional_nth(1).expect("checked through parser");
+
+        let ([cond, then_expr], else_case) = {
+            let mut iter = call.positional_iter();
+            (
+                iter.next_array().expect("checked through parser"),
+                iter.next(),
+            )
+        };
+
         let then_block = then_expr
             .as_block()
             .ok_or_else(|| ShellError::TypeMismatch {
                 err_message: "expected block".into(),
                 span: then_expr.span,
             })?;
-        let else_case = call.positional_nth(2);
 
         if eval_constant(working_set, cond)?.as_bool()? {
             let block = working_set.get_block(then_block);

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -141,27 +141,19 @@ impl Command for IntoDatetime {
             let cell_paths = call.rest(engine_state, stack, 0)?;
             let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
 
-            // if zone-offset is specified, then zone will be neglected
-            let timezone = call.get_flag::<Spanned<String>>(engine_state, stack, "timezone")?;
-            let zone_options =
-                match &call.get_flag::<Spanned<i64>>(engine_state, stack, "offset")? {
-                    Some(zone_offset) => Some(Spanned {
-                        item: Zone::new(zone_offset.item),
-                        span: zone_offset.span,
-                    }),
-                    None => timezone.as_ref().map(|zone| Spanned {
-                        item: Zone::from_string(&zone.item),
-                        span: zone.span,
-                    }),
-                };
+            let zone_options = {
+                // if zone-offset is specified, then zone will be neglected
+                let offset = call.get_flag::<Spanned<i64>>(engine_state, stack, "offset")?;
+                let timezone = call.get_flag::<Spanned<String>>(engine_state, stack, "timezone")?;
+
+                offset
+                    .map(|offset| offset.map(Zone::new))
+                    .or_else(|| timezone.map(|tz| tz.as_deref().map(Zone::from_string)))
+            };
 
             let format_options = call
                 .get_flag::<Spanned<String>>(engine_state, stack, "format")?
-                .as_ref()
-                .map(|fmt| Spanned {
-                    item: DatetimeFormat(fmt.item.to_string()),
-                    span: fmt.span,
-                });
+                .map(|fmt| fmt.map(DatetimeFormat));
 
             let args = Arguments {
                 zone_options,

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -94,32 +94,19 @@ impl Command for IntoDuration {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let cell_paths = call.rest(engine_state, stack, 0)?;
-        let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
+        let unit = call
+            .get_flag::<Spanned<String>>(engine_state, stack, "unit")?
+            .map(|Spanned { item, span }| match Unit::from_str(&item) {
+                Err(_) | Ok(Unit::Filesize(_)) => Err(ShellError::InvalidUnit {
+                    span,
+                    supported_units: SUPPORTED_DURATION_UNITS.join(", "),
+                }),
+                Ok(u) => Ok(u.into_spanned(span)),
+            })
+            .transpose()?;
 
-        let unit = match call.get_flag::<Spanned<String>>(engine_state, stack, "unit")? {
-            Some(spanned_unit) => match Unit::from_str(&spanned_unit.item) {
-                Ok(u) => match u {
-                    Unit::Filesize(_) => {
-                        return Err(ShellError::InvalidUnit {
-                            span: spanned_unit.span,
-                            supported_units: SUPPORTED_DURATION_UNITS.join(", "),
-                        });
-                    }
-                    _ => Some(Spanned {
-                        item: u,
-                        span: spanned_unit.span,
-                    }),
-                },
-                Err(_) => {
-                    return Err(ShellError::InvalidUnit {
-                        span: spanned_unit.span,
-                        supported_units: SUPPORTED_DURATION_UNITS.join(", "),
-                    });
-                }
-            },
-            None => None,
-        };
+        let cell_paths = Some(call.rest(engine_state, stack, 0)?).filter(|x| !x.is_empty());
+
         let args = Arguments { unit, cell_paths };
         operate(action, args, input, call.head, engine_state.signals())
     }

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -37,7 +37,9 @@ impl Command for Cd {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let physical = call.has_flag(engine_state, stack, "physical")?;
-        let path_val: Option<Spanned<String>> = call.opt(engine_state, stack, 0)?;
+        let path_val = call
+            .opt::<Spanned<String>>(engine_state, stack, 0)?
+            .map(|p| p.map(nu_utils::strip_ansi_string_unlikely));
 
         // If getting PWD failed, default to the home directory. The user can
         // use `cd` to reset PWD to a good state.
@@ -47,17 +49,6 @@ impl Command for Cd {
             .or_else(nu_path::home_dir)
             .map(|path| path.into_std_path_buf())
             .unwrap_or_default();
-
-        let path_val = {
-            if let Some(path) = path_val {
-                Some(Spanned {
-                    item: nu_utils::strip_ansi_string_unlikely(path.item),
-                    span: path.span,
-                })
-            } else {
-                path_val
-            }
-        };
 
         let path = match path_val {
             Some(v) => {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -366,16 +366,7 @@ fn ls_for_one_pattern(
                     "empty string('') directory or file does not exist",
                 )));
             }
-            match path.item {
-                NuGlob::DoNotExpand(p) => Some(Spanned {
-                    item: NuGlob::DoNotExpand(nu_utils::strip_ansi_string_unlikely(p)),
-                    span: path.span,
-                }),
-                NuGlob::Expand(p) => Some(Spanned {
-                    item: NuGlob::Expand(nu_utils::strip_ansi_string_unlikely(p)),
-                    span: path.span,
-                }),
-            }
+            Some(path.map(NuGlob::strip_ansi_string_unlikely))
         } else {
             pattern_arg
         }

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -150,15 +150,7 @@ fn rm(
         {
             unique_argument_check = Some(path.span);
         }
-        let corrected_path = Spanned {
-            item: match path.item {
-                NuGlob::DoNotExpand(s) => {
-                    NuGlob::DoNotExpand(nu_utils::strip_ansi_string_unlikely(s))
-                }
-                NuGlob::Expand(s) => NuGlob::Expand(nu_utils::strip_ansi_string_unlikely(s)),
-            },
-            span: path.span,
-        };
+        let corrected_path = path.map(NuGlob::strip_ansi_string_unlikely);
         let _ = std::mem::replace(&mut paths[idx], corrected_path);
     }
 

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -75,18 +75,13 @@ impl Command for Save {
         let span = call.head;
         let cwd = engine_state.cwd(Some(stack))?.into_std_path_buf();
 
-        let path_arg = call.req::<Spanned<PathBuf>>(engine_state, stack, 0)?;
-        let path = Spanned {
-            item: expand_path_with(path_arg.item, &cwd, true),
-            span: path_arg.span,
-        };
+        let path = call
+            .req::<Spanned<PathBuf>>(engine_state, stack, 0)?
+            .map(|p| expand_path_with(p, &cwd, true));
 
         let stderr_path = call
             .get_flag::<Spanned<PathBuf>>(engine_state, stack, "stderr")?
-            .map(|arg| Spanned {
-                item: expand_path_with(arg.item, cwd, true),
-                span: arg.span,
-            });
+            .map(|arg| arg.map(|p| expand_path_with(p, cwd, true)));
 
         let from_io_error = IoError::factory(span, path.item.as_path());
         let save_byte_stream = |stream, metadata| {
@@ -160,14 +155,7 @@ impl Command for Save {
                     let val_span = v.span();
                     let val = v.into_custom_value()?;
                     return val
-                        .save(
-                            Spanned {
-                                item: &path.item,
-                                span: path.span,
-                            },
-                            val_span,
-                            span,
-                        )
+                        .save(path.as_deref(), val_span, span)
                         .map(|()| PipelineData::empty());
                 }
 

--- a/crates/nu-command/src/filesystem/start.rs
+++ b/crates/nu-command/src/filesystem/start.rs
@@ -36,11 +36,9 @@ impl Command for Start {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let path = call.req::<Spanned<String>>(engine_state, stack, 0)?;
-        let path = Spanned {
-            item: nu_utils::strip_ansi_string_unlikely(path.item),
-            span: path.span,
-        };
+        let path = call
+            .req::<Spanned<String>>(engine_state, stack, 0)?
+            .map(nu_utils::strip_ansi_string_unlikely);
         let path_no_whitespace = path.item.trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
         // Attempt to parse the input as a URL
         if let Ok(url) = url::Url::parse(path_no_whitespace) {

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -135,7 +135,7 @@ impl CallExt for ast::Call {
         stack: &mut Stack,
         pos: usize,
     ) -> Result<Option<T>, ShellError> {
-        if let Some(expr) = self.positional_nth(pos) {
+        if let Some(expr) = self.positional_iter().nth(pos) {
             let stack = &mut stack.use_call_arg_out_dest();
             let result = eval_expression::<WithoutDebug>(engine_state, stack, expr)?;
             if result.is_nothing() {
@@ -153,7 +153,7 @@ impl CallExt for ast::Call {
         working_set: &StateWorkingSet,
         pos: usize,
     ) -> Result<Option<T>, ShellError> {
-        if let Some(expr) = self.positional_nth(pos) {
+        if let Some(expr) = self.positional_iter().nth(pos) {
             let result = eval_constant(working_set, expr)?;
             if result.is_nothing() {
                 Ok(None)
@@ -171,7 +171,7 @@ impl CallExt for ast::Call {
         stack: &mut Stack,
         pos: usize,
     ) -> Result<T, ShellError> {
-        if let Some(expr) = self.positional_nth(pos) {
+        if let Some(expr) = self.positional_iter().nth(pos) {
             let stack = &mut stack.use_call_arg_out_dest();
             let result = eval_expression::<WithoutDebug>(engine_state, stack, expr)?;
             FromValue::from_value(result)

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -171,18 +171,21 @@ impl CallExt for ast::Call {
         stack: &mut Stack,
         pos: usize,
     ) -> Result<T, ShellError> {
-        if let Some(expr) = self.positional_iter().nth(pos) {
-            let stack = &mut stack.use_call_arg_out_dest();
-            let result = eval_expression::<WithoutDebug>(engine_state, stack, expr)?;
-            FromValue::from_value(result)
-        } else if self.positional_len() == 0 {
-            Err(ShellError::AccessEmptyContent { span: self.head })
-        } else {
-            Err(ShellError::AccessBeyondEnd {
-                max_idx: self.positional_len() - 1,
-                span: self.head,
-            })
-        }
+        let maybe_expr = self.positional_iter().nth(pos);
+        let expr = maybe_expr.ok_or_else(|| {
+            let max_idx = self.positional_iter().count().checked_sub(1);
+            match max_idx {
+                None => ShellError::AccessEmptyContent { span: self.head },
+                Some(max_idx) => ShellError::AccessBeyondEnd {
+                    max_idx,
+                    span: self.head,
+                },
+            }
+        })?;
+
+        let stack = &mut stack.use_call_arg_out_dest();
+        let result = eval_expression::<WithoutDebug>(engine_state, stack, expr)?;
+        FromValue::from_value(result)
     }
 
     fn req_parser_info<T: FromValue>(
@@ -287,16 +290,19 @@ impl CallExt for ir::Call {
         stack: &mut Stack,
         pos: usize,
     ) -> Result<T, ShellError> {
-        if let Some(val) = self.positional_iter(stack).nth(pos).cloned() {
-            T::from_value(val)
-        } else if self.positional_len(stack) == 0 {
-            Err(ShellError::AccessEmptyContent { span: self.head })
-        } else {
-            Err(ShellError::AccessBeyondEnd {
-                max_idx: self.positional_len(stack) - 1,
-                span: self.head,
-            })
-        }
+        let maybe_val = self.positional_iter(stack).nth(pos).cloned();
+        let val = maybe_val.ok_or_else(|| {
+            let max_idx = self.positional_iter(stack).count().checked_sub(1);
+            match max_idx {
+                None => ShellError::AccessEmptyContent { span: self.head },
+                Some(max_idx) => ShellError::AccessBeyondEnd {
+                    max_idx,
+                    span: self.head,
+                },
+            }
+        })?;
+
+        T::from_value(val)
     }
 
     fn req_parser_info<T: FromValue>(

--- a/crates/nu-engine/src/compile/call.rs
+++ b/crates/nu-engine/src/compile/call.rs
@@ -430,21 +430,11 @@ pub(crate) fn compile_unlet(
     io_reg: RegId,
 ) -> Result<(), CompileError> {
     // unlet takes one or more positional arguments which should be variable references
-    if call.positional_len() == 0 {
-        return Err(CompileError::InvalidLiteral {
-            msg: "unlet takes at least one argument".into(),
-            span: call.head,
-        });
-    }
+    let mut iter_empty = true;
 
     // Process each positional argument
-    for i in 0..call.positional_len() {
-        let Some(arg) = call.positional_nth(i) else {
-            return Err(CompileError::InvalidLiteral {
-                msg: "Expected positional argument".into(),
-                span: call.head,
-            });
-        };
+    for arg in call.positional_iter() {
+        iter_empty = false;
 
         // Extract variable ID from the expression
         // Handle both direct variable references (Expr::Var) and full cell paths (Expr::FullCellPath)
@@ -498,6 +488,13 @@ pub(crate) fn compile_unlet(
                 });
             }
         }
+    }
+
+    if iter_empty {
+        return Err(CompileError::InvalidLiteral {
+            msg: "unlet takes at least one argument".into(),
+            span: call.head,
+        });
     }
 
     // Load empty value as the result

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -30,9 +30,9 @@ pub(crate) fn compile_if(
         span: call.head,
     };
 
-    let condition = call.positional_nth(0).ok_or_else(invalid)?;
-    let true_block_arg = call.positional_nth(1).ok_or_else(invalid)?;
-    let else_arg = call.positional_nth(2);
+    let (condition, true_block_arg, else_arg) = Some(call.positional_iter())
+        .and_then(|mut iter| Some((iter.next()?, iter.next()?, iter.next())))
+        .ok_or_else(invalid)?;
 
     let true_block_id = true_block_arg.as_block().ok_or_else(invalid)?;
     let true_block = working_set.get_block(true_block_id);
@@ -171,9 +171,10 @@ pub(crate) fn compile_match(
         span: call.head,
     };
 
-    let match_expr = call.positional_nth(0).ok_or_else(invalid)?;
+    let (match_expr, match_block_arg) = Some(call.positional_iter())
+        .and_then(|mut iter| Some((iter.next()?, iter.next()?)))
+        .ok_or_else(invalid)?;
 
-    let match_block_arg = call.positional_nth(1).ok_or_else(invalid)?;
     let match_block = match_block_arg.as_match_block().ok_or_else(invalid)?;
 
     let match_reg = builder.next_register()?;
@@ -331,16 +332,19 @@ pub(crate) fn compile_let(
         span: call.head,
     };
 
-    let var_decl_arg = call.positional_nth(0).ok_or_else(invalid)?;
+    let (var_decl_arg, block_arg) = Some(call.positional_iter())
+        .and_then(|mut iter| Some((iter.next()?, iter.next())))
+        .ok_or_else(invalid)?;
+
     let var_id = var_decl_arg.as_var().ok_or_else(invalid)?;
 
     // Handle the two syntax forms:
     // 1. `let var = expr`: compile expr and store result
     // 2. `let var` (no =): use input_reg as the value
-    let has_initial_value = call.positional_nth(1).is_some();
+    let has_initial_value = block_arg.is_some();
     if has_initial_value {
         // Safe to use expect here since we just checked is_some()
-        let block_arg = call.positional_nth(1).expect("checked above");
+        let block_arg = block_arg.expect("checked above");
         let block_id = block_arg.as_block().ok_or_else(invalid)?;
         let block = working_set.get_block(block_id);
 
@@ -456,32 +460,35 @@ pub(crate) fn compile_try(
         span: call.head,
     };
 
-    let block_arg = call.positional_nth(0).ok_or_else(invalid)?;
-    let block_id = block_arg.as_block().ok_or_else(invalid)?;
-    let block = working_set.get_block(block_id);
+    let (try_block, catch_or_finally, finally) = Some(call.positional_iter())
+        .and_then(|mut iter| Some((iter.next()?, iter.next(), iter.next())))
+        .ok_or_else(invalid)?;
 
-    // manually parsing for `catch` or `finally`.
-    let mut catch_expr = None;
-    let mut finally_expr = None;
-    if let Some(kw_expr) = call.positional_nth(1) {
-        let (keyword, expr) = kw_expr.as_keyword_with_name().ok_or_else(invalid)?;
-        if keyword == b"catch" {
-            catch_expr = Some(expr);
-        } else if keyword == b"finally" {
-            finally_expr = Some(expr);
-        }
+    let block = {
+        let block_id = try_block.as_block().ok_or_else(invalid)?;
+        working_set.get_block(block_id)
     };
-    if let Some(kw_expr) = call.positional_nth(2) {
-        let (keyword, expr) = kw_expr.as_keyword_with_name().ok_or_else(invalid)?;
-        if keyword == b"catch" {
-            // just deny it, because it should only be valid in 1st positional arguments.
-            return Err(invalid());
-        } else if keyword == b"finally" {
-            // deny duplicate finally.
-            if finally_expr.is_some() {
+
+    let (catch_expr, finally_expr) = {
+        let catch_or_finally = catch_or_finally
+            .map(|expr| expr.as_keyword_with_name().ok_or_else(invalid))
+            .transpose()?;
+
+        let finally = finally
+            .map(|expr| expr.as_keyword_with_name().ok_or_else(invalid))
+            .transpose()?;
+
+        match (catch_or_finally, finally) {
+            (None, None) => (None, None),
+            (Some((b"catch", catch_expr)), None) => (Some(catch_expr), None),
+            (Some((b"finally", finally_expr)), None) => (None, Some(finally_expr)),
+            (Some((b"catch", catch_expr)), Some((b"finally", finally_expr))) => {
+                (Some(catch_expr), Some(finally_expr))
+            }
+            _ => {
+                // Should be unreachable
                 return Err(invalid());
             }
-            finally_expr = Some(expr);
         }
     };
 
@@ -775,9 +782,14 @@ pub(crate) fn compile_loop(
         span: call.head,
     };
 
-    let block_arg = call.positional_nth(0).ok_or_else(invalid)?;
-    let block_id = block_arg.as_block().ok_or_else(invalid)?;
-    let block = working_set.get_block(block_id);
+    let block = {
+        let block_id = call
+            .positional_iter()
+            .next()
+            .and_then(Expression::as_block)
+            .ok_or_else(invalid)?;
+        working_set.get_block(block_id)
+    };
 
     let loop_ = builder.begin_loop();
     builder.load_empty(io_reg)?;
@@ -833,10 +845,14 @@ pub(crate) fn compile_while(
         span: call.head,
     };
 
-    let cond_arg = call.positional_nth(0).ok_or_else(invalid)?;
-    let block_arg = call.positional_nth(1).ok_or_else(invalid)?;
-    let block_id = block_arg.as_block().ok_or_else(invalid)?;
-    let block = working_set.get_block(block_id);
+    let (cond_arg, block_arg) = Some(call.positional_iter())
+        .and_then(|mut iter| Some((iter.next()?, iter.next()?)))
+        .ok_or_else(invalid)?;
+
+    let block = {
+        let block_id = block_arg.as_block().ok_or_else(invalid)?;
+        working_set.get_block(block_id)
+    };
 
     let loop_ = builder.begin_loop();
     builder.set_label(loop_.continue_label, builder.here())?;
@@ -915,13 +931,12 @@ pub(crate) fn compile_for(
         return Err(invalid());
     }
 
-    let var_decl_arg = call.positional_nth(0).ok_or_else(invalid)?;
+    let (var_decl_arg, in_arg, block_arg) = Some(call.positional_iter())
+        .and_then(|mut iter| Some((iter.next()?, iter.next()?, iter.next()?)))
+        .ok_or_else(invalid)?;
+
     let var_id = var_decl_arg.as_var().ok_or_else(invalid)?;
-
-    let in_arg = call.positional_nth(1).ok_or_else(invalid)?;
     let in_expr = in_arg.as_keyword().ok_or_else(invalid)?;
-
-    let block_arg = call.positional_nth(2).ok_or_else(invalid)?;
     let block_id = block_arg.as_block().ok_or_else(invalid)?;
     let block = working_set.get_block(block_id);
 
@@ -1058,7 +1073,7 @@ pub(crate) fn compile_return(
     //
     // %io_reg <- <arg_expr>
     // return-early %io_reg
-    if let Some(arg_expr) = call.positional_nth(0) {
+    if let Some(arg_expr) = call.positional_iter().next() {
         compile_expression(
             working_set,
             builder,
@@ -1107,7 +1122,7 @@ pub(crate) fn compile_collect(
 
     builder.push(Instruction::Collect { src_dst: io_reg }.into_spanned(call.head))?;
 
-    if let Some(arg_expr) = call.positional_nth(0) {
+    if let Some(arg_expr) = call.positional_iter().next() {
         // We have to compile the expression into a closure,
         // then compile a closure call
         let closure_reg = builder.next_register()?;

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -341,39 +341,39 @@ pub(crate) fn compile_let(
     // Handle the two syntax forms:
     // 1. `let var = expr`: compile expr and store result
     // 2. `let var` (no =): use input_reg as the value
-    let has_initial_value = block_arg.is_some();
-    if has_initial_value {
-        // Safe to use expect here since we just checked is_some()
-        let block_arg = block_arg.expect("checked above");
-        let block_id = block_arg.as_block().ok_or_else(invalid)?;
-        let block = working_set.get_block(block_id);
+    match (block_arg, input_reg) {
+        (Some(block_arg), _) => {
+            let block_id = block_arg.as_block().ok_or_else(invalid)?;
+            let block = working_set.get_block(block_id);
 
-        // Pass the input_reg to the block so expressions like `let x = (str length)`
-        // can access the pipeline input from the enclosing context
-        compile_block(
-            working_set,
-            builder,
-            block,
-            RedirectModes::value(call.head),
-            input_reg,
-            io_reg,
-        )?;
-    } else if let Some(input_reg) = input_reg {
-        // For `let var` without =, assign the input value
-        builder.push(Instruction::Collect { src_dst: input_reg }.into_spanned(call.head))?;
-        if input_reg != io_reg {
-            builder.push(
-                Instruction::Move {
-                    dst: io_reg,
-                    src: input_reg,
-                }
-                .into_spanned(call.head),
+            // Pass the input_reg to the block so expressions like `let x = (str length)`
+            // can access the pipeline input from the enclosing context
+            compile_block(
+                working_set,
+                builder,
+                block,
+                RedirectModes::value(call.head),
+                input_reg,
+                io_reg,
             )?;
         }
+        (None, Some(input_reg)) => {
+            // For `let var` without =, assign the input value
+            builder.push(Instruction::Collect { src_dst: input_reg }.into_spanned(call.head))?;
+            if input_reg != io_reg {
+                builder.push(
+                    Instruction::Move {
+                        dst: io_reg,
+                        src: input_reg,
+                    }
+                    .into_spanned(call.head),
+                )?;
+            }
+        }
+        (None, None) => {
+            // If no initial_value and no input_reg, io_reg should already be empty (this shouldn't normally occur)
+        }
     }
-    // If no initial_value and no input_reg, io_reg should already be empty (this shouldn't normally occur)
-
-    let variable = working_set.get_variable(var_id);
 
     // If the variable is annotated with type `glob`, convert the value to
     // a `Glob` (expandable) *before* storing.  We use `GlobFrom { no_expand: false }`
@@ -381,7 +381,7 @@ pub(crate) fn compile_let(
     // runtime (e.g. `let g: glob = "*.toml"; ls $g` should expand).  This
     // mirrors the `into glob` conversion and matches interpreter coercion in
     // `nu-cmd-lang::let` (see tests in `nu-command`).
-    if variable.ty == Type::Glob {
+    if working_set.get_variable(var_id).ty == Type::Glob {
         builder.push(
             Instruction::GlobFrom {
                 src_dst: io_reg,
@@ -400,7 +400,7 @@ pub(crate) fn compile_let(
     )?;
     builder.add_comment("let");
 
-    if has_initial_value {
+    if block_arg.is_some() {
         // `let var = expr`: suppress output (traditional assignment, no display)
         builder.load_empty(io_reg)?;
     } else {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -902,11 +902,13 @@ fn parse_extern_inner(
             (call, call_span)
         }
     };
-    let name_expr = call.positional_nth(0);
-    let sig = call.positional_nth(1);
-    let body = call.positional_nth(2);
 
-    if let (Some(name_expr), Some(sig)) = (name_expr, sig) {
+    let (name_and_sig_exprs, body_expr) = {
+        let mut positional_iter = call.positional_iter();
+        (positional_iter.next_array::<2>(), positional_iter.next())
+    };
+
+    if let Some([name_expr, sig]) = name_and_sig_exprs {
         if let (Some(name), Some(mut signature)) = (&name_expr.as_string(), sig.as_signature()) {
             if let Some(mod_name) = module_name
                 && name.as_bytes() == mod_name
@@ -942,7 +944,7 @@ fn parse_extern_inner(
 
                 let declaration = working_set.get_decl_mut(decl_id);
 
-                if let Some(block_id) = body.and_then(|x| x.as_block()) {
+                if let Some(block_id) = body_expr.and_then(|x| x.as_block()) {
                     if signature.rest_positional.is_none() {
                         working_set.error(ParseError::InternalError(
                             "Extern block must have a rest positional argument".into(),
@@ -1213,7 +1215,7 @@ pub fn parse_alias(
             return alias_pipeline;
         }
 
-        let Some(alias_name_expr) = alias_call.positional_nth(0) else {
+        let Some(alias_name_expr) = alias_call.positional_iter().next() else {
             working_set.error(ParseError::UnknownState(
                 "Missing positional after call check".to_string(),
                 Span::concat(spans),
@@ -1814,7 +1816,7 @@ pub fn parse_export_env(
         }
     };
 
-    let block_id = if let Some(block) = call.positional_nth(0) {
+    let block_id = if let Some(block) = call.positional_iter().next() {
         if let Some(block_id) = block.as_block() {
             block_id
         } else {
@@ -2339,43 +2341,39 @@ pub fn parse_module(
         }
     };
 
-    let (module_name_or_path, module_name_or_path_span) = if let Some(name) = call.positional_nth(0)
-    {
-        if let Some(s) = name.as_string() {
-            if let Some(mod_name) = module_name
-                && s.as_bytes() == mod_name
-            {
-                working_set.error(ParseError::NamedAsModule(
-                    "module".to_string(),
-                    s,
-                    "mod".to_string(),
-                    name.span,
-                ));
-                return (
-                    Pipeline::from_vec(vec![Expression::new(
-                        working_set,
-                        Expr::Call(call),
-                        call_span,
-                        Type::Any,
-                    )]),
-                    None,
-                );
-            }
-            (s, name.span)
-        } else {
-            working_set.error(ParseError::UnknownState(
-                "internal error: name not a string".into(),
-                Span::concat(spans),
-            ));
-            return (garbage_pipeline(working_set, spans), None);
-        }
-    } else {
+    let Some(name_expr) = call.positional_iter().next() else {
         working_set.error(ParseError::UnknownState(
             "internal error: missing positional".into(),
             Span::concat(spans),
         ));
         return (garbage_pipeline(working_set, spans), None);
     };
+    let Some(name) = name_expr.as_string() else {
+        working_set.error(ParseError::UnknownState(
+            "internal error: name not a string".into(),
+            Span::concat(spans),
+        ));
+        return (garbage_pipeline(working_set, spans), None);
+    };
+
+    if module_name.is_some_and(|mod_name| mod_name == name.as_bytes()) {
+        working_set.error(ParseError::NamedAsModule(
+            "module".to_string(),
+            name,
+            "mod".to_string(),
+            name_expr.span,
+        ));
+        return (
+            Pipeline::from_vec(vec![Expression::new(
+                working_set,
+                Expr::Call(call),
+                call_span,
+                Type::Any,
+            )]),
+            None,
+        );
+    }
+    let (module_name_or_path, module_name_or_path_span) = (name, name_expr.span);
 
     if spans.len() == split_id + 1 {
         let pipeline = Pipeline::from_vec(vec![Expression::new(

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -694,9 +694,10 @@ fn parse_def_inner(
     };
 
     // All positional arguments must be in the call positional vector by this point
-    let name_expr = call.positional_nth(0).expect("def call already checked");
-    let sig = call.positional_nth(1).expect("def call already checked");
-    let block = call.positional_nth(2).expect("def call already checked");
+    let [name_expr, sig_expr, block_expr] = call
+        .positional_iter()
+        .next_array()
+        .expect("def call already checked");
 
     let Some(name) = name_expr.as_string() else {
         working_set.error(ParseError::UnknownState(
@@ -725,10 +726,17 @@ fn parse_def_inner(
 
     let mut result = None;
 
-    if let (Some(mut signature), Some(block_id)) = (sig.as_signature(), block.as_block()) {
+    if let (Some(mut signature), Some(block_id)) = (sig_expr.as_signature(), block_expr.as_block())
+    {
         if has_wrapped {
-            let Some(rest) = &mut signature.rest_positional else {
-                working_set.error(ParseError::MissingPositional("...rest-like positional argument".to_string(), name_expr.span, "def --wrapped must have a ...rest-like positional argument. Add '...rest: string' to the command's signature.".to_string()));
+            let Some(rest) = signature.rest_positional.as_mut() else {
+                working_set.error(ParseError::MissingPositional(
+                    "...rest-like positional argument".to_string(),
+                    name_expr.span,
+                    "def --wrapped must have a ...rest-like positional argument. \
+                            Add '...rest: string' to the command's signature."
+                        .to_string(),
+                ));
 
                 return (
                     Expression::new(working_set, Expr::Call(call), call_span, Type::Any),
@@ -736,7 +744,10 @@ fn parse_def_inner(
                 );
             };
 
-            if !rest_param_is_type_annotated(working_set.get_span_contents(sig.span), &rest.name) {
+            if !rest_param_is_type_annotated(
+                working_set.get_span_contents(sig_expr.span),
+                &rest.name,
+            ) {
                 rest.shape = SyntaxShape::ExternalArgument;
             }
 
@@ -745,10 +756,15 @@ fn parse_def_inner(
 
                 if rest_var.ty != Type::Any && rest_var.ty != Type::List(Box::new(Type::String)) {
                     working_set.error(ParseError::TypeMismatchHelp(
-                            Type::List(Box::new(Type::String)),
-                            rest_var.ty.clone(),
-                            rest_var.declaration_span,
-                            format!("...rest-like positional argument used in 'def --wrapped' supports only strings. Change the type annotation of ...{} to 'string'.", &rest.name)));
+                        Type::List(Box::new(Type::String)),
+                        rest_var.ty.clone(),
+                        rest_var.declaration_span,
+                        format!(
+                            "...rest-like positional argument used in 'def --wrapped' supports only strings. \
+                                Change the type annotation of ...{} to 'string'.",
+                            &rest.name
+                        ),
+                    ));
 
                     return (
                         Expression::new(working_set, Expr::Call(call), call_span, Type::Any),

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -8,6 +8,7 @@ use crate::{
     type_check::{check_block_input_output, type_compatible},
 };
 
+use itertools::Itertools;
 use log::trace;
 use nu_path::absolute_with;
 use nu_path::is_windows_device_path;
@@ -320,99 +321,84 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
     // Parsing the spans and checking that they match the register signature
     // Using a parsed call makes more sense than checking for how many spans are in the call
     // Also, by creating a call, it can be checked if it matches the declaration signature
-    let (call, call_span) = match working_set.find_decl(b"for") {
-        None => {
-            working_set.error(ParseError::UnknownState(
-                "internal error: for declaration not found".into(),
-                Span::concat(spans),
-            ));
-            return garbage(working_set, spans[0]);
-        }
-        Some(decl_id) => {
-            let starting_error_count = working_set.parse_errors.len();
-            working_set.enter_scope();
-            let ParsedInternalCall {
-                call,
-                output,
-                call_kind,
-            } = parse_internal_call(
-                working_set,
-                spans[0],
-                &spans[1..],
-                decl_id,
-                ArgumentParsingLevel::Full,
-            );
-
-            if working_set
-                .parse_errors
-                .get(starting_error_count..)
-                .is_none_or(|new_errors| {
-                    new_errors
-                        .iter()
-                        .all(|e| !matches!(e, ParseError::Unclosed(token, _) if token == "}"))
-                })
-            {
-                working_set.exit_scope();
-            }
-
-            let call_span = Span::concat(spans);
-            let decl = working_set.get_decl(decl_id);
-            let sig = decl.signature();
-
-            if call_kind != CallKind::Valid {
-                return Expression::new(working_set, Expr::Call(call), call_span, output);
-            }
-
-            // Let's get our block and make sure it has the right signature
-            if let Some(
-                Expression {
-                    expr: Expr::Block(block_id),
-                    ..
-                }
-                | Expression {
-                    expr: Expr::RowCondition(block_id),
-                    ..
-                },
-            ) = call.positional_nth(2)
-            {
-                {
-                    let block = working_set.get_block_mut(*block_id);
-
-                    *block.signature = sig;
-                }
-            }
-
-            (call, call_span)
-        }
+    let Some(decl_id) = working_set.find_decl(b"for") else {
+        working_set.error(ParseError::UnknownState(
+            "internal error: for declaration not found".into(),
+            Span::concat(spans),
+        ));
+        return garbage(working_set, spans[0]);
     };
 
-    // All positional arguments must be in the call positional vector by this point
-    let var_decl = call.positional_nth(0).expect("for call already checked");
-    let iteration_expr = call.positional_nth(1).expect("for call already checked");
-    let block = call.positional_nth(2).expect("for call already checked");
+    let starting_error_count = working_set.parse_errors.len();
+    working_set.enter_scope();
+    let ParsedInternalCall {
+        call,
+        output,
+        call_kind,
+    } = parse_internal_call(
+        working_set,
+        spans[0],
+        &spans[1..],
+        decl_id,
+        ArgumentParsingLevel::Full,
+    );
 
-    let iteration_expr_ty = iteration_expr.ty.clone();
+    if working_set
+        .parse_errors
+        .get(starting_error_count..)
+        .is_none_or(|new_errors| {
+            new_errors
+                .iter()
+                .all(|e| !matches!(e, ParseError::Unclosed(token, _) if token == "}"))
+        })
+    {
+        working_set.exit_scope();
+    }
+
+    let call_span = Span::concat(spans);
+    let decl = working_set.get_decl(decl_id);
+    let sig = decl.signature();
+
+    if call_kind != CallKind::Valid {
+        return Expression::new(working_set, Expr::Call(call), call_span, output);
+    }
+
+    // All positional arguments must be in the call positional vector by this point
+    let [var_decl, iteration_expr, block_expr] = call
+        .positional_iter()
+        .next_array()
+        .expect("for call already checked");
+
+    // Let's get our block and make sure it has the right signature
+    if let Expression {
+        expr: Expr::Block(block_id) | Expr::RowCondition(block_id),
+        ..
+    } = block_expr
+    {
+        let block = working_set.get_block_mut(*block_id);
+
+        *block.signature = sig;
+    };
 
     // Figure out the type of the variable the `for` uses for iteration
-    let var_type = match iteration_expr_ty {
+    let var_type = match iteration_expr.ty.clone() {
         Type::List(x) => *x,
         Type::Table(x) => Type::Record(x),
         Type::Range => Type::Number, // Range elements can be int or float
         x => x,
     };
 
-    if let (Some(var_id), Some(block_id)) = (&var_decl.as_var(), block.as_block()) {
-        working_set.set_variable_type(*var_id, var_type.clone());
+    if let (Some(var_id), Some(block_id)) = (var_decl.as_var(), block_expr.as_block()) {
+        working_set.set_variable_type(var_id, var_type.clone());
 
         let block = working_set.get_block_mut(block_id);
-
         block.signature.required_positional.insert(
             0,
             PositionalArg {
                 name: String::new(),
                 desc: String::new(),
                 shape: var_type.to_shape(),
-                var_id: Some(*var_id),
+                var_id: Some(var_id),
                 default_value: None,
                 completion: None,
             },

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -657,26 +657,25 @@ fn parse_def_inner(
     let sig = decl.signature();
 
     // Let's get our block and make sure it has the right signature
-    if let Some(arg) = call.positional_nth(2) {
-        match arg {
-            Expression {
-                expr: Expr::Closure(block_id),
-                ..
-            } => {
-                // Custom command bodies' are compiled eagerly
-                // 1.  `module`s are not compiled, since they aren't ran/don't have any
-                //     executable code. So `def`s inside modules have to be compiled by
-                //     themselves.
-                // 2.  `def` calls in scripts/runnable code don't *run* any code either,
-                //     they are handled completely by the parser.
-                compile_block_with_id(working_set, *block_id);
-                *working_set.get_block_mut(*block_id).signature = sig.clone();
-            }
-            _ => working_set.error(ParseError::Expected(
-                "definition body closure { ... }",
-                arg.span,
-            )),
+    match call.positional_iter().nth(2) {
+        Some(Expression {
+            expr: Expr::Closure(block_id),
+            ..
+        }) => {
+            // Custom command bodies' are compiled eagerly
+            // 1.  `module`s are not compiled, since they aren't ran/don't have any
+            //     executable code. So `def`s inside modules have to be compiled by
+            //     themselves.
+            // 2.  `def` calls in scripts/runnable code don't *run* any code either,
+            //     they are handled completely by the parser.
+            compile_block_with_id(working_set, *block_id);
+            *working_set.get_block_mut(*block_id).signature = sig.clone();
         }
+        Some(arg) => working_set.error(ParseError::Expected(
+            "definition body closure { ... }",
+            arg.span,
+        )),
+        None => (),
     }
 
     if call_kind != CallKind::Valid {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -727,38 +727,34 @@ fn parse_def_inner(
 
     if let (Some(mut signature), Some(block_id)) = (sig.as_signature(), block.as_block()) {
         if has_wrapped {
-            if let Some(rest) = &mut signature.rest_positional {
-                if !rest_param_is_type_annotated(
-                    working_set.get_span_contents(sig.span),
-                    &rest.name,
-                ) {
-                    rest.shape = SyntaxShape::ExternalArgument;
-                }
-
-                if let Some(var_id) = rest.var_id {
-                    let rest_var = &working_set.get_variable(var_id);
-
-                    if rest_var.ty != Type::Any && rest_var.ty != Type::List(Box::new(Type::String))
-                    {
-                        working_set.error(ParseError::TypeMismatchHelp(
-                            Type::List(Box::new(Type::String)),
-                            rest_var.ty.clone(),
-                            rest_var.declaration_span,
-                            format!("...rest-like positional argument used in 'def --wrapped' supports only strings. Change the type annotation of ...{} to 'string'.", &rest.name)));
-
-                        return (
-                            Expression::new(working_set, Expr::Call(call), call_span, Type::Any),
-                            result,
-                        );
-                    }
-                }
-            } else {
+            let Some(rest) = &mut signature.rest_positional else {
                 working_set.error(ParseError::MissingPositional("...rest-like positional argument".to_string(), name_expr.span, "def --wrapped must have a ...rest-like positional argument. Add '...rest: string' to the command's signature.".to_string()));
 
                 return (
                     Expression::new(working_set, Expr::Call(call), call_span, Type::Any),
                     result,
                 );
+            };
+
+            if !rest_param_is_type_annotated(working_set.get_span_contents(sig.span), &rest.name) {
+                rest.shape = SyntaxShape::ExternalArgument;
+            }
+
+            if let Some(var_id) = rest.var_id {
+                let rest_var = &working_set.get_variable(var_id);
+
+                if rest_var.ty != Type::Any && rest_var.ty != Type::List(Box::new(Type::String)) {
+                    working_set.error(ParseError::TypeMismatchHelp(
+                            Type::List(Box::new(Type::String)),
+                            rest_var.ty.clone(),
+                            rest_var.declaration_span,
+                            format!("...rest-like positional argument used in 'def --wrapped' supports only strings. Change the type annotation of ...{} to 'string'.", &rest.name)));
+
+                    return (
+                        Expression::new(working_set, Expr::Call(call), call_span, Type::Any),
+                        result,
+                    );
+                }
             }
         }
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -698,32 +698,30 @@ fn parse_def_inner(
     let sig = call.positional_nth(1).expect("def call already checked");
     let block = call.positional_nth(2).expect("def call already checked");
 
-    let name = if let Some(name) = name_expr.as_string() {
-        if let Some(mod_name) = module_name
-            && name.as_bytes() == mod_name
-        {
-            let name_expr_span = name_expr.span;
-
-            working_set.error(ParseError::NamedAsModule(
-                "command".to_string(),
-                name,
-                "main".to_string(),
-                name_expr_span,
-            ));
-            return (
-                Expression::new(working_set, Expr::Call(call), call_span, Type::Any),
-                None,
-            );
-        }
-
-        name
-    } else {
+    let Some(name) = name_expr.as_string() else {
         working_set.error(ParseError::UnknownState(
             "Could not get string from string expression".into(),
             name_expr.span,
         ));
         return garbage_result(working_set);
     };
+
+    if let Some(mod_name) = module_name
+        && name.as_bytes() == mod_name
+    {
+        let name_expr_span = name_expr.span;
+
+        working_set.error(ParseError::NamedAsModule(
+            "command".to_string(),
+            name,
+            "main".to_string(),
+            name_expr_span,
+        ));
+        return (
+            Expression::new(working_set, Expr::Call(call), call_span, Type::Any),
+            None,
+        );
+    }
 
     let mut result = None;
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -606,89 +606,85 @@ fn parse_def_inner(
         return garbage_result(working_set);
     };
 
-    let (call, call_span) = {
-        working_set.enter_scope();
-        let (command_spans, rest_spans) = spans.split_at(split_id);
+    working_set.enter_scope();
+    let (command_spans, rest_spans) = spans.split_at(split_id);
 
-        // Find the first span that is not a flag
-        let mut decl_name_span = None;
+    // Find the first span that is not a flag
+    let mut decl_name_span = None;
 
-        for span in rest_spans {
-            if !working_set.get_span_contents(*span).starts_with(b"-") {
-                decl_name_span = Some(*span);
-                break;
-            }
+    for span in rest_spans {
+        if !working_set.get_span_contents(*span).starts_with(b"-") {
+            decl_name_span = Some(*span);
+            break;
         }
+    }
 
-        if let Some(name_span) = decl_name_span {
-            // Check whether name contains [] or () -- possible missing space error
-            if let Some(err) = detect_params_in_name(working_set, name_span, decl_id) {
-                working_set.error(err);
-                return garbage_result(working_set);
-            }
+    if let Some(name_span) = decl_name_span {
+        // Check whether name contains [] or () -- possible missing space error
+        if let Some(err) = detect_params_in_name(working_set, name_span, decl_id) {
+            working_set.error(err);
+            return garbage_result(working_set);
         }
+    }
 
-        let starting_error_count = working_set.parse_errors.len();
-        let ParsedInternalCall {
-            call,
-            output,
-            call_kind,
-        } = parse_internal_call(
-            working_set,
-            Span::concat(command_spans),
-            rest_spans,
-            decl_id,
-            ArgumentParsingLevel::Full,
+    let starting_error_count = working_set.parse_errors.len();
+    let ParsedInternalCall {
+        call,
+        output,
+        call_kind,
+    } = parse_internal_call(
+        working_set,
+        Span::concat(command_spans),
+        rest_spans,
+        decl_id,
+        ArgumentParsingLevel::Full,
+    );
+
+    if working_set
+        .parse_errors
+        .get(starting_error_count..)
+        .is_none_or(|new_errors| {
+            new_errors
+                .iter()
+                .all(|e| !matches!(e, ParseError::Unclosed(token, _) if token == "}"))
+        })
+    {
+        working_set.exit_scope();
+    }
+
+    let call_span = Span::concat(spans);
+    let decl = working_set.get_decl(decl_id);
+    let sig = decl.signature();
+
+    // Let's get our block and make sure it has the right signature
+    if let Some(arg) = call.positional_nth(2) {
+        match arg {
+            Expression {
+                expr: Expr::Closure(block_id),
+                ..
+            } => {
+                // Custom command bodies' are compiled eagerly
+                // 1.  `module`s are not compiled, since they aren't ran/don't have any
+                //     executable code. So `def`s inside modules have to be compiled by
+                //     themselves.
+                // 2.  `def` calls in scripts/runnable code don't *run* any code either,
+                //     they are handled completely by the parser.
+                compile_block_with_id(working_set, *block_id);
+                *working_set.get_block_mut(*block_id).signature = sig.clone();
+            }
+            _ => working_set.error(ParseError::Expected(
+                "definition body closure { ... }",
+                arg.span,
+            )),
+        }
+    }
+
+    if call_kind != CallKind::Valid {
+        return (
+            Expression::new(working_set, Expr::Call(call), call_span, output),
+            None,
         );
-
-        if working_set
-            .parse_errors
-            .get(starting_error_count..)
-            .is_none_or(|new_errors| {
-                new_errors
-                    .iter()
-                    .all(|e| !matches!(e, ParseError::Unclosed(token, _) if token == "}"))
-            })
-        {
-            working_set.exit_scope();
-        }
-
-        let call_span = Span::concat(spans);
-        let decl = working_set.get_decl(decl_id);
-        let sig = decl.signature();
-
-        // Let's get our block and make sure it has the right signature
-        if let Some(arg) = call.positional_nth(2) {
-            match arg {
-                Expression {
-                    expr: Expr::Closure(block_id),
-                    ..
-                } => {
-                    // Custom command bodies' are compiled eagerly
-                    // 1.  `module`s are not compiled, since they aren't ran/don't have any
-                    //     executable code. So `def`s inside modules have to be compiled by
-                    //     themselves.
-                    // 2.  `def` calls in scripts/runnable code don't *run* any code either,
-                    //     they are handled completely by the parser.
-                    compile_block_with_id(working_set, *block_id);
-                    *working_set.get_block_mut(*block_id).signature = sig.clone();
-                }
-                _ => working_set.error(ParseError::Expected(
-                    "definition body closure { ... }",
-                    arg.span,
-                )),
-            }
-        }
-
-        if call_kind != CallKind::Valid {
-            return (
-                Expression::new(working_set, Expr::Call(call), call_span, output),
-                None,
-            );
-        }
-
-        (call, call_span)
-    };
+    }
 
     let Ok(has_env) = has_flag_const(working_set, &call, "env") else {
         return garbage_result(working_set);

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2902,27 +2902,22 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
 pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
     let call_span = call.span();
 
-    let (overlay_name, _) = if let Some(expr) = call.positional_nth(0) {
-        match eval_constant(working_set, expr) {
-            Ok(val) => match val.coerce_into_string() {
-                Ok(s) => (s, expr.span),
-                Err(err) => {
-                    working_set.error(err.wrap(working_set, call_span));
-                    return garbage_pipeline(working_set, &[call_span]);
-                }
-            },
-            Err(err) => {
-                working_set.error(err.wrap(working_set, call_span));
-                return garbage_pipeline(working_set, &[call_span]);
-            }
-        }
-    } else {
+    let Some(expr) = call.positional_iter().next() else {
         working_set.error(ParseError::UnknownState(
             "internal error: Missing required positional after call parsing".into(),
             call_span,
         ));
         return garbage_pipeline(working_set, &[call_span]);
     };
+
+    let (overlay_name, _) =
+        match eval_constant(working_set, expr).and_then(Value::coerce_into_string) {
+            Ok(s) => (s, expr.span),
+            Err(err) => {
+                working_set.error(err.wrap(working_set, call_span));
+                return garbage_pipeline(working_set, &[call_span]);
+            }
+        };
 
     let pipeline = Pipeline::from_vec(vec![Expression::new(
         working_set,
@@ -2950,34 +2945,12 @@ pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
 pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
     let call_span = call.span();
 
-    let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_nth(0) {
-        match eval_constant(working_set, expr) {
-            Ok(Value::Nothing { .. }) => {
-                let mut call = call;
-                call.set_parser_info(
-                    "noop".to_string(),
-                    Expression::new_unknown(Expr::Bool(true), Span::unknown(), Type::Bool),
-                );
-                return Pipeline::from_vec(vec![Expression::new(
-                    working_set,
-                    Expr::Call(call),
-                    call_span,
-                    Type::Any,
-                )]);
-            }
-            Ok(val) => match val.coerce_into_string() {
-                Ok(s) => (s, expr.span),
-                Err(err) => {
-                    working_set.error(err.wrap(working_set, call_span));
-                    return garbage_pipeline(working_set, &[call_span]);
-                }
-            },
-            Err(err) => {
-                working_set.error(err.wrap(working_set, call_span));
-                return garbage_pipeline(working_set, &[call_span]);
-            }
-        }
-    } else {
+    let (overlay_name_expr, as_name_expr) = {
+        let mut iter = call.positional_iter();
+        (iter.next(), iter.next())
+    };
+
+    let Some(overlay_name_expr) = overlay_name_expr else {
         working_set.error(ParseError::UnknownState(
             "internal error: Missing required positional after call parsing".into(),
             call_span,
@@ -2985,30 +2958,47 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         return garbage_pipeline(working_set, &[call_span]);
     };
 
-    let new_name = if let Some(kw_expression) = call.positional_nth(1) {
-        if let Some(new_name_expression) = kw_expression.as_keyword() {
-            match eval_constant(working_set, new_name_expression) {
-                Ok(val) => match val.coerce_into_string() {
-                    Ok(s) => Some(Spanned {
-                        item: s,
-                        span: new_name_expression.span,
-                    }),
-                    Err(err) => {
-                        working_set.error(err.wrap(working_set, call_span));
-                        return garbage_pipeline(working_set, &[call_span]);
-                    }
-                },
-                Err(err) => {
-                    working_set.error(err.wrap(working_set, call_span));
-                    return garbage_pipeline(working_set, &[call_span]);
-                }
+    let (overlay_name, overlay_name_span) = match eval_constant(working_set, overlay_name_expr) {
+        Ok(Value::Nothing { .. }) => {
+            let mut call = call;
+            call.set_parser_info(
+                "noop".to_string(),
+                Expression::new_unknown(Expr::Bool(true), Span::unknown(), Type::Bool),
+            );
+            return Pipeline::from_vec(vec![Expression::new(
+                working_set,
+                Expr::Call(call),
+                call_span,
+                Type::Any,
+            )]);
+        }
+        result => match result.and_then(Value::coerce_into_string) {
+            Ok(s) => (s, overlay_name_expr.span),
+            Err(err) => {
+                working_set.error(err.wrap(working_set, call_span));
+                return garbage_pipeline(working_set, &[call_span]);
             }
-        } else {
+        },
+    };
+
+    let new_name = if let Some(as_name_expr) = as_name_expr {
+        let Some((b"as", new_name_expression)) = as_name_expr.as_keyword_with_name() else {
             working_set.error(ParseError::ExpectedKeyword(
                 "as keyword".to_string(),
-                kw_expression.span,
+                as_name_expr.span,
             ));
             return garbage_pipeline(working_set, &[call_span]);
+        };
+
+        match eval_constant(working_set, new_name_expression).and_then(Value::coerce_into_string) {
+            Ok(s) => Some(Spanned {
+                item: s,
+                span: new_name_expression.span,
+            }),
+            Err(err) => {
+                working_set.error(err.wrap(working_set, call_span));
+                return garbage_pipeline(working_set, &[call_span]);
+            }
         }
     } else {
         None
@@ -3188,7 +3178,7 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
 pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
     let call_span = call.span();
 
-    let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_nth(0) {
+    let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_iter().next() {
         match eval_constant(working_set, expr) {
             Ok(val) => match val.coerce_into_string() {
                 Ok(s) => (s, expr.span),
@@ -3683,7 +3673,8 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
             }
 
             // Command and one file name
-            if let Some(expr) = call.positional_nth(0) {
+            let first_expr = call.positional_iter().next();
+            if let Some(expr) = first_expr {
                 let val = match eval_constant(working_set, expr) {
                     Ok(val) => val,
                     Err(err) => {
@@ -3886,7 +3877,8 @@ pub fn parse_plugin_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> P
 
     if let Err(err) = (|| {
         let name = call
-            .positional_nth(0)
+            .positional_iter()
+            .next()
             .map(|expr| {
                 eval_constant(working_set, expr)
                     .and_then(Spanned::<String>::from_value)

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -598,97 +598,96 @@ fn parse_def_inner(
     // NOTE: Here we only search for `def` in the permanent state,
     // since recursively redefining `def` is dangerous,
     // see https://github.com/nushell/nushell/issues/16586
-    let (call, call_span) = match working_set.permanent_state.find_decl(def_call, &[]) {
-        None => {
-            working_set.error(ParseError::UnknownState(
-                "internal error: def declaration not found".into(),
-                Span::concat(spans),
-            ));
-            return garbage_result(working_set);
+    let Some(decl_id) = working_set.permanent_state.find_decl(def_call, &[]) else {
+        working_set.error(ParseError::UnknownState(
+            "internal error: def declaration not found".into(),
+            Span::concat(spans),
+        ));
+        return garbage_result(working_set);
+    };
+
+    let (call, call_span) = {
+        working_set.enter_scope();
+        let (command_spans, rest_spans) = spans.split_at(split_id);
+
+        // Find the first span that is not a flag
+        let mut decl_name_span = None;
+
+        for span in rest_spans {
+            if !working_set.get_span_contents(*span).starts_with(b"-") {
+                decl_name_span = Some(*span);
+                break;
+            }
         }
-        Some(decl_id) => {
-            working_set.enter_scope();
-            let (command_spans, rest_spans) = spans.split_at(split_id);
 
-            // Find the first span that is not a flag
-            let mut decl_name_span = None;
-
-            for span in rest_spans {
-                if !working_set.get_span_contents(*span).starts_with(b"-") {
-                    decl_name_span = Some(*span);
-                    break;
-                }
+        if let Some(name_span) = decl_name_span {
+            // Check whether name contains [] or () -- possible missing space error
+            if let Some(err) = detect_params_in_name(working_set, name_span, decl_id) {
+                working_set.error(err);
+                return garbage_result(working_set);
             }
+        }
 
-            if let Some(name_span) = decl_name_span {
-                // Check whether name contains [] or () -- possible missing space error
-                if let Some(err) = detect_params_in_name(working_set, name_span, decl_id) {
-                    working_set.error(err);
-                    return garbage_result(working_set);
+        let starting_error_count = working_set.parse_errors.len();
+        let ParsedInternalCall {
+            call,
+            output,
+            call_kind,
+        } = parse_internal_call(
+            working_set,
+            Span::concat(command_spans),
+            rest_spans,
+            decl_id,
+            ArgumentParsingLevel::Full,
+        );
+
+        if working_set
+            .parse_errors
+            .get(starting_error_count..)
+            .is_none_or(|new_errors| {
+                new_errors
+                    .iter()
+                    .all(|e| !matches!(e, ParseError::Unclosed(token, _) if token == "}"))
+            })
+        {
+            working_set.exit_scope();
+        }
+
+        let call_span = Span::concat(spans);
+        let decl = working_set.get_decl(decl_id);
+        let sig = decl.signature();
+
+        // Let's get our block and make sure it has the right signature
+        if let Some(arg) = call.positional_nth(2) {
+            match arg {
+                Expression {
+                    expr: Expr::Closure(block_id),
+                    ..
+                } => {
+                    // Custom command bodies' are compiled eagerly
+                    // 1.  `module`s are not compiled, since they aren't ran/don't have any
+                    //     executable code. So `def`s inside modules have to be compiled by
+                    //     themselves.
+                    // 2.  `def` calls in scripts/runnable code don't *run* any code either,
+                    //     they are handled completely by the parser.
+                    compile_block_with_id(working_set, *block_id);
+                    *working_set.get_block_mut(*block_id).signature = sig.clone();
                 }
+                _ => working_set.error(ParseError::Expected(
+                    "definition body closure { ... }",
+                    arg.span,
+                )),
             }
+        }
 
-            let starting_error_count = working_set.parse_errors.len();
-            let ParsedInternalCall {
-                call,
-                output,
-                call_kind,
-            } = parse_internal_call(
-                working_set,
-                Span::concat(command_spans),
-                rest_spans,
-                decl_id,
-                ArgumentParsingLevel::Full,
+        if call_kind != CallKind::Valid {
+            return (
+                Expression::new(working_set, Expr::Call(call), call_span, output),
+                None,
             );
-
-            if working_set
-                .parse_errors
-                .get(starting_error_count..)
-                .is_none_or(|new_errors| {
-                    new_errors
-                        .iter()
-                        .all(|e| !matches!(e, ParseError::Unclosed(token, _) if token == "}"))
-                })
-            {
-                working_set.exit_scope();
-            }
-
-            let call_span = Span::concat(spans);
-            let decl = working_set.get_decl(decl_id);
-            let sig = decl.signature();
-
-            // Let's get our block and make sure it has the right signature
-            if let Some(arg) = call.positional_nth(2) {
-                match arg {
-                    Expression {
-                        expr: Expr::Closure(block_id),
-                        ..
-                    } => {
-                        // Custom command bodies' are compiled eagerly
-                        // 1.  `module`s are not compiled, since they aren't ran/don't have any
-                        //     executable code. So `def`s inside modules have to be compiled by
-                        //     themselves.
-                        // 2.  `def` calls in scripts/runnable code don't *run* any code either,
-                        //     they are handled completely by the parser.
-                        compile_block_with_id(working_set, *block_id);
-                        *working_set.get_block_mut(*block_id).signature = sig.clone();
-                    }
-                    _ => working_set.error(ParseError::Expected(
-                        "definition body closure { ... }",
-                        arg.span,
-                    )),
-                }
-            }
-
-            if call_kind != CallKind::Valid {
-                return (
-                    Expression::new(working_set, Expr::Call(call), call_span, output),
-                    None,
-                );
-            }
-
-            (call, call_span)
         }
+
+        (call, call_span)
     };
 
     let Ok(has_env) = has_flag_const(working_set, &call, "env") else {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -198,7 +198,7 @@ pub(crate) fn check_call(
         return CallKind::Help;
     }
 
-    if call.positional_len() < sig.required_positional.len() {
+    if call.positional_iter().count() < sig.required_positional.len() {
         let end_offset = call
             .positional_iter()
             .last()
@@ -225,7 +225,7 @@ pub(crate) fn check_call(
             }
         }
 
-        let missing = &sig.required_positional[call.positional_len()];
+        let missing = &sig.required_positional[call.positional_iter().count()];
         working_set.error(ParseError::MissingPositional(
             missing.name.clone(),
             Span::new(end_offset, end_offset),
@@ -1078,7 +1078,7 @@ pub fn parse_internal_call(
             call = *wrapped_call.clone();
             call.head = command_span;
             // Skip positionals passed to aliased call
-            positional_idx = call.positional_len();
+            positional_idx = call.positional_iter().count();
         } else {
             working_set.error(ParseError::UnknownState(
                 "Alias does not point to internal call.".to_string(),

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1515,7 +1515,7 @@ fn test_redirection_with_letmut(#[case] phase: &[u8]) {
     assert!(element.redirection.is_none()); // it should be in the let block, not here
 
     if let Expr::Call(call) = &element.expr.expr {
-        let arg = call.positional_nth(1).expect("no positional args");
+        let arg = call.positional_iter().nth(1).expect("no positional args");
         let block_id = arg.as_block().expect("arg 1 is not a block");
         let block = working_set.get_block(block_id);
         let inner_element = &block.pipelines[0].elements[0];

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -713,10 +713,7 @@ fn custom_value_op(
             path,
             save_call_span,
         } => {
-            let path = Spanned {
-                item: path.item.as_path(),
-                span: path.span,
-            };
+            let path = path.as_deref();
             let result = plugin.custom_value_save(engine, local_value, path, save_call_span);
             engine.write_ok(result)
         }

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -188,14 +188,6 @@ impl Call {
             })
     }
 
-    pub fn positional_nth(&self, i: usize) -> Option<&Expression> {
-        self.positional_iter().nth(i)
-    }
-
-    pub fn positional_len(&self) -> usize {
-        self.positional_iter().count()
-    }
-
     /// Returns every argument to the rest parameter, as well as whether each argument
     /// is spread or a normal positional argument (true for spread, false for normal)
     pub fn rest_iter(&self, start: usize) -> impl Iterator<Item = (&Expression, bool)> {

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -188,6 +188,16 @@ impl Call {
             })
     }
 
+    #[deprecated(since = "0.113.0", note = "use .positional_iter().nth(n) instead")]
+    pub fn positional_nth(&self, i: usize) -> Option<&Expression> {
+        self.positional_iter().nth(i)
+    }
+
+    #[deprecated(since = "0.113.0", note = "use .positional_iter().count(n) instead")]
+    pub fn positional_len(&self) -> usize {
+        self.positional_iter().count()
+    }
+
     /// Returns every argument to the rest parameter, as well as whether each argument
     /// is spread or a normal positional argument (true for spread, false for normal)
     pub fn rest_iter(&self, start: usize) -> impl Iterator<Item = (&Expression, bool)> {

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -336,17 +336,18 @@ impl Call {
         working_set: &StateWorkingSet,
         pos: usize,
     ) -> Result<T, ShellError> {
-        if let Some(expr) = self.positional_iter().nth(pos) {
-            let result = eval_constant(working_set, expr)?;
-            FromValue::from_value(result)
-        } else if self.positional_len() == 0 {
-            Err(ShellError::AccessEmptyContent { span: self.head })
-        } else {
-            Err(ShellError::AccessBeyondEnd {
-                max_idx: self.positional_len() - 1,
-                span: self.head,
-            })
-        }
+        let expr = self.positional_iter().nth(pos).ok_or_else(|| {
+            match self.positional_iter().count().checked_sub(1) {
+                None => ShellError::AccessEmptyContent { span: self.head },
+                Some(n) => ShellError::AccessBeyondEnd {
+                    max_idx: n,
+                    span: self.head,
+                },
+            }
+        })?;
+
+        let result = eval_constant(working_set, expr)?;
+        FromValue::from_value(result)
     }
 
     pub fn span(&self) -> Span {

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -336,7 +336,7 @@ impl Call {
         working_set: &StateWorkingSet,
         pos: usize,
     ) -> Result<T, ShellError> {
-        if let Some(expr) = self.positional_nth(pos) {
+        if let Some(expr) = self.positional_iter().nth(pos) {
             let result = eval_constant(working_set, expr)?;
             FromValue::from_value(result)
         } else if self.positional_len() == 0 {

--- a/crates/nu-protocol/src/engine/call.rs
+++ b/crates/nu-protocol/src/engine/call.rs
@@ -184,8 +184,8 @@ impl Call<'_> {
     /// unless the decl specified `requires_ast_for_arguments()`
     pub fn positional_nth<'a>(&'a self, stack: &'a Stack, index: usize) -> Option<&'a Expression> {
         match &self.inner {
-            CallImpl::AstRef(call) => call.positional_nth(index),
-            CallImpl::AstBox(call) => call.positional_nth(index),
+            CallImpl::AstRef(call) => call.positional_iter().nth(index),
+            CallImpl::AstBox(call) => call.positional_iter().nth(index),
             CallImpl::IrRef(call) => call.positional_ast(stack, index).map(|arc| arc.as_ref()),
             CallImpl::IrBox(call) => call.positional_ast(stack, index).map(|arc| arc.as_ref()),
         }

--- a/crates/nu-protocol/src/value/glob.rs
+++ b/crates/nu-protocol/src/value/glob.rs
@@ -14,11 +14,15 @@ pub enum NuGlob {
 }
 
 impl NuGlob {
-    pub fn strip_ansi_string_unlikely(self) -> Self {
+    pub fn map(self, f: impl FnOnce(String) -> String) -> Self {
         match self {
-            NuGlob::DoNotExpand(s) => NuGlob::DoNotExpand(nu_utils::strip_ansi_string_unlikely(s)),
-            NuGlob::Expand(s) => NuGlob::Expand(nu_utils::strip_ansi_string_unlikely(s)),
+            NuGlob::DoNotExpand(s) => NuGlob::DoNotExpand(f(s)),
+            NuGlob::Expand(s) => NuGlob::Expand(f(s)),
         }
+    }
+
+    pub fn strip_ansi_string_unlikely(self) -> Self {
+        self.map(nu_utils::strip_ansi_string_unlikely)
     }
 
     pub fn is_expand(&self) -> bool {

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_split.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_split.rs
@@ -64,13 +64,10 @@ impl PluginCommand for StrSplit {
         call: &EvaluatedCall,
         mut input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
-        let separator = call.req::<Spanned<Value>>(0).and_then(|sep| {
-            let sep_expr = NuExpression::try_from_value(plugin, &sep.item)?;
-            Ok(Spanned {
-                item: sep_expr,
-                span: sep.span,
-            })
-        })?;
+        let separator = call
+            .req::<Spanned<Value>>(0)?
+            .map(|sep| NuExpression::try_from_value(plugin, &sep))
+            .transpose()?;
 
         let metadata = input.take_metadata();
         let expr = NuExpression::try_from_pipeline(plugin, input, call.head)?;


### PR DESCRIPTION
## Description

Mostly improving readability/maintainability, possibly increasing performance in the parser and compiler.

- ~Removed~ _Deprecated_ `ast::Call`'s `positional_nth` and `positonal_len` methods. They are deceptively heavy, constructing and then consuming an iterator with each call.
- Use `Spanned::map` instead of de-structuring and constructing `Spanned` values.
- Use `NuGlob::string_ansi_string_unlikely` instead of manually applying the operation to each variant.
- Replace some if-else chains with match expressions to clarify which cases are handled and how.
- Use let-else to reduce nesting.

## User-facing changes (Release notes)
N/A