### PR TITLE
make mv -v and mkdir -v returns structured data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4559,6 +4559,7 @@ dependencies = [
  "fff-search",
  "filesize",
  "filetime",
+ "fluent",
  "fuzzy-matcher",
  "getrandom 0.4.2",
  "http 1.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ fancy-regex = "0.18"
 filesize = "0.2"
 filetime = "0.2.27"
 fff-search = { version = "0.7.0", default-features = false }
+fluent = "0.17.0"
 fuzzy-matcher = { version = "^0.3.7" }
 gatekeeper = "3.0.0"
 heck = "0.5.0"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -66,6 +66,7 @@ encoding_rs = { workspace = true }
 fancy-regex = { workspace = true }
 filesize = { workspace = true }
 filetime = { workspace = true }
+fluent = { workspace = true }
 fuzzy-matcher = { workspace = true }
 http = { workspace = true }
 human-date-parser = { workspace = true }

--- a/crates/nu-command/src/filesystem/umkdir.rs
+++ b/crates/nu-command/src/filesystem/umkdir.rs
@@ -41,7 +41,23 @@ impl Command for UMkdir {
 
     fn signature(&self) -> Signature {
         Signature::build("mkdir")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![
+                (Type::Nothing, Type::Nothing),
+                (
+                    Type::Nothing,
+                    Type::Table(
+                        [
+                            ("path".to_string(), Type::String),
+                            ("created".to_string(), Type::Bool),
+                            (
+                                "error".to_string(),
+                                Type::OneOf([Type::Nothing, Type::Error].into()),
+                            ),
+                        ]
+                        .into(),
+                    ),
+                ),
+            ])
             .rest(
                 "rest",
                 SyntaxShape::OneOf(vec![SyntaxShape::GlobPattern, SyntaxShape::Directory]),
@@ -84,36 +100,47 @@ impl Command for UMkdir {
         let config = uu_mkdir::Config {
             recursive: IS_RECURSIVE,
             mode: get_mode(),
-            verbose: is_verbose,
+            verbose: false,
             set_security_context: false,
             context: None,
         };
 
-        let mut verbose_out = String::new();
+        let mut verbose_out = Vec::new();
         for dir in directories {
             if let Err(error) = mkdir(&dir, &config) {
-                return Err(ShellError::Generic(GenericError::new_internal(
-                    format!("{error}"),
-                    translate!(&error.to_string()),
-                )));
-            }
-            if is_verbose {
-                verbose_out.push_str(
-                    format!(
-                        "{} ",
-                        &dir.as_path()
-                            .file_name()
-                            .unwrap_or_default()
-                            .to_string_lossy()
+                if is_verbose {
+                    verbose_out.push(
+                        record! {
+                            "path" => Value::string(dir.display().to_string(), call.head),
+                            "created" => Value::bool(false, call.head),
+                            "error" => Value::error(ShellError::Generic(GenericError::new_internal(
+                                format!("{error}"),
+                                translate!(&error.to_string()),
+                            )), call.head),
+                        }
+                        .into_value(call.head),
                     )
-                    .as_str(),
+                } else {
+                    return Err(ShellError::Generic(GenericError::new_internal(
+                        format!("{error}"),
+                        translate!(&error.to_string()),
+                    )));
+                }
+            } else if is_verbose {
+                verbose_out.push(
+                    record! {
+                        "path" => Value::string(dir.display().to_string(), call.head),
+                        "created" => Value::bool(true, call.head),
+                        "error" => Value::nothing(call.head),
+                    }
+                    .into_value(call.head),
                 );
             }
         }
 
         if is_verbose {
             Ok(PipelineData::value(
-                Value::string(verbose_out.trim(), call.head),
+                Value::list(verbose_out, call.head),
                 None,
             ))
         } else {
@@ -131,7 +158,24 @@ impl Command for UMkdir {
             Example {
                 description: "Make multiple directories and show the paths created.",
                 example: "mkdir -v foo/bar foo2",
-                result: None,
+                result: Some(Value::test_list(vec![
+                    Value::record(
+                        record! {
+                            "path" => Value::string("foo/bar".to_string(), Span::test_data()),
+                            "created" => Value::bool(true, Span::test_data()),
+                            "error" => Value::nothing(Span::test_data()),
+                        },
+                        Span::test_data(),
+                    ),
+                    Value::record(
+                        record! {
+                            "path" => Value::string("foo2".to_string(), Span::test_data()),
+                            "created" => Value::bool(true, Span::test_data()),
+                            "error" => Value::nothing(Span::test_data()),
+                        },
+                        Span::test_data(),
+                    ),
+                ])),
             },
         ]
     }

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -2,7 +2,7 @@ use nu_engine::command_prelude::*;
 use nu_glob::MatchOptions;
 use nu_path::expand_path_with;
 use nu_protocol::{
-    NuGlob,
+    NuGlob, record,
     shell_error::{self, generic::GenericError, io::IoError},
 };
 use std::{ffi::OsString, path::PathBuf};
@@ -48,6 +48,18 @@ impl Command for UMv {
                 example: "mv test.txt .../my/",
                 result: None,
             },
+            Example {
+                description: "Move a file and show what is being done.",
+                example: "mv -v before.txt after.txt",
+                result: Some(Value::test_list(vec![
+                    record! {
+                        "source" => Value::string("before.txt", Span::test_data()),
+                        "destination" => Value::string("after.txt", Span::test_data()),
+                        "message" => Value::string("renamed ", Span::test_data()),
+                    }
+                    .into_value(Span::test_data()),
+                ])),
+            },
         ]
     }
 
@@ -57,7 +69,20 @@ impl Command for UMv {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("mv")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![
+                (
+                    Type::Nothing,
+                    Type::Table(
+                        [
+                            ("source".into(), Type::String),
+                            ("destination".into(), Type::String),
+                            ("message".into(), Type::String),
+                        ]
+                        .into(),
+                    ),
+                ),
+                (Type::Nothing, Type::Nothing),
+            ])
             .switch("force", "Do not prompt before overwriting.", Some('f'))
             .switch("verbose", "Explain what is being done.", Some('v'))
             .switch("progress", "Display a progress bar.", Some('p'))
@@ -182,7 +207,7 @@ impl Command for UMv {
                 }
             }
         }
-        let mut files: Vec<PathBuf> = files.into_iter().flat_map(|x| x.0).collect();
+        let source_files: Vec<PathBuf> = files.into_iter().flat_map(|x| x.0).collect();
 
         // Add back the target after globbing
         let abs_target_path = expand_path_with(
@@ -190,15 +215,33 @@ impl Command for UMv {
             &cwd,
             matches!(spanned_target.item, NuGlob::Expand(..)),
         );
-        files.push(abs_target_path.clone());
-        let files = files
+
+        // Collect verbose messages before the move
+        let verbose_msgs: Vec<(PathBuf, PathBuf)> = if verbose {
+            source_files
+                .iter()
+                .map(|src| {
+                    let dest = if abs_target_path.is_dir() {
+                        abs_target_path.join(src.file_name().unwrap_or_default())
+                    } else {
+                        abs_target_path.clone()
+                    };
+                    (src.clone(), dest)
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let mut files_for_mv = source_files;
+        files_for_mv.push(abs_target_path.clone());
+        let files_for_mv = files_for_mv
             .into_iter()
             .map(|p| p.into_os_string())
             .collect::<Vec<OsString>>();
         let options = uu_mv::Options {
             overwrite,
             progress_bar: progress,
-            verbose,
+            verbose: false,
             suffix: String::from("~"),
             backup: BackupMode::None,
             update,
@@ -208,12 +251,32 @@ impl Command for UMv {
             debug: false,
             context: None,
         };
-        if let Err(error) = uu_mv::mv(&files, &options) {
+        if let Err(error) = uu_mv::mv(&files_for_mv, &options) {
             return Err(ShellError::Generic(GenericError::new_internal(
                 format!("{error}"),
                 translate!(&error.to_string()),
             )));
         }
-        Ok(PipelineData::empty())
+
+        if verbose {
+            let output: Vec<Value> = verbose_msgs
+                .into_iter()
+                .map(|(src, dest)| {
+                    record! {
+                        "source" => Value::string(src.display().to_string(), call.head),
+                        "destination" => Value::string(dest.display().to_string(), call.head),
+                        "message" => Value::string(translate!(
+                            "mv-verbose-renamed",
+                            "from" => src.display().to_string(),
+                            "to" => dest.display().to_string(),
+                        ), call.head)
+                    }
+                    .into_value(call.head)
+                })
+                .collect();
+            Ok(PipelineData::Value(Value::list(output, call.head), None))
+        } else {
+            Ok(PipelineData::empty())
+        }
     }
 }

--- a/crates/nu-command/tests/commands/move_/umv.rs
+++ b/crates/nu-command/tests/commands/move_/umv.rs
@@ -718,3 +718,21 @@ fn mv_with_tilde() {
         assert!(files_exist_at(&["f1.txt"], dirs.test()));
     })
 }
+
+#[test]
+fn mv_verbose_message_mentions_source_and_destination() {
+    Playground::setup("umv_verbose_message", |dirs, sandbox| {
+        sandbox.with_files(&[EmptyFile("before.txt")]);
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            "mv -v before.txt after.txt | to json"
+        );
+
+        assert!(actual.err.is_empty());
+        assert!(actual.out.contains("before.txt"));
+        assert!(actual.out.contains("after.txt"));
+        assert!(dirs.test().join("after.txt").exists());
+        assert!(!dirs.test().join("before.txt").exists());
+    });
+}


### PR DESCRIPTION
## Description
As title, this pr makes `mv -v` and `mkdir -v` returns structured data, so users can deal with return value, this is a follow up to #17240 

The output format of mkdir is suggested by @NotTheDr01ds : https://github.com/nushell/nushell/issues/15409#issuecomment-2751538585

> Off-topic, but I've always kind of thought we could do more with structured data and the filesystem commands:
mkdir foo bar /etc/ack
╭───┬──────────┬─────────┬───────────────────╮
│ # │   path   │ created │       error       │
├───┼──────────┼─────────┼───────────────────┤
│ 0 │ foo      │ true    │                   │
│ 1 │ bar      │ false   │                   │
│ 2 │ /etc/ack │ false   │ permission denied │
╰───┴──────────┴─────────┴───────────────────╯

## User-facing changes (Release notes)
### (Breaking change!)`mkdir -v` now returns a table
Previously mkdir -v returns a string, now it returns a table
#### Before
```
> let x = mkdir -v foo bar
nu: created directory '/tmp/foo'
nu: created directory '/tmp/bar'
> $x
foo bar
```

#### After
```
> let x = mkdir -v dir_1 dir_2 dir_3
> $x
╭───┬────────────┬─────────┬───────╮
│ # │    path    │ created │ error │
├───┼────────────┼─────────┼───────┤
│ 0 │ /tmp/dir_1 │ true    │       │
│ 1 │ /tmp/dir_2 │ true    │       │
│ 2 │ /tmp/dir_3 │ true    │       │
╰───┴────────────┴─────────┴───────╯
```
### `mv -v` returns a table too
```
> touch before.txt
>  mv -v before.txt after.txt
╭───┬─────────────────┬────────────────┬────────────────────╮
│ # │     source      │  destination   │      message       │
├───┼─────────────────┼────────────────┼────────────────────┤
│ 0 │ /tmp/before.txt │ /tmp/after.txt │ mv-verbose-renamed │
╰───┴─────────────────┴────────────────┴────────────────────╯
```

## Additional notes
Fixes: #16926
Closes: #10411