### PR TITLE
fix: use lossy UTF-8 conversion in ByteStream lines iterator

### DIFF
--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -16,6 +16,7 @@ impl Command for Lines {
         Signature::build("lines")
             .input_output_types(vec![(Type::Any, Type::List(Box::new(Type::String)))])
             .switch("skip-empty", "Skip empty lines.", Some('s'))
+            .switch("strict", "Validate UTF-8 strictly.", None)
             .category(Category::Filters)
     }
     fn run(
@@ -27,6 +28,7 @@ impl Command for Lines {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         let skip_empty = call.has_flag(engine_state, stack, "skip-empty")?;
+        let strict = call.has_flag(engine_state, stack, "strict")?;
 
         let span = input.span().unwrap_or(call.head);
         match input {
@@ -84,7 +86,7 @@ impl Command for Lines {
                 Ok(PipelineData::list_stream(stream, metadata))
             }
             PipelineData::ByteStream(stream, ..) => {
-                if let Some(lines) = stream.lines() {
+                if let Some(lines) = stream.lines().map(|l| l.strict(strict)) {
                     Ok(lines
                         .map(move |line| match line {
                             Ok(line) => Value::string(line, head),

--- a/crates/nu-command/tests/commands/lines.rs
+++ b/crates/nu-command/tests/commands/lines.rs
@@ -57,3 +57,14 @@ fn lines_on_error() {
 
     assert!(actual.err.contains("Is a directory"));
 }
+
+#[test]
+fn lines_handles_invalid_utf8() {
+    let actual = nu!(cwd: "tests/fixtures/formats", "
+        open invalid_utf8.txt
+        | lines
+        | length
+    ");
+
+    assert_eq!(actual.out, "3");
+}

--- a/crates/nu-command/tests/commands/lines.rs
+++ b/crates/nu-command/tests/commands/lines.rs
@@ -68,3 +68,13 @@ fn lines_handles_invalid_utf8() {
 
     assert_eq!(actual.out, "3");
 }
+
+#[test]
+fn lines_strict_fails_on_invalid_utf8() {
+    let actual = nu!(cwd: "tests/fixtures/formats", "
+        open invalid_utf8.txt
+        | lines --strict
+    ");
+
+    assert!(!actual.err.is_empty());
+}

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -853,9 +853,7 @@ impl Iterator for Lines {
             match self.reader.read_until(b'\n', &mut buf) {
                 Ok(0) => None,
                 Ok(_) => {
-                    let Ok(mut string) = String::from_utf8(buf) else {
-                        return Some(Err(ShellError::NonUtf8 { span: self.span }));
-                    };
+                    let mut string = String::from_utf8_lossy(&buf).into_owned();
                     trim_end_newline(&mut string);
                     Some(Ok(string))
                 }

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -508,6 +508,7 @@ impl ByteStream {
             reader: BufReader::new(reader),
             span: self.span,
             signals: self.signals,
+            strict: false,
         })
     }
 
@@ -834,11 +835,17 @@ pub struct Lines {
     reader: BufReader<SourceReader>,
     span: Span,
     signals: Signals,
+    strict: bool,
 }
 
 impl Lines {
     pub fn span(&self) -> Span {
         self.span
+    }
+
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
     }
 }
 
@@ -853,7 +860,14 @@ impl Iterator for Lines {
             match self.reader.read_until(b'\n', &mut buf) {
                 Ok(0) => None,
                 Ok(_) => {
-                    let mut string = String::from_utf8_lossy(&buf).into_owned();
+                    let mut string = if self.strict {
+                        match String::from_utf8(buf) {
+                            Ok(s) => s,
+                            Err(_) => return Some(Err(ShellError::NonUtf8 { span: self.span })),
+                        }
+                    } else {
+                        String::from_utf8_lossy(&buf).into_owned()
+                    };
                     trim_end_newline(&mut string);
                     Some(Ok(string))
                 }

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -835,6 +835,14 @@ pub struct Lines {
     reader: BufReader<SourceReader>,
     span: Span,
     signals: Signals,
+    /// Controls UTF-8 decoding behavior for each line.
+    ///
+    /// When `false` (the default), invalid UTF-8 bytes are replaced with the Unicode
+    /// replacement character (U+FFFD) using lossy conversion, so processing continues
+    /// uninterrupted even if the input is not valid UTF-8.
+    ///
+    /// When `true`, any line containing invalid UTF-8 bytes will immediately produce
+    /// a [`ShellError::NonUtf8`] error instead of a string value.
     strict: bool,
 }
 
@@ -843,6 +851,11 @@ impl Lines {
         self.span
     }
 
+    /// Sets the UTF-8 decoding mode for this iterator.
+    ///
+    /// When `strict` is `true`, any line that contains invalid UTF-8 bytes will yield
+    /// a [`ShellError::NonUtf8`] error. When `false` (the default), invalid bytes are
+    /// silently replaced with the Unicode replacement character (U+FFFD `\u{FFFD}`).
     pub fn strict(mut self, strict: bool) -> Self {
         self.strict = strict;
         self

--- a/tests/fixtures/formats/invalid_utf8.txt
+++ b/tests/fixtures/formats/invalid_utf8.txt
@@ -1,0 +1,3 @@
+valid line
+hello ÿþ world
+last line


### PR DESCRIPTION
## Description

This PR fixes how `lines` handles byte streams that contain invalid UTF-8.

Previously, piping a file with invalid UTF-8 bytes into `lines` caused `ByteStream::lines()` to return a `ShellError::NonUtf8`, which surfaced as an unsupported input error instead of allowing the stream to be split into lines.

The default behavior now uses lossy UTF-8 conversion for byte streams, replacing invalid byte sequences with the Unicode replacement character so `lines` can continue processing. A new `--strict` flag preserves strict UTF-8 validation for callers that want invalid UTF-8 to remain an error.

Regression tests cover both the new default lossy behavior and the strict failure behavior for invalid UTF-8 input.

## User-facing changes (Release notes)

Fixed an issue where `lines` failed on input containing invalid UTF-8. By default, `lines` now replaces invalid UTF-8 bytes and continues processing, and `lines --strict` can be used to fail on invalid UTF-8.

## Additional notes

Fixes #6880
