### PR TITLE
Inaccurate error message when using negative index in cell path

### DIFF
--- a/crates/nu-command/src/conversions/into/cell_path.rs
+++ b/crates/nu-command/src/conversions/into/cell_path.rs
@@ -142,7 +142,12 @@ fn int_to_cell_path(val: i64, span: Span) -> Value {
 
 fn int_to_path_member(val: i64, span: Span) -> Result<PathMember, ShellError> {
     let Ok(val) = val.try_into() else {
-        return Err(ShellError::NeedsPositiveValue { span });
+        return Err(ShellError::CantConvert {
+            to_type: "cell path".into(),
+            from_type: "negative number".into(),
+            span,
+            help: None,
+        });
     };
 
     Ok(PathMember::int(val, false, span))

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -83,6 +83,14 @@ impl Command for Reject {
                     new_columns.push(cv.clone());
                 }
                 Value::Int { val, .. } => {
+                    if val < 0 {
+                        return Err(ShellError::CantConvert {
+                            to_type: "cell path".into(),
+                            from_type: "negative number".into(),
+                            span: *col_span,
+                            help: None,
+                        });
+                    }
                     let cv = CellPath {
                         members: vec![PathMember::Int {
                             val: val as usize,

--- a/crates/nu-command/tests/commands/conversions/into/cell_path.rs
+++ b/crates/nu-command/tests/commands/conversions/into/cell_path.rs
@@ -1,0 +1,21 @@
+use nu_protocol::{ShellError, Value};
+use nu_test_support::prelude::*;
+
+#[test]
+fn into_cell_path_with_negative_number_errors_out() -> Result {
+    let val: Value = test().run("(-2) | into cell-path")?;
+    let Value::Error { error, .. } = val else {
+        panic!("expected Value::Error, got {val:?}");
+    };
+
+    match *error {
+        ShellError::CantConvert {
+            to_type, from_type, ..
+        } => {
+            assert_eq!(to_type, "cell path");
+            assert_eq!(from_type, "negative number");
+            Ok(())
+        }
+        err => Err(err.into()),
+    }
+}

--- a/crates/nu-command/tests/commands/conversions/into/mod.rs
+++ b/crates/nu-command/tests/commands/conversions/into/mod.rs
@@ -1,3 +1,4 @@
 mod binary;
+mod cell_path;
 mod int;
 mod record;

--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -214,6 +214,17 @@ fn test_const() {
     assert_eq!(actual.out, "2");
 }
 
+#[test]
+fn get_with_negative_number_reports_clear_error() {
+    let actual = nu!("[1 2 3] | get (-2)");
+
+    assert!(
+        actual
+            .err
+            .contains("can't convert negative number to cell path")
+    );
+}
+
 enum Metadata {
     Keep,
     Drop,

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -240,5 +240,9 @@ fn forwards_error_properly() -> Result {
 fn reject_with_negative_index_reports_clear_error() {
     let actual = nu!("[1 2 3] | reject (-2)");
 
-    assert!(actual.err.contains("can't convert negative number to cell path"));
+    assert!(
+        actual
+            .err
+            .contains("can't convert negative number to cell path")
+    );
 }

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -235,3 +235,10 @@ fn forwards_error_properly() -> Result {
 
     Ok(())
 }
+
+#[test]
+fn reject_with_negative_index_reports_clear_error() {
+    let actual = nu!("[1 2 3] | reject (-2)");
+
+    assert!(actual.err.contains("can't convert negative number to cell path"));
+}

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2743,11 +2743,21 @@ pub fn parse_cell_path(
                     expr: Expr::Int(val),
                     span,
                     ..
-                } => tail.push(PathMember::Int {
-                    val: val as usize,
-                    span,
-                    optional: false,
-                }),
+                } => {
+                    if val < 0 {
+                        working_set.error(ParseError::InvalidLiteral(
+                            "negative index is not supported".into(),
+                            "cell path".into(),
+                            span,
+                        ));
+                        return tail;
+                    }
+                    tail.push(PathMember::Int {
+                        val: val as usize,
+                        span,
+                        optional: false,
+                    })
+                }
                 _ => {
                     let result = parse_string(working_set, path_element.span);
                     match result {

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -727,7 +727,12 @@ impl FromValue for CellPath {
             }),
             Value::Int { val, .. } => {
                 if val.is_negative() {
-                    Err(ShellError::NeedsPositiveValue { span })
+                    Err(ShellError::CantConvert {
+                        to_type: "cell path".into(),
+                        from_type: "negative number".into(),
+                        span,
+                        help: None,
+                    })
                 } else {
                     Ok(CellPath {
                         members: vec![PathMember::Int {

--- a/tests/repl/test_cell_path.rs
+++ b/tests/repl/test_cell_path.rs
@@ -130,6 +130,14 @@ fn list_row_access_failure() -> TestResult {
 }
 
 #[test]
+fn list_negative_row_access_reports_clear_error() -> TestResult {
+    fail_test(
+        "[{foo: 'bar'}, {foo: 'baz'}].-1",
+        "negative index is not supported in cell path",
+    )
+}
+
+#[test]
 fn list_row_optional_access_succeeds() -> TestResult {
     run_test("[{foo: 'bar'}, {foo: 'baz'}].2? | to nuon", "null")?;
     run_test("[{foo: 'bar'}, {foo: 'baz'}].3? | to nuon", "null")


### PR DESCRIPTION
## Description

This PR should close #18281

After applying this patch.
```
/content/nushell/target/release> [["A", "B"], ["1", "2"]] | get  0.-1
Error: nu::parser::error

  × Invalid literal
   ╭─[repl_entry #1:1:35]
 1 │ [["A", "B"], ["1", "2"]] | get  0.-1
   ·                                   ─┬
   ·                                    ╰── negative index is not supported in cell path
   ╰────
```

```
/content/nushell/target/release> [1, 2, 3] | reject (-1)
Error: nu::shell::cant_convert

  × Can't convert to cell path.
   ╭─[repl_entry #5:1:20]
 1 │ [1, 2, 3] | reject (-1)
   ·                    ──┬─
   ·                      ╰── can't convert negative number to cell path
   ╰────                                                                                                                                     
```




<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
### Improved errors for negative indices in cell paths
Improved error messages when negative indices are used in cell paths.

Previously, negative indices could produce misleading "Row number too large" errors (e.g., `[["foo", "bar"], ["foo", "baz"]] | get 0.-1`) or generic "NeedsPositiveValue" errors (e.g., `["foo", "bar", "baz"] | get (-1)`). 

Now Nushell reports clear messages such as "negative index is not supported in cell path" or "can't convert negative number to cell path".

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->