### PR TITLE
make env_hook case insensitive

### DIFF
--- a/crates/nu-cmd-base/src/hook.rs
+++ b/crates/nu-cmd-base/src/hook.rs
@@ -4,20 +4,20 @@ use nu_parser::parse;
 use nu_protocol::{
     PipelineData, PositionalArg, ShellError, Span, Type, Value, VarId,
     debugger::WithoutDebug,
-    engine::{Closure, EngineState, Stack, StateWorkingSet},
+    engine::{Closure, EngineState, EnvName, Stack, StateWorkingSet},
     report_error::{report_parse_error, report_shell_error},
     shell_error::generic::GenericError,
 };
 use std::{collections::HashMap, sync::Arc};
 
 pub fn eval_env_change_hook(
-    env_change_hook: &HashMap<String, Vec<Value>>,
+    env_change_hook: &HashMap<EnvName, Vec<Value>>,
     engine_state: &mut EngineState,
     stack: &mut Stack,
 ) -> Result<(), ShellError> {
     for (env, hooks) in env_change_hook {
         let before = engine_state.previous_env_vars.get(env);
-        let after = stack.get_env_var(engine_state, env);
+        let after = stack.get_env_var(engine_state, env.as_str());
         if before != after {
             let before = before.cloned().unwrap_or_default();
             let after = after.cloned().unwrap_or_default();

--- a/crates/nu-protocol/src/config/hooks.rs
+++ b/crates/nu-protocol/src/config/hooks.rs
@@ -1,13 +1,13 @@
 use super::prelude::*;
-use crate as nu_protocol;
+use crate::engine::EnvName;
 use std::collections::HashMap;
 
 /// Definition of a parsed hook from the config object
-#[derive(Clone, Debug, IntoValue, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Hooks {
     pub pre_prompt: Vec<Value>,
     pub pre_execution: Vec<Value>,
-    pub env_change: HashMap<String, Vec<Value>>,
+    pub env_change: HashMap<EnvName, Vec<Value>>,
     pub display_output: Option<Value>,
     pub command_not_found: Option<Value>,
 }
@@ -30,6 +30,25 @@ impl Hooks {
 impl Default for Hooks {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl IntoValue for Hooks {
+    fn into_value(self, span: Span) -> Value {
+        let env_change = self
+            .env_change
+            .into_iter()
+            .map(|(key, value)| (key.into_string(), value.into_value(span)))
+            .collect::<crate::Record>();
+
+        record! {
+            "pre_prompt" => self.pre_prompt.into_value(span),
+            "pre_execution" => self.pre_execution.into_value(span),
+            "env_change" => env_change.into_value(span),
+            "display_output" => self.display_output.into_value(span),
+            "command_not_found" => self.command_not_found.into_value(span),
+        }
+        .into_value(span)
     }
 }
 
@@ -67,7 +86,10 @@ impl UpdateFromValue for Hooks {
                         self.env_change = record
                             .iter()
                             .map(|(key, val)| {
-                                let old = self.env_change.remove(key).unwrap_or_default();
+                                let old = self
+                                    .env_change
+                                    .remove(&EnvName::from(key))
+                                    .unwrap_or_default();
                                 let new = if let Ok(hooks) = val.as_list() {
                                     hooks.into()
                                 } else {

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -102,7 +102,7 @@ pub struct EngineState {
     signals: Signals,
     pub signal_handlers: Option<Handlers>,
     pub env_vars: Arc<EnvVars>,
-    pub previous_env_vars: Arc<HashMap<String, Value>>,
+    pub previous_env_vars: Arc<HashMap<EnvName, Value>>,
     pub config: Arc<Config>,
     pub pipeline_externals_state: Arc<(AtomicU32, AtomicU32)>,
     pub repl_state: Arc<Mutex<ReplState>>,

--- a/crates/nu-protocol/src/engine/env_name.rs
+++ b/crates/nu-protocol/src/engine/env_name.rs
@@ -15,10 +15,11 @@
 //! - Case is preserved when storing the variable name
 //! - Existing scripts may need updates if they relied on case sensitivity
 
+use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 
 /// A `String` that's case-insensitive for all environment variable names, used for environment variable names.
-#[derive(Clone, derive_more::Debug)]
+#[derive(Clone, derive_more::Debug, Serialize, Deserialize)]
 #[debug("{_0:?}")]
 pub struct EnvName(pub(crate) String);
 

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -391,6 +391,24 @@ fn env_change_block_condition_pwd() {
 }
 
 #[test]
+fn env_change_block_condition_pwd_is_case_insensitive() {
+    let inp = &[
+        &env_change_hook_code_condition(
+            "pWD",
+            "{|before, after| ($after | path basename) == samples }",
+            "'source-env .nu-env'",
+        ),
+        "cd samples",
+        "$env.SPAM",
+    ];
+
+    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+
+    assert_eq!(actual_repl.err, "");
+    assert_eq!(actual_repl.out, "spam");
+}
+
+#[test]
 fn env_change_block_condition_correct_args() {
     let inp = &[
         "$env.FOO = 1",


### PR DESCRIPTION
## Description
As title

I make it by changing type of `env_change_hook`  to `HashMap<EnvName, Vec<Value>>`, and then `EnvName` handles remaining thing for me.

## User-facing changes (Release notes)
Before
```
$env.config.hooks.env_change.pwd = [{|| print "dir changed" }]
cd ..
# => No result
```

After
```
$env.config.hooks.env_change.pwd = [{|| print "dir changed" }]
cd ..
# => nushell prints out `dir changed`.
```

## Additional notes
Closes: #14944 