### PR TITLE
feat(parser): add benchmarks for parser performance and throughput analysis

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,18 +1,21 @@
 #![allow(clippy::unwrap_used)]
 
 use nu_cli::{eval_source, evaluate_commands};
+use nu_parser::{lex, lite_parse, parse, parse_block};
 use nu_plugin_core::{Encoder, EncodingType};
 use nu_plugin_protocol::{PluginCallResponse, PluginOutput};
 use nu_protocol::{
     PipelineData, Signals, Span, Spanned, Type, Value,
-    engine::{EngineState, Stack},
+    engine::{EngineState, Stack, StateWorkingSet},
 };
 use nu_std::load_standard_library;
 use nu_table::{NuTable, TableTheme};
 use nu_utils::ConfigFileKind;
 use std::{
     fmt::Write,
+    fs,
     hint::black_box,
+    path::{Path, PathBuf},
     rc::Rc,
     sync::{Arc, atomic::AtomicBool},
 };
@@ -529,6 +532,214 @@ fn bench_type_widen_chain() -> impl IntoBenchmarks {
     })]
 }
 
+// Parsing benchmarks (nu-parser)
+// These benchmark names intentionally include source byte/char sizes for throughput reporting.
+// Benchmarks are broken into stages (lex, lite, parse_block, full parse) with three corpus sizes:
+// - small: synthetic short pipeline (noise-resistant signal)
+// - medium: synthetic generated pipeline (scales predictably)
+// - large: entire nu-std/std directory (all real stdlib code)
+// - real_world: toolkit/mod.nu (representative Nushell scripts)
+//
+// Each benchmark name encodes byte/char counts: parser_<stage>_<dataset>_<size>b_<chars>c
+// This format enables automatic derivation of throughput metrics (chars/sec, bytes/sec)
+// for publication in PR descriptions and performance tracking.
+
+const PARSER_REAL_WORLD_TOOLKIT_MOD: &str = include_str!("../toolkit/mod.nu");
+
+/// Recursively discover all .nu files under a directory.
+fn collect_nu_files_recursive(root: &Path, files: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_nu_files_recursive(&path, files);
+        } else if path.extension().is_some_and(|ext| ext == "nu") {
+            files.push(path);
+        }
+    }
+}
+
+/// Collect all .nu source files from crates/nu-std/std into a single concatenated string.
+/// Files are sorted by path for deterministic output across runs.
+/// Returns None if the directory cannot be read (will panic at benchmark time to fail loudly).
+fn collect_all_std_nu_sources() -> Option<String> {
+    let std_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/nu-std/std");
+    let mut files = Vec::new();
+    collect_nu_files_recursive(&std_root, &mut files);
+
+    files.sort();
+
+    let mut combined = String::new();
+    for path in files {
+        if let Ok(contents) = fs::read_to_string(path) {
+            combined.push_str(&contents);
+            combined.push('\n');
+        }
+    }
+
+    if combined.is_empty() {
+        None
+    } else {
+        Some(combined)
+    }
+}
+
+fn parser_bench_name(stage: &str, dataset: &str, source: &str) -> String {
+    // Encode the byte and character counts in the benchmark name for automatic throughput derivation.
+    // Example: parser_lex_small_127b_125c
+    format!(
+        "parser_{stage}_{dataset}_{}b_{}c",
+        source.len(),
+        source.chars().count()
+    )
+}
+
+/// Generate a synthetic medium-sized Nushell script with multiple pipelines.
+/// Scales predictably with `commands` parameter for A/B testing.
+fn create_parser_pipeline_script(commands: usize) -> String {
+    let mut script = String::new();
+
+    for i in 0..commands {
+        writeln!(
+            script,
+            "let row_{i} = ({i}..{} | each {{|x| $x + 1 }} | math sum)",
+            i + 20
+        )
+        .expect("writing to a String is infallible");
+    }
+
+    script.push_str("$row_0 | ignore");
+    script
+}
+
+/// Set up a minimal EngineState for parser benchmarks (required for StateWorkingSet).
+/// Sets PWD environment variable to allow parsing code that references it.
+fn parser_engine_state() -> EngineState {
+    let mut engine_state = EngineState::new();
+
+    if let Ok(cwd) = std::env::current_dir() {
+        engine_state.add_env_var(
+            "PWD".into(),
+            Value::string(cwd.to_string_lossy().to_string(), Span::test_data()),
+        );
+    }
+
+    engine_state
+}
+
+/// Benchmark lexer throughput: tokenize input without parsing or AST construction.
+/// Isolates lexer performance from parser/AST overhead.
+/// Benchmark name format: parser_lex_<dataset>_<size>b_<chars>c
+fn bench_parser_lex(dataset: &str, source: String) -> impl IntoBenchmarks {
+    let bench_name = parser_bench_name("lex", dataset, &source);
+    let input = source.into_bytes();
+
+    [benchmark_fn(bench_name, move |b| {
+        let input = input.clone();
+        b.iter(move || {
+            black_box(lex(&input, 0, &[], &[], false));
+        })
+    })]
+}
+
+/// Benchmark lite-parse stage: convert tokens to LiteBlock (pipeline structure, no AST).
+/// Isolates the pipeline/command grouping logic from full AST generation.
+/// Benchmark name format: parser_lite_<dataset>_<size>b_<chars>c
+fn bench_parser_lite(dataset: &str, source: String) -> impl IntoBenchmarks {
+    let bench_name = parser_bench_name("lite", dataset, &source);
+    let input = source.into_bytes();
+
+    [benchmark_fn(bench_name, move |b| {
+        let input = input.clone();
+        b.iter(move || {
+            let (tokens, lex_error) = lex(&input, 0, &[], &[], false);
+            assert!(
+                lex_error.is_none(),
+                "parser benchmark input must lex cleanly"
+            );
+            let engine_state = parser_engine_state();
+            let working_set = StateWorkingSet::new(&engine_state);
+            black_box(lite_parse(&tokens, &working_set));
+        })
+    })]
+}
+
+/// Benchmark parse_block stage: convert pre-lexed tokens to Block (AST without compilation).
+/// Isolates AST generation cost from lexing overhead.
+/// Each iteration re-lexes to keep ownership model clean.
+/// Benchmark name format: parser_parse_block_<dataset>_<size>b_<chars>c
+fn bench_parser_parse_block(dataset: &str, source: String) -> impl IntoBenchmarks {
+    let bench_name = parser_bench_name("parse_block", dataset, &source);
+    let input = source.into_bytes();
+
+    [benchmark_fn(bench_name, move |b| {
+        let input = input.clone();
+        b.iter(move || {
+            let (tokens, lex_error) = lex(&input, 0, &[], &[], false);
+            assert!(
+                lex_error.is_none(),
+                "parser benchmark input must lex cleanly"
+            );
+            let span = Span::new(0, input.len());
+            let engine_state = parser_engine_state();
+            let mut working_set = StateWorkingSet::new(&engine_state);
+            black_box(parse_block(&mut working_set, &tokens, span, true, false));
+        })
+    })]
+}
+
+/// Benchmark full parse pipeline: lex + lite-parse + AST + compilation.
+/// End-to-end measurement from source bytes to compiled Block.
+/// Includes eager IR compilation of top-level blocks.
+/// Benchmark name format: parser_parse_<dataset>_<size>b_<chars>c
+fn bench_parser_full_parse(dataset: &str, source: String) -> impl IntoBenchmarks {
+    let bench_name = parser_bench_name("parse", dataset, &source);
+    let input = source.into_bytes();
+
+    [benchmark_fn(bench_name, move |b| {
+        let input = input.clone();
+        b.iter(move || {
+            let engine_state = parser_engine_state();
+            let mut working_set = StateWorkingSet::new(&engine_state);
+            black_box(parse(
+                &mut working_set,
+                Some("parser_bench.nu"),
+                &input,
+                true,
+            ));
+        })
+    })]
+}
+
+/// Small parser benchmark input: synthetic short pipeline (~127 bytes).
+/// Measures lex/parse overhead with minimal variability for signal clarity.
+fn parser_input_small() -> String {
+    "let xs = [1 2 3 4 5]\n$xs | each {|x| $x + 1 } | where $it > 2 | math sum | ignore\n"
+        .to_string()
+}
+
+/// Medium parser benchmark input: synthetic 80-command pipeline (scales predictably).
+/// Measures throughput on moderately-sized real-world scripts.
+fn parser_input_medium() -> String {
+    create_parser_pipeline_script(80)
+}
+
+/// Large parser benchmark input: entire crates/nu-std/std directory as concatenated .nu files.
+/// Comprehensive real-world benchmark covering all stdlib modules.
+/// Panics if directory discovery or file reads fail to ensure reliable benchmarks.
+fn parser_input_large() -> String {
+    collect_all_std_nu_sources().expect("parser benchmark requires readable nu-std/std directory")
+}
+
+/// Real-world parser benchmark input: toolkit/mod.nu (Nushell dev scripts).
+/// Provides realistic parsing workload covering procedural and module code.
+fn parser_input_real_world() -> String {
+    PARSER_REAL_WORLD_TOOLKIT_MOD.to_string()
+}
+
 // Table rendering benchmarks (nu-table)
 // Benchmark the NuTable::draw path for varying table sizes and themes.
 
@@ -590,6 +801,19 @@ tango_benchmarks!(
     bench_type_widen_large_records(),
     bench_type_widen_large_oneof(),
     bench_type_widen_chain(),
+    // Parsing (nu-parser)
+    bench_parser_lex("small", parser_input_small()),
+    bench_parser_lex("medium", parser_input_medium()),
+    bench_parser_lex("large", parser_input_large()),
+    bench_parser_lite("small", parser_input_small()),
+    bench_parser_lite("medium", parser_input_medium()),
+    bench_parser_lite("real_world", parser_input_real_world()),
+    bench_parser_parse_block("small", parser_input_small()),
+    bench_parser_parse_block("medium", parser_input_medium()),
+    bench_parser_parse_block("real_world", parser_input_real_world()),
+    bench_parser_full_parse("small", parser_input_small()),
+    bench_parser_full_parse("medium", parser_input_medium()),
+    bench_parser_full_parse("large", parser_input_large()),
     // Data types
     // Record
     bench_record_create(1),

--- a/scripts/parser-bench-run.nu
+++ b/scripts/parser-bench-run.nu
@@ -1,0 +1,38 @@
+#!/usr/bin/env nu
+# Run parser-focused benchmarks and persist the full output for throughput analysis.
+
+def main [
+    --filter: string = "parser_*"   # benchmark name glob filter (tango uses glob matching)
+    --bench: string = "benchmarks"  # bench target name
+    --out-dir: path = "target/parser-bench"  # directory where logs are written
+] {
+    mkdir $out_dir
+
+    let timestamp = (date now | format date "%Y%m%d-%H%M%S")
+    let safe_filter = ($filter | str replace -ar '[^A-Za-z0-9_-]' "_")
+    let log_file = ($out_dir | path join $"($bench)-($safe_filter)-($timestamp).log")
+
+    print $"Running parser benchmarks with filter: ($filter)"
+
+    # Tango-bench: `cargo bench -- solo --filter <glob>` runs matching benchmarks.
+    # The glob is passed to tango's --filter (-f) flag which uses glob_match internally.
+    let result = (do { ^cargo bench --bench $bench -- solo --filter $filter } | complete)
+
+    let combined_output = [$result.stdout $result.stderr]
+        | where {|line| ($line | is-not-empty) }
+        | str join (char nl)
+
+    $combined_output | save --force $log_file
+
+    if $result.exit_code == 0 {
+        print $"Saved parser benchmark log to ($log_file)"
+        $log_file
+    } else {
+        print $"Cargo bench failed with exit code ($result.exit_code)"
+        print $"Output saved to ($log_file)"
+        error make {
+            msg: "cargo bench exited with non-zero code"
+            help: $"Review output: ($log_file)"
+        }
+    }
+}

--- a/scripts/parser-bench-throughput.nu
+++ b/scripts/parser-bench-throughput.nu
@@ -122,8 +122,8 @@ def main [
     | select benchmark chars_per_unit
     | table)
 
-    print "\nFull table of all parsed benchmarks with throughput metrics:"
-    print $rows
+    # print "\nFull table of all parsed benchmarks with throughput metrics:"
+    # print $rows
     
     print $"\nBenchmark logfile: ($log_file)"
     open $log_file

--- a/scripts/parser-bench-throughput.nu
+++ b/scripts/parser-bench-throughput.nu
@@ -1,0 +1,130 @@
+#!/usr/bin/env nu
+# Parse parser benchmark output and report throughput (chars/sec and bytes/sec).
+# Compatible with Nushell 0.112.2.
+
+def unit-to-seconds [value: float, unit: string] {
+    match $unit {
+        "ns" => { $value / 1_000_000_000.0 }
+        "us" => { $value / 1_000_000.0 }
+        "µs" => { $value / 1_000_000.0 }
+        "ms" => { $value / 1_000.0 }
+        "s" => { $value }
+        _ => { null }
+    }
+}
+
+def normalize-time-unit [unit: string] {
+    let normalized = ($unit | str downcase)
+
+    match $normalized {
+        "sec" | "s" | "second" | "seconds" => { "sec" }
+        "milli" | "ms" | "millisecond" | "milliseconds" => { "milli" }
+        "micro" | "us" | "µs" | "microsecond" | "microseconds" => { "micro" }
+        "nano" | "ns" | "nanosecond" | "nanoseconds" => { "nano" }
+        _ => { null }
+    }
+}
+
+def selected-unit-to-seconds [unit: string] {
+    match $unit {
+        "sec" => { 1.0 }
+        "milli" => { 0.001 }
+        "micro" => { 0.000001 }
+        "nano" => { 0.000000001 }
+        _ => { null }
+    }
+}
+
+def extract-sizes [name: string] {
+    let capture = ($name | parse -r '_(?<bytes>[0-9]+)b_(?<chars>[0-9]+)c$')
+
+    if ($capture | is-empty) {
+        null
+    } else {
+        {
+            bytes: ($capture.0.bytes | into int)
+            chars: ($capture.0.chars | into int)
+        }
+    }
+}
+
+def main [
+    log_file?: path   # output file produced by parser-bench-0.112.2-run.nu
+    --name-prefix: string = "parser_"
+    --time-unit: string = "micro"  # throughput time base: sec|milli|micro|nano
+] {
+    if $log_file == null {
+        error make {
+            msg: "Missing required argument: log_file"
+            help: "Usage: parser-bench-throughput.nu <log-file>\n\nExample:\n  ./target/debug/nu scripts/parser-bench-throughput.nu target/parser-bench/benchmarks-parser__-20260519-125213.log"
+        }
+    }
+
+    let normalized_time_unit = (normalize-time-unit $time_unit)
+    if $normalized_time_unit == null {
+        error make {
+            msg: $"unsupported time unit: ($time_unit)"
+            help: "supported values: sec, milli, micro, nano"
+        }
+    }
+
+    let selected_unit_seconds = (selected-unit-to-seconds $normalized_time_unit)
+
+    let rows = (
+        open $log_file
+        | lines
+        | parse -r '^(?<name>parser_[A-Za-z0-9_]+)\s+\[.*?\.\.\.\s*(?<value>[0-9]+(?:\.[0-9]+)?)\s*(?<unit>ns|us|µs|ms|s)\s*\.\.\.'
+        | where {|row| $row.name | str starts-with $name_prefix }
+        | each {|row|
+            let seconds = (unit-to-seconds ($row.value | into float) $row.unit)
+            let sizes = (extract-sizes $row.name)
+            let unit_time = if $seconds == null {
+                null
+            } else {
+                $seconds / $selected_unit_seconds
+            }
+
+            if ($seconds == null or $sizes == null or $unit_time == null or $unit_time == 0.0) {
+                null
+            } else {
+                {
+                    benchmark: $row.name
+                    seconds: ($seconds | into float)
+                    chars: $sizes.chars
+                    bytes: $sizes.bytes
+                    time_unit: $normalized_time_unit
+                    chars_per_unit: (($sizes.chars | into float) / $unit_time)
+                    bytes_per_unit: (($sizes.bytes | into float) / $unit_time)
+                }
+            }
+        }
+        | compact
+        | uniq-by benchmark
+        | sort-by benchmark
+    )
+
+    if ($rows | is-empty) {
+        error make {
+            msg: "no parser benchmark rows were parsed"
+            help: "ensure the log contains parser benchmark output lines with timing units"
+        }
+    }
+
+    print $"Throughput summary \(derived from benchmark timing, unit: ($normalized_time_unit)\):"
+    print ($rows
+    | select benchmark chars bytes seconds time_unit chars_per_unit bytes_per_unit
+    | table)
+
+    print $"\nHeadline metric candidates \(chars/($normalized_time_unit)\):"
+    print ($rows
+    | sort-by chars_per_unit --reverse
+    | first 5
+    | select benchmark chars_per_unit
+    | table)
+
+    print "\nFull table of all parsed benchmarks with throughput metrics:"
+    print $rows
+    
+    print $"\nBenchmark logfile: ($log_file)"
+    open $log_file
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR adds some parser benchmarks. See how to run them below. You should get an output similar this below. Hopefully my math is right.
```nushell
Throughput summary (derived from benchmark timing, unit: micro):
╭────┬─────────────────────────────────────────┬───────┬───────┬─────────┬───────────┬────────────────┬────────────────╮
│  # │                benchmark                │ chars │ bytes │ seconds │ time_unit │ chars_per_unit │ bytes_per_unit │
├────┼─────────────────────────────────────────┼───────┼───────┼─────────┼───────────┼────────────────┼────────────────┤
│  0 │ parser_lex_large_97332b_97098c          │ 97098 │ 97332 │    0.00 │ micro     │         246.38 │         246.97 │
│  1 │ parser_lex_medium_4315b_4315c           │  4315 │  4315 │    0.00 │ micro     │         169.22 │         169.22 │
│  2 │ parser_lex_small_82b_82c                │    82 │    82 │    0.00 │ micro     │         106.11 │         106.11 │
│  3 │ parser_lite_medium_4315b_4315c          │  4315 │  4315 │    0.00 │ micro     │          95.46 │          95.46 │
│  4 │ parser_lite_real_world_620b_620c        │   620 │   620 │    0.00 │ micro     │          38.51 │          38.51 │
│  5 │ parser_lite_small_82b_82c               │    82 │    82 │    0.00 │ micro     │           5.99 │           5.99 │
│  6 │ parser_parse_block_medium_4315b_4315c   │  4315 │  4315 │    0.00 │ micro     │          37.52 │          37.52 │
│  7 │ parser_parse_block_real_world_620b_620c │   620 │   620 │    0.00 │ micro     │          24.31 │          24.31 │
│  8 │ parser_parse_block_small_82b_82c        │    82 │    82 │    0.00 │ micro     │           4.77 │           4.77 │
│  9 │ parser_parse_large_97332b_97098c        │ 97098 │ 97332 │    0.00 │ micro     │          97.10 │          97.33 │
│ 10 │ parser_parse_medium_4315b_4315c         │  4315 │  4315 │    0.00 │ micro     │          44.62 │          44.62 │
│ 11 │ parser_parse_small_82b_82c              │    82 │    82 │    0.00 │ micro     │           4.27 │           4.27 │
╰────┴─────────────────────────────────────────┴───────┴───────┴─────────┴───────────┴────────────────┴────────────────╯


Headline metric candidates (chars/micro):
╭───┬──────────────────────────────────┬────────────────╮
│ # │            benchmark             │ chars_per_unit │
├───┼──────────────────────────────────┼────────────────┤
│ 0 │ parser_lex_large_97332b_97098c   │         246.38 │
│ 1 │ parser_lex_medium_4315b_4315c    │         169.22 │
│ 2 │ parser_lex_small_82b_82c         │         106.11 │
│ 3 │ parser_parse_large_97332b_97098c │          97.10 │
│ 4 │ parser_lite_medium_4315b_4315c   │          95.46 │
╰───┴──────────────────────────────────┴────────────────╯


Benchmark logfile: target/parser-bench/benchmarks-parser__-20260519-125213.log
parser_lex_small_82b_82c                            [ 758.0 ns ... 772.8 ns ... 829.7 ns ]  stddev:  14.8 ns
parser_lex_medium_4315b_4315c                       [  25.2 us ...  25.5 us ...  26.1 us ]  stddev: 248.3 ns
parser_lex_large_97332b_97098c                      [ 389.0 us ... 394.1 us ... 410.0 us ]  stddev:   4.7 us
parser_lite_small_82b_82c                           [  13.2 us ...  13.7 us ...  17.7 us ]  stddev: 670.6 ns
parser_lite_medium_4315b_4315c                      [  45.0 us ...  45.2 us ...  46.0 us ]  stddev: 183.7 ns
parser_lite_real_world_620b_620c                    [  15.9 us ...  16.1 us ...  18.1 us ]  stddev: 374.2 ns
parser_parse_block_small_82b_82c                    [  16.7 us ...  17.2 us ...  19.0 us ]  stddev: 402.0 ns
parser_parse_block_medium_4315b_4315c               [ 111.0 us ... 115.0 us ... 124.3 us ]  stddev:   3.1 us
parser_parse_block_real_world_620b_620c             [  25.0 us ...  25.5 us ...  26.6 us ]  stddev: 411.2 ns
parser_parse_small_82b_82c                          [  18.7 us ...  19.2 us ...  20.8 us ]  stddev: 508.7 ns
parser_parse_medium_4315b_4315c                     [  95.2 us ...  96.7 us ... 113.4 us ]  stddev:   3.2 us
parser_parse_large_97332b_97098c                    [   1.0 ms ...   1.0 ms ...   1.0 ms ]  stddev:   3.8 us

   Compiling nu-cmd-lang v0.112.3 (/Users/fdncred/src/nushell/crates/nu-cmd-lang)
   Compiling nu-test-support v0.112.3 (/Users/fdncred/src/nushell/crates/nu-test-support)
   Compiling nu v0.112.3 (/Users/fdncred/src/nushell)
    Finished `bench` profile [optimized] target(s) in 1m 12s
     Running benches/benchmarks.rs (target/release/deps/benchmarks-5a8a0256451b1c57)
```
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## Instructions
Run the new parser benchmarks like this:
```nushell
nu scripts/parser-bench-run.nu
```
The `parser-bench-run.nu` script has these arguments.
```nushell
    --filter: string = "parser_*"   # benchmark name glob filter (tango uses glob matching)
    --bench: string = "benchmarks"  # bench target name
    --out-dir: path = "target/parser-bench"  # directory where logs are written
```

Analyze the new parser benchmarks like this:
```nushell
nu scripts/parser-bench-throughput.nu target/parser-bench/benchmarks-parser__-20260519-125213.log
```
The `parser-bench-throughput.nu` script has these arguments
```nushell
    log_file?: path   # output file produced by parser-bench-0.112.2-run.nu
    --name-prefix: string = "parser_" # benchmark name glob filter
    --time-unit: string = "micro"  # throughput time base: sec|milli|micro|nano
```
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## User-facing changes (Release notes)
n/a

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->