### PR TITLE
test(append): simplify test pipeline formatting

### DIFF
--- a/crates/nu-command/tests/commands/append.rs
+++ b/crates/nu-command/tests/commands/append.rs
@@ -2,11 +2,9 @@ use nu_test_support::prelude::*;
 
 #[test]
 fn adds_a_row_to_the_end() -> Result {
-    let code = r#"
-            echo  [ "Andrés N. Robalino", "JT Turner", "Yehuda Katz" ]
-            | append "pollo loco"
-            | get 3
-    "#;
-
-    test().run(code).expect_value_eq("pollo loco")
+    test()
+        .run(
+            r#"echo [ "Andrés N. Robalino", "JT Turner", "Yehuda Katz" ] | append "pollo loco" | get 3"#,
+        )
+        .expect_value_eq("pollo loco")
 }


### PR DESCRIPTION
## Summary
- Simplify `adds_a_row_to_the_end` to a single-line pipeline string
- Part of ongoing test cleanup (unnecessary multi-line `nu!` blocks)

Related to #8670