### PR TITLE
fix(config): show $nu.env-path in config env editor error help

### DIFF
--- a/crates/nu-cmd-base/src/util.rs
+++ b/crates/nu-cmd-base/src/util.rs
@@ -26,12 +26,16 @@ pub fn process_range(range: &Range) -> Result<(isize, isize), MakeRangeError> {
     }
 }
 
-const HELP_MSG: &str = "Nushell's config file can be found with the command: $nu.config-path. \
+pub const CONFIG_PATH_HELP: &str = "Nushell's config file can be found with the command: $nu.config-path. \
+For more help: (https://nushell.sh/book/configuration.html#configurations-with-built-in-commands)";
+
+pub const ENV_CONFIG_HELP: &str = "Nushell's environment config file can be found with the command: $nu.env-path. \
 For more help: (https://nushell.sh/book/configuration.html#configurations-with-built-in-commands)";
 
 fn get_editor_commandline(
     value: &Value,
     var_name: &str,
+    help: &str,
 ) -> Result<(String, Vec<String>), ShellError> {
     match value {
         Value::String { val, .. } if !val.is_empty() => Ok((val.to_string(), Vec::new())),
@@ -48,7 +52,7 @@ fn get_editor_commandline(
                         "Set the first element to an executable",
                         value.span(),
                     )
-                    .with_help(HELP_MSG),
+                    .with_help(help),
                 )),
             }
         }
@@ -58,7 +62,7 @@ fn get_editor_commandline(
                 "Specify an executable here",
                 value.span(),
             )
-            .with_help(HELP_MSG),
+            .with_help(help),
         )),
         x => Err(ShellError::CantConvert {
             to_type: "string or list<string>".into(),
@@ -74,16 +78,25 @@ pub fn get_editor(
     stack: &Stack,
     span: Span,
 ) -> Result<(String, Vec<String>), ShellError> {
+    get_editor_with_help(engine_state, stack, span, CONFIG_PATH_HELP)
+}
+
+pub fn get_editor_with_help(
+    engine_state: &EngineState,
+    stack: &Stack,
+    span: Span,
+    help: &str,
+) -> Result<(String, Vec<String>), ShellError> {
     let config = stack.get_config(engine_state);
 
     if let Ok(buff_editor) =
-        get_editor_commandline(&config.buffer_editor, "$env.config.buffer_editor")
+        get_editor_commandline(&config.buffer_editor, "$env.config.buffer_editor", help)
     {
         Ok(buff_editor)
     } else if let Some(value) = stack.get_env_var(engine_state, "VISUAL") {
-        get_editor_commandline(value, "$env.VISUAL")
+        get_editor_commandline(value, "$env.VISUAL", help)
     } else if let Some(value) = stack.get_env_var(engine_state, "EDITOR") {
-        get_editor_commandline(value, "$env.EDITOR")
+        get_editor_commandline(value, "$env.EDITOR", help)
     } else {
         Err(ShellError::Generic(
             GenericError::new(
@@ -91,7 +104,8 @@ pub fn get_editor(
                 "Please specify one via `$env.config.buffer_editor` or `$env.EDITOR`/`$env.VISUAL`",
                 span,
             )
-            .with_help(HELP_MSG),
+            .with_help(help),
         ))
     }
 }
+

--- a/crates/nu-command/src/env/config/config_.rs
+++ b/crates/nu-command/src/env/config/config_.rs
@@ -1,4 +1,4 @@
-use nu_cmd_base::util::get_editor;
+use nu_cmd_base::util::{get_editor_with_help, CONFIG_PATH_HELP, ENV_CONFIG_HELP};
 use nu_engine::{command_prelude::*, env_to_strings, get_full_help};
 use nu_protocol::{PipelineMetadata, shell_error::generic::GenericError, shell_error::io::IoError};
 use nu_system::ForegroundChild;
@@ -70,7 +70,11 @@ pub(super) fn start_editor(
 ) -> Result<PipelineData, ShellError> {
     // Find the editor executable.
 
-    let (editor_name, editor_args) = get_editor(engine_state, stack, call.head)?;
+    let help = match kind {
+        ConfigFileKind::Config => CONFIG_PATH_HELP,
+        ConfigFileKind::Env => ENV_CONFIG_HELP,
+    };
+    let (editor_name, editor_args) = get_editor_with_help(engine_state, stack, call.head, help)?;
     let paths = nu_engine::env::path_str(engine_state, stack, call.head)?;
     let cwd = engine_state.cwd(Some(stack))?;
     let editor_executable =


### PR DESCRIPTION
## Summary
- `config env` editor errors now suggest `$nu.env-path` instead of `$nu.config-path`
- `config nu` continues to suggest `$nu.config-path`

Fixes #15702