### PR TITLE
test: stderr/stdout full tests should not read user config

### DIFF
--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -68,7 +68,7 @@ fn exit_failure_if_stdout_full() {
     let mut child = std::process::Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "{:?} > /dev/full",
+            "{:?} -n > /dev/full",
             nu_test_support::fs::executable_path()
         ))
         .spawn()
@@ -101,7 +101,7 @@ fn exit_failure_if_stderr_full() {
     let mut child = std::process::Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "{:?} 2>/dev/full",
+            "{:?} -n 2>/dev/full",
             nu_test_support::fs::executable_path()
         ))
         .spawn()


### PR DESCRIPTION
## Description

Reading my config (which had some elaborate startup code) caused these tests to fail. Likely because of `term query` calls.

## User-facing changes (Release notes)
N/A

## Additional notes

Tests being affected by user config is unfortunately a reoccurring issue.

We should consider setting `XDG_{CONFIG,DATA,CACHE}_HOME` and `XDG_DATA_DIRS` to empty directories during tests to avoid this problem all together rather than patching it on a test by test basis.