### PR TITLE
Fix nested update closure for table columns

### DIFF
--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -113,13 +113,18 @@ fn update_recursive(
     match input {
         PipelineData::Value(mut value, metadata) => {
             if let Value::Closure { val, .. } = replacement {
-                update_single_value_by_closure(
-                    &mut value,
-                    ClosureEvalOnce::new(engine_state, stack, *val),
-                    head_span,
-                    cell_paths,
-                    false,
-                )?;
+                if matches!(cell_paths.first(), Some(PathMember::Int { .. })) {
+                    update_single_value_by_closure(
+                        &mut value,
+                        ClosureEvalOnce::new(engine_state, stack, *val),
+                        head_span,
+                        cell_paths,
+                        false,
+                    )?;
+                } else {
+                    let mut closure = ClosureEval::new(engine_state, stack, *val);
+                    update_value_by_closure(&mut value, &mut closure, head_span, cell_paths)?;
+                }
             } else {
                 value.update_data_at_cell_path(cell_paths, replacement)?;
             }
@@ -252,29 +257,161 @@ fn update(
     )
 }
 
+/// Applies `closure` to every leaf cell reached by following `cell_path` inside `value`.
+///
+/// Captures the initial value as the row context before descending, then delegates to
+/// [`update_value_by_closure_recursive`] for the actual traversal.
 fn update_value_by_closure(
     value: &mut Value,
     closure: &mut ClosureEval,
     span: Span,
     cell_path: &[PathMember],
 ) -> Result<(), ShellError> {
-    let value_at_path = value.follow_cell_path(cell_path)?;
+    let row_value = value.clone();
+    update_value_by_closure_recursive(value, &row_value, closure, span, cell_path)
+}
 
-    // Don't run the closure for optional paths that don't exist
-    let is_optional = cell_path.iter().any(|member| match member {
-        PathMember::String { optional, .. } => *optional,
-        PathMember::Int { optional, .. } => *optional,
-    });
-    if is_optional && matches!(value_at_path.as_ref(), Value::Nothing { .. }) {
+/// Recursively walks `cell_path` inside `value`, applying `closure` at every leaf cell.
+///
+/// # Parameters
+/// * `value` - The current cell being traversed. At the leaf it is overwritten with the closure result.
+/// * `row_value` - The enclosing *row* passed as the positional argument (`|row|` / `$it`)
+///   to the closure. When descending through a list-of-records this is updated to each
+///   individual nested record, so the closure always receives the most-immediately-enclosing
+///   row rather than a projected list of column values.
+/// * `closure` - The user-supplied closure, evaluated once per leaf cell.
+/// * `span` - Span used when converting the closure output back to a [`Value`].
+/// * `cell_path` - Remaining path members to traverse.
+fn update_value_by_closure_recursive(
+    value: &mut Value,
+    row_value: &Value,
+    closure: &mut ClosureEval,
+    span: Span,
+    cell_path: &[PathMember],
+) -> Result<(), ShellError> {
+    // Base case: no more path to traverse — evaluate the closure at this leaf cell.
+    // `$in` receives the current cell value; the optional positional arg receives the row.
+    let Some((member, path)) = cell_path.split_first() else {
+        let new_value = closure
+            .add_arg(row_value.clone())?
+            .run_with_input(value.clone().into_pipeline_data())?
+            .into_value(span)?;
+        *value = new_value;
         return Ok(());
+    };
+
+    let v_span = value.span();
+
+    match member {
+        PathMember::String {
+            val: col_name,
+            span: path_span,
+            casing,
+            optional,
+        } => {
+            // Copy the span once per arm so all inner branches share the same value.
+            let path_span = Span::new(path_span.start, path_span.end);
+            match value {
+                Value::List { vals, .. } => {
+                    for val in vals.iter_mut() {
+                        // Each nested record becomes the new row context so that `|row|`
+                        // refers to the immediately-enclosing record, not the outer row.
+                        let row_context = val.clone();
+                        let val_span = val.span();
+
+                        match val {
+                            Value::Record { val: record, .. } => {
+                                if let Some(cell) =
+                                    record.to_mut().cased_mut(*casing).get_mut(col_name)
+                                {
+                                    update_value_by_closure_recursive(
+                                        cell,
+                                        &row_context,
+                                        closure,
+                                        path_span,
+                                        path,
+                                    )?;
+                                } else if !*optional {
+                                    return Err(ShellError::CantFindColumn {
+                                        col_name: col_name.clone(),
+                                        span: Some(path_span),
+                                        src_span: val_span,
+                                    });
+                                }
+                            }
+                            Value::Error { error, .. } => return Err(*error.clone()),
+                            _ => {
+                                if !*optional {
+                                    return Err(ShellError::CantFindColumn {
+                                        col_name: col_name.clone(),
+                                        span: Some(path_span),
+                                        src_span: val_span,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+                Value::Record { val: record, .. } => {
+                    if let Some(cell) = record.to_mut().cased_mut(*casing).get_mut(col_name) {
+                        update_value_by_closure_recursive(
+                            cell, row_value, closure, path_span, path,
+                        )?;
+                    } else if !*optional {
+                        return Err(ShellError::CantFindColumn {
+                            col_name: col_name.clone(),
+                            span: Some(path_span),
+                            src_span: v_span,
+                        });
+                    }
+                }
+                Value::Error { error, .. } => return Err(*error.clone()),
+                v => {
+                    if !*optional {
+                        return Err(ShellError::CantFindColumn {
+                            col_name: col_name.clone(),
+                            span: Some(path_span),
+                            src_span: v.span(),
+                        });
+                    }
+                }
+            }
+        }
+        PathMember::Int {
+            val: row_num,
+            span: path_span,
+            optional,
+        } => {
+            let path_span = Span::new(path_span.start, path_span.end);
+            match value {
+                Value::List { vals, .. } => {
+                    if let Some(cell) = vals.get_mut(*row_num) {
+                        update_value_by_closure_recursive(
+                            cell, row_value, closure, path_span, path,
+                        )?;
+                    } else if !*optional {
+                        if vals.is_empty() {
+                            return Err(ShellError::AccessEmptyContent { span: path_span });
+                        }
+
+                        return Err(ShellError::AccessBeyondEnd {
+                            max_idx: vals.len() - 1,
+                            span: path_span,
+                        });
+                    }
+                }
+                Value::Error { error, .. } => return Err(*error.clone()),
+                v => {
+                    return Err(ShellError::NotAList {
+                        dst_span: path_span,
+                        src_span: v.span(),
+                    });
+                }
+            }
+        }
     }
 
-    let new_value = closure
-        .add_arg(value.clone())?
-        .run_with_input(value_at_path.into_owned().into_pipeline_data())?
-        .into_value(span)?;
-
-    value.update_data_at_cell_path(cell_path, new_value)
+    Ok(())
 }
 
 fn update_single_value_by_closure(

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -341,3 +341,21 @@ fn update_optional_in_list_stream_with_closure() -> Result {
         .run("[{a: 1}, {b: 2}, {a: 3}] | every 1 | update a? { $in * 10 } | to nuon")
         .expect_value_eq("[{a: 10}, {b: 2}, {a: 30}]")
 }
+
+#[test]
+fn update_nested_table_column_closure_updates_each_nested_row() -> Result {
+    test()
+        .run(
+            "{ rss_item: [[pubDate]; [1], [2], [3]] } | update rss_item.pubDate { $in + 10 } | get rss_item | to nuon",
+        )
+        .expect_value_eq("[[pubDate]; [11], [12], [13]]")
+}
+
+#[test]
+fn update_nested_table_column_closure_with_in_place_transform() -> Result {
+    test()
+        .run(
+            "{ rss_item: [[pubDate]; [1773429600], [1774325700], [1775448000]] } | update rss_item.pubDate { into datetime -f '%s' } | get rss_item.0.pubDate | describe",
+        )
+        .expect_value_eq("datetime")
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This fixes a bug where update with a nested column path and closure (for example rss_item.pubDate) could evaluate the closure against a projected list and write the same result back to every row.

- Switched nested closure updates to a recursive per-cell traversal so closures run once per targeted leaf value.
- Preserved existing behavior for index-first paths (for example update 0.a with a closure).

<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
This fixes a bug where update with a nested column path and closure (for example rss_item.pubDate) could evaluate the closure against a projected list and write the same result back to every row.

### Before
```nushell
{
  rss_item: [
    [  pubDate];
    [1773429600],
    [1774325700],
    [1775448000]
  ]
} | update rss_item.pubDate { into datetime -f "%s" } | table -e
╭──────────┬──────────────────────────────╮
│          │ ╭─#─┬───────pubDate────────╮ │
│ rss_item │ │ 0 │ ╭───┬──────────────╮ │ │
│          │ │   │ │ 0 │ 2 months ago │ │ │
│          │ │   │ │ 1 │ 2 months ago │ │ │
│          │ │   │ │ 2 │ a month ago  │ │ │
│          │ │   │ ╰───┴──────────────╯ │ │
│          │ │ 1 │ ╭───┬──────────────╮ │ │
│          │ │   │ │ 0 │ 2 months ago │ │ │
│          │ │   │ │ 1 │ 2 months ago │ │ │
│          │ │   │ │ 2 │ a month ago  │ │ │
│          │ │   │ ╰───┴──────────────╯ │ │
│          │ │ 2 │ ╭───┬──────────────╮ │ │
│          │ │   │ │ 0 │ 2 months ago │ │ │
│          │ │   │ │ 1 │ 2 months ago │ │ │
│          │ │   │ │ 2 │ a month ago  │ │ │
│          │ │   │ ╰───┴──────────────╯ │ │
│          │ ╰─#─┴───────pubDate────────╯ │
╰──────────┴──────────────────────────────╯
```

### After
```nushell
{
  rss_item: [
    [  pubDate];
    [1773429600],
    [1774325700],
    [1775448000]
  ]
} | update rss_item.pubDate { into datetime -f "%s" } | table -e
╭──────────┬──────────────────────╮
│          │ ╭─#─┬───pubDate────╮ │
│ rss_item │ │ 0 │ 2 months ago │ │
│          │ │ 1 │ 2 months ago │ │
│          │ │ 2 │ a month ago  │ │
│          │ ╰───┴──────────────╯ │
╰──────────┴──────────────────────╯
```
### Before
```nushell
{ w: { x: [ { y: "1" } { y: "2" } ] } } | update w.x.y { into float } | to yaml
w:
  x:
    - 'y':
        - 1.0
        - 2.0
    - 'y':
        - 1.0
        - 2.0
```
### After
```nushell
{ w: { x: [ { y: "1" } { y: "2" } ] } } | update w.x.y { into float } | to yaml
w:
  x:
    - 'y': 1.0
    - 'y': 2.0
```
### Before
```nushell
[{w: {x: [{y: "1"} {y: "2"}]}}] | update w.x.y { into float } | to yaml
- w:
    x:
      - 'y':
          - 1.0
          - 2.0
      - 'y':
          - 1.0
          - 2.0
```
### After
```nushell
[{w: {x: [{y: "1"} {y: "2"}]}}] | update w.x.y { into float } | to yaml
- w:
    x:
      - 'y': 1.0
      - 'y': 2.0
```
### Before
```nushell
[ [[a]; [1] [2]] ] | update a {into float} | to yaml
-
  - a:
      - 1.0
      - 2.0
  - a:
      - 1.0
      - 2.0
```
### After
```nushell
[ [[a]; [1] [2]] ] | update a {into float} | to yaml
-
  - a: 1.0
  - a: 2.0
```
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
closes https://github.com/nushell/nushell/issues/15726
related https://github.com/nushell/nushell/pull/15789

<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->