### PR TITLE
Constrain output types of commands with multiple I/O signatures

### DIFF
--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -3329,6 +3329,24 @@ mod input_types {
     #[case::vardecl(b"let a: table<a: int b: int> = [[a b]; [1 1]]", false)]
     #[case::vardecl(b"let a: list<string asd> = []", true)]
     #[case::vardecl(b"let a: record<a: int b: record<a: int> = {a: 1 b: {a: 1}}", true)]
+    #[case::multiple_output_command_to_variable_oneof(
+        br#"
+            def str-or-int []: [nothing -> int, nothing -> string] { if (random bool) { 42 } else { "hello" } }
+            mut x = str-or-int
+            $x = "string"
+            $x = 42
+        "#,
+        false
+    )]
+    #[ignore]
+    #[case::multiple_output_command_to_variable_not_any(
+        br#"
+            def str-or-int []: [nothing -> int, nothing -> string] { if (random bool) { 42 } else { "hello" } }
+            mut x = str-or-int
+            $x = [1 2 3]
+        "#,
+        true
+    )]
     fn test_type_annotations(#[case] phrase: &[u8], #[case] expect_errors: bool) {
         let mut engine_state = EngineState::new();
         add_declarations(&mut engine_state);

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -3338,7 +3338,6 @@ mod input_types {
         "#,
         false
     )]
-    #[ignore]
     #[case::multiple_output_command_to_variable_not_any(
         br#"
             def str-or-int []: [nothing -> int, nothing -> string] { if (random bool) { 42 } else { "hello" } }

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -393,27 +393,18 @@ impl Signature {
 
     /// Gets the output type from the signature
     ///
-    /// If the output was unspecified or the signature has several different
-    /// input types, [`Type::Any`] is returned.  Otherwise, if the signature has
-    /// one or same output types, this type is returned.
+    /// - If the output was unspecified [`Type::Any`] is returned.
+    /// - If the signature has a single or multiple identical output types, this type is returned.
+    /// - If the signature has several different input types, supertype of all of them is returned.
+    ///   (see [`Type::widen`])
     // XXX: remove?
     pub fn get_output_type(&self) -> Type {
-        match self.input_output_types.len() {
-            0 => Type::Any,
-            1 => self.input_output_types[0].1.clone(),
-            _ => {
-                let first = &self.input_output_types[0].1;
-                if self
-                    .input_output_types
-                    .iter()
-                    .all(|(_, output)| output == first)
-                {
-                    first.clone()
-                } else {
-                    Type::Any
-                }
-            }
-        }
+        self.input_output_types
+            .iter()
+            .map(|(_, out)| out)
+            .cloned()
+            .reduce(Type::widen)
+            .unwrap_or(Type::Any)
     }
 
     /// Add a default help option to a signature


### PR DESCRIPTION
## Description

Previously a command with multiple different output types would have the parse time type of `any`. (this is currently handled separately from pipeline input output type checking)

This PR constrains the output types to the smallest super-type of possible output types.

Before: 
<img width="434" height="215" alt="image" src="https://github.com/user-attachments/assets/efa9a959-a8f7-49cc-ad89-1f0fb16fc91f" />

After: 
<img width="434" height="215" alt="image" src="https://github.com/user-attachments/assets/dbbe629e-bd3b-4f69-ae48-7bf2edbec619" />


## User-facing changes (Release notes)

TODO