### PR TITLE
fix(`parser`): make interpolated strings coerced into globs

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2209,7 +2209,7 @@ pub(crate) fn parse_dollar_expr(
     let contents = working_set.get_span_contents(span);
 
     if contents.starts_with(b"$\"") || contents.starts_with(b"$'") {
-        if matches!(shape, SyntaxShape::GlobPattern) {
+        if matches!(shape, SyntaxShape::GlobPattern) && is_bare_string_interpolation(contents) {
             parse_glob_pattern(working_set, span)
         } else {
             parse_string_interpolation(working_set, span)

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -468,7 +468,7 @@ fn parse_external_arg(working_set: &mut StateWorkingSet, span: Span) -> External
 
 fn parse_regular_external_arg(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     match working_set.get_span_contents(span) {
-        [b'$', ..] => parse_dollar_expr(working_set, span),
+        [b'$', ..] => parse_dollar_expr(working_set, span, &SyntaxShape::Any),
         [b'(', ..] => parse_paren_expr(working_set, span, &SyntaxShape::Any),
         [b'[', ..] => parse_list_expression(working_set, span, &SyntaxShape::Any),
         _ => parse_external_string(working_set, span),
@@ -514,7 +514,7 @@ fn ensure_flag_arg_type(
     arg_shape: &SyntaxShape,
     long_name_span: Span,
 ) -> (Spanned<String>, Expression) {
-    if !type_compatible(&arg.ty, &arg_shape.to_type()) {
+    if !type_compatible(&arg_shape.to_type(), &arg.ty) {
         working_set.error(ParseError::TypeMismatch(
             arg_shape.to_type(),
             arg.ty,
@@ -2200,12 +2200,20 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Option<Expr
     ))
 }
 
-pub(crate) fn parse_dollar_expr(working_set: &mut StateWorkingSet, span: Span) -> Expression {
+pub(crate) fn parse_dollar_expr(
+    working_set: &mut StateWorkingSet,
+    span: Span,
+    shape: &SyntaxShape,
+) -> Expression {
     trace!("parsing: dollar expression");
     let contents = working_set.get_span_contents(span);
 
     if contents.starts_with(b"$\"") || contents.starts_with(b"$'") {
-        parse_string_interpolation(working_set, span)
+        if matches!(shape, SyntaxShape::GlobPattern) {
+            parse_glob_pattern(working_set, span)
+        } else {
+            parse_string_interpolation(working_set, span)
+        }
     } else if contents.starts_with(b"$.") {
         parse_simple_cell_path(working_set, Span::new(span.start + 2, span.end))
     } else {
@@ -2308,7 +2316,11 @@ pub fn parse_paren_expr(
             });
         if malformed_subexpr {
             working_set.parse_errors.truncate(starting_error_count);
-            parse_string_interpolation(working_set, span)
+            if matches!(shape, SyntaxShape::GlobPattern) {
+                parse_glob_pattern(working_set, span)
+            } else {
+                parse_string_interpolation(working_set, span)
+            }
         } else {
             fcp_expr
         }
@@ -5734,7 +5746,7 @@ pub fn parse_value(
     }
 
     match bytes[0] {
-        b'$' => return parse_dollar_expr(working_set, span),
+        b'$' => return parse_dollar_expr(working_set, span, shape),
         b'(' => return parse_paren_expr(working_set, span, shape),
         b'{' => return parse_brace_expr(working_set, span, shape),
         b'[' => match shape {
@@ -6395,7 +6407,7 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
         let rhs = if spans[pos].start + point < spans[pos].end {
             let rhs_span = Span::new(spans[pos].start + point, spans[pos].end);
             if split[1].starts_with(b"$") {
-                parse_dollar_expr(working_set, rhs_span)
+                parse_dollar_expr(working_set, rhs_span, &SyntaxShape::Any)
             } else {
                 parse_string_strict(working_set, rhs_span)
             }

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -39,6 +39,7 @@ fn non_xdg_config_dir() -> AbsolutePathBuf {
     let mut config_dir_nushell =
         AbsolutePathBuf::try_from(config_dir).expect("Invalid config directory");
     config_dir_nushell.push("nushell");
+    // Canonicalize path to avoid errors if config dir is symlinked
     if let Ok(canon) = config_dir_nushell.canonicalize() {
         canon.into_absolute()
     } else {

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -39,7 +39,11 @@ fn non_xdg_config_dir() -> AbsolutePathBuf {
     let mut config_dir_nushell =
         AbsolutePathBuf::try_from(config_dir).expect("Invalid config directory");
     config_dir_nushell.push("nushell");
-    config_dir_nushell
+    if let Ok(canon) = config_dir_nushell.canonicalize() {
+        canon.into_absolute()
+    } else {
+        config_dir_nushell
+    }
 }
 
 fn run(playground: &mut Playground, command: &str) -> String {

--- a/tests/repl/test_custom_commands.rs
+++ b/tests/repl/test_custom_commands.rs
@@ -345,3 +345,19 @@ fn glob_no_interpolation() -> TestResult {
         "glob",
     )
 }
+
+#[test]
+fn glob_literal_string_interpolation() -> TestResult {
+    run_test(
+        "def spam [foo: glob] { $foo }; spam $\"/path/to/file\"",
+        "/path/to/file",
+    )
+}
+
+#[test]
+fn glob_literal_string_interpolation_with_metachars() -> TestResult {
+    run_test(
+        "def spam [foo: glob] { $foo }; spam $\"/path/[foo]*.txt\"",
+        "/path/[foo]*.txt",
+    )
+}

--- a/tests/repl/test_custom_commands.rs
+++ b/tests/repl/test_custom_commands.rs
@@ -305,3 +305,43 @@ fn allow_pass_negative_float() -> TestResult {
     run_test("def spam [val: float] { $val }; spam -1.4", "-1.4")?;
     run_test("def spam [val: float] { $val }; spam -2", "-2.0")
 }
+
+#[test]
+fn glob_bare_word_with_interpolation() -> TestResult {
+    run_test(
+        "def spam [foo: glob] { $foo | describe }; let var = 'val'; spam ~/($var)/test",
+        "glob",
+    )?;
+    run_test(
+        "def spam [--foo: glob] { $foo | describe }; let var = 'val'; spam --foo ~/($var)",
+        "glob",
+    )?;
+    run_test(
+        "def spam [foo: glob] { $foo | describe }; let var = 'val'; spam ($var)/test",
+        "glob",
+    )
+}
+
+#[test]
+fn glob_string_interpolation() -> TestResult {
+    run_test(
+        "def spam [--foo: glob] { $foo | describe }; let var = 'val'; spam --foo $\"/path/($var)\"",
+        "glob",
+    )
+}
+
+#[test]
+fn glob_no_interpolation() -> TestResult {
+    run_test(
+        "def spam [foo: glob] { $foo | describe }; spam *.nu",
+        "glob",
+    )?;
+    run_test(
+        "def spam [--foo: glob] { $foo | describe }; spam --foo '*.nu'",
+        "glob",
+    )?;
+    run_test(
+        "def spam [foo: glob] { $foo | describe }; spam `*.nu`",
+        "glob",
+    )
+}


### PR DESCRIPTION
## Description

Fixed that string interpolations are not converted to globs when in a flag or argument of type glob to custom command unlike with regular strings.

I also added a fix with `canonicalize` so that 3 config path tests don't fail every time I run them because I have my nushell config dir symlinked to another location.

## User-facing changes (Release notes)

Now, when you pass an interpolated string (e. g. `$"($env.pwd)/foo"`, `~/($bar)`) to a flag or argument of type `glob` they will be converted automatically just like with regular strings instead of throwing a type error.