### PR TITLE
Update roxmltree from 0.20 to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7425,9 +7425,12 @@ dependencies = [
 
 [[package]]
 name = "roxmltree"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "rstest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ rayon = "1.12.0"
 reedline = "0.47.0"
 rmp = "0.8.15"
 rmp-serde = "1.3.1"
-roxmltree = "0.20.0"
+roxmltree = "0.21.1"
 rstest = { version = "0.26.1", default-features = false }
 rstest_reuse = "0.7"
 rusqlite = "0.37"

--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -328,6 +328,11 @@ fn process_xml_parse_error(source: String, err: roxmltree::Error, span: Span) ->
         roxmltree::Error::InvalidExternalID(pos) => {
             make_xml_error_spanned("Invalid ExternalID in the DTD.", source, pos)
         }
+        roxmltree::Error::EntityResolver(pos, msg) => make_xml_error_spanned(
+            format!("Resolving the given entity yielded an error: {}.", msg),
+            source,
+            pos,
+        ),
         roxmltree::Error::InvalidComment(pos) => make_xml_error_spanned(
             "A comment cannot contain `--` or end with `-`.",
             source,


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
This updates the `roxmltree` dependency from 0.20 to the latest 0.21, which includes some bug fixes: https://github.com/RazrFalcon/roxmltree/blob/v0.21.1/CHANGELOG.md

This required adding a match arm for the newly introduced `roxmltree::Error` enum value [`EntityResolver`](https://docs.rs/roxmltree/latest/roxmltree/enum.Error.html#variant.EntityResolver).

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

N/A

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->

I confirmed that `cargo test --workspace -- --exact --skip commands::network::http::helpful_dns_error_for_unknown_domain` and `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` still pass.