### PR TITLE
Fix cp --no-dereference for symlinks

### DIFF
--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -4,7 +4,7 @@ use nu_protocol::{
     NuGlob,
     shell_error::{self, generic::GenericError, io::IoError},
 };
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use uu_cp::{BackupMode, CopyMode, CpError, UpdateMode};
 use uucore::{localized_help_template, translate};
 
@@ -36,6 +36,11 @@ impl Command for UCp {
         Signature::build("cp")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .switch("recursive", "Copy directories recursively.", Some('r'))
+            .switch(
+                "no-dereference",
+                "Copy symbolic links as symbolic links instead of their targets.",
+                Some('P'),
+            )
             .switch("verbose", "Explicitly state what is being done.", Some('v'))
             .switch(
                 "force",
@@ -105,6 +110,11 @@ impl Command for UCp {
                 result: None,
             },
             Example {
+                description: "Copy a symbolic link without copying the target.",
+                example: "cp --no-dereference link-to-file newlink",
+                result: None,
+            },
+            Example {
                 description: "Copy file to a directory three levels above its current location.",
                 example: "cp myfile ....",
                 result: None,
@@ -133,6 +143,7 @@ impl Command for UCp {
         let no_clobber = call.has_flag(engine_state, stack, "no-clobber")?;
         let progress = call.has_flag(engine_state, stack, "progress")?;
         let recursive = call.has_flag(engine_state, stack, "recursive")?;
+        let no_dereference = call.has_flag(engine_state, stack, "no-dereference")?;
         let verbose = call.has_flag(engine_state, stack, "verbose")?;
         let preserve: Option<Value> = call.get_flag(engine_state, stack, "preserve")?;
         let all = call.has_flag(engine_state, stack, "all")?;
@@ -221,7 +232,7 @@ impl Command for UCp {
             for v in exp_files {
                 match v {
                     Ok(path) => {
-                        if !recursive && path.is_dir() {
+                        if !recursive && source_path_is_dir(&path, !no_dereference) {
                             return Err(ShellError::Generic(
                                 GenericError::new(
                                     "could_not_copy_directory",
@@ -259,7 +270,7 @@ impl Command for UCp {
             debug,
             attributes,
             verbose: verbose || debug,
-            dereference: !recursive,
+            dereference: !recursive && !no_dereference,
             progress_bar: progress,
             attributes_only: false,
             backup: BackupMode::None,
@@ -325,6 +336,16 @@ fn make_attributes(preserve: Option<Value>) -> Result<uu_cp::Attributes, ShellEr
         // https://docs.rs/uu_cp/latest/uu_cp/struct.Attributes.html
         Ok(uu_cp::Attributes::NONE)
     }
+}
+
+fn source_path_is_dir(path: &Path, follow_symlink: bool) -> bool {
+    if follow_symlink {
+        return path.is_dir();
+    }
+
+    matches!(path.symlink_metadata(),
+        Ok(metadata) if metadata.file_type().is_dir()
+    )
 }
 
 fn parse_and_set_attributes_list(

--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -618,6 +618,62 @@ fn copy_file_with_read_permission_impl(progress: bool) {
     });
 }
 
+#[test]
+fn copies_file_symlink_without_dereferencing() {
+    copies_file_symlink_without_dereferencing_impl(false);
+    copies_file_symlink_without_dereferencing_impl(true);
+}
+
+fn copies_file_symlink_without_dereferencing_impl(progress: bool) {
+    Playground::setup("ucp_file_symlink_no_dereference", |_dirs, sandbox| {
+        sandbox
+            .with_files(&[EmptyFile("file")])
+            .symlink("file", "link_to_file");
+
+        let progress_flag = if progress { "-p" } else { "" };
+
+        nu!(
+            cwd: sandbox.cwd(),
+            format!(
+                "cp {progress_flag} --no-dereference link_to_file second_link_to_file"
+            )
+        );
+
+        let second_link = sandbox.cwd().join("second_link_to_file");
+        assert!(second_link.is_symlink());
+        assert_eq!(
+            std::fs::read_link(second_link).unwrap(),
+            sandbox.cwd().join("file")
+        );
+    });
+}
+
+#[test]
+fn copies_directory_symlink_without_dereferencing() {
+    copies_directory_symlink_without_dereferencing_impl(false);
+    copies_directory_symlink_without_dereferencing_impl(true);
+}
+
+fn copies_directory_symlink_without_dereferencing_impl(progress: bool) {
+    Playground::setup("ucp_dir_symlink_no_dereference", |_dirs, sandbox| {
+        sandbox.mkdir("dir").symlink("dir", "link_to_dir");
+
+        let progress_flag = if progress { "-p" } else { "" };
+
+        nu!(
+            cwd: sandbox.cwd(),
+            format!("cp {progress_flag} -P link_to_dir second_link_to_dir")
+        );
+
+        let second_link = sandbox.cwd().join("second_link_to_dir");
+        assert!(second_link.is_symlink());
+        assert_eq!(
+            std::fs::read_link(second_link).unwrap(),
+            sandbox.cwd().join("dir")
+        );
+    });
+}
+
 // uutils/coreutils copy tests
 static TEST_EXISTING_FILE: &str = "existing_file.txt";
 static TEST_HELLO_WORLD_SOURCE: &str = "hello_world.txt";


### PR DESCRIPTION
## Description

This PR fixes `cp` so symlinks can be copied as symlinks instead of always being dereferenced.

Before this change, `cp` had two user-visible issues here:
- copying a symlink to a directory failed early with the usual “Directories must be copied using `--recursive`” error
- copying a symlink to a file would only copy the target file contents, with no way to preserve the link itself

This adds `-P` / `--no-dereference` to Nushell's `cp` command and passes that behavior through to the existing `uu_cp` implementation. I also updated the local directory check so it matches the requested symlink behavior instead of rejecting directory symlinks before the copy logic runs.

I added:
- a `cp --no-dereference` example
- regression tests for both file symlinks and directory symlinks
- assertions that the copied symlink still points to the same target

## User-facing changes (Release notes)

Fixed an issue where `cp` could not copy symbolic links as links. Nushell now supports `cp -P` and `cp --no-dereference`, including for symlinks that point to directories.

## Additional notes

Fixes #18147