### PR TITLE
Empty blocks' output types are the same as their input types

### DIFF
--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -851,7 +851,7 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
 
     for (input_type, output_type) in &block.signature.input_output_types {
         let current_output_types = match block.pipelines.as_slice() {
-            [] => vec![Type::Nothing],
+            [] => vec![input_type.clone()],
             pipelines => {
                 pipelines
                     .iter()

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -777,54 +777,54 @@ pub fn check_pipeline_type(
     pipeline: &Pipeline,
     input_type: Type,
 ) -> (Vec<Type>, Option<Vec<ParseError>>) {
-    let mut current_types: Vec<Type>;
-    let mut new_types: Vec<Type> = vec![input_type];
+    let mut input_types: Vec<Type>;
+    let mut output_types: Vec<Type> = vec![input_type];
 
     let mut output_errors: Option<Vec<ParseError>> = None;
 
     for elem in &pipeline.elements {
-        current_types = std::mem::take(&mut new_types);
-        current_types.sort();
-        current_types.dedup();
+        input_types = std::mem::take(&mut output_types);
+        input_types.sort();
+        input_types.dedup();
 
         if elem.redirection.is_some() {
-            new_types = vec![Type::Any];
+            output_types = vec![Type::Any];
             continue;
         }
         if let Expr::Call(call) = &elem.expr.expr {
             // Dynamic percent dispatch uses a placeholder decl_id that is rewritten later in IR.
             // Defer type constraints for this call at parse/type-check time.
             if call.parser_info.contains_key("percent_forced_builtin") {
-                new_types = vec![Type::Any];
+                output_types = vec![Type::Any];
                 continue;
             }
 
             let decl = working_set.get_decl(call.decl_id);
             let io_types = decl.signature().input_output_types;
-            if new_types.contains(&Type::Any) {
+            if output_types.contains(&Type::Any) {
                 // if input type is any, then output type could be any of the valid output types
-                new_types = io_types.into_iter().map(|(_, out_type)| out_type).collect();
+                output_types = io_types.into_iter().map(|(_, out_type)| out_type).collect();
             } else {
                 // any current type which matches an input type is a possible output type
-                new_types = io_types
+                output_types = io_types
                     .into_iter()
                     .filter(|(in_type, _)| {
-                        current_types.iter().any(|ty| type_compatible(in_type, ty))
+                        input_types.iter().any(|ty| type_compatible(in_type, ty))
                     })
                     .map(|(_, out_type)| out_type)
                     .collect();
             }
 
-            if !new_types.is_empty() {
+            if !output_types.is_empty() {
                 continue;
             }
 
             if decl.signature().input_output_types.is_empty() {
-                new_types = vec![Type::Any];
+                output_types = vec![Type::Any];
                 continue;
             }
 
-            let Some(types_string) = combined_type_string(&current_types, "or") else {
+            let Some(types_string) = combined_type_string(&input_types, "or") else {
                 output_errors
                     .get_or_insert_default()
                     .push(ParseError::InternalError(
@@ -838,11 +838,11 @@ pub fn check_pipeline_type(
                 .get_or_insert_default()
                 .push(ParseError::InputMismatch(types_string, call.head));
         } else {
-            new_types = vec![elem.expr.ty.clone()];
+            output_types = vec![elem.expr.ty.clone()];
         }
     }
 
-    (new_types, output_errors)
+    (output_types, output_errors)
 }
 
 pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) -> Vec<ParseError> {

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -777,25 +777,27 @@ pub fn check_pipeline_type(
     pipeline: &Pipeline,
     input_type: Type,
 ) -> (Vec<Type>, Option<Vec<ParseError>>) {
-    let mut input_types: Vec<Type>;
-    let mut output_types: Vec<Type> = vec![input_type];
+    let mut input_types = Vec::new();
+    let mut output_types = Vec::new();
 
     let mut output_errors: Option<Vec<ParseError>> = None;
 
+    output_types.push(input_type);
     for elem in &pipeline.elements {
-        input_types = std::mem::take(&mut output_types);
+        std::mem::swap(&mut input_types, &mut output_types);
+        output_types.clear();
         input_types.sort();
         input_types.dedup();
 
         if elem.redirection.is_some() {
-            output_types = vec![Type::Any];
+            output_types.push(Type::Any);
             continue;
         }
         if let Expr::Call(call) = &elem.expr.expr {
             // Dynamic percent dispatch uses a placeholder decl_id that is rewritten later in IR.
             // Defer type constraints for this call at parse/type-check time.
             if call.parser_info.contains_key("percent_forced_builtin") {
-                output_types = vec![Type::Any];
+                output_types.push(Type::Any);
                 continue;
             }
 
@@ -803,16 +805,17 @@ pub fn check_pipeline_type(
             let io_types = decl.signature().input_output_types;
             if output_types.contains(&Type::Any) {
                 // if input type is any, then output type could be any of the valid output types
-                output_types = io_types.into_iter().map(|(_, out_type)| out_type).collect();
+                output_types.extend(io_types.into_iter().map(|(_, out_type)| out_type));
             } else {
                 // any current type which matches an input type is a possible output type
-                output_types = io_types
-                    .into_iter()
-                    .filter(|(in_type, _)| {
-                        input_types.iter().any(|ty| type_compatible(in_type, ty))
-                    })
-                    .map(|(_, out_type)| out_type)
-                    .collect();
+                output_types.extend(
+                    io_types
+                        .into_iter()
+                        .filter(|(in_type, _)| {
+                            input_types.iter().any(|ty| type_compatible(in_type, ty))
+                        })
+                        .map(|(_, out_type)| out_type),
+                );
             }
 
             if !output_types.is_empty() {
@@ -820,7 +823,7 @@ pub fn check_pipeline_type(
             }
 
             if decl.signature().input_output_types.is_empty() {
-                output_types = vec![Type::Any];
+                output_types.push(Type::Any);
                 continue;
             }
 
@@ -838,7 +841,7 @@ pub fn check_pipeline_type(
                 .get_or_insert_default()
                 .push(ParseError::InputMismatch(types_string, call.head));
         } else {
-            output_types = vec![elem.expr.ty.clone()];
+            output_types.push(elem.expr.ty.clone());
         }
     }
 

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -808,6 +808,12 @@ pub fn check_pipeline_type(
 
         let decl = working_set.get_decl(call.decl_id);
         let io_types = decl.signature().input_output_types;
+
+        if io_types.is_empty() {
+            output_types.push(Type::Any);
+            continue;
+        }
+
         if output_types.contains(&Type::Any) {
             // if input type is any, then output type could be any of the valid output types
             output_types.extend(io_types.into_iter().map(|(_, out_type)| out_type));
@@ -824,11 +830,6 @@ pub fn check_pipeline_type(
         }
 
         if !output_types.is_empty() {
-            continue;
-        }
-
-        if decl.signature().input_output_types.is_empty() {
-            output_types.push(Type::Any);
             continue;
         }
 

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -816,7 +816,7 @@ pub fn check_pipeline_type(
             continue;
         }
 
-        if output_types.contains(&Type::Any) {
+        if input_types.contains(&Type::Any) {
             // if input type is any, then output type could be any of the valid output types
             output_types.extend(io_types.into_iter().map(|(_, out_type)| out_type));
         } else {

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -806,8 +806,10 @@ pub fn check_pipeline_type(
             continue;
         }
 
-        let decl = working_set.get_decl(call.decl_id);
-        let io_types = decl.signature().input_output_types;
+        let io_types = working_set
+            .get_decl(call.decl_id)
+            .signature()
+            .input_output_types;
 
         if io_types.is_empty() {
             output_types.push(Type::Any);

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -788,6 +788,8 @@ pub fn check_pipeline_type(
         output_types.clear();
         input_types.sort();
         input_types.dedup();
+        // Should be immutable from this point forward
+        let input_types = input_types.as_slice();
 
         if elem.redirection.is_some() {
             output_types.push(Type::Any);
@@ -827,7 +829,7 @@ pub fn check_pipeline_type(
                 continue;
             }
 
-            let Some(types_string) = combined_type_string(&input_types, "or") else {
+            let Some(types_string) = combined_type_string(input_types, "or") else {
                 output_errors
                     .get_or_insert_default()
                     .push(ParseError::InternalError(

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -795,56 +795,56 @@ pub fn check_pipeline_type(
             output_types.push(Type::Any);
             continue;
         }
-        if let Expr::Call(call) = &elem.expr.expr {
-            // Dynamic percent dispatch uses a placeholder decl_id that is rewritten later in IR.
-            // Defer type constraints for this call at parse/type-check time.
-            if call.parser_info.contains_key("percent_forced_builtin") {
-                output_types.push(Type::Any);
-                continue;
-            }
+        let Expr::Call(call) = &elem.expr.expr else {
+            output_types.push(elem.expr.ty.clone());
+            continue;
+        };
+        // Dynamic percent dispatch uses a placeholder decl_id that is rewritten later in IR.
+        // Defer type constraints for this call at parse/type-check time.
+        if call.parser_info.contains_key("percent_forced_builtin") {
+            output_types.push(Type::Any);
+            continue;
+        }
 
-            let decl = working_set.get_decl(call.decl_id);
-            let io_types = decl.signature().input_output_types;
-            if output_types.contains(&Type::Any) {
-                // if input type is any, then output type could be any of the valid output types
-                output_types.extend(io_types.into_iter().map(|(_, out_type)| out_type));
-            } else {
-                // any current type which matches an input type is a possible output type
-                output_types.extend(
-                    io_types
-                        .into_iter()
-                        .filter(|(in_type, _)| {
-                            input_types.iter().any(|ty| type_compatible(in_type, ty))
-                        })
-                        .map(|(_, out_type)| out_type),
-                );
-            }
+        let decl = working_set.get_decl(call.decl_id);
+        let io_types = decl.signature().input_output_types;
+        if output_types.contains(&Type::Any) {
+            // if input type is any, then output type could be any of the valid output types
+            output_types.extend(io_types.into_iter().map(|(_, out_type)| out_type));
+        } else {
+            // any current type which matches an input type is a possible output type
+            output_types.extend(
+                io_types
+                    .into_iter()
+                    .filter(|(in_type, _)| {
+                        input_types.iter().any(|ty| type_compatible(in_type, ty))
+                    })
+                    .map(|(_, out_type)| out_type),
+            );
+        }
 
-            if !output_types.is_empty() {
-                continue;
-            }
+        if !output_types.is_empty() {
+            continue;
+        }
 
-            if decl.signature().input_output_types.is_empty() {
-                output_types.push(Type::Any);
-                continue;
-            }
+        if decl.signature().input_output_types.is_empty() {
+            output_types.push(Type::Any);
+            continue;
+        }
 
-            let Some(types_string) = combined_type_string(input_types, "or") else {
-                output_errors
-                    .get_or_insert_default()
-                    .push(ParseError::InternalError(
-                        "Pipeline has no type at this point".to_string(),
-                        elem.expr.span,
-                    ));
-                continue;
-            };
-
+        let Some(types_string) = combined_type_string(input_types, "or") else {
             output_errors
                 .get_or_insert_default()
-                .push(ParseError::InputMismatch(types_string, call.head));
-        } else {
-            output_types.push(elem.expr.ty.clone());
-        }
+                .push(ParseError::InternalError(
+                    "Pipeline has no type at this point".to_string(),
+                    elem.expr.span,
+                ));
+            continue;
+        };
+
+        output_errors
+            .get_or_insert_default()
+            .push(ParseError::InputMismatch(types_string, call.head));
     }
 
     (output_types, output_errors)

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -875,22 +875,18 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
             .iter()
             .any(|ty| type_compatible(output_type, ty))
         {
-            let span = if block.pipelines.is_empty() {
-                if let Some(span) = block.span {
-                    span
-                } else {
-                    continue;
+            let span = match block.pipelines.as_slice() {
+                [] => match block.span {
+                    Some(span) => span,
+                    None => continue,
+                },
+                [.., last] => {
+                    last.elements
+                        .last()
+                        .expect("internal error: we should have elements")
+                        .expr
+                        .span
                 }
-            } else {
-                block
-                    .pipelines
-                    .last()
-                    .expect("internal error: we should have pipelines")
-                    .elements
-                    .last()
-                    .expect("internal error: we should have elements")
-                    .expr
-                    .span
             };
 
             let Some(current_ty_string) = combined_type_string(&current_output_types, "or") else {

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -850,22 +850,22 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
     let mut output_errors = vec![];
 
     for (input_type, output_type) in &block.signature.input_output_types {
-        let mut current_type = input_type.clone();
-        let mut current_output_types = vec![];
-
-        for pipeline in &block.pipelines {
-            let (checked_output_types, err) =
-                check_pipeline_type(working_set, pipeline, current_type);
-            current_output_types = checked_output_types;
-            current_type = Type::Nothing;
-            if let Some(err) = err {
-                output_errors.extend_from_slice(&err);
+        let current_output_types = match block.pipelines.as_slice() {
+            [] => vec![Type::Nothing],
+            pipelines => {
+                pipelines
+                    .iter()
+                    .fold((input_type.clone(), vec![]), |(ct, _cots), pipeline| {
+                        let (checked_output_types, err) =
+                            check_pipeline_type(working_set, pipeline, ct);
+                        if let Some(err) = err {
+                            output_errors.extend(err);
+                        }
+                        (Type::Nothing, checked_output_types)
+                    })
+                    .1
             }
-        }
-
-        if block.pipelines.is_empty() {
-            current_output_types = vec![Type::Nothing];
-        }
+        };
 
         if output_type == &Type::Any || current_output_types.contains(&Type::Any) {
             continue;

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -3277,22 +3277,15 @@ mod input_types {
         b"def q []: nothing -> record<c: record<a: int b: int> e: int> {{c: {a: 1 b: 2} e: 1}}",
         false
     )]
-    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
     #[case::input_output_pass_through(b"def q []: int -> int {}", false)]
-    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
     #[case::input_output_pass_through(b"def q []: string -> string {}", false)]
-    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
     #[case::input_output_pass_through(b"def q []: [int -> int, string -> string] {}", false)]
-    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
     #[case::input_output_pass_through(b"def q []: [int -> string, string -> int] {}", true)]
-    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
     #[case::input_output_pass_through(
         b"def q []: record<a: int, b: string> -> record<a: int, b: string> {}",
         false
     )]
-    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
     #[case::input_output_pass_through_incorrect(b"def q []: int -> nothing {}", true)]
-    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
     #[case::input_output_pass_through_incorrect(b"def q []: nothing -> int {}", true)]
     #[case::input_output(b"def q []: nothing -> list<string {[]}", true)]
     #[case::input_output(b"def q []: nothing -> record<c: int e: int {{c: 1 e: 1}}", true)]

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -3277,6 +3277,23 @@ mod input_types {
         b"def q []: nothing -> record<c: record<a: int b: int> e: int> {{c: {a: 1 b: 2} e: 1}}",
         false
     )]
+    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
+    #[case::input_output_pass_through(b"def q []: int -> int {}", false)]
+    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
+    #[case::input_output_pass_through(b"def q []: string -> string {}", false)]
+    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
+    #[case::input_output_pass_through(b"def q []: [int -> int, string -> string] {}", false)]
+    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
+    #[case::input_output_pass_through(b"def q []: [int -> string, string -> int] {}", true)]
+    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
+    #[case::input_output_pass_through(
+        b"def q []: record<a: int, b: string> -> record<a: int, b: string> {}",
+        false
+    )]
+    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
+    #[case::input_output_pass_through_incorrect(b"def q []: int -> nothing {}", true)]
+    #[ignore = "empty blocks are always inferred to return nothing, regardles of input types"]
+    #[case::input_output_pass_through_incorrect(b"def q []: nothing -> int {}", true)]
     #[case::input_output(b"def q []: nothing -> list<string {[]}", true)]
     #[case::input_output(b"def q []: nothing -> record<c: int e: int {{c: 1 e: 1}}", true)]
     #[case::input_output(b"def q []: record<c: int e: int -> record<a: int> {{a: 1}}", true)]


### PR DESCRIPTION
## Description

Empty blocks used to be inferred to return `nothing` regardless of their input type, meaning this would fail the type check:
```nushell
def pass-through []: int -> int { }
```

This PR fixes that.

## User-facing changes (Release notes)

Previously empty blocks (a command's body, if-else branch, match arm etc.) were inferred to return `nothing` regardless of their input type. This caused code like the following to fail type checking despite being correct:
```nushell
def pass-through []: int -> int { }
```
The type checker now correctly recognizes that empty blocks pass their inputs as they are.

## Additional notes
> [!TIP]
> This PR also contains significant refactors.
> 
> - Going commit by commit is recommended, changes are split over multiple commits to make reviewing easier.
> - Some changes mainly affect indentation, to reduce the noise hide white space.
>
> [Start Here](./18213/commits/485079baf3d8bb74edb9caa3ec33ddfeb35d160a?w=1)