### PR TITLE
Fix oneof bracket

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5764,6 +5764,22 @@ pub fn parse_closure_expression(
     Expression::new(working_set, Expr::Closure(block_id), span, Type::Closure)
 }
 
+fn could_start_with_bracket(shape: &SyntaxShape) -> bool {
+    match shape {
+        SyntaxShape::Any
+        | SyntaxShape::List(_)
+        | SyntaxShape::Table(_)
+        | SyntaxShape::Signature
+        | SyntaxShape::ExternalSignature
+        | SyntaxShape::Filepath
+        | SyntaxShape::String
+        | SyntaxShape::GlobPattern
+        | SyntaxShape::ExternalArgument => true,
+        SyntaxShape::OneOf(shapes) => shapes.iter().any(could_start_with_bracket),
+        _ => false,
+    }
+}
+
 pub fn parse_value(
     working_set: &mut StateWorkingSet,
     span: Span,
@@ -5782,30 +5798,10 @@ pub fn parse_value(
         b'$' => return parse_dollar_expr(working_set, span),
         b'(' => return parse_paren_expr(working_set, span, shape),
         b'{' => return parse_brace_expr(working_set, span, shape),
-        b'[' => match shape {
-            SyntaxShape::Any
-            | SyntaxShape::List(_)
-            | SyntaxShape::Table(_)
-            | SyntaxShape::Signature
-            | SyntaxShape::ExternalSignature
-            | SyntaxShape::Filepath
-            | SyntaxShape::String
-            | SyntaxShape::GlobPattern
-            | SyntaxShape::ExternalArgument => {}
-            SyntaxShape::OneOf(possible_shapes) => {
-                if !possible_shapes
-                    .iter()
-                    .any(|s| matches!(s, SyntaxShape::List(_)))
-                {
-                    working_set.error(ParseError::ExpectedWithStringMsg(shape.to_string(), span));
-                    return Expression::garbage(working_set, span);
-                }
-            }
-            _ => {
-                working_set.error(ParseError::ExpectedWithStringMsg(shape.to_string(), span));
-                return Expression::garbage(working_set, span);
-            }
-        },
+        b'[' if !could_start_with_bracket(shape) => {
+            working_set.error(ParseError::ExpectedWithStringMsg(shape.to_string(), span));
+            return Expression::garbage(working_set, span);
+        }
         b'r' if bytes.len() > 1 && bytes[1] == b'#' => {
             return parse_raw_string(working_set, span);
         }

--- a/tests/repl/test_signatures.rs
+++ b/tests/repl/test_signatures.rs
@@ -1,3 +1,6 @@
+use nu_protocol::{test_record, test_table};
+use nu_test_support::prelude::*;
+
 use crate::repl::tests::{TestResult, fail_test, run_test};
 use rstest::rstest;
 
@@ -353,6 +356,35 @@ fn oneof_annotations(
 
     let input = format!("def run [t: oneof<{types}>] {{ $t }}; run {argument} | describe");
     run_test(&input, expected)
+}
+
+#[rstest]
+#[case::positional_parameter("", "")]
+#[case::flag("--", "--param ")]
+fn one_of_flag_and_positional_consistent(
+    #[case] param_prefix: &str,
+    #[case] call_prefix: &str,
+    #[values(
+        ("{value: 1}", test_record! {"value" => 1}),
+        (
+            "[{value: 1}, {value: 2}]",
+            vec![
+                test_record! {"value" => 1},
+                test_record! {"value" => 2}
+            ]
+        ),
+        ("[[value]; [1], [2]]", test_table! [["value"]; [1], [2]])
+    )]
+    (argument_src, expected): (&str, impl IntoValue),
+) -> Result {
+    let mut tester = test();
+    let definition_src = format!(
+        "def cmd [{param_prefix}param: oneof<record<value: int>, table<value: int>>] {{ $param }}"
+    );
+    let () = tester.run(definition_src)?;
+
+    let call_src = format!("cmd {call_prefix}{argument_src}");
+    tester.run(call_src).expect_value_eq(expected)
 }
 
 #[rstest]


### PR DESCRIPTION
## Description

This worked as expected:
```nushell
def cmd [param: oneof<record, table>] {}
cmd {foo: 1}
cmd [[foo]; 1]
```
But for some reason following failed:
```nushell
def cmd [--flag: oneof<record, table>] {}
cmd --flag {foo: 1}  # OK
cmd --flag [[foo]; 1]
# Error: nu::parser::parse_mismatch_with_full_string_msg
# 
#   × Parse mismatch during operation.
#    ╭─[repl_entry #2:1:12]
#  1 │ cmd --flag [[foo]; [1]]
#    ·            ──────┬─────
#    ·                  ╰── expected oneof<record, table>
#    ╰────
```

Looking at the code, it's clear why the parser complained in the second case.
However I have no idea why it was ok with it when it was a positional instead of a flag :shrug:

## User-facing changes (Release notes)

In some specific cases the parser could reject values provided to `oneof` typed parameters, such as rejecting table literal syntax for `oneof<.., table>`:

```nushell
def cmd [--flag: oneof<record, table>] {}
cmd --flag [[foo]; 1]
# Error: nu::parser::parse_mismatch_with_full_string_msg
# 
#   × Parse mismatch during operation.
#    ╭─[repl_entry #2:1:12]
#  1 │ cmd --flag [[foo]; [1]]
#    ·            ──────┬─────
#    ·                  ╰── expected oneof<record, table>
#    ╰────
```

The parser no longer considers such code invalid.