### PR TITLE
docs: fix duplicated words in comments

### DIFF
--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -81,8 +81,8 @@ impl Command for StrReplace {
     fn extra_description(&self) -> &str {
         "The pattern to find can be a substring (default) or a regular expression (with `--regex`).
 
-The replacement can be a a string, possibly containing references to numbered (`$1` etc) or
-named capture groups (`$name`), or it can be closure that is invoked for each match.
+The replacement can be a string, possibly containing references to numbered (`$1` etc) or
+named capture groups (`$name`), or it can be a closure that is invoked for each match.
 In the latter case, the closure is invoked with the entire match as its input and any capture
 groups as its argument. It must return a string that will be used as a replacement for the match.
 "

--- a/crates/nu-protocol/src/completion.rs
+++ b/crates/nu-protocol/src/completion.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// protocol should not rely on a cli relative interface.
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct DynamicSuggestion {
-    /// String replacement that will be introduced to the the buffer
+    /// String replacement that will be introduced to the buffer
     pub value: String,
     /// If given, overrides `value` as text displayed to user
     pub display_override: Option<String>,

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -735,7 +735,7 @@ impl Stack {
     ///
     /// For use in third-party applications pipes might be very useful as they allow using the
     /// stdout of external commands for different uses.
-    /// For example the [`os_pipe`](https://docs.rs/os_pipe) crate provides a elegant way to to
+    /// For example the [`os_pipe`](https://docs.rs/os_pipe) crate provides an elegant way to
     /// access the stdout.
     ///
     /// ```

--- a/crates/nu-system/src/netbsd.rs
+++ b/crates/nu-system/src/netbsd.rs
@@ -288,7 +288,7 @@ unsafe fn get_ctl<T>(ctl_name: &[i32]) -> io::Result<T> {
     assert_eq!(
         value_len,
         mem::size_of_val(&value),
-        "Data requested from from `sysctl` diverged in size from the expected return type. For variable length data you need to manually truncate the data to the valid returned size!"
+        "Data requested from `sysctl` diverged in size from the expected return type. For variable length data you need to manually truncate the data to the valid returned size!"
     );
     Ok(unsafe { value.assume_init() })
 }

--- a/crates/nu_plugin_polars/src/dataframe/command/data/len.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/len.rs
@@ -29,7 +29,7 @@ impl PluginCommand for ExprLen {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Count the number of rows in the the dataframe.",
+                description: "Count the number of rows in the dataframe.",
                 example: "[[a b]; [1 2] [3 4]] | polars into-df | polars select (polars len) | polars collect",
                 result: Some(
                     NuDataFrame::try_from_columns(


### PR DESCRIPTION
Fixes a few duplicated words and small grammar issues in comments/doc text. No behavior change.