### PR TITLE
feat: lock $env.config.history.path after REPL startup

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -301,6 +301,11 @@ fn get_line_editor(engine_state: &mut EngineState, use_color: bool) -> Result<Re
 
         line_editor = setup_history(engine_state, line_editor, history)?;
 
+        // Lock `$env.config.history.path` against further changes. Reedline owns the history
+        // backend from this point on, so runtime mutations of the path would silently do
+        // nothing
+        engine_state.history_path_locked = true;
+
         perf!("setup history", start_time, use_color);
     }
     Ok(line_editor)

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -301,10 +301,11 @@ fn get_line_editor(engine_state: &mut EngineState, use_color: bool) -> Result<Re
 
         line_editor = setup_history(engine_state, line_editor, history)?;
 
-        // Lock `$env.config.history.path` against further changes. Reedline owns the history
-        // backend from this point on, so runtime mutations of the path would silently do
-        // nothing
-        engine_state.history_path_locked = true;
+        // Lock the startup-only `$env.config.history.*` options (`path`, `max_size`,
+        // `file_format`, `isolation`) against further changes. Reedline owns the history
+        // backend from this point on, so runtime mutations of these fields would silently do
+        // nothing — better to reject them outright.
+        engine_state.history_locked_after_startup = true;
 
         perf!("setup history", start_time, use_color);
     }

--- a/crates/nu-protocol/src/config/error.rs
+++ b/crates/nu-protocol/src/config/error.rs
@@ -5,6 +5,7 @@ use crate::{Config, ConfigError, ConfigWarning, ShellError, ShellWarning, Span, 
 #[must_use]
 pub(super) struct ConfigErrors<'a> {
     config: &'a Config,
+    history_path_locked: bool,
     errors: Vec<ConfigError>,
     warnings: Vec<ConfigWarning>,
 }
@@ -13,9 +14,23 @@ impl<'a> ConfigErrors<'a> {
     pub fn new(config: &'a Config) -> Self {
         Self {
             config,
+            history_path_locked: false,
             errors: Vec::new(),
             warnings: Vec::new(),
         }
+    }
+
+    pub fn with_history_path_locked(mut self, locked: bool) -> Self {
+        self.history_path_locked = locked;
+        self
+    }
+
+    pub fn config(&self) -> &Config {
+        self.config
+    }
+
+    pub fn history_path_locked(&self) -> bool {
+        self.history_path_locked
     }
 
     pub fn has_errors(&self) -> bool {
@@ -73,6 +88,13 @@ impl<'a> ConfigErrors<'a> {
         self.error(ConfigError::UnknownOption {
             path: path.to_string(),
             span: value.span(),
+        });
+    }
+
+    pub fn locked_after_startup(&mut self, path: &ConfigPath, span: Span) {
+        self.error(ConfigError::LockedAfterStartup {
+            path: path.to_string(),
+            span,
         });
     }
 

--- a/crates/nu-protocol/src/config/error.rs
+++ b/crates/nu-protocol/src/config/error.rs
@@ -5,7 +5,7 @@ use crate::{Config, ConfigError, ConfigWarning, ShellError, ShellWarning, Span, 
 #[must_use]
 pub(super) struct ConfigErrors<'a> {
     config: &'a Config,
-    history_path_locked: bool,
+    history_locked_after_startup: bool,
     errors: Vec<ConfigError>,
     warnings: Vec<ConfigWarning>,
 }
@@ -14,14 +14,14 @@ impl<'a> ConfigErrors<'a> {
     pub fn new(config: &'a Config) -> Self {
         Self {
             config,
-            history_path_locked: false,
+            history_locked_after_startup: false,
             errors: Vec::new(),
             warnings: Vec::new(),
         }
     }
 
-    pub fn with_history_path_locked(mut self, locked: bool) -> Self {
-        self.history_path_locked = locked;
+    pub fn with_history_locked_after_startup(mut self, locked: bool) -> Self {
+        self.history_locked_after_startup = locked;
         self
     }
 
@@ -29,8 +29,8 @@ impl<'a> ConfigErrors<'a> {
         self.config
     }
 
-    pub fn history_path_locked(&self) -> bool {
-        self.history_path_locked
+    pub fn history_locked_after_startup(&self) -> bool {
+        self.history_locked_after_startup
     }
 
     pub fn has_errors(&self) -> bool {

--- a/crates/nu-protocol/src/config/history.rs
+++ b/crates/nu-protocol/src/config/history.rs
@@ -154,14 +154,28 @@ impl UpdateFromValue for HistoryConfig {
                 "file_format" => self.file_format.update(val, path, errors),
                 "path" => match val {
                     Value::String { val: s, .. } => {
-                        if s.is_empty() {
-                            self.path = HistoryPath::Default;
+                        let new_path = if s.is_empty() {
+                            HistoryPath::Default
+                        } else {
+                            HistoryPath::Custom(PathBuf::from(s))
+                        };
+
+                        if errors.history_path_locked() && new_path != errors.config().history.path
+                        {
+                            errors.locked_after_startup(path, val.span());
                             continue;
                         }
 
-                        self.path = HistoryPath::Custom(PathBuf::from(s));
+                        self.path = new_path;
                     }
                     Value::Nothing { .. } => {
+                        if errors.history_path_locked()
+                            && errors.config().history.path != HistoryPath::Disabled
+                        {
+                            errors.locked_after_startup(path, val.span());
+                            continue;
+                        }
+
                         self.path = HistoryPath::Disabled;
                     }
                     _ => {
@@ -185,5 +199,116 @@ impl UpdateFromValue for HistoryConfig {
             (true, HistoryFileFormat::Sqlite) => (),
             (false, _) => (),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Config;
+
+    fn config_with_history_path(path: HistoryPath) -> Config {
+        let mut config = Config::default();
+        config.history.path = path;
+        config
+    }
+
+    #[test]
+    fn lock_blocks_changing_to_custom_path() {
+        let old = config_with_history_path(HistoryPath::Default);
+        let mut new = old.clone();
+        let value = Value::test_record(record! {
+            "history" => Value::test_record(record! {
+                "path" => Value::test_string("/tmp/locked.txt"),
+            }),
+        });
+
+        let result = new.update_from_value_with_options(&old, &value, true);
+
+        let err = result.expect_err("should fail when locked");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("LockedAfterStartup"),
+            "expected LockedAfterStartup error, got: {msg}",
+        );
+        assert_eq!(new.history.path, HistoryPath::Default);
+    }
+
+    #[test]
+    fn lock_blocks_disabling_history_at_runtime() {
+        let old = config_with_history_path(HistoryPath::Custom("/tmp/h.txt".into()));
+        let mut new = old.clone();
+        let value = Value::test_record(record! {
+            "history" => Value::test_record(record! {
+                "path" => Value::nothing(Span::test_data()),
+            }),
+        });
+
+        let result = new.update_from_value_with_options(&old, &value, true);
+
+        let err = result.expect_err("should fail when locked");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("LockedAfterStartup"),
+            "expected LockedAfterStartup error, got: {msg}",
+        );
+        assert_eq!(new.history.path, HistoryPath::Custom("/tmp/h.txt".into()));
+    }
+
+    #[test]
+    fn lock_allows_setting_same_value() {
+        let old = config_with_history_path(HistoryPath::Custom("/tmp/h.txt".into()));
+        let mut new = old.clone();
+        let value = Value::test_record(record! {
+            "history" => Value::test_record(record! {
+                "path" => Value::test_string("/tmp/h.txt"),
+            }),
+        });
+
+        let result = new.update_from_value_with_options(&old, &value, true);
+
+        assert!(
+            result.is_ok(),
+            "no-op assignment should succeed: {result:?}"
+        );
+        assert_eq!(new.history.path, HistoryPath::Custom("/tmp/h.txt".into()));
+    }
+
+    #[test]
+    fn lock_allows_setting_default_when_already_default() {
+        let old = config_with_history_path(HistoryPath::Default);
+        let mut new = old.clone();
+        let value = Value::test_record(record! {
+            "history" => Value::test_record(record! {
+                "path" => Value::test_string(""),
+            }),
+        });
+
+        let result = new.update_from_value_with_options(&old, &value, true);
+
+        assert!(
+            result.is_ok(),
+            "no-op assignment should succeed: {result:?}"
+        );
+        assert_eq!(new.history.path, HistoryPath::Default);
+    }
+
+    #[test]
+    fn unlocked_update_changes_path() {
+        let old = config_with_history_path(HistoryPath::Default);
+        let mut new = old.clone();
+        let value = Value::test_record(record! {
+            "history" => Value::test_record(record! {
+                "path" => Value::test_string("/tmp/unlocked.txt"),
+            }),
+        });
+
+        let result = new.update_from_value_with_options(&old, &value, false);
+
+        assert!(result.is_ok(), "unlocked update should succeed: {result:?}");
+        assert_eq!(
+            new.history.path,
+            HistoryPath::Custom("/tmp/unlocked.txt".into())
+        );
     }
 }

--- a/crates/nu-protocol/src/config/history.rs
+++ b/crates/nu-protocol/src/config/history.rs
@@ -147,11 +147,36 @@ impl UpdateFromValue for HistoryConfig {
             match col.as_str() {
                 "isolation" => {
                     isolation_span = val.span();
-                    self.isolation.update(val, path, errors)
+                    let prev = self.isolation;
+                    self.isolation.update(val, path, errors);
+                    if errors.history_locked_after_startup()
+                        && self.isolation != errors.config().history.isolation
+                    {
+                        self.isolation = prev;
+                        errors.locked_after_startup(path, val.span());
+                    }
                 }
                 "sync_on_enter" => self.sync_on_enter.update(val, path, errors),
-                "max_size" => self.max_size.update(val, path, errors),
-                "file_format" => self.file_format.update(val, path, errors),
+                "max_size" => {
+                    let prev = self.max_size;
+                    self.max_size.update(val, path, errors);
+                    if errors.history_locked_after_startup()
+                        && self.max_size != errors.config().history.max_size
+                    {
+                        self.max_size = prev;
+                        errors.locked_after_startup(path, val.span());
+                    }
+                }
+                "file_format" => {
+                    let prev = self.file_format;
+                    self.file_format.update(val, path, errors);
+                    if errors.history_locked_after_startup()
+                        && self.file_format != errors.config().history.file_format
+                    {
+                        self.file_format = prev;
+                        errors.locked_after_startup(path, val.span());
+                    }
+                }
                 "path" => match val {
                     Value::String { val: s, .. } => {
                         let new_path = if s.is_empty() {
@@ -160,7 +185,8 @@ impl UpdateFromValue for HistoryConfig {
                             HistoryPath::Custom(PathBuf::from(s))
                         };
 
-                        if errors.history_path_locked() && new_path != errors.config().history.path
+                        if errors.history_locked_after_startup()
+                            && new_path != errors.config().history.path
                         {
                             errors.locked_after_startup(path, val.span());
                             continue;
@@ -169,7 +195,7 @@ impl UpdateFromValue for HistoryConfig {
                         self.path = new_path;
                     }
                     Value::Nothing { .. } => {
-                        if errors.history_path_locked()
+                        if errors.history_locked_after_startup()
                             && errors.config().history.path != HistoryPath::Disabled
                         {
                             errors.locked_after_startup(path, val.span());
@@ -310,5 +336,123 @@ mod tests {
             new.history.path,
             HistoryPath::Custom("/tmp/unlocked.txt".into())
         );
+    }
+
+    #[test]
+    fn lock_blocks_changing_max_size() {
+        let old = Config::default();
+        let original_max_size = old.history.max_size;
+        let mut new = old.clone();
+        let value = Value::test_record(record! {
+            "history" => Value::test_record(record! {
+                "max_size" => Value::test_int(original_max_size + 1),
+            }),
+        });
+
+        let result = new.update_from_value_with_options(&old, &value, true);
+
+        let err = result.expect_err("should fail when locked");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("LockedAfterStartup"),
+            "expected LockedAfterStartup error, got: {msg}",
+        );
+        assert_eq!(new.history.max_size, original_max_size);
+    }
+
+    #[test]
+    fn lock_allows_setting_same_max_size() {
+        let old = Config::default();
+        let original_max_size = old.history.max_size;
+        let mut new = old.clone();
+        let value = Value::test_record(record! {
+            "history" => Value::test_record(record! {
+                "max_size" => Value::test_int(original_max_size),
+            }),
+        });
+
+        let result = new.update_from_value_with_options(&old, &value, true);
+
+        assert!(
+            result.is_ok(),
+            "no-op assignment should succeed: {result:?}"
+        );
+        assert_eq!(new.history.max_size, original_max_size);
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn lock_blocks_changing_file_format() {
+        let old = Config::default();
+        let original_file_format = old.history.file_format;
+        let (_other_format, other_format_str) = match original_file_format {
+            HistoryFileFormat::Plaintext => (HistoryFileFormat::Sqlite, "sqlite"),
+            HistoryFileFormat::Sqlite => (HistoryFileFormat::Plaintext, "plaintext"),
+        };
+        let mut new = old.clone();
+        let value = Value::test_record(record! {
+            "history" => Value::test_record(record! {
+                "file_format" => Value::test_string(other_format_str),
+            }),
+        });
+
+        let result = new.update_from_value_with_options(&old, &value, true);
+
+        let err = result.expect_err("should fail when locked");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("LockedAfterStartup"),
+            "expected LockedAfterStartup error, got: {msg}",
+        );
+        assert_eq!(new.history.file_format, original_file_format);
+    }
+
+    #[test]
+    fn lock_blocks_changing_isolation() {
+        let old = Config::default();
+        let original_isolation = old.history.isolation;
+        let mut new = old.clone();
+        let value = Value::test_record(record! {
+            "history" => Value::test_record(record! {
+                "isolation" => Value::test_bool(!original_isolation),
+            }),
+        });
+
+        let result = new.update_from_value_with_options(&old, &value, true);
+
+        let err = result.expect_err("should fail when locked");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("LockedAfterStartup"),
+            "expected LockedAfterStartup error, got: {msg}",
+        );
+        assert_eq!(new.history.isolation, original_isolation);
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn unlocked_update_changes_max_size_file_format_isolation() {
+        let old = Config::default();
+        let mut new = old.clone();
+        let new_max_size = old.history.max_size + 1;
+        let (new_file_format, new_file_format_str) = match old.history.file_format {
+            HistoryFileFormat::Plaintext => (HistoryFileFormat::Sqlite, "sqlite"),
+            HistoryFileFormat::Sqlite => (HistoryFileFormat::Plaintext, "plaintext"),
+        };
+        let new_isolation = !old.history.isolation;
+        let value = Value::test_record(record! {
+            "history" => Value::test_record(record! {
+                "max_size" => Value::test_int(new_max_size),
+                "file_format" => Value::test_string(new_file_format_str),
+                "isolation" => Value::test_bool(new_isolation),
+            }),
+        });
+
+        let result = new.update_from_value_with_options(&old, &value, false);
+
+        assert!(result.is_ok(), "unlocked update should succeed: {result:?}");
+        assert_eq!(new.history.max_size, new_max_size);
+        assert_eq!(new.history.file_format, new_file_format);
+        assert_eq!(new.history.isolation, new_isolation);
     }
 }

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -259,21 +259,24 @@ impl Config {
     }
 
     /// Like [`Config::update_from_value`], but allows callers to indicate that runtime-locked
-    /// options (currently only `history.path`) should refuse to change.
+    /// options should refuse to change.
     ///
-    /// `history_path_locked` should be set to `true` once the REPL has finished initializing
-    /// reedline's history backend, at that point changing `history.path` has no effect, so we
-    /// reject the assignment with a clear error instead of silently ignoring it.
+    /// `history_locked_after_startup` should be set to `true` once the REPL has finished
+    /// initializing reedline's history backend. After that point, changing any of the
+    /// startup-only history fields (`path`, `max_size`, `file_format`, `isolation`) has no
+    /// effect on the live history, so we reject the assignment with a clear error instead of
+    /// silently ignoring it.
     pub fn update_from_value_with_options(
         &mut self,
         old: &Config,
         value: &Value,
-        history_path_locked: bool,
+        history_locked_after_startup: bool,
     ) -> Result<Option<ShellWarning>, ShellError> {
         // Current behaviour is that config errors are displayed, but do not prevent the rest
         // of the config from being updated (fields with errors are skipped/not updated).
         // Errors are simply collected one-by-one and wrapped into a ShellError variant at the end.
-        let mut errors = ConfigErrors::new(old).with_history_path_locked(history_path_locked);
+        let mut errors =
+            ConfigErrors::new(old).with_history_locked_after_startup(history_locked_after_startup);
         let mut path = ConfigPath::new();
 
         self.update(value, &mut path, &mut errors);

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -255,10 +255,25 @@ impl Config {
         old: &Config,
         value: &Value,
     ) -> Result<Option<ShellWarning>, ShellError> {
+        self.update_from_value_with_options(old, value, false)
+    }
+
+    /// Like [`Config::update_from_value`], but allows callers to indicate that runtime-locked
+    /// options (currently only `history.path`) should refuse to change.
+    ///
+    /// `history_path_locked` should be set to `true` once the REPL has finished initializing
+    /// reedline's history backend, at that point changing `history.path` has no effect, so we
+    /// reject the assignment with a clear error instead of silently ignoring it.
+    pub fn update_from_value_with_options(
+        &mut self,
+        old: &Config,
+        value: &Value,
+        history_path_locked: bool,
+    ) -> Result<Option<ShellWarning>, ShellError> {
         // Current behaviour is that config errors are displayed, but do not prevent the rest
         // of the config from being updated (fields with errors are skipped/not updated).
         // Errors are simply collected one-by-one and wrapped into a ShellError variant at the end.
-        let mut errors = ConfigErrors::new(old);
+        let mut errors = ConfigErrors::new(old).with_history_path_locked(history_path_locked);
         let mut path = ConfigPath::new();
 
         self.update(value, &mut path, &mut errors);

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -115,13 +115,14 @@ pub struct EngineState {
     config_path: HashMap<String, PathBuf>,
     pub history_enabled: bool,
     pub history_session_id: i64,
-    /// Whether `$env.config.history.path` is locked from further changes.
+    /// Whether the startup-only `$env.config.history.*` options are locked from further
+    /// changes (currently `path`, `max_size`, `file_format`, `isolation`).
     ///
     /// Set to `true` once the REPL has finished initializing reedline's history backend.
-    /// After that point, changing `history.path` would have no effect on where history is
-    /// actually written, so attempts to mutate it are rejected with an error instead of
-    /// being silently ignored.
-    pub history_path_locked: bool,
+    /// After that point, changing any of these options would have no effect on the live
+    /// history, so attempts to mutate them are rejected with an error instead of being
+    /// silently ignored.
+    pub history_locked_after_startup: bool,
     // Path to the file Nushell is currently evaluating, or None if we're in an interactive session.
     pub file: Option<PathBuf>,
     pub regex_cache: Arc<Mutex<LruCache<String, Regex>>>,
@@ -211,7 +212,7 @@ impl EngineState {
             config_path: HashMap::new(),
             history_enabled: true,
             history_session_id: 0,
-            history_path_locked: false,
+            history_locked_after_startup: false,
             file: None,
             regex_cache: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(REGEX_CACHE_SIZE).expect("tried to create cache of size zero"),

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -115,6 +115,13 @@ pub struct EngineState {
     config_path: HashMap<String, PathBuf>,
     pub history_enabled: bool,
     pub history_session_id: i64,
+    /// Whether `$env.config.history.path` is locked from further changes.
+    ///
+    /// Set to `true` once the REPL has finished initializing reedline's history backend.
+    /// After that point, changing `history.path` would have no effect on where history is
+    /// actually written, so attempts to mutate it are rejected with an error instead of
+    /// being silently ignored.
+    pub history_path_locked: bool,
     // Path to the file Nushell is currently evaluating, or None if we're in an interactive session.
     pub file: Option<PathBuf>,
     pub regex_cache: Arc<Mutex<LruCache<String, Regex>>>,
@@ -204,6 +211,7 @@ impl EngineState {
             config_path: HashMap::new(),
             history_enabled: true,
             history_session_id: 0,
+            history_path_locked: false,
             file: None,
             regex_cache: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(REGEX_CACHE_SIZE).expect("tried to create cache of size zero"),

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -219,7 +219,11 @@ impl Stack {
         if let Some(value) = self.get_env_var(engine_state, "config") {
             let old = self.get_config(engine_state);
             let mut config = (*old).clone();
-            let result = config.update_from_value(&old, value);
+            let result = config.update_from_value_with_options(
+                &old,
+                value,
+                engine_state.history_path_locked,
+            );
             // The config value is modified by the update, so we should add it again
             self.add_env_var("config".into(), config.clone().into_value(value.span()));
             self.config = Some(config.into());

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -222,7 +222,7 @@ impl Stack {
             let result = config.update_from_value_with_options(
                 &old,
                 value,
-                engine_state.history_path_locked,
+                engine_state.history_locked_after_startup,
             );
             // The config value is modified by the update, so we should add it again
             self.add_env_var("config".into(), config.clone().into_value(value.span()));

--- a/crates/nu-protocol/src/errors/config.rs
+++ b/crates/nu-protocol/src/errors/config.rs
@@ -51,6 +51,18 @@ pub enum ConfigError {
         #[label("deprecated")]
         span: Span,
     },
+    #[error("{path} cannot be changed after Nushell has started")]
+    #[diagnostic(
+        code(nu::shell::config_option_locked_after_startup),
+        help(
+            "set {path} in your config.nu (or via --config / the relevant env var) and restart Nushell"
+        )
+    )]
+    LockedAfterStartup {
+        path: String,
+        #[label("cannot be changed at runtime")]
+        span: Span,
+    },
     // TODO: remove this
     #[error(transparent)]
     #[diagnostic(transparent)]

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -41,11 +41,17 @@
 # history.file_format (string): The format used for the command history file.
 # "sqlite": Store history in an SQLite database with additional context (timestamps, etc.).
 # "plaintext": Store one command per line without additional context.
+# Note: This option is read once at startup. Changing it from the REPL
+# (e.g. `$env.config.history.file_format = "..."`) will produce an error -
+# set it in your `config.nu`, via `--config`, or via env, then restart Nushell.
 # Default: "plaintext"
 $env.config.history.file_format = "plaintext"
 
 # history.max_size (int): Maximum number of entries allowed in the history.
 # After exceeding this value, the oldest history items will be removed.
+# Note: This option is read once at startup. Changing it from the REPL
+# (e.g. `$env.config.history.max_size = ...`) will produce an error -
+# set it in your `config.nu`, via `--config`, or via env, then restart Nushell.
 # Default: 100_000
 $env.config.history.max_size = 100_000
 
@@ -61,6 +67,9 @@ $env.config.history.sync_on_enter = true
 # when scrolling through history (Up/Down keys).
 # false: All commands from other sessions are mixed with the current shell's history.
 # Note: Only applies to SQLite-backed history. Older history items are always shown.
+# Note: This option is read once at startup. Changing it from the REPL
+# (e.g. `$env.config.history.isolation = ...`) will produce an error -
+# set it in your `config.nu`, via `--config`, or via env, then restart Nushell.
 # Default: false
 $env.config.history.isolation = false
 

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -67,6 +67,9 @@ $env.config.history.isolation = false
 # history.path (string): Path to the history file.
 # If not set, Nushell will use the default location.
 # You can also provide a custom path for your history file.
+# Note: This option is read once at startup. Changing it from the REPL
+# (e.g. `$env.config.history.path = "..."`) will produce an error -
+# set it in your `config.nu`, via `--config`, or via env, then restart Nushell.
 # Examples:
 # Use a custom location (e.g., in your home directory):
 $env.config.history.path = "~/custom/my-history.txt"


### PR DESCRIPTION
## Description

Reedline takes ownership of the history backend the moment the REPL finishes calling `setup_history`. After that point, mutating `$env.config.history.path` from the prompt has no effect, reedline keeps writing to wherever it was originally pointed, which is what was reported in #18188 

Per the discussion in the issue, this PR matches the approach @fdncred suggested: instead of trying to live-reload
reedline's history backend, refuse the assignment from the REPL with a clear error. This is conceptually similar to how
$nu is protected today, but enforced one layer down (at config-apply time) since `$env` itself has to remain mutable

## How it works:

 - A new `history_path_locked: bool` flag on `EngineState` (defaults to `false`) gets flipped to true immediately after `setup_history` succeeds in `get_line_editor`
 - `Stack::update_config` reads that flag and forwards it to a new `Config::update_from_value_with_options(..., 
history_path_locked)`. The original `update_from_value` is kept as a thin wrapper for non-REPL callers
 - The flag is threaded through `ConfigErrors`, so `HistoryConfig::update` can check it when handling the path field. If the lock is set and the new value differs from the current one, it pushes a new `ConfigError::LockedAfterStartup` instead of applying
 - Setting the same value (no-op) is still allowed, so reassigning the whole `$env.config` record doesn't trigger spurious errors

`config.nu`, `--config`, env-based config, and `-c` are all unaffected because the lock is only flipped after `setup_history` runs, which happens after config has already been loaded.

## User-facing changes (Release notes)

### Locked history related config values during REPL

The following `$env.config.history` fields are now read-only after the REPL starts, since reedline only reads them once at startup and silently ignored later changes:

- `$env.config.history.path`
- `$env.config.history.max_size`
- `$env.config.history.file_format`
- `$env.config.history.isolation`

`sync_on_enter` and `ignore_space_prefixed` remain mutable from the REPL since they are re-read on each prompt.

Attempting to change one of the locked fields from the REPL now produces a clear error instead of being silently ignored:

```bash
> $env.config.history.path = "/tmp/elsewhere.txt"
Error: nu::shell::config_option_locked_after_startup

  × $env.config.history.path cannot be changed after Nushell has started
   ╭─[repl_entry #1:1:28]
  1 │ $env.config.history.path = "/tmp/elsewhere.txt"
    ·                            ─────────┬──────────
    ·                                     ╰── cannot be changed at runtime
    ╰────
  help: set $env.config.history.path in your config.nu (or via --config / the relevant env var) and restart Nushell
```

## Additional notes

Closes #18188