### PR TITLE
fix: make `each` maintain the metadata of closure result if input is scalar

### DIFF
--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -226,8 +226,7 @@ list of lists like `list<list<string>>` into a flat list like `list<string>`."#
             // which is currently considered undesirable (Nov 2022).
             PipelineData::Value(value, metadata) => {
                 ClosureEvalOnce::new(engine_state, stack, closure)
-                    .add_arg(value.clone())?
-                    .run_with_input(value.into_pipeline_data_with_metadata(metadata))
+                    .run_with_value_and_metadata(value, metadata)
             }
         };
 

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -226,7 +226,7 @@ list of lists like `list<list<string>>` into a flat list like `list<string>`."#
             // which is currently considered undesirable (Nov 2022).
             PipelineData::Value(value, metadata) => {
                 ClosureEvalOnce::new(engine_state, stack, closure)
-                    .add_arg(value.clone())? // How can we avoid `.clone()` here?
+                    .add_arg(value.clone())?
                     .run_with_input(value.into_pipeline_data_with_metadata(metadata))
             }
         };

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -224,8 +224,10 @@ list of lists like `list<list<string>>` into a flat list like `list<string>`."#
             }
             // This match allows non-iterables to be accepted,
             // which is currently considered undesirable (Nov 2022).
-            PipelineData::Value(..) => {
-                ClosureEvalOnce::new(engine_state, stack, closure).run_with_input(input)
+            PipelineData::Value(value, metadata) => {
+                ClosureEvalOnce::new(engine_state, stack, closure)
+                    .add_arg(value.clone())? // How can we avoid `.clone()` here?
+                    .run_with_input(value.into_pipeline_data_with_metadata(metadata))
             }
         };
 

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -138,7 +138,6 @@ list of lists like `list<list<string>>` into a flat list like `list<string>`."#
         let keep_empty = call.has_flag(engine_state, stack, "keep-empty")?;
         let flatten = call.has_flag(engine_state, stack, "flatten")?;
 
-        // let metadata = input.take_metadata();
         let result = match input {
             PipelineData::Empty | PipelineData::Value(Value::Nothing { .. }, ..) => {
                 return Ok(input);
@@ -226,7 +225,7 @@ list of lists like `list<list<string>>` into a flat list like `list<string>`."#
             // which is currently considered undesirable (Nov 2022).
             PipelineData::Value(value, metadata) => {
                 ClosureEvalOnce::new(engine_state, stack, closure)
-                    .run_with_value_and_metadata(value, metadata)
+                    .run_with_value_with_metadata(value, metadata)
             }
         };
 

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -138,14 +138,15 @@ list of lists like `list<list<string>>` into a flat list like `list<string>`."#
         let keep_empty = call.has_flag(engine_state, stack, "keep-empty")?;
         let flatten = call.has_flag(engine_state, stack, "flatten")?;
 
-        let metadata = input.take_metadata();
+        // let metadata = input.take_metadata();
         let result = match input {
             PipelineData::Empty | PipelineData::Value(Value::Nothing { .. }, ..) => {
-                return Ok(input.set_metadata(metadata));
+                return Ok(input);
             }
             PipelineData::Value(Value::Range { .. }, ..)
             | PipelineData::Value(Value::List { .. }, ..)
             | PipelineData::ListStream(..) => {
+                let metadata = input.take_metadata();
                 let mut closure = ClosureEval::new(engine_state, stack, closure);
 
                 let out = if flatten {
@@ -166,11 +167,12 @@ list of lists like `list<list<string>>` into a flat list like `list<string>`."#
                         })
                         .into_pipeline_data(head, engine_state.signals().clone())
                 };
-                Ok(out)
+                Ok(out.set_metadata(metadata))
             }
             // Handle iterable custom values (like SQLiteQueryBuilder)
             #[expect(deprecated)]
             PipelineData::Value(Value::Custom { ref val, .. }, ..) if val.is_iterable() => {
+                let metadata = input.take_metadata();
                 let mut closure = ClosureEval::new(engine_state, stack, closure);
 
                 let out = if flatten {
@@ -191,9 +193,9 @@ list of lists like `list<list<string>>` into a flat list like `list<string>`."#
                         })
                         .into_pipeline_data(head, engine_state.signals().clone())
                 };
-                Ok(out)
+                Ok(out.set_metadata(metadata))
             }
-            PipelineData::ByteStream(stream, ..) => {
+            PipelineData::ByteStream(stream, metadata) => {
                 let Some(chunks) = stream.chunks() else {
                     return Ok(PipelineData::empty());
                 };
@@ -218,12 +220,12 @@ list of lists like `list<list<string>>` into a flat list like `list<string>`."#
                         })
                         .into_pipeline_data(head, engine_state.signals().clone())
                 };
-                Ok(out)
+                Ok(out.set_metadata(metadata))
             }
             // This match allows non-iterables to be accepted,
             // which is currently considered undesirable (Nov 2022).
-            PipelineData::Value(value, ..) => {
-                ClosureEvalOnce::new(engine_state, stack, closure).run_with_value(value)
+            PipelineData::Value(..) => {
+                ClosureEvalOnce::new(engine_state, stack, closure).run_with_input(input)
             }
         };
 
@@ -232,7 +234,6 @@ list of lists like `list<list<string>>` into a flat list like `list<string>`."#
         } else {
             result.and_then(|x| x.filter(|v| !v.is_nothing(), engine_state.signals()))
         }
-        .map(|data| data.set_metadata(metadata))
     }
 }
 

--- a/crates/nu-engine/src/closure_eval.rs
+++ b/crates/nu-engine/src/closure_eval.rs
@@ -1,6 +1,6 @@
 use crate::{eval::CallEval, get_eval_block_with_early_return};
 use nu_protocol::{
-    IntoPipelineData, PipelineData, ShellError, Span, Value,
+    IntoPipelineData, PipelineData, PipelineMetadata, ShellError, Span, Value,
     ast::Block,
     engine::{Closure, EngineState, EnvName, EnvVars, Stack},
 };
@@ -145,6 +145,20 @@ impl ClosureEval {
         self.call_eval
             .add_positional(&self.block.signature, Cow::Borrowed(&value))?;
         self.run_with_input(value.into_pipeline_data())
+    }
+
+    /// Run the closure using the given [`Value`] as both the pipeline input with metadata and the first argument.
+    ///
+    /// Using this function after or in combination with [`add_arg`](Self::add_arg) is most likely an error.
+    /// This function is equivalent to `self.add_arg(value)` followed by `self.run_with_input(value.into_pipeline_data_with_metadata(metadata))`.
+    pub fn run_with_value_and_metadata(
+        &mut self,
+        value: Value,
+        metadata: Option<PipelineMetadata>,
+    ) -> Result<PipelineData, ShellError> {
+        self.call_eval
+            .add_positional(&self.block.signature, Cow::Borrowed(&value))?;
+        self.run_with_input(value.into_pipeline_data_with_metadata(metadata))
     }
 }
 
@@ -297,5 +311,19 @@ impl<'a> ClosureEvalOnce<'a> {
         self.call_eval
             .add_positional(&self.block.signature, Cow::Borrowed(&value))?;
         self.run_with_input(value.into_pipeline_data())
+    }
+
+    /// Run the closure using the given [`Value`] as both the pipeline input with metadata and the first argument.
+    ///
+    /// Using this function after or in combination with [`add_arg`](Self::add_arg) is most likely an error.
+    /// This function is equivalent to `self.add_arg(value)` followed by `self.run_with_input(value.into_pipeline_data_with_metadata(metadata))`.
+    pub fn run_with_value_and_metadata(
+        mut self,
+        value: Value,
+        metadata: Option<PipelineMetadata>,
+    ) -> Result<PipelineData, ShellError> {
+        self.call_eval
+            .add_positional(&self.block.signature, Cow::Borrowed(&value))?;
+        self.run_with_input(value.into_pipeline_data_with_metadata(metadata))
     }
 }

--- a/crates/nu-engine/src/closure_eval.rs
+++ b/crates/nu-engine/src/closure_eval.rs
@@ -151,7 +151,7 @@ impl ClosureEval {
     ///
     /// Using this function after or in combination with [`add_arg`](Self::add_arg) is most likely an error.
     /// This function is equivalent to `self.add_arg(value)` followed by `self.run_with_input(value.into_pipeline_data_with_metadata(metadata))`.
-    pub fn run_with_value_and_metadata(
+    pub fn run_with_value_with_metadata(
         &mut self,
         value: Value,
         metadata: Option<PipelineMetadata>,
@@ -317,7 +317,7 @@ impl<'a> ClosureEvalOnce<'a> {
     ///
     /// Using this function after or in combination with [`add_arg`](Self::add_arg) is most likely an error.
     /// This function is equivalent to `self.add_arg(value)` followed by `self.run_with_input(value.into_pipeline_data_with_metadata(metadata))`.
-    pub fn run_with_value_and_metadata(
+    pub fn run_with_value_with_metadata(
         mut self,
         value: Value,
         metadata: Option<PipelineMetadata>,


### PR DESCRIPTION
## Description
Previously `"test" | each { ls }` wouldn't keep the metadata of `ls`, this pr solves this by not overriding the metadata of the closure return value when the input is scalar.

## User-facing changes (Release notes)
The `each` command now preserves the metadata of the output of the closure if the input is a scalar value.

## Additional notes
See https://github.com/nushell/nushell/discussions/18199