### PR TITLE
update to 0.8.4, add follow-symlinks, fix `idx` family bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,9 +2207,9 @@ checksum = "ea55fa73c4dde6d81e09d9042ac8ca481ea12a4324f88a9896b708f2a3e2925c"
 
 [[package]]
 name = "fff-search"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6144000c57f638a965ba41e3f7d2e6939468ce154bd6cd4de3029d976b2e3cc6"
+checksum = "bcd88a6f9a27e8ce7a16120a4507c6a0ee6ed0119eccf79e9606129412135169"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "fff-grep"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697e1af89b7fc59645ffceb88ea71ab30c579d9d78f96f7800408418cf072a43"
+checksum = "68286213d07412846c0010a0b227b79c08fbc214cf7822f85cabd9e3f36606ae"
 dependencies = [
  "bstr",
  "memchr",
@@ -2201,15 +2201,15 @@ dependencies = [
 
 [[package]]
 name = "fff-query-parser"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eaa5f10169c5e1e34d4d8a7bef6cd89371a4bdbc84b9c88e2e3987f4650a13a"
+checksum = "f5eb0a0363657b57a3a60d12a76a41f799406514b238123487e54290a6f1a62f"
 
 [[package]]
 name = "fff-search"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a394dc08d526390e26c974fa2fbaa91103ae3b73d9973dcef4d878f73f0f3b"
+checksum = "1b6b4517eb8a9b87a46d09e9958f2ddbc036440a9fb5d5ddfc05e6dcf4655ce2"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "fff-grep"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a573d3815f0db13a1efbd44d5f990f3233143555652212a48adf88cce8f728cf"
+checksum = "697e1af89b7fc59645ffceb88ea71ab30c579d9d78f96f7800408418cf072a43"
 dependencies = [
  "bstr",
  "memchr",
@@ -2201,15 +2201,15 @@ dependencies = [
 
 [[package]]
 name = "fff-query-parser"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea55fa73c4dde6d81e09d9042ac8ca481ea12a4324f88a9896b708f2a3e2925c"
+checksum = "0eaa5f10169c5e1e34d4d8a7bef6cd89371a4bdbc84b9c88e2e3987f4650a13a"
 
 [[package]]
 name = "fff-search"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd88a6f9a27e8ce7a16120a4507c6a0ee6ed0119eccf79e9606129412135169"
+checksum = "e0a394dc08d526390e26c974fa2fbaa91103ae3b73d9973dcef4d878f73f0f3b"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ encoding_rs = "0.8"
 fancy-regex = "0.18"
 filesize = "0.2"
 filetime = "0.2.27"
-fff-search = { version = "0.8.4", default-features = false }
+fff-search = { version = "=0.8.4", default-features = false }
 fluent = "0.17.0"
 fuzzy-matcher = { version = "^0.3.7" }
 gatekeeper = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ encoding_rs = "0.8"
 fancy-regex = "0.18"
 filesize = "0.2"
 filetime = "0.2.27"
-fff-search = { version = "0.8.3", default-features = false }
+fff-search = { version = "0.8.4", default-features = false }
 fluent = "0.17.0"
 fuzzy-matcher = { version = "^0.3.7" }
 gatekeeper = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ encoding_rs = "0.8"
 fancy-regex = "0.18"
 filesize = "0.2"
 filetime = "0.2.27"
-fff-search = { version = "0.8.2", default-features = false }
+fff-search = { version = "0.8.3", default-features = false }
 fluent = "0.17.0"
 fuzzy-matcher = { version = "^0.3.7" }
 gatekeeper = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ encoding_rs = "0.8"
 fancy-regex = "0.18"
 filesize = "0.2"
 filetime = "0.2.27"
-fff-search = { version = "0.8.1", default-features = false }
+fff-search = { version = "0.8.2", default-features = false }
 fluent = "0.17.0"
 fuzzy-matcher = { version = "^0.3.7" }
 gatekeeper = "3.0.0"

--- a/crates/nu-command/src/filesystem/idx/dirs.rs
+++ b/crates/nu-command/src/filesystem/idx/dirs.rs
@@ -10,30 +10,43 @@ impl Command for IdxDirs {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
+            .optional(
+                "query",
+                SyntaxShape::String,
+                "Optional fuzzy query to filter indexed directories.",
+            )
             .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::record())))])
             .category(Category::FileSystem)
     }
 
     fn description(&self) -> &str {
-        "List indexed directories from idx state."
+        "List indexed directories, or fuzzy-match directories by query."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![Example {
-            description: "List all indexed directories",
-            example: "idx dirs",
-            result: None,
-        }]
+        vec![
+            Example {
+                description: "List all indexed directories",
+                example: "idx dirs",
+                result: None,
+            },
+            Example {
+                description: "Fuzzy-match indexed directories by query",
+                example: "idx dirs src",
+                result: None,
+            },
+        ]
     }
 
     fn run(
         &self,
         engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let query = call.opt::<String>(engine_state, stack, 0)?;
         let signals = engine_state.signals();
-        stream_dirs(call.head, signals)
+        stream_dirs(query, call.head, signals)
     }
 }

--- a/crates/nu-command/src/filesystem/idx/files.rs
+++ b/crates/nu-command/src/filesystem/idx/files.rs
@@ -12,16 +12,16 @@ impl Command for IdxFiles {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .optional(
-                "path",
+                "query",
                 SyntaxShape::String,
-                "Optional path to lookup in index.",
+                "Optional fuzzy query to filter indexed files.",
             )
             .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::record())))])
             .category(Category::FileSystem)
     }
 
     fn description(&self) -> &str {
-        "List indexed files, or lookup a specific indexed path."
+        "List indexed files, or fuzzy-match files by query."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -32,8 +32,8 @@ impl Command for IdxFiles {
                 result: None,
             },
             Example {
-                description: "Lookup a specific file path in the index",
-                example: "idx files src/main.rs",
+                description: "Fuzzy-match indexed files by query",
+                example: "idx files main",
                 result: None,
             },
         ]
@@ -46,8 +46,8 @@ impl Command for IdxFiles {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let path = call.opt::<String>(engine_state, stack, 0)?;
+        let query = call.opt::<String>(engine_state, stack, 0)?;
         let signals = engine_state.signals();
-        stream_files(path, call.head, signals)
+        stream_files(query, call.head, signals)
     }
 }

--- a/crates/nu-command/src/filesystem/idx/find.rs
+++ b/crates/nu-command/src/filesystem/idx/find.rs
@@ -18,7 +18,7 @@ impl Command for IdxFind {
             .named(
                 "limit",
                 SyntaxShape::Int,
-                "Maximum number of rows to return.",
+                "Maximum number of rows to return (default 100).",
                 Some('l'),
             )
             .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::record())))])

--- a/crates/nu-command/src/filesystem/idx/import.rs
+++ b/crates/nu-command/src/filesystem/idx/import.rs
@@ -25,7 +25,7 @@ impl Command for IdxImport {
     }
 
     fn extra_description(&self) -> &str {
-        "Reads a SQLite snapshot created by `idx export` and hydrates the runtime from stored rows. Watch mode is not restored from the snapshot."
+        "Reads a SQLite snapshot created by `idx export` and auto-initializes idx runtime for immediate queries. Watch mode is not restored from the snapshot."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {

--- a/crates/nu-command/src/filesystem/idx/import.rs
+++ b/crates/nu-command/src/filesystem/idx/import.rs
@@ -25,7 +25,7 @@ impl Command for IdxImport {
     }
 
     fn extra_description(&self) -> &str {
-        "Reads a SQLite snapshot created by `idx export` and auto-initializes idx runtime for immediate queries. Watch mode is not restored from the snapshot."
+        "Reads a SQLite snapshot created by `idx export` and auto-initializes idx runtime for immediate queries."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {

--- a/crates/nu-command/src/filesystem/idx/init.rs
+++ b/crates/nu-command/src/filesystem/idx/init.rs
@@ -17,6 +17,11 @@ impl Command for IdxInit {
                 "Block until the initial scan completes before returning.",
                 Some('w'),
             )
+            .switch(
+                "follow-symlinks",
+                "Whether to follow symlinks when indexing.",
+                Some('f'),
+            )
             .input_output_types(vec![(Type::Nothing, Type::record())])
             .category(Category::FileSystem)
     }
@@ -53,12 +58,13 @@ impl Command for IdxInit {
     ) -> Result<PipelineData, ShellError> {
         let path: Spanned<String> = call.req(engine_state, stack, 0)?;
         let wait = call.has_flag(engine_state, stack, "wait")?;
+        let follow = call.has_flag(engine_state, stack, "follow-symlinks")?;
         let cwd = engine_state.cwd(Some(stack))?;
         let abs = nu_path::expand_path_with(path.item, cwd, true);
         // There is a functionality in fff-search to update the index via watch but it was non-trivial to get working
         // So, for now, let's always default to watch = false.
         let watch = false;
-        let status = init_runtime(&abs, watch, wait, call.head)?;
+        let status = init_runtime(&abs, watch, wait, follow, call.head)?;
         Ok(PipelineData::value(status.to_value(call.head), None))
     }
 }

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -15,6 +15,7 @@ use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{ListStream, PipelineMetadata, Signals};
 use nu_utils::time::Instant;
+use chrono::{DateTime, Local, LocalResult, TimeZone, Utc};
 #[cfg(feature = "sqlite")]
 use rusqlite::{Connection, OptionalExtension, params};
 #[cfg(feature = "sqlite")]
@@ -35,7 +36,7 @@ pub struct IdxRuntime {
     pub shared_picker: SharedFilePicker,
     pub scan_start_time: Instant,
     pub scan_completed: Arc<AtomicBool>,
-    pub scan_duration_ms: Arc<AtomicU64>,
+    pub scan_duration_ns: Arc<AtomicU64>,
     pub restored_files: Option<Arc<Vec<IdxRestoredFile>>>,
     pub restored_dirs: Option<Arc<Vec<IdxRestoredDir>>>,
     pub restored_arena_bytes_base: usize,
@@ -87,7 +88,7 @@ pub struct IdxStatus {
     pub base_path: String,
     pub watch: bool,
     pub scanning: bool,
-    pub scan_duration_ms: u128,
+    pub scan_duration_ns: u64,
     pub files: usize,
     pub dirs: usize,
     pub arena_bytes_base: usize,
@@ -111,11 +112,8 @@ impl IdxStatus {
                 ("watch".to_string(), Value::bool(self.watch, span)),
                 ("scanning".to_string(), Value::bool(self.scanning, span)),
                 (
-                    "scan_duration_ms".to_string(),
-                    Value::int(
-                        i64::try_from(self.scan_duration_ms).unwrap_or(i64::MAX),
-                        span,
-                    ),
+                    "scan_duration".to_string(),
+                    Value::duration(i64::try_from(self.scan_duration_ns).unwrap_or(i64::MAX), span),
                 ),
                 (
                     "files".to_string(),
@@ -126,28 +124,28 @@ impl IdxStatus {
                     Value::int(i64::try_from(self.dirs).unwrap_or(i64::MAX), span),
                 ),
                 (
-                    "arena_bytes_base".to_string(),
+                    "arena_size_base".to_string(),
                     Value::filesize(
                         i64::try_from(self.arena_bytes_base).unwrap_or(i64::MAX),
                         span,
                     ),
                 ),
                 (
-                    "arena_bytes_overflow".to_string(),
+                    "arena_size_overflow".to_string(),
                     Value::filesize(
                         i64::try_from(self.arena_bytes_overflow).unwrap_or(i64::MAX),
                         span,
                     ),
                 ),
                 (
-                    "arena_bytes_untracked".to_string(),
+                    "arena_size_untracked".to_string(),
                     Value::filesize(
                         i64::try_from(self.arena_bytes_untracked).unwrap_or(i64::MAX),
                         span,
                     ),
                 ),
                 (
-                    "arena_bytes_total".to_string(),
+                    "arena_size_total".to_string(),
                     Value::filesize(
                         i64::try_from(
                             self.arena_bytes_base
@@ -249,14 +247,14 @@ fn idx_status_from_picker(
     base_path: &Path,
     watch: bool,
     picker: &FilePicker,
-    scan_duration_ms: u128,
+    scan_duration_ns: u64,
 ) -> IdxStatus {
     IdxStatus {
         initialized: true,
         base_path: base_path.display().to_string(),
         watch,
         scanning: picker.is_scan_active(),
-        scan_duration_ms,
+        scan_duration_ns,
         files: picker.get_files().len(),
         dirs: picker.get_dirs().len(),
         arena_bytes_base: picker.arena_bytes().0,
@@ -265,9 +263,9 @@ fn idx_status_from_picker(
     }
 }
 
-/// Get elapsed milliseconds since the given scan start time.
-fn elapsed_ms(scan_start: Instant) -> u64 {
-    u64::try_from(scan_start.elapsed().as_millis()).unwrap_or(u64::MAX)
+/// Get elapsed nanoseconds since the given scan start time.
+fn elapsed_ns(scan_start: Instant) -> u64 {
+    u64::try_from(scan_start.elapsed().as_nanos()).unwrap_or(u64::MAX)
 }
 
 /// Compute the scan duration, freezing it once the scan completes.
@@ -276,28 +274,28 @@ fn elapsed_ms(scan_start: Instant) -> u64 {
 /// even if called concurrently from multiple threads.
 fn freeze_scan_duration_if_needed(
     scan_completed: &AtomicBool,
-    scan_duration_ms: &AtomicU64,
+    scan_duration_ns: &AtomicU64,
     scan_start: Instant,
     scanning: bool,
-) -> u128 {
+) -> u64 {
     if scan_completed.load(Ordering::Acquire) {
-        return u128::from(scan_duration_ms.load(Ordering::Acquire));
+        return scan_duration_ns.load(Ordering::Acquire);
     }
 
-    let elapsed = elapsed_ms(scan_start);
+    let elapsed = elapsed_ns(scan_start);
     if !scanning {
         if scan_completed
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_ok()
         {
-            scan_duration_ms.store(elapsed, Ordering::Release);
-            return u128::from(elapsed);
+            scan_duration_ns.store(elapsed, Ordering::Release);
+            return elapsed;
         }
 
-        return u128::from(scan_duration_ms.load(Ordering::Acquire));
+        return scan_duration_ns.load(Ordering::Acquire);
     }
 
-    u128::from(elapsed)
+    elapsed
 }
 
 /// Poll until the background scan completes or times out.
@@ -354,7 +352,7 @@ fn runtime_snapshot() -> Option<RuntimeSnapshot> {
         shared_picker: runtime.shared_picker.clone(),
         scan_start_time: runtime.scan_start_time,
         scan_completed: runtime.scan_completed.clone(),
-        scan_duration_ms: runtime.scan_duration_ms.clone(),
+        scan_duration_ns: runtime.scan_duration_ns.clone(),
         restored_files: runtime.restored_files.clone(),
         restored_dirs: runtime.restored_dirs.clone(),
         restored_arena_bytes_base: runtime.restored_arena_bytes_base,
@@ -385,7 +383,7 @@ pub fn current_status(scan_start_override: Option<Instant>) -> IdxStatus {
             base_path: snapshot.base_path.display().to_string(),
             watch: snapshot.watch,
             scanning: false,
-            scan_duration_ms: 0,
+            scan_duration_ns: 0,
             files: restored_files.len(),
             dirs: restored_dirs.len(),
             arena_bytes_base: snapshot.restored_arena_bytes_base,
@@ -399,7 +397,7 @@ pub fn current_status(scan_start_override: Option<Instant>) -> IdxStatus {
     let Ok(guard) = snapshot.shared_picker.read() else {
         let duration = freeze_scan_duration_if_needed(
             &snapshot.scan_completed,
-            &snapshot.scan_duration_ms,
+            &snapshot.scan_duration_ns,
             scan_start,
             false,
         );
@@ -408,7 +406,7 @@ pub fn current_status(scan_start_override: Option<Instant>) -> IdxStatus {
             base_path: snapshot.base_path.display().to_string(),
             watch: snapshot.watch,
             scanning: false,
-            scan_duration_ms: duration,
+            scan_duration_ns: duration,
             ..Default::default()
         };
     };
@@ -419,7 +417,7 @@ pub fn current_status(scan_start_override: Option<Instant>) -> IdxStatus {
             let scanning = picker.is_scan_active();
             let duration = freeze_scan_duration_if_needed(
                 &snapshot.scan_completed,
-                &snapshot.scan_duration_ms,
+                &snapshot.scan_duration_ns,
                 scan_start,
                 scanning,
             );
@@ -473,7 +471,7 @@ pub fn init_runtime(
         shared_picker: shared_picker.clone(),
         scan_start_time: Instant::now(),
         scan_completed: Arc::new(AtomicBool::new(false)),
-        scan_duration_ms: Arc::new(AtomicU64::new(0)),
+        scan_duration_ns: Arc::new(AtomicU64::new(0)),
         restored_files: None,
         restored_dirs: None,
         restored_arena_bytes_base: 0,
@@ -858,6 +856,7 @@ fn build_file_record(
     base_path: &Path,
     span: Span,
 ) -> Value {
+    let file_name = item.file_name(picker);
     let full_path = item.absolute_path(picker, base_path);
     build_record_from_cols(
         [
@@ -871,7 +870,11 @@ fn build_file_record(
             ),
             (
                 "file_name".to_string(),
-                Value::string(item.file_name(picker), span),
+                Value::string(file_name.clone(), span),
+            ),
+            (
+                "ext".to_string(),
+                Value::string(file_extension(&file_name), span),
             ),
             (
                 "directory".to_string(),
@@ -879,11 +882,11 @@ fn build_file_record(
             ),
             (
                 "size".to_string(),
-                Value::int(i64::try_from(item.size).unwrap_or(i64::MAX), span),
+                Value::filesize(i64::try_from(item.size).unwrap_or(i64::MAX), span),
             ),
             (
                 "modified".to_string(),
-                Value::int(i64::try_from(item.modified).unwrap_or(i64::MAX), span),
+                modified_to_date_value(item.modified, span),
             ),
         ],
         span,
@@ -924,20 +927,51 @@ fn build_restored_file_record(item: &IdxRestoredFile, span: Span) -> Value {
                 Value::string(item.file_name.clone(), span),
             ),
             (
+                "ext".to_string(),
+                Value::string(file_extension(&item.file_name), span),
+            ),
+            (
                 "directory".to_string(),
                 Value::string(item.directory.clone(), span),
             ),
             (
                 "size".to_string(),
-                Value::int(i64::try_from(item.size).unwrap_or(i64::MAX), span),
+                Value::filesize(i64::try_from(item.size).unwrap_or(i64::MAX), span),
             ),
             (
                 "modified".to_string(),
-                Value::int(i64::try_from(item.modified).unwrap_or(i64::MAX), span),
+                modified_to_date_value(item.modified, span),
             ),
         ],
         span,
     )
+}
+
+/// Convert an indexed file timestamp (unix seconds) to a Nushell date value.
+fn modified_to_date_value(modified: u64, span: Span) -> Value {
+    let to_fixed = |secs: i64| -> Option<DateTime<chrono::FixedOffset>> {
+        let utc = match Utc.timestamp_opt(secs, 0) {
+            LocalResult::Single(ts) => ts,
+            _ => return None,
+        };
+        let local = utc.with_timezone(&Local);
+        Some(local.with_timezone(local.offset()))
+    };
+
+    let secs = i64::try_from(modified).unwrap_or(i64::MAX);
+    if let Some(dt) = to_fixed(secs).or_else(|| to_fixed(0)) {
+        Value::date(dt, span)
+    } else {
+        Value::nothing(span)
+    }
+}
+
+/// Extract a file extension without the leading dot.
+fn file_extension(file_name: &str) -> String {
+    Path::new(file_name)
+        .extension()
+        .map(|ext| ext.to_string_lossy().to_string())
+        .unwrap_or_default()
 }
 
 /// Helper to construct a Nushell record from a small array of columns.
@@ -1755,7 +1789,7 @@ pub fn restore_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
         shared_picker: shared_picker.clone(),
         scan_start_time: Instant::now(),
         scan_completed: Arc::new(AtomicBool::new(true)),
-        scan_duration_ms: Arc::new(AtomicU64::new(0)),
+        scan_duration_ns: Arc::new(AtomicU64::new(0)),
         restored_files: Some(restored_files.clone()),
         restored_dirs: Some(restored_dirs.clone()),
         restored_arena_bytes_base: arena_bytes_base,

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -7,6 +7,7 @@
 //! The runtime is stored as a thread-safe singleton (`IDX_RUNTIME`) and can be accessed by all idx subcommands.
 //! Public functions handle initialization, status reporting, and streaming results to Nushell.
 
+use chrono::{DateTime, Local, LocalResult, TimeZone, Utc};
 use fff_search::{
     FFFMode, FilePicker, FilePickerOptions, FuzzySearchOptions, GrepMode, GrepSearchOptions,
     MixedItemRef, PaginationArgs, QueryParser, SharedFilePicker, SharedFrecency,
@@ -15,7 +16,6 @@ use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{ListStream, PipelineMetadata, Signals};
 use nu_utils::time::Instant;
-use chrono::{DateTime, Local, LocalResult, TimeZone, Utc};
 #[cfg(feature = "sqlite")]
 use rusqlite::{Connection, OptionalExtension, params};
 #[cfg(feature = "sqlite")]
@@ -113,7 +113,10 @@ impl IdxStatus {
                 ("scanning".to_string(), Value::bool(self.scanning, span)),
                 (
                     "scan_duration".to_string(),
-                    Value::duration(i64::try_from(self.scan_duration_ns).unwrap_or(i64::MAX), span),
+                    Value::duration(
+                        i64::try_from(self.scan_duration_ns).unwrap_or(i64::MAX),
+                        span,
+                    ),
                 ),
                 (
                     "files".to_string(),

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -1,3 +1,12 @@
+//! In-process file indexing runtime for the `idx` command family.
+//!
+//! This module manages two types of index backends:
+//! - **Live mode** (after `idx init`): Backed by a `fff-search` FilePicker that scans and watches the filesystem
+//! - **Snapshot mode** (after `idx import`): Backed by pre-computed file/directory metadata restored from a snapshot
+//!
+//! The runtime is stored as a thread-safe singleton (`IDX_RUNTIME`) and can be accessed by all idx subcommands.
+//! Public functions handle initialization, status reporting, and streaming results to Nushell.
+
 use fff_search::{
     FFFMode, FilePicker, FilePickerOptions, FuzzySearchOptions, GrepMode, GrepSearchOptions,
     MixedItemRef, PaginationArgs, QueryParser, SharedFilePicker, SharedFrecency,
@@ -15,6 +24,11 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
+/// Global in-process runtime for idx commands.
+///
+/// The runtime is shared by all idx subcommands and can be backed either by
+/// a live `fff-search` picker (after `idx init`) or by restored snapshot rows
+/// (after `idx import`).
 pub struct IdxRuntime {
     pub base_path: PathBuf,
     pub watch: bool,
@@ -22,6 +36,42 @@ pub struct IdxRuntime {
     pub scan_start_time: Instant,
     pub scan_completed: Arc<AtomicBool>,
     pub scan_duration_ms: Arc<AtomicU64>,
+    pub restored_files: Option<Arc<Vec<IdxRestoredFile>>>,
+    pub restored_dirs: Option<Arc<Vec<IdxRestoredDir>>>,
+    pub restored_arena_bytes_base: usize,
+    pub restored_arena_bytes_overflow: usize,
+}
+
+#[derive(Clone, Debug)]
+/// Snapshot-backed file row used by imported idx runtimes.
+///
+/// Fields are restored from the SQLite snapshot database and are used for
+/// fuzzy searching when the original filesystem may no longer be available.
+pub struct IdxRestoredFile {
+    /// Relative path from the index base directory.
+    pub relative_path: String,
+    /// Absolute path to the file (may not exist on disk).
+    pub full_path: String,
+    /// Just the filename component without directory path.
+    pub file_name: String,
+    /// Parent directory path as a string.
+    pub directory: String,
+    /// File size in bytes.
+    pub size: u64,
+    /// Last modified timestamp as seconds since epoch.
+    pub modified: u64,
+}
+
+#[derive(Clone, Debug)]
+/// Snapshot-backed directory row used by imported idx runtimes.
+///
+/// Fields are restored from the SQLite snapshot database for use in
+/// fuzzy directory searches when the filesystem may not be available.
+pub struct IdxRestoredDir {
+    /// Relative path from the index base directory.
+    pub relative_path: String,
+    /// Absolute path to the directory (may not exist on disk).
+    pub full_path: String,
 }
 
 /// A cloned snapshot of the current runtime state, obtained while holding the
@@ -31,6 +81,7 @@ pub struct IdxRuntime {
 pub type RuntimeSnapshot = IdxRuntime;
 
 #[derive(Clone, Debug, Default)]
+/// User-facing runtime status for `idx status`.
 pub struct IdxStatus {
     pub initialized: bool,
     pub base_path: String,
@@ -45,6 +96,7 @@ pub struct IdxStatus {
 }
 
 impl IdxStatus {
+    /// Convert status to Nushell record output.
     pub fn to_value(&self, span: Span) -> Value {
         Value::record(
             [
@@ -120,6 +172,7 @@ fn runtime() -> &'static Mutex<Option<IdxRuntime>> {
     IDX_RUNTIME.get_or_init(|| Mutex::new(None))
 }
 
+/// Convert a `fff_search` error to a Nushell [`ShellError`].
 fn fff_error<E: std::fmt::Display>(err: E, span: Span) -> ShellError {
     ShellError::Generic(GenericError::new(
         "idx operation failed",
@@ -128,6 +181,50 @@ fn fff_error<E: std::fmt::Display>(err: E, span: Span) -> ShellError {
     ))
 }
 
+/// Error when the idx runtime has not been initialized.
+fn idx_not_initialized_error(span: Span) -> ShellError {
+    ShellError::Generic(GenericError::new(
+        "idx is not initialized",
+        "run `idx init <path>` first",
+        span,
+    ))
+}
+
+/// Read lock on the shared FilePicker, returning a guard that dereferences to `Option<FilePicker>`.
+fn read_picker_guard<'a>(
+    shared_picker: &'a SharedFilePicker,
+    span: Span,
+) -> Result<impl std::ops::Deref<Target = Option<FilePicker>> + 'a, ShellError> {
+    shared_picker.read().map_err(|err| fff_error(err, span))
+}
+
+/// Extract the FilePicker reference from a guard, or error if not initialized.
+fn picker_from_guard(guard: &Option<FilePicker>, span: Span) -> Result<&FilePicker, ShellError> {
+    guard
+        .as_ref()
+        .ok_or_else(|| idx_not_initialized_error(span))
+}
+
+/// Validate that the picker has been initialized.
+///
+/// Returns an error if the runtime is not yet initialized or if the shared
+/// picker lock is poisoned.
+fn ensure_picker_initialized(
+    shared_picker: &SharedFilePicker,
+    span: Span,
+) -> Result<(), ShellError> {
+    let guard = read_picker_guard(shared_picker, span)?;
+    let _ = picker_from_guard(&guard, span)?;
+    Ok(())
+}
+
+/// Shut down the shared FilePicker and its background workers cleanly.
+///
+/// # Important
+///
+/// Never hold the shared picker write lock while joining the watcher thread,
+/// otherwise the owner thread can deadlock waiting for the same lock while
+/// processing a final event batch.
 fn shutdown_shared_picker(shared_picker: &SharedFilePicker, span: Span) -> Result<(), ShellError> {
     // Important: never join the watcher thread while holding the shared
     // picker write lock, otherwise the owner thread can deadlock waiting for
@@ -147,6 +244,7 @@ fn shutdown_shared_picker(shared_picker: &SharedFilePicker, span: Span) -> Resul
     Ok(())
 }
 
+/// Build an `IdxStatus` from the current FilePicker state.
 fn idx_status_from_picker(
     base_path: &Path,
     watch: bool,
@@ -167,10 +265,15 @@ fn idx_status_from_picker(
     }
 }
 
+/// Get elapsed milliseconds since the given scan start time.
 fn elapsed_ms(scan_start: Instant) -> u64 {
     u64::try_from(scan_start.elapsed().as_millis()).unwrap_or(u64::MAX)
 }
 
+/// Compute the scan duration, freezing it once the scan completes.
+///
+/// This uses atomic operations to ensure the completion time is recorded exactly once,
+/// even if called concurrently from multiple threads.
 fn freeze_scan_duration_if_needed(
     scan_completed: &AtomicBool,
     scan_duration_ms: &AtomicU64,
@@ -197,6 +300,51 @@ fn freeze_scan_duration_if_needed(
     u128::from(elapsed)
 }
 
+/// Poll until the background scan completes or times out.
+fn wait_for_scan_completion(
+    shared_picker: &SharedFilePicker,
+    timeout: Duration,
+    span: Span,
+) -> Result<(), ShellError> {
+    let poll_interval = Duration::from_millis(10);
+    let startup_grace = Duration::from_millis(250);
+    let wait_start = Instant::now();
+    let mut saw_active_scan = false;
+
+    loop {
+        let guard = read_picker_guard(shared_picker, span)?;
+        let picker = picker_from_guard(&guard, span)?;
+        let scanning = picker.is_scan_active();
+        drop(guard);
+
+        if scanning {
+            saw_active_scan = true;
+        }
+
+        if saw_active_scan && !scanning {
+            return Ok(());
+        }
+
+        if !saw_active_scan && !scanning && wait_start.elapsed() >= startup_grace {
+            return Ok(());
+        }
+
+        if wait_start.elapsed() >= timeout {
+            return Err(ShellError::Generic(GenericError::new(
+                "idx scan timed out",
+                "timed out waiting for the initial scan to finish (300 s). The index is still available with partial results.",
+                span,
+            )));
+        }
+
+        std::thread::sleep(poll_interval);
+    }
+}
+
+/// Retrieve a thread-safe snapshot of the current idx runtime state.
+///
+/// This is a cheap operation that clones only Arc/Copy data, so callers can
+/// work with the snapshot after releasing the global lock.
 fn runtime_snapshot() -> Option<RuntimeSnapshot> {
     let guard = runtime().lock().ok()?;
     let runtime = guard.as_ref()?;
@@ -207,23 +355,44 @@ fn runtime_snapshot() -> Option<RuntimeSnapshot> {
         scan_start_time: runtime.scan_start_time,
         scan_completed: runtime.scan_completed.clone(),
         scan_duration_ms: runtime.scan_duration_ms.clone(),
+        restored_files: runtime.restored_files.clone(),
+        restored_dirs: runtime.restored_dirs.clone(),
+        restored_arena_bytes_base: runtime.restored_arena_bytes_base,
+        restored_arena_bytes_overflow: runtime.restored_arena_bytes_overflow,
     })
 }
 
+/// Get a runtime snapshot, or error if the runtime is not initialized.
 fn require_runtime(span: Span) -> Result<RuntimeSnapshot, ShellError> {
-    runtime_snapshot().ok_or_else(|| {
-        ShellError::Generic(GenericError::new(
-            "idx is not initialized",
-            "run `idx init <path>` first",
-            span,
-        ))
-    })
+    runtime_snapshot().ok_or_else(|| idx_not_initialized_error(span))
 }
 
+/// Return the current idx runtime status.
+///
+/// `scan_start_override` exists for callers that need deterministic status
+/// snapshots while coordinating scan lifecycle checks.
 pub fn current_status(scan_start_override: Option<Instant>) -> IdxStatus {
     let Some(snapshot) = runtime_snapshot() else {
         return IdxStatus::default();
     };
+
+    if let (Some(restored_files), Some(restored_dirs)) = (
+        snapshot.restored_files.as_ref(),
+        snapshot.restored_dirs.as_ref(),
+    ) {
+        return IdxStatus {
+            initialized: true,
+            base_path: snapshot.base_path.display().to_string(),
+            watch: snapshot.watch,
+            scanning: false,
+            scan_duration_ms: 0,
+            files: restored_files.len(),
+            dirs: restored_dirs.len(),
+            arena_bytes_base: snapshot.restored_arena_bytes_base,
+            arena_bytes_overflow: snapshot.restored_arena_bytes_overflow,
+            arena_bytes_untracked: 0,
+        };
+    }
 
     let scan_start = scan_start_override.unwrap_or(snapshot.scan_start_time);
 
@@ -259,6 +428,9 @@ pub fn current_status(scan_start_override: Option<Instant>) -> IdxStatus {
         .unwrap_or_default()
 }
 
+/// Initialize a live idx runtime backed by `fff-search`.
+///
+/// When `wait` is true this blocks until the initial filesystem scan finishes.
 pub fn init_runtime(
     path: &Path,
     watch: bool,
@@ -302,6 +474,10 @@ pub fn init_runtime(
         scan_start_time: Instant::now(),
         scan_completed: Arc::new(AtomicBool::new(false)),
         scan_duration_ms: Arc::new(AtomicU64::new(0)),
+        restored_files: None,
+        restored_dirs: None,
+        restored_arena_bytes_base: 0,
+        restored_arena_bytes_overflow: 0,
     });
 
     // Drop the lock before potentially blocking on --wait so other threads
@@ -319,13 +495,7 @@ pub fn init_runtime(
     // generous so that large repos complete without errors.
     if wait {
         const WAIT_TIMEOUT: Duration = Duration::from_secs(300);
-        if !shared_picker.wait_for_scan(WAIT_TIMEOUT) {
-            return Err(ShellError::Generic(GenericError::new(
-                "idx scan timed out",
-                "timed out waiting for the initial scan to finish (300 s). The index is still available with partial results.",
-                span,
-            )));
-        }
+        wait_for_scan_completion(&shared_picker, WAIT_TIMEOUT, span)?;
         if watch && !shared_picker.wait_for_watcher(WAIT_TIMEOUT) {
             return Err(ShellError::Generic(GenericError::new(
                 "idx watcher startup timed out",
@@ -334,17 +504,10 @@ pub fn init_runtime(
             )));
         }
     }
-    let status = IdxStatus {
-        initialized: true,
-        base_path: path.display().to_string(),
-        watch,
-        scanning: true,
-        ..Default::default()
-    };
-
-    Ok(status)
+    Ok(current_status(None))
 }
 
+/// Drop the active idx runtime and stop background workers.
 pub fn drop_runtime(span: Span) -> Result<Value, ShellError> {
     let mut guard = runtime().lock().map_err(|_| {
         ShellError::Generic(GenericError::new(
@@ -374,113 +537,145 @@ pub fn drop_runtime(span: Span) -> Result<Value, ShellError> {
     ))
 }
 
-pub fn stream_dirs(span: Span, signals: &Signals) -> Result<PipelineData, ShellError> {
-    let snapshot = require_runtime(span)?;
-    let guard = snapshot
-        .shared_picker
-        .read()
-        .map_err(|err| fff_error(err, span))?;
-    let picker = guard.as_ref().ok_or_else(|| {
-        ShellError::Generic(GenericError::new(
-            "idx is not initialized",
-            "run `idx init <path>` first",
-            span,
-        ))
-    })?;
-
-    let base_path = snapshot.base_path.clone();
-    let dirs_data: Vec<_> = picker
-        .get_dirs()
-        .iter()
-        .map(|item| {
-            let rel_path = item.relative_path(picker);
-            let full_path = item.absolute_path(picker, &base_path);
-
-            Value::record(
-                [
-                    ("relative_path".to_string(), Value::string(rel_path, span)),
-                    (
-                        "full_path".to_string(),
-                        Value::string(full_path.to_string_lossy().to_string(), span),
-                    ),
-                ]
-                .into_iter()
-                .collect(),
-                span,
-            )
-        })
-        .collect();
-
-    drop(guard);
-
-    let stream_signals = signals.clone();
-    let stream = dirs_data.into_iter().map(move |value| {
-        if let Err(err) = stream_signals.check(&span) {
-            return Value::error(err, span);
-        }
-        value
-    });
-
-    Ok(PipelineData::ListStream(
-        ListStream::new(stream, span, signals.clone()),
-        Some(PipelineMetadata::default()),
-    ))
-}
-
-pub fn stream_files(
-    path: Option<String>,
+/// Stream indexed directories, optionally filtered by a fuzzy query.
+///
+/// Uses snapshot-backed rows when runtime comes from `idx import`, otherwise
+/// reads from the live picker.
+pub fn stream_dirs(
+    query: Option<String>,
     span: Span,
     signals: &Signals,
 ) -> Result<PipelineData, ShellError> {
     let snapshot = require_runtime(span)?;
-    let guard = snapshot
-        .shared_picker
-        .read()
-        .map_err(|err| fff_error(err, span))?;
-    let picker = guard.as_ref().ok_or_else(|| {
-        ShellError::Generic(GenericError::new(
-            "idx is not initialized",
-            "run `idx init <path>` first",
-            span,
-        ))
-    })?;
 
+    if let Some(restored_dirs) = snapshot.restored_dirs.clone() {
+        let ranked_indices = query
+            .as_deref()
+            .map(|q| rank_snapshot_matches(&restored_dirs, q, |dir| &dir.relative_path));
+
+        let stream_signals = signals.clone();
+        let stream: Box<dyn Iterator<Item = Value> + Send> = match ranked_indices {
+            Some(indices) => {
+                let mut iter = indices.into_iter();
+                let restored_dirs = restored_dirs.clone();
+                Box::new(std::iter::from_fn(move || {
+                    if let Err(err) = stream_signals.check(&span) {
+                        return Some(Value::error(err, span));
+                    }
+
+                    let idx = iter.next()?;
+                    restored_dirs
+                        .get(idx)
+                        .map(|item| build_restored_dir_record(item, span))
+                }))
+            }
+            None => {
+                let mut idx = 0usize;
+                let restored_dirs = restored_dirs.clone();
+                Box::new(std::iter::from_fn(move || {
+                    if let Err(err) = stream_signals.check(&span) {
+                        return Some(Value::error(err, span));
+                    }
+
+                    let item = restored_dirs.get(idx)?;
+                    idx = idx.saturating_add(1);
+                    Some(build_restored_dir_record(item, span))
+                }))
+            }
+        };
+
+        return Ok(PipelineData::ListStream(
+            ListStream::new(stream, span, signals.clone()),
+            Some(PipelineMetadata::default()),
+        ));
+    }
+
+    let shared_picker = snapshot.shared_picker.clone();
     let base_path = snapshot.base_path.clone();
 
-    let files_data: Vec<_> = if let Some(path_str) = path {
-        let lookup_path = Path::new(&path_str);
+    // Validate runtime before constructing the lazy iterator.
+    ensure_picker_initialized(&shared_picker, span)?;
 
-        // Try relative path first, then strip base_path prefix from absolute paths.
-        let item = picker.get_file_by_path(lookup_path).or_else(|| {
-            if lookup_path.is_absolute() {
-                lookup_path
-                    .strip_prefix(&base_path)
-                    .ok()
-                    .and_then(|rel| picker.get_file_by_path(rel))
-            } else {
-                None
+    let stream: Box<dyn Iterator<Item = Value> + Send> = if let Some(query) = query {
+        let shared_picker_for_query = shared_picker.clone();
+        let matched_paths = {
+            let guard = read_picker_guard(&shared_picker_for_query, span)?;
+            let picker = picker_from_guard(&guard, span)?;
+
+            let parser = QueryParser::default();
+            let parsed = parser.parse(&query);
+            let options = FuzzySearchOptions {
+                max_threads: 0,
+                current_file: None,
+                project_path: None,
+                combo_boost_score_multiplier: 0,
+                min_combo_count: 0,
+                pagination: PaginationArgs {
+                    offset: 0,
+                    limit: picker.get_dirs().len(),
+                },
+            };
+
+            picker
+                .fuzzy_search_directories(&parsed, options)
+                .items
+                .iter()
+                .map(|item| item.relative_path(picker))
+                .collect::<Vec<_>>()
+        };
+
+        let mut path_iter = matched_paths.into_iter();
+        let stream_signals = signals.clone();
+        let shared_picker = shared_picker.clone();
+        Box::new(std::iter::from_fn(move || {
+            loop {
+                if let Err(err) = stream_signals.check(&span) {
+                    return Some(Value::error(err, span));
+                }
+
+                let path = path_iter.next()?;
+
+                let guard = match read_picker_guard(&shared_picker, span) {
+                    Ok(guard) => guard,
+                    Err(err) => return Some(Value::error(err, span)),
+                };
+                let picker = match picker_from_guard(&guard, span) {
+                    Ok(picker) => picker,
+                    Err(err) => return Some(Value::error(err, span)),
+                };
+
+                let item = picker
+                    .get_dirs()
+                    .iter()
+                    .find(|item| item.relative_path(picker) == path);
+                if let Some(item) = item {
+                    return Some(build_dir_record(item, picker, &base_path, span));
+                }
             }
-        });
-
-        item.map(|i| vec![build_file_record(i, picker, &base_path, span)])
-            .unwrap_or_default()
+        }))
     } else {
-        picker
-            .get_files()
-            .iter()
-            .map(|item| build_file_record(item, picker, &base_path, span))
-            .collect()
+        let mut idx = 0usize;
+        let stream_signals = signals.clone();
+        let shared_picker = shared_picker.clone();
+        Box::new(std::iter::from_fn(move || {
+            if let Err(err) = stream_signals.check(&span) {
+                return Some(Value::error(err, span));
+            }
+
+            let guard = match read_picker_guard(&shared_picker, span) {
+                Ok(guard) => guard,
+                Err(err) => return Some(Value::error(err, span)),
+            };
+            let picker = match picker_from_guard(&guard, span) {
+                Ok(picker) => picker,
+                Err(err) => return Some(Value::error(err, span)),
+            };
+
+            let item = picker.get_dirs().get(idx)?;
+            idx = idx.saturating_add(1);
+            Some(build_dir_record(item, picker, &base_path, span))
+        }))
     };
-
-    drop(guard);
-
-    let stream_signals = signals.clone();
-    let stream = files_data.into_iter().map(move |value| {
-        if let Err(err) = stream_signals.check(&span) {
-            return Value::error(err, span);
-        }
-        value
-    });
 
     Ok(PipelineData::ListStream(
         ListStream::new(stream, span, signals.clone()),
@@ -488,6 +683,175 @@ pub fn stream_files(
     ))
 }
 
+/// Stream indexed files, optionally filtered by a fuzzy query.
+///
+/// Uses snapshot-backed rows when runtime comes from `idx import`, otherwise
+/// reads from the live picker.
+pub fn stream_files(
+    query: Option<String>,
+    span: Span,
+    signals: &Signals,
+) -> Result<PipelineData, ShellError> {
+    let snapshot = require_runtime(span)?;
+
+    if let Some(restored_files) = snapshot.restored_files.clone() {
+        let ranked_indices = query
+            .as_deref()
+            .map(|q| rank_snapshot_matches(&restored_files, q, |file| &file.relative_path));
+
+        let stream_signals = signals.clone();
+        let stream: Box<dyn Iterator<Item = Value> + Send> = match ranked_indices {
+            Some(indices) => {
+                let mut iter = indices.into_iter();
+                let restored_files = restored_files.clone();
+                Box::new(std::iter::from_fn(move || {
+                    if let Err(err) = stream_signals.check(&span) {
+                        return Some(Value::error(err, span));
+                    }
+
+                    let idx = iter.next()?;
+                    restored_files
+                        .get(idx)
+                        .map(|item| build_restored_file_record(item, span))
+                }))
+            }
+            None => {
+                let mut idx = 0usize;
+                let restored_files = restored_files.clone();
+                Box::new(std::iter::from_fn(move || {
+                    if let Err(err) = stream_signals.check(&span) {
+                        return Some(Value::error(err, span));
+                    }
+
+                    let item = restored_files.get(idx)?;
+                    idx = idx.saturating_add(1);
+                    Some(build_restored_file_record(item, span))
+                }))
+            }
+        };
+
+        return Ok(PipelineData::ListStream(
+            ListStream::new(stream, span, signals.clone()),
+            Some(PipelineMetadata::default()),
+        ));
+    }
+
+    let shared_picker = snapshot.shared_picker.clone();
+    let base_path = snapshot.base_path.clone();
+
+    // Validate runtime before constructing the lazy iterator.
+    ensure_picker_initialized(&shared_picker, span)?;
+
+    let stream: Box<dyn Iterator<Item = Value> + Send> = if let Some(query) = query {
+        let shared_picker_for_query = shared_picker.clone();
+        let matched_paths = {
+            let guard = read_picker_guard(&shared_picker_for_query, span)?;
+            let picker = picker_from_guard(&guard, span)?;
+
+            let parser = QueryParser::default();
+            let parsed = parser.parse(&query);
+            let options = FuzzySearchOptions {
+                max_threads: 0,
+                current_file: None,
+                project_path: None,
+                combo_boost_score_multiplier: 0,
+                min_combo_count: 0,
+                pagination: PaginationArgs {
+                    offset: 0,
+                    limit: picker.get_files().len(),
+                },
+            };
+
+            picker
+                .fuzzy_search(&parsed, None, options)
+                .items
+                .iter()
+                .map(|item| item.relative_path(picker))
+                .collect::<Vec<_>>()
+        };
+
+        let mut path_iter = matched_paths.into_iter();
+        let stream_signals = signals.clone();
+        let shared_picker = shared_picker.clone();
+        Box::new(std::iter::from_fn(move || {
+            loop {
+                if let Err(err) = stream_signals.check(&span) {
+                    return Some(Value::error(err, span));
+                }
+
+                let path = path_iter.next()?;
+
+                let guard = match read_picker_guard(&shared_picker, span) {
+                    Ok(guard) => guard,
+                    Err(err) => return Some(Value::error(err, span)),
+                };
+                let picker = match picker_from_guard(&guard, span) {
+                    Ok(picker) => picker,
+                    Err(err) => return Some(Value::error(err, span)),
+                };
+
+                let item = picker
+                    .get_files()
+                    .iter()
+                    .find(|item| item.relative_path(picker) == path);
+                if let Some(item) = item {
+                    return Some(build_file_record(item, picker, &base_path, span));
+                }
+            }
+        }))
+    } else {
+        let mut idx = 0usize;
+        let stream_signals = signals.clone();
+        let shared_picker = shared_picker.clone();
+        Box::new(std::iter::from_fn(move || {
+            if let Err(err) = stream_signals.check(&span) {
+                return Some(Value::error(err, span));
+            }
+
+            let guard = match read_picker_guard(&shared_picker, span) {
+                Ok(guard) => guard,
+                Err(err) => return Some(Value::error(err, span)),
+            };
+            let picker = match picker_from_guard(&guard, span) {
+                Ok(picker) => picker,
+                Err(err) => return Some(Value::error(err, span)),
+            };
+
+            let item = picker.get_files().get(idx)?;
+            idx = idx.saturating_add(1);
+            Some(build_file_record(item, picker, &base_path, span))
+        }))
+    };
+
+    Ok(PipelineData::ListStream(
+        ListStream::new(stream, span, signals.clone()),
+        Some(PipelineMetadata::default()),
+    ))
+}
+
+/// Build a directory record from a live picker's DirItem.
+fn build_dir_record(
+    item: &fff_search::DirItem,
+    picker: &FilePicker,
+    base_path: &Path,
+    span: Span,
+) -> Value {
+    let rel_path = item.relative_path(picker);
+    let full_path = item.absolute_path(picker, base_path);
+
+    build_record_from_cols(
+        [
+            ("relative_path".to_string(), Value::string(rel_path, span)),
+            (
+                "full_path".to_string(),
+                Value::string(full_path.to_string_lossy().to_string(), span),
+            ),
+        ],
+        span,
+    )
+}
+
+/// Build a file record from a live picker's FileItem.
 fn build_file_record(
     item: &fff_search::FileItem,
     picker: &FilePicker,
@@ -495,7 +859,7 @@ fn build_file_record(
     span: Span,
 ) -> Value {
     let full_path = item.absolute_path(picker, base_path);
-    Value::record(
+    build_record_from_cols(
         [
             (
                 "relative_path".to_string(),
@@ -521,17 +885,136 @@ fn build_file_record(
                 "modified".to_string(),
                 Value::int(i64::try_from(item.modified).unwrap_or(i64::MAX), span),
             ),
-        ]
-        .into_iter()
-        .collect(),
+        ],
         span,
     )
 }
 
+/// Build a directory record from a restored snapshot.
+fn build_restored_dir_record(item: &IdxRestoredDir, span: Span) -> Value {
+    build_record_from_cols(
+        [
+            (
+                "relative_path".to_string(),
+                Value::string(item.relative_path.clone(), span),
+            ),
+            (
+                "full_path".to_string(),
+                Value::string(item.full_path.clone(), span),
+            ),
+        ],
+        span,
+    )
+}
+
+/// Build a file record from a restored snapshot.
+fn build_restored_file_record(item: &IdxRestoredFile, span: Span) -> Value {
+    build_record_from_cols(
+        [
+            (
+                "relative_path".to_string(),
+                Value::string(item.relative_path.clone(), span),
+            ),
+            (
+                "full_path".to_string(),
+                Value::string(item.full_path.clone(), span),
+            ),
+            (
+                "file_name".to_string(),
+                Value::string(item.file_name.clone(), span),
+            ),
+            (
+                "directory".to_string(),
+                Value::string(item.directory.clone(), span),
+            ),
+            (
+                "size".to_string(),
+                Value::int(i64::try_from(item.size).unwrap_or(i64::MAX), span),
+            ),
+            (
+                "modified".to_string(),
+                Value::int(i64::try_from(item.modified).unwrap_or(i64::MAX), span),
+            ),
+        ],
+        span,
+    )
+}
+
+/// Helper to construct a Nushell record from a small array of columns.
+#[inline]
+fn build_record_from_cols<const N: usize>(cols: [(String, Value); N], span: Span) -> Value {
+    Value::record(cols.into_iter().collect(), span)
+}
+
+/// Score how well a path matches a query using fuzzy matching heuristics.
+///
+/// Returns `None` if no match found, `Some(score)` where higher scores are better matches.
+/// Scoring prioritizes exact matches, prefix matches, substring matches, and finally
+/// fuzzy character sequences.
+fn score_snapshot_match(path: &str, query: &str) -> Option<i64> {
+    let query = query.trim();
+    if query.is_empty() {
+        return Some(0);
+    }
+
+    let path_lower = path.to_ascii_lowercase();
+    let query_lower = query.to_ascii_lowercase();
+
+    if path_lower == query_lower {
+        return Some(4_000);
+    }
+
+    if path_lower.starts_with(&query_lower) {
+        return Some(3_000);
+    }
+
+    if let Some(pos) = path_lower.find(&query_lower) {
+        let proximity = i64::try_from(pos).unwrap_or(i64::MAX);
+        return Some(2_000_i64.saturating_sub(proximity));
+    }
+
+    let mut query_iter = query_lower.chars();
+    let mut needle = query_iter.next()?;
+    for ch in path_lower.chars() {
+        if ch == needle {
+            if let Some(next) = query_iter.next() {
+                needle = next;
+            } else {
+                return Some(1_000);
+            }
+        }
+    }
+
+    None
+}
+
+/// Rank items by how well their keys match the query.
+///
+/// Returns a vec of indices sorted by descending match score, with ties broken
+/// by ascending original index to maintain stable order.
+fn rank_snapshot_matches<T>(items: &[T], query: &str, key: impl Fn(&T) -> &str) -> Vec<usize> {
+    let mut ranked = items
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, item)| score_snapshot_match(key(item), query).map(|score| (idx, score)))
+        .collect::<Vec<_>>();
+
+    ranked.sort_unstable_by(|(lhs_idx, lhs_score), (rhs_idx, rhs_score)| {
+        rhs_score.cmp(lhs_score).then_with(|| lhs_idx.cmp(rhs_idx))
+    });
+
+    ranked.into_iter().map(|(idx, _)| idx).collect()
+}
+
+/// Convert a usize to i64, saturating at i64::MAX to avoid overflow.
 fn usize_to_i64(value: usize) -> i64 {
     i64::try_from(value).unwrap_or(i64::MAX)
 }
 
+/// Run a fuzzy find across indexed files and/or directories.
+///
+/// For imported snapshots this uses lightweight in-memory ranking over
+/// restored path metadata.
 pub fn stream_find(
     query: &str,
     files_only: bool,
@@ -542,6 +1025,111 @@ pub fn stream_find(
     signals: &Signals,
 ) -> Result<PipelineData, ShellError> {
     let snapshot = require_runtime(span)?;
+
+    if let (Some(restored_files), Some(restored_dirs)) = (
+        snapshot.restored_files.clone(),
+        snapshot.restored_dirs.clone(),
+    ) {
+        let mut ranked_files = restored_files
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, item)| {
+                score_snapshot_match(&item.relative_path, query).map(|score| ("file", idx, score))
+            })
+            .collect::<Vec<_>>();
+
+        let mut ranked_dirs = restored_dirs
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, item)| {
+                score_snapshot_match(&item.relative_path, query).map(|score| ("dir", idx, score))
+            })
+            .collect::<Vec<_>>();
+
+        if files_only {
+            ranked_dirs.clear();
+        }
+        if dirs_only {
+            ranked_files.clear();
+        }
+
+        let mut combined = Vec::with_capacity(ranked_files.len().saturating_add(ranked_dirs.len()));
+        combined.extend(ranked_files);
+        combined.extend(ranked_dirs);
+        combined.sort_unstable_by(
+            |(lhs_kind, lhs_idx, lhs_score), (rhs_kind, rhs_idx, rhs_score)| {
+                rhs_score
+                    .cmp(lhs_score)
+                    .then_with(|| lhs_kind.cmp(rhs_kind))
+                    .then_with(|| lhs_idx.cmp(rhs_idx))
+            },
+        );
+        combined.truncate(limit);
+
+        let find_data = combined
+            .into_iter()
+            .enumerate()
+            .map(|(rank, (kind, idx, score))| {
+                let path = if kind == "file" {
+                    restored_files
+                        .get(idx)
+                        .map(|row| row.relative_path.clone())
+                        .unwrap_or_default()
+                } else {
+                    restored_dirs
+                        .get(idx)
+                        .map(|row| row.relative_path.clone())
+                        .unwrap_or_default()
+                };
+
+                let mut cols = vec![
+                    ("kind".to_string(), Value::string(kind, span)),
+                    ("path".to_string(), Value::string(path, span)),
+                    ("rank".to_string(), Value::int(usize_to_i64(rank + 1), span)),
+                    ("score".to_string(), Value::int(score, span)),
+                ];
+
+                if verbose {
+                    if !files_only && !dirs_only {
+                        cols.push((
+                            "score_details".to_string(),
+                            Value::record(
+                                [
+                                    ("base_score".to_string(), Value::int(score, span)),
+                                    ("filename_bonus".to_string(), Value::int(0, span)),
+                                    ("special_filename_bonus".to_string(), Value::int(0, span)),
+                                    ("frecency_boost".to_string(), Value::int(0, span)),
+                                ]
+                                .into_iter()
+                                .collect(),
+                                span,
+                            ),
+                        ));
+                    } else if files_only {
+                        cols.push(("match_type".to_string(), Value::string("snapshot", span)));
+                    } else {
+                        cols.push(("exact_match".to_string(), Value::bool(false, span)));
+                    }
+                }
+
+                Value::record(cols.into_iter().collect(), span)
+            })
+            .collect::<Vec<_>>();
+
+        let stream_signals = signals.clone();
+        let stream = find_data.into_iter().map(move |value| {
+            if let Err(err) = stream_signals.check(&span) {
+                return Value::error(err, span);
+            }
+            value
+        });
+
+        return Ok(PipelineData::ListStream(
+            ListStream::new(stream, span, signals.clone()),
+            Some(PipelineMetadata::default()),
+        ));
+    }
+
     let guard = snapshot
         .shared_picker
         .read()
@@ -727,20 +1315,12 @@ pub struct IdxSnapshotDir {
     pub is_overflow: bool,
 }
 
+/// Persist the current idx runtime into a SQLite snapshot file.
 #[cfg(feature = "sqlite")]
 pub fn store_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
     let snapshot = require_runtime(span)?;
-    let guard = snapshot
-        .shared_picker
-        .read()
-        .map_err(|err| fff_error(err, span))?;
-    let picker = guard.as_ref().ok_or_else(|| {
-        ShellError::Generic(GenericError::new(
-            "idx is not initialized",
-            "run `idx init <path>` first",
-            span,
-        ))
-    })?;
+    let guard = read_picker_guard(&snapshot.shared_picker, span)?;
+    let picker = picker_from_guard(&guard, span)?;
 
     let files = picker
         .get_files()
@@ -954,6 +1534,10 @@ pub fn store_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
     ))
 }
 
+/// Restore idx runtime from a SQLite snapshot file.
+///
+/// The restored runtime is immediately queryable by `idx files`, `idx dirs`,
+/// `idx find`, and `idx status` without a filesystem scan.
 #[cfg(feature = "sqlite")]
 pub fn restore_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
     // Open SQLite database
@@ -996,7 +1580,7 @@ pub fn restore_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
             ))
         })?;
 
-    let (version, base_path_str, watch, file_count, dir_count) = metadata;
+    let (version, base_path_str, _watch, _file_count, _dir_count) = metadata;
 
     if version != 1 {
         return Err(ShellError::Generic(GenericError::new(
@@ -1111,19 +1695,79 @@ pub fn restore_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
         }
     }
 
-    // Create status from restored snapshot data (no live scanning)
-    let status = IdxStatus {
-        initialized: true,
-        base_path: base_path_str.clone(),
-        watch,
-        scanning: false, // offline restore doesn't scan
-        scan_duration_ms: 0,
-        files: file_count,
-        dirs: dir_count,
-        arena_bytes_base,
-        arena_bytes_overflow,
-        arena_bytes_untracked: 0,
-    };
+    let restored_files = Arc::new(
+        files
+            .iter()
+            .map(|row| IdxRestoredFile {
+                relative_path: row.relative_path.clone(),
+                full_path: row.full_path.clone(),
+                file_name: row.file_name.clone(),
+                directory: row.directory.clone(),
+                size: row.size,
+                modified: row.modified,
+            })
+            .collect::<Vec<_>>(),
+    );
+
+    let restored_dirs = Arc::new(
+        dirs.iter()
+            .map(|row| IdxRestoredDir {
+                relative_path: row.relative_path.clone(),
+                full_path: row.full_path.clone(),
+            })
+            .collect::<Vec<_>>(),
+    );
+
+    let mut guard = runtime().lock().map_err(|_| {
+        ShellError::Generic(GenericError::new(
+            "idx runtime lock failed",
+            "idx runtime lock poisoned",
+            span,
+        ))
+    })?;
+
+    let shared_picker = SharedFilePicker::default();
+    let shared_frecency = SharedFrecency::noop();
+
+    // Try to initialize a live picker for the base_path to enable grep search.
+    // This happens in the background; if the path no longer exists, grep will
+    // simply return no results.
+    let _ = FilePicker::new_with_shared_state(
+        shared_picker.clone(),
+        shared_frecency,
+        FilePickerOptions {
+            base_path: base_path_str.clone(),
+            enable_mmap_cache: false,
+            enable_content_indexing: false,
+            mode: FFFMode::Ai,
+            cache_budget: None,
+            watch: false,
+            follow_symlinks: false,
+        },
+    );
+
+    // Wait for the picker scan to complete so grep can search indexed content.
+    let _ = shared_picker.wait_for_scan(Duration::from_secs(300));
+
+    let previous = guard.replace(IdxRuntime {
+        base_path: PathBuf::from(&base_path_str),
+        watch: false,
+        shared_picker: shared_picker.clone(),
+        scan_start_time: Instant::now(),
+        scan_completed: Arc::new(AtomicBool::new(true)),
+        scan_duration_ms: Arc::new(AtomicU64::new(0)),
+        restored_files: Some(restored_files.clone()),
+        restored_dirs: Some(restored_dirs.clone()),
+        restored_arena_bytes_base: arena_bytes_base,
+        restored_arena_bytes_overflow: arena_bytes_overflow,
+    });
+    drop(guard);
+
+    if let Some(old_runtime) = previous {
+        let _ = shutdown_shared_picker(&old_runtime.shared_picker, span);
+    }
+
+    let status = current_status(None);
 
     Ok(Value::record(
         [
@@ -1136,19 +1780,22 @@ pub fn restore_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
                 "base_path".to_string(),
                 Value::string(base_path_str.clone(), span),
             ),
-            ("watch".to_string(), Value::bool(watch, span)),
+            ("watch".to_string(), Value::bool(false, span)),
             (
                 "rehydration_mode".to_string(),
-                Value::string("offline_from_snapshot_rows", span),
+                Value::string("snapshot_runtime_restored", span),
             ),
             ("status".to_string(), status.to_value(span)),
             (
                 "restored_files".to_string(),
-                Value::int(i64::try_from(files.len()).unwrap_or(i64::MAX), span),
+                Value::int(
+                    i64::try_from(restored_files.len()).unwrap_or(i64::MAX),
+                    span,
+                ),
             ),
             (
                 "restored_dirs".to_string(),
-                Value::int(i64::try_from(dirs.len()).unwrap_or(i64::MAX), span),
+                Value::int(i64::try_from(restored_dirs.len()).unwrap_or(i64::MAX), span),
             ),
             ("format".to_string(), Value::string("sqlite", span)),
         ]
@@ -1158,6 +1805,10 @@ pub fn restore_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
     ))
 }
 
+/// Search indexed file contents (`idx search`).
+///
+/// When backed by an imported snapshot, grep searches the live filesystem for the base_path.
+/// If the base_path no longer exists or files have been moved, grep will return no results.
 pub fn stream_grep(
     patterns: &[String],
     mode: GrepMode,
@@ -1166,17 +1817,9 @@ pub fn stream_grep(
     signals: &Signals,
 ) -> Result<PipelineData, ShellError> {
     let snapshot = require_runtime(span)?;
-    let guard = snapshot
-        .shared_picker
-        .read()
-        .map_err(|err| fff_error(err, span))?;
-    let picker = guard.as_ref().ok_or_else(|| {
-        ShellError::Generic(GenericError::new(
-            "idx is not initialized",
-            "run `idx init <path>` first",
-            span,
-        ))
-    })?;
+
+    let guard = read_picker_guard(&snapshot.shared_picker, span)?;
+    let picker = picker_from_guard(&guard, span)?;
 
     let options = GrepSearchOptions {
         mode,
@@ -1193,85 +1836,75 @@ pub fn stream_grep(
         picker.multi_grep(&refs, &[], &options)
     };
 
-    let grep_data: Vec<Value> = result
-        .matches
+    let file_paths = result
+        .files
         .iter()
-        .map(|item| {
-            let path = result
-                .files
-                .get(item.file_index)
-                .map(|f| f.relative_path(picker))
-                .unwrap_or_else(|| "<unknown>".to_string());
-
-            let offsets = item
-                .match_byte_offsets
-                .iter()
-                .map(|(start, end)| {
-                    let start = i64::from(*start);
-                    let end = i64::from(*end);
-                    Value::record(
-                        [
-                            // ("start".to_string(), Value::int(start, span)),
-                            // ("end".to_string(), Value::int(end, span)),
-
-                            // I'm guessing calculated offset to match start, end is more valuable
-                            // than just the offset to start and end of the match
-                            (
-                                "start".to_string(),
-                                // byte_offset is the offset to the beginning of the line,
-                                // so match start is offset + start
-                                Value::int(start + item.byte_offset as i64, span),
-                            ),
-                            (
-                                "end".to_string(),
-                                // byte_offset is the offset to the beginning of the line,
-                                // so match end is offset + start + length or offset + end
-                                Value::int(item.byte_offset as i64 + end, span),
-                            ),
-                        ]
-                        .into_iter()
-                        .collect(),
-                        span,
-                    )
-                })
-                .collect::<Vec<_>>();
-
-            Value::record(
-                [
-                    ("path".to_string(), Value::string(path, span)),
-                    (
-                        "line_number".to_string(),
-                        Value::int(i64::try_from(item.line_number).unwrap_or(i64::MAX), span),
-                    ),
-                    (
-                        "column".to_string(),
-                        Value::int(usize_to_i64(item.col), span),
-                    ),
-                    (
-                        "byte_offset".to_string(),
-                        Value::int(i64::try_from(item.byte_offset).unwrap_or(i64::MAX), span),
-                    ),
-                    (
-                        "line".to_string(),
-                        Value::string(item.line_content.clone(), span),
-                    ),
-                    ("matches".to_string(), Value::list(offsets, span)),
-                ]
-                .into_iter()
-                .collect(),
-                span,
-            )
-        })
-        .collect();
+        .map(|f| f.relative_path(picker))
+        .collect::<Vec<_>>();
+    let matches = result.matches;
 
     drop(guard);
 
     let stream_signals = signals.clone();
-    let stream = grep_data.into_iter().map(move |value| {
+    let stream = matches.into_iter().map(move |item| {
         if let Err(err) = stream_signals.check(&span) {
             return Value::error(err, span);
         }
-        value
+
+        let path = file_paths
+            .get(item.file_index)
+            .cloned()
+            .unwrap_or_else(|| "<unknown>".to_string());
+
+        let offsets = item
+            .match_byte_offsets
+            .iter()
+            .map(|(start, end)| {
+                let start = i64::from(*start);
+                let end = i64::from(*end);
+                Value::record(
+                    [
+                        (
+                            "start".to_string(),
+                            Value::int(start + item.byte_offset as i64, span),
+                        ),
+                        (
+                            "end".to_string(),
+                            Value::int(item.byte_offset as i64 + end, span),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    span,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        Value::record(
+            [
+                ("path".to_string(), Value::string(path, span)),
+                (
+                    "line_number".to_string(),
+                    Value::int(i64::try_from(item.line_number).unwrap_or(i64::MAX), span),
+                ),
+                (
+                    "column".to_string(),
+                    Value::int(usize_to_i64(item.col), span),
+                ),
+                (
+                    "byte_offset".to_string(),
+                    Value::int(i64::try_from(item.byte_offset).unwrap_or(i64::MAX), span),
+                ),
+                (
+                    "line".to_string(),
+                    Value::string(item.line_content.clone(), span),
+                ),
+                ("matches".to_string(), Value::list(offsets, span)),
+            ]
+            .into_iter()
+            .collect(),
+            span,
+        )
     });
 
     Ok(PipelineData::ListStream(

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -263,6 +263,7 @@ pub fn init_runtime(
     path: &Path,
     watch: bool,
     wait: bool,
+    follow_symlinks: bool,
     span: Span,
 ) -> Result<IdxStatus, ShellError> {
     let shared_picker = SharedFilePicker::default();
@@ -278,6 +279,7 @@ pub fn init_runtime(
             mode: FFFMode::Ai,
             cache_budget: None,
             watch,
+            follow_symlinks,
         },
     )
     .map_err(|err| fff_error(err, span))?;

--- a/crates/nu-command/tests/commands/idx.rs
+++ b/crates/nu-command/tests/commands/idx.rs
@@ -48,6 +48,22 @@ fn idx_status_reports_watch_disabled_by_default() -> Result {
 
 #[test]
 #[serial]
+fn idx_status_reports_scan_duration_as_duration() -> Result {
+    Playground::setup(
+        "idx_status_reports_scan_duration_as_duration",
+        |dirs, sandbox| {
+            sandbox.with_files(&[EmptyFile("timed.txt")]);
+
+            test()
+                .cwd(dirs.test())
+                .run("idx init . --wait; idx status | get scan_duration | describe")
+                .expect_value_eq("duration")
+        },
+    )
+}
+
+#[test]
+#[serial]
 fn idx_files_returns_records_with_full_path() -> Result {
     Playground::setup(
         "idx_files_returns_records_with_full_path",
@@ -57,6 +73,22 @@ fn idx_files_returns_records_with_full_path() -> Result {
             test()
                 .cwd(dirs.test())
                 .run("idx init . --wait; idx files | get 0.full_path | str contains gamma.txt")
+                .expect_value_eq(true)
+        },
+    )
+}
+
+#[test]
+#[serial]
+fn idx_files_returns_ext_and_native_types() -> Result {
+    Playground::setup(
+        "idx_files_returns_ext_and_native_types",
+        |dirs, sandbox| {
+            sandbox.with_files(&[EmptyFile("quote.txt")]);
+
+            test()
+                .cwd(dirs.test())
+                .run("idx init . --wait; let row = (idx files quote | where file_name == quote.txt | first); let modified_kind = ($row.modified | describe | str downcase); ($row.ext == 'txt') and (($row.size | describe) == 'filesize') and ($modified_kind | str contains 'date')")
                 .expect_value_eq(true)
         },
     )

--- a/crates/nu-command/tests/commands/idx.rs
+++ b/crates/nu-command/tests/commands/idx.rs
@@ -64,6 +64,77 @@ fn idx_files_returns_records_with_full_path() -> Result {
 
 #[test]
 #[serial]
+fn idx_init_wait_reports_scanning_as_false() -> Result {
+    Playground::setup(
+        "idx_init_wait_reports_scanning_as_false",
+        |dirs, sandbox| {
+            sandbox.with_files(&[EmptyFile("scan-me.txt")]);
+
+            test()
+                .cwd(dirs.test())
+                .run("idx init . --wait | get scanning")
+                .expect_value_eq(false)
+        },
+    )
+}
+
+#[test]
+#[serial]
+fn idx_init_wait_indexes_generated_files_before_returning() -> Result {
+    Playground::setup(
+        "idx_init_wait_indexes_generated_files_before_returning",
+        |dirs, _sandbox| {
+            test()
+                .cwd(dirs.test())
+                .run("let expected = 600; 0..($expected - 1) | each {|i| touch $\"bulk-($i).txt\" }; idx init . --wait; idx files | where {|row| $row.file_name | str starts-with 'bulk-' } | length")
+                .expect_value_eq(600)
+        },
+    )
+}
+
+#[test]
+#[serial]
+fn idx_init_wait_status_reports_indexed_file_count() -> Result {
+    Playground::setup(
+        "idx_init_wait_status_reports_indexed_file_count",
+        |dirs, sandbox| {
+            sandbox.with_files(&[
+                EmptyFile("alpha.txt"),
+                EmptyFile("beta.txt"),
+                EmptyFile("gamma.txt"),
+            ]);
+
+            test()
+                .cwd(dirs.test())
+                .run("let status = (idx init . --wait); let counted = (idx files | length); ($status | get files) == $counted")
+                .expect_value_eq(true)
+        },
+    )
+}
+
+#[test]
+#[serial]
+fn idx_files_optional_query_uses_fuzzy_matching() -> Result {
+    Playground::setup(
+        "idx_files_optional_query_uses_fuzzy_matching",
+        |dirs, sandbox| {
+            sandbox.mkdir("src");
+            sandbox.with_files(&[
+                EmptyFile("src/main.rs"),
+                EmptyFile("src/lib.rs"),
+                EmptyFile("README.md"),
+            ]);
+
+            test()
+                .cwd(dirs.test())
+                .run("idx init . --wait; idx files mai | where file_name == main.rs | length")
+                .expect_value_eq(1)
+        },
+    )
+}
+
+#[test]
+#[serial]
 fn idx_dirs_returns_records_with_full_path() -> Result {
     Playground::setup(
         "idx_dirs_returns_records_with_full_path",
@@ -75,6 +146,27 @@ fn idx_dirs_returns_records_with_full_path() -> Result {
                 .cwd(dirs.test())
                 .run("idx init . --wait; idx dirs | get full_path | any {|path| $path | str contains 'nested' }")
                 .expect_value_eq(true)
+        },
+    )
+}
+
+#[test]
+#[serial]
+fn idx_dirs_optional_query_filters_results() -> Result {
+    Playground::setup(
+        "idx_dirs_optional_query_filters_results",
+        |dirs, sandbox| {
+            sandbox.mkdir("src/components");
+            sandbox.mkdir("tests/fixtures");
+            sandbox.with_files(&[
+                EmptyFile("src/components/widget.nu"),
+                EmptyFile("tests/fixtures/spec.nu"),
+            ]);
+
+            test()
+            .cwd(dirs.test())
+            .run("idx init . --wait; idx dirs comp | get full_path | any {|path| $path | str contains 'src/components' }")
+            .expect_value_eq(true)
         },
     )
 }
@@ -114,6 +206,90 @@ fn idx_export_and_import_roundtrip() -> Result {
             .cwd(dirs.test())
             .run("idx import snapshot.json | get restored")
             .expect_value_eq(true)
+    })
+}
+
+#[test]
+#[serial]
+fn idx_import_auto_initializes_runtime_for_queries() -> Result {
+    Playground::setup(
+        "idx_import_auto_initializes_runtime_for_queries",
+        |dirs, sandbox| {
+            sandbox.with_files(&[
+                FileWithContent("searchable.txt", "hello from idx import"),
+                FileWithContent("other.txt", "unrelated"),
+            ]);
+
+            test()
+                .cwd(dirs.test())
+                .run("idx init . --wait; idx export snapshot.db | get stored")
+                .expect_value_eq(true)?;
+
+            test()
+                .cwd(dirs.test())
+                .run("idx drop | get dropped")
+                .expect_value_eq(true)?;
+
+            test()
+                .cwd(dirs.test())
+                .run("idx import snapshot.db; idx files searchable | where file_name == searchable.txt | length")
+                .expect_value_eq(1)
+        },
+    )
+}
+
+#[test]
+#[serial]
+fn idx_import_restores_queryable_snapshot_when_files_are_gone() -> Result {
+    Playground::setup(
+        "idx_import_restores_queryable_snapshot_when_files_are_gone",
+        |dirs, sandbox| {
+            sandbox.with_files(&[
+                FileWithContent("searchable.txt", "hello from idx import"),
+                FileWithContent("other.txt", "unrelated"),
+            ]);
+
+            test()
+                .cwd(dirs.test())
+                .run("idx init . --wait; idx export snapshot.db | get stored")
+                .expect_value_eq(true)?;
+
+            test()
+                .cwd(dirs.test())
+                .run("idx drop | get dropped")
+                .expect_value_eq(true)?;
+
+            test()
+                .cwd(dirs.test())
+                .run("rm searchable.txt other.txt; idx import snapshot.db; idx files searchable | where file_name == searchable.txt | length")
+                .expect_value_eq(1)
+        },
+    )
+}
+
+#[test]
+#[serial]
+fn idx_search_works_on_imported_snapshot() -> Result {
+    Playground::setup("idx_search_works_on_imported_snapshot", |dirs, sandbox| {
+        sandbox.with_files(&[
+            FileWithContent("searchable.txt", "hello from idx import"),
+            FileWithContent("other.txt", "unrelated content"),
+        ]);
+
+        test()
+            .cwd(dirs.test())
+            .run("idx init . --wait; idx export snapshot.db | get stored")
+            .expect_value_eq(true)?;
+
+        test()
+            .cwd(dirs.test())
+            .run("idx drop | get dropped")
+            .expect_value_eq(true)?;
+
+        test()
+            .cwd(dirs.test())
+            .run("idx import snapshot.db; idx search hello | where path == searchable.txt | length")
+            .expect_value_eq(1)
     })
 }
 

--- a/crates/nu-command/tests/commands/idx.rs
+++ b/crates/nu-command/tests/commands/idx.rs
@@ -81,17 +81,14 @@ fn idx_files_returns_records_with_full_path() -> Result {
 #[test]
 #[serial]
 fn idx_files_returns_ext_and_native_types() -> Result {
-    Playground::setup(
-        "idx_files_returns_ext_and_native_types",
-        |dirs, sandbox| {
-            sandbox.with_files(&[EmptyFile("quote.txt")]);
+    Playground::setup("idx_files_returns_ext_and_native_types", |dirs, sandbox| {
+        sandbox.with_files(&[EmptyFile("quote.txt")]);
 
-            test()
+        test()
                 .cwd(dirs.test())
                 .run("idx init . --wait; let row = (idx files quote | where file_name == quote.txt | first); let modified_kind = ($row.modified | describe | str downcase); ($row.ext == 'txt') and (($row.size | describe) == 'filesize') and ($modified_kind | str contains 'date')")
                 .expect_value_eq(true)
-        },
-    )
+    })
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/idx.rs
+++ b/crates/nu-command/tests/commands/idx.rs
@@ -165,7 +165,7 @@ fn idx_dirs_optional_query_filters_results() -> Result {
 
             test()
             .cwd(dirs.test())
-            .run("idx init . --wait; idx dirs comp | get full_path | any {|path| $path | str contains 'src/components' }")
+            .run("idx init . --wait; idx dirs comp | get relative_path | any {|path| ($path | str contains 'src/components') or ($path | str contains 'src\\components') }")
             .expect_value_eq(true)
         },
     )


### PR DESCRIPTION
## Description
This PR updates `idx` dependencies and fixes the api due to changes introduced with fff-search 0.8.2. It also fixes a bunch of bugs recently identified.

## User-facing changes (Release notes)
### `idx` dependency update and command reliability improvements
Update the `idx` fff-search dependency and fix bugs.

- `idx init . --wait` now properly blocks
- `idx init` now has a `--follow-links` switch
- `idx status` reports accurate counts after indexing
- `idx import` fully restores snapshot for queries — The `idx import` command now properly restores snapshots to enable all query operations. Imported snapshots remain queryable even if the original project files have been deleted or moved.
- `idx files` works on imported snapshots
- `idx files` has a `query` parameter now for easy searching (renamed from `path` for consistency)
- `idx dirs` works on imported snapshots
- `idx dirs` has a `query` parameter now for easy searching
- `idx find` (fuzzy search) works on imported snapshots
- `idx search` (content search) works on imported snapshots
- changed output to nushell values for commands that return tables
- updated some help strings to be more helpful

Files are ignored during indexing due to the use of the `ignore` crate. These are the rules for ignore https://docs.rs/ignore/latest/ignore/struct.WalkBuilder.html#ignore-rules. There's no way to override this in the current version.

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->