### PR TITLE
Fix bit shift default byte size (#15155)

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/mod.rs
@@ -65,9 +65,10 @@ impl InputNumType {
 fn get_number_bytes(
     number_bytes: Option<Spanned<usize>>,
     head: Span,
+    default: NumberBytes,
 ) -> Result<NumberBytes, ShellError> {
     match number_bytes {
-        None => Ok(NumberBytes::Auto),
+        None => Ok(default),
         Some(Spanned { item: 1, .. }) => Ok(NumberBytes::One),
         Some(Spanned { item: 2, .. }) => Ok(NumberBytes::Two),
         Some(Spanned { item: 4, .. }) => Ok(NumberBytes::Four),

--- a/crates/nu-cmd-extra/src/extra/bits/not.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/not.rs
@@ -70,7 +70,7 @@ impl Command for BitsNot {
         let signed = call.has_flag(engine_state, stack, "signed")?;
         let number_bytes: Option<Spanned<usize>> =
             call.get_flag(engine_state, stack, "number-bytes")?;
-        let number_size = get_number_bytes(number_bytes, head)?;
+        let number_size = get_number_bytes(number_bytes, head, NumberBytes::Auto)?;
 
         // This doesn't match explicit nulls
         if let PipelineData::Empty = input {

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -73,7 +73,7 @@ impl Command for BitsRol {
         let signed = call.has_flag(engine_state, stack, "signed")?;
         let number_bytes: Option<Spanned<usize>> =
             call.get_flag(engine_state, stack, "number-bytes")?;
-        let number_size = get_number_bytes(number_bytes, head)?;
+        let number_size = get_number_bytes(number_bytes, head, NumberBytes::Auto)?;
 
         // This doesn't match explicit nulls
         if let PipelineData::Empty = input {

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -73,7 +73,7 @@ impl Command for BitsRor {
         let signed = call.has_flag(engine_state, stack, "signed")?;
         let number_bytes: Option<Spanned<usize>> =
             call.get_flag(engine_state, stack, "number-bytes")?;
-        let number_size = get_number_bytes(number_bytes, head)?;
+        let number_size = get_number_bytes(number_bytes, head, NumberBytes::Auto)?;
 
         // This doesn't match explicit nulls
         if let PipelineData::Empty = input {

--- a/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
@@ -50,7 +50,7 @@ impl Command for BitsShl {
             .named(
                 "number-bytes",
                 SyntaxShape::Int,
-                "The word size in number of bytes. Must be `1`, `2`, `4`, or `8` (defaults to the smallest of those that fits the input number).",
+                "The word size in number of bytes. Must be `1`, `2`, `4`, or `8` (defaults to `8`).",
                 Some('n'),
             )
             .category(Category::Bits)
@@ -78,7 +78,7 @@ impl Command for BitsShl {
         let signed = call.has_flag(engine_state, stack, "signed")?;
         let number_bytes: Option<Spanned<usize>> =
             call.get_flag(engine_state, stack, "number-bytes")?;
-        let number_size = get_number_bytes(number_bytes, head)?;
+        let number_size = get_number_bytes(number_bytes, head, NumberBytes::Eight)?;
 
         // This doesn't match explicit nulls
         if let PipelineData::Empty = input {
@@ -99,7 +99,7 @@ impl Command for BitsShl {
             Example {
                 description: "Shift left a number by 7 bits",
                 example: "2 | bits shl 7",
-                result: Some(Value::test_int(0)),
+                result: Some(Value::test_int(256)),
             },
             Example {
                 description: "Shift left a number with 2 byte by 7 bits",
@@ -108,7 +108,7 @@ impl Command for BitsShl {
             },
             Example {
                 description: "Shift left a signed number by 1 bit",
-                example: "0x7F | bits shl 1 --signed",
+                example: "0x7F | bits shl 1 --signed --number-bytes 1",
                 result: Some(Value::test_int(-2)),
             },
             Example {

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -46,7 +46,7 @@ impl Command for BitsShr {
             .named(
                 "number-bytes",
                 SyntaxShape::Int,
-                "The word size in number of bytes. Must be `1`, `2`, `4`, or `8` (defaults to the smallest of those that fits the input number).",
+                "The word size in number of bytes. Must be `1`, `2`, `4`, or `8` (defaults to `8`).",
                 Some('n'),
             )
             .category(Category::Bits)
@@ -74,7 +74,7 @@ impl Command for BitsShr {
         let signed = call.has_flag(engine_state, stack, "signed")?;
         let number_bytes: Option<Spanned<usize>> =
             call.get_flag(engine_state, stack, "number-bytes")?;
-        let number_size = get_number_bytes(number_bytes, head)?;
+        let number_size = get_number_bytes(number_bytes, head, NumberBytes::Eight)?;
 
         // This doesn't match explicit nulls
         if let PipelineData::Empty = input {

--- a/tests/repl/test_bits.rs
+++ b/tests/repl/test_bits.rs
@@ -77,10 +77,8 @@ fn bits_shift_left_exceeding2() -> TestResult {
 }
 
 #[test]
-fn bits_shift_left_exceeding3() -> TestResult {
-    // This is purely down to the current autodetect feature limiting to the smallest integer
-    // type thus assuming a u8
-    fail_test("8 | bits shl 9", "more than the available bits")
+fn bits_shift_left_defaults_to_eight_bytes() -> TestResult {
+    run_test("1 | bits shl 20", "1048576")
 }
 
 #[test]
@@ -92,7 +90,7 @@ fn bits_shift_left_negative() -> TestResult {
 fn bits_shift_left_list() -> TestResult {
     run_test(
         "[1 2 7 32 9 10] | bits shl 3 | str join '.'",
-        "8.16.56.0.72.80",
+        "8.16.56.256.72.80",
     )
 }
 
@@ -163,10 +161,8 @@ fn bits_shift_right_exceeding2() -> TestResult {
 }
 
 #[test]
-fn bits_shift_right_exceeding3() -> TestResult {
-    // This is purely down to the current autodetect feature limiting to the smallest integer
-    // type thus assuming a u8
-    fail_test("8 | bits shr 9", "more than the available bits")
+fn bits_shift_right_defaults_to_eight_bytes() -> TestResult {
+    run_test("8 | bits shr 9", "0")
 }
 
 #[test]


### PR DESCRIPTION
## Description

Fixes #15155.

`bits shl` and `bits shr` now use an 8-byte word size when `--number-bytes` is omitted, matching the documented default. The shared number-byte parser now takes an explicit default so `bits not` and the rotate commands keep their existing auto-sized behavior.

This also updates the affected shift examples and regression tests for shifts that previously failed because auto-sizing picked a one-byte word.

## User-facing changes (Release notes)

`bits shl` and `bits shr` now default to an 8-byte word size when `--number-bytes` is not provided, so shifts such as `1 | bits shl 20` no longer fail because the input was auto-sized to one byte.

## Additional notes

Testing:

- `cargo test --package nu --test tests -- repl::test_bits::bits_shift_left_defaults_to_eight_bytes repl::test_bits::bits_shift_right_defaults_to_eight_bytes --exact` (failed before the fix, passed after)
- `cargo test --package nu --test tests -- repl::test_bits`
- `cargo test -p nu-cmd-extra`
- `PATH="$HOME/.cargo/bin:$PATH" ./target/debug/nu -c "use toolkit.nu; toolkit check pr"`
- `git diff --check`

Note: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.
