### PR TITLE
fix(completions): Subcommand completions are now wrapped in quotes for `which`

### DIFF
--- a/crates/nu-cli/src/completions/arg_value_completion.rs
+++ b/crates/nu-cli/src/completions/arg_value_completion.rs
@@ -185,6 +185,7 @@ impl<'a> Completer for ArgValueCompletion<'a> {
                         internals: true,
                         externals: true,
                         builtins_only: false,
+                        quote_internals: true,
                     };
                     return self.completer.process_completion(&mut completer, &ctx);
                 }
@@ -193,6 +194,7 @@ impl<'a> Completer for ArgValueCompletion<'a> {
                         internals: true,
                         externals: false,
                         builtins_only: false,
+                        quote_internals: true,
                     };
                     return self.completer.process_completion(&mut completer, &ctx);
                 }

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -9,16 +9,11 @@ use reedline::Suggestion;
 
 use super::{SemanticSuggestion, completion_options::NuMatcher};
 
-fn formatted_name(name: String, wrap: bool) -> String {
-    if !wrap {
-        return name;
-    }
-    if name.contains('\'') {
-        format!("\"{}\"", name.replace('\\', "\\\\").replace('"', r#"\""#))
-    } else if name.contains(' ') || name.contains('"') {
-        format!("'{name}'")
+fn formatted_name(name: &str, wrap: bool) -> String {
+    if wrap && nu_utils::needs_quoting(name) {
+        nu_utils::escape_quote_string(name)
     } else {
-        name
+        name.to_string()
     }
 }
 
@@ -210,10 +205,7 @@ impl Completer for CommandCompletion {
                 }
             } else {
                 working_set.traverse_commands(|name, decl_id| {
-                    let name = formatted_name(
-                        String::from_utf8_lossy(name).into_owned(),
-                        self.quote_internals,
-                    );
+                    let name = formatted_name(&String::from_utf8_lossy(name), self.quote_internals);
                     let command = working_set.get_decl(decl_id);
                     if command.signature().category == Category::Removed {
                         return;

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -29,7 +29,7 @@ pub struct CommandCompletion {
     pub externals: bool,
     /// Whether internal completion should include only built-in commands
     pub builtins_only: bool,
-    /// Whether to quote space-seperated internal commands
+    /// Whether to quote space-separated internal commands
     pub quote_internals: bool,
 }
 

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -9,7 +9,19 @@ use reedline::Suggestion;
 
 use super::{SemanticSuggestion, completion_options::NuMatcher};
 
-// TODO: Add a toggle for quoting multi word commands. Useful for: `which` and `attr complete`
+fn formatted_name(name: String, wrap: bool) -> String {
+    if !wrap {
+        return name;
+    }
+    if name.contains('\'') {
+        format!("\"{}\"", name.replace('"', r#"\""#))
+    } else if name.contains(' ') || name.contains('"') {
+        format!("'{name}'")
+    } else {
+        name
+    }
+}
+
 pub struct CommandCompletion {
     /// Whether to include internal commands
     pub internals: bool,
@@ -17,6 +29,8 @@ pub struct CommandCompletion {
     pub externals: bool,
     /// Whether internal completion should include only built-in commands
     pub builtins_only: bool,
+    /// Whether to quote space-seperated internal commands
+    pub quote_internals: bool,
 }
 
 impl CommandCompletion {
@@ -196,7 +210,10 @@ impl Completer for CommandCompletion {
                 }
             } else {
                 working_set.traverse_commands(|name, decl_id| {
-                    let name = String::from_utf8_lossy(name);
+                    let name = formatted_name(
+                        String::from_utf8_lossy(name).into_owned(),
+                        self.quote_internals,
+                    );
                     let command = working_set.get_decl(decl_id);
                     if command.signature().category == Category::Removed {
                         return;
@@ -204,7 +221,7 @@ impl Completer for CommandCompletion {
 
                     let matched = matcher.add_semantic_suggestion(SemanticSuggestion {
                         suggestion: Suggestion {
-                            value: name.to_string(),
+                            value: name.clone(),
                             description: Some(command.description().to_string()),
                             span: sugg_span,
                             append_whitespace: true,
@@ -216,7 +233,7 @@ impl Completer for CommandCompletion {
                         )),
                     });
                     if matched {
-                        internal_suggs.insert(name.to_string());
+                        internal_suggs.insert(name);
                     }
                 });
             }

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -14,7 +14,7 @@ fn formatted_name(name: String, wrap: bool) -> String {
         return name;
     }
     if name.contains('\'') {
-        format!("\"{}\"", name.replace('"', r#"\""#))
+        format!("\"{}\"", name.replace('\\', "\\\\").replace('"', r#"\""#))
     } else if name.contains(' ') || name.contains('"') {
         format!("'{name}'")
     } else {

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -350,6 +350,7 @@ impl NuCompleter {
                         internals: need_internals,
                         externals: need_externals,
                         builtins_only: force_builtins_only,
+                        quote_internals: false,
                     },
                     strip,
                 ))
@@ -591,6 +592,7 @@ impl NuCompleter {
                                         internals: true,
                                         externals: true,
                                         builtins_only: false,
+                                        quote_internals: false,
                                     },
                                     strip,
                                 );
@@ -678,6 +680,7 @@ impl NuCompleter {
             externals: !options.internals
                 || (options.externals && config.completions.external.enable),
             builtins_only: options.builtins_only,
+            quote_internals: options.quote_internals,
         };
         let (new_span, prefix) = strip_placeholder_if_any(working_set, &span, strip);
         let ctx = Context::new(working_set, new_span, prefix, offset);
@@ -764,6 +767,7 @@ struct CommandCompletionOptions {
     internals: bool,
     externals: bool,
     builtins_only: bool,
+    quote_internals: bool,
 }
 
 impl ReedlineCompleter for NuCompleter {

--- a/crates/nu-cli/src/completions/exportable_completions.rs
+++ b/crates/nu-cli/src/completions/exportable_completions.rs
@@ -15,13 +15,10 @@ pub struct ExportableCompletion<'a> {
 
 /// If name contains space, wrap it in quotes
 fn wrapped_name(name: String) -> String {
-    if !name.contains(' ') {
-        return name;
-    }
-    if name.contains('\'') {
-        format!("\"{}\"", name.replace('"', r#"\""#))
+    if nu_utils::needs_quoting(&name) {
+        nu_utils::escape_quote_string(&name)
     } else {
-        format!("'{name}'")
+        name
     }
 }
 

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -776,20 +776,25 @@ fn which_command_completions() {
 fn which_command_quoted_completions() {
     let (_, _, mut engine, mut stack) = new_engine();
     let command = r#"def "foo's" [] {}
-        def 'foo"s' [] {}
         def "foo\"b\"a'r" [] {}
+        def 'foo"s' [] {}
         def "foo\\'s'" [] {}"#;
     assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     // Commands with spaces
     let completion_str = "which \"detect";
     let suggestions = completer.complete(completion_str, completion_str.len());
-    let expected: Vec<_> = vec!["detect", "'detect columns'", "'detect type'"];
+    let expected: Vec<_> = vec!["detect", "\"detect columns\"", "\"detect type\""];
     match_suggestions(&expected, &suggestions);
     // Commands with quotes
     let completion_str = "which foo";
     let suggestions = completer.complete(completion_str, completion_str.len());
-    let expected: Vec<_> = vec!["'foo\"s'", "\"foo's\"", r#""foo\"b\"a'r""#, r#""foo\\'s'""#];
+    let expected: Vec<_> = vec![
+        r#""foo's""#,
+        r#""foo\"b\"a'r""#,
+        r#""foo\"s""#,
+        r#""foo\\'s'""#,
+    ];
     match_suggestions(&expected, &suggestions);
 }
 

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1020,7 +1020,7 @@ fn exportable_completions() {
 
     let completion_str = "use std/assert \"not eq";
     let suggestions = completer.complete(completion_str, completion_str.len());
-    match_suggestions(&vec!["'not equal'"], &suggestions);
+    match_suggestions(&vec!["\"not equal\""], &suggestions);
 
     let completion_str = "use std/math [E, `TAU";
     let suggestions = completer.complete(completion_str, completion_str.len());

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -770,10 +770,23 @@ fn which_command_completions() {
     #[cfg(not(windows))]
     let expected: Vec<_> = vec!["sleep", "%sleep", "^sleep"];
     match_suggestions(&expected, &suggestions);
-    // commands with spaces
-    let completion_str = "which detect";
+}
+
+#[test]
+fn which_command_quoted_completions() {
+    let (_, _, mut engine, mut stack) = new_engine();
+    let command = r#"def "foo's" [] {}; def 'foo"s' [] {}; def "foo\"b\"a'r" [] {}"#;
+    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    // Commands with spaces
+    let completion_str = "which \"detect";
     let suggestions = completer.complete(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["detect", "'detect columns'", "'detect type'"];
+    match_suggestions(&expected, &suggestions);
+    // Commands with quotes
+    let completion_str = "which foo";
+    let suggestions = completer.complete(completion_str, completion_str.len());
+    let expected: Vec<_> = vec!["'foo\"s'", "\"foo's\"", r#""foo\"b\"a'r""#];
     match_suggestions(&expected, &suggestions);
 }
 

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -775,7 +775,10 @@ fn which_command_completions() {
 #[test]
 fn which_command_quoted_completions() {
     let (_, _, mut engine, mut stack) = new_engine();
-    let command = r#"def "foo's" [] {}; def 'foo"s' [] {}; def "foo\"b\"a'r" [] {}"#;
+    let command = r#"def "foo's" [] {}
+        def 'foo"s' [] {}
+        def "foo\"b\"a'r" [] {}
+        def "foo\\'s'" [] {}"#;
     assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     // Commands with spaces
@@ -786,7 +789,7 @@ fn which_command_quoted_completions() {
     // Commands with quotes
     let completion_str = "which foo";
     let suggestions = completer.complete(completion_str, completion_str.len());
-    let expected: Vec<_> = vec!["'foo\"s'", "\"foo's\"", r#""foo\"b\"a'r""#];
+    let expected: Vec<_> = vec!["'foo\"s'", "\"foo's\"", r#""foo\"b\"a'r""#, r#""foo\\'s'""#];
     match_suggestions(&expected, &suggestions);
 }
 

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -770,6 +770,11 @@ fn which_command_completions() {
     #[cfg(not(windows))]
     let expected: Vec<_> = vec!["sleep", "%sleep", "^sleep"];
     match_suggestions(&expected, &suggestions);
+    // commands with spaces
+    let completion_str = "which detect";
+    let suggestions = completer.complete(completion_str, completion_str.len());
+    let expected: Vec<_> = vec!["detect", "'detect columns'", "'detect type'"];
+    match_suggestions(&expected, &suggestions);
 }
 
 /// hide-env completes environment variable names


### PR DESCRIPTION
## Description

When tab-completing commands with spaces in them as parameters to `which`, completed arguments lacked quotes, treating the text as two (or more) commands instead.

This PR aims to fix that by quoting completed `which` arguments when needed. It also modifies the completion for `@complete` to do the same thing.

## User-facing changes (Release notes)

### Subcommand completions are now wrapped in quotes for `which`

Tab completions for `which` and `attr complete`/`@complete` commands will now properly quote command names containing spaces.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>

<tr>
<td>

```nushell
> which 'path par  # Tab pressed
> which path parse
╭───┬─────────┬──────┬──────────╮
│ # │ command │ path │   type   │
├───┼─────────┼──────┼──────────┤
│ 0 │ path    │      │ built-in │
│ 1 │ parse   │      │ built-in │
╰───┴─────────┴──────┴──────────╯
```

</td>
<td>

```nushell
> which 'path par   # Tab pressed
> which 'path parse'
╭───┬────────────┬──────┬──────────╮
│ # │  command   │ path │   type   │
├───┼────────────┼──────┼──────────┤
│ 0 │ path parse │      │ built-in │
╰───┴────────────┴──────┴──────────╯
 
```

</td>
</tr>
</table>

## Additional notes

First time working on a non-command PR. Let me know if I missed anything obvious.