### PR TITLE
Optional parameters are typed `oneof<T, nothing>`

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4953,10 +4953,39 @@ pub fn parse_signature_helper(
                     }
                     sig.required_positional.push(positional)
                 } else {
+                    // optional parameters can be `null`
+                    // their type within the block should reflect that
+                    if positional.default_value.is_none() {
+                        let var_id = positional
+                            .var_id
+                            .expect("internal error: all custom parameters must have var_ids");
+                        let ty = working_set
+                            .get_variable(var_id)
+                            .ty
+                            .clone()
+                            .widen(Type::Nothing);
+                        working_set.set_variable_type(var_id, ty);
+                    }
                     sig.optional_positional.push(positional)
                 }
             }
-            Arg::Flag { flag, .. } => sig.named.push(flag),
+            Arg::Flag {
+                flag,
+                type_annotated,
+            } => {
+                if type_annotated && flag.default_value.is_none() {
+                    let var_id = flag
+                        .var_id
+                        .expect("internal error: all custom parameters must have var_ids");
+                    let ty = working_set
+                        .get_variable(var_id)
+                        .ty
+                        .clone()
+                        .widen(Type::Nothing);
+                    working_set.set_variable_type(var_id, ty);
+                }
+                sig.named.push(flag)
+            }
             Arg::RestPositional(positional) => {
                 if positional.name.is_empty() {
                     working_set.error(ParseError::RestNeedsName(span))

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -3329,6 +3329,18 @@ mod input_types {
     #[case::vardecl(b"let a: table<a: int b: int> = [[a b]; [1 1]]", false)]
     #[case::vardecl(b"let a: list<string asd> = []", true)]
     #[case::vardecl(b"let a: record<a: int b: record<a: int> = {a: 1 b: {a: 1}}", true)]
+    #[ignore = "`x` gets its type from the `p` (int), an error is thrown when a null value is assigned instead"]
+    #[case::opt_param_is_nullable(b"def f [p?: int] { mut x = $p; $x = null }", false)]
+    #[ignore = "`x` gets its type from the `flag` (int), an error is thrown when a null value is assigned instead"]
+    #[case::flag_with_type_is_nullable(b"def f [--flag: int] { mut x = $flag; $x = null }", false)]
+    #[case::opt_param_with_default_is_not_nullable(
+        b"def f [p?: int = 42] { mut x = $p; $x = null }",
+        true
+    )]
+    #[case::flag_with_type_and_default_is_not_nullable(
+        b"def f [--flag: int = 42] { mut x = $flag; $x = null }",
+        true
+    )]
     fn test_type_annotations(#[case] phrase: &[u8], #[case] expect_errors: bool) {
         let mut engine_state = EngineState::new();
         add_declarations(&mut engine_state);

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -3329,9 +3329,7 @@ mod input_types {
     #[case::vardecl(b"let a: table<a: int b: int> = [[a b]; [1 1]]", false)]
     #[case::vardecl(b"let a: list<string asd> = []", true)]
     #[case::vardecl(b"let a: record<a: int b: record<a: int> = {a: 1 b: {a: 1}}", true)]
-    #[ignore = "`x` gets its type from the `p` (int), an error is thrown when a null value is assigned instead"]
     #[case::opt_param_is_nullable(b"def f [p?: int] { mut x = $p; $x = null }", false)]
-    #[ignore = "`x` gets its type from the `flag` (int), an error is thrown when a null value is assigned instead"]
     #[case::flag_with_type_is_nullable(b"def f [--flag: int] { mut x = $flag; $x = null }", false)]
     #[case::opt_param_with_default_is_not_nullable(
         b"def f [p?: int = 42] { mut x = $p; $x = null }",

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -313,7 +313,6 @@ fn array_of_wrong_types() -> TestResult {
 
 #[test]
 #[exp(ENFORCE_RUNTIME_ANNOTATIONS)]
-#[ignore = "`var` gets its type from the param/flag (int), an error is thrown when a null value is assigned instead"]
 fn optional_parameters_and_flags_are_nullable() -> Result {
     let mut tester = test();
 

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -1,4 +1,6 @@
 use crate::repl::tests::{TestResult, fail_test, run_test, run_test_contains};
+use nu_experimental::ENFORCE_RUNTIME_ANNOTATIONS;
+use nu_test_support::prelude::*;
 use rstest::rstest;
 
 #[test]
@@ -307,4 +309,29 @@ fn array_of_wrong_types() -> TestResult {
         "0..128 | each {} | into string | bytes collect",
         "nu::shell::only_supports_this_input_type",
     )
+}
+
+#[test]
+#[exp(ENFORCE_RUNTIME_ANNOTATIONS)]
+#[ignore = "`var` gets its type from the param/flag (int), an error is thrown when a null value is assigned instead"]
+fn optional_parameters_and_flags_are_nullable() -> Result {
+    let mut tester = test();
+
+    let code = "
+        def foo [opt_param?: int] {
+            let var = $opt_param
+        }
+        foo
+    ";
+    let () = tester.run(code)?;
+
+    let code = "
+        def foo [--flag: int] {
+            let var = $flag
+        }
+        foo
+    ";
+    let () = tester.run(code)?;
+
+    Ok(())
 }


### PR DESCRIPTION
## Description

optional parameters and flags with a type annotation (type T)
- if no default value is given, their type should be `oneof<T, nothing>`
- if a default value is given, their type should be `T`

this pr contains tests for both parse time type checking and
runtime type checking (specifically with `ENFORCE_RUNTIME_ANNOTATIONS`)

demonstrating with lsp inlay hints:

before:
<img width="442" height="100" alt="image" src="https://github.com/user-attachments/assets/ea0ef6f6-4cec-4708-bdc2-9a095d21763c" />

after:
<img width="442" height="100" alt="image" src="https://github.com/user-attachments/assets/44ba6cc8-18eb-4569-9498-9ec0eb0285ae" />
<img width="442" height="100" alt="image" src="https://github.com/user-attachments/assets/167dcd0b-d16a-4ae8-8d2c-0fcaac166ba6" />


## User-facing changes (Release notes)

TODO