### PR TITLE
add 'run' command support and related parsing and testing functionality

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -100,6 +100,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
         bind_command! {
             DeleteVar,
             Panic,
+            Run,
             Source,
             Tutor,
         };

--- a/crates/nu-command/src/misc/mod.rs
+++ b/crates/nu-command/src/misc/mod.rs
@@ -1,9 +1,11 @@
 mod panic;
+mod run;
 mod source;
 mod tutor;
 mod unlet;
 
 pub use panic::Panic;
+pub use run::Run;
 pub use source::Source;
 pub use tutor::Tutor;
 pub use unlet::DeleteVar;

--- a/crates/nu-command/src/misc/run.rs
+++ b/crates/nu-command/src/misc/run.rs
@@ -3,7 +3,6 @@ use nu_engine::{
 };
 use nu_path::{absolute_with, is_windows_device_path};
 use nu_protocol::{BlockId, Value, engine::CommandType, shell_error::io::IoError};
-use std::borrow::Cow;
 use std::sync::Arc;
 
 /// Run a script file in an isolated scope as part of a pipeline.
@@ -55,7 +54,7 @@ impl Command for Run {
         // `run null` is parsed as a no-op so pipelines can keep flowing without
         // introducing conditional command dispatch in the runtime path.
         if call.get_parser_info(stack, "noop").is_some() {
-            return Ok(PipelineData::empty());
+            return Ok(input);
         }
 
         // Parser-time metadata tells us exactly which script block was compiled for this call.
@@ -124,25 +123,21 @@ impl Command for Run {
                     eval_block_with_early_return,
                 );
 
-                let mut input_for_main = input;
-                // When `main` declares positional parameters, bind piped input to the first one so:
-                //   "value" | run script.nu --flag x
-                // behaves like:
-                //   main "value" --flag x
-                //
-                // If there are no positional parameters, keep pipeline data as `$in`.
-                if !signature.required_positional.is_empty()
-                    || !signature.optional_positional.is_empty()
-                {
-                    let piped_input_value = input_for_main.into_value(call.head)?;
-                    call_eval.add_positional(&signature, Cow::Owned(piped_input_value))?;
-                    input_for_main = PipelineData::empty();
-                }
-
                 // Forward remaining run arguments (`run file.nu ...args`) to `main`.
-                // This helper normalizes long/short flags and supports AST+IR call representations.
+                // This helper normalizes long/short flags and supports AST+IR call representations
+                // while delegating actual binding/type validation to CallEval.
                 bind_main_arguments(engine_state, stack, call, &signature, &mut call_eval)?;
-                call_eval.run(engine_state, &main_block, input_for_main)
+                call_eval.finalize_for_signature(&signature)?;
+
+                // Execute a signature-stripped copy of `main` after manually binding all
+                // arguments so pipeline input remains available as `$in` and is not rebound
+                // to positional parameters by call-time argument machinery.
+                // Pipeline input passes through as `$in`; positional args come only from
+                // explicit `run file.nu ...args` tokens bound above.
+                let mut executable_main_block = (*main_block).clone();
+                *executable_main_block.signature = Signature::new("main");
+
+                call_eval.run_prebound(engine_state, &executable_main_block, input)
             } else {
                 // No explicit `main`: execute the script block directly in an isolated child stack.
                 // Parent scope values remain readable via stack parenting, but script mutations do
@@ -240,10 +235,11 @@ fn parse_flag_token(engine_state: &EngineState, value: &Value) -> Option<(String
 }
 
 /// Check whether a parsed flag token matches a named parameter from a signature.
+///
+/// Matches on the long name (`--char` → `"char"`) or by comparing the single short character
+/// extracted from a `-c` token against the flag's declared short character.
 fn matches_named_flag(named: &Flag, long: &str, short: Option<&str>) -> bool {
-    named.long == long
-        || short.and_then(|name| name.chars().next()) == named.short
-        || named.short.map(|name| name.to_string()).as_deref() == Some(long)
+    named.long == long || short.and_then(|name| name.chars().next()) == named.short
 }
 
 /// Resolve a parsed flag token to the matching signature flag, if any.
@@ -258,43 +254,53 @@ fn resolve_named_flag<'a>(
         .find(|named| matches_named_flag(named, long, short))
 }
 
-/// Bind `run` arguments (after the script filename) to a script `def main` signature.
-///
-/// Arguments are read in evaluator-agnostic form so this works for both AST and IR execution.
+/// Bind explicit `run file.nu ...args` arguments onto a script `def main` call evaluator.
 fn bind_main_arguments(
     engine_state: &EngineState,
-    stack: &mut Stack,
+    caller_stack: &mut Stack,
     call: &Call,
     signature: &Signature,
     call_eval: &mut CallEval,
 ) -> Result<(), ShellError> {
-    let eval_expression = get_eval_expression(engine_state);
-    let rest_values = call.rest_iter_flattened(engine_state, stack, eval_expression, 1)?;
+    let rest_values = collect_explicit_run_arguments(engine_state, caller_stack, call)?;
 
     let mut index = 0;
     while index < rest_values.len() {
         if let Some((long, short)) = parse_flag_token(engine_state, &rest_values[index]) {
             let matched_flag = resolve_named_flag(signature, &long, short.as_deref());
-            let canonical_long = matched_flag.map(|flag| flag.long.as_str()).unwrap_or(&long);
-            let expects_value = matched_flag.is_some_and(|flag| flag.arg.is_some());
+            if let Some(flag) = matched_flag {
+                let expects_value = flag.arg.is_some();
+                let value = if expects_value
+                    && index + 1 < rest_values.len()
+                    && parse_flag_token(engine_state, &rest_values[index + 1]).is_none()
+                {
+                    index += 1;
+                    Some(std::borrow::Cow::Owned(rest_values[index].clone()))
+                } else {
+                    None
+                };
 
-            let value = if expects_value
-                && index + 1 < rest_values.len()
-                && parse_flag_token(engine_state, &rest_values[index + 1]).is_none()
-            {
-                index += 1;
-                Some(Cow::Owned(rest_values[index].clone()))
-            } else {
-                None
-            };
-
-            call_eval.add_named(signature, canonical_long, short, value)?;
+                call_eval.add_named(signature, &flag.long, short, value)?;
+            }
         } else {
-            call_eval.add_positional(signature, Cow::Owned(rest_values[index].clone()))?;
+            call_eval.add_positional(
+                signature,
+                std::borrow::Cow::Owned(rest_values[index].clone()),
+            )?;
         }
 
         index += 1;
     }
 
     Ok(())
+}
+
+/// Collect only the explicit run arguments after the script filename.
+fn collect_explicit_run_arguments(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+) -> Result<Vec<Value>, ShellError> {
+    let eval_expression = get_eval_expression(engine_state);
+    call.rest_iter_flattened(engine_state, stack, eval_expression, 1)
 }

--- a/crates/nu-command/src/misc/run.rs
+++ b/crates/nu-command/src/misc/run.rs
@@ -1,0 +1,303 @@
+use nu_engine::{
+    CallEval, command_prelude::*, get_eval_block_with_early_return, get_eval_expression,
+};
+use nu_path::{absolute_with, is_windows_device_path};
+use nu_protocol::{BlockId, DeclId, Value, engine::CommandType, shell_error::io::IoError};
+use std::borrow::Cow;
+use std::sync::Arc;
+
+/// Run a script file in an isolated scope as part of a pipeline.
+#[derive(Clone)]
+pub struct Run;
+
+impl Command for Run {
+    fn name(&self) -> &str {
+        "run"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("run")
+            .input_output_types(vec![(Type::Any, Type::Any)])
+            .required(
+                "filename",
+                SyntaxShape::OneOf(vec![SyntaxShape::Filepath, SyntaxShape::Nothing]),
+                "The filepath to the script file to run (`null` for no-op).",
+            )
+            .rest(
+                "arguments",
+                SyntaxShape::Any,
+                "Arguments to pass to the script's `def main` if it exists.",
+            )
+            .allows_unknown_args()
+            .category(Category::Core)
+    }
+
+    fn description(&self) -> &str {
+        "Runs a script file in an isolated scope as part of a pipeline."
+    }
+
+    fn extra_description(&self) -> &str {
+        "This command is a parser keyword. For details, check:
+   https://www.nushell.sh/book/thinking_in_nu.html"
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        // `run null` is parsed as a no-op so pipelines can keep flowing without
+        // introducing conditional command dispatch in the runtime path.
+        if call.get_parser_info(stack, "noop").is_some() {
+            return Ok(PipelineData::empty());
+        }
+
+        // Parser-time metadata tells us exactly which script block was compiled for this call.
+        // We intentionally execute that precompiled block instead of reparsing at runtime.
+        //
+        // - `block_id`: block compiled from the resolved script file
+        // - `block_id_name`: script file path string captured at parse time
+        let block_id: i64 = call.req_parser_info(engine_state, stack, "block_id")?;
+        let block_id_name: String = call.req_parser_info(engine_state, stack, "block_id_name")?;
+        let block_id = BlockId::new(block_id as usize);
+        let block = engine_state.get_block(block_id).clone();
+
+        // Resolve the script path to an absolute path for consistent `CURRENT_FILE` / `FILE_PWD`
+        // behavior. Device paths on Windows are already absolute-like and must be preserved.
+        let cwd = engine_state.cwd_as_string(Some(stack))?;
+        let pb = std::path::PathBuf::from(block_id_name);
+        let parent = pb.parent().unwrap_or(std::path::Path::new(""));
+        let file_path = if is_windows_device_path(pb.as_path()) {
+            pb.clone()
+        } else {
+            let path = absolute_with(pb.as_path(), cwd)
+                .map_err(|err| IoError::new(err, call.head, pb.clone()))?;
+            match path.try_exists() {
+                Ok(true) => {}
+                Ok(false) => {
+                    return Err(IoError::new(ErrorKind::FileNotFound, call.head, pb.clone()).into());
+                }
+                Err(e) => return Err(IoError::new(e, call.head, pb.clone()).into()),
+            };
+            path
+        };
+
+        // Stash caller values so we can restore them after execution. `run` should expose file
+        // context to the script, but must not leak modified values back to the caller.
+        let old_file_pwd = stack.get_env_var(engine_state, "FILE_PWD").cloned();
+        let old_current_file = stack.get_env_var(engine_state, "CURRENT_FILE").cloned();
+
+        // Mirror `source`-style file context for script execution.
+        stack.add_env_var(
+            "FILE_PWD".to_string(),
+            Value::string(parent.to_string_lossy(), call.head),
+        );
+        stack.add_env_var(
+            "CURRENT_FILE".to_string(),
+            Value::string(file_path.to_string_lossy(), call.head),
+        );
+
+        let eval_block_with_early_return = get_eval_block_with_early_return(engine_state);
+        let return_result = (|| {
+            // If parser metadata includes a `main` entrypoint, invoke that specific declaration.
+            // Otherwise evaluate the full script block as a pipeline transform.
+            if call.get_parser_info(stack, "main_block_id").is_some() {
+                // These IDs are parser-scoped to the resolved script and avoid cross-script `main`
+                // lookup collisions from ambient declarations.
+                let main_decl_id: i64 =
+                    call.req_parser_info(engine_state, stack, "main_decl_id")?;
+                let main_block_id: i64 =
+                    call.req_parser_info(engine_state, stack, "main_block_id")?;
+                let main_decl_id = DeclId::new(main_decl_id as usize);
+                let main_block = engine_state
+                    .get_block(BlockId::new(main_block_id as usize))
+                    .clone();
+                let signature = engine_state.get_decl(main_decl_id).signature().clone();
+                let callee_stack = stack.gather_captures(engine_state, &main_block.captures);
+                let mut call_eval = CallEval::new(
+                    callee_stack,
+                    call.head,
+                    main_block.span.unwrap_or(call.head),
+                    eval_block_with_early_return,
+                );
+
+                let mut input_for_main = input;
+                // When `main` declares positional parameters, bind piped input to the first one so:
+                //   "value" | run script.nu --flag x
+                // behaves like:
+                //   main "value" --flag x
+                //
+                // If there are no positional parameters, keep pipeline data as `$in`.
+                if !signature.required_positional.is_empty()
+                    || !signature.optional_positional.is_empty()
+                {
+                    let piped_input_value = input_for_main.into_value(call.head)?;
+                    call_eval.add_positional(&signature, Cow::Owned(piped_input_value))?;
+                    input_for_main = PipelineData::empty();
+                }
+
+                // Forward remaining run arguments (`run file.nu ...args`) to `main`.
+                // This helper normalizes long/short flags and supports AST+IR call representations.
+                bind_main_arguments(engine_state, stack, call, &signature, &mut call_eval)?;
+                call_eval.run(engine_state, &main_block, input_for_main)
+            } else {
+                // No explicit `main`: execute the script block directly in an isolated child stack.
+                // Parent scope values remain readable via stack parenting, but script mutations do
+                // not leak back to the caller.
+                let parent_stack = Arc::new(stack.clone());
+                let mut callee_stack = Stack::with_parent(parent_stack);
+                eval_block_with_early_return(engine_state, &mut callee_stack, &block, input)
+                    .map(|p| p.body)
+            }
+        })();
+
+        // Always restore caller file-context env after script evaluation (success or error).
+        // If values did not exist before `run`, remove them instead of leaving command-introduced
+        // entries behind.
+        if let Some(old_file_pwd) = old_file_pwd {
+            stack.add_env_var("FILE_PWD".to_string(), old_file_pwd);
+        } else {
+            stack.remove_env_var(engine_state, "FILE_PWD");
+        }
+        if let Some(old_current_file) = old_current_file {
+            stack.add_env_var("CURRENT_FILE".to_string(), old_current_file);
+        } else {
+            stack.remove_env_var(engine_state, "CURRENT_FILE");
+        }
+
+        return_result
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                description: "Run a simple transformation script in a pipeline.",
+                example: r#""hello" | run transform.nu"#,
+                result: None,
+            },
+            Example {
+                description: "Run a script with arguments.",
+                example: r#""test" | run format.nu --prefix ">>>" "#,
+                result: None,
+            },
+            Example {
+                description: "Run a script as part of a larger pipeline.",
+                example: "ls | run process.nu | select name size",
+                result: None,
+            },
+        ]
+    }
+}
+
+/// Parse a source token that looks like a long or short named flag.
+///
+/// Returns `(long_name, short_name)` where:
+/// - `--char` becomes `("char", None)`
+/// - `-c` becomes `("c", Some("c"))`
+fn parse_flag_name(token: &str) -> Option<(String, Option<String>)> {
+    if let Some(flag_name) = token.strip_prefix("--")
+        && !flag_name.is_empty()
+    {
+        return Some((flag_name.to_string(), None));
+    }
+
+    let mut chars = token.chars();
+    if chars.next() == Some('-')
+        && let Some(short) = chars.next()
+        && chars.next().is_none()
+        && short.is_ascii_alphabetic()
+    {
+        let short = short.to_string();
+        return Some((short.clone(), Some(short)));
+    }
+
+    None
+}
+
+/// Parse a forwarded argument value into a flag token.
+///
+/// Source text is preferred so quoted literals like `"-c"` stay positional values.
+fn parse_flag_token(engine_state: &EngineState, value: &Value) -> Option<(String, Option<String>)> {
+    let span = value.span();
+    let span_contents = engine_state.get_span_contents(span);
+    if let Ok(token) = std::str::from_utf8(span_contents) {
+        if let Some(flag) = parse_flag_name(token) {
+            return Some(flag);
+        }
+
+        if token.starts_with('"') || token.starts_with('\'') {
+            return None;
+        }
+    }
+
+    match value {
+        Value::String { val, .. } => parse_flag_name(val),
+        _ => None,
+    }
+}
+
+/// Check whether a parsed flag token matches a named parameter from a signature.
+fn matches_named_flag(named: &Flag, long: &str, short: Option<&str>) -> bool {
+    named.long == long
+        || short.and_then(|name| name.chars().next()) == named.short
+        || named.short.map(|name| name.to_string()).as_deref() == Some(long)
+}
+
+/// Resolve a parsed flag token to the matching signature flag, if any.
+fn resolve_named_flag<'a>(
+    signature: &'a Signature,
+    long: &str,
+    short: Option<&str>,
+) -> Option<&'a Flag> {
+    signature
+        .named
+        .iter()
+        .find(|named| matches_named_flag(named, long, short))
+}
+
+/// Bind `run` arguments (after the script filename) to a script `def main` signature.
+///
+/// Arguments are read in evaluator-agnostic form so this works for both AST and IR execution.
+fn bind_main_arguments(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+    signature: &Signature,
+    call_eval: &mut CallEval,
+) -> Result<(), ShellError> {
+    let eval_expression = get_eval_expression(engine_state);
+    let rest_values = call.rest_iter_flattened(engine_state, stack, eval_expression, 1)?;
+
+    let mut index = 0;
+    while index < rest_values.len() {
+        if let Some((long, short)) = parse_flag_token(engine_state, &rest_values[index]) {
+            let matched_flag = resolve_named_flag(signature, &long, short.as_deref());
+            let canonical_long = matched_flag.map(|flag| flag.long.as_str()).unwrap_or(&long);
+            let expects_value = matched_flag.is_some_and(|flag| flag.arg.is_some());
+
+            let value = if expects_value
+                && index + 1 < rest_values.len()
+                && parse_flag_token(engine_state, &rest_values[index + 1]).is_none()
+            {
+                index += 1;
+                Some(Cow::Owned(rest_values[index].clone()))
+            } else {
+                None
+            };
+
+            call_eval.add_named(signature, canonical_long, short, value)?;
+        } else {
+            call_eval.add_positional(signature, Cow::Owned(rest_values[index].clone()))?;
+        }
+
+        index += 1;
+    }
+
+    Ok(())
+}

--- a/crates/nu-command/src/misc/run.rs
+++ b/crates/nu-command/src/misc/run.rs
@@ -2,7 +2,7 @@ use nu_engine::{
     CallEval, command_prelude::*, get_eval_block_with_early_return, get_eval_expression,
 };
 use nu_path::{absolute_with, is_windows_device_path};
-use nu_protocol::{BlockId, DeclId, Value, engine::CommandType, shell_error::io::IoError};
+use nu_protocol::{BlockId, Value, engine::CommandType, shell_error::io::IoError};
 use std::borrow::Cow;
 use std::sync::Arc;
 
@@ -110,15 +110,12 @@ impl Command for Run {
             if call.get_parser_info(stack, "main_block_id").is_some() {
                 // These IDs are parser-scoped to the resolved script and avoid cross-script `main`
                 // lookup collisions from ambient declarations.
-                let main_decl_id: i64 =
-                    call.req_parser_info(engine_state, stack, "main_decl_id")?;
                 let main_block_id: i64 =
                     call.req_parser_info(engine_state, stack, "main_block_id")?;
-                let main_decl_id = DeclId::new(main_decl_id as usize);
                 let main_block = engine_state
                     .get_block(BlockId::new(main_block_id as usize))
                     .clone();
-                let signature = engine_state.get_decl(main_decl_id).signature().clone();
+                let signature = (*main_block.signature).clone();
                 let callee_stack = stack.gather_captures(engine_state, &main_block.captures);
                 let mut call_eval = CallEval::new(
                     callee_stack,

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -96,6 +96,7 @@ mod reverse;
 mod rm;
 mod roll;
 mod rotate;
+mod run;
 mod run_external;
 mod save;
 mod select;

--- a/crates/nu-command/tests/commands/run.rs
+++ b/crates/nu-command/tests/commands/run.rs
@@ -36,6 +36,15 @@ fn run_script_with_main_implicit_in() {
 }
 
 #[test]
+fn run_null_passes_pipeline_input_through() {
+    Playground::setup("run_null_passes_pipeline_input_through", |dirs, _| {
+        let actual = nu!(cwd: dirs.test(), r#""hello" | run null"#);
+        assert_eq!(actual.out, "hello");
+        assert!(actual.err.is_empty());
+    });
+}
+
+#[test]
 fn run_script_with_main_parameters_and_flags() {
     Playground::setup(
         "run_script_with_main_parameters_and_flags",
@@ -44,13 +53,13 @@ fn run_script_with_main_parameters_and_flags() {
                 "format.nu",
                 "
                 def main [value: string, --char: string] {
-                    $\"($value) ($char)\"
+                    $\"($in) ($value) ($char)\"
                 }
             ",
             )]);
 
-            let actual = nu!(cwd: dirs.test(), r#""hello" | run format.nu --char "!" "#);
-            assert_eq!(actual.out, "hello !");
+            let actual = nu!(cwd: dirs.test(), r#""hello" | run format.nu "arg" --char "!" "#);
+            assert_eq!(actual.out, "hello arg !");
             assert!(actual.err.is_empty());
         },
     );
@@ -65,16 +74,106 @@ fn run_script_with_main_parameters_and_short_flags() {
                 "format_short.nu",
                 "
                 def main [value: string, --char(-c): string] {
-                    $\"($value) ($char)\"
+                    $\"($in) ($value) ($char)\"
                 }
             ",
             )]);
 
-            let actual = nu!(cwd: dirs.test(), r#""hello" | run format_short.nu -c "!" "#);
-            assert_eq!(actual.out, "hello !");
+            let actual = nu!(cwd: dirs.test(), r#""hello" | run format_short.nu "arg" -c "!" "#);
+            assert_eq!(actual.out, "hello arg !");
             assert!(actual.err.is_empty());
         },
     );
+}
+
+#[test]
+fn run_script_with_main_required_positional_does_not_implicitly_bind_pipeline_input() {
+    Playground::setup(
+        "run_script_with_main_required_positional_does_not_implicitly_bind_pipeline_input",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "needs_arg.nu",
+                "
+                def main [value: string] {
+                    $value
+                }
+            ",
+            )]);
+
+            let actual = nu!(cwd: dirs.test(), r#""hello" | run needs_arg.nu"#);
+            assert!(actual.out.is_empty());
+            assert!(!actual.err.is_empty());
+        },
+    );
+}
+
+#[test]
+fn run_script_with_main_keeps_pipeline_input_in_in_when_positional_is_provided() {
+    Playground::setup(
+        "run_script_with_main_keeps_pipeline_input_in_in_when_positional_is_provided",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "in_and_arg.nu",
+                "
+                def main [file: path] {
+                    $\"($in) -> ($file)\"
+                }
+            ",
+            )]);
+
+            let actual = nu!(cwd: dirs.test(), r#""stream" | run in_and_arg.nu "path.txt""#);
+            assert_eq!(actual.out, "stream -> path.txt");
+            assert!(actual.err.is_empty());
+        },
+    );
+}
+
+#[test]
+fn run_script_with_exported_main_uses_main_entrypoint() {
+    Playground::setup(
+        "run_script_with_exported_main_uses_main_entrypoint",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "exported_main.nu",
+                "
+                export def main [] {
+                    $in | str upcase
+                }
+            ",
+            )]);
+
+            let actual = nu!(cwd: dirs.test(), r#""hello" | run exported_main.nu"#);
+            assert_eq!(actual.out, "HELLO");
+            assert!(actual.err.is_empty());
+        },
+    );
+}
+
+#[test]
+fn run_script_with_exported_env_main_uses_main_entrypoint_without_leaking_env() -> Result {
+    Playground::setup(
+        "run_script_with_exported_env_main_uses_main_entrypoint_without_leaking_env",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "exported_env_main.nu",
+                "
+                    export def --env main [] {
+                        $env.RUN_LOCAL = 'secret'
+                        $in | str upcase
+                    }
+                ",
+            )]);
+
+            let mut tester = test().cwd(dirs.test());
+            tester
+                .run(r#""hello" | run exported_env_main.nu"#)
+                .expect_value_eq("HELLO")?;
+            match tester.run("$env.RUN_LOCAL").expect_shell_error()? {
+                ShellError::CantFindColumn { col_name, .. } if col_name == "RUN_LOCAL" => Ok(()),
+                err => Err(err.into()),
+            }
+        },
+    )
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/run.rs
+++ b/crates/nu-command/tests/commands/run.rs
@@ -1,0 +1,310 @@
+use nu_protocol::ShellError;
+use nu_test_support::{fs::Stub::FileWithContentToBeTrimmed, prelude::*};
+
+#[test]
+fn run_script_without_main_in_pipeline() {
+    Playground::setup("run_script_without_main_in_pipeline", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
+            "up.nu",
+            "
+                str upcase
+            ",
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), r#""hello" | run up.nu"#);
+        assert_eq!(actual.out, "HELLO");
+        assert!(actual.err.is_empty());
+    });
+}
+
+#[test]
+fn run_script_with_main_implicit_in() {
+    Playground::setup("run_script_with_main_implicit_in", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
+            "main_up.nu",
+            "
+                def main [] {
+                    $in | str upcase
+                }
+            ",
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), r#""hello" | run main_up.nu"#);
+        assert_eq!(actual.out, "HELLO");
+        assert!(actual.err.is_empty());
+    });
+}
+
+#[test]
+fn run_script_with_main_parameters_and_flags() {
+    Playground::setup(
+        "run_script_with_main_parameters_and_flags",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "format.nu",
+                "
+                def main [value: string, --char: string] {
+                    $\"($value) ($char)\"
+                }
+            ",
+            )]);
+
+            let actual = nu!(cwd: dirs.test(), r#""hello" | run format.nu --char "!" "#);
+            assert_eq!(actual.out, "hello !");
+            assert!(actual.err.is_empty());
+        },
+    );
+}
+
+#[test]
+fn run_script_with_main_parameters_and_short_flags() {
+    Playground::setup(
+        "run_script_with_main_parameters_and_short_flags",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "format_short.nu",
+                "
+                def main [value: string, --char(-c): string] {
+                    $\"($value) ($char)\"
+                }
+            ",
+            )]);
+
+            let actual = nu!(cwd: dirs.test(), r#""hello" | run format_short.nu -c "!" "#);
+            assert_eq!(actual.out, "hello !");
+            assert!(actual.err.is_empty());
+        },
+    );
+}
+
+#[test]
+fn run_script_without_main_large_input_in_each() {
+    Playground::setup(
+        "run_script_without_main_large_input_in_each",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "double.nu",
+                "
+                $in * 2
+            ",
+            )]);
+
+            let actual = nu!(cwd: dirs.test(), "1..1000 | each { run double.nu } | math sum");
+            assert_eq!(actual.out, "1001000");
+            assert!(actual.err.is_empty());
+        },
+    );
+}
+
+#[test]
+fn run_does_not_leak_env_from_script_without_main() -> Result {
+    Playground::setup(
+        "run_does_not_leak_env_from_script_without_main",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "set_env.nu",
+                "
+                $env.RUN_LOCAL = 'secret'
+                $in
+            ",
+            )]);
+
+            let mut tester = test().cwd(dirs.test());
+            tester
+                .run(r#""hello" | run set_env.nu"#)
+                .expect_value_eq("hello")?;
+            match tester.run("$env.RUN_LOCAL").expect_shell_error()? {
+                ShellError::CantFindColumn { col_name, .. } if col_name == "RUN_LOCAL" => Ok(()),
+                err => Err(err.into()),
+            }
+        },
+    )
+}
+
+#[test]
+fn run_does_not_leak_env_from_script_main() -> Result {
+    Playground::setup("run_does_not_leak_env_from_script_main", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
+            "set_env_main.nu",
+            "
+                def main [] {
+                    $env.RUN_LOCAL = 'secret'
+                    $in
+                }
+            ",
+        )]);
+
+        let mut tester = test().cwd(dirs.test());
+        tester
+            .run(r#""hello" | run set_env_main.nu"#)
+            .expect_value_eq("hello")?;
+        match tester.run("$env.RUN_LOCAL").expect_shell_error()? {
+            ShellError::CantFindColumn { col_name, .. } if col_name == "RUN_LOCAL" => Ok(()),
+            err => Err(err.into()),
+        }
+    })
+}
+
+#[test]
+fn run_missing_script_reports_error() {
+    Playground::setup("run_missing_script_reports_error", |dirs, _| {
+        let actual = nu!(cwd: dirs.test(), r#""hello" | run does_not_exist.nu"#);
+        assert!(actual.out.is_empty());
+        assert!(actual.err.contains("not found") || actual.err.contains("not_exist"));
+    });
+}
+
+#[test]
+fn run_script_parse_error_reports_error() {
+    Playground::setup("run_script_parse_error_reports_error", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
+            "bad.nu",
+            "
+                def main [ {
+                    $in
+                }
+            ",
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), r#""hello" | run bad.nu"#);
+        assert!(actual.out.is_empty());
+        assert!(!actual.err.is_empty());
+    });
+}
+
+#[test]
+fn run_script_runtime_error_reports_error() {
+    Playground::setup("run_script_runtime_error_reports_error", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
+            "runtime_fail.nu",
+            "
+                def main [] {
+                    error make { msg: 'boom from run' }
+                }
+            ",
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), r#""hello" | run runtime_fail.nu"#);
+        assert!(actual.out.is_empty());
+        assert!(actual.err.contains("boom from run"));
+    });
+}
+
+#[test]
+fn run_multiple_scripts_in_pipeline() {
+    Playground::setup("run_multiple_scripts_in_pipeline", |dirs, sandbox| {
+        sandbox.with_files(&[
+            FileWithContentToBeTrimmed(
+                "up.nu",
+                "
+                    str upcase
+                ",
+            ),
+            FileWithContentToBeTrimmed(
+                "len.nu",
+                "
+                    def main [] {
+                        str length
+                    }
+                ",
+            ),
+        ]);
+
+        let actual = nu!(cwd: dirs.test(), r#""hello" | run up.nu | run len.nu"#);
+        assert_eq!(actual.out, "5");
+        assert!(actual.err.is_empty());
+    });
+}
+
+#[test]
+fn run_nested_pipeline_with_each() {
+    Playground::setup("run_nested_pipeline_with_each", |dirs, sandbox| {
+        sandbox.with_files(&[
+            FileWithContentToBeTrimmed(
+                "up.nu",
+                "
+                    str upcase
+                ",
+            ),
+            FileWithContentToBeTrimmed(
+                "len.nu",
+                "
+                    def main [] {
+                        str length
+                    }
+                ",
+            ),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            "['a', 'bb', 'ccc'] | each { |x| $x | run up.nu | run len.nu } | math sum"
+        );
+        assert_eq!(actual.out, "6");
+        assert!(actual.err.is_empty());
+    });
+}
+
+#[test]
+fn run_does_not_cross_script_main_between_invocations() -> Result {
+    Playground::setup(
+        "run_does_not_cross_script_main_between_invocations",
+        |dirs, sandbox| {
+            sandbox.with_files(&[
+                FileWithContentToBeTrimmed(
+                    "run-test1.nu",
+                    "
+                        str upcase
+                    ",
+                ),
+                FileWithContentToBeTrimmed(
+                    "run-test2.nu",
+                    "
+                        def main [] {
+                            str length
+                        }
+                    ",
+                ),
+            ]);
+
+            let mut tester = test().cwd(dirs.test());
+            tester
+                .run(r#""hello" | run run-test1.nu"#)
+                .expect_value_eq("HELLO")?;
+            tester
+                .run(r#""hello" | run run-test2.nu"#)
+                .expect_value_eq(5)?;
+            tester
+                .run(r#""hello" | run run-test1.nu"#)
+                .expect_value_eq("HELLO")
+        },
+    )
+}
+
+#[test]
+fn run_main_script_can_be_invoked_repeatedly() -> Result {
+    Playground::setup(
+        "run_main_script_can_be_invoked_repeatedly",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "run-test2.nu",
+                "
+                def main [] {
+                    str length
+                }
+            ",
+            )]);
+
+            let mut tester = test().cwd(dirs.test());
+            tester
+                .run(r#""hello" | run run-test2.nu"#)
+                .expect_value_eq(5)?;
+            tester
+                .run(r#""hello" | run run-test2.nu"#)
+                .expect_value_eq(5)?;
+            tester
+                .run(r#""hello" | run run-test2.nu"#)
+                .expect_value_eq(5)
+        },
+    )
+}

--- a/crates/nu-command/tests/commands/run.rs
+++ b/crates/nu-command/tests/commands/run.rs
@@ -308,3 +308,29 @@ fn run_main_script_can_be_invoked_repeatedly() -> Result {
         },
     )
 }
+
+#[test]
+fn run_main_script_tracks_file_edits_in_repl_session() -> Result {
+    Playground::setup(
+        "run_main_script_tracks_file_edits_in_repl_session",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "run-edit.nu",
+                "
+                def main [] {
+                    'hello'
+                }
+            ",
+            )]);
+
+            let mut tester = test().cwd(dirs.test());
+            tester.run("run run-edit.nu").expect_value_eq("hello")?;
+            tester.run::<()>(r#"'def main [] { "hello world" }' | save --force run-edit.nu"#)?;
+            tester
+                .run("run run-edit.nu")
+                .expect_value_eq("hello world")?;
+            tester.run::<()>(r#"'def main [] { "hello" }' | save --force run-edit.nu"#)?;
+            tester.run("run run-edit.nu").expect_value_eq("hello")
+        },
+    )
+}

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -187,6 +187,30 @@ impl CallEval {
         (self.eval)(engine_state, &mut self.callee_stack, block, input).map(|p| p.body)
     }
 
+    /// Finalize missing/default/rest arguments without evaluating the block yet.
+    ///
+    /// This is useful for callers that need to bind arguments against one signature and then
+    /// evaluate a modified copy of the block without re-running the argument finalization step.
+    pub fn finalize_for_signature(
+        &mut self,
+        signature: &Signature,
+    ) -> Result<&mut Self, ShellError> {
+        self.finalize_arguments(signature)?;
+        Ok(self)
+    }
+
+    /// Run a block after arguments have already been fully bound onto the callee stack.
+    pub fn run_prebound(
+        &mut self,
+        engine_state: &EngineState,
+        block: &Block,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        self.arg_index = 0;
+        self.rest_args.clear();
+        (self.eval)(engine_state, &mut self.callee_stack, block, input).map(|p| p.body)
+    }
+
     /// Export the modified environment from callee to the caller.
     pub fn redirect_env(&self, engine_state: &EngineState, stack: &mut Stack) {
         redirect_env(engine_state, stack, &self.callee_stack);

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -20,7 +20,7 @@ pub use compile::compile;
 pub use documentation::get_full_help;
 pub use env::*;
 pub use eval::{
-    eval_block, eval_block_with_early_return, eval_call, eval_expression,
+    CallEval, eval_block, eval_block_with_early_return, eval_call, eval_expression,
     eval_expression_with_input, eval_subexpression, eval_variable, redirect_env,
 };
 pub use eval_helpers::*;

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -87,6 +87,7 @@ pub const UNALIASABLE_PARSER_KEYWORDS: &[&[u8]] = &[
     b"export-env",
     b"source-env",
     b"source",
+    b"run",
     b"where",
     b"plugin use",
 ];
@@ -3791,6 +3792,236 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
         Span::concat(spans),
     ));
     garbage_pipeline(working_set, spans)
+}
+
+pub fn parse_run(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
+    trace!("parsing run");
+    let expr = parse_run_expr_internal(working_set, &lite_command.parts, lite_command);
+    Pipeline::from_vec(vec![expr])
+}
+
+fn parse_run_expr_internal(
+    working_set: &mut StateWorkingSet,
+    spans: &[Span],
+    lite_command: &LiteCommand,
+) -> Expression {
+    trace!("parsing run expression");
+    let name = working_set.get_span_contents(spans.first().copied().unwrap_or(Span::unknown()));
+
+    if name == b"run" {
+        if let Some(redirection) = lite_command.redirection.as_ref() {
+            working_set.error(redirecting_builtin_error("run", redirection));
+            return garbage(working_set, Span::concat(spans));
+        }
+
+        if let Some(decl_id) = working_set.find_decl(name) {
+            #[allow(deprecated)]
+            let cwd = working_set.get_cwd();
+
+            let ParsedInternalCall {
+                call,
+                output,
+                call_kind,
+            } = parse_internal_call(
+                working_set,
+                spans[0],
+                &spans[1..],
+                decl_id,
+                ArgumentParsingLevel::Full,
+            );
+
+            if call_kind == CallKind::Help {
+                return Expression::new(working_set, Expr::Call(call), Span::concat(spans), output);
+            }
+
+            // Get the script filename (first positional argument)
+            let first_expr = call.positional_iter().next();
+            if let Some(expr) = first_expr {
+                let val = match eval_constant(working_set, expr) {
+                    Ok(val) => val,
+                    Err(err) => {
+                        working_set.error(err.wrap(working_set, Span::concat(&spans[1..])));
+                        return Expression::new(
+                            working_set,
+                            Expr::Call(call),
+                            Span::concat(&spans[1..]),
+                            Type::Any,
+                        );
+                    }
+                };
+
+                if val.is_nothing() {
+                    let mut call = call;
+                    call.set_parser_info(
+                        "noop".to_string(),
+                        Expression::new_unknown(Expr::Nothing, Span::unknown(), Type::Nothing),
+                    );
+                    return Expression::new(
+                        working_set,
+                        Expr::Call(call),
+                        Span::concat(spans),
+                        Type::Any,
+                    );
+                }
+
+                let filename = match val.coerce_into_string() {
+                    Ok(s) => s,
+                    Err(err) => {
+                        working_set.error(err.wrap(working_set, Span::concat(&spans[1..])));
+                        return Expression::new(
+                            working_set,
+                            Expr::Call(call),
+                            Span::concat(&spans[1..]),
+                            Type::Any,
+                        );
+                    }
+                };
+
+                if let Some(path) = find_in_dirs(&filename, working_set, &cwd, Some(LIB_DIRS_VAR)) {
+                    if let Some(contents) = path.read(working_set) {
+                        let script_has_main_def = {
+                            let (tokens, err) = lex(&contents, 0, &[], &[], false);
+                            if let Some(err) = err {
+                                working_set.error(err);
+                            }
+                            let (lite_block, err) = lite_parse(&tokens, working_set);
+                            if let Some(err) = err {
+                                working_set.error(err);
+                            }
+
+                            lite_block.block.iter().any(|pipeline| {
+                                if pipeline.commands.len() != 1 {
+                                    return false;
+                                }
+
+                                let command_parts = pipeline.commands[0].command_parts();
+                                match (command_parts.first(), command_parts.get(1)) {
+                                    (Some(head), Some(name)) => {
+                                        let head_bytes =
+                                            contents.get(head.start..head.end).unwrap_or_default();
+                                        let name_bytes =
+                                            contents.get(name.start..name.end).unwrap_or_default();
+
+                                        head_bytes == b"def" && name_bytes == b"main"
+                                    }
+                                    _ => false,
+                                }
+                            })
+                        };
+
+                        // Add the file to the stack of files being processed.
+                        if let Err(e) = working_set.files.push(path.clone().path_buf(), spans[1]) {
+                            working_set.error(e);
+                            return garbage(working_set, Span::concat(spans));
+                        }
+
+                        // Parse the script as a non-scoped block
+                        let mut block = parse(
+                            working_set,
+                            Some(&path.path().to_string_lossy()),
+                            &contents,
+                            false,
+                        );
+                        if block.ir_block.is_none() {
+                            let block_mut = Arc::make_mut(&mut block);
+                            compile_block(working_set, block_mut);
+                        }
+
+                        // Remove the file from the stack of files being processed.
+                        working_set.files.pop();
+
+                        // Save the block into the working set
+                        let block_id = working_set.add_block(block);
+                        let script_main_decl_id = if script_has_main_def {
+                            working_set.find_decl(b"main")
+                        } else {
+                            None
+                        };
+                        let script_main_block_id = script_main_decl_id
+                            .and_then(|main_decl_id| working_set.get_decl(main_decl_id).block_id());
+
+                        let mut call_with_block = call;
+
+                        // Store the block_id as parser info
+                        call_with_block.set_parser_info(
+                            "block_id".to_string(),
+                            Expression::new(
+                                working_set,
+                                Expr::Int(block_id.get() as i64),
+                                spans[1],
+                                Type::Any,
+                            ),
+                        );
+
+                        // Store the file path for debugging
+                        call_with_block.set_parser_info(
+                            "block_id_name".to_string(),
+                            Expression::new(
+                                working_set,
+                                Expr::Filepath(path.path_buf().display().to_string(), false),
+                                spans[1],
+                                Type::String,
+                            ),
+                        );
+                        if let Some(main_block_id) = script_main_block_id {
+                            call_with_block.set_parser_info(
+                                "main_block_id".to_string(),
+                                Expression::new(
+                                    working_set,
+                                    Expr::Int(main_block_id.get() as i64),
+                                    spans[1],
+                                    Type::Any,
+                                ),
+                            );
+                        }
+                        if let Some(main_decl_id) = script_main_decl_id {
+                            call_with_block.set_parser_info(
+                                "main_decl_id".to_string(),
+                                Expression::new(
+                                    working_set,
+                                    Expr::Int(main_decl_id.get() as i64),
+                                    spans[1],
+                                    Type::Any,
+                                ),
+                            );
+                        }
+
+                        return Expression::new(
+                            working_set,
+                            Expr::Call(call_with_block),
+                            Span::concat(spans),
+                            Type::Any,
+                        );
+                    }
+                } else {
+                    working_set.error(ParseError::SourcedFileNotFound(filename, spans[1]));
+                }
+            }
+            return Expression::new(
+                working_set,
+                Expr::Call(call),
+                Span::concat(spans),
+                Type::Any,
+            );
+        }
+    }
+    working_set.error(ParseError::UnknownState(
+        "internal error: run statement unparsable".into(),
+        Span::concat(spans),
+    ));
+    garbage(working_set, Span::concat(spans))
+}
+
+pub fn parse_run_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expression {
+    // Create a temporary LiteCommand for internal use
+    let lite_command = LiteCommand {
+        parts: spans.to_vec(),
+        pipe: None,
+        redirection: None,
+        comments: vec![],
+        attribute_idx: vec![],
+    };
+    parse_run_expr_internal(working_set, spans, &lite_command)
 }
 
 pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expression {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3930,15 +3930,14 @@ fn parse_run_expr_internal(
                         // Remove the file from the stack of files being processed.
                         working_set.files.pop();
 
-                        // Save the block into the working set
-                        let block_id = working_set.add_block(block);
-                        let script_main_decl_id = if script_has_main_def {
-                            working_set.find_decl(b"main")
+                        let script_main_block_id = if script_has_main_def {
+                            find_main_block_id_in_script(working_set, &block)
                         } else {
                             None
                         };
-                        let script_main_block_id = script_main_decl_id
-                            .and_then(|main_decl_id| working_set.get_decl(main_decl_id).block_id());
+
+                        // Save the block into the working set
+                        let block_id = working_set.add_block(block);
 
                         let mut call_with_block = call;
 
@@ -3974,18 +3973,6 @@ fn parse_run_expr_internal(
                                 ),
                             );
                         }
-                        if let Some(main_decl_id) = script_main_decl_id {
-                            call_with_block.set_parser_info(
-                                "main_decl_id".to_string(),
-                                Expression::new(
-                                    working_set,
-                                    Expr::Int(main_decl_id.get() as i64),
-                                    spans[1],
-                                    Type::Any,
-                                ),
-                            );
-                        }
-
                         return Expression::new(
                             working_set,
                             Expr::Call(call_with_block),
@@ -4010,6 +3997,34 @@ fn parse_run_expr_internal(
         Span::concat(spans),
     ));
     garbage(working_set, Span::concat(spans))
+}
+
+fn find_main_block_id_in_script(
+    working_set: &StateWorkingSet<'_>,
+    script_block: &Block,
+) -> Option<BlockId> {
+    script_block.pipelines.iter().find_map(|pipeline| {
+        if pipeline.elements.len() != 1 {
+            return None;
+        }
+
+        let expr = &pipeline.elements[0].expr;
+        let Expr::Call(call) = &expr.expr else {
+            return None;
+        };
+        if working_set.get_decl(call.decl_id).name() != "def" {
+            return None;
+        }
+
+        let mut positional = call.positional_iter();
+        let command_name = positional.next().and_then(Expression::as_string)?;
+        if command_name != "main" {
+            return None;
+        }
+
+        let _ = positional.next();
+        positional.next().and_then(Expression::as_block)
+    })
 }
 
 pub fn parse_run_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expression {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3794,12 +3794,26 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
     garbage_pipeline(working_set, spans)
 }
 
+/// Parse a `run` statement from a full [`LiteCommand`] (keyword entrypoint from the pipeline
+/// parser).
+///
+/// Delegates all real work to [`parse_run_expr_internal`] and wraps the resulting expression in a
+/// single-element [`Pipeline`].
 pub fn parse_run(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
     trace!("parsing run");
     let expr = parse_run_expr_internal(working_set, &lite_command.parts, lite_command);
     Pipeline::from_vec(vec![expr])
 }
 
+/// Core parser for a `run` expression.
+///
+/// Resolves the script filename at parse time, reads and compiles the script into a [`Block`],
+/// stores it in the working set, and annotates the call with hidden parser-info entries:
+///
+/// - `"block_id"` — the compiled script block
+/// - `"block_id_name"` — the resolved file path (for `CURRENT_FILE` / `FILE_PWD`)
+/// - `"main_block_id"` — the `def main` block inside the script, if one exists
+/// - `"noop"` — present when the filename argument is `null` (pipeline pass-through)
 fn parse_run_expr_internal(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
@@ -3879,36 +3893,6 @@ fn parse_run_expr_internal(
 
                 if let Some(path) = find_in_dirs(&filename, working_set, &cwd, Some(LIB_DIRS_VAR)) {
                     if let Some(contents) = path.read(working_set) {
-                        let script_has_main_def = {
-                            let (tokens, err) = lex(&contents, 0, &[], &[], false);
-                            if let Some(err) = err {
-                                working_set.error(err);
-                            }
-                            let (lite_block, err) = lite_parse(&tokens, working_set);
-                            if let Some(err) = err {
-                                working_set.error(err);
-                            }
-
-                            lite_block.block.iter().any(|pipeline| {
-                                if pipeline.commands.len() != 1 {
-                                    return false;
-                                }
-
-                                let command_parts = pipeline.commands[0].command_parts();
-                                match (command_parts.first(), command_parts.get(1)) {
-                                    (Some(head), Some(name)) => {
-                                        let head_bytes =
-                                            contents.get(head.start..head.end).unwrap_or_default();
-                                        let name_bytes =
-                                            contents.get(name.start..name.end).unwrap_or_default();
-
-                                        head_bytes == b"def" && name_bytes == b"main"
-                                    }
-                                    _ => false,
-                                }
-                            })
-                        };
-
                         // Add the file to the stack of files being processed.
                         if let Err(e) = working_set.files.push(path.clone().path_buf(), spans[1]) {
                             working_set.error(e);
@@ -3930,11 +3914,8 @@ fn parse_run_expr_internal(
                         // Remove the file from the stack of files being processed.
                         working_set.files.pop();
 
-                        let script_main_block_id = if script_has_main_def {
-                            find_main_block_id_in_script(working_set, &block)
-                        } else {
-                            None
-                        };
+                        let script_main_block_id =
+                            find_main_block_id_in_script(working_set, &block);
 
                         // Save the block into the working set
                         let block_id = working_set.add_block(block);
@@ -3999,6 +3980,11 @@ fn parse_run_expr_internal(
     garbage(working_set, Span::concat(spans))
 }
 
+/// Search a freshly-parsed script block for a top-level `def main` (or `export def main`)
+/// definition and return its [`BlockId`].
+///
+/// Returns `None` if the script contains no such definition, which causes `run` to execute the
+/// script block directly instead of dispatching through the `main` entrypoint.
 fn find_main_block_id_in_script(
     working_set: &StateWorkingSet<'_>,
     script_block: &Block,
@@ -4012,7 +3998,8 @@ fn find_main_block_id_in_script(
         let Expr::Call(call) = &expr.expr else {
             return None;
         };
-        if working_set.get_decl(call.decl_id).name() != "def" {
+        let decl_name = working_set.get_decl(call.decl_id).name();
+        if decl_name != "def" && decl_name != "export def" {
             return None;
         }
 
@@ -4027,6 +4014,11 @@ fn find_main_block_id_in_script(
     })
 }
 
+/// Parse a `run` expression from raw [`Span`] slices (expression-context entrypoint).
+///
+/// Constructs a minimal [`LiteCommand`] (no pipe, no redirection) and forwards to
+/// [`parse_run_expr_internal`]. Used by the expression parser when `run` appears inside a larger
+/// expression rather than at the start of a pipeline element.
 pub fn parse_run_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expression {
     // Create a temporary LiteCommand for internal use
     let lite_command = LiteCommand {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6479,6 +6479,7 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
                 }
             }
             b"where" => parse_where_expr(working_set, &spans[pos..]),
+            b"run" => parse_run_expr(working_set, &spans[pos..]),
             #[cfg(feature = "plugin")]
             b"plugin" => {
                 if spans.len() > 1 && working_set.get_span_contents(spans[1]) == b"use" {
@@ -6626,6 +6627,7 @@ pub fn parse_builtin_commands(
             parse_keyword(working_set, lite_command)
         }
         b"source" | b"source-env" => parse_source(working_set, lite_command),
+        b"run" => parse_run(working_set, lite_command),
         b"hide" => parse_hide(working_set, lite_command),
         b"where" => parse_where(working_set, lite_command),
         // Only "plugin use" is a keyword

--- a/crates/nu-std/tests/logger_tests/test_basic_commands.nu
+++ b/crates/nu-std/tests/logger_tests/test_basic_commands.nu
@@ -1,7 +1,7 @@
 use std/testing *
 use std/assert
 
-def run [
+def run-command [
     system_level,
     message_level
     --short
@@ -18,7 +18,7 @@ def "assert no message" [
     system_level,
     message_level
 ] {
-    let output = (run $system_level $message_level)
+    let output = (run-command $system_level $message_level)
     assert equal "" $output
 }
 
@@ -27,7 +27,7 @@ def "assert message" [
     message_level,
     message_level_str
 ] {
-    let output = (run $system_level $message_level)
+    let output = (run-command $system_level $message_level)
     assert str contains $output $message_level_str
     assert str contains $output "test message"
 }
@@ -37,7 +37,7 @@ def "assert message short" [
     message_level,
     message_level_str
 ] {
-    let output = (run --short $system_level $message_level)
+    let output = (run-command --short $system_level $message_level)
     assert str contains $output $message_level_str
     assert str contains $output "test message"
 }

--- a/tests/repl/test_signatures.rs
+++ b/tests/repl/test_signatures.rs
@@ -45,7 +45,8 @@ fn list_annotations_empty_4() -> TestResult {
 
 #[test]
 fn list_annotations_nested() -> TestResult {
-    let input = "def my_run [list: list<list<float>>] {$list | length}; my_run [ [2.0] [5.0] [4.0]]";
+    let input =
+        "def my_run [list: list<list<float>>] {$list | length}; my_run [ [2.0] [5.0] [4.0]]";
     let expected = "3";
     run_test(input, expected)
 }
@@ -59,7 +60,8 @@ fn list_annotations_unknown_inner_type() -> TestResult {
 
 #[test]
 fn list_annotations_nested_unknown_inner() -> TestResult {
-    let input = "def my_run [list: list<list<str>>] {$list | length}; my_run [ [nushell] [nunu] [nana]]";
+    let input =
+        "def my_run [list: list<list<str>>] {$list | length}; my_run [ [nushell] [nunu] [nana]]";
     let expected = "unknown type";
     fail_test(input, expected)
 }
@@ -171,15 +173,15 @@ fn record_annotations_key_with_no_type() -> TestResult {
 
 #[test]
 fn record_annotations_two_types_one_with_no_type() -> TestResult {
-    let input =
-        "def my_run [rec: record<name: string, age>] { $rec }; my_run {name: nushell age: 3} | describe";
+    let input = "def my_run [rec: record<name: string, age>] { $rec }; my_run {name: nushell age: 3} | describe";
     let expected = "record<name: string, age: int>";
     run_test(input, expected)
 }
 
 #[test]
 fn record_annotations_two_types_both_with_no_types() -> TestResult {
-    let input = "def my_run [rec: record<name age>] { $rec }; my_run {name: nushell age: 3} | describe";
+    let input =
+        "def my_run [rec: record<name age>] { $rec }; my_run {name: nushell age: 3} | describe";
     let expected = "record<name: string, age: int>";
     run_test(input, expected)
 }

--- a/tests/repl/test_signatures.rs
+++ b/tests/repl/test_signatures.rs
@@ -3,168 +3,168 @@ use rstest::rstest;
 
 #[test]
 fn list_annotations() -> TestResult {
-    let input = "def run [list: list<int>] {$list | length}; run [2 5 4]";
+    let input = "def my_run [list: list<int>] {$list | length}; my_run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_unknown_prefix() -> TestResult {
-    let input = "def run [list: listint>] {$list | length}; run [2 5 4]";
+    let input = "def my_run [list: listint>] {$list | length}; my_run [2 5 4]";
     let expected = "unknown type";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_empty_1() -> TestResult {
-    let input = "def run [list: list] {$list | length}; run [2 5 4]";
+    let input = "def my_run [list: list] {$list | length}; my_run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_empty_2() -> TestResult {
-    let input = "def run [list: list<>] {$list | length}; run [2 5 4]";
+    let input = "def my_run [list: list<>] {$list | length}; my_run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_empty_3() -> TestResult {
-    let input = "def run [list: list< >] {$list | length}; run [2 5 4]";
+    let input = "def my_run [list: list< >] {$list | length}; my_run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_empty_4() -> TestResult {
-    let input = "def run [list: list<\n>] {$list | length}; run [2 5 4]";
+    let input = "def my_run [list: list<\n>] {$list | length}; my_run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_nested() -> TestResult {
-    let input = "def run [list: list<list<float>>] {$list | length}; run [ [2.0] [5.0] [4.0]]";
+    let input = "def my_run [list: list<list<float>>] {$list | length}; my_run [ [2.0] [5.0] [4.0]]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_unknown_inner_type() -> TestResult {
-    let input = "def run [list: list<str>] {$list | length}; run ['nushell' 'nunu' 'nana']";
+    let input = "def my_run [list: list<str>] {$list | length}; my_run ['nushell' 'nunu' 'nana']";
     let expected = "unknown type";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_nested_unknown_inner() -> TestResult {
-    let input = "def run [list: list<list<str>>] {$list | length}; run [ [nushell] [nunu] [nana]]";
+    let input = "def my_run [list: list<list<str>>] {$list | length}; my_run [ [nushell] [nunu] [nana]]";
     let expected = "unknown type";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_unterminated() -> TestResult {
-    let input = "def run [list: list<string] {$list | length}; run [nu she ll]";
+    let input = "def my_run [list: list<string] {$list | length}; my_run [nu she ll]";
     let expected = "expected closing >";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_nested_unterminated() -> TestResult {
-    let input = "def run [list: list<list<>] {$list | length}; run [2 5 4]";
+    let input = "def my_run [list: list<list<>] {$list | length}; my_run [2 5 4]";
     let expected = "expected closing >";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_space_within_1() -> TestResult {
-    let input = "def run [list: list< range>] {$list | length}; run [2..32 5..<64 4..128]";
+    let input = "def my_run [list: list< range>] {$list | length}; my_run [2..32 5..<64 4..128]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_space_within_2() -> TestResult {
-    let input = "def run [list: list<number >] {$list | length}; run [2 5 4]";
+    let input = "def my_run [list: list<number >] {$list | length}; my_run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_space_within_3() -> TestResult {
-    let input = "def run [list: list< int >] {$list | length}; run [2 5 4]";
+    let input = "def my_run [list: list< int >] {$list | length}; my_run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_space_before() -> TestResult {
-    let input = "def run [list: list <int>] {$list | length}; run [2 5 4]";
+    let input = "def my_run [list: list <int>] {$list | length}; my_run [2 5 4]";
     let expected = "expected valid variable name for this parameter";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_unknown_separators() -> TestResult {
-    let input = "def run [list: list<int, string>] {$list | length}; run [2 5 4]";
+    let input = "def my_run [list: list<int, string>] {$list | length}; my_run [2 5 4]";
     let expected = "only one parameter allowed";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_with_default_val_1() -> TestResult {
-    let input = "def run [list: list<int> = [2 5 4]] {$list | length}; run";
+    let input = "def my_run [list: list<int> = [2 5 4]] {$list | length}; my_run";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_with_default_val_2() -> TestResult {
-    let input = "def run [list: list<string> = [2 5 4]] {$list | length}; run";
+    let input = "def my_run [list: list<string> = [2 5 4]] {$list | length}; my_run";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_with_extra_characters() -> TestResult {
-    let input = "def run [list: list<int>extra] {$list | length}; run [1 2 3]";
+    let input = "def my_run [list: list<int>extra] {$list | length}; my_run [1 2 3]";
     let expected = "Extra characters in the parameter name";
     fail_test(input, expected)
 }
 
 #[test]
 fn record_annotations_none() -> TestResult {
-    let input = "def run [rec: record] { $rec }; run {} | describe";
+    let input = "def my_run [rec: record] { $rec }; my_run {} | describe";
     let expected = "record";
     run_test(input, expected)
 }
 
 #[test]
 fn record_annotations() -> TestResult {
-    let input = "def run [rec: record<age: int>] { $rec }; run {age: 3} | describe";
+    let input = "def my_run [rec: record<age: int>] { $rec }; my_run {age: 3} | describe";
     let expected = "record<age: int>";
     run_test(input, expected)
 }
 
 #[test]
 fn record_annotations_two_types() -> TestResult {
-    let input = "def run [rec: record<name: string age: int>] { $rec }; run {name: nushell age: 3} | describe";
+    let input = "def my_run [rec: record<name: string age: int>] { $rec }; my_run {name: nushell age: 3} | describe";
     let expected = "record<name: string, age: int>";
     run_test(input, expected)
 }
 
 #[test]
 fn record_annotations_two_types_comma_sep() -> TestResult {
-    let input = "def run [rec: record<name: string, age: int>] { $rec }; run {name: nushell age: 3} | describe";
+    let input = "def my_run [rec: record<name: string, age: int>] { $rec }; my_run {name: nushell age: 3} | describe";
     let expected = "record<name: string, age: int>";
     run_test(input, expected)
 }
 
 #[test]
 fn record_annotations_key_with_no_type() -> TestResult {
-    let input = "def run [rec: record<name>] { $rec }; run {name: nushell} | describe";
+    let input = "def my_run [rec: record<name>] { $rec }; my_run {name: nushell} | describe";
     let expected = "record<name: string>";
     run_test(input, expected)
 }
@@ -172,21 +172,21 @@ fn record_annotations_key_with_no_type() -> TestResult {
 #[test]
 fn record_annotations_two_types_one_with_no_type() -> TestResult {
     let input =
-        "def run [rec: record<name: string, age>] { $rec }; run {name: nushell age: 3} | describe";
+        "def my_run [rec: record<name: string, age>] { $rec }; my_run {name: nushell age: 3} | describe";
     let expected = "record<name: string, age: int>";
     run_test(input, expected)
 }
 
 #[test]
 fn record_annotations_two_types_both_with_no_types() -> TestResult {
-    let input = "def run [rec: record<name age>] { $rec }; run {name: nushell age: 3} | describe";
+    let input = "def my_run [rec: record<name age>] { $rec }; my_run {name: nushell age: 3} | describe";
     let expected = "record<name: string, age: int>";
     run_test(input, expected)
 }
 
 #[test]
 fn record_annotations_nested() -> TestResult {
-    let input = "def run [
+    let input = "def my_run [
         err: record<
             msg: string,
             label: record<
@@ -196,7 +196,7 @@ fn record_annotations_nested() -> TestResult {
             >>
     ] {
         $err 
-    }; run {
+    }; my_run {
         msg: 'error message'
         label: {
             text: 'here is the error'
@@ -210,63 +210,63 @@ fn record_annotations_nested() -> TestResult {
 
 #[test]
 fn record_annotations_type_inference_1() -> TestResult {
-    let input = "def run [rec: record<age: any>] { $rec }; run {age: 2wk} | describe";
+    let input = "def my_run [rec: record<age: any>] { $rec }; my_run {age: 2wk} | describe";
     let expected = "record<age: duration>";
     run_test(input, expected)
 }
 
 #[test]
 fn record_annotations_type_inference_2() -> TestResult {
-    let input = "def run [rec: record<size>] { $rec }; run {size: 2mb} | describe";
+    let input = "def my_run [rec: record<size>] { $rec }; my_run {size: 2mb} | describe";
     let expected = "record<size: filesize>";
     run_test(input, expected)
 }
 
 #[test]
 fn record_annotations_not_terminated() -> TestResult {
-    let input = "def run [rec: record<age: int] { $rec }";
+    let input = "def my_run [rec: record<age: int] { $rec }";
     let expected = "expected closing >";
     fail_test(input, expected)
 }
 
 #[test]
 fn record_annotations_not_terminated_inner() -> TestResult {
-    let input = "def run [rec: record<name: string, repos: list<string>] { $rec }";
+    let input = "def my_run [rec: record<name: string, repos: list<string>] { $rec }";
     let expected = "expected closing >";
     fail_test(input, expected)
 }
 
 #[test]
 fn record_annotations_no_type_after_colon() -> TestResult {
-    let input = "def run [rec: record<name: >] { $rec }";
+    let input = "def my_run [rec: record<name: >] { $rec }";
     let expected = "type after colon";
     fail_test(input, expected)
 }
 
 #[test]
 fn record_annotations_type_mismatch_key() -> TestResult {
-    let input = "def run [rec: record<name: string>] { $rec }; run {nme: nushell}";
+    let input = "def my_run [rec: record<name: string>] { $rec }; my_run {nme: nushell}";
     let expected = "expected record<name: string>, found record<nme: string>";
     fail_test(input, expected)
 }
 
 #[test]
 fn record_annotations_type_mismatch_shape() -> TestResult {
-    let input = "def run [rec: record<age: int>] { $rec }; run {age: 2wk}";
+    let input = "def my_run [rec: record<age: int>] { $rec }; my_run {age: 2wk}";
     let expected = "expected record<age: int>, found record<age: duration>";
     fail_test(input, expected)
 }
 
 #[test]
 fn record_annotations_with_extra_characters() -> TestResult {
-    let input = "def run [list: record<int>extra] {$list | length}; run [1 2 3]";
+    let input = "def my_run [list: record<int>extra] {$list | length}; my_run [1 2 3]";
     let expected = "Extra characters in the parameter name";
     fail_test(input, expected)
 }
 
 #[test]
 fn table_annotations_none() -> TestResult {
-    let input = "def run [t: table] { $t }; run [[]; []] | describe";
+    let input = "def my_run [t: table] { $t }; my_run [[]; []] | describe";
     let expected = "table";
     run_test(input, expected)
 }
@@ -292,49 +292,49 @@ fn table_annotations(
         true => format!("list<record<{record_annotation}>>"),
         false => format!("table<{record_annotation}>"),
     };
-    let input = format!("def run [t: {type_annotation}] {{ $t }}; run {data} | describe");
+    let input = format!("def my_run [t: {type_annotation}] {{ $t }}; my_run {data} | describe");
     let expected = format!("table<{inferred_type}>");
     run_test(&input, &expected)
 }
 
 #[test]
 fn table_annotations_not_terminated() -> TestResult {
-    let input = "def run [t: table<age: int] { $t }";
+    let input = "def my_run [t: table<age: int] { $t }";
     let expected = "expected closing >";
     fail_test(input, expected)
 }
 
 #[test]
 fn table_annotations_not_terminated_inner() -> TestResult {
-    let input = "def run [t: table<name: string, repos: list<string>] { $t }";
+    let input = "def my_run [t: table<name: string, repos: list<string>] { $t }";
     let expected = "expected closing >";
     fail_test(input, expected)
 }
 
 #[test]
 fn table_annotations_no_type_after_colon() -> TestResult {
-    let input = "def run [t: table<name: >] { $t }";
+    let input = "def my_run [t: table<name: >] { $t }";
     let expected = "type after colon";
     fail_test(input, expected)
 }
 
 #[test]
 fn table_annotations_type_mismatch_column() -> TestResult {
-    let input = "def run [t: table<name: string>] { $t }; run [[nme]; [nushell]]";
+    let input = "def my_run [t: table<name: string>] { $t }; my_run [[nme]; [nushell]]";
     let expected = "expected table<name: string>, found table<nme: string>";
     fail_test(input, expected)
 }
 
 #[test]
 fn table_annotations_type_mismatch_shape() -> TestResult {
-    let input = "def run [t: table<age: int>] { $t }; run [[age]; [2wk]]";
+    let input = "def my_run [t: table<age: int>] { $t }; my_run [[age]; [2wk]]";
     let expected = "expected table<age: int>, found table<age: duration>";
     fail_test(input, expected)
 }
 
 #[test]
 fn table_annotations_with_extra_characters() -> TestResult {
-    let input = "def run [t: table<int>extra] {$t | length}; run [[int]; [8]]";
+    let input = "def my_run [t: table<int>extra] {$t | length}; my_run [[int]; [8]]";
     let expected = "Extra characters in the parameter name";
     fail_test(input, expected)
 }
@@ -351,7 +351,7 @@ fn oneof_annotations(
 ) -> TestResult {
     let (types, argument, expected) = annotation_data;
 
-    let input = format!("def run [t: oneof<{types}>] {{ $t }}; run {argument} | describe");
+    let input = format!("def my_run [t: oneof<{types}>] {{ $t }}; my_run {argument} | describe");
     run_test(&input, expected)
 }
 
@@ -366,21 +366,21 @@ fn oneof_type_checking(
     #[case] expect: &str,
 ) {
     let _ = testfn(
-        &format!("def run [p: record<a: oneof<int, nothing>>] {{ }}; run {argument}"),
+        &format!("def my_run [p: record<a: oneof<int, nothing>>] {{ }}; my_run {argument}"),
         expect,
     );
 }
 
 #[test]
 fn oneof_annotations_not_terminated() -> TestResult {
-    let input = "def run [t: oneof<binary, string] { $t }";
+    let input = "def my_run [t: oneof<binary, string] { $t }";
     let expected = "expected closing >";
     fail_test(input, expected)
 }
 
 #[test]
 fn oneof_annotations_with_extra_characters() -> TestResult {
-    let input = "def run [t: oneof<int, string>extra] {$t}";
+    let input = "def my_run [t: oneof<int, string>extra] {$t}";
     let expected = "Extra characters in the parameter name";
     fail_test(input, expected)
 }


### PR DESCRIPTION
## Description
This PR adds a new `run` command for pipeline script execution (without spawning another Nu process).

## User-facing changes (Release notes)

### Added `run` command for using scripts in pipelines

There's a new command named `run` that allows scripts to participate in a nushell pipeline with input and output. 

It keeps execution isolated so script artifacts do not leak into the parent scope. Script resolution remains aligned with existing behavior (cwd / NU_LIB_DIRS / explicit paths); PATH-based lookup is not included at this time.

#### Script Forms Supported
##### Bare scripts (scripts without def main)
The script body is evaluated directly as a pipeline transform (using implicit or explicit `$in` as usual).
```nushell
❯ open run-script1.nu
str upcase
❯ "Hello Nushell!" | run run-script1.nu
HELLO NUSHELL!
```

##### Scripts with `def main` entry point
If a top-level `def main` is defined, run invokes that entrypoint.
```nushell
❯ open run-script2.nu
def main [] {
  str length
}
❯ "Hello Nushell!" | run run-script2.nu
14
```
##### Scripts with full pipelines
```nushell
❯ "Hello Nushell!" | run run-script1.nu | str camel-case 
helloNushell
❯ "Hello Nushell!" | run run-script2.nu | $in + 5
19
```

## Additional notes
closes #9373

### Input and argument behavior

For scripts with `def main`:

- If `main` has positional parameters, piped input is bound as `$in`, like normal.
- Remaining CLI arguments after the script name are forwarded to main as positionals/named flags.
- Long and short flags are both supported (including short aliases like `--char(-c)`).
- If `main` has no positional params, piped data remains available as `$in`.

This enables patterns like:

```nushell
"hello" | run script.nu --char "!"
"hello" | run script.nu -c "!"
```

### Scope and isolation semantics

`run` executes in an isolated scope:

- Script-local environment changes, variables, defs, aliases, and exports do not leak into the caller scope.
- Parent scope data is available to execution as read context.
- Only pipeline input/output crosses the boundary.
- `FILE_PWD` and `CURRENT_FILE` are set for script execution and restored afterward.

### Error behavior

- Missing script / parse-time script issues surface as parse diagnostics.
- Runtime failures inside the script propagate as runtime errors.
- run null is treated as an explicit no-op stage.

