### PR TITLE
make ctrl-c works with try..finally while running script

### DIFF
--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -297,7 +297,13 @@ fn eval_ir_block_impl<D: DebugContext>(
                 }
             }
             Err(err) => {
-                let is_interrupted = matches!(err, ShellError::Interrupted { .. });
+                #[cfg(unix)]
+                let is_terminated_by_signal = matches!(&err, ShellError::TerminatedBySignal { .. });
+                #[cfg(not(unix))]
+                let is_terminated_by_signal = false;
+
+                let is_interrupted =
+                    matches!(err, ShellError::Interrupted { .. }) || is_terminated_by_signal;
                 if let Some(error_handler) = ctx.stack.error_handlers.pop(ctx.error_handler_base) {
                     if is_interrupted {
                         ctx.engine_state.signals().reset();
@@ -427,9 +433,9 @@ fn eval_instruction<D: DebugContext>(
         Instruction::TryCollect { src_dst } => {
             let data = ctx.take_reg(*src_dst);
             #[cfg(feature = "os")]
-            let value = collect_respecting_signals(data, *span, false, ctx.engine_state.signals())?;
+            let value = collect(data, *span, false)?;
             #[cfg(not(feature = "os"))]
-            let value = collect_respecting_signals(data, *span, ctx.engine_state.signals())?;
+            let value = collect(data, *span)?;
             ctx.put_reg(*src_dst, PipelineExecutionData::from(value));
             Ok(Continue)
         }
@@ -1688,97 +1694,6 @@ fn collect(
     }
     let value = data.into_value(span)?;
     Ok(PipelineData::value(value, metadata))
-}
-
-/// Like `collect`, but for ListStream collects items manually while checking `signals` on each
-/// iteration. When interrupted, returns `ShellError::Interrupted`.
-#[cfg(feature = "os")]
-fn collect_respecting_signals(
-    pipe: PipelineExecutionData,
-    fallback_span: Span,
-    ignore_error: bool,
-    signals: &Signals,
-) -> Result<PipelineData, ShellError> {
-    let mut data = pipe.body;
-    let span = data.span().unwrap_or(fallback_span);
-    let metadata = data.take_metadata().and_then(|m| m.for_collect());
-
-    if nu_experimental::PIPE_FAIL.get() && !ignore_error {
-        check_exit_status_future(pipe.exit)?;
-    }
-
-    match data {
-        PipelineData::Empty => Ok(PipelineData::value(Value::nothing(span), metadata)),
-        PipelineData::Value(mut val, ..) => {
-            if val.span() == Span::unknown() {
-                val = val.with_span(span);
-            }
-            Ok(PipelineData::value(val, metadata))
-        }
-        PipelineData::ListStream(mut list_stream, ..) => {
-            let mut iter = list_stream.into_inner();
-            let mut vals = Vec::new();
-            loop {
-                if signals.interrupted() {
-                    return Err(ShellError::Interrupted { span });
-                }
-                match iter.next() {
-                    Some(v) => match v {
-                        Value::Error { error, .. } => return Err(*error),
-                        other => vals.push(other),
-                    },
-                    None => break,
-                }
-            }
-            Ok(PipelineData::value(Value::list(vals, span), metadata))
-        }
-        PipelineData::ByteStream(byte_stream, ..) => {
-            let value = byte_stream.into_value()?;
-            Ok(PipelineData::value(value, metadata))
-        }
-    }
-}
-
-#[cfg(not(feature = "os"))]
-fn collect_respecting_signals(
-    pipe: PipelineExecutionData,
-    fallback_span: Span,
-    signals: &Signals,
-) -> Result<PipelineData, ShellError> {
-    let mut data = pipe.body;
-    let span = data.span().unwrap_or(fallback_span);
-    let metadata = data.take_metadata().and_then(|m| m.for_collect());
-
-    match data {
-        PipelineData::Empty => Ok(PipelineData::value(Value::nothing(span), metadata)),
-        PipelineData::Value(mut val, ..) => {
-            if val.span() == Span::unknown() {
-                val = val.with_span(span);
-            }
-            Ok(PipelineData::value(val, metadata))
-        }
-        PipelineData::ListStream(mut list_stream, ..) => {
-            let mut iter = list_stream.into_inner();
-            let mut vals = Vec::new();
-            loop {
-                if signals.interrupted() {
-                    return Err(ShellError::Interrupted { span });
-                }
-                match iter.next() {
-                    Some(v) => match v {
-                        Value::Error { error, .. } => return Err(*error),
-                        other => vals.push(other),
-                    },
-                    None => break,
-                }
-            }
-            Ok(PipelineData::value(Value::list(vals, span), metadata))
-        }
-        PipelineData::ByteStream(byte_stream, ..) => {
-            let value = byte_stream.into_value()?;
-            Ok(PipelineData::value(value, metadata))
-        }
-    }
 }
 
 /// Helper for drain behavior.

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -427,9 +427,9 @@ fn eval_instruction<D: DebugContext>(
         Instruction::TryCollect { src_dst } => {
             let data = ctx.take_reg(*src_dst);
             #[cfg(feature = "os")]
-            let value = collect(data, *span, false)?;
+            let value = collect_respecting_signals(data, *span, false, ctx.engine_state.signals())?;
             #[cfg(not(feature = "os"))]
-            let value = collect(data, *span)?;
+            let value = collect_respecting_signals(data, *span, ctx.engine_state.signals())?;
             ctx.put_reg(*src_dst, PipelineExecutionData::from(value));
             Ok(Continue)
         }
@@ -1688,6 +1688,97 @@ fn collect(
     }
     let value = data.into_value(span)?;
     Ok(PipelineData::value(value, metadata))
+}
+
+/// Like `collect`, but for ListStream collects items manually while checking `signals` on each
+/// iteration. When interrupted, returns `ShellError::Interrupted`.
+#[cfg(feature = "os")]
+fn collect_respecting_signals(
+    pipe: PipelineExecutionData,
+    fallback_span: Span,
+    ignore_error: bool,
+    signals: &Signals,
+) -> Result<PipelineData, ShellError> {
+    let mut data = pipe.body;
+    let span = data.span().unwrap_or(fallback_span);
+    let metadata = data.take_metadata().and_then(|m| m.for_collect());
+
+    if nu_experimental::PIPE_FAIL.get() && !ignore_error {
+        check_exit_status_future(pipe.exit)?;
+    }
+
+    match data {
+        PipelineData::Empty => Ok(PipelineData::value(Value::nothing(span), metadata)),
+        PipelineData::Value(mut val, ..) => {
+            if val.span() == Span::unknown() {
+                val = val.with_span(span);
+            }
+            Ok(PipelineData::value(val, metadata))
+        }
+        PipelineData::ListStream(mut list_stream, ..) => {
+            let mut iter = list_stream.into_inner();
+            let mut vals = Vec::new();
+            loop {
+                if signals.interrupted() {
+                    return Err(ShellError::Interrupted { span });
+                }
+                match iter.next() {
+                    Some(v) => match v {
+                        Value::Error { error, .. } => return Err(*error),
+                        other => vals.push(other),
+                    },
+                    None => break,
+                }
+            }
+            Ok(PipelineData::value(Value::list(vals, span), metadata))
+        }
+        PipelineData::ByteStream(byte_stream, ..) => {
+            let value = byte_stream.into_value()?;
+            Ok(PipelineData::value(value, metadata))
+        }
+    }
+}
+
+#[cfg(not(feature = "os"))]
+fn collect_respecting_signals(
+    pipe: PipelineExecutionData,
+    fallback_span: Span,
+    signals: &Signals,
+) -> Result<PipelineData, ShellError> {
+    let mut data = pipe.body;
+    let span = data.span().unwrap_or(fallback_span);
+    let metadata = data.take_metadata().and_then(|m| m.for_collect());
+
+    match data {
+        PipelineData::Empty => Ok(PipelineData::value(Value::nothing(span), metadata)),
+        PipelineData::Value(mut val, ..) => {
+            if val.span() == Span::unknown() {
+                val = val.with_span(span);
+            }
+            Ok(PipelineData::value(val, metadata))
+        }
+        PipelineData::ListStream(mut list_stream, ..) => {
+            let mut iter = list_stream.into_inner();
+            let mut vals = Vec::new();
+            loop {
+                if signals.interrupted() {
+                    return Err(ShellError::Interrupted { span });
+                }
+                match iter.next() {
+                    Some(v) => match v {
+                        Value::Error { error, .. } => return Err(*error),
+                        other => vals.push(other),
+                    },
+                    None => break,
+                }
+            }
+            Ok(PipelineData::value(Value::list(vals, span), metadata))
+        }
+        PipelineData::ByteStream(byte_stream, ..) => {
+            let value = byte_stream.into_value()?;
+            Ok(PipelineData::value(value, metadata))
+        }
+    }
 }
 
 /// Helper for drain behavior.

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -297,13 +297,20 @@ fn eval_ir_block_impl<D: DebugContext>(
                 }
             }
             Err(err) => {
+                let is_interrupted = matches!(err, ShellError::Interrupted { .. });
                 if let Some(error_handler) = ctx.stack.error_handlers.pop(ctx.error_handler_base) {
+                    if is_interrupted {
+                        ctx.engine_state.signals().reset();
+                    }
                     // If an error handler is set, branch there
                     prepare_error_handler(ctx, error_handler, Some(err.into_spanned(*span)));
                     pc = error_handler.handler_index;
                 } else if let Some(always_run_handler) =
                     ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
                 {
+                    if is_interrupted {
+                        ctx.engine_state.signals().reset();
+                    }
                     prepare_error_handler(
                         ctx,
                         always_run_handler,


### PR DESCRIPTION
## Description

It's caused when running a nushell script, and pressing ctrl-c, the signal is still set.  So catch or finally block won't running.
I'm not sure why it works in repl, but the signal should be reset too.

## User-facing changes (Release notes)
### `try` blocks may now be interrupted with ctrl-c
Finally block will run if try block is interruped with ctrl-c, for example:
```
# cc.nu
#!/usr/bin/env nu
"test content" | save -f cleanup-test.txt
print $"before try: cleanup-test.txt exists = ('cleanup-test.txt' | path exists)"
try {
    ^ping -n 30 127.0.0.1   # or `^ping -c 30 127.0.0.1` on Linux/macOS
} finally {
    print "finally ran"
    rm -f cleanup-test.txt
}
print $"after try: cleanup-test.txt exists = ('cleanup-test.txt' | path exists)"
```
And run it with:
```
> nu cc.nu
```
press ctrl-c during printing, it'll output `finally ran`

## Additional notes
fixes #18090