### PR TITLE
chore: Omit some unnecessary allocations from the parser

### DIFF
--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -203,8 +203,8 @@ pub fn lex_item(
                         span,
                     },
                     Some(ParseError::Unbalanced(
-                        "{".to_string(),
-                        "}".to_string(),
+                        "{",
+                        "}",
                         Span::new(span.end - 1, span.end),
                     )),
                 );
@@ -228,8 +228,8 @@ pub fn lex_item(
                         span,
                     },
                     Some(ParseError::Unbalanced(
-                        "(".to_string(),
-                        ")".to_string(),
+                        "(",
+                        ")",
                         Span::new(span.end - 1, span.end),
                     )),
                 );

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -349,7 +349,7 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
         .is_none_or(|new_errors| {
             new_errors
                 .iter()
-                .all(|e| !matches!(e, ParseError::Unclosed(token, _) if token == "}"))
+                .all(|e| !matches!(e, ParseError::Unclosed(token, _) if *token == "}"))
         })
     {
         working_set.exit_scope();
@@ -646,7 +646,7 @@ fn parse_def_inner(
         .is_none_or(|new_errors| {
             new_errors
                 .iter()
-                .all(|e| !matches!(e, ParseError::Unclosed(token, _) if token == "}"))
+                .all(|e| !matches!(e, ParseError::Unclosed(token, _) if *token == "}"))
         })
     {
         working_set.exit_scope();
@@ -2425,7 +2425,7 @@ pub fn parse_module(
     if block_bytes.ends_with(b"}") {
         end -= 1;
     } else {
-        working_set.error(ParseError::Unclosed("}".into(), Span::new(end, end)));
+        working_set.error(ParseError::Unclosed("}", Span::new(end, end)));
     }
 
     let block_content_span = Span::new(start, end);

--- a/crates/nu-parser/src/parse_patterns.rs
+++ b/crates/nu-parser/src/parse_patterns.rs
@@ -90,7 +90,7 @@ pub fn parse_list_pattern(working_set: &mut StateWorkingSet, span: Span) -> Matc
     if bytes.ends_with(b"]") {
         end -= 1;
     } else {
-        working_set.error(ParseError::Unclosed("]".into(), Span::new(end, end)));
+        working_set.error(ParseError::Unclosed("]", Span::new(end, end)));
     }
 
     let inner_span = Span::new(start, end);
@@ -176,7 +176,7 @@ pub fn parse_record_pattern(working_set: &mut StateWorkingSet, span: Span) -> Ma
     if bytes.ends_with(b"}") {
         end -= 1;
     } else {
-        working_set.error(ParseError::Unclosed("}".into(), Span::new(end, end)));
+        working_set.error(ParseError::Unclosed("}", Span::new(end, end)));
     }
 
     let inner_span = Span::new(start, end);

--- a/crates/nu-parser/src/parse_shape_specs.rs
+++ b/crates/nu-parser/src/parse_shape_specs.rs
@@ -207,10 +207,8 @@ fn split_generic_params<'a>(
     bytes: &'a [u8],
     span: Span,
 ) -> (&'a [u8], Option<Spanned<&'a [u8]>>) {
-    let n = bytes.iter().position(|&c| c == b'<');
-    let (open_delim_pos, close_delim) = match n.and_then(|n| Some((n, bytes.get(n)?))) {
-        Some((n, b'<')) => (n, b'>'),
-        _ => return (bytes, None),
+    let Some(open_delim_pos) = bytes.iter().position(|&c| c == b'<') else {
+        return (bytes, None);
     };
 
     let type_name = &bytes[..(open_delim_pos)];
@@ -218,13 +216,13 @@ fn split_generic_params<'a>(
 
     let start = span.start + type_name.len() + 1;
 
-    if params.ends_with(&[close_delim]) {
+    if params.ends_with(b">") {
         let end = span.end - 1;
         (
             type_name,
             Some((&params[..(params.len() - 1)]).into_spanned(Span::new(start, end))),
         )
-    } else if let Some(close_delim_pos) = params.iter().position(|it| it == &close_delim) {
+    } else if let Some(close_delim_pos) = params.iter().position(|it| *it == b'>') {
         let span = Span::new(span.start + close_delim_pos, span.end);
 
         working_set.error(ParseError::LabeledError(
@@ -235,7 +233,7 @@ fn split_generic_params<'a>(
 
         (bytes, None)
     } else {
-        working_set.error(ParseError::Unclosed((close_delim as char).into(), span));
+        working_set.error(ParseError::Unclosed(">", span));
         (bytes, None)
     }
 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3983,7 +3983,7 @@ pub fn parse_var_with_opt_type(
     mutable: bool,
 ) -> (Expression, Option<Type>) {
     let name_span = spans[*spans_idx];
-    let bytes = working_set.get_span_contents(name_span).to_vec();
+    let bytes = working_set.get_span_contents(name_span);
 
     if bytes.contains(&b' ')
         || bytes.contains(&b'"')
@@ -4052,7 +4052,7 @@ pub fn parse_var_with_opt_type(
             )
         }
     } else {
-        let var_name = bytes;
+        let var_name = bytes.to_vec();
 
         if !is_variable(&var_name) {
             working_set.error(ParseError::Expected(

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -7039,7 +7039,7 @@ pub fn parse_pipeline(working_set: &mut StateWorkingSet, pipeline: &LitePipeline
                 let element = parse_pipeline_element(working_set, element);
                 // Handle $in for pipeline elements beyond the first one
                 if index > 0 && element.has_in_variable(working_set) {
-                    wrap_element_with_collect(working_set, element.clone())
+                    wrap_element_with_collect(working_set, element)
                 } else {
                     element
                 }
@@ -7609,7 +7609,7 @@ fn wrap_element_with_collect(
     }
 }
 
-fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: Expression) -> Expression {
+fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, mut expr: Expression) -> Expression {
     let span = expr.span;
 
     // IN_VARIABLE_ID should get replaced with a unique variable, so that we don't have to
@@ -7620,7 +7620,6 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: Expression) -
         Type::Any,
         false,
     );
-    let mut expr = expr.clone();
     expr.replace_in_variable(working_set, var_id);
 
     // Bind the custom `$in` variable for that particular expression

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -808,7 +808,7 @@ fn parse_oneof(
             false => parse_value(working_set, spans[*spans_idx], shape),
         };
 
-        let new_errors = working_set.parse_errors[starting_error_count..].to_vec();
+        let new_errors = &working_set.parse_errors[starting_error_count..];
         // no new errors found means success
         let Some(first_error_offset) = new_errors.iter().map(|e| e.span().start).min() else {
             return value;
@@ -829,7 +829,8 @@ fn parse_oneof(
             };
             max_first_error_offset = first_error_offset;
             best_guess = Some(value);
-            best_guess_errors = new_errors;
+            best_guess_errors.clear();
+            best_guess_errors.extend_from_slice(new_errors);
         }
         working_set.parse_errors.truncate(starting_error_count);
     }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2252,11 +2252,7 @@ pub fn parse_raw_string(working_set: &mut StateWorkingSet, span: Span) -> Expres
     // check for unbalanced # and single quotes.
     let postfix_bytes = &bytes[bytes.len() - expect_postfix_sharp_cnt..bytes.len()];
     if postfix_bytes.iter().any(|b| *b != b'#') {
-        working_set.error(ParseError::Unbalanced(
-            "prefix #".to_string(),
-            "postfix #".to_string(),
-            span,
-        ));
+        working_set.error(ParseError::Unbalanced("prefix #", "postfix #", span));
         return garbage(working_set, span);
     }
     // check for unblanaced single quotes.
@@ -2304,7 +2300,7 @@ pub fn parse_paren_expr(
             .first()
             .is_some_and(|e| match e {
                 ParseError::Unclosed(right, _) if (right == ")") => true,
-                ParseError::Unbalanced(left, right, _) if left == "(" && right == ")" => true,
+                ParseError::Unbalanced(left, right, _) if *left == "(" && *right == ")" => true,
                 _ => false,
             });
         if malformed_subexpr {
@@ -6764,8 +6760,8 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
     };
     while !lex_state.input.is_empty() {
         if let Some(ParseError::Unbalanced(left, right, _)) = lex_state.error.as_ref()
-            && left == "{"
-            && right == "}"
+            && *left == "{"
+            && *right == "}"
         {
             extra_tokens = true;
             unclosed = false;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2245,7 +2245,7 @@ pub fn parse_raw_string(working_set: &mut StateWorkingSet, span: Span) -> Expres
     // the whole raw string should contains at least
     // 1(r) + prefix_sharp_cnt + 1(') + 1(') + postfix_sharp characters
     if bytes.len() < prefix_sharp_cnt + expect_postfix_sharp_cnt + 3 {
-        working_set.error(ParseError::Unclosed('\''.into(), span));
+        working_set.error(ParseError::Unclosed("'", span));
         return garbage(working_set, span);
     }
 
@@ -2259,7 +2259,7 @@ pub fn parse_raw_string(working_set: &mut StateWorkingSet, span: Span) -> Expres
     if bytes[1 + prefix_sharp_cnt] != b'\''
         || bytes[bytes.len() - expect_postfix_sharp_cnt - 1] != b'\''
     {
-        working_set.error(ParseError::Unclosed('\''.into(), span));
+        working_set.error(ParseError::Unclosed("'", span));
         return garbage(working_set, span);
     }
 
@@ -2299,7 +2299,7 @@ pub fn parse_paren_expr(
         let malformed_subexpr = working_set.parse_errors[starting_error_count..]
             .first()
             .is_some_and(|e| match e {
-                ParseError::Unclosed(right, _) if (right == ")") => true,
+                ParseError::Unclosed(right, _) if (*right == ")") => true,
                 ParseError::Unbalanced(left, right, _) if *left == "(" && *right == ")" => true,
                 _ => false,
             });
@@ -2853,7 +2853,7 @@ pub fn parse_full_cell_path(
             if bytes.ends_with(b")") {
                 end -= 1;
             } else {
-                working_set.error(ParseError::Unclosed(")".into(), Span::new(end, end)));
+                working_set.error(ParseError::Unclosed(")", Span::new(end, end)));
                 is_closed = false;
             }
 
@@ -3778,15 +3778,15 @@ pub fn parse_string_strict(working_set: &mut StateWorkingSet, span: Span) -> Exp
             bytes
         };
         if bytes.starts_with(b"\"") && (bytes.len() == 1 || !bytes.ends_with(b"\"")) {
-            working_set.error(ParseError::Unclosed("\"".into(), span));
+            working_set.error(ParseError::Unclosed("\"", span));
             return garbage(working_set, span);
         }
         if bytes.starts_with(b"\'") && (bytes.len() == 1 || !bytes.ends_with(b"\'")) {
-            working_set.error(ParseError::Unclosed("\'".into(), span));
+            working_set.error(ParseError::Unclosed("\'", span));
             return garbage(working_set, span);
         }
         if bytes.starts_with(b"r#") && (bytes.len() == 1 || !bytes.ends_with(b"#")) {
-            working_set.error(ParseError::Unclosed("r#".into(), span));
+            working_set.error(ParseError::Unclosed("r#", span));
             return garbage(working_set, span);
         }
     }
@@ -4347,7 +4347,7 @@ pub fn parse_signature(
     if (has_paren && bytes.ends_with(b")")) || (!has_paren && bytes.ends_with(b"]")) {
         end -= 1;
     } else {
-        working_set.error(ParseError::Unclosed("] or )".into(), Span::new(end, end)));
+        working_set.error(ParseError::Unclosed("] or )", Span::new(end, end)));
     }
 
     let sig = parse_signature_helper(working_set, Span::new(start, end), is_external);
@@ -5048,7 +5048,7 @@ pub fn parse_list_expression(
     if bytes.ends_with(b"]") {
         end -= 1;
     } else {
-        working_set.error(ParseError::Unclosed("]".into(), Span::new(end, end)));
+        working_set.error(ParseError::Unclosed("]", Span::new(end, end)));
     }
 
     let inner_span = Span::new(start, end);
@@ -5169,7 +5169,7 @@ fn parse_table_expression(
             span.end - 1
         } else {
             let end = span.end;
-            working_set.error(ParseError::Unclosed("]".into(), Span::new(end, end)));
+            working_set.error(ParseError::Unclosed("]", Span::new(end, end)));
             span.end
         };
 
@@ -5332,7 +5332,7 @@ pub fn parse_block_expression(working_set: &mut StateWorkingSet, span: Span) -> 
     if bytes.ends_with(b"}") {
         end -= 1;
     } else {
-        working_set.error(ParseError::Unclosed("}".into(), Span::new(end, end)));
+        working_set.error(ParseError::Unclosed("}", Span::new(end, end)));
         is_closed = false;
     }
 
@@ -5392,7 +5392,7 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
     if bytes.ends_with(b"}") {
         end -= 1;
     } else {
-        working_set.error(ParseError::Unclosed("}".into(), Span::new(end, end)));
+        working_set.error(ParseError::Unclosed("}", Span::new(end, end)));
         is_closed = false;
     }
 
@@ -5597,7 +5597,7 @@ pub fn parse_closure_expression(
     if bytes.ends_with(b"}") {
         end -= 1;
     } else {
-        working_set.error(ParseError::Unclosed("}".into(), Span::new(end, end)));
+        working_set.error(ParseError::Unclosed("}", Span::new(end, end)));
         is_closed = false;
     }
 
@@ -5639,7 +5639,7 @@ pub fn parse_closure_expression(
             let end_point = if let Some(span) = end_span {
                 span.end
             } else {
-                working_set.error(ParseError::Unclosed("|".into(), Span::new(end, end)));
+                working_set.error(ParseError::Unclosed("|", Span::new(end, end)));
                 end
             };
 
@@ -6796,7 +6796,7 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
     let (tokens, err) = (lex_state.output, lex_state.error);
 
     if unclosed {
-        working_set.error(ParseError::Unclosed("}".into(), Span::new(end, end)));
+        working_set.error(ParseError::Unclosed("}", Span::new(end, end)));
     } else if extra_tokens {
         working_set.error(ParseError::ExtraTokensAfterClosingDelimiter(Span::new(
             lex_state.span_offset,

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -2037,7 +2037,7 @@ mod string {
 
             assert!(
                 working_set.parse_errors.iter().any(
-                    |err| matches!(err, ParseError::Unclosed(delimiter, _) if delimiter == ")")
+                    |err| matches!(err, ParseError::Unclosed(delimiter, _) if *delimiter == ")")
                 )
             );
         }

--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -45,7 +45,11 @@ pub enum ParseError {
 
     #[error("Unbalanced delimiter.")]
     #[diagnostic(code(nu::parser::unbalanced_delimiter))]
-    Unbalanced(String, String, #[label("unbalanced {0} and {1}")] Span),
+    Unbalanced(
+        &'static str,
+        &'static str,
+        #[label("unbalanced {0} and {1}")] Span,
+    ),
 
     #[error("Parse mismatch during operation.")]
     #[diagnostic(code(nu::parser::parse_mismatch))]

--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -41,7 +41,7 @@ pub enum ParseError {
 
     #[error("Unclosed delimiter.")]
     #[diagnostic(code(nu::parser::unclosed_delimiter))]
-    Unclosed(String, #[label("unclosed {0}")] Span),
+    Unclosed(&'static str, #[label("unclosed {0}")] Span),
 
     #[error("Unbalanced delimiter.")]
     #[diagnostic(code(nu::parser::unbalanced_delimiter))]


### PR DESCRIPTION
## Description
Don't expect a significant impact on general benchmarks, just best practices to trim the temporary allocations a bit.

- **Restructure vec clone to avoid duplicate clone**
- **Omit/Reuse allocation in `parse_oneof`**
- **Remove defensive clones in `$in` Expression handling**
- **Use static `str`s for `ParseError::Unbalanced`**
- **Use static `str`s for `ParseError::Unclosed`**

## User-facing changes (Release notes)
N/A
