### PR TITLE
runtime type checking for flag value

### DIFF
--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1454,6 +1454,8 @@ fn gather_arguments(
                 ..
             } => {
                 let var_id = find_named_var_id(&block.signature, &data[name], &data[short], span)?;
+                let variable = engine_state.get_var(var_id);
+                check_type(&val, &variable.ty)?;
                 callee_stack.add_var(var_id, val)
             }
             Argument::ParserInfo { .. } => (),

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1454,12 +1454,11 @@ fn gather_arguments(
                 ..
             } => {
                 let var_id = find_named_var_id(&block.signature, &data[name], &data[short], span)?;
+
+                // In this path, `Nothing` means a named argument was not passed, such as when an
+                // unset optional flag is forwarded. Do not type-check it as the flag value; the
+                // defaulting step below will treat it as omitted so the callee's default can apply.
                 if !matches!(val, Value::Nothing { .. }) {
-                    // don't need to check type if the value is `null`
-                    // since `null` can be assigned if user don't pass value to a named argument
-                    //
-                    // In the case we'll pass through it, then later the underlying commands can
-                    // be able to apply default flag value.
                     let variable = engine_state.get_var(var_id);
                     check_type(&val, &variable.ty)?;
                 }
@@ -1493,6 +1492,9 @@ fn gather_arguments(
             // For named arguments, we do this check by looking to see if the variable was set yet on
             // the stack. This assumes that the stack's variables was previously empty, but that's a
             // fair assumption for a brand new callee stack.
+            //
+            // Treat a forwarded `Nothing` value the same as an omitted named argument so defaults
+            // are applied consistently.
             let variable_not_on_stack = callee_stack.vars.iter().all(|(id, _)| *id != var_id);
             let variable_is_nothing = callee_stack
                 .vars

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1455,7 +1455,11 @@ fn gather_arguments(
             } => {
                 let var_id = find_named_var_id(&block.signature, &data[name], &data[short], span)?;
                 if !matches!(val, Value::Nothing { .. }) {
-                    // allow passing null to typed flag.
+                    // don't need to check type if the value is `null`
+                    // since `null` can be assigned if user don't pass value to a named argument
+                    //
+                    // In the case we'll pass through it, then later the underlying commands can
+                    // be able to apply default flag value.
                     let variable = engine_state.get_var(var_id);
                     check_type(&val, &variable.ty)?;
                 }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1454,8 +1454,11 @@ fn gather_arguments(
                 ..
             } => {
                 let var_id = find_named_var_id(&block.signature, &data[name], &data[short], span)?;
-                let variable = engine_state.get_var(var_id);
-                check_type(&val, &variable.ty)?;
+                if !matches!(val, Value::Nothing { .. }) {
+                    // allow passing null to typed flag.
+                    let variable = engine_state.get_var(var_id);
+                    check_type(&val, &variable.ty)?;
+                }
                 callee_stack.add_var(var_id, val)
             }
             Argument::ParserInfo { .. } => (),
@@ -1486,7 +1489,13 @@ fn gather_arguments(
             // For named arguments, we do this check by looking to see if the variable was set yet on
             // the stack. This assumes that the stack's variables was previously empty, but that's a
             // fair assumption for a brand new callee stack.
-            if !callee_stack.vars.iter().any(|(id, _)| *id == var_id) {
+            let variable_not_on_stack = callee_stack.vars.iter().all(|(id, _)| *id != var_id);
+            let variable_is_nothing = callee_stack
+                .vars
+                .iter()
+                .any(|(id, val)| *id == var_id && val.is_nothing());
+
+            if variable_not_on_stack || variable_is_nothing {
                 let val = if named_arg.arg.is_none() {
                     Value::bool(false, call_head)
                 } else if let Some(value) = &named_arg.default_value {

--- a/tests/repl/test_custom_commands.rs
+++ b/tests/repl/test_custom_commands.rs
@@ -309,7 +309,7 @@ fn allow_pass_negative_float() -> TestResult {
 #[test]
 fn test_runtime_check_for_flag() -> TestResult {
     fail_test(
-        r#"
+        "
 def foo [
   --target: record<url: string> 
 ] {
@@ -320,7 +320,7 @@ def barboozle [] {
   {a: 1}
 }
 
-foo --target (barboozle)"#,
+foo --target (barboozle)",
         "can't convert record<a: int> to record<url: string>",
     )
 }

--- a/tests/repl/test_custom_commands.rs
+++ b/tests/repl/test_custom_commands.rs
@@ -324,3 +324,18 @@ foo --target (barboozle)",
         "can't convert record<a: int> to record<url: string>",
     )
 }
+
+#[test]
+fn test_flags_will_respect_default_values() -> TestResult {
+    run_test(
+        "
+def concrete [--platform: string = 'default_value'] {
+  print 'platform is ($platform)'
+}
+
+def main [--platform: string] {
+  concrete --platform=$platform
+}",
+        "platform is default_value",
+    )
+}

--- a/tests/repl/test_custom_commands.rs
+++ b/tests/repl/test_custom_commands.rs
@@ -305,3 +305,22 @@ fn allow_pass_negative_float() -> TestResult {
     run_test("def spam [val: float] { $val }; spam -1.4", "-1.4")?;
     run_test("def spam [val: float] { $val }; spam -2", "-2.0")
 }
+
+#[test]
+fn test_runtime_check_for_flag() -> TestResult {
+    fail_test(
+        r#"
+def foo [
+  --target: record<url: string> 
+] {
+  echo $target
+}
+
+def barboozle [] {
+  {a: 1}
+}
+
+foo --target (barboozle)"#,
+        "can't convert record<a: int> to record<url: string>",
+    )
+}

--- a/tests/repl/test_custom_commands.rs
+++ b/tests/repl/test_custom_commands.rs
@@ -330,7 +330,7 @@ fn test_flags_will_respect_default_values() -> TestResult {
     run_test(
         "
 def concrete [--platform: string = 'default_value'] {
-  print 'platform is ($platform)'
+  print $'platform is ($platform)'
 }
 
 def main [--platform: string] {


### PR DESCRIPTION
## Description
This pr enables runtime type checking for flag value.

Sometimes it have to be check during runtime because it's declared any.

Although the diff is small, I'm not sure how to express my change well, because it's too subtle :-(

## User-facing changes (Release notes)
### flag value will be checked during runtime
```
> def foo [
  --target: record<url: string> 
] {
  echo $target
}
def barboozle [] {
  {a: 1}
}

> foo --target (barboozle)
Error: nu::shell::cant_convert

  × Can't convert to record<url: string>.
   ╭─[repl_entry #2:1:5]
 1 │ foo --target (barboozle)
   ·     ──────────┬─────────
   ·               ╰── can't convert record<a: int> to record<url: string>
   ╰────
```
Previously it outputs `{a: 1}`.

### Flags will respect default values when a value of type nothing is passed
```
> def concrete [--platform: string = "default_value"] {
  print $"platform is ($platform)"
}

def main [--platform: string] {
  concrete --platform=$platform
}

> main
platform is default_value
```
Previously it outputs `platform is`, which is wrong because users don't pass `--platform` to main.

Note that inside function body, `$platform` is null and it's allowed to pass to underlying `concrete`, it's handled by nushell internally.  Which means users still can't pass `null` to the command at top level.
```
> main --platform=null
Error: nu::parser::parse_mismatch_with_full_string_msg

  × Parse mismatch during operation.
   ╭─[repl_entry #6:1:17]
 1 │ main --platform=null
   ·                 ──┬─
   ·                   ╰── expected string
   ╰────
```
It still raises error as expected.

## Additional notes
fixes: #14963 
fixes: #17016