### PR TITLE
fix(math abs): return overflow error instead of panicking on i64::MIN

### DIFF
--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -91,9 +91,33 @@ impl Command for MathAbs {
 fn abs_helper(val: Value, head: Span) -> Value {
     let span = val.span();
     match val {
-        Value::Int { val, .. } => Value::int(val.abs(), span),
+        Value::Int { val, .. } => match val.checked_abs() {
+            Some(abs) => Value::int(abs, span),
+            None => Value::error(
+                ShellError::OperatorOverflow {
+                    msg: "absolute value operation overflowed".into(),
+                    span,
+                    help: Some(format!(
+                        "the absolute value of {val} cannot be represented as a 64-bit integer"
+                    )),
+                },
+                span,
+            ),
+        },
         Value::Float { val, .. } => Value::float(val.abs(), span),
-        Value::Duration { val, .. } => Value::duration(val.abs(), span),
+        Value::Duration { val, .. } => match val.checked_abs() {
+            Some(abs) => Value::duration(abs, span),
+            None => Value::error(
+                ShellError::OperatorOverflow {
+                    msg: "absolute value operation overflowed".into(),
+                    span,
+                    help: Some(
+                        "the absolute value of the minimum duration cannot be represented".into(),
+                    ),
+                },
+                span,
+            ),
+        },
         Value::Error { .. } => val,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {

--- a/crates/nu-command/tests/commands/math/abs.rs
+++ b/crates/nu-command/tests/commands/math/abs.rs
@@ -21,3 +21,24 @@ fn cannot_abs_infinite_range() -> Result {
     assert!(matches!(outcome, ShellError::IncorrectValue { .. }));
     Ok(())
 }
+
+#[test]
+fn abs_int_min_overflows_without_panic() -> Result {
+    // i64::MIN has no representable absolute value; `math abs` must report an
+    // overflow error rather than panic. i64::MIN is produced via `into int` to
+    // avoid relying on negated-literal parsing.
+    let code = "0x[00 00 00 00 00 00 00 80] | into int --endian little | math abs";
+    let outcome = test().run(code).expect_shell_error()?;
+
+    assert!(matches!(outcome, ShellError::OperatorOverflow { .. }));
+    Ok(())
+}
+
+#[test]
+fn abs_duration_min_overflows_without_panic() -> Result {
+    let code = "0x[00 00 00 00 00 00 00 80] | into int --endian little | into duration | math abs";
+    let outcome = test().run(code).expect_shell_error()?;
+
+    assert!(matches!(outcome, ShellError::OperatorOverflow { .. }));
+    Ok(())
+}


### PR DESCRIPTION
## Description

`math abs` crashed the interpreter when given the minimum 64-bit integer or the minimum `Duration`. `abs_helper` called `i64::abs()` directly, which panics with "attempt to negate with overflow" for `i64::MIN`, since the absolute value (+9223372036854775808) is not representable in an i64. The `Duration` arm (also i64 nanoseconds) had the same flaw. A command should report an error, not panic.

Reproduce (i64::MIN is produced via `into int` to avoid relying on negated-literal parsing):

```
0x[00 00 00 00 00 00 00 80] | into int --endian little | math abs
```

Before (panic):

```
Error:   × Main thread panicked.
  ├─▶ at .../library/core/src/num/mod.rs:319:5
  ╰─▶ attempt to negate with overflow
  help: set the `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

After (clean error):

```
Error: nu::shell::operator_overflow

  x Operator overflow.
   ,-[source:1:31]
 1 | 0x[00 00 00 00 00 00 00 80] | into int --endian little | math abs
   :                               ^^^^|^^^
   :                                   `-- absolute value operation overflowed
   `----
  help: the absolute value of -9223372036854775808 cannot be represented as a 64-bit integer
```

Approach: use `checked_abs()` for the `Int` and `Duration` arms and return `ShellError::OperatorOverflow` when the value has no representable absolute value, matching how Nushell's arithmetic operators already handle overflow.

## User-facing changes (Release notes)

- Fixed an issue where `math abs` would crash Nushell when given the minimum 64-bit integer or duration; it now reports an overflow error instead.

## Tests

Added regression tests for the integer and duration `i64::MIN` cases (`abs_int_min_overflows_without_panic`, `abs_duration_min_overflows_without_panic`).
