### PR TITLE
Allow filtering custom completions by description

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -746,6 +746,7 @@ impl NuCompleter {
             case_sensitive: config.completions.case_sensitive,
             match_algorithm: config.completions.algorithm.into(),
             sort: config.completions.sort,
+            match_description: false,
         };
 
         completer.fetch(

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -309,6 +309,7 @@ pub struct CompletionOptions {
     pub case_sensitive: bool,
     pub match_algorithm: MatchAlgorithm,
     pub sort: CompletionSort,
+    pub match_description: bool,
 }
 
 impl Default for CompletionOptions {
@@ -317,6 +318,7 @@ impl Default for CompletionOptions {
             case_sensitive: true,
             match_algorithm: MatchAlgorithm::Prefix,
             sort: Default::default(),
+            match_description: false,
         }
     }
 }

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -230,6 +230,13 @@ impl<T: Completer> Completer for CustomCompletion<T> {
                             completion_options.case_sensitive = case_sensitive;
                         }
 
+                        if let Some(md) = options
+                            .get("match_description")
+                            .and_then(|val| val.as_bool().ok())
+                        {
+                            completion_options.match_description = md;
+                        }
+
                         let positional =
                             options.get("positional").and_then(|val| val.as_bool().ok());
                         if positional.is_some() {
@@ -290,10 +297,16 @@ impl<T: Completer> Completer for CustomCompletion<T> {
         let mut matcher = NuMatcher::new(prefix.as_ref(), &completion_options, should_sort);
 
         for sugg in suggestions {
-            matcher.add(
-                strip_ansi_string_unlikely(sugg.suggestion.display_value().to_string()),
-                sugg,
-            );
+            let value = strip_ansi_string_unlikely(sugg.suggestion.display_value().to_string());
+            if matcher.check_match(&value).is_some() {
+                matcher.add(value, sugg);
+            } else if completion_options.match_description
+                && let Some(description) = sugg.suggestion.description.as_deref()
+                && matcher.check_match(description).is_some()
+            {
+                let description = description.to_string();
+                matcher.add(description, sugg);
+            }
         }
         matcher.suggestion_results()
     }

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -352,6 +352,51 @@ fn custom_completions_override_display_value() {
 }
 
 #[test]
+fn custom_completions_filter_by_description() {
+    let (_, _, mut engine, mut stack) = new_engine();
+    let command = r#"
+        def comp [] {
+            {
+                completions: [
+                    { value: red,   description: "warm color" },
+                    { value: blue,  description: "cool color" },
+                    { value: green, description: "warm-ish color" },
+                    { value: cyan,  description: "another cool one" },
+                ],
+                options: { match_description: true }
+            }
+        }
+        def my-command [arg: string@comp] {}"#;
+    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let completion_str = "my-command warm";
+    let suggestions = completer.complete(completion_str, completion_str.len());
+    match_suggestions(&vec!["red", "green"], &suggestions);
+}
+
+#[test]
+fn custom_completions_match_description_disabled_by_default() {
+    let (_, _, mut engine, mut stack) = new_engine();
+    let command = r#"
+        def comp [] {
+            [
+                { value: red,   description: "warm color" },
+                { value: blue,  description: "cool color" },
+                { value: green, description: "warm-ish color" },
+                { value: cyan,  description: "another cool one" },
+            ]
+        }
+        def my-command [arg: string@comp] {}"#;
+    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let completion_str = "my-command warm";
+    let suggestions = completer.complete(completion_str, completion_str.len());
+    match_suggestions(&Vec::<&str>::new(), &suggestions);
+}
+
+#[test]
 fn custom_completions_strip_ansi_from_values() {
     let (_, _, mut engine, mut stack) = new_engine();
     let command = r#"


### PR DESCRIPTION
## Description

Allow filtering custom completions by description

When a custom completer returns suggestions with descriptions, only the `value` field was matched against the user's prefix. This made it impossible to narrow down a list by typing a fragment of the human-readable description — e.g. completing an email like `lk446763made-up@gmx.net` by typing the user's name "Lennart".

Add a new `match_description` option (default `false`) to the custom completion options record. When enabled, `CustomCompletion::fetch` also checks each suggestion's `description` against the active prefix using the configured `match_algorithm`, keeping a suggestion if either its `value` or `description` matches. The completed value remains the suggestion's `value` — only filtering is affected. Default behavior is unchanged.

Per review feedback, the option lives on the `CompletionOptions` struct rather than being threaded around as a separate bool, keeping completion configuration in one place.

## User-facing changes (Release notes)

Custom completers can now opt into matching the user's prefix against suggestion descriptions in addition to values, by setting `match_description: true` in the returned `options` record. The inserted completion is still the suggestion's `value`.

```nu
def "nu-complete users" [] {
  {
    options: { match_description: true, completion_algorithm: "substring" }
    completions: [
      { value: "lk446763@example.com", description: "Lennart Kiil" }
      { value: "ab123456@example.com", description: "Alice Bob" }
    ]
  }
}
```

## Additional notes

Addresses #18139