### PR TITLE
fix: prevent double escaping of string output in eval_on_state and add test

### DIFF
--- a/crates/nu-mcp/src/evaluation.rs
+++ b/crates/nu-mcp/src/evaluation.rs
@@ -620,6 +620,11 @@ fn eval_on_state(
         .unwrap_or(0);
     let timestamp_value = chrono::DateTime::from_timestamp_nanos(timestamp).fixed_offset();
 
+    let output_for_response = match &output_value {
+        Value::String { val, .. } | Value::Glob { val, .. } => val.clone(),
+        _ => output_nuon.clone(),
+    };
+
     // Store in history
     let history_index = history.push(output_value, engine_state, stack);
 
@@ -641,11 +646,12 @@ fn eval_on_state(
             ),
         );
     } else {
-        record.push("output", Value::string(&output_nuon, block_span));
+        record.push("output", Value::string(output_for_response, block_span));
     }
 
     let nuon_config = nuon::ToNuonConfig::default()
         .style(nuon::ToStyle::Raw)
+        .raw_strings(true)
         .span(Some(block_span));
 
     let response = nuon::to_nuon(
@@ -897,6 +903,28 @@ mod tests {
             result.contains("42"),
             "Output should contain the evaluated value, got: {result}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_string_output_is_not_double_escaped() -> Result<(), Box<dyn std::error::Error>> {
+        let engine_state = nu_cmd_lang::create_default_context();
+        let evaluator = Evaluator::new(engine_state);
+
+        let result_nuon = evaluator.eval("'hello world'")?;
+        let result = nuon::from_nuon(&result_nuon, None)?;
+
+        let output = result
+            .into_record()?
+            .remove("output")
+            .ok_or("missing output field in evaluate response")?
+            .into_string()?;
+
+        assert_eq!(
+            output, "hello world",
+            "string output should not include serialized quote wrappers, got: {result_nuon}"
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION


<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
Talking in discord, we discovered that nu-mcp was escaping nuon mutliple times in the output. This PR tries to address that.
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)

### Reduced escaping in `nu-mcp` evaluation output

Reduce the amount of escaping that nu-mcp does by using raw-strings.
### Before
```json
  {
    "jsonrpc": "2.0",
    "id": 3,
    "result": {
      "content": [
        {
          "type": "text",
          "text": "{cwd:/Users/fdncred/src/nushell,history_index:0,timestamp:2026-05-21T15:10:18.619935+00:00,output:\"\\\"[\n  {\n    \\\\\\\"name\\\\\\\": \\\\\\\"assets\\\\\\\",\n    \\\\\\\"type\\\\\\\": \\\\\\\"dir\\\\\\\",\n    \\\\\\\"size\\\\\\\": 160,\n    \\\\\\\"modified\\\\\\\": \\\\\\\"2024-09-14T07:06:47.316979108-05:00\\\\\\\"\n  },\n  {\n    \\\\\\\"name\\\\\\\": \\\\\\\"ast-grep\\\\\\\",\n    \\\\\\\"type\\\\\\\": \\\\\\\"dir\\\\\\\",\n    \\\\\\\"size\\\\\\\": 160,\n    \\\\\\\"modified\\\\\\\": \\\\\\\"2026-01-07T06:22:12.488582817-06:00\\\\\\\"\n  },\n  {\n    \\\\\\\"name\\\\\\\": \\\\\\\"benches\\\\\\\",\n    \\\\\\\"type\\\\\\\": \\\\\\\"dir\\\\\\\",\n    \\\\\\\"size\\\\\\\": 128,\n    \\\\\\\"modified\\\\\\\": \\\\\\\"2026-05-21T08:31:29.486599444-05:00\\\\\\\"\n  }\n]\\\"\"}"
        }
      ],
      "isError": false
    }
  }
```
### After
```json
  {
    "jsonrpc": "2.0",
    "id": 3,
    "result": {
      "content": [
        {
          "type": "text",
          "text": "{cwd:/Users/fdncred/src/nushell,history_index:0,timestamp:2026-05-21T15:20:18.004016+00:00,output:r#'[\n  {\n    \"name\": \"assets\",\n    \"type\": \"dir\",\n    \"size\": 160,\n    \"modified\": \"2024-09-14T07:06:47.316979108-05:00\"\n  },\n  {\n    \"name\": \"ast-grep\",\n    \"type\": \"dir\",\n    \"size\": 160,\n    \"modified\": \"2026-01-07T06:22:12.488582817-06:00\"\n  },\n  {\n    \"name\": \"benches\",\n    \"type\": \"dir\",\n    \"size\": 128,\n    \"modified\": \"2026-05-21T08:31:29.486599444-05:00\"\n  }\n]'#}"
        }
      ],
      "isError": false
    }
  }
```
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->