### PR TITLE
feat: accept optional column argument for `grid` command

### DIFF
--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -31,7 +31,7 @@ impl Command for Griddle {
             .optional(
                 "column",
                 SyntaxShape::CellPath,
-                "Format this column in a grid",
+                "Format this column in a grid.",
             )
             .named(
                 "width",
@@ -85,39 +85,31 @@ column named 'name'. This is subject to change in the future."
         match input {
             PipelineData::Value(Value::List { vals, .. }, ..) => {
                 // dbg!("value::list");
-                let data = convert_to_list(vals, cell_path, config)?;
-                if let Some(items) = data {
-                    Ok(create_grid_output(
-                        items,
-                        call,
-                        width_param,
-                        use_color,
-                        separator_param,
-                        env_str,
-                        icons_param,
-                        cwd.as_ref(),
-                    )?)
-                } else {
-                    Ok(PipelineData::empty())
-                }
+                let items = convert_to_list(vals, cell_path, config)?;
+                Ok(create_grid_output(
+                    items,
+                    call,
+                    width_param,
+                    use_color,
+                    separator_param,
+                    env_str,
+                    icons_param,
+                    cwd.as_ref(),
+                )?)
             }
             PipelineData::ListStream(stream, ..) => {
                 // dbg!("value::stream");
-                let data = convert_to_list(stream, cell_path, config)?;
-                if let Some(items) = data {
-                    Ok(create_grid_output(
-                        items,
-                        call,
-                        width_param,
-                        use_color,
-                        separator_param,
-                        env_str,
-                        icons_param,
-                        cwd.as_ref(),
-                    )?)
-                } else {
-                    Ok(PipelineData::empty())
-                }
+                let items = convert_to_list(stream, cell_path, config)?;
+                Ok(create_grid_output(
+                    items,
+                    call,
+                    width_param,
+                    use_color,
+                    separator_param,
+                    env_str,
+                    icons_param,
+                    cwd.as_ref(),
+                )?)
             }
             PipelineData::Value(Value::Record { val, .. }, ..) => {
                 // dbg!("value::record");
@@ -277,7 +269,7 @@ fn convert_to_list(
     iter: impl IntoIterator<Item = Value>,
     cell_path: Option<CellPath>,
     config: &Config,
-) -> Result<Option<Vec<String>>, ShellError> {
+) -> Result<Vec<String>, ShellError> {
     let Some(cell_path) = cell_path else {
         return convert_to_list_legacy(iter, config);
     };
@@ -288,17 +280,11 @@ fn convert_to_list(
                 return Err(*error);
             }
 
-            let val = match item.follow_cell_path(&cell_path.members) {
-                Ok(val) => val.into_owned(),
-                Err(err) => return Err(err),
-            };
+            let string = item
+                .follow_cell_path(&cell_path.members)?
+                .to_expanded_string(", ", config);
 
-            if let Value::Error { error, .. } = val {
-                return Err(*error);
-            }
-            let string = val.to_expanded_string(", ", config);
-
-            Ok(Some(string))
+            Ok(string)
         })
         .collect()
 }
@@ -306,18 +292,18 @@ fn convert_to_list(
 fn convert_to_list_legacy(
     iter: impl IntoIterator<Item = Value>,
     config: &Config,
-) -> Result<Option<Vec<String>>, ShellError> {
+) -> Result<Vec<String>, ShellError> {
     let mut iter = iter.into_iter().peekable();
 
     let Some(first) = iter.peek() else {
-        return Ok(None);
+        return Ok(vec![]);
     };
 
     let headers = first.columns().collect::<Vec<_>>();
     let has_name_header = headers.iter().any(|&str| str == NAME_COLUMN);
 
     if !headers.is_empty() && !has_name_header {
-        return Ok(Some(vec![]));
+        return Ok(vec![]);
     }
 
     iter.map(|item| {
@@ -344,7 +330,7 @@ fn convert_to_list_legacy(
             }
         };
 
-        Ok(Some(string))
+        Ok(string)
     })
     .collect()
 }

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -2,11 +2,20 @@ use devicons::icon_for_file;
 use lscolors::Style;
 use nu_color_config::lookup_ansi_color_style;
 use nu_engine::{command_prelude::*, env_to_string};
-use nu_protocol::Config;
 use nu_protocol::shell_error::generic::GenericError;
+use nu_protocol::{Config, ReportMode, report_shell_warning};
 use nu_term_grid::grid::{Alignment, Cell, Direction, Filling, Grid, GridOptions};
 use nu_utils::{get_ls_colors, terminal_size};
 use std::path::Path;
+
+// TODO: there are some deprecated stuff that should be removed after version
+// 0.113.0 is released. Things to remove:
+// - `PipelineData::Value(Value::Record { .. }, ..)` arm
+// - the example which showcases record as input
+// - the `DeprecationInfo` struct and other associated code
+// - the `NAME_COLUMN` const
+// and finally, `convert_to_list` and `convert_to_list_legacy` should be merged
+// and cleaned up removing the deprecated code
 
 const NAME_COLUMN: &str = "name";
 
@@ -82,10 +91,15 @@ column named 'name'. This is subject to change in the future."
         let use_color: bool = color_param && config.use_ansi_coloring.get(engine_state);
         let cwd = engine_state.cwd(Some(stack))?;
 
+        let deprecation_info = DeprecationInfo {
+            engine_state,
+            span: call.head,
+        };
+
         match input {
             PipelineData::Value(Value::List { vals, .. }, ..) => {
                 // dbg!("value::list");
-                let items = convert_to_list(vals, cell_path, config)?;
+                let items = convert_to_list(vals, cell_path, config, deprecation_info)?;
                 create_grid_output(
                     items,
                     call,
@@ -99,7 +113,7 @@ column named 'name'. This is subject to change in the future."
             }
             PipelineData::ListStream(stream, ..) => {
                 // dbg!("value::stream");
-                let items = convert_to_list(stream, cell_path, config)?;
+                let items = convert_to_list(stream, cell_path, config, deprecation_info)?;
                 create_grid_output(
                     items,
                     call,
@@ -111,9 +125,28 @@ column named 'name'. This is subject to change in the future."
                     cwd.as_ref(),
                 )
             }
-            PipelineData::Value(Value::Record { val, .. }, ..) => {
+            PipelineData::Value(record @ Value::Record { .. }, ..) => {
                 // dbg!("value::record");
-                let items = val
+
+                report_shell_warning(
+                    Some(stack),
+                    engine_state,
+                    &ShellWarning::Deprecated {
+                        dep_type: "Behavior".into(),
+                        label: "wrap the record inside a list.".into(),
+                        span: record.span(),
+                        help: Some(
+                            "Since 0.112.2, passing a record to `grid` command is deprecated. \
+                        It is expected to be removed in version 0.114.0"
+                                .into(),
+                        ),
+                        report_mode: ReportMode::FirstUse,
+                    },
+                );
+
+                let items = record
+                    .into_record()
+                    .expect("this is a record")
                     .get(NAME_COLUMN)
                     .map(|v| v.to_expanded_string(", ", config))
                     .into_iter()
@@ -265,13 +298,19 @@ fn create_grid_output(
     }
 }
 
+struct DeprecationInfo<'a> {
+    engine_state: &'a EngineState,
+    span: Span,
+}
+
 fn convert_to_list(
     iter: impl IntoIterator<Item = Value>,
     cell_path: Option<CellPath>,
     config: &Config,
+    deprecation_info: DeprecationInfo,
 ) -> Result<Vec<String>, ShellError> {
     let Some(cell_path) = cell_path else {
-        return convert_to_list_legacy(iter, config);
+        return convert_to_list_legacy(iter, config, deprecation_info);
     };
 
     iter.into_iter()
@@ -292,6 +331,7 @@ fn convert_to_list(
 fn convert_to_list_legacy(
     iter: impl IntoIterator<Item = Value>,
     config: &Config,
+    deprecation_info: DeprecationInfo,
 ) -> Result<Vec<String>, ShellError> {
     let mut iter = iter.into_iter().peekable();
 
@@ -301,6 +341,20 @@ fn convert_to_list_legacy(
 
     let headers = first.columns().collect::<Vec<_>>();
     let has_name_header = headers.iter().any(|&str| str == NAME_COLUMN);
+
+    if has_name_header {
+        report_shell_warning(
+            None,
+            deprecation_info.engine_state,
+            &ShellWarning::Deprecated {
+                dep_type: "Behavior".into(),
+                label: "add the name of the column you want to display (e.g. name)".into(),
+                span: deprecation_info.span,
+                help: Some("It is expected to be removed in version 0.114.0".into()),
+                report_mode: ReportMode::FirstUse,
+            },
+        );
+    }
 
     if !headers.is_empty() && !has_name_header {
         return Ok(vec![]);

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -9,13 +9,14 @@ use nu_utils::{get_ls_colors, terminal_size};
 use std::path::Path;
 
 // TODO: there are some deprecated stuff that should be removed after version
-// 0.113.0 is released. Things to remove:
-// - `PipelineData::Value(Value::Record { .. }, ..)` arm
-// - the example which showcases record as input
-// - the `DeprecationInfo` struct and other associated code
-// - the `NAME_COLUMN` const
-// and finally, `convert_to_list` and `convert_to_list_legacy` should be merged
-// and cleaned up removing the deprecated code
+// 0.113.0 is released. Things to do:
+// - remove the `PipelineData::Value(Value::Record { .. }, ..)` arm
+// - remove the `Type::record()` from the command signature
+// - remove the example which showcases record as input
+// - remove the `DeprecationInfo` struct and other associated code
+// - remove the `NAME_COLUMN` const
+// - merge and clean up`convert_to_list` and `convert_to_list_legacy`
+// - and finally update the tests
 
 const NAME_COLUMN: &str = "name";
 
@@ -64,10 +65,9 @@ impl Command for Griddle {
     }
 
     fn extra_description(&self) -> &str {
-        "The `grid` command was built to give a concise gridded layout for ls. It
-prints every item of the list in a grid layout. However, for table
-or record, it determines what to put in the grid by looking for a
-column named 'name'. This is subject to change in the future."
+        "The `grid` command creates a concise gridded layout for the input. It
+prints every item of the list in a grid layout. However, for table,
+you need to provide the name of the column you want to put in the grid."
     }
 
     fn run(
@@ -200,7 +200,7 @@ column named 'name'. This is subject to change in the future."
             },
             Example {
                 description: "Render a table with 'name' column in it to a grid with icons and colors",
-                example: "[[name patch]; [Cargo.toml false] [README.md true] [SECURITY.md false]] | grid --icons --color name",
+                example: "ls | grid --icons --color name",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -28,6 +28,11 @@ impl Command for Griddle {
                 (Type::List(Box::new(Type::Any)), Type::String),
                 (Type::record(), Type::String),
             ])
+            .optional(
+                "column",
+                SyntaxShape::CellPath,
+                "Format this column in a grid",
+            )
             .named(
                 "width",
                 SyntaxShape::Int,
@@ -63,6 +68,7 @@ column named 'name'. This is subject to change in the future."
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_path: Option<CellPath> = call.opt(engine_state, stack, 0)?;
         let width_param: Option<i64> = call.get_flag(engine_state, stack, "width")?;
         let color_param: bool = call.has_flag(engine_state, stack, "color")?;
         let separator_param: Option<String> = call.get_flag(engine_state, stack, "separator")?;
@@ -79,7 +85,7 @@ column named 'name'. This is subject to change in the future."
         match input {
             PipelineData::Value(Value::List { vals, .. }, ..) => {
                 // dbg!("value::list");
-                let data = convert_to_list(vals, config)?;
+                let data = convert_to_list(vals, cell_path, config)?;
                 if let Some(items) = data {
                     Ok(create_grid_output(
                         items,
@@ -97,7 +103,7 @@ column named 'name'. This is subject to change in the future."
             }
             PipelineData::ListStream(stream, ..) => {
                 // dbg!("value::stream");
-                let data = convert_to_list(stream, config)?;
+                let data = convert_to_list(stream, cell_path, config)?;
                 if let Some(items) = data {
                     Ok(create_grid_output(
                         items,
@@ -110,7 +116,6 @@ column named 'name'. This is subject to change in the future."
                         cwd.as_ref(),
                     )?)
                 } else {
-                    // dbg!(data);
                     Ok(PipelineData::empty())
                 }
             }
@@ -268,8 +273,37 @@ fn create_grid_output(
     }
 }
 
-#[allow(clippy::type_complexity)]
 fn convert_to_list(
+    iter: impl IntoIterator<Item = Value>,
+    cell_path: Option<CellPath>,
+    config: &Config,
+) -> Result<Option<Vec<String>>, ShellError> {
+    let Some(cell_path) = cell_path else {
+        return convert_to_list_legacy(iter, config);
+    };
+
+    iter.into_iter()
+        .map(|item| {
+            if let Value::Error { error, .. } = item {
+                return Err(*error);
+            }
+
+            let val = match item.follow_cell_path(&cell_path.members) {
+                Ok(val) => val.into_owned(),
+                Err(err) => return Err(err),
+            };
+
+            if let Value::Error { error, .. } = val {
+                return Err(*error);
+            }
+            let string = val.to_expanded_string(", ", config);
+
+            Ok(Some(string))
+        })
+        .collect()
+}
+
+fn convert_to_list_legacy(
     iter: impl IntoIterator<Item = Value>,
     config: &Config,
 ) -> Result<Option<Vec<String>>, ShellError> {

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -86,7 +86,7 @@ column named 'name'. This is subject to change in the future."
             PipelineData::Value(Value::List { vals, .. }, ..) => {
                 // dbg!("value::list");
                 let items = convert_to_list(vals, cell_path, config)?;
-                Ok(create_grid_output(
+                create_grid_output(
                     items,
                     call,
                     width_param,
@@ -95,12 +95,12 @@ column named 'name'. This is subject to change in the future."
                     env_str,
                     icons_param,
                     cwd.as_ref(),
-                )?)
+                )
             }
             PipelineData::ListStream(stream, ..) => {
                 // dbg!("value::stream");
                 let items = convert_to_list(stream, cell_path, config)?;
-                Ok(create_grid_output(
+                create_grid_output(
                     items,
                     call,
                     width_param,
@@ -109,7 +109,7 @@ column named 'name'. This is subject to change in the future."
                     env_str,
                     icons_param,
                     cwd.as_ref(),
-                )?)
+                )
             }
             PipelineData::Value(Value::Record { val, .. }, ..) => {
                 // dbg!("value::record");
@@ -147,27 +147,27 @@ column named 'name'. This is subject to change in the future."
             },
             Example {
                 description: "The above example is the same as:",
-                example: "[1 2 3 a b c] | wrap name | grid",
+                example: "[1 2 3 a b c] | wrap name | grid name",
                 result: Some(Value::test_string("1 │ 2 │ 3 │ a │ b │ c\n")),
             },
             Example {
-                description: "Render a record to a grid",
+                description: "Render a record to a grid (deprecated)",
                 example: "{name: 'foo', b: 1, c: 2} | grid",
                 result: Some(Value::test_string("foo\n")),
             },
             Example {
                 description: "Render a list of records to a grid",
-                example: "[{name: 'A', v: 1} {name: 'B', v: 2} {name: 'C', v: 3}] | grid",
+                example: "[{name: 'A', v: 1} {name: 'B', v: 2} {name: 'C', v: 3}] | grid name",
                 result: Some(Value::test_string("A │ B │ C\n")),
             },
             Example {
                 description: "Render a table with 'name' column in it to a grid",
-                example: "[[name patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | grid",
+                example: "[[name patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | grid name",
                 result: Some(Value::test_string("0.1.0 │ 0.1.1 │ 0.2.0\n")),
             },
             Example {
                 description: "Render a table with 'name' column in it to a grid with icons and colors",
-                example: "[[name patch]; [Cargo.toml false] [README.md true] [SECURITY.md false]] | grid --icons --color",
+                example: "[[name patch]; [Cargo.toml false] [README.md true] [SECURITY.md false]] | grid --icons --color name",
                 result: None,
             },
         ]

--- a/crates/nu-command/tests/commands/griddle.rs
+++ b/crates/nu-command/tests/commands/griddle.rs
@@ -38,8 +38,17 @@ fn grid_errors_with_few_columns() -> Result {
     "[{test: name} a 33 {name: in_the_middle} null {record: without_name} [ijkl {name: e}]]",
     ""
 )]
-fn test_output(#[case] code: &str, #[case] expected: &str) -> Result {
+fn test_output_without_column_name(#[case] code: &str, #[case] expected: &str) -> Result {
     test()
         .run(format!("{code} | grid --width 100"))
+        .expect_value_eq(expected)
+}
+
+#[rstest]
+#[case::record_with_name("{name: test}", "test\n")]
+#[case::table_with_name("[Darren Juhan Piep] | wrap name", "Darren │ Juhan │ Piep\n")]
+fn test_output_with_column_name(#[case] code: &str, #[case] expected: &str) -> Result {
+    test()
+        .run(format!("{code} | grid name --width 100"))
         .expect_value_eq(expected)
 }

--- a/crates/nu-command/tests/commands/griddle.rs
+++ b/crates/nu-command/tests/commands/griddle.rs
@@ -17,6 +17,7 @@ fn grid_errors_with_few_columns() -> Result {
 // and there are some other inconsistencies.
 
 #[rstest]
+#[case::empty_list("[]", "")]
 #[case::empty_record("{}", "")]
 #[case::list_of_string("[a b c]", "a │ b │ c\n")]
 #[case::list_of_various_data_types(
@@ -41,9 +42,4 @@ fn test_output(#[case] code: &str, #[case] expected: &str) -> Result {
     test()
         .run(format!("{code} | grid --width 100"))
         .expect_value_eq(expected)
-}
-
-#[test]
-fn empty_list_returns_nothing() -> Result {
-    test().run("[] | grid").expect_value_eq(())
 }


### PR DESCRIPTION
## Description
The `grid` command is hardcoded to always look for `name` column. This pr attempts to solve this issue by accepting an additional column parameter.

Also, `grid` command used to return `nothing` instead of string if the input was an empty list, it is now resolved.

## User-facing changes (Release notes)
### Deprecated implicit `name`  column for `grid` command
The `grid` command now accepts an optional column name to display the contents of that column in a grid. One should no longer rely on the old behavior which automatically displays the `name` column as it is deprecated. Moreover, passing in a record as the input is also deprecated.

```nushell
# before
ls | grid
{ name: test } | grid

# after
ls | grid name
[{ name: test }] | grid name
```

## Additional notes
N/A