### PR TITLE
add `--no-commas` flag to `to nuon` for compact output without comma separators

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -43,6 +43,11 @@ impl Command for ToNuon {
                 "Serialize table values as list-of-records instead of table syntax.",
                 Some('l'),
             )
+            .switch(
+                "no-commas",
+                "Do not use commas between items in tables and lists.",
+                Some('c'),
+            )
             .category(Category::Formats)
     }
 
@@ -60,6 +65,7 @@ impl Command for ToNuon {
         let serialize_types = call.has_flag(engine_state, stack, "serialize")?;
         let raw_strings = call.has_flag(engine_state, stack, "raw-strings")?;
         let list_of_records = call.has_flag(engine_state, stack, "list-of-records")?;
+        let no_commas = call.has_flag(engine_state, stack, "no-commas")?;
         let style = if call.has_flag(engine_state, stack, "raw")? {
             nuon::ToStyle::Raw
         } else if let Some(t) = call.get_flag(engine_state, stack, "tabs")? {
@@ -83,7 +89,8 @@ impl Command for ToNuon {
             .span(Some(span))
             .serialize_types(serialize_types)
             .raw_strings(raw_strings)
-            .list_of_records(list_of_records);
+            .list_of_records(list_of_records)
+            .use_commas(!no_commas);
 
         match nuon::to_nuon(engine_state, &value, config) {
             Ok(serde_nuon_string) => Ok(Value::string(serde_nuon_string, span)
@@ -139,6 +146,16 @@ impl Command for ToNuon {
                 description: "Serialize table values as list of records with pretty indentation.",
                 example: "[[a, b]; [1, 2], [3, 4]] | to nuon --list-of-records --indent 2",
                 result: Some(Value::test_string("[\n  {a: 1, b: 2},\n  {a: 3, b: 4}\n]")),
+            },
+            Example {
+                description: "Output a list without commas between items.",
+                example: "[1 2 3] | to nuon --no-commas",
+                result: Some(Value::test_string("[1 2 3]")),
+            },
+            Example {
+                description: "Output a record without commas between fields.",
+                example: "{a: 1, b: 2} | to nuon --no-commas",
+                result: Some(Value::test_string("{a: 1 b: 2}")),
             },
         ]
     }

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -1,6 +1,6 @@
-use std::os::unix::ffi::OsStrExt;
-
-use nu_protocol::{shell_error, test_record};
+use nu_protocol::{shell_error};
+#[cfg(unix)]
+use nu_protocol::{test_record};
 use nu_test_support::{fs::Stub::EmptyFile, prelude::*};
 
 #[test]
@@ -51,6 +51,7 @@ fn filesystem_change_from_current_directory_using_absolute_path() -> Result {
     })
 }
 
+#[cfg(unix)]
 #[test]
 fn filesystem_change_from_current_directory_using_absolute_path_with_trailing_slash() -> Result {
     Playground::setup("cd_test_2", |dirs, _| {
@@ -59,7 +60,7 @@ fn filesystem_change_from_current_directory_using_absolute_path_with_trailing_sl
             // It works and is unlikely to break, but is not explicitly documented behavior
             // Also Path::with_trailing_sep is unstable
             dir.push("");
-            assert!(dir.as_os_str().as_bytes().ends_with(b"/"));
+            assert!(dir.as_os_str().as_encoded_bytes().ends_with(b"/"));
             dir
         };
 

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -1,6 +1,6 @@
-use nu_protocol::{shell_error};
+use nu_protocol::shell_error;
 #[cfg(unix)]
-use nu_protocol::{test_record};
+use nu_protocol::test_record;
 use nu_test_support::{fs::Stub::EmptyFile, prelude::*};
 
 #[test]

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -14,7 +14,7 @@ use nu_utils::{ObviousFloat, as_raw_string, escape_quote_string, needs_quoting};
 ///     .raw_strings(true);
 /// to_nuon(&engine_state, &value, config)?;
 /// ```
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct ToNuonConfig {
     /// Formatting style (indentation)
@@ -27,6 +27,22 @@ pub struct ToNuonConfig {
     pub raw_strings: bool,
     /// Serialize list-of-records values as list-of-records instead of table syntax
     pub list_of_records: bool,
+    /// Use commas to separate items. Defaults to `true`.
+    /// When `false`, produces compact NUON without commas.
+    pub use_commas: bool,
+}
+
+impl Default for ToNuonConfig {
+    fn default() -> Self {
+        Self {
+            style: ToStyle::default(),
+            span: None,
+            serialize_types: false,
+            raw_strings: false,
+            list_of_records: false,
+            use_commas: true,
+        }
+    }
 }
 
 impl ToNuonConfig {
@@ -57,6 +73,11 @@ impl ToNuonConfig {
     /// Serialize list-of-records values as list-of-records instead of table syntax
     pub fn list_of_records(mut self, list_of_records: bool) -> Self {
         self.list_of_records = list_of_records;
+        self
+    }
+
+    pub fn use_commas(mut self, use_commas: bool) -> Self {
+        self.use_commas = use_commas;
         self
     }
 }
@@ -139,6 +160,7 @@ pub fn to_nuon(
             serialize_types: config.serialize_types,
             raw_strings: config.raw_strings,
             list_of_records: config.list_of_records,
+            use_commas: config.use_commas,
         },
     )?;
 
@@ -150,8 +172,15 @@ struct StringifyOptions {
     serialize_types: bool,
     raw_strings: bool,
     list_of_records: bool,
+    use_commas: bool,
 }
 
+/// Converts a Nushell [`Value`] to its NUON string representation.
+///
+/// This function handles all value types and respects the formatting options
+/// provided in [`StringifyOptions`]. The `use_commas` option controls whether
+/// commas are included as separators in arrays, records, and table rows.
+/// When `false`, produces more compact output while remaining valid NUON.
 fn value_to_string(
     engine_state: &EngineState,
     v: &Value,
@@ -164,6 +193,9 @@ fn value_to_string(
     let idt = get_true_indentation(depth, indent);
     let idt_po = get_true_indentation(depth + 1, indent);
     let idt_pt = get_true_indentation(depth + 2, indent);
+    // Comma separator: either "," or "" (empty) based on use_commas option.
+    // Using a single variable ensures consistent comma handling across all formatting paths.
+    let c = if options.use_commas { "," } else { "" };
 
     match v {
         Value::Binary { val, .. } => {
@@ -263,9 +295,9 @@ fn value_to_string(
                 };
 
                 if indent.is_some_and(|i| !i.is_empty()) {
-                    let header_row = format!("[{}];", headers.join(", "));
+                    let header_row = format!("[{}];", headers.join(c));
 
-                    let value_rows = record_rows(&|row| format!("[{}]", row.join(", ")))?
+                    let value_rows = record_rows(&|row| format!("[{}]", row.join(c)))?
                         .join(&format!(",{nl}{idt_po}"));
 
                     Ok(format!(
@@ -273,11 +305,11 @@ fn value_to_string(
                         header_row, value_rows
                     ))
                 } else {
-                    let headers_output = headers.join(&format!(",{sep}{nl}{idt_pt}"));
+                    let headers_output = headers.join(&format!("{c}{sep}{nl}{idt_pt}"));
 
                     let table_output =
-                        record_rows(&|row| row.join(&format!(",{sep}{nl}{idt_pt}")))?
-                            .join(&format!("{nl}{idt_po}],{sep}{nl}{idt_po}[{nl}{idt_pt}"));
+                        record_rows(&|row| row.join(&format!("{c}{sep}{nl}{idt_pt}")))?
+                            .join(&format!("{nl}{idt_po}]{c}{sep}{nl}{idt_po}[{nl}{idt_pt}"));
 
                     Ok(format!(
                         "[{nl}{idt_po}[{nl}{idt_pt}{}{nl}{idt_po}];{sep}{nl}{idt_po}[{nl}{idt_pt}{}{nl}{idt_po}]{nl}{idt}]",
@@ -304,7 +336,7 @@ fn value_to_string(
 
                 Ok(format!(
                     "[{nl}{}{nl}{idt}]",
-                    collection.join(&format!(",{sep}{nl}"))
+                    collection.join(&format!("{c}{sep}{nl}"))
                 ))
             } else {
                 let mut collection = vec![];
@@ -323,7 +355,7 @@ fn value_to_string(
                 }
                 Ok(format!(
                     "[{nl}{}{nl}{idt}]",
-                    collection.join(&format!(",{sep}{nl}"))
+                    collection.join(&format!("{c}{sep}{nl}"))
                 ))
             }
         }
@@ -354,7 +386,7 @@ fn value_to_string(
             }
             Ok(format!(
                 "{{{nl}{}{nl}{idt}}}",
-                collection.join(&format!(",{sep}{nl}"))
+                collection.join(&format!("{c}{sep}{nl}"))
             ))
         }
         // All strings outside data structures are quoted because they are in 'command position'


### PR DESCRIPTION
## Description
This PR adds a `--no-commas` flag to `to nuon` so that nuon can be even more succinct by not using commas.
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
### Added `--no-commas` flag to `to nuon` to exclude optional commas
When you use the new `--no-commas` flag on `to nuon` you won't have to see commas. Since nuon doesn't require commas, this will make the output more succinct. Some may argue that it's harder to read, which may be true, but nuon doesn't care about that.

```nushell
❯ ls | to nuon --indent 2 --list-of-records | str length
3312
❯ ls | to nuon --indent 2 --list-of-records --no-commas | str length
3169
❯ ls | to nuon | str length
2260
❯ ls | to nuon --no-commas | str length
2114
```
Sometimes, every little bit helps.

<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->