### PR TITLE
bytes index-of panics when given empty byte slices

### DIFF
--- a/crates/nu-command/src/bytes/index_of.rs
+++ b/crates/nu-command/src/bytes/index_of.rs
@@ -42,7 +42,7 @@ impl Command for BytesIndexOf {
                 SyntaxShape::CellPath,
                 "For a data structure input, find the indexes at the given cell paths.",
             )
-            .switch("all", "Returns all matched index.", Some('a'))
+            .switch("all", "Returns all matched indices.", Some('a'))
             .switch("end", "Search from the end of the binary.", Some('e'))
             .category(Category::Bytes)
     }
@@ -62,15 +62,24 @@ impl Command for BytesIndexOf {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let pattern: Vec<u8> = call.req(engine_state, stack, 0)?;
+        let pattern: Spanned<Vec<u8>> = call.req(engine_state, stack, 0)?;
         let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
         let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
+
+        if pattern.item.is_empty() {
+            return Err(ShellError::TypeMismatch {
+                err_message: "the pattern to find cannot be empty".to_string(),
+                span: pattern.span,
+            });
+        }
+
         let arg = Arguments {
-            pattern,
+            pattern: pattern.item,
             end: call.has_flag(engine_state, stack, "end")?,
             all: call.has_flag(engine_state, stack, "all")?,
             cell_paths,
         };
+
         operate(index_of, arg, input, call.head, engine_state.signals())
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
Don't do that

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
`bytes index-of` doesn't panic on empty patterns anymore

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->