### PR TITLE
improve escape handling

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2992,9 +2992,38 @@ pub fn parse_full_cell_path(
     }
 }
 
-pub fn parse_directory(working_set: &mut StateWorkingSet, span: Span) -> Expression {
+/// Common helper for parsing path-like expressions (filepath, directory, glob pattern).
+///
+/// This function consolidates the repetitive logic for parsing path types, including:
+/// - Bare word interpolation detection
+/// - Escape sequence processing
+/// - Quote state tracking
+/// - Error handling
+///
+/// # Arguments
+///
+/// * `working_set` - The current parser state
+/// * `span` - The source span of the expression
+/// * `trace_name` - Name for trace logging (e.g., "directory", "filepath")
+/// * `error_msg` - Error message if parsing fails
+/// * `make_expr` - Closure to construct the appropriate Expr variant
+/// * `make_interp_expr` - Closure to construct the interpolation Expr variant
+///   (used if bare word interpolation is detected and converted)
+fn parse_path_like<F, I>(
+    working_set: &mut StateWorkingSet,
+    span: Span,
+    trace_name: &'static str,
+    error_msg: &'static str,
+    make_expr: F,
+    make_interp_expr: I,
+) -> Expression
+where
+    F: Fn(String, bool) -> Expr,
+    I: Fn(Vec<Expression>, bool) -> Expr,
+{
     let bytes = working_set.get_span_contents(span);
-    trace!("parsing: directory");
+    let quoted = is_quoted(bytes);
+    trace!("parsing: {trace_name}");
 
     // Check for bare word interpolation
     if !bytes.is_empty()
@@ -3003,59 +3032,64 @@ pub fn parse_directory(working_set: &mut StateWorkingSet, span: Span) -> Express
         && bytes[0] != b'`'
         && bytes.contains(&b'(')
     {
-        return parse_string_interpolation(working_set, span);
+        let interpolation_expr = parse_string_interpolation(working_set, span);
+
+        // Convert StringInterpolation to the appropriate interpolation type
+        if let Expr::StringInterpolation(exprs) = interpolation_expr.expr {
+            return Expression::new(
+                working_set,
+                make_interp_expr(exprs, quoted),
+                span,
+                interpolation_expr.ty.clone(),
+            );
+        }
+
+        return interpolation_expr;
     }
 
-    let quoted = is_quoted(bytes);
     let (token, err) = unescape_unquote_string(bytes, span);
+    let is_quoted_internal = is_quoted(bytes);
 
     if err.is_none() {
         trace!("-- found {token}");
 
         Expression::new(
             working_set,
-            Expr::Directory(token, quoted),
+            make_expr(token, is_quoted_internal),
             span,
-            Type::String,
+            if matches!(make_expr("".into(), false), Expr::GlobPattern(_, _)) {
+                Type::Glob
+            } else {
+                Type::String
+            },
         )
     } else {
-        working_set.error(ParseError::Expected("directory", span));
+        working_set.error(ParseError::Expected(error_msg, span));
 
         garbage(working_set, span)
     }
 }
 
+pub fn parse_directory(working_set: &mut StateWorkingSet, span: Span) -> Expression {
+    parse_path_like(
+        working_set,
+        span,
+        "directory",
+        "directory",
+        Expr::Directory,
+        |exprs, _quoted| Expr::StringInterpolation(exprs),
+    )
+}
+
 pub fn parse_filepath(working_set: &mut StateWorkingSet, span: Span) -> Expression {
-    let bytes = working_set.get_span_contents(span);
-    trace!("parsing: filepath");
-
-    // Check for bare word interpolation
-    if !bytes.is_empty()
-        && bytes[0] != b'\''
-        && bytes[0] != b'"'
-        && bytes[0] != b'`'
-        && bytes.contains(&b'(')
-    {
-        return parse_string_interpolation(working_set, span);
-    }
-
-    let quoted = is_quoted(bytes);
-    let (token, err) = unescape_unquote_string(bytes, span);
-
-    if err.is_none() {
-        trace!("-- found {token}");
-
-        Expression::new(
-            working_set,
-            Expr::Filepath(token, quoted),
-            span,
-            Type::String,
-        )
-    } else {
-        working_set.error(ParseError::Expected("filepath", span));
-
-        garbage(working_set, span)
-    }
+    parse_path_like(
+        working_set,
+        span,
+        "filepath",
+        "filepath",
+        Expr::Filepath,
+        |exprs, _quoted| Expr::StringInterpolation(exprs),
+    )
 }
 
 /// Parse a datetime type, eg '2022-02-02'
@@ -3409,50 +3443,128 @@ fn modf(x: f64) -> (f64, f64) {
 }
 
 pub fn parse_glob_pattern(working_set: &mut StateWorkingSet, span: Span) -> Expression {
-    let bytes = working_set.get_span_contents(span);
-    let quoted = is_quoted(bytes);
-    trace!("parsing: glob pattern");
-
-    // Check for bare word interpolation
-    if !bytes.is_empty()
-        && bytes[0] != b'\''
-        && bytes[0] != b'"'
-        && bytes[0] != b'`'
-        && bytes.contains(&b'(')
-    {
-        let interpolation_expr = parse_string_interpolation(working_set, span);
-
-        // Convert StringInterpolation to GlobInterpolation
-        if let Expr::StringInterpolation(exprs) = interpolation_expr.expr {
-            return Expression::new(
-                working_set,
-                Expr::GlobInterpolation(exprs, quoted),
-                span,
-                Type::Glob,
-            );
-        }
-
-        return interpolation_expr;
-    }
-
-    let (token, err) = unescape_unquote_string(bytes, span);
-
-    if err.is_none() {
-        trace!("-- found {token}");
-
-        Expression::new(
-            working_set,
-            Expr::GlobPattern(token, quoted),
-            span,
-            Type::Glob,
-        )
-    } else {
-        working_set.error(ParseError::Expected("glob pattern string", span));
-
-        garbage(working_set, span)
-    }
+    parse_path_like(
+        working_set,
+        span,
+        "glob pattern",
+        "glob pattern string",
+        Expr::GlobPattern,
+        Expr::GlobInterpolation,
+    )
 }
 
+/// Parse a hex escape sequence in the form `\xHH` (exactly 2 hex digits).
+///
+/// Returns the parsed byte value and the new index position.
+fn parse_hex_escape(bytes: &[u8], start_idx: usize, span: Span) -> Result<(u8, usize), ParseError> {
+    let mut hex_digits = String::with_capacity(2);
+    let mut cur_idx = start_idx + 1;
+
+    for _ in 0..2 {
+        match bytes.get(cur_idx) {
+            Some(&b) if b.is_ascii_hexdigit() => {
+                hex_digits.push(b as char);
+                cur_idx += 1;
+            }
+            Some(_) => {
+                return Err(ParseError::InvalidLiteral(
+                    "invalid hex escape '\\xHH', expected exactly 2 hex digits".into(),
+                    "string".into(),
+                    Span::new(span.start + start_idx, span.end),
+                ));
+            }
+            None => {
+                return Err(ParseError::InvalidLiteral(
+                    "incomplete hex escape '\\xHH', expected 2 hex digits".into(),
+                    "string".into(),
+                    Span::new(span.start + start_idx, span.end),
+                ));
+            }
+        }
+    }
+
+    u8::from_str_radix(&hex_digits, 16)
+        .map(|byte_val| (byte_val, cur_idx))
+        .map_err(|_| {
+            ParseError::InvalidLiteral(
+                "invalid hex escape '\\xHH'".into(),
+                "string".into(),
+                Span::new(span.start + start_idx, span.end),
+            )
+        })
+}
+
+/// Parse a Unicode escape sequence in the form `\u{XXXXXX}` (1-6 hex digits, max 0x10FFFF).
+///
+/// Returns the UTF-8 encoded bytes of the Unicode character and the new index position.
+fn parse_unicode_escape(
+    bytes: &[u8],
+    start_idx: usize,
+    span: Span,
+) -> Result<(Vec<u8>, usize), ParseError> {
+    let mut digits = String::with_capacity(10);
+    let mut cur_idx = start_idx + 1;
+
+    if let Some(b'{') = bytes.get(start_idx + 1) {
+        cur_idx = start_idx + 2;
+        loop {
+            match bytes.get(cur_idx) {
+                Some(b'}') => {
+                    cur_idx += 1;
+                    break;
+                }
+                Some(c) => {
+                    digits.push(*c as char);
+                    cur_idx += 1;
+                }
+                _ => {
+                    return Err(ParseError::InvalidLiteral(
+                        "incomplete unicode escape '\\u{...}', missing closing '}'".into(),
+                        "string".into(),
+                        Span::new(span.start + start_idx, span.end),
+                    ));
+                }
+            }
+        }
+    }
+
+    if (1..=6).contains(&digits.len()) {
+        let int = u32::from_str_radix(&digits, 16);
+
+        if let Ok(int) = int
+            && int <= 0x10ffff
+            && let Some(result) = char::from_u32(int)
+        {
+            let mut buffer = [0; 4];
+            let encoded = result.encode_utf8(&mut buffer);
+            return Ok((encoded.bytes().collect(), cur_idx));
+        }
+    }
+
+    Err(ParseError::InvalidLiteral(
+        "invalid unicode escape '\\u{...}', must be 1-6 hex digits, max codepoint 0x10FFFF".into(),
+        "string".into(),
+        Span::new(span.start + start_idx, span.end),
+    ))
+}
+
+/// Parse and process POSIX escape sequences in a byte string.
+///
+/// This function handles the following escape sequences:
+/// - Simple: `\n`, `\r`, `\t`, `\\`, `\"`, `\'`
+/// - Control: `\0`, `\a`, `\b`, `\e`, `\f`
+/// - Hex: `\xHH` (exactly 2 hex digits)
+/// - Unicode: `\u{XXXXXX}` (1-6 hex digits, max 0x10FFFF)
+/// - Special: `\/`, `\(`, `\)`, `\{`, `\}`, `\$`, `\^`, `\#`, `\|`, `\~`
+///
+/// The function processes escapes in a single pass. If no backslashes are present,
+/// the input is returned as-is for efficiency.
+///
+/// # Returns
+///
+/// A tuple of `(processed_bytes, parse_error)` where:
+/// - `processed_bytes` contains the unescaped content
+/// - `parse_error` is `Some` if an invalid escape sequence was encountered, `None` otherwise
 pub fn unescape_string(bytes: &[u8], span: Span) -> (Vec<u8>, Option<ParseError>) {
     let mut output = Vec::new();
     let mut error = None;
@@ -3549,69 +3661,50 @@ pub fn unescape_string(bytes: &[u8], span: Span) -> (Vec<u8>, Option<ParseError>
                     output.push(b'\t');
                     idx += 1;
                 }
+                Some(b'0') => {
+                    output.push(b'\0');
+                    idx += 1;
+                }
+                Some(b'x') => {
+                    // Hex escape: \xHH (exactly 2 hex digits)
+                    match parse_hex_escape(bytes, idx, span) {
+                        Ok((byte_val, new_idx)) => {
+                            output.push(byte_val);
+                            idx = new_idx;
+                        }
+                        Err(err) => {
+                            error = error.or(Some(err));
+                            break 'us_loop;
+                        }
+                    }
+                }
                 Some(b'u') => {
-                    let mut digits = String::with_capacity(10);
-                    let mut cur_idx = idx + 1; // index of first beyond current end of token
-
-                    if let Some(b'{') = bytes.get(idx + 1) {
-                        cur_idx = idx + 2;
-                        loop {
-                            match bytes.get(cur_idx) {
-                                Some(b'}') => {
-                                    cur_idx += 1;
-                                    break;
-                                }
-                                Some(c) => {
-                                    digits.push(*c as char);
-                                    cur_idx += 1;
-                                }
-                                _ => {
-                                    error = error.or(Some(ParseError::InvalidLiteral(
-                                        "missing '}' for unicode escape '\\u{X...}'".into(),
-                                        "string".into(),
-                                        Span::new(span.start + idx, span.end),
-                                    )));
-                                    break 'us_loop;
-                                }
-                            }
+                    // Unicode escape: \u{XXXXXX} (1-6 hex digits, max 0x10FFFF)
+                    match parse_unicode_escape(bytes, idx, span) {
+                        Ok((utf8_bytes, new_idx)) => {
+                            output.extend(utf8_bytes);
+                            idx = new_idx;
+                        }
+                        Err(err) => {
+                            error = error.or(Some(err));
+                            break 'us_loop;
                         }
                     }
+                }
 
-                    if (1..=6).contains(&digits.len()) {
-                        let int = u32::from_str_radix(&digits, 16);
-
-                        if let Ok(int) = int
-                            && int <= 0x10ffff
-                        {
-                            let result = char::from_u32(int);
-
-                            if let Some(result) = result {
-                                let mut buffer = [0; 4];
-                                let result = result.encode_utf8(&mut buffer);
-
-                                for elem in result.bytes() {
-                                    output.push(elem);
-                                }
-
-                                idx = cur_idx;
-                                continue 'us_loop;
-                            }
-                        }
-                    }
-                    // fall through -- escape not accepted above, must be error.
+                Some(other) => {
                     error = error.or(Some(ParseError::InvalidLiteral(
-                            "invalid unicode escape '\\u{X...}', must be 1-6 hex digits, max value 10FFFF".into(),
-                            "string".into(),
-                            Span::new(span.start + idx, span.end),
+                        format!("unrecognized escape sequence '\\{}'", *other as char),
+                        "string".into(),
+                        Span::new(span.start + idx, span.end),
                     )));
                     break 'us_loop;
                 }
-
-                _ => {
+                None => {
                     error = error.or(Some(ParseError::InvalidLiteral(
-                        "unrecognized escape after '\\'".into(),
+                        "incomplete escape sequence after '\\'".into(),
                         "string".into(),
-                        Span::new(span.start + idx, span.end),
+                        Span::new(span.end.saturating_sub(1), span.end),
                     )));
                     break 'us_loop;
                 }
@@ -3625,6 +3718,17 @@ pub fn unescape_string(bytes: &[u8], span: Span) -> (Vec<u8>, Option<ParseError>
     (output, error)
 }
 
+/// Unescapes and unquotes a string, returning the content and any parse errors.
+///
+/// This function handles both quoted and unquoted strings, processing POSIX escape
+/// sequences only within double-quoted strings. Single-quoted and unquoted strings
+/// are returned as-is after removing their delimiters.
+///
+/// # Returns
+///
+/// A tuple of `(unescaped_string, parse_error)` where:
+/// - `unescaped_string` contains the processed content
+/// - `parse_error` is `Some` if an invalid escape sequence was encountered, `None` otherwise
 pub fn unescape_unquote_string(bytes: &[u8], span: Span) -> (String, Option<ParseError>) {
     if bytes.starts_with(b"\"") {
         // Needs unescaping
@@ -3704,6 +3808,10 @@ pub fn parse_string(working_set: &mut StateWorkingSet, span: Span) -> Expression
     Expression::new(working_set, Expr::String(s), span, Type::String)
 }
 
+/// Check if a byte sequence is quoted with either single or double quotes.
+///
+/// Returns `true` if the bytes start and end with matching quotes (either `"` or `'`)
+/// and have at least one character between them.
 fn is_quoted(bytes: &[u8]) -> bool {
     (bytes.starts_with(b"\"") && bytes.ends_with(b"\"") && bytes.len() > 1)
         || (bytes.starts_with(b"\'") && bytes.ends_with(b"\'") && bytes.len() > 1)

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3491,51 +3491,52 @@ fn parse_unicode_escape(
     bytes: &[u8],
     start_idx: usize,
     span: Span,
-) -> Result<(Vec<u8>, usize), ParseError> {
-    let mut digits = String::with_capacity(10);
-    let mut cur_idx = start_idx + 1;
+) -> Result<(char, usize), ParseError> {
+    let mut slice = &bytes[(start_idx + 1)..];
+    let mut current_idx = start_idx + 1;
 
-    if let Some(b'{') = bytes.get(start_idx + 1) {
-        cur_idx = start_idx + 2;
-        loop {
-            match bytes.get(cur_idx) {
-                Some(b'}') => {
-                    cur_idx += 1;
-                    break;
-                }
-                Some(c) => {
-                    digits.push(*c as char);
-                    cur_idx += 1;
-                }
-                _ => {
-                    return Err(ParseError::InvalidLiteral(
-                        "incomplete unicode escape '\\u{...}', missing closing '}'".into(),
-                        "string".into(),
-                        Span::new(span.start + start_idx, span.end),
-                    ));
-                }
-            }
-        }
-    }
+    // NOTE: this is a more defensive approach meant to avoid reading too much, but requires
+    //       changing error messages
+    // read no more than 8 bytes "{xxxxxx}"
+    // slice = &slice[..(8.min(slice.len()))];
 
-    if (1..=6).contains(&digits.len()) {
-        let int = u32::from_str_radix(&digits, 16);
+    slice = slice.strip_prefix(b"{").ok_or_else(|| {
+        ParseError::InvalidLiteral(
+            "invalid unicode escape '\\u{...}', must be 1-6 hex digits, max codepoint 0x10FFFF"
+                .into(),
+            "string".into(),
+            Span::new(span.start + start_idx, span.end),
+        )
+    })?;
+    current_idx += 1;
 
-        if let Ok(int) = int
-            && int <= 0x10ffff
-            && let Some(result) = char::from_u32(int)
-        {
-            let mut buffer = [0; 4];
-            let encoded = result.encode_utf8(&mut buffer);
-            return Ok((encoded.bytes().collect(), cur_idx));
-        }
-    }
+    let end = slice.iter().position(|b| *b == b'}').ok_or_else(|| {
+        ParseError::InvalidLiteral(
+            "incomplete unicode escape '\\u{...}', missing closing '}'".into(),
+            "string".into(),
+            Span::new(span.start + start_idx, span.end),
+        )
+    })?;
+    let digits = &slice[..end];
+    current_idx += end; // the digits
+    current_idx += 1; // closing brace
+    let current_idx = current_idx;
 
-    Err(ParseError::InvalidLiteral(
-        "invalid unicode escape '\\u{...}', must be 1-6 hex digits, max codepoint 0x10FFFF".into(),
-        "string".into(),
-        Span::new(span.start + start_idx, span.end),
-    ))
+    let ch = Some(digits)
+        .filter(|b| (1..=6).contains(&b.len()))
+        .and_then(|b| str::from_utf8(b).ok())
+        .and_then(|s| u32::from_str_radix(s, 0x10).ok())
+        .and_then(char::from_u32)
+        .ok_or_else(|| {
+            ParseError::InvalidLiteral(
+                "invalid unicode escape '\\u{...}', must be 1-6 hex digits, max codepoint 0x10FFFF"
+                    .into(),
+                "string".into(),
+                Span::new(span.start + start_idx, span.end),
+            )
+        })?;
+
+    Ok((ch, current_idx))
 }
 
 /// Parse and process POSIX escape sequences in a byte string.
@@ -3671,8 +3672,9 @@ pub fn unescape_string(bytes: &[u8], span: Span) -> (Vec<u8>, Option<ParseError>
                 Some(b'u') => {
                     // Unicode escape: \u{XXXXXX} (1-6 hex digits, max 0x10FFFF)
                     match parse_unicode_escape(bytes, idx, span) {
-                        Ok((utf8_bytes, new_idx)) => {
-                            output.extend(utf8_bytes);
+                        Ok((ch, new_idx)) => {
+                            let mut ch_buf = [0u8; 4];
+                            output.extend(ch.encode_utf8(&mut ch_buf).as_bytes());
                             idx = new_idx;
                         }
                         Err(err) => {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3457,35 +3457,25 @@ pub fn parse_glob_pattern(working_set: &mut StateWorkingSet, span: Span) -> Expr
 ///
 /// Returns the parsed byte value and the new index position.
 fn parse_hex_escape(bytes: &[u8], start_idx: usize, span: Span) -> Result<(u8, usize), ParseError> {
-    let mut hex_digits = String::with_capacity(2);
-    let mut cur_idx = start_idx + 1;
-
-    for _ in 0..2 {
-        match bytes.get(cur_idx) {
-            Some(&b) if b.is_ascii_hexdigit() => {
-                hex_digits.push(b as char);
-                cur_idx += 1;
-            }
-            Some(_) => {
-                return Err(ParseError::InvalidLiteral(
-                    "invalid hex escape '\\xHH', expected exactly 2 hex digits".into(),
-                    "string".into(),
-                    Span::new(span.start + start_idx, span.end),
-                ));
-            }
-            None => {
-                return Err(ParseError::InvalidLiteral(
-                    "incomplete hex escape '\\xHH', expected 2 hex digits".into(),
-                    "string".into(),
-                    Span::new(span.start + start_idx, span.end),
-                ));
-            }
-        }
+    let hex_digits = bytes.get(start_idx + 1..start_idx + 3).ok_or_else(|| {
+        ParseError::InvalidLiteral(
+            "incomplete hex escape '\\xHH', expected 2 hex digits".into(),
+            "string".into(),
+            Span::new(span.start + start_idx, span.end),
+        )
+    })?;
+    if !hex_digits.iter().all(u8::is_ascii_hexdigit) {
+        return Err(ParseError::InvalidLiteral(
+            "invalid hex escape '\\xHH', expected exactly 2 hex digits".into(),
+            "string".into(),
+            Span::new(span.start + start_idx, span.end),
+        ));
     }
-
-    u8::from_str_radix(&hex_digits, 16)
-        .map(|byte_val| (byte_val, cur_idx))
-        .map_err(|_| {
+    str::from_utf8(hex_digits)
+        .ok()
+        .and_then(|s| u8::from_str_radix(s, 0x10).ok())
+        .map(|byte_val| (byte_val, start_idx + 3))
+        .ok_or_else(|| {
             ParseError::InvalidLiteral(
                 "invalid hex escape '\\xHH'".into(),
                 "string".into(),

--- a/crates/nu-parser/tests/test_parser_unicode_escapes.rs
+++ b/crates/nu-parser/tests/test_parser_unicode_escapes.rs
@@ -68,16 +68,25 @@ pub fn unicode_escapes_in_strings_expected_failures() {
         // template: Tc(br#""<string literal without #'s>"", "<pattern in expected error>")
         //deprecated Tc(br#""\u06e""#, "any shape"), // 4digit too short, next char is EOF
         //deprecatedTc(br#""\u06ex""#, "any shape"), // 4digit too short, next char is non-hex-digit
-        Tc(br#""hello \u{6e""#, "missing '}'"), // extended, missing close delim
+        Tc(br#""hello \u{6e""#, "missing closing '}'"), // extended, missing close delim
         Tc(
             br#""\u{39}8\u{000000000000000000000000000000000000000000000037}""#,
             "must be 1-6 hex digits",
         ), // hex too long, but small value
-        Tc(br#""\u{110000}""#, "max value 10FFF"), // max unicode <= 0x10ffff
+        Tc(br#""\u{110000}""#, "max codepoint 0x10FFFF"), // max unicode <= 0x10ffff
     ];
 
     for tci in test_vec {
         println!("Expecting failure containing: {}", tci.1);
         do_test(tci.0, "--success not expected--", Some(tci.1));
     }
+}
+
+#[test]
+pub fn trailing_backslash_escape_does_not_panic() {
+    do_test(
+        b"\"say \\",
+        "--success not expected--",
+        Some("UnexpectedEof"),
+    );
 }

--- a/crates/nuon/src/from.rs
+++ b/crates/nuon/src/from.rs
@@ -336,7 +336,7 @@ fn convert_to_value(
             msg: "signatures not supported in nuon".into(),
             span: expr.span,
         }),
-        Expr::String(s) | Expr::RawString(s) => Ok(Value::string(s, span)),
+        Expr::String(s) | Expr::RawString(s) => Ok(Value::string(s.clone(), span)),
         Expr::StringInterpolation(..) => Err(ShellError::OutsideSpannedLabeledError {
             src: original_text.to_string(),
             error: "Error when loading".into(),

--- a/tests/parsing/escaping.rs
+++ b/tests/parsing/escaping.rs
@@ -1,90 +1,63 @@
-use nu_test_support::{fs::Stub::FileWithContentToBeTrimmed, prelude::*};
+use nu_test_support::prelude::*;
+use rstest::rstest;
 
-fn assert_parse_error_contains(code: &str, expected: &str) -> Result {
+use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
+
+#[rstest]
+#[case::basic(r#""line1\nline2""#, "line1\nline2")]
+#[case::basic(r#""col1\tcol2""#, "col1\tcol2")]
+#[case::basic(r#""test\rmore""#, "test\rmore")]
+#[case::basic(r#""path\\file""#, "path\\file")]
+#[case::basic(r#""say \"hello\"""#, "say \"hello\"")]
+#[case::basic(r#""it's \"quoted\"""#, "it's \"quoted\"")]
+#[case::posix("\"x\\0y\"", "x\0y")]
+#[case::posix("\"x\\ay\"", "x\u{7}y")]
+#[case::posix("\"x\\by\"", "x\u{8}y")]
+#[case::posix("\"x\\ey\"", "x\u{1b}y")]
+#[case::posix("\"x\\fy\"", "x\u{c}y")]
+#[case::posix("\"\\x41\\x42\\x43\"", "ABC")]
+#[case::posix("\"hello\\x20world\"", "hello world")]
+#[case::unicode(r#""\u{0041}""#, "A")]
+#[case::unicode(r#""\u{1F600}""#, "😀")]
+#[case::unicode(r#""\u{1234}""#, "ሴ")]
+#[case::interpolation(
+    r#"
+        let name = "world"
+        $"hello\n($name)"
+    "#,
+    "hello\nworld"
+)]
+#[case::interpolation(r#"$"tab\there""#, "tab\there")]
+#[case::backward_compatible("\"line1\\nline2\"", "line1\nline2")]
+#[case::backward_compatible("\"col1\\tcol2\"", "col1\tcol2")]
+#[case::backward_compatible("\"path\\\\file\"", "path\\file")]
+#[case::backward_compatible("\"say \\\"hello\\\"\"", "say \"hello\"")]
+#[case::special_syntax_character("\"ignore\\$this\"", "ignore$this")]
+#[case::special_syntax_character("\"not\\(expanded\\)\"", "not(expanded)")]
+#[case::special_syntax_character("\"literal\\{curly\\}\"", "literal{curly}")]
+fn escape_sequences_work(#[case] code: &str, #[case] expected: impl IntoValue) -> Result {
+    test().run(code).expect_value_eq(expected)
+}
+
+#[rstest]
+#[case(r#""hello \u{6e""#, "missing closing '}'")]
+#[case(r#""\u{110000}""#, "max codepoint 0x10FFFF")]
+#[case(
+    r#""\u{000000000000000000000000000000000000000000000037}""#,
+    "must be 1-6 hex digits"
+)]
+#[case(r#""\x4""#, "incomplete hex escape")]
+#[case(r#""\x4z""#, "invalid hex escape")]
+#[case(r#""\q""#, "unrecognized escape sequence")]
+fn invalid_escape_sequences_report_parse_errors(
+    #[case] code: &str,
+    #[case] expected: &str,
+) -> Result {
     let err = format!("{:?}", test().run(code).expect_parse_error()?);
     assert!(
         err.contains(expected),
         "expected parse error containing {expected:?}, got {err:?}"
     );
-    Ok(())
-}
-
-#[test]
-fn basic_escape_sequences_work() -> Result {
-    test()
-        .run("\"line1\\nline2\"")
-        .expect_value_eq("line1\nline2")?;
-    test()
-        .run("\"col1\\tcol2\"")
-        .expect_value_eq("col1\tcol2")?;
-    test()
-        .run("\"test\\rmore\"")
-        .expect_value_eq("test\rmore")?;
-    test()
-        .run("\"path\\\\file\"")
-        .expect_value_eq("path\\file")?;
-    test()
-        .run("\"say \\\"hello\\\"\"")
-        .expect_value_eq("say \"hello\"")?;
-    test()
-        .run("\"it's \\\"quoted\\\"\"")
-        .expect_value_eq("it's \"quoted\"")?;
-
-    Ok(())
-}
-
-#[test]
-fn posix_escape_sequences_work() -> Result {
-    test().run("\"x\\0y\"").expect_value_eq("x\0y")?;
-    test().run("\"x\\ay\"").expect_value_eq("x\u{7}y")?;
-    test().run("\"x\\by\"").expect_value_eq("x\u{8}y")?;
-    test().run("\"x\\ey\"").expect_value_eq("x\u{1b}y")?;
-    test().run("\"x\\fy\"").expect_value_eq("x\u{c}y")?;
-    test().run("\"\\x41\\x42\\x43\"").expect_value_eq("ABC")?;
-    test()
-        .run("\"hello\\x20world\"")
-        .expect_value_eq("hello world")?;
-
-    Ok(())
-}
-
-#[test]
-fn unicode_escape_sequences_work() -> Result {
-    test().run(r#""\u{0041}""#).expect_value_eq("A")?;
-    test().run(r#""\u{1F600}""#).expect_value_eq("😀")?;
-    test().run(r#""\u{1234}""#).expect_value_eq("ሴ")?;
-
-    Ok(())
-}
-
-#[test]
-fn invalid_escape_sequences_report_parse_errors() -> Result {
-    assert_parse_error_contains(r#""hello \u{6e""#, "missing closing '}'")?;
-    assert_parse_error_contains(r#""\u{110000}""#, "max codepoint 0x10FFFF")?;
-    assert_parse_error_contains(
-        r#""\u{000000000000000000000000000000000000000000000037}""#,
-        "must be 1-6 hex digits",
-    )?;
-    assert_parse_error_contains(r#""\x4""#, "incomplete hex escape")?;
-    assert_parse_error_contains(r#""\x4z""#, "invalid hex escape")?;
-    assert_parse_error_contains(r#""\q""#, "unrecognized escape sequence")?;
-
-    Ok(())
-}
-
-#[test]
-fn interpolation_escape_sequences_work() -> Result {
-    test()
-        .run(
-            r#"
-                let name = "world"
-                $"hello\n($name)"
-            "#,
-        )
-        .expect_value_eq("hello\nworld")?;
-
-    test().run(r#"$"tab\there""#).expect_value_eq("tab\there")?;
-
     Ok(())
 }
 
@@ -149,37 +122,4 @@ fn quoted_glob_path_stays_literal() -> Result {
             )
             .expect_value_eq(["file[1].txt"])
     })
-}
-
-#[test]
-fn backward_compatible_escape_sequences_still_work() -> Result {
-    test()
-        .run("\"line1\\nline2\"")
-        .expect_value_eq("line1\nline2")?;
-    test()
-        .run("\"col1\\tcol2\"")
-        .expect_value_eq("col1\tcol2")?;
-    test()
-        .run("\"path\\\\file\"")
-        .expect_value_eq("path\\file")?;
-    test()
-        .run("\"say \\\"hello\\\"\"")
-        .expect_value_eq("say \"hello\"")?;
-
-    Ok(())
-}
-
-#[test]
-fn special_syntax_character_escaping_works() -> Result {
-    test()
-        .run("\"ignore\\$this\"")
-        .expect_value_eq("ignore$this")?;
-    test()
-        .run("\"not\\(expanded\\)\"")
-        .expect_value_eq("not(expanded)")?;
-    test()
-        .run("\"literal\\{curly\\}\"")
-        .expect_value_eq("literal{curly}")?;
-
-    Ok(())
 }

--- a/tests/parsing/escaping.rs
+++ b/tests/parsing/escaping.rs
@@ -1,0 +1,183 @@
+use nu_test_support::{fs::Stub::FileWithContentToBeTrimmed, prelude::*};
+
+fn assert_parse_error_contains(code: &str, expected: &str) -> Result {
+    let err = format!("{:?}", test().run(code).expect_parse_error()?);
+    assert!(
+        err.contains(expected),
+        "expected parse error containing {expected:?}, got {err:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn basic_escape_sequences_work() -> Result {
+    test()
+        .run("\"line1\\nline2\"")
+        .expect_value_eq("line1\nline2")?;
+    test()
+        .run("\"col1\\tcol2\"")
+        .expect_value_eq("col1\tcol2")?;
+    test()
+        .run("\"test\\rmore\"")
+        .expect_value_eq("test\rmore")?;
+    test()
+        .run("\"path\\\\file\"")
+        .expect_value_eq("path\\file")?;
+    test()
+        .run("\"say \\\"hello\\\"\"")
+        .expect_value_eq("say \"hello\"")?;
+    test()
+        .run("\"it's \\\"quoted\\\"\"")
+        .expect_value_eq("it's \"quoted\"")?;
+
+    Ok(())
+}
+
+#[test]
+fn posix_escape_sequences_work() -> Result {
+    test().run("\"x\\0y\"").expect_value_eq("x\0y")?;
+    test().run("\"x\\ay\"").expect_value_eq("x\u{7}y")?;
+    test().run("\"x\\by\"").expect_value_eq("x\u{8}y")?;
+    test().run("\"x\\ey\"").expect_value_eq("x\u{1b}y")?;
+    test().run("\"x\\fy\"").expect_value_eq("x\u{c}y")?;
+    test().run("\"\\x41\\x42\\x43\"").expect_value_eq("ABC")?;
+    test()
+        .run("\"hello\\x20world\"")
+        .expect_value_eq("hello world")?;
+
+    Ok(())
+}
+
+#[test]
+fn unicode_escape_sequences_work() -> Result {
+    test().run(r#""\u{0041}""#).expect_value_eq("A")?;
+    test().run(r#""\u{1F600}""#).expect_value_eq("😀")?;
+    test().run(r#""\u{1234}""#).expect_value_eq("ሴ")?;
+
+    Ok(())
+}
+
+#[test]
+fn invalid_escape_sequences_report_parse_errors() -> Result {
+    assert_parse_error_contains(r#""hello \u{6e""#, "missing closing '}'")?;
+    assert_parse_error_contains(r#""\u{110000}""#, "max codepoint 0x10FFFF")?;
+    assert_parse_error_contains(
+        r#""\u{000000000000000000000000000000000000000000000037}""#,
+        "must be 1-6 hex digits",
+    )?;
+    assert_parse_error_contains(r#""\x4""#, "incomplete hex escape")?;
+    assert_parse_error_contains(r#""\x4z""#, "invalid hex escape")?;
+    assert_parse_error_contains(r#""\q""#, "unrecognized escape sequence")?;
+
+    Ok(())
+}
+
+#[test]
+fn interpolation_escape_sequences_work() -> Result {
+    test()
+        .run(
+            r#"
+                let name = "world"
+                $"hello\n($name)"
+            "#,
+        )
+        .expect_value_eq("hello\nworld")?;
+
+    test().run(r#"$"tab\there""#).expect_value_eq("tab\there")?;
+
+    Ok(())
+}
+
+#[test]
+fn external_command_escape_sequences_work() -> Result {
+    test()
+        .add_nu_to_path()
+        .run(
+            r#"
+                let quoted_text = "hello\nworld"
+                nu --testbin cococo $quoted_text | str contains (char newline)
+            "#,
+        )
+        .expect_value_eq(true)
+}
+
+#[test]
+fn escaped_glob_pattern_reports_current_error() -> Result {
+    Playground::setup(
+        "escaped_glob_pattern_reports_current_error",
+        |dirs, sandbox| {
+            sandbox.with_files(&[
+                FileWithContentToBeTrimmed("file[1].txt", "literal"),
+                FileWithContentToBeTrimmed("file1.txt", "pattern"),
+            ]);
+
+            let mut tester = test().cwd(dirs.test());
+            let err = match tester.run::<Value>(r#"ls file\[1\].txt"#) {
+                Ok(value) => panic!("expected escaped glob path to fail, got {value:?}"),
+                Err(err) => err.to_string(),
+            };
+
+            assert!(
+                err.contains("unrecognized escape")
+                    || (err.contains("No matches found for Expand(")
+                        && err.contains("Pattern, file or folder not found")),
+                "expected escaped glob error, got {err:?}"
+            );
+
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn quoted_glob_path_stays_literal() -> Result {
+    Playground::setup("quoted_glob_path_stays_literal", |dirs, sandbox| {
+        sandbox.with_files(&[
+            FileWithContentToBeTrimmed("file[1].txt", "literal"),
+            FileWithContentToBeTrimmed("file1.txt", "pattern"),
+        ]);
+
+        test()
+            .cwd(dirs.test())
+            .run(
+                r#"
+                    let quoted = "file[1].txt"
+                    ls $quoted | get name | path basename
+                "#,
+            )
+            .expect_value_eq(["file[1].txt"])
+    })
+}
+
+#[test]
+fn backward_compatible_escape_sequences_still_work() -> Result {
+    test()
+        .run("\"line1\\nline2\"")
+        .expect_value_eq("line1\nline2")?;
+    test()
+        .run("\"col1\\tcol2\"")
+        .expect_value_eq("col1\tcol2")?;
+    test()
+        .run("\"path\\\\file\"")
+        .expect_value_eq("path\\file")?;
+    test()
+        .run("\"say \\\"hello\\\"\"")
+        .expect_value_eq("say \"hello\"")?;
+
+    Ok(())
+}
+
+#[test]
+fn special_syntax_character_escaping_works() -> Result {
+    test()
+        .run("\"ignore\\$this\"")
+        .expect_value_eq("ignore$this")?;
+    test()
+        .run("\"not\\(expanded\\)\"")
+        .expect_value_eq("not(expanded)")?;
+    test()
+        .run("\"literal\\{curly\\}\"")
+        .expect_value_eq("literal{curly}")?;
+
+    Ok(())
+}

--- a/tests/parsing/escaping.rs
+++ b/tests/parsing/escaping.rs
@@ -120,7 +120,9 @@ fn escaped_glob_pattern_reports_current_error() -> Result {
             assert!(
                 err.contains("unrecognized escape")
                     || (err.contains("No matches found for Expand(")
-                        && err.contains("Pattern, file or folder not found")),
+                        && err.contains("Pattern, file or folder not found"))
+                    || (err.contains("Error extracting glob pattern")
+                        && err.contains("invalid range pattern")),
                 "expected escaped glob error, got {err:?}"
             );
 

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -1,3 +1,5 @@
+mod escaping;
+
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
For years nushell has had "ok" escaping when used with double quotes and `\` for escapes. Nushell wasn't necessarily bad, but it wasn't real good either. This PR updates parser escaping behavior when `\` is used in double quotes or in string interpolation with double quotes. It also does some minor refactoring of the related parser internals for path-like values.

I also added quite a few regression tests to ensure proper functionality.

<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
### Improved escape handling
Nushell handles escaping better with the back slash `\` when use with double quotes or string interpolation with double quotes where escapes are interpreted.

Nushell now supports and validates more backslash escape forms consistently in string parsing, and reports clearer errors for invalid unicode/hex escapes (including better wording around missing `}` and unicode code point limits).

Parse and process escape sequences in a byte string.

Now, the following escape sequences are handled:
  - Simple: `\n`, `\r`, `\t`, `\\`, `\"`, `\'`
  - Control: `\0`, `\a`, `\b`, `\e`, `\f`
  - Hex: `\xHH` (exactly 2 hex digits)
  - Unicode: `\u{XXXXXX}` (1-6 hex digits, max 0x10FFFF)
  - Special: `\/`, `\(`, `\)`, `\{`, `\}`, `\$`, `\^`, `\#`, `\|`, `\~`


<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
- Closes #12464
- Closes #11944

- Related #9939
- Related #13758
- Related #6465
- Related #16264
- Related #13249
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->