### PR TITLE
Gate idx import and export commands behind sqlite feature

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -260,11 +260,15 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             IdxStatus,
             IdxFind,
             IdxSearch,
-            IdxExport,
-            IdxImport,
             IdxDrop,
             IdxDirs,
             IdxFiles,
+        };
+
+        #[cfg(feature = "sqlite")]
+        bind_command! {
+            IdxExport,
+            IdxImport,
         };
 
         // Platform

--- a/crates/nu-command/src/filesystem/idx/mod.rs
+++ b/crates/nu-command/src/filesystem/idx/mod.rs
@@ -1,9 +1,11 @@
 mod dirs;
 mod drop;
+#[cfg(feature = "sqlite")]
 mod export;
 mod files;
 mod find;
 mod idx_;
+#[cfg(feature = "sqlite")]
 mod import;
 mod init;
 mod search;
@@ -12,10 +14,12 @@ mod status;
 
 pub use dirs::IdxDirs;
 pub use drop::IdxDrop;
+#[cfg(feature = "sqlite")]
 pub use export::IdxExport;
 pub use files::IdxFiles;
 pub use find::IdxFind;
 pub use idx_::Idx;
+#[cfg(feature = "sqlite")]
 pub use import::IdxImport;
 pub use init::IdxInit;
 pub use search::IdxSearch;

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -6,7 +6,9 @@ use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{ListStream, PipelineMetadata, Signals};
 use nu_utils::time::Instant;
+#[cfg(feature = "sqlite")]
 use rusqlite::{Connection, OptionalExtension, params};
+#[cfg(feature = "sqlite")]
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -697,6 +699,7 @@ pub fn stream_find(
     ))
 }
 
+#[cfg(feature = "sqlite")]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IdxSnapshotFile {
     pub relative_path: String,
@@ -712,6 +715,7 @@ pub struct IdxSnapshotFile {
     pub is_overflow: bool,
 }
 
+#[cfg(feature = "sqlite")]
 #[derive(Debug)]
 pub struct IdxSnapshotDir {
     pub relative_path: String,
@@ -721,6 +725,7 @@ pub struct IdxSnapshotDir {
     pub is_overflow: bool,
 }
 
+#[cfg(feature = "sqlite")]
 pub fn store_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
     let snapshot = require_runtime(span)?;
     let guard = snapshot
@@ -947,6 +952,7 @@ pub fn store_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
     ))
 }
 
+#[cfg(feature = "sqlite")]
 pub fn restore_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
     // Open SQLite database
     let conn = Connection::open(path).map_err(|err| {

--- a/crates/nu-command/src/filesystem/mod.rs
+++ b/crates/nu-command/src/filesystem/mod.rs
@@ -19,9 +19,9 @@ pub use self::open::Open;
 pub use cd::Cd;
 pub use du::Du;
 pub use glob::Glob;
-pub use idx::{
-    Idx, IdxDirs, IdxDrop, IdxExport, IdxFiles, IdxFind, IdxImport, IdxInit, IdxSearch, IdxStatus,
-};
+pub use idx::{Idx, IdxDirs, IdxDrop, IdxFiles, IdxFind, IdxInit, IdxSearch, IdxStatus};
+#[cfg(feature = "sqlite")]
+pub use idx::{IdxExport, IdxImport};
 pub use ls::Ls;
 pub use mktemp::Mktemp;
 pub use rm::Rm;


### PR DESCRIPTION
## Description
This commit gates the new `idx import` and `idx export` commands behind the `sqlite` feature. Before this PR, it's not possible to build nushell without the `sqlite` feature since these commands don't have feature gates. After this PR, it's possible to build nushell wtihout the `sqlite` feature again.

## User-facing changes (Release notes)
N/A