### PR TITLE
fix clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,6 +246,10 @@ result_large_err = "allow"
 unchecked_time_subtraction = "warn"
 unwrap_used = "deny"
 used_underscore_binding = "warn"
+# need to allow this temporarily because it may change code logic.
+# let's keep it until we update rustc version to 1.96
+# which resolve the issue: https://github.com/rust-lang/rust-clippy/issues/16875
+collapsible_match = "allow"
 
 [lints]
 workspace = true

--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -287,7 +287,7 @@ fn histogram_impl(
             ),
         ));
     }
-    result.sort_by(|a, b| b.0.cmp(&a.0));
+    result.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     Value::list(result.into_iter().map(|x| x.1).collect(), span).into_pipeline_data()
 }
 

--- a/crates/nu-command/src/filters/tee.rs
+++ b/crates/nu-command/src/filters/tee.rs
@@ -465,12 +465,7 @@ fn spawn_tee(
         .name("tee".into())
         .spawn(move || {
             // We use Signals::empty() here because we assume there already is a Signals on the other side
-            let stream = ByteStream::from_iter(
-                receiver.into_iter(),
-                info.span,
-                Signals::empty(),
-                info.type_,
-            );
+            let stream = ByteStream::from_iter(receiver, info.span, Signals::empty(), info.type_);
             eval_block(PipelineData::byte_stream(stream, info.metadata))
         })
         .map_err(|err| {

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -870,11 +870,9 @@ impl<'a> SelectWidget<'a> {
     /// Generate the separator line based on current terminal width
     fn generate_separator_line(&mut self) {
         let sep_width = self.config.separator_char.width();
-        let repeat_count = if sep_width > 0 {
-            self.term_width as usize / sep_width
-        } else {
-            self.term_width as usize
-        };
+        let repeat_count = (self.term_width as usize)
+            .checked_div(sep_width)
+            .unwrap_or(self.term_width as usize);
         self.separator_line = self.config.separator_char.repeat(repeat_count);
     }
 
@@ -2459,7 +2457,7 @@ impl<'a> SelectWidget<'a> {
                     .collect()
             };
             // Sort by score descending
-            scored.sort_by(|a, b| b.1.cmp(&a.1));
+            scored.sort_by_key(|entry| std::cmp::Reverse(entry.1));
             self.filtered_indices = scored.into_iter().map(|(i, _)| i).collect();
         }
 

--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -782,14 +782,14 @@ impl PluginInterface {
                         span,
                     )
                     .with_help(help)
-                    .with_inner(existing_error.into_iter())
+                    .with_inner(existing_error)
                 } else {
                     GenericError::new_internal(
                         format!("Plugin `{}` closed unexpectedly", self.state.source.name()),
                         "can't complete this operation because the plugin is closed",
                     )
                     .with_help(help)
-                    .with_inner(existing_error.into_iter())
+                    .with_inner(existing_error)
                 };
                 ShellError::Generic(error)
             })?;

--- a/crates/nu-term-grid/src/grid.rs
+++ b/crates/nu-term-grid/src/grid.rs
@@ -307,7 +307,7 @@ impl Grid {
         let mut col_total_width_so_far = 0;
 
         let mut cells = self.cells.clone();
-        cells.sort_unstable_by(|a, b| b.width.cmp(&a.width)); // Sort in reverse order
+        cells.sort_unstable_by_key(|cell| std::cmp::Reverse(cell.width)); // Sort in reverse order
 
         for cell in &cells {
             if cell.width + col_total_width_so_far <= maximum_width {

--- a/crates/nu_plugin_polars/src/dataframe/command/data/sql_context.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/sql_context.rs
@@ -158,7 +158,7 @@ impl SQLContext {
                 .chain(agg_proj_pos)
                 .collect::<Vec<_>>();
 
-            final_proj_pos.sort_by(|(proj_pa, _), (proj_pb, _)| proj_pa.cmp(proj_pb));
+            final_proj_pos.sort_by_key(|(proj_p, _)| *proj_p);
             let final_proj = final_proj_pos
                 .into_iter()
                 .map(|(_, shm_p)| {


### PR DESCRIPTION
## Description
I noticed some clippy warning while running `toolkit clippy` under rustc 1.95, clippy 0.1.95, this pr is going to fix them.

Note that I had too #[allow(clippy::collapsible_match)], due to this clippy issue: https://github.com/rust-lang/rust-clippy/issues/16875

## User-facing changes (Release notes)
NaN

## Additional notes
NaN