### PR TITLE
docs: clarify the `--output` flag of `explore config`

### DIFF
--- a/crates/nu-explore/src/explore_config/command.rs
+++ b/crates/nu-explore/src/explore_config/command.rs
@@ -55,7 +55,7 @@ impl Command for ExploreConfigCommand {
             .named(
                 "output",
                 SyntaxShape::String,
-                "Optional output file to save changes to (default: output.json).",
+                "Optional output file to save changes to (default: output.json). Ignored when editing nushell config.",
                 Some('o'),
             )
             .category(Category::Viewers)


### PR DESCRIPTION
## Description
See below

## User-facing changes (Release notes)
Changes are not saved to the file when editing nushell config using the `explore config` command even if the `--output` flag is specified. This was already the case before but now help text is updated to reflect it.

## Additional notes
N/A