### PR TITLE
fix try may causes other code run twice

### DIFF
--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -409,3 +409,17 @@ fn try_wont_generate_extra_output() {
     );
     assert_eq!(actual.out, "here")
 }
+
+#[test]
+fn try_wont_run_twice_when_no_catch_and_finally_block() {
+    let actual = nu!(
+        experimental: vec!["pipefail".to_string()],
+        r#"
+        do {
+            try {}
+            print "aa"
+            not_real_cmd
+        }"#
+    );
+    assert_eq!(actual.out, "aa")
+}

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -616,9 +616,7 @@ pub(crate) fn compile_try(
     } else {
         builder.push(Instruction::DrainIfEnd { src: io_reg }.into_spanned(call.head))?;
     }
-    if catch_expr.is_some() {
-        builder.push(Instruction::PopErrorHandler.into_spanned(call.head))?;
-    }
+    builder.push(Instruction::PopErrorHandler.into_spanned(call.head))?;
 
     builder.end_try()?;
 


### PR DESCRIPTION
## Description
This is a fix for user reported issue about `try`: https://discord.com/channels/601130461678272522/614593951969574961/1501638518345039893

> The print statement runs twice. This caused some weird behavior in a script of mine that caught an error further in the code.
```
["one_item"] | each {
    # With this try block, even when empty causes the print to run twice
    try {}

    # print runs again (or other commands)
    print "Look, I ran twice!"

    not_a_real_command
}
```

Thanks @weirdan pointing out that it lacks `pop-error-handler` in IR.  So I makes `try` block always generate `pop-error-handler` instruction.

## User-facing changes (Release notes)
### Fixed issue causing `try` to execute code twice
Now the following code won't run print statement twice.

Before:
```
> do -i {try {}; print "Look, I ran twice!"; not_a }
Look, I ran twice!
Look, I ran twice!
```
After:
```
> do -i {try {}; print "Look!"; not_a }
Look!
```


## Additional notes
NaN