### PR TITLE
fix(help): align first/last/hash input types with behavior (part of #9573)

### DIFF
--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -22,6 +22,7 @@ impl Command for First {
                     Type::List(Box::new(Type::Any)),
                     Type::Any,
                 ),
+                (Type::table(), Type::Any),
                 (Type::Binary, Type::Binary),
                 (Type::Range, Type::Any),
             ])
@@ -40,7 +41,7 @@ impl Command for First {
     }
 
     fn description(&self) -> &str {
-        "Return only the first several rows of the input. Counterpart of `last`. Opposite of `skip`."
+        "Return only the first several rows of the input. Works on lists, tables, ranges, and binary values. Counterpart of `last`. Opposite of `skip`."
     }
 
     fn run(

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -22,6 +22,7 @@ impl Command for Last {
                     Type::List(Box::new(Type::Any)),
                     Type::Any,
                 ),
+                (Type::table(), Type::Any),
                 (Type::Binary, Type::Binary),
                 (Type::Range, Type::Any),
             ])
@@ -40,7 +41,7 @@ impl Command for Last {
     }
 
     fn description(&self) -> &str {
-        "Return only the last several rows of the input. Counterpart of `first`. Opposite of `drop`."
+        "Return only the last several rows of the input. Works on lists, tables, ranges, binaries, and streams. Counterpart of `first`. Opposite of `drop`."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -56,6 +56,14 @@ where
                     Type::Binary,
                     Type::OneOf(Box::new([Type::String, Type::Binary])),
                 ),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
+                (
+                    Type::List(Box::new(Type::Binary)),
+                    Type::List(Box::new(Type::Binary)),
+                ),
                 (Type::table(), Type::table()),
                 (Type::record(), Type::record()),
             ])


### PR DESCRIPTION
## Summary
- Add `table` to `first`/`last` input types and expand descriptions to mention supported types.
- Add `list<string>` and `list<binary>` to hash digest command signatures.

## Test plan
- [x] Docs/signature-only change (help text generation)

Part of #9573