### PR TITLE
fix(bits): default --number-bytes to 8 for bits commands

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/mod.rs
@@ -67,7 +67,7 @@ fn get_number_bytes(
     head: Span,
 ) -> Result<NumberBytes, ShellError> {
     match number_bytes {
-        None => Ok(NumberBytes::Auto),
+        None => Ok(NumberBytes::Eight),
         Some(Spanned { item: 1, .. }) => Ok(NumberBytes::One),
         Some(Spanned { item: 2, .. }) => Ok(NumberBytes::Two),
         Some(Spanned { item: 4, .. }) => Ok(NumberBytes::Four),


### PR DESCRIPTION
## Summary
- Default `--number-bytes` to 8 when omitted, matching the documented help text
- Fixes `1 | bits shl 20` failing without an explicit `--number-bytes 8`

Fixes #15155