### PR TITLE
Added dynamic dispatch for `%` sigil commands

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -126,6 +126,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             External,
             Exec,
             NuCheck,
+            RunInternal,
             Sys,
             SysCpu,
             SysDisks,

--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -1,6 +1,6 @@
 use crate::help::{help_aliases, help_commands, help_modules};
-use nu_engine::{HELP_DECL_ID_PARSER_INFO, command_prelude::*, get_full_help};
-use nu_protocol::{DeclId, ast::Expr, engine::CommandType};
+use nu_engine::{HELP_DECL_ID_PARSER_INFO, command_prelude::*, find_builtin_decl, get_full_help};
+use nu_protocol::{DeclId, ast::Expr};
 
 #[derive(Clone)]
 pub struct Help;
@@ -61,7 +61,7 @@ There already is an alternative `help` command in the standard library you can t
         if find.is_none()
             && let Some(name) = builtin_help_lookup_name(&rest)
         {
-            if let Some(decl_id) = find_builtin_decl_id(engine_state, &name) {
+            if let Some(decl_id) = find_builtin_decl(engine_state, &name) {
                 return Ok(help_for_decl_id(engine_state, stack, head, decl_id));
             }
 
@@ -188,18 +188,4 @@ fn builtin_help_lookup_name(rest: &[Spanned<String>]) -> Option<String> {
     }
 
     Some(name)
-}
-
-// Mirror parser-side `%` behavior by selecting only declarations with command type `Builtin`.
-fn find_builtin_decl_id(engine_state: &EngineState, name: &str) -> Option<DeclId> {
-    for idx in (0..engine_state.num_decls()).rev() {
-        let decl_id = DeclId::new(idx);
-        let decl = engine_state.get_decl(decl_id);
-
-        if decl.command_type() == CommandType::Builtin && decl.name() == name {
-            return Some(decl_id);
-        }
-    }
-
-    None
 }

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -16,6 +16,7 @@ mod registry;
 #[cfg(windows)]
 mod registry_query;
 mod run_external;
+mod run_internal;
 mod sys;
 mod uname;
 mod which_;
@@ -38,6 +39,7 @@ pub use registry::Registry;
 #[cfg(windows)]
 pub use registry_query::RegistryQuery;
 pub use run_external::{External, command_not_found, eval_external_arguments, which};
+pub use run_internal::RunInternal;
 pub use sys::*;
 pub use uname::UName;
 pub use which_::Which;

--- a/crates/nu-command/src/system/run_internal.rs
+++ b/crates/nu-command/src/system/run_internal.rs
@@ -1,0 +1,80 @@
+use nu_engine::{CallExt, command_prelude::*};
+use nu_protocol::{DeclId, engine::CommandType, ir};
+
+/// Find a built-in declaration by name, ignoring normal scope visibility.
+///
+/// This intentionally mirrors static `%name` behavior in the parser, where `%` means
+/// "resolve as built-in" even if a custom declaration shadows the same name.
+fn find_builtin_decl(engine_state: &EngineState, name: &[u8]) -> Option<DeclId> {
+    for idx in (0..engine_state.num_decls()).rev() {
+        let decl_id = DeclId::new(idx);
+        let decl = engine_state.get_decl(decl_id);
+        if decl.command_type() == CommandType::Builtin && decl.name().as_bytes() == name {
+            return Some(decl_id);
+        }
+    }
+
+    None
+}
+
+/// Internal command used by the `%($cmd)`/`%$cmd` dynamic builtin dispatch syntax.
+///
+/// The `%` sigil statically resolves a builtin at parse time. When the head is a runtime
+/// expression (`%($cmd)` or `%$cmd`), the parser defers resolution and the IR compiler
+/// rewrites the call as `run-internal <head-expr> ...args`. This command then looks up the
+/// target builtin at runtime and enforces that it is a `CommandType::Builtin`.
+#[derive(Clone)]
+pub struct RunInternal;
+
+impl Command for RunInternal {
+    fn name(&self) -> &str {
+        "run-internal"
+    }
+
+    fn description(&self) -> &str {
+        "Run a built-in command by name. Used internally by `%($cmd)` dynamic dispatch."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("run-internal")
+            .input_output_types(vec![(Type::Any, Type::Any)])
+            .required(
+                "name",
+                SyntaxShape::String,
+                "The name of the built-in command to run.",
+            )
+            .rest(
+                "args",
+                SyntaxShape::Any,
+                "Arguments to pass to the built-in command.",
+            )
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        let name: String = call.req(engine_state, stack, 0)?;
+        let rest_vals: Vec<Value> = call.rest(engine_state, stack, 1)?;
+
+        let decl_id = find_builtin_decl(engine_state, name.as_bytes())
+            .ok_or(ShellError::CommandNotFound { span: head })?;
+
+        let decl = engine_state.get_decl(decl_id);
+
+        // Build an IR call frame for the target builtin, forwarding the evaluated rest args.
+        let mut builder = ir::Call::build(decl_id, head);
+        for val in rest_vals {
+            builder.add_positional(stack, head, val);
+        }
+
+        // Ensure temporary IR arguments are always cleaned up after dispatch.
+        builder.with(stack, |stack, engine_call| {
+            decl.run(engine_state, stack, engine_call, input)
+        })
+    }
+}

--- a/crates/nu-command/src/system/run_internal.rs
+++ b/crates/nu-command/src/system/run_internal.rs
@@ -1,21 +1,5 @@
-use nu_engine::{CallExt, command_prelude::*};
-use nu_protocol::{DeclId, engine::CommandType, ir};
-
-/// Find a built-in declaration by name, ignoring normal scope visibility.
-///
-/// This intentionally mirrors static `%name` behavior in the parser, where `%` means
-/// "resolve as built-in" even if a custom declaration shadows the same name.
-fn find_builtin_decl(engine_state: &EngineState, name: &[u8]) -> Option<DeclId> {
-    for idx in (0..engine_state.num_decls()).rev() {
-        let decl_id = DeclId::new(idx);
-        let decl = engine_state.get_decl(decl_id);
-        if decl.command_type() == CommandType::Builtin && decl.name().as_bytes() == name {
-            return Some(decl_id);
-        }
-    }
-
-    None
-}
+use nu_engine::{CallExt, command_prelude::*, find_builtin_decl};
+use nu_protocol::ir;
 
 /// Internal command used by the `%($cmd)`/`%$cmd` dynamic builtin dispatch syntax.
 ///
@@ -60,7 +44,7 @@ impl Command for RunInternal {
         let head = call.head;
         let name: String = call.req(engine_state, stack, 0)?;
 
-        let decl_id = find_builtin_decl(engine_state, name.as_bytes())
+        let decl_id = find_builtin_decl(engine_state, &name)
             .ok_or(ShellError::CommandNotFound { span: head })?;
 
         let decl = engine_state.get_decl(decl_id);
@@ -72,13 +56,23 @@ impl Command for RunInternal {
         let mut builder = ir::Call::build(decl_id, head);
         for (val, is_spread) in rest_args {
             if is_spread {
-                builder.add_spread(stack, head, val);
+                // Skip empty spreads so builtins with no-argument defaults (e.g. `ls`
+                // listing the cwd when called with no path) are not confused by an
+                // empty `...$args` forwarded as an empty list.
+                match val {
+                    Value::List { ref vals, .. } if vals.is_empty() => continue,
+                    Value::Nothing { .. } => continue,
+                    _ => {
+                        builder.add_spread(stack, head, val);
+                    }
+                }
             } else {
                 builder.add_positional(stack, head, val);
             }
         }
 
-        // Ensure temporary IR arguments are always cleaned up after dispatch.
+        // `builder.with` is a scoped guard: it registers temporary IR argument slots,
+        // calls the closure, then always deallocates those slots on exit.
         builder.with(stack, |stack, engine_call| {
             decl.run(engine_state, stack, engine_call, input)
         })

--- a/crates/nu-command/src/system/run_internal.rs
+++ b/crates/nu-command/src/system/run_internal.rs
@@ -59,17 +59,23 @@ impl Command for RunInternal {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         let name: String = call.req(engine_state, stack, 0)?;
-        let rest_vals: Vec<Value> = call.rest(engine_state, stack, 1)?;
 
         let decl_id = find_builtin_decl(engine_state, name.as_bytes())
             .ok_or(ShellError::CommandNotFound { span: head })?;
 
         let decl = engine_state.get_decl(decl_id);
+        // Preserve spread markers here so `%($cmd) ...$args` forwards the same argument shape the
+        // target builtin would receive in a direct call.
+        let rest_args: Vec<(Value, bool)> = call.rest_preserving_spreads(engine_state, stack, 1)?;
 
-        // Build an IR call frame for the target builtin, forwarding the evaluated rest args.
+        // Build an IR call frame for the target builtin, preserving spread arguments.
         let mut builder = ir::Call::build(decl_id, head);
-        for val in rest_vals {
-            builder.add_positional(stack, head, val);
+        for (val, is_spread) in rest_args {
+            if is_spread {
+                builder.add_spread(stack, head, val);
+            } else {
+                builder.add_positional(stack, head, val);
+            }
         }
 
         // Ensure temporary IR arguments are always cleaned up after dispatch.

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -1,3 +1,4 @@
+use nu_test_support::fs::Stub;
 use nu_test_support::prelude::*;
 use rstest::rstest;
 use std::fs;
@@ -357,6 +358,22 @@ fn def_wrapped_explicit_string_rest_keeps_double_quoted_equals_value() {
 fn def_wrapped_explicit_string_rest_keeps_tilde_literal() {
     let actual = nu!("def --wrapped foo [...rest: string] { $rest.0 }; foo ~");
     assert_eq!(actual.out, "~");
+}
+
+#[test]
+fn def_wrapped_dynamic_percent_builtin_preserves_no_arg_defaults() {
+    Playground::setup(
+        "def_wrapped_dynamic_percent_builtin_preserves_no_arg_defaults",
+        |dirs, play| {
+            play.with_files(&[Stub::EmptyFile("probe.txt")]);
+            let actual = nu!(
+                cwd: dirs.test(),
+                "export def --wrapped builtin [arg1, ...args] { %($arg1) ...$args }; let direct = (ls | where name =~ 'probe.txt' | length); let wrapped = (builtin ls | where name =~ 'probe.txt' | length); [$direct $wrapped] | to nuon"
+            );
+
+            assert_eq!(actual.out, "[1, 1]");
+        },
+    );
 }
 
 #[test]

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -33,6 +33,18 @@ pub trait CallExt {
         starting_pos: usize,
     ) -> Result<Vec<T>, ShellError>;
 
+    /// Returns the rest arguments starting at `starting_pos`, preserving whether each item was
+    /// passed as a spread argument.
+    ///
+    /// The tuple contains `(value, is_spread)`. This differs from [`CallExt::rest()`], which
+    /// flattens spread arguments into a single list of values.
+    fn rest_preserving_spreads<T: FromValue>(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        starting_pos: usize,
+    ) -> Result<Vec<(T, bool)>, ShellError>;
+
     fn opt<T: FromValue>(
         &self,
         engine_state: &EngineState,
@@ -127,6 +139,21 @@ impl CallExt for ast::Call {
         .into_iter()
         .map(FromValue::from_value)
         .collect()
+    }
+
+    fn rest_preserving_spreads<T: FromValue>(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        starting_pos: usize,
+    ) -> Result<Vec<(T, bool)>, ShellError> {
+        let stack = &mut stack.use_call_arg_out_dest();
+        self.rest_iter(starting_pos)
+            .map(|(expr, is_spread)| {
+                let result = eval_expression::<WithoutDebug>(engine_state, stack, expr)?;
+                Ok((T::from_value(result)?, is_spread))
+            })
+            .collect()
     }
 
     fn opt<T: FromValue>(
@@ -256,6 +283,17 @@ impl CallExt for ir::Call {
             .collect()
     }
 
+    fn rest_preserving_spreads<T: FromValue>(
+        &self,
+        _engine_state: &EngineState,
+        stack: &mut Stack,
+        starting_pos: usize,
+    ) -> Result<Vec<(T, bool)>, ShellError> {
+        self.rest_iter(stack, starting_pos)
+            .map(|(val, is_spread)| Ok((T::from_value(val.clone())?, is_spread)))
+            .collect()
+    }
+
     fn opt<T: FromValue>(
         &self,
         _engine_state: &EngineState,
@@ -366,6 +404,15 @@ impl CallExt for engine::Call<'_> {
         starting_pos: usize,
     ) -> Result<Vec<T>, ShellError> {
         proxy!(self.rest(engine_state, stack, starting_pos))
+    }
+
+    fn rest_preserving_spreads<T: FromValue>(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        starting_pos: usize,
+    ) -> Result<Vec<(T, bool)>, ShellError> {
+        proxy!(self.rest_preserving_spreads(engine_state, stack, starting_pos))
     }
 
     fn opt<T: FromValue>(

--- a/crates/nu-engine/src/compile/call.rs
+++ b/crates/nu-engine/src/compile/call.rs
@@ -16,6 +16,37 @@ pub(crate) fn compile_call(
     input_reg: Option<RegId>,
     io_reg: RegId,
 ) -> Result<(), CompileError> {
+    // Handle dynamic percent builtin dispatch: `%($cmd)` or `%$cmd`.
+    // The parser stored the head expression in parser_info as a placeholder.
+    // Rewrite this call as `run-internal <head-expr> ...args`, mirroring how
+    // `compile_external_call` rewrites dynamic external calls to `run-external`.
+    if let Some(head_expr) = call.parser_info.get("percent_forced_builtin") {
+        let run_internal_id = working_set.find_decl(b"run-internal").ok_or_else(|| {
+            CompileError::MissingRequiredDeclaration {
+                decl_name: "run-internal".into(),
+                span: call.head,
+            }
+        })?;
+
+        let mut new_call = Call::new(call.head);
+        new_call.decl_id = run_internal_id;
+        new_call
+            .arguments
+            .push(Argument::Positional(head_expr.clone()));
+        for arg in &call.arguments {
+            new_call.arguments.push(arg.clone());
+        }
+
+        return compile_call(
+            working_set,
+            builder,
+            &new_call,
+            redirect_modes,
+            input_reg,
+            io_reg,
+        );
+    }
+
     let decl = working_set.get_decl(call.decl_id);
 
     // Check if this call has --help - if so, just redirect to `help`

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -26,3 +26,4 @@ pub use eval::{
 pub use eval_helpers::*;
 pub use eval_ir::eval_ir_block;
 pub use glob_from::glob_from;
+pub use scope::find_builtin_decl;

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -1,7 +1,7 @@
 use nu_protocol::{
     CommandWideCompleter, DeclId, ModuleId, Signature, Span, Type, Value, VarId,
     ast::Expr,
-    engine::{Command, EngineState, Stack, Visibility},
+    engine::{Command, CommandType, EngineState, Stack, Visibility},
     record,
 };
 use std::{cmp::Ordering, collections::HashMap};
@@ -590,4 +590,20 @@ fn sort_rows(decls: &mut [Value]) {
         }
         _ => Ordering::Equal,
     });
+}
+
+/// Find the first declaration with `CommandType::Builtin` whose name matches `name`,
+/// scanning from the most-recently registered declaration backwards.
+///
+/// This mirrors the static `%name` parser behavior: `%` always resolves to a built-in,
+/// even when a custom declaration shadows the same name in the current scope.
+pub fn find_builtin_decl(engine_state: &EngineState, name: &str) -> Option<DeclId> {
+    for idx in (0..engine_state.num_decls()).rev() {
+        let decl_id = DeclId::new(idx);
+        let decl = engine_state.get_decl(decl_id);
+        if decl.command_type() == CommandType::Builtin && decl.name() == name {
+            return Some(decl_id);
+        }
+    }
+    None
 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -27,6 +27,8 @@ use std::{
     sync::Arc,
 };
 
+pub(crate) const PERCENT_FORCED_BUILTIN_PARSER_INFO: &str = "percent_forced_builtin";
+
 pub fn garbage(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     Expression::garbage(working_set, span)
 }
@@ -1444,6 +1446,53 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
     if call_sigil == Some(b'^') {
         trace!("parsing: forced external call");
         return parse_external_call(working_set, resolution_spans, call_span);
+    }
+
+    // Check if we have a percent sigil with a dynamic head (variable or expression).
+    // Supports two token layouts:
+    //   - single token: `%$cmd` or `%($cmd)` — stripping `%` leaves `$cmd` / `($cmd)` in [0]
+    //   - two tokens:   `%` and `($cmd)`    — stripping `%` leaves an empty span in [0]; head is [1]
+    // If so, defer builtin validation to runtime (the IR compiler will rewrite to `run-internal`).
+    if call_sigil == Some(b'%') && !resolution_spans.is_empty() {
+        // Locate the actual head span, skipping an empty leading span.
+        let (head_idx, head_span) = {
+            let first = working_set.get_span_contents(resolution_spans[0]);
+            if first.is_empty() && resolution_spans.len() > 1 {
+                (1, resolution_spans[1])
+            } else {
+                (0, resolution_spans[0])
+            }
+        };
+
+        let dynamic_head_contents = working_set.get_span_contents(head_span);
+        let is_dynamic_head = !dynamic_head_contents.is_empty()
+            && (dynamic_head_contents[0] == b'$' || dynamic_head_contents[0] == b'(');
+
+        if is_dynamic_head {
+            trace!("parsing: dynamic percent builtin dispatch");
+
+            let head_expr = parse_expression(working_set, &[head_span]);
+
+            // Create a placeholder call; the IR compiler will rewrite this to `run-internal`.
+            let mut call = Call::new(call_span);
+            call.decl_id = DeclId::new(0);
+
+            // Store the head expression for the IR compiler to pick up.
+            call.set_parser_info(PERCENT_FORCED_BUILTIN_PARSER_INFO.to_string(), head_expr);
+
+            // Parse remaining spans as positional arguments.
+            for arg_span in resolution_spans.iter().skip(head_idx + 1) {
+                let arg_expr = parse_value(working_set, *arg_span, &SyntaxShape::Any);
+                call.arguments.push(Argument::Positional(arg_expr));
+            }
+
+            return Expression::new(
+                working_set,
+                Expr::Call(Box::new(call)),
+                call_span,
+                Type::Any,
+            );
+        }
     }
 
     let (cmd_start, pos, _name, maybe_decl_id) = if call_sigil == Some(b'%') {
@@ -6467,6 +6516,9 @@ pub fn parse_builtin_commands(
                     expr: Expr::Call(call),
                     ..
                 } = call_expr
+                    && !call
+                        .parser_info
+                        .contains_key(PERCENT_FORCED_BUILTIN_PARSER_INFO)
                 {
                     // Apply parse keyword side effects
                     let cmd = working_set.get_decl(call.decl_id);
@@ -6560,6 +6612,18 @@ pub fn parse_builtin_commands(
                 ..
             } = &element.expr
             {
+                // Dynamic percent dispatch stores a placeholder call plus parser
+                // metadata for later IR rewrite. Skip parser-keyword side-effects lookup here,
+                // because there is no declaration to resolve yet.
+                if call
+                    .parser_info
+                    .contains_key(PERCENT_FORCED_BUILTIN_PARSER_INFO)
+                {
+                    return Pipeline {
+                        elements: vec![element],
+                    };
+                }
+
                 // Apply parse keyword side effects
                 let cmd = working_set.get_decl(call.decl_id);
                 match cmd.name() {
@@ -7240,49 +7304,53 @@ pub fn discover_captures_in_expr(
         Expr::Binary(_) => {}
         Expr::Bool(_) => {}
         Expr::Call(call) => {
-            let decl = working_set.get_decl(call.decl_id);
-            if let Some(block_id) = decl.block_id() {
-                match seen_blocks.get(&block_id) {
-                    Some(capture_list) => {
-                        // Push captures onto the outer closure that aren't created by that outer closure
-                        for capture in capture_list {
-                            if !seen.contains(&capture.0) {
-                                output.push(*capture);
-                            }
-                        }
-                    }
-                    None => {
-                        let block = working_set.get_block(block_id);
-                        if !block.captures.is_empty() {
-                            for (capture, span) in &block.captures {
-                                if !seen.contains(capture) {
-                                    output.push((*capture, *span));
-                                }
-                            }
-                        } else {
-                            let result = {
-                                let mut seen = vec![];
-                                seen_blocks.insert(block_id, vec![]);
-
-                                let mut result = vec![];
-                                discover_captures_in_closure(
-                                    working_set,
-                                    block,
-                                    &mut seen,
-                                    seen_blocks,
-                                    &mut result,
-                                )?;
-
-                                result
-                            };
+            if let Some(head_expr) = call.parser_info.get(PERCENT_FORCED_BUILTIN_PARSER_INFO) {
+                discover_captures_in_expr(working_set, head_expr, seen, seen_blocks, output)?;
+            } else {
+                let decl = working_set.get_decl(call.decl_id);
+                if let Some(block_id) = decl.block_id() {
+                    match seen_blocks.get(&block_id) {
+                        Some(capture_list) => {
                             // Push captures onto the outer closure that aren't created by that outer closure
-                            for capture in &result {
+                            for capture in capture_list {
                                 if !seen.contains(&capture.0) {
                                     output.push(*capture);
                                 }
                             }
+                        }
+                        None => {
+                            let block = working_set.get_block(block_id);
+                            if !block.captures.is_empty() {
+                                for (capture, span) in &block.captures {
+                                    if !seen.contains(capture) {
+                                        output.push((*capture, *span));
+                                    }
+                                }
+                            } else {
+                                let result = {
+                                    let mut seen = vec![];
+                                    seen_blocks.insert(block_id, vec![]);
 
-                            seen_blocks.insert(block_id, result);
+                                    let mut result = vec![];
+                                    discover_captures_in_closure(
+                                        working_set,
+                                        block,
+                                        &mut seen,
+                                        seen_blocks,
+                                        &mut result,
+                                    )?;
+
+                                    result
+                                };
+                                // Push captures onto the outer closure that aren't created by that outer closure
+                                for capture in &result {
+                                    if !seen.contains(&capture.0) {
+                                        output.push(*capture);
+                                    }
+                                }
+
+                                seen_blocks.insert(block_id, result);
+                            }
                         }
                     }
                 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1480,10 +1480,24 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
             // Store the head expression for the IR compiler to pick up.
             call.set_parser_info(PERCENT_FORCED_BUILTIN_PARSER_INFO.to_string(), head_expr);
 
-            // Parse remaining spans as positional arguments.
+            // Mirror the dynamic external-call path by preserving `...expr` as an explicit spread
+            // argument so runtime dispatch can forward it without flattening first.
             for arg_span in resolution_spans.iter().skip(head_idx + 1) {
-                let arg_expr = parse_value(working_set, *arg_span, &SyntaxShape::Any);
-                call.arguments.push(Argument::Positional(arg_expr));
+                let contents = working_set.get_span_contents(*arg_span);
+                if contents.len() > 3
+                    && contents.starts_with(b"...")
+                    && (contents[3] == b'$' || contents[3] == b'[' || contents[3] == b'(')
+                {
+                    let spread_expr = parse_value(
+                        working_set,
+                        Span::new(arg_span.start + 3, arg_span.end),
+                        &SyntaxShape::List(Box::new(SyntaxShape::Any)),
+                    );
+                    call.arguments.push(Argument::Spread(spread_expr));
+                } else {
+                    let arg_expr = parse_value(working_set, *arg_span, &SyntaxShape::Any);
+                    call.arguments.push(Argument::Positional(arg_expr));
+                }
             }
 
             return Expression::new(

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -792,6 +792,13 @@ pub fn check_pipeline_type(
             continue;
         }
         if let Expr::Call(call) = &elem.expr.expr {
+            // Dynamic percent dispatch uses a placeholder decl_id that is rewritten later in IR.
+            // Defer type constraints for this call at parse/type-check time.
+            if call.parser_info.contains_key("percent_forced_builtin") {
+                new_types = vec![Type::Any];
+                continue;
+            }
+
             let decl = working_set.get_decl(call.decl_id);
             let io_types = decl.signature().input_output_types;
             if new_types.contains(&Type::Any) {

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -922,6 +922,78 @@ fn parse_percent_prefixed_internal_call() {
 }
 
 #[test]
+fn parse_percent_prefixed_dynamic_dispatch() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let block = parse(&mut working_set, None, b"%('echo') hello", true);
+
+    assert!(working_set.parse_errors.is_empty());
+
+    let pipeline = &block.pipelines[0];
+    let element = &pipeline.elements[0];
+
+    match &element.expr.expr {
+        Expr::Call(call) => {
+            // Check that the call has the percent_forced_builtin marker
+            assert!(call.parser_info.contains_key("percent_forced_builtin"));
+        }
+        other => {
+            panic!("Expected internal call with percent marker, got: {other:?}");
+        }
+    }
+}
+
+#[test]
+fn parse_percent_prefixed_dynamic_dispatch_bare_var() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let block = parse(&mut working_set, None, b"%$cmd hello", true);
+
+    assert!(
+        working_set
+            .parse_errors
+            .iter()
+            .any(|err| matches!(err, ParseError::VariableNotFound(..)))
+    );
+
+    let pipeline = &block.pipelines[0];
+    let element = &pipeline.elements[0];
+
+    match &element.expr.expr {
+        Expr::Call(call) => {
+            assert!(call.parser_info.contains_key("percent_forced_builtin"));
+        }
+        other => {
+            panic!("Expected internal call with percent marker, got: {other:?}");
+        }
+    }
+}
+
+#[test]
+fn parse_percent_prefixed_dynamic_dispatch_with_spaced_head() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let block = parse(&mut working_set, None, b"% ('echo') hello", true);
+
+    assert!(working_set.parse_errors.is_empty());
+
+    let pipeline = &block.pipelines[0];
+    let element = &pipeline.elements[0];
+
+    match &element.expr.expr {
+        Expr::Call(call) => {
+            assert!(call.parser_info.contains_key("percent_forced_builtin"));
+        }
+        other => {
+            panic!("Expected internal call with percent marker, got: {other:?}");
+        }
+    }
+}
+
+#[test]
 fn parse_caret_prefixed_call_forces_external_parse() {
     let mut engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -994,6 +994,34 @@ fn parse_percent_prefixed_dynamic_dispatch_with_spaced_head() {
 }
 
 #[test]
+fn parse_percent_prefixed_dynamic_dispatch_with_spread_arg() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let block = parse(&mut working_set, None, b"%('echo') ...$args", true);
+
+    assert!(
+        working_set
+            .parse_errors
+            .iter()
+            .any(|err| matches!(err, ParseError::VariableNotFound(..)))
+    );
+
+    let pipeline = &block.pipelines[0];
+    let element = &pipeline.elements[0];
+
+    match &element.expr.expr {
+        Expr::Call(call) => {
+            assert!(call.parser_info.contains_key("percent_forced_builtin"));
+            assert!(matches!(call.arguments.first(), Some(Argument::Spread(_))));
+        }
+        other => {
+            panic!("Expected internal call with percent marker, got: {other:?}");
+        }
+    }
+}
+
+#[test]
 fn parse_caret_prefixed_call_forces_external_parse() {
     let mut engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -519,6 +519,60 @@ fn percent_requires_builtin(#[case] code: &str) -> Result {
 }
 
 #[test]
+fn percent_dynamic_dispatch_with_builtin() -> Result {
+    let code = "let cmd = 'echo'; %($cmd) 'hello'";
+    test().run(code).expect_value_eq("hello")
+}
+
+#[test]
+fn percent_dynamic_dispatch_bare_var() -> Result {
+    let code = "let cmd = 'echo'; %$cmd 'hello'";
+    test().run(code).expect_value_eq("hello")
+}
+
+#[test]
+fn percent_dynamic_dispatch_with_paren_expr() -> Result {
+    let code = "%('echo') 'world'";
+    test().run(code).expect_value_eq("world")
+}
+
+#[test]
+fn percent_dynamic_dispatch_with_non_builtin() -> Result {
+    let code = "let cmd = 'my_nonexistent_cmd'; %($cmd)";
+    let err = test().run(code).expect_error()?;
+    assert!(matches!(err, ShellError::CommandNotFound { .. }));
+    Ok(())
+}
+
+#[test]
+fn percent_dynamic_dispatch_with_custom_command() -> Result {
+    let code = "def custom_cmd [] { 'nope' }; let cmd = 'custom_cmd'; %($cmd)";
+    let err = test().run(code).expect_error()?;
+    assert!(matches!(err, ShellError::CommandNotFound { .. }));
+    Ok(())
+}
+
+#[test]
+fn percent_dynamic_dispatch_prefers_builtin_when_custom_shadows_name() -> Result {
+    let code = "def echo [] { 'shadowed' }; let cmd = 'echo'; %($cmd) 'hello'";
+    test().run(code).expect_value_eq("hello")
+}
+
+#[test]
+fn percent_dynamic_dispatch_prefers_builtin_inside_same_name_wrapper() -> Result {
+    let code = "def echo [] { 'shadowed' }; def wrapper [cmd] { %($cmd) 'hello' }; wrapper 'echo'";
+    test().run(code).expect_value_eq("hello")
+}
+
+#[test]
+fn percent_dynamic_dispatch_alias_to_custom_command_is_not_builtin() -> Result {
+    let code = "def custom_cmd [] { 'shadowed' }; alias maybe_builtin = custom_cmd; let cmd = 'maybe_builtin'; %($cmd)";
+    let err = test().run(code).expect_error()?;
+    assert!(matches!(err, ShellError::CommandNotFound { .. }));
+    Ok(())
+}
+
+#[test]
 fn string_interpolation_paren_test() -> TestResult {
     run_test(r#"$"('(')(')')""#, "()")
 }

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -1,6 +1,6 @@
 use crate::repl::tests::{TestResult, fail_test, run_test, run_test_contains, run_test_with_env};
 use nu_protocol::ParseError;
-use nu_test_support::{nu_repl_code, prelude::*};
+use nu_test_support::{fs::Stub, nu_repl_code, prelude::*};
 use rstest::rstest;
 use std::collections::HashMap;
 
@@ -588,6 +588,21 @@ fn percent_dynamic_dispatch_with_mixed_positional_and_spread_args() -> Result {
 fn percent_dynamic_dispatch_in_wrapped_command_forwards_rest_args() -> Result {
     let code = "export def --wrapped builtin [arg1, ...args] { %($arg1) ...$args }; builtin echo hello world | to nuon";
     test().run(code).expect_value_eq(r#"["hello", "world"]"#)
+}
+
+#[test]
+fn percent_dynamic_dispatch_in_wrapped_command_preserves_no_arg_builtin_defaults() {
+    Playground::setup(
+        "percent_dynamic_dispatch_in_wrapped_command_preserves_no_arg_builtin_defaults",
+        |dirs, play| {
+            play.with_files(&[Stub::EmptyFile("probe.txt")]);
+            let actual = nu!(
+                cwd: dirs.test(),
+                "export def --wrapped builtin [arg1, ...args] { %($arg1) ...$args }; let direct = (ls | where name =~ 'probe.txt' | length); let wrapped = (builtin ls | where name =~ 'probe.txt' | length); [$direct $wrapped] | to nuon"
+            );
+            assert_eq!(actual.out, "[1, 1]");
+        },
+    );
 }
 
 #[test]

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -573,6 +573,24 @@ fn percent_dynamic_dispatch_alias_to_custom_command_is_not_builtin() -> Result {
 }
 
 #[test]
+fn percent_dynamic_dispatch_with_spread_args() -> Result {
+    let code = "let cmd = 'echo'; let args = ['hello' 'world']; %($cmd) ...$args | to nuon";
+    test().run(code).expect_value_eq("[hello, world]")
+}
+
+#[test]
+fn percent_dynamic_dispatch_with_mixed_positional_and_spread_args() -> Result {
+    let code = "let cmd = 'echo'; let args = ['middle' 'end']; %($cmd) 'start' ...$args | to nuon";
+    test().run(code).expect_value_eq("[start, middle, end]")
+}
+
+#[test]
+fn percent_dynamic_dispatch_in_wrapped_command_forwards_rest_args() -> Result {
+    let code = "export def --wrapped builtin [arg1, ...args] { %($arg1) ...$args }; builtin echo hello world | to nuon";
+    test().run(code).expect_value_eq(r#"["hello", "world"]"#)
+}
+
+#[test]
 fn string_interpolation_paren_test() -> TestResult {
     run_test(r#"$"('(')(')')""#, "()")
 }


### PR DESCRIPTION
## Description

This PR adds dynamic builtin dispatch for the percent sigil so users can write:

- %($cmd) arg1 arg2
- %$cmd arg1 arg2

Previously, percent dispatch only worked when the command name was statically known at parse time. With this change, the builtin name can come from a runtime expression while still preserving percent semantics: resolve and run builtin commands only.

<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)

Nushell now supports dynamic percent builtin dispatch with forms like %($cmd) and %$cmd.

This preserves percent safety semantics while allowing runtime command selection:

- only builtins are eligible targets
- non-builtin/custom/alias targets are rejected
- arguments are forwarded as parsed values (not string-evaluated like shell eval)

This should work very similarly to dynamic dispatch of externals. The same model was followed to implement it.

Here's a couple examples that are also tests.
### Built-ins resolve
```nushell
❯ let cmd = 'echo'; %$cmd 'hello'
hello
❯ %('echo') 'world'
world
❯ let cmd = 'echo'; %($cmd) 'hello'
hello
```
### Missing commands fail
```nushell
❯ let cmd = 'my_nonexistent_cmd'; %($cmd)
Error: nu::shell::command_not_found

  × Command not found
   ╭─[repl_entry #7:1:33]
 1 │ let cmd = 'my_nonexistent_cmd'; %($cmd)
   ·                                 ───┬───
   ·                                    ╰── command not found
   ╰────
```
### Custom commands aren't built-in commands so they fail too
```nushell
❯ def custom_cmd [] { 'nope' }; let cmd = 'custom_cmd'; %($cmd)
Error: nu::shell::command_not_found

  × Command not found
   ╭─[repl_entry #8:1:55]
 1 │ def custom_cmd [] { 'nope' }; let cmd = 'custom_cmd'; %($cmd)
   ·                                                       ───┬───
   ·                                                          ╰── command not found
   ╰────
```

<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
closes https://github.com/nushell/nushell/issues/18150
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->