### PR TITLE
feat(std-rfc/iter): new `prod` command for cartesian products

### DIFF
--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -224,3 +224,88 @@ export def only [
     _ => (only-error "expected only one element in table/list" $pipe.meta "has more than one element")
   }
 }
+
+def prod-error-helper [] {
+    items {|k v|
+        match $v {
+            [..] => null
+            _ => {
+                let ty = $v | describe
+                {
+                    span: (metadata $v).span
+                    text: $'expected list, got ($ty)'
+                }
+            }
+        }
+    }
+    | compact -e
+    | let labels
+
+    if $labels != [] {
+        error make {
+            msg: "Type mismatch. All values must be lists."
+            code: "nu::shell::type_mismatch"
+            labels: $labels
+        }
+    }
+}
+
+def prod-mk-fn [src: record]: nothing -> closure {
+    $src | prod-error-helper
+    $src
+    | transpose name items
+    | reduce --fold ({|| }) {|source prev_fn|
+        {||
+            do $prev_fn
+            | each --flatten {|l|
+                $source.items | each {|r|
+                    $l | merge {($source.name): $r}
+                }
+            }
+        }
+    }
+}
+
+# Cartesian product of multiple lists as a table.
+@search-terms cartesian product combination
+@category generators
+@example "Product of two lists" {
+    [1, 2] | prod { rhs: [a, b] }
+} --result [
+    [in, rhs];
+    [1, a]
+    [1, b]
+    [2, a]
+    [2, b]
+]
+@example "All element combinations of multiple lists" {
+    prod {
+        size: [little, big]
+        color: [red, blue]
+        shape: [circle, box]
+    }
+} --result [
+    [size, color, shape];
+    [little, red, circle],
+    [little, red, box],
+    [little, blue, circle],
+    [little, blue, box],
+    [big, red, circle],
+    [big, red, box],
+    [big, blue, circle],
+    [big, blue, box]
+]
+export def prod [
+    src: record # Lists to combine. All values must be lists.
+]: [
+    nothing -> table
+    list -> table
+] {
+    peek | metadata access {|md|
+        match $md.peek {
+            {type: "list"} => { wrap in }
+            {type: "empty"} => { [{}] }
+        }
+    }
+    | do (prod-mk-fn $src)
+}

--- a/crates/nu-std/tests/test_std-rfc_iter.nu
+++ b/crates/nu-std/tests/test_std-rfc_iter.nu
@@ -121,3 +121,66 @@ def only-none [] {
     (assert ($err.msg has "non-empty"))
   }
 }
+
+@test
+def "multiple list prod test" [] {
+    # test runner may provide context record as $in
+    # it is discarded to make `prod` work correctly
+    null
+    let got = prod {
+        color: [red, green]
+        size: [small, large]
+        letter: [A, B]
+    }
+
+    let expected = [
+        [color, size, letter];
+        [red, small, A]
+        [red, small, B]
+        [red, large, A]
+        [red, large, B]
+        [green, small, A]
+        [green, small, B]
+        [green, large, A]
+        [green, large, B]
+    ]
+
+    assert equal $got $expected
+}
+
+@test
+def "two list prod with input" [] {
+    let got = [1, 2, 3] | prod {right: [a, b, c]}
+    let expected = [
+        [in, right];
+        [1, a]
+        [1, b]
+        [1, c]
+        [2, a]
+        [2, b]
+        [2, c]
+        [3, a]
+        [3, b]
+        [3, c]
+    ]
+
+    assert equal $got $expected
+}
+
+@test
+def "multi list prod with input" [] {
+    let got = [1, 2] | prod {lower: [a, b], upper: [A, B]}
+    let expected = [
+        [in, lower, upper];
+        [1, a, A]
+        [1, a, B]
+        [1, b, A]
+        [1, b, B]
+        [2, a, A]
+        [2, a, B]
+        [2, b, A]
+        [2, b, B]
+    ]
+
+    assert equal $got $expected
+}


### PR DESCRIPTION
## Description

- closes #18176

## User-facing changes (Release notes)
### New `std-rfc/iter prod` comand to produce cartesian products

A new command for producing cartesian products of an arbitrary number of lists, accessible as `std-rfc/iter prod`.

It takes a record with list values and returns a table where each column has items from the corresponding list:
```nushell
prod {
    size: [little, big]
    color: [red, blue]
    shape: [circle, box]
}
# returns
[
    [size, color, shape];
    [little, red, circle],
    [little, red, box],
    [little, blue, circle],
    [little, blue, box],
    [big, red, circle],
    [big, red, box],
    [big, blue, circle],
    [big, blue, box]
]
```

It can also take an input stream, items of which will be in the `"in"` column:
```nushell
[1, 2] | prod { rhs: [a, b] }
# returns
[
    [in, rhs];
    [1, a]
    [1, b]
    [2, a]
    [2, b]
]
```

`prod` generates its output lazily, so it doesn't collect its input.