### PR TITLE
Document limit if not specified

### DIFF
--- a/crates/nu-command/src/filesystem/idx/find.rs
+++ b/crates/nu-command/src/filesystem/idx/find.rs
@@ -18,7 +18,7 @@ impl Command for IdxFind {
             .named(
                 "limit",
                 SyntaxShape::Int,
-                "Maximum number of rows to return.",
+                "Maximum number of rows to return (default 100).",
                 Some('l'),
             )
             .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::record())))])


### PR DESCRIPTION
## Description

Minor update to `idx find --limit` help to show the default max/limit if none is specified.

## User-facing changes (Release notes)

Updated `idx find --limit` help to show the default max/limit if none is specified.
