### PR TITLE
Implement history archival feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4442,6 +4442,7 @@ dependencies = [
  "percent-encoding",
  "reedline",
  "rstest",
+ "serde_json",
  "strum",
  "sysinfo",
  "tempfile",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -55,6 +55,7 @@ strum = { workspace = true }
 unicode-segmentation = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 which = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 plugin = ["nu-plugin-engine"]

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -15,7 +15,7 @@ use crate::{
     util::eval_source,
 };
 use crossterm::cursor::SetCursorStyle;
-use log::{error, trace, warn};
+use log::{error, info, trace, warn};
 use miette::{ErrReport, IntoDiagnostic, Result};
 use nu_cmd_base::util::get_editor;
 use nu_color_config::StyleComputer;
@@ -24,7 +24,7 @@ use nu_engine::env_to_strings;
 use nu_engine::exit::cleanup_exit;
 use nu_parser::{lex, parse, trim_quotes_str};
 use nu_protocol::shell_error::io::IoError;
-use nu_protocol::{BannerKind, shell_error};
+use nu_protocol::{BannerKind, IntoInterruptiblePipelineData, shell_error};
 use nu_protocol::{
     Config, HistoryConfig, HistoryFileFormat, PipelineData, ShellError, Span, Spanned, Value,
     config::NuCursorShape,
@@ -40,8 +40,8 @@ use nu_utils::{
 use reedline::SqliteBackedHistory;
 use reedline::{
     CursorConfig, CwdAwareHinter, DefaultCompleter, EditCommand, Emacs, FileBackedHistory,
-    HistorySessionId, MouseClickMode, Osc133ClickEventsMarkers, Osc633Markers, Reedline,
-    SemanticPromptMarkers, Vi,
+    HistoryItem, HistorySessionId, MouseClickMode, Osc133ClickEventsMarkers, Osc633Markers,
+    Reedline, SemanticPromptMarkers, Vi,
 };
 use std::sync::atomic::Ordering;
 use std::{
@@ -705,6 +705,21 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
                 warn!("Could not fill in result related history metadata: {e}");
             }
 
+            if let Some(history_cfg) = engine_state.history_config() {
+                // archive old history entries if hit the max_size history entries
+                // and the archival_hook is set.
+                match maybe_archive_history(
+                    engine_state,
+                    &mut stack,
+                    &mut line_editor,
+                    &history_cfg,
+                ) {
+                    Ok(0) => {}
+                    Ok(x) => info!("Archived {x} entries"),
+                    Err(e) => warn!("Could not archive history: {e}"),
+                }
+            }
+
             if shell_integration_osc2 {
                 run_shell_integration_osc2(None, engine_state, &mut stack, use_color);
             }
@@ -840,6 +855,112 @@ fn fill_in_result_related_history_metadata(
             })
             .into_diagnostic()?; // todo: don't stop repl if error here?
     }
+    Ok(())
+}
+
+/// Archive the history and delete old entries if the archived correctly.
+fn maybe_archive_history(
+    engine_state: &mut EngineState,
+    stack: &mut Stack,
+    line_editor: &mut Reedline,
+    history_cfg: &HistoryConfig,
+) -> Result<usize> {
+    let Some(hook) = &history_cfg.archival_hook else {
+        // there is no hook that can be used to archive the history
+        return Ok(0);
+    };
+    let count = line_editor.history().count_all().into_diagnostic()?;
+    if count < history_cfg.max_size {
+        // there are no enough history entries to archive
+        return Ok(0);
+    }
+
+    // archive history if it surpasses the max size
+    let archive_num = count.saturating_sub(history_cfg.archival_keep);
+    archive_history(engine_state, stack, line_editor, hook, archive_num)?;
+    // delete the entries that were archived
+    let keep = engine_state
+        .config
+        .history
+        .archival_keep
+        .try_into()
+        .unwrap_or(usize::MAX);
+    line_editor.history_mut().delete_old(keep).into_diagnostic()
+}
+
+/// Archive the history
+fn archive_history(
+    engine_state: &mut EngineState,
+    stack: &mut Stack,
+    line_editor: &mut Reedline,
+    hook: &Value,
+    number: i64,
+) -> Result<()> {
+    let signals = engine_state.signals().clone();
+
+    let items_archive = line_editor
+        .history()
+        .search(reedline::SearchQuery {
+            limit: Some(number),
+            ..reedline::SearchQuery::everything(reedline::SearchDirection::Forward, None)
+        })
+        .into_diagnostic()?
+        .into_iter()
+        .map(|item| {
+            // At the time of writing there is no directly HistoryItem -> Record
+            // conversion method.
+            // NOTE this deconstruction is to require the developer attention
+            // in case the HistoryItem struct change in the future
+            let HistoryItem {
+                id,
+                start_timestamp,
+                command_line,
+                session_id,
+                hostname,
+                cwd,
+                duration,
+                exit_status,
+                more_info,
+            } = item;
+            let span = Span::unknown();
+            let record = [("command_line".into(), Value::string(command_line, span))]
+                .into_iter()
+                .chain(id.map(|x| ("id".into(), Value::int(x.0, span))))
+                .chain(
+                    start_timestamp
+                        .map(|x| ("start_timestamp".into(), Value::date(x.into(), span))),
+                )
+                .chain(session_id.map(|x| ("session_id".into(), Value::int(x.as_raw(), span))))
+                .chain(hostname.map(|x| ("hostname".into(), Value::string(x, span))))
+                .chain(cwd.map(|x| ("cwd".into(), Value::string(x, span))))
+                .chain(duration.map(|x| {
+                    (
+                        "duration_ms".into(),
+                        Value::duration(x.as_millis().min(i64::MAX as u128) as i64, span),
+                    )
+                }))
+                .chain(exit_status.map(|x| ("exit_status".into(), Value::int(x, span))))
+                .chain(more_info.map(|x| {
+                    (
+                        "more_info".into(),
+                        Value::string(serde_json::to_string(&x).unwrap_or("".into()), span),
+                    )
+                }))
+                .collect();
+            Value::record(record, span)
+        })
+        .into_pipeline_data(Span::unknown(), signals);
+
+    let _data = nu_cmd_base::hook::eval_hook(
+        engine_state,
+        stack,
+        Some(items_archive),
+        vec![],
+        hook,
+        "archival_hook",
+    )
+    .into_diagnostic()?;
+
     Ok(())
 }
 

--- a/crates/nu-protocol/src/config/history.rs
+++ b/crates/nu-protocol/src/config/history.rs
@@ -43,7 +43,7 @@ impl UpdateFromValue for HistoryFileFormat {
         if *self == HistoryFileFormat::Sqlite {
             *self = HistoryFileFormat::Plaintext;
             errors.warn(ConfigWarning::IncompatibleOptions {
-                label: "SQLite-based history file only supported with the `sqlite` feature, falling back to plain text history", 
+                label: "SQLite-based history file only supported with the `sqlite` feature, falling back to plain text history",
                 span: value.span(),
                 help: "Compile Nushell with `sqlite` feature enabled",
             });
@@ -58,9 +58,11 @@ pub enum HistoryPath {
     Disabled,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct HistoryConfig {
     pub max_size: i64,
+    pub archival_keep: i64,
+    pub archival_hook: Option<Value>,
     pub sync_on_enter: bool,
     pub file_format: HistoryFileFormat,
     pub isolation: bool,
@@ -83,6 +85,8 @@ impl IntoValue for HistoryConfig {
         Value::record(
             record! {
                 "max_size" => self.max_size.into_value(span),
+                "archival_keep" => self.archival_keep.into_value(span),
+                "archival_hook" => self.archival_hook.into_value(span),
                 "sync_on_enter" => self.sync_on_enter.into_value(span),
                 "file_format" => self.file_format.into_value(span),
                 "isolation" => self.isolation.into_value(span),
@@ -117,6 +121,8 @@ impl Default for HistoryConfig {
     fn default() -> Self {
         Self {
             max_size: 100_000,
+            archival_keep: 0,
+            archival_hook: None,
             sync_on_enter: true,
             file_format: HistoryFileFormat::Plaintext,
             isolation: false,
@@ -141,6 +147,7 @@ impl UpdateFromValue for HistoryConfig {
         // might not be correct if file format was changed away from sqlite rather than isolation,
         // but this is an edge case and the span of the relevant value here should be close enough
         let mut isolation_span = value.span();
+        let mut archival_keep = value.span();
 
         for (col, val) in record.iter() {
             let path = &mut path.push(col);
@@ -151,6 +158,17 @@ impl UpdateFromValue for HistoryConfig {
                 }
                 "sync_on_enter" => self.sync_on_enter.update(val, path, errors),
                 "max_size" => self.max_size.update(val, path, errors),
+                "archival_keep" => {
+                    archival_keep = val.span();
+                    self.archival_keep.update(val, path, errors)
+                }
+                "archival_hook" => {
+                    self.archival_hook = (!val.is_nothing()).then(|| {
+                        let mut value = Value::default();
+                        value.update(val, path, errors);
+                        value
+                    })
+                }
                 "file_format" => self.file_format.update(val, path, errors),
                 "path" => match val {
                     Value::String { val: s, .. } => {
@@ -184,6 +202,14 @@ impl UpdateFromValue for HistoryConfig {
             }
             (true, HistoryFileFormat::Sqlite) => (),
             (false, _) => (),
+        }
+
+        if self.archival_keep != 0 && self.archival_keep >= self.max_size {
+            errors.warn(ConfigWarning::IncompatibleOptions {
+                label: "history archival keep needs to be smaller than max_size",
+                span: archival_keep,
+                help: "reduce its size to be smaller than max_size",
+            })
         }
     }
 }

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -49,6 +49,21 @@ $env.config.history.file_format = "plaintext"
 # Default: 100_000
 $env.config.history.max_size = 100_000
 
+# history.archival_hook (string|closure|null): Hook invoked when the active history
+# exceeds max_size. The hook receives in the input the
+# oldest history entries, excluding `archival_keep` number of the newest entries.
+# After the hook runs, those items are deleted from the active history.
+# Example: Save surplus items to a backup file before they are removed.
+# $env.config.history.archival_hook = {
+#     to csv | save --append ~/.config/nushell/history_archive.csv
+# }
+$env.config.history.archival_hook = null
+
+# history.archival_keep (int): Number of newest entries that will not be deleted
+# during the archival process of old entries.
+# Default: 0 (archive immediately when count exceeds max_size)
+$env.config.history.archival_keep = 0
+
 # history.sync_on_enter (bool): Whether the history file is updated after each command.
 # true: Write to history file after each command is entered.
 # false: Only write history when the shell exits.

--- a/tests/repl/test_config.rs
+++ b/tests/repl/test_config.rs
@@ -184,3 +184,15 @@ fn mutate_nu_config_history_ignore_space() -> TestResult {
         "false",
     )
 }
+
+#[test]
+fn mutate_nu_config_history_archival_bigger_then_max_size() -> TestResult {
+    fail_test(
+        "
+            $env.config.history.max_size = 100
+            $env.config.history.archival_keep = 100
+            $env.config.history.archival_hook = \"dummy\"
+        ",
+        "archival keep need to be smaller then max_size",
+    )
+}


### PR DESCRIPTION
## Description

Implement a archival feature for nushell history.

This allows to keep a permanent record for the history, it works by:
- Once the history hit `$env.config.history_max_size`.
- Call the hook `$env.config.history.archival_hook` to archive all history entries, excluding the newest `$env.config.history.archival_keep`.
- If the hook is executed correctly, saving those old entries, delete all old entries, keeping `$env.config.history.archival_keep` number of the newest entries.

The archival trigger is called from the main iterative loop, after the history entry metadata is populated.

## User-facing changes

Add the configuration `$env.config.history.archival_hook` and `$env.config.history.archival_keep` to control the history archival feature.

## More info
This PR requires https://github.com/nushell/reedline/pull/1082 and will not work without it merged.