### PR TITLE
feat(std-rfc): add `std-rfc/url` module

### DIFF
--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -139,6 +139,11 @@ pub fn load_standard_library(
             include_str!("../std-rfc/xml/mod.nu"),
         ),
         ("mod.nu", "std-rfc/pb", include_str!("../std-rfc/pb/mod.nu")),
+        (
+            "mod.nu",
+            "std-rfc/url",
+            include_str!("../std-rfc/url/mod.nu"),
+        ),
     ];
 
     for (filename, std_rfc_subdir_name, content) in std_rfc_submodules.drain(..) {

--- a/crates/nu-std/std-rfc/mod.nu
+++ b/crates/nu-std/std-rfc/mod.nu
@@ -1,7 +1,7 @@
 export use conversions *
 export use tables *
 export use path *
-export use url *
+export module url
 export module str
 export module iter
 export module random

--- a/crates/nu-std/std-rfc/mod.nu
+++ b/crates/nu-std/std-rfc/mod.nu
@@ -1,6 +1,7 @@
 export use conversions *
 export use tables *
 export use path *
+export use url *
 export module str
 export module iter
 export module random

--- a/crates/nu-std/std-rfc/url/mod.nu
+++ b/crates/nu-std/std-rfc/url/mod.nu
@@ -7,29 +7,66 @@ def with-field [field: string, value: any]: string -> string {
   | url join
 }
 
+alias 'url with-host' = with-host
+
 # Replace the host of input url
+@example 'Change the host portion of an input url to use another search engine' {
+    'https://www.google.com/search?q=nushell' | url with-host 'www.bing.com'
+} --result 'https://www.bing.com/search?q=nushell'
 export def with-host [host: string]: string -> string {
     with-field host $host
 }
 
+alias 'url with-port' = with-port
+
 # Set or replace the port of input url
+@example 'Define the port for an input url to use' {
+    'http://localhost' | url with-port '80'
+} --result 'http://localhost:80/'
+@example 'Remove the port of an input url' {
+    'http://localhost:22/' | url with-port ''
+} --result 'http://localhost/'
 export def with-port [port: oneof<int, string>]: string -> string {
     with-field port $port
 }
 
+alias 'url with-path' = with-path
+
 # Replace the path of input url
+@example 'Change the path of a GitHub url to point to another repo' {
+    'https://github.com/nushell/nushell/' | url with-path 'nushell/reedline'
+} --result 'https://github.com/nushell/reedline'
 export def with-path [path: string]: string -> string {
     with-field path $path
 }
 
-# Replace the fragment of input url
+alias 'url with-fragment' = with-fragment
+
+# Replace the fragment, or anchor, of input url
+@example 'Travel to a different section of a Nushell Book chapter' {
+    'https://www.nushell.sh/book/types_of_data.html#basic-data-types' | url with-fragment 'types-at-a-glance'
+}
 export def with-fragment [fragment: string]: string -> string {
     with-field fragment $fragment
 }
 
+alias 'url with-params' = with-params
+
 # Set or replace query parameters of input url
 #
 # Note that they can be provided as a record of key value pairs, or in table form with key and value columns.
+@example 'Set parameter values of an input url with a record' {
+    let params = {discussions_q: 'is:open is:unanswered'}
+    'https://github.com/nushell/nushell/discussions' | url with-params $params
+} --result 'https://github.com/nushell/nushell/discussions?discussions_q=is%3Aopen+is%3Aunanswered'
+@example 'Set parameter values of an input url with a table' {
+    let params = [[key, value]; [q, "is:issue state:open"]]
+    'https://github.com/nushell/nushell/issues' | url with-params $params
+} --result 'https://github.com/nushell/nushell/issues?q=is%3Aissue+state%3Aopen'
+@example 'Remove the query string from an input url by providing an empty value' {
+    'https://github.com/nushell/nushell/discussions?discussions_q=is%3Aopen+is%3Aunanswered'
+    | url with-params []
+} --result 'https://github.com/nushell/nushell/discussions'
 export def with-params [query: oneof<record, table<key: string, value: any>>]: string -> string {
     url parse
     | update params $query

--- a/crates/nu-std/std-rfc/url/mod.nu
+++ b/crates/nu-std/std-rfc/url/mod.nu
@@ -1,0 +1,38 @@
+# Quickly edit sections of a url without needing to `url parse` and `url join`
+
+# Helper function to reuse code
+def with-field [field: string, value: any] {
+  url parse
+  | update $field $value
+  | url join
+}
+
+# Replace the host of input url
+export def with-host [host: string] {
+    with-field host $host
+}
+
+# Set or replace the port of input url
+export def with-port [port: oneof<int, nothing>] {
+    with-field port $port
+}
+
+# Replace the path of input url
+export def with-path [path: string] {
+    with-field path $path
+}
+
+# Replace the fragment of input url
+export def with-fragment [fragment: string] {
+    with-field fragment $fragment
+}
+
+# Set or replace query parameters of input url
+#
+# Note that they can be provided as a record of key value pairs, or in table form with key and value columns.
+export def with-params [query: oneof<record, table<key: string, value: any>>] {
+    url parse
+    | update params $query
+    | update query { $query | url build-query }
+    | url join
+}

--- a/crates/nu-std/std-rfc/url/mod.nu
+++ b/crates/nu-std/std-rfc/url/mod.nu
@@ -13,7 +13,7 @@ export def with-host [host: string]: string -> string {
 }
 
 # Set or replace the port of input url
-export def with-port [port: oneof<int, nothing>]: string -> string {
+export def with-port [port: oneof<int, string>]: string -> string {
     with-field port $port
 }
 

--- a/crates/nu-std/std-rfc/url/mod.nu
+++ b/crates/nu-std/std-rfc/url/mod.nu
@@ -73,3 +73,33 @@ export def with-params [query: oneof<record, table<key: string, value: any>>]: s
     | update query { $query | url build-query }
     | url join
 }
+
+alias 'url replace' = replace
+
+# Replace multiple fields of an input url at once using flags
+#
+# See individual `url with-*` commands' help for more information about valid values.
+@example 'Replace a combination of fields of an input url' {
+    'https://github.com/nushell/nushell'
+    | url replace --host 'www.nushell.sh' --path 'book/types_of_data.html' --fragment '#integers'
+} --result 'https://www.nushell.sh/book/types_of_data.html#integers'
+export def replace [
+	--host: string
+	--port: oneof<int, string>
+	--path: string
+	--fragment: string
+	--params: oneof<record, table<key: string, value: any>>
+]: string -> string {
+    url parse
+    | merge (
+		{
+			host: $host
+			port: $port
+			path: $path
+			fragment: $fragment
+			params: $params
+			query: (if $params != null { $params | url build-query })
+		} | compact
+	)
+	| url join
+}

--- a/crates/nu-std/std-rfc/url/mod.nu
+++ b/crates/nu-std/std-rfc/url/mod.nu
@@ -1,36 +1,36 @@
 # Quickly edit sections of a url without needing to `url parse` and `url join`
 
 # Helper function to reuse code
-def with-field [field: string, value: any] {
+def with-field [field: string, value: any]: string -> string {
   url parse
   | update $field $value
   | url join
 }
 
 # Replace the host of input url
-export def with-host [host: string] {
+export def with-host [host: string]: string -> string {
     with-field host $host
 }
 
 # Set or replace the port of input url
-export def with-port [port: oneof<int, nothing>] {
+export def with-port [port: oneof<int, nothing>]: string -> string {
     with-field port $port
 }
 
 # Replace the path of input url
-export def with-path [path: string] {
+export def with-path [path: string]: string -> string {
     with-field path $path
 }
 
 # Replace the fragment of input url
-export def with-fragment [fragment: string] {
+export def with-fragment [fragment: string]: string -> string {
     with-field fragment $fragment
 }
 
 # Set or replace query parameters of input url
 #
 # Note that they can be provided as a record of key value pairs, or in table form with key and value columns.
-export def with-params [query: oneof<record, table<key: string, value: any>>] {
+export def with-params [query: oneof<record, table<key: string, value: any>>]: string -> string {
     url parse
     | update params $query
     | update query { $query | url build-query }

--- a/crates/nu-std/tests/test_std-rfc_url.nu
+++ b/crates/nu-std/tests/test_std-rfc_url.nu
@@ -1,0 +1,41 @@
+use std-rfc/url
+use std/assert
+use std/testing *
+
+@test
+def url_with_host [] {
+    let new_url = 'https://www.nushell.sh/blog/' | url with-host 'www.google.com'
+    assert equal $new_url 'https://www.google.com/blog/'
+}
+
+@test
+def url_with_port [] {
+    let new_url = 'http://localhost' | url with-port 8080
+    assert equal $new_url 'http://localhost:8080/'
+}
+
+@test
+def url_with_path [] {
+    let new_url = 'https://www.nushell.sh/' | url with-path 'blog'
+    assert equal $new_url 'https://www.nushell.sh/blog'
+}
+
+@test
+def url_with_fragment [] {
+    let new_url = 'https://www.nushell.sh/book/#this-book' | url with-fragment 'introduction'
+    assert equal $new_url 'https://www.nushell.sh/book/#introduction'
+}
+
+@test
+def url_with_params_record [] {
+    let new_url = 'https://github.com/nushell/nushell/pulls?q=is%3Aopen' | url with-params {q: 'is:closed'}
+    assert equal $new_url 'https://github.com/nushell/nushell/pulls?q=is%3Aclosed'
+}
+
+@test
+def url_with_params_table [] {
+    let new_url = 'https://github.com/nushell/nushell/pulls?q=is%3Aopen'
+    | url with-params [[key, value]; ['q', 'is:closed']]
+
+    assert equal $new_url 'https://github.com/nushell/nushell/pulls?q=is%3Aclosed'
+}

--- a/crates/nu-std/tests/test_std-rfc_url.nu
+++ b/crates/nu-std/tests/test_std-rfc_url.nu
@@ -39,3 +39,21 @@ def url_with_params_table [] {
 
     assert equal $new_url 'https://github.com/nushell/nushell/pulls?q=is%3Aclosed'
 }
+
+@test
+def url_replace_passthru [] {
+    let new_url = 'https://www.nushell.sh/book' | url replace
+    assert equal $new_url 'https://www.nushell.sh/book'
+}
+
+@test
+def url_replace_single_field [] {
+    let new_url = 'https://www.nushell.sh/book' | url replace --path 'book/nu_fundamentals.html'
+    assert equal $new_url 'https://www.nushell.sh/book/nu_fundamentals.html'
+}
+
+@test
+def url_replace_multiple_fields [] {
+    let new_url = 'https://github.com/nushell/nushell' | url replace --path 'nushell/reedline/issues' --params {q: 'is:issue'}
+    assert equal $new_url 'https://github.com/nushell/reedline/issues?q=is%3Aissue'
+}


### PR DESCRIPTION
## Description

This PR adds a new `std-rfc` module, `url`, which provides functionality similar to the `std-rfc/path` module. This allows users to edit urls more seamlessly with various helper commands.

Includes the following subcommands (named after `url parse` fields):
- `url with-host`
- `url with-port`
- `url with-path`
- `url with-fragment`
- `url with-params` - Keeps `params` and `query` fields in sync
- `url replace` - Combination of the previous commands by providing flags corresponding to each field

## User-facing changes (Release notes)
Added the `std-rfc/url` module to modify urls more concisely.