### PR TITLE
ps -l: introduce working_size, paged_size on windows and linux system

### DIFF
--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -135,6 +135,8 @@ fn run_ps(
                 // record.push("tpg_id", Value::int(proc_stat.tpgid as i64, span));
                 record.push("priority", Value::int(proc_stat.priority, span));
                 record.push("process_threads", Value::int(proc_stat.num_threads, span));
+                record.push("working", Value::filesize(proc.working_size() as i64, span));
+                record.push("paged", Value::filesize(proc.paged_size() as i64, span));
                 record.push("cwd", Value::string(proc.cwd(), span));
             }
             #[cfg(windows)]
@@ -165,6 +167,8 @@ fn run_ps(
                     ),
                 );
                 record.push("priority", Value::int(proc.priority as i64, span));
+                record.push("working", Value::filesize(proc.working_size() as i64, span));
+                record.push("paged", Value::filesize(proc.paged_size() as i64, span));
                 record.push("cwd", Value::string(proc.cwd(), span));
                 record.push(
                     "environment",

--- a/crates/nu-system/src/linux.rs
+++ b/crates/nu-system/src/linux.rs
@@ -229,6 +229,26 @@ impl ProcessInfo {
         }
     }
 
+    /// Working set size in bytes
+    pub fn working_size(&self) -> u64 {
+        // PowerShell aliases WS to WorkingSet64, and .NET maps that to VmRSS on Linux:
+        // https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs#L1112-L1116
+        // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs#L103-L114
+        self.mem_size()
+    }
+
+    /// Paged memory size in bytes
+    pub fn paged_size(&self) -> u64 {
+        // PowerShell aliases PM to PagedMemorySize64, and .NET maps that to VmSwap on Linux:
+        // https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs#L1120-L1124
+        // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs#L103-L114
+        self.curr_status
+            .as_ref()
+            .and_then(|status| status.vmswap)
+            .map(|swap_kib| swap_kib.saturating_mul(1024))
+            .unwrap_or_default()
+    }
+
     /// Virtual memory size in bytes
     pub fn virtual_size(&self) -> u64 {
         self.curr_proc.stat().map(|p| p.vsize).unwrap_or_default()

--- a/crates/nu-system/src/linux.rs
+++ b/crates/nu-system/src/linux.rs
@@ -231,17 +231,11 @@ impl ProcessInfo {
 
     /// Working set size in bytes
     pub fn working_size(&self) -> u64 {
-        // PowerShell aliases WS to WorkingSet64, and .NET maps that to VmRSS on Linux:
-        // https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs#L1112-L1116
-        // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs#L103-L114
         self.mem_size()
     }
 
     /// Paged memory size in bytes
     pub fn paged_size(&self) -> u64 {
-        // PowerShell aliases PM to PagedMemorySize64, and .NET maps that to VmSwap on Linux:
-        // https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs#L1120-L1124
-        // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs#L103-L114
         self.curr_status
             .as_ref()
             .and_then(|status| status.vmswap)

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -1062,15 +1062,11 @@ impl ProcessInfo {
 
     /// Working set size in bytes
     pub fn working_size(&self) -> u64 {
-        // PowerShell aliases WS to WorkingSet64 on System.Diagnostics.Process:
-        // https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs#L1112-L1116
         self.memory_info.working_set_size
     }
 
     /// Paged memory size in bytes
     pub fn paged_size(&self) -> u64 {
-        // PowerShell aliases PM to PagedMemorySize64 on System.Diagnostics.Process:
-        // https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs#L1120-L1124
         self.memory_info.page_file_usage
     }
 

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -1060,6 +1060,20 @@ impl ProcessInfo {
         self.memory_info.working_set_size
     }
 
+    /// Working set size in bytes
+    pub fn working_size(&self) -> u64 {
+        // PowerShell aliases WS to WorkingSet64 on System.Diagnostics.Process:
+        // https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs#L1112-L1116
+        self.memory_info.working_set_size
+    }
+
+    /// Paged memory size in bytes
+    pub fn paged_size(&self) -> u64 {
+        // PowerShell aliases PM to PagedMemorySize64 on System.Diagnostics.Process:
+        // https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/TypeTable_Types_Ps1Xml.cs#L1120-L1124
+        self.memory_info.page_file_usage
+    }
+
     /// Virtual memory size in bytes
     pub fn virtual_size(&self) -> u64 {
         self.memory_info.private_usage


### PR DESCRIPTION
## Description
As title, this pr introduce 2 columns (working, paged) to `ps -l`.

I use AI to search powershell and dotnet runtime code, and figure out they are only used on `windows` and `linux` system.  They are meaningless in freebsd and MacOS.

## User-facing changes (Release notes)
### ps -l have more columns
```
> ps -l | select pid name mem virtual working paged
╭────┬───────┬─────────────────┬──────────┬──────────┬──────────┬──────────╮
│  # │  pid  │      name       │   mem    │ virtual  │ working  │  paged   │
├────┼───────┼─────────────────┼──────────┼──────────┼──────────┼──────────┤
│  0 │     1 │ init(openSUSE-T │   2.2 MB │   3.1 MB │   2.2 MB │      0 B │
│  1 │     7 │ init            │   2.6 MB │   3.2 MB │   2.6 MB │      0 B │
│  2 │    10 │ SessionLeader   │ 917.5 kB │   3.1 MB │ 917.5 kB │      0 B │
│  3 │    11 │ Relay(12)       │   1.1 MB │   3.1 MB │   1.1 MB │      0 B │
│  4 │    12 │ nu              │  28.4 MB │ 688.3 MB │  28.4 MB │   6.4 MB │
│  5 │    53 │ zellij          │  70.3 MB │  25.3 GB │  70.3 MB │  31.7 MB │
├────┼───────┼─────────────────┼──────────┼──────────┼──────────┼──────────┤
│  # │  pid  │      name       │   mem    │ virtual  │ working  │  paged   │
╰────┴───────┴─────────────────┴──────────┴──────────┴──────────┴──────────╯
```

## Additional notes
Closes:  #11300 