### PR TITLE
`peek` returns the actual type of values

### DIFF
--- a/crates/nu-command/src/filters/peek.rs
+++ b/crates/nu-command/src/filters/peek.rs
@@ -61,7 +61,8 @@ impl Command for Peek {
                     Ok(PipelineData::value(val, metadata))
                 }
                 _ => {
-                    let metadata = add_peek_metadata(metadata, "value", false, None, call.head);
+                    let r#type = val.get_type_shallow().get_non_specified_string();
+                    let metadata = add_peek_metadata(metadata, r#type, false, None, call.head);
                     Ok(PipelineData::value(val, metadata))
                 }
             },
@@ -127,7 +128,7 @@ impl Command for Peek {
                 description: "Peeking non-list values won't return any values.",
                 example: "'hello' | peek 1 | metadata | $in.peek",
                 result: Some(test_record! {
-                    "type" => "value",
+                    "type" => "string",
                     "stream" => false,
                 }),
             },
@@ -145,7 +146,7 @@ impl Command for Peek {
 
 fn add_peek_metadata(
     mut metadata: Option<PipelineMetadata>,
-    r#type: &str,
+    r#type: impl Into<String>,
     stream: bool,
     value: Option<Value>,
     span: Span,
@@ -153,7 +154,7 @@ fn add_peek_metadata(
     let mut record = Record::new();
     let record_handle = record.as_mut().case_sensitive();
 
-    record_handle.insert("type", r#type.into_value(span));
+    record_handle.insert("type", r#type.into().into_value(span));
     record_handle.insert("stream", stream.into_value(span));
     if let Some(value) = value {
         record_handle.insert("value", value);

--- a/crates/nu-command/tests/commands/peek.rs
+++ b/crates/nu-command/tests/commands/peek.rs
@@ -40,6 +40,58 @@ fn peek_works_with_list_stream() -> Result {
         .expect_value_eq([1, 2, 3, 4, 5])
 }
 
+#[test]
+fn peek_works_with_list_value() -> Result {
+    let code = "[1 2 3 4 5] | peek 2";
+    let outcome = test().run_raw_with_data(code, PipelineData::Empty)?;
+
+    let PipelineData::Value(value, Some(metadata)) = outcome.body else {
+        panic!("Output must be a value with metadata")
+    };
+
+    let peek_record = PeekRecord::from_value(metadata.custom.get("peek").unwrap().clone())?;
+    assert_eq!(
+        peek_record,
+        PeekRecord {
+            r#type: "list".into(),
+            stream: false,
+            value: Some(
+                [1, 2]
+                    .into_iter()
+                    .map(|x| x.into_value(Span::test_data()))
+                    .collect::<Vec<_>>()
+            ),
+        },
+    );
+
+    Ok(value).expect_value_eq([1, 2, 3, 4, 5])
+}
+
+#[rstest]
+#[case::string(r#"'hello' | peek 2"#, "string")]
+#[case::binary(r#"0x[de ad be ef] | peek 2"#, "binary")]
+#[case::string(r#"42 | peek 2"#, "int")]
+fn peek_with_value(#[case] code: &str, #[case] expected_type: &str) -> Result {
+    let outcome = test().run_raw(code)?;
+
+    let PipelineData::Value(_, Some(metadata)) = outcome.body else {
+        panic!("Output must be a value with metadata")
+    };
+
+    let peek_record = PeekRecord::from_value(metadata.custom.get("peek").unwrap().clone())?;
+
+    assert_eq!(
+        peek_record,
+        PeekRecord {
+            r#type: expected_type.into(),
+            stream: false,
+            value: None,
+        },
+    );
+
+    Ok(())
+}
+
 #[rstest]
 #[case::binary("random binary 16b | peek 2", ByteStreamType::Binary, PeekRecord {r#type: "binary".into(), stream: true, value: None})]
 #[case::string("random chars --length 16 | peek 2", ByteStreamType::String, PeekRecord {r#type: "string".into(), stream: true, value: None})]

--- a/crates/nu-command/tests/commands/peek.rs
+++ b/crates/nu-command/tests/commands/peek.rs
@@ -68,9 +68,9 @@ fn peek_works_with_list_value() -> Result {
 }
 
 #[rstest]
-#[case::string(r#"'hello' | peek 2"#, "string")]
-#[case::binary(r#"0x[de ad be ef] | peek 2"#, "binary")]
-#[case::string(r#"42 | peek 2"#, "int")]
+#[case::string("'hello' | peek 2", "string")]
+#[case::binary("0x[de ad be ef] | peek 2", "binary")]
+#[case::string("42 | peek 2", "int")]
 fn peek_with_value(#[case] code: &str, #[case] expected_type: &str) -> Result {
     let outcome = test().run_raw(code)?;
 

--- a/crates/nu-command/tests/commands/peek.rs
+++ b/crates/nu-command/tests/commands/peek.rs
@@ -70,7 +70,7 @@ fn peek_works_with_list_value() -> Result {
 #[rstest]
 #[case::string("'hello' | peek 2", "string")]
 #[case::binary("0x[de ad be ef] | peek 2", "binary")]
-#[case::string("42 | peek 2", "int")]
+#[case::int("42 | peek 2", "int")]
 fn peek_with_value(#[case] code: &str, #[case] expected_type: &str) -> Result {
     let outcome = test().run_raw(code)?;
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -841,6 +841,30 @@ impl Value {
         }
     }
 
+    /// Get the type of the current Value, without inner type specification of lists, tables and
+    /// records
+    pub fn get_type_shallow(&self) -> Type {
+        match self {
+            Value::Bool { .. } => Type::Bool,
+            Value::Int { .. } => Type::Int,
+            Value::Float { .. } => Type::Float,
+            Value::Filesize { .. } => Type::Filesize,
+            Value::Duration { .. } => Type::Duration,
+            Value::Date { .. } => Type::Date,
+            Value::Range { .. } => Type::Range,
+            Value::String { .. } => Type::String,
+            Value::Glob { .. } => Type::Glob,
+            Value::Record { .. } => Type::record(),
+            Value::List { .. } => Type::list(Type::Any),
+            Value::Nothing { .. } => Type::Nothing,
+            Value::Closure { .. } => Type::Closure,
+            Value::Error { .. } => Type::Error,
+            Value::Binary { .. } => Type::Binary,
+            Value::CellPath { .. } => Type::CellPath,
+            Value::Custom { val, .. } => Type::Custom(val.type_name().into()),
+        }
+    }
+
     /// Determine of the [`Value`] is a [subtype](https://en.wikipedia.org/wiki/Subtyping) of `other`
     ///
     /// If you have a [`Value`], this method should always be used over chaining [`Value::get_type`] with [`Type::is_subtype_of`](crate::Type::is_subtype_of).


### PR DESCRIPTION
## Description

After some discussion with @Juhan280 we decided `peek` should specify the type of values (non-streams) rather than just returning `"value"`. This type information will be shallow (no inner type info like `list<int>`, `table<index: int, item: any>` etc) to avoid unnecessary computation.

I want to get this in before the release, otherwise it feels like we're introducing `peek` in an non-complete state.

No release note description necessary, as the PR introducing `peek` did not mention the limitation addressed by this PR.

## User-facing changes (Release notes)
N/A