### PR TITLE
feat(`std-rfc/iter recurse`): support multiple cell-paths

### DIFF
--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -86,20 +86,16 @@ def make-depth-first-fn [descend: closure]: nothing -> closure {
 }
 
 def make-breadth-first-fn [descend: closure]: nothing -> closure {
-    {|out|
-        let children = $out
-        | each --flatten {|e|
-            $e.item
-            | do $descend $e.item
-            | add-parent $e.path
+    {|queue| match $queue {
+        [] => { {} }
+        [$head, ..$tail] => {
+            let children = $head.item | do $descend $head.item | add-parent $head.path
+            {
+                out: $head,
+                next: ($tail ++ $children),
+            }
         }
-
-        if ($children | is-not-empty) {
-            {out: $out, next: $children}
-        } else {
-            {out: $out}
-        }
-    }
+    }}
 }
 
 # Recursively descend a nested value, returning each value along with its path.
@@ -194,7 +190,6 @@ export def recurse [
     }
 
     generate $fn [{path: ($.), item: $root }]
-    | if not $depth_first { flatten } else { }
 }
 
 # Helper for `only` errors

--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -17,19 +17,22 @@ def get-children []: [any -> table<path: cell-path, item: any>] {
     }
 }
 
-def get-children-at [path: cell-path]: [any -> table<path: cell-path, item: any>] {
-    let x = try { get $path } catch { return [] }
-
-    match $x {
-        [..] => {
-            $x | get-children | add-parent $path
+def get-children-at [path: cell-path ...paths: cell-path]: [any -> table<path: cell-path, item: any>] {
+    match $in {
+        {} => {
+            get -o $path ...$paths $.""
+            | zip [$path ...$paths]
+            | each --flatten {|e|
+                match $e.0 {
+                    null | [] => []
+                    [..] => {
+                        $e.0 | get-children | add-parent $e.1
+                    }
+                    $x => [{path: $e.1, item: $x}]
+                }
+            }
         }
-        _ => {
-            [{
-                path: $path
-                item: $x
-            }]
-        }
+        _ => { get-children }
     }
 }
 

--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -72,6 +72,36 @@ def make-descend-fn [arg] {
     }
 }
 
+def make-depth-first-fn [descend: closure]: nothing -> closure {
+    {|stack| match $stack {
+        [] => { {} }
+        [$head, ..$tail] => {
+            let children = $head.item | do $descend $head.item | add-parent $head.path
+            {
+                out: $head,
+                next: ($tail | prepend $children),
+            }
+        }
+    }}
+}
+
+def make-breadth-first-fn [descend: closure]: nothing -> closure {
+    {|out|
+        let children = $out
+        | each --flatten {|e|
+            $e.item
+            | do $descend $e.item
+            | add-parent $e.path
+        }
+
+        if ($children | is-not-empty) {
+            {out: $out, next: $children}
+        } else {
+            {out: $out}
+        }
+    }
+}
+
 # Recursively descend a nested value, returning each value along with its path.
 #
 # Recursively descends its input, producing all values as a stream, along with
@@ -158,30 +188,9 @@ export def recurse [
     }
 
     let fn = if $depth_first {
-        {|stack|
-            match $stack {
-                [] => { {} }
-                [$head, ..$tail] => {
-                    let children = $head.item | do $descend $head.item | add-parent $head.path
-                    {
-                        out: $head,
-                        next: ($tail | prepend $children),
-                    }
-                }
-            }
-        }
+        make-depth-first-fn $descend
     } else {
-        {|out|
-            let children = $out
-            | each {|e| $e.item | do $descend $e.item | add-parent $e.path }
-            | flatten
-
-            if ($children | is-not-empty) {
-                {out: $out, next: $children}
-            } else {
-                {out: $out}
-            }
-        }
+        make-breadth-first-fn $descend
     }
 
     generate $fn [{path: ($.), item: $root }]

--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -10,10 +10,9 @@ def add-parent [parent: cell-path]: table<path: cell-path> -> table<path: cell-p
 }
 
 def get-children []: [any -> table<path: cell-path, item: any>] {
-    let val = $in
-    match ($val | describe --detailed).type {
-        "record" => { $val | transpose path item }
-        "list" => { $val | enumerate | rename path item }
+    match $in {
+        {} => { transpose path item }
+        [..] => { enumerate | rename path item }
         _ => { return [] }
     }
 }
@@ -21,13 +20,16 @@ def get-children []: [any -> table<path: cell-path, item: any>] {
 def get-children-at [path: cell-path]: [any -> table<path: cell-path, item: any>] {
     let x = try { get $path } catch { return [] }
 
-    if ($x | describe --detailed).type == "list" {
-        $x | get-children | add-parent $path
-    } else {
-        [{
-            path: $path
-            item: $x
-        }]
+    match $x {
+        [..] => {
+            $x | get-children | add-parent $path
+        }
+        _ => {
+            [{
+                path: $path
+                item: $x
+            }]
+        }
     }
 }
 

--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -150,6 +150,8 @@ export def recurse [
     get_children?: oneof<cell-path, closure> # Specify how to get children from parent value.
     --depth-first # Descend depth-first rather than breadth first
 ]: [any -> list<any>] {
+    let root = $in
+
     let descend = make-descend-fn {
         item: $get_children
         span: (metadata $get_children).span
@@ -182,7 +184,7 @@ export def recurse [
         }
     }
 
-    generate $fn [{path: ($.), item: ($in) }]
+    generate $fn [{path: ($.), item: $root }]
     | if not $depth_first { flatten } else { }
 }
 

--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -33,6 +33,45 @@ def get-children-at [path: cell-path]: [any -> table<path: cell-path, item: any>
     }
 }
 
+def make-descend-fn [arg] {
+    match ($arg.item | describe --detailed).type {
+        "nothing" => {
+            {|| get-children }
+        }
+        "cell-path" | "string" | "int" => {
+            {|| get-children-at $arg.item }
+        }
+        "closure" => {
+            {|parent|
+                let output = try {
+                    $parent | do $arg.item $parent
+                } catch {
+                    return []
+                }
+                | append []
+
+                let has_item = try { $output | get item; true } catch { false }
+
+                $output
+                | if not $has_item { wrap item } else { }
+                | default "<closure>" path
+            }
+        }
+        $type => {
+            error make {
+                msg: "Type mismatch."
+                labels: [
+                    {
+                        text: $"Cannot get child values using a ($type)"
+                        span: $arg.span
+                    }
+                ]
+                help: "Try using a cell-path or a closure."
+            }
+        }
+    }
+}
+
 # Recursively descend a nested value, returning each value along with its path.
 #
 # Recursively descends its input, producing all values as a stream, along with
@@ -111,38 +150,9 @@ export def recurse [
     get_children?: oneof<cell-path, closure> # Specify how to get children from parent value.
     --depth-first # Descend depth-first rather than breadth first
 ]: [any -> list<any>] {
-    let descend = match ($get_children | describe --detailed).type {
-        "nothing" => {
-            {|| get-children }
-        }
-        "cell-path" | "string" | "int" => {
-            {|| get-children-at $get_children }
-        }
-        "closure" => {
-            {|parent|
-                let output = try {
-                    $parent | do $get_children $parent
-                } catch {
-                    return []
-                }
-                | append []
-                let has_item = try { $output | get item; true } catch { false }
-
-                $output
-                | if not $has_item { wrap item } else { }
-                | default "<closure>" path
-            }
-        }
-        $type => {
-            error make {
-                msg: "Type mismatch."
-                label: {
-                    text: $"Cannot get child values using a ($type)"
-                    span: (metadata $get_children).span
-                }
-                help: "Try using a cell-path or a closure."
-            }
-        }
+    let descend = make-descend-fn {
+        item: $get_children
+        span: (metadata $get_children).span
     }
 
     let fn = if $depth_first {

--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -79,7 +79,7 @@ def make-depth-first-fn [descend: closure]: nothing -> closure {
             let children = $head.item | do $descend $head.item | add-parent $head.path
             {
                 out: $head,
-                next: ($tail | prepend $children),
+                next: ($children ++ $tail),
             }
         }
     }}

--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -36,15 +36,40 @@ def get-children-at [path: cell-path ...paths: cell-path]: [any -> table<path: c
     }
 }
 
-def make-descend-fn [arg] {
-    match ($arg.item | describe --detailed).type {
-        "nothing" => {
+def make-descend-fn [arg, rest] {
+    let arg_type = match ($arg.item | describe --detailed).type {
+        "string" | "int" => "cell-path",
+        $x => $x,
+    }
+    match [$arg_type, $rest.item] {
+        ["nothing", []] => {
             {|| get-children }
         }
-        "cell-path" | "string" | "int" => {
+        ["cell-path", []] => {
             {|| get-children-at $arg.item }
         }
-        "closure" => {
+        ["cell-path", _] => {
+            let labels = $rest.item | each {|e|
+                let md = metadata
+                match ($e | describe) {
+                    "cell-path" | "string" | "int" => { }
+                    $type => {
+                        {
+                            span: $md.span
+                            text: $'expected cell-path, got ($type)'
+                        }
+                    }
+                }
+            }
+            if $labels != [] {
+                error make {
+                    msg: "Type mismatch"
+                    labels: $labels
+                }
+            }
+            {|| get-children-at $arg.item ...$rest.item }
+        }
+        ["closure", []] => {
             {|parent|
                 let output = try {
                     $parent | do $arg.item $parent
@@ -60,7 +85,23 @@ def make-descend-fn [arg] {
                 | default "<closure>" path
             }
         }
-        $type => {
+        ["closure", _] => {
+            error make {
+                msg: "Closure accessor can't be combined with other accessors."
+                labels: [
+                    {
+                        text: "closure",
+                        span: $arg.span
+                    }
+                    {
+                        text: "additional accessors not allowed",
+                        span: $rest.span
+                    }
+                ]
+                help: "Remove the additional accessors, or modify the closure to access the same values."
+            }
+        }
+        [$type, _] => {
             error make {
                 msg: "Type mismatch."
                 labels: [
@@ -176,15 +217,21 @@ def make-breadth-first-fn [descend: closure]: nothing -> closure {
 ]
 @search-terms jq ".." nested
 export def recurse [
-    get_children?: oneof<cell-path, closure> # Specify how to get children from parent value.
+    accessor?: oneof<cell-path, closure> # Specify how to get children from parent value.
+    ...rest: cell-path # additional cell-paths (can't be combined with closure `accessor`)
     --depth-first # Descend depth-first rather than breadth first
 ]: [any -> list<any>] {
     let root = $in
 
-    let descend = make-descend-fn {
-        item: $get_children
-        span: (metadata $get_children).span
+    let spanned_accessor = {
+        item: $accessor
+        span: (metadata $accessor).span
     }
+    let spanned_rest = {
+        item: $rest
+        span: (metadata $rest).span
+    }
+    let descend = make-descend-fn $spanned_accessor $spanned_rest
 
     let fn = if $depth_first {
         make-depth-first-fn $descend

--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -1,6 +1,7 @@
 def cell-path-join []: list<cell-path> -> cell-path {
-    each {|e| try { split cell-path } catch { $e } }
-    | flatten
+    each --flatten {|e|
+        try { split cell-path } catch { [$e] }
+    }
     | into cell-path
 }
 

--- a/crates/nu-std/tests/test_std-rfc_iter.nu
+++ b/crates/nu-std/tests/test_std-rfc_iter.nu
@@ -80,6 +80,61 @@ def recurse-example-closure [] {
     assert equal $out $expected
 }
 
+const complex_tree = {
+    id: 0
+    A: [
+        {id: 1,
+            A: [
+                {id: 11, B: [
+                    {id: 111}]}]
+            B: [
+                {id: 12}]}
+        {id: 2, B: [
+            {id: 21}]}]
+    B: [
+        {id: 3}
+        {id: 4, C: [
+            {id: 41}]}]
+    C: [
+        {id: 5, A: [
+            {id: 51}]}]
+}
+
+@test
+def "recurse complex tree with a single cell-path" [] {
+    let out = $complex_tree
+    | recurse A
+    | update item { reject -o A B C }
+
+    let expected = [[path, item];
+        [$., {id: 0}]
+        [$.A.0, {id: 1}]
+        [$.A.1, {id: 2}]
+        [$.A.0.A.0, {id: 11}]
+    ]
+
+    assert equal $out $expected
+}
+
+@test
+def "recurse complex tree with multiple cell-paths" [] {
+    let out = $complex_tree
+    | recurse A C
+    | update item { reject -o A B C }
+
+    let expected = [
+        [path, item];
+        [$., {id: 0}]
+        [$.A.0, {id: 1}]
+        [$.A.1, {id: 2}]
+        [$.C.0, {id: 5}]
+        [$.A.0.A.0, {id: 11}]
+        [$.C.0.A.0, {id: 51}]
+    ]
+
+    assert equal $out $expected
+}
+
 @test
 def only-example-list [] {
   let out = [5] | only


### PR DESCRIPTION
## Description

- make breadth-first (default) descend lazier 
- use language constructs instead of commands where possible for small performance wins
- break up `recurse` into more helper commands
- add support for multiple cell-path arguments

## User-facing changes (Release notes)

`std-rfc/iter recurse` now supports multiple cell-path arguments.