### PR TITLE
Implement POSIX Guideline 10 `--` end-of-options delimiter

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -544,7 +544,7 @@ fn ensure_flag_arg_type(
 /// or the end-of-options delimiter `--` was found (which stops all flag parsing).
 enum LongFlagParseResult {
     /// A long flag was successfully parsed: (flag_name, value_expression)
-    FoundFlag(Option<Spanned<String>>, Option<Expression>),
+    FoundFlag(Spanned<String>, Option<Expression>),
     /// No long flag found at this position
     NoFlag,
     /// End-of-options delimiter `--` found; stop flag parsing
@@ -587,14 +587,14 @@ fn parse_long_flag(
                             arg_shape,
                             Span::new(arg_span.start, arg_span.start + long_name_len + 2),
                         );
-                        LongFlagParseResult::FoundFlag(Some(arg_name), Some(val_expression))
+                        LongFlagParseResult::FoundFlag(arg_name, Some(val_expression))
                     } else if let Some(arg) = spans.get(*spans_idx + 1) {
                         let arg = parse_value(working_set, *arg, arg_shape);
 
                         *spans_idx += 1;
                         let (arg_name, val_expression) =
                             ensure_flag_arg_type(working_set, long_name, arg, arg_shape, arg_span);
-                        LongFlagParseResult::FoundFlag(Some(arg_name), Some(val_expression))
+                        LongFlagParseResult::FoundFlag(arg_name, Some(val_expression))
                     } else {
                         working_set.error(ParseError::MissingFlagParam(
                             arg_shape.to_string(),
@@ -603,10 +603,10 @@ fn parse_long_flag(
                         // NOTE: still need to cover this incomplete flag in the final expression
                         // see https://github.com/nushell/nushell/issues/16375
                         LongFlagParseResult::FoundFlag(
-                            Some(Spanned {
+                            Spanned {
                                 item: long_name,
                                 span: arg_span,
-                            }),
+                            },
                             None,
                         )
                     }
@@ -628,13 +628,13 @@ fn parse_long_flag(
                             &SyntaxShape::Boolean,
                             Span::new(arg_span.start, arg_span.start + long_name_len + 2),
                         );
-                        LongFlagParseResult::FoundFlag(Some(arg_name), Some(val_expression))
+                        LongFlagParseResult::FoundFlag(arg_name, Some(val_expression))
                     } else {
                         LongFlagParseResult::FoundFlag(
-                            Some(Spanned {
+                            Spanned {
                                 item: long_name,
                                 span: arg_span,
-                            }),
+                            },
                             None,
                         )
                     }
@@ -650,20 +650,20 @@ fn parse_long_flag(
                     suggestion,
                 ));
                 LongFlagParseResult::FoundFlag(
-                    Some(Spanned {
+                    Spanned {
                         item: long_name.clone(),
                         span: arg_span,
-                    }),
+                    },
                     None,
                 )
             }
         } else {
             working_set.error(ParseError::NonUtf8(arg_span));
             LongFlagParseResult::FoundFlag(
-                Some(Spanned {
+                Spanned {
                     item: "--".into(),
                     span: arg_span,
-                }),
+                },
                 None,
             )
         }
@@ -1106,25 +1106,22 @@ pub fn parse_internal_call(
                     }
                 }
                 LongFlagParseResult::FoundFlag(long_name, arg) => {
-                    if let Some(long_name) = long_name {
-                        // We found a long flag, like --bar
-                        if working_set.parse_errors[starting_error_count..]
-                            .iter()
-                            .any(|x| matches!(x, ParseError::UnknownFlag(_, _, _, _)))
-                            && signature.allows_unknown_args
-                        {
-                            working_set.parse_errors.truncate(starting_error_count);
-                            let arg = parse_unknown_arg(working_set, arg_span, &signature);
+                    // We found a long flag, like --bar
+                    if working_set.parse_errors[starting_error_count..]
+                        .iter()
+                        .any(|x| matches!(x, ParseError::UnknownFlag(_, _, _, _)))
+                        && signature.allows_unknown_args
+                    {
+                        working_set.parse_errors.truncate(starting_error_count);
+                        let arg = parse_unknown_arg(working_set, arg_span, &signature);
 
-                            call.add_unknown(arg);
-                        } else {
-                            call.add_named((long_name, None, arg));
-                        }
-
-                        spans_idx += 1;
-                        continue;
+                        call.add_unknown(arg);
+                    } else {
+                        call.add_named((long_name, None, arg));
                     }
-                    // If long_name is None, fall through to short flag parsing
+
+                    spans_idx += 1;
+                    continue;
                 }
                 LongFlagParseResult::NoFlag => {
                     // No long flag found, continue to short flag parsing

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -538,16 +538,34 @@ fn ensure_flag_arg_type(
     }
 }
 
+/// Result of attempting to parse a long flag.
+///
+/// This tri-state enum indicates whether a long flag was found, no flag was found,
+/// or the end-of-options delimiter `--` was found (which stops all flag parsing).
+enum LongFlagParseResult {
+    /// A long flag was successfully parsed: (flag_name, value_expression)
+    FoundFlag(Option<Spanned<String>>, Option<Expression>),
+    /// No long flag found at this position
+    NoFlag,
+    /// End-of-options delimiter `--` found; stop flag parsing
+    EndOfOptions,
+}
+
 fn parse_long_flag(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
     spans_idx: &mut usize,
     sig: &Signature,
-) -> (Option<Spanned<String>>, Option<Expression>) {
+) -> LongFlagParseResult {
     let arg_span = spans[*spans_idx];
     let arg_contents = working_set.get_span_contents(arg_span);
 
     if arg_contents.starts_with(b"--") {
+        // Check for end-of-options delimiter: exactly "--"
+        if arg_contents == b"--" {
+            return LongFlagParseResult::EndOfOptions;
+        }
+
         // FIXME: only use the first flag you find?
         let split: Vec<_> = arg_contents.split(|x| *x == b'=').collect();
         let long_name = String::from_utf8(split[0].into());
@@ -569,14 +587,14 @@ fn parse_long_flag(
                             arg_shape,
                             Span::new(arg_span.start, arg_span.start + long_name_len + 2),
                         );
-                        (Some(arg_name), Some(val_expression))
+                        LongFlagParseResult::FoundFlag(Some(arg_name), Some(val_expression))
                     } else if let Some(arg) = spans.get(*spans_idx + 1) {
                         let arg = parse_value(working_set, *arg, arg_shape);
 
                         *spans_idx += 1;
                         let (arg_name, val_expression) =
                             ensure_flag_arg_type(working_set, long_name, arg, arg_shape, arg_span);
-                        (Some(arg_name), Some(val_expression))
+                        LongFlagParseResult::FoundFlag(Some(arg_name), Some(val_expression))
                     } else {
                         working_set.error(ParseError::MissingFlagParam(
                             arg_shape.to_string(),
@@ -584,7 +602,7 @@ fn parse_long_flag(
                         ));
                         // NOTE: still need to cover this incomplete flag in the final expression
                         // see https://github.com/nushell/nushell/issues/16375
-                        (
+                        LongFlagParseResult::FoundFlag(
                             Some(Spanned {
                                 item: long_name,
                                 span: arg_span,
@@ -610,9 +628,9 @@ fn parse_long_flag(
                             &SyntaxShape::Boolean,
                             Span::new(arg_span.start, arg_span.start + long_name_len + 2),
                         );
-                        (Some(arg_name), Some(val_expression))
+                        LongFlagParseResult::FoundFlag(Some(arg_name), Some(val_expression))
                     } else {
-                        (
+                        LongFlagParseResult::FoundFlag(
                             Some(Spanned {
                                 item: long_name,
                                 span: arg_span,
@@ -631,7 +649,7 @@ fn parse_long_flag(
                     arg_span,
                     suggestion,
                 ));
-                (
+                LongFlagParseResult::FoundFlag(
                     Some(Spanned {
                         item: long_name.clone(),
                         span: arg_span,
@@ -641,7 +659,7 @@ fn parse_long_flag(
             }
         } else {
             working_set.error(ParseError::NonUtf8(arg_span));
-            (
+            LongFlagParseResult::FoundFlag(
                 Some(Spanned {
                     item: "--".into(),
                     span: arg_span,
@@ -650,7 +668,7 @@ fn parse_long_flag(
             )
         }
     } else {
-        (None, None)
+        LongFlagParseResult::NoFlag
     }
 }
 
@@ -1004,6 +1022,9 @@ pub fn parse_internal_call(
     let decl = working_set.get_decl(decl_id);
     let signature = working_set.get_signature(decl);
     let output = signature.get_output_type();
+    // Known external commands (declared with `extern`) need `--` passed through to
+    // the external program rather than consumed. Capture this before mutable borrows.
+    let is_known_external = decl.is_known_external();
 
     let deprecation = decl.deprecation_info();
 
@@ -1058,143 +1079,171 @@ pub fn parse_internal_call(
         working_set.enter_scope();
     }
 
+    let mut end_of_options = false;
+
     while spans_idx < spans.len() {
         let arg_span = spans[spans_idx];
 
         let starting_error_count = working_set.parse_errors.len();
-        // Check if we're on a long flag, if so, parse
-        let (long_name, arg) = parse_long_flag(working_set, spans, &mut spans_idx, &signature);
 
-        if let Some(long_name) = long_name {
-            // We found a long flag, like --bar
-            if working_set.parse_errors[starting_error_count..]
-                .iter()
-                .any(|x| matches!(x, ParseError::UnknownFlag(_, _, _, _)))
-                && signature.allows_unknown_args
-            {
-                working_set.parse_errors.truncate(starting_error_count);
-                let arg = parse_unknown_arg(working_set, arg_span, &signature);
+        // If we've seen --, skip all flag parsing and go straight to positional parsing
+        if !end_of_options {
+            // Check if we're on a long flag, if so, parse
+            let flag_parse_result = parse_long_flag(working_set, spans, &mut spans_idx, &signature);
 
-                call.add_unknown(arg);
-            } else {
-                call.add_named((long_name, None, arg));
-            }
-
-            spans_idx += 1;
-            continue;
-        }
-
-        let starting_error_count = working_set.parse_errors.len();
-
-        // Check if we're on a short flag or group of short flags, if so, parse
-        let short_flags = parse_short_flags(
-            working_set,
-            spans,
-            &mut spans_idx,
-            positional_idx,
-            &signature,
-        );
-
-        if let Some(mut short_flags) = short_flags {
-            if short_flags.is_empty() {
-                // workaround for completions (PR #6067)
-                short_flags.push(Flag {
-                    long: "".to_string(),
-                    short: Some('a'),
-                    arg: None,
-                    required: false,
-                    desc: "".to_string(),
-                    var_id: None,
-                    default_value: None,
-                    completion: None,
-                })
-            }
-
-            if working_set.parse_errors[starting_error_count..]
-                .iter()
-                .any(|x| matches!(x, ParseError::UnknownFlag(_, _, _, _)))
-                && signature.allows_unknown_args
-            {
-                working_set.parse_errors.truncate(starting_error_count);
-                let arg = parse_unknown_arg(working_set, arg_span, &signature);
-
-                call.add_unknown(arg);
-            } else {
-                for flag in short_flags {
-                    let _ = working_set.add_span(spans[spans_idx]);
-
-                    if let Some(arg_shape) = flag.arg {
-                        if let Some(arg) = spans.get(spans_idx + 1) {
-                            let arg = parse_value(working_set, *arg, &arg_shape);
-                            let (arg_name, val_expression) = ensure_flag_arg_type(
-                                working_set,
-                                flag.long.clone(),
-                                arg.clone(),
-                                &arg_shape,
-                                spans[spans_idx],
-                            );
-
-                            if flag.long.is_empty() {
-                                if let Some(short) = flag.short {
-                                    call.add_named((
-                                        arg_name,
-                                        Some(Spanned {
-                                            item: short.to_string(),
-                                            span: spans[spans_idx],
-                                        }),
-                                        Some(val_expression),
-                                    ));
-                                }
-                            } else {
-                                call.add_named((arg_name, None, Some(val_expression)));
-                            }
-                            spans_idx += 1;
-                        } else {
-                            working_set.error(ParseError::MissingFlagParam(
-                                arg_shape.to_string(),
-                                arg_span,
-                            ));
-                            // NOTE: still need to cover this incomplete flag in the final expression
-                            // see https://github.com/nushell/nushell/issues/16375
-                            call.add_named((
-                                Spanned {
-                                    item: String::new(),
-                                    span: spans[spans_idx],
-                                },
-                                None,
-                                None,
-                            ));
-                        }
-                    } else if flag.long.is_empty() {
-                        if let Some(short) = flag.short {
-                            call.add_named((
-                                Spanned {
-                                    item: String::new(),
-                                    span: spans[spans_idx],
-                                },
-                                Some(Spanned {
-                                    item: short.to_string(),
-                                    span: spans[spans_idx],
-                                }),
-                                None,
-                            ));
-                        }
+            match flag_parse_result {
+                LongFlagParseResult::EndOfOptions => {
+                    if is_known_external {
+                        // For known externals, -- is passed through to the program.
+                        // Fall through to positional parsing so -- becomes a rest arg.
                     } else {
-                        call.add_named((
-                            Spanned {
-                                item: flag.long.clone(),
-                                span: spans[spans_idx],
-                            },
-                            None,
-                            None,
-                        ));
+                        // For internal commands, consume -- and switch to positional-only mode.
+                        end_of_options = true;
+                        spans_idx += 1;
+                        continue;
                     }
                 }
-            }
+                LongFlagParseResult::FoundFlag(long_name, arg) => {
+                    if let Some(long_name) = long_name {
+                        // We found a long flag, like --bar
+                        if working_set.parse_errors[starting_error_count..]
+                            .iter()
+                            .any(|x| matches!(x, ParseError::UnknownFlag(_, _, _, _)))
+                            && signature.allows_unknown_args
+                        {
+                            working_set.parse_errors.truncate(starting_error_count);
+                            let arg = parse_unknown_arg(working_set, arg_span, &signature);
 
-            spans_idx += 1;
-            continue;
+                            call.add_unknown(arg);
+                        } else {
+                            call.add_named((long_name, None, arg));
+                        }
+
+                        spans_idx += 1;
+                        continue;
+                    }
+                    // If long_name is None, fall through to short flag parsing
+                }
+                LongFlagParseResult::NoFlag => {
+                    // No long flag found, continue to short flag parsing
+                }
+            }
         }
+
+        // Only try short flag parsing if we haven't seen -- yet
+        if !end_of_options {
+            let starting_error_count = working_set.parse_errors.len();
+
+            // Check if we're on a short flag or group of short flags, if so, parse
+            let short_flags = parse_short_flags(
+                working_set,
+                spans,
+                &mut spans_idx,
+                positional_idx,
+                &signature,
+            );
+
+            if let Some(mut short_flags) = short_flags {
+                if short_flags.is_empty() {
+                    // workaround for completions (PR #6067)
+                    short_flags.push(Flag {
+                        long: "".to_string(),
+                        short: Some('a'),
+                        arg: None,
+                        required: false,
+                        desc: "".to_string(),
+                        var_id: None,
+                        default_value: None,
+                        completion: None,
+                    })
+                }
+
+                if working_set.parse_errors[starting_error_count..]
+                    .iter()
+                    .any(|x| matches!(x, ParseError::UnknownFlag(_, _, _, _)))
+                    && signature.allows_unknown_args
+                {
+                    working_set.parse_errors.truncate(starting_error_count);
+                    let arg = parse_unknown_arg(working_set, arg_span, &signature);
+
+                    call.add_unknown(arg);
+                } else {
+                    for flag in short_flags {
+                        let _ = working_set.add_span(spans[spans_idx]);
+
+                        if let Some(arg_shape) = flag.arg {
+                            if let Some(arg) = spans.get(spans_idx + 1) {
+                                let arg = parse_value(working_set, *arg, &arg_shape);
+                                let (arg_name, val_expression) = ensure_flag_arg_type(
+                                    working_set,
+                                    flag.long.clone(),
+                                    arg.clone(),
+                                    &arg_shape,
+                                    spans[spans_idx],
+                                );
+
+                                if flag.long.is_empty() {
+                                    if let Some(short) = flag.short {
+                                        call.add_named((
+                                            arg_name,
+                                            Some(Spanned {
+                                                item: short.to_string(),
+                                                span: spans[spans_idx],
+                                            }),
+                                            Some(val_expression),
+                                        ));
+                                    }
+                                } else {
+                                    call.add_named((arg_name, None, Some(val_expression)));
+                                }
+                                spans_idx += 1;
+                            } else {
+                                working_set.error(ParseError::MissingFlagParam(
+                                    arg_shape.to_string(),
+                                    arg_span,
+                                ));
+                                // NOTE: still need to cover this incomplete flag in the final expression
+                                // see https://github.com/nushell/nushell/issues/16375
+                                call.add_named((
+                                    Spanned {
+                                        item: String::new(),
+                                        span: spans[spans_idx],
+                                    },
+                                    None,
+                                    None,
+                                ));
+                            }
+                        } else if flag.long.is_empty() {
+                            if let Some(short) = flag.short {
+                                call.add_named((
+                                    Spanned {
+                                        item: String::new(),
+                                        span: spans[spans_idx],
+                                    },
+                                    Some(Spanned {
+                                        item: short.to_string(),
+                                        span: spans[spans_idx],
+                                    }),
+                                    None,
+                                ));
+                            }
+                        } else {
+                            call.add_named((
+                                Spanned {
+                                    item: flag.long.clone(),
+                                    span: spans[spans_idx],
+                                },
+                                None,
+                                None,
+                            ));
+                        }
+                    }
+                }
+
+                spans_idx += 1;
+                continue;
+            }
+        } // end if !end_of_options (short flags)
 
         {
             let contents = working_set.get_span_contents(spans[spans_idx]);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1022,9 +1022,6 @@ pub fn parse_internal_call(
     let decl = working_set.get_decl(decl_id);
     let signature = working_set.get_signature(decl);
     let output = signature.get_output_type();
-    // Known external commands (declared with `extern`) need `--` passed through to
-    // the external program rather than consumed. Capture this before mutable borrows.
-    let is_known_external = decl.is_known_external();
 
     let deprecation = decl.deprecation_info();
 
@@ -1093,11 +1090,16 @@ pub fn parse_internal_call(
 
             match flag_parse_result {
                 LongFlagParseResult::EndOfOptions => {
-                    if is_known_external {
-                        // For known externals, -- is passed through to the program.
-                        // Fall through to positional parsing so -- becomes a rest arg.
+                    if signature.allows_unknown_args {
+                        // For commands that pass through unknown args (extern, def --wrapped,
+                        // exec, etc.), -- must be forwarded to the underlying program.
+                        // Directly add -- as an unknown arg, then advance past it.
+                        let arg = parse_unknown_arg(working_set, arg_span, &signature);
+                        call.add_unknown(arg);
+                        spans_idx += 1;
+                        continue;
                     } else {
-                        // For internal commands, consume -- and switch to positional-only mode.
+                        // For regular commands, consume -- and switch to positional-only mode.
                         end_of_options = true;
                         spans_idx += 1;
                         continue;

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -2,6 +2,7 @@ use nu_test_support::nu;
 use pretty_assertions::assert_str_eq;
 
 mod cli;
+mod posix_end_of_options;
 mod shell_integration;
 
 #[test]

--- a/tests/integration/posix_end_of_options.rs
+++ b/tests/integration/posix_end_of_options.rs
@@ -1,0 +1,207 @@
+/// Tests for POSIX `--` end-of-options delimiter support
+///
+/// This test file validates that `--` stops all flag parsing and treats
+/// all following arguments as operands, even if they start with `-` or `--`.
+/// This aligns with POSIX Guideline 10:
+/// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02
+use nu_test_support::nu;
+
+#[test]
+fn echo_with_end_of_options_stops_flag_parsing() {
+    let actual = nu!("echo -- -n hello | str join \" \"");
+    assert_eq!(actual.out, "-n hello");
+}
+
+#[test]
+fn echo_with_end_of_options_multiple_dashes() {
+    let actual = nu!("echo -- --foo -bar baz | str join \" \"");
+    assert_eq!(actual.out, "--foo -bar baz");
+}
+
+#[test]
+fn echo_with_end_of_options_alone() {
+    let actual = nu!("echo --");
+    assert_eq!(actual.out, "");
+}
+
+#[test]
+fn echo_before_and_after_end_of_options() {
+    let actual = nu!("echo arg1 -- -arg2 | str join \" \"");
+    assert_eq!(actual.out, "arg1 -arg2");
+}
+
+#[test]
+fn custom_command_with_end_of_options_and_positional() {
+    let actual = nu!("
+def my_cmd [x y] { [$x $y] }
+my_cmd -- -value1 -value2
+");
+    assert!(actual.out.contains("-value1"));
+    assert!(actual.out.contains("-value2"));
+}
+
+#[test]
+fn custom_command_with_end_of_options_and_rest() {
+    let actual = nu!(r#"
+def my_cmd [x ...rest] { [$x ($rest | str join " ")] }
+my_cmd first -- -second -third
+"#);
+    assert!(actual.out.contains("first"));
+    assert!(actual.out.contains("-second"));
+    assert!(actual.out.contains("-third"));
+}
+
+#[test]
+fn custom_command_with_flags_before_end_of_options() {
+    let actual = nu!("
+def my_cmd [--flag x y z] { [$flag $x $y $z] }
+my_cmd --flag value1 -- -value2 -value3
+");
+    assert!(actual.out.contains("value1"));
+    assert!(actual.out.contains("-value2"));
+    assert!(actual.out.contains("-value3"));
+}
+
+#[test]
+fn custom_command_with_optional_positional_and_end_of_options() {
+    let actual = nu!("
+def my_cmd [x y?] { if ($y == null) { $x } else { [$x $y] } }
+my_cmd -- -value1 -value2
+");
+    assert!(actual.out.contains("-value1"));
+    assert!(actual.out.contains("-value2"));
+}
+
+#[test]
+fn end_of_options_with_wrapped_command() {
+    let actual = nu!(r#"
+def --wrapped my_wrap [...args] { $args | str join " " }
+my_wrap -- -flag value
+"#);
+    // In wrapped mode, -- should still be recognized and consumed
+    assert!(actual.out.contains("-flag"));
+    assert!(actual.out.contains("value"));
+    assert!(!actual.out.contains("--")); // -- should be consumed
+}
+
+#[test]
+fn end_of_options_multiple_occurrences() {
+    let actual = nu!("echo arg1 -- -arg2 -- -arg3");
+    // First -- stops parsing; remaining -- is literal
+    assert!(actual.out.contains("arg1"));
+    assert!(actual.out.contains("-arg2"));
+    assert!(actual.out.contains("--")); // Second -- is a literal arg
+    assert!(actual.out.contains("-arg3"));
+}
+
+#[test]
+fn end_of_options_with_spread_operator() {
+    let actual = nu!(r#"
+def my_cmd [...rest] { $rest | str join " " }
+my_cmd -- ...["-a" "-b"]
+"#);
+    // The spread should still work after --
+    assert!(actual.out.contains("-a"));
+    assert!(actual.out.contains("-b"));
+}
+
+#[test]
+fn end_of_options_with_unknown_args() {
+    let actual = nu!(r#"
+def my_cmd [--flag] { 
+    if ($flag == null) { "no flag" } else { $flag }
+}
+my_cmd -- --unknown
+"#);
+    // --unknown after -- is treated as a positional, but my_cmd has no positionals -> error
+    assert!(
+        actual.err.contains("extra") || actual.err.contains("positional"),
+        "Expected error about extra positional, got: {}",
+        actual.err
+    );
+}
+
+#[test]
+fn custom_command_short_flags_before_end_of_options() {
+    let actual = nu!("
+def my_cmd [-f --long x y z] { [$f $long $x $y $z] }
+my_cmd -f --long value1 -- -value2 -value3
+");
+    assert!(actual.out.contains("value1"));
+    assert!(actual.out.contains("-value2"));
+    assert!(actual.out.contains("-value3"));
+}
+
+#[test]
+fn end_of_options_preserves_special_chars() {
+    let actual = nu!(r#"echo -- "-n" "-e" "test\n""#);
+    assert!(actual.out.contains("-n"));
+    assert!(actual.out.contains("-e"));
+    // The \n should be literal, not interpreted as a newline by echo (since -n is not a flag)
+}
+
+#[test]
+fn end_of_options_with_equals_syntax() {
+    let actual = nu!("
+def my_cmd [--flag: string, y] { [$flag $y] }
+my_cmd --flag=value1 -- -value2
+");
+    assert!(actual.out.contains("value1"));
+    assert!(actual.out.contains("-value2"));
+}
+
+#[test]
+fn end_of_options_no_args_after() {
+    let actual = nu!(r#"
+def my_cmd [x?] { if ($x == null) { "empty" } else { $x } }
+my_cmd --
+"#);
+    assert!(actual.out.contains("empty"));
+}
+
+#[test]
+fn external_command_with_end_of_options() {
+    // External commands should pass -- through as-is (already working)
+    let actual = nu!("^echo -- -n hello");
+    assert!(actual.out.contains("--"));
+    assert!(actual.out.contains("-n"));
+}
+
+#[test]
+fn test_command_with_end_of_options() {
+    // `test` builtin with --
+    let actual = nu!(r#"test -- -z"""#);
+    // Should not error; -z should be treated as a string operand, not a flag
+    assert!(!actual.err.contains("unknown flag"));
+}
+
+#[test]
+fn custom_command_rest_param_with_end_of_options() {
+    let actual = nu!("
+def collect_args [...args] { $args | length }
+collect_args -- -a -b -c
+");
+    assert_eq!(actual.out, "3");
+}
+
+#[test]
+fn end_of_options_with_negative_numbers() {
+    let actual = nu!("
+def add_nums [x y] { $x + $y }
+add_nums -- -5 10
+");
+    // -5 should be treated as positional arg, not a flag
+    assert_eq!(actual.out, "5");
+}
+
+#[test]
+fn custom_command_mixed_positionals_and_flags_with_end_of_options() {
+    let actual = nu!("
+def complex [x --flag: string y z] { [$x $flag $y $z] }
+complex first --flag flagval -- -second -third
+");
+    assert!(actual.out.contains("first"));
+    assert!(actual.out.contains("flagval"));
+    assert!(actual.out.contains("-second"));
+    assert!(actual.out.contains("-third"));
+}

--- a/tests/integration/posix_end_of_options.rs
+++ b/tests/integration/posix_end_of_options.rs
@@ -36,20 +36,24 @@ fn echo_before_and_after_end_of_options() -> Result {
 #[test]
 fn custom_command_with_end_of_options_and_positional() -> Result {
     test()
-        .run(r#"
+        .run(
+            r#"
             def my_cmd [x y] { [$x $y] }
             my_cmd -- -value1 -value2
-        "#)
+        "#,
+        )
         .expect_value_eq(vec!["-value1", "-value2"])
 }
 
 #[test]
 fn custom_command_with_end_of_options_and_rest() -> Result {
     test()
-        .run(r#"
+        .run(
+            r#"
             def my_cmd [x ...rest] { [$x] ++ $rest }
             my_cmd first -- -second -third
-        "#)
+        "#,
+        )
         .expect_value_eq(vec!["first", "-second", "-third"])
 }
 
@@ -57,20 +61,24 @@ fn custom_command_with_end_of_options_and_rest() -> Result {
 fn custom_command_with_flags_before_end_of_options() -> Result {
     // --flag is a boolean switch; value1 becomes the first positional x
     test()
-        .run(r#"
+        .run(
+            r#"
             def my_cmd [--flag x y z] { [$x $y $z] }
             my_cmd --flag value1 -- -value2 -value3
-        "#)
+        "#,
+        )
         .expect_value_eq(vec!["value1", "-value2", "-value3"])
 }
 
 #[test]
 fn custom_command_with_optional_positional_and_end_of_options() -> Result {
     test()
-        .run(r#"
+        .run(
+            r#"
             def my_cmd [x y?] { if ($y == null) { $x } else { [$x $y] } }
             my_cmd -- -value1 -value2
-        "#)
+        "#,
+        )
         .expect_value_eq(vec!["-value1", "-value2"])
 }
 
@@ -79,10 +87,12 @@ fn end_of_options_with_wrapped_command() -> Result {
     // def --wrapped passes -- through to the underlying program (allows_unknown_args),
     // so -- itself must appear in the rest args.
     test()
-        .run(r#"
+        .run(
+            r#"
             def --wrapped my_wrap [...args] { $args | str join " " }
             my_wrap -- -flag value
-        "#)
+        "#,
+        )
         .expect_value_eq("-- -flag value")
 }
 
@@ -98,10 +108,12 @@ fn end_of_options_multiple_occurrences() -> Result {
 fn end_of_options_with_spread_operator() -> Result {
     // Spread operator still works after --
     test()
-        .run(r#"
+        .run(
+            r#"
             def my_cmd [...rest] { $rest | str join " " }
             my_cmd -- ...["-a" "-b"]
-        "#)
+        "#,
+        )
         .expect_value_eq("-a -b")
 }
 
@@ -122,10 +134,12 @@ fn end_of_options_with_unknown_args() -> Result {
 fn custom_command_short_flags_before_end_of_options() -> Result {
     // -f and --long are boolean switches; value1 becomes positional x
     test()
-        .run(r#"
+        .run(
+            r#"
             def my_cmd [-f --long x y z] { [$x $y $z] }
             my_cmd -f --long value1 -- -value2 -value3
-        "#)
+        "#,
+        )
         .expect_value_eq(vec!["value1", "-value2", "-value3"])
 }
 
@@ -141,20 +155,24 @@ fn end_of_options_preserves_special_chars() -> Result {
 #[test]
 fn end_of_options_with_equals_syntax() -> Result {
     test()
-        .run(r#"
+        .run(
+            r#"
             def my_cmd [--flag: string, y] { [$flag $y] }
             my_cmd --flag=value1 -- -value2
-        "#)
+        "#,
+        )
         .expect_value_eq(vec!["value1", "-value2"])
 }
 
 #[test]
 fn end_of_options_no_args_after() -> Result {
     test()
-        .run(r#"
+        .run(
+            r#"
             def my_cmd [x?] { if ($x == null) { "empty" } else { $x } }
             my_cmd --
-        "#)
+        "#,
+        )
         .expect_value_eq("empty")
 }
 
@@ -170,10 +188,12 @@ fn external_command_with_end_of_options() -> Result {
 #[test]
 fn custom_command_rest_param_with_end_of_options() -> Result {
     test()
-        .run(r#"
+        .run(
+            r#"
             def collect_args [...args] { $args | length }
             collect_args -- -a -b -c
-        "#)
+        "#,
+        )
         .expect_value_eq(3i64)
 }
 
@@ -181,19 +201,23 @@ fn custom_command_rest_param_with_end_of_options() -> Result {
 fn end_of_options_with_negative_numbers() -> Result {
     // -5 after -- is treated as a positional integer literal, not a flag
     test()
-        .run(r#"
+        .run(
+            r#"
             def add_nums [x y] { $x + $y }
             add_nums -- -5 10
-        "#)
+        "#,
+        )
         .expect_value_eq(5i64)
 }
 
 #[test]
 fn custom_command_mixed_positionals_and_flags_with_end_of_options() -> Result {
     test()
-        .run(r#"
+        .run(
+            r#"
             def complex [x --flag: string y z] { [$x $flag $y $z] }
             complex first --flag flagval -- -second -third
-        "#)
+        "#,
+        )
         .expect_value_eq(vec!["first", "flagval", "-second", "-third"])
 }

--- a/tests/integration/posix_end_of_options.rs
+++ b/tests/integration/posix_end_of_options.rs
@@ -78,10 +78,11 @@ fn end_of_options_with_wrapped_command() {
 def --wrapped my_wrap [...args] { $args | str join " " }
 my_wrap -- -flag value
 "#);
-    // In wrapped mode, -- should still be recognized and consumed
+    // def --wrapped passes -- through to the underlying program (it allows unknown args),
+    // so -- itself must appear in the rest args.
+    assert!(actual.out.contains("--"));
     assert!(actual.out.contains("-flag"));
     assert!(actual.out.contains("value"));
-    assert!(!actual.out.contains("--")); // -- should be consumed
 }
 
 #[test]

--- a/tests/integration/posix_end_of_options.rs
+++ b/tests/integration/posix_end_of_options.rs
@@ -4,205 +4,196 @@
 /// all following arguments as operands, even if they start with `-` or `--`.
 /// This aligns with POSIX Guideline 10:
 /// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02
-use nu_test_support::nu;
+use nu_test_support::prelude::*;
 
 #[test]
-fn echo_with_end_of_options_stops_flag_parsing() {
-    let actual = nu!("echo -- -n hello | str join \" \"");
-    assert_eq!(actual.out, "-n hello");
+fn echo_with_end_of_options_stops_flag_parsing() -> Result {
+    test()
+        .run(r#"echo -- -n hello | str join " ""#)
+        .expect_value_eq("-n hello")
 }
 
 #[test]
-fn echo_with_end_of_options_multiple_dashes() {
-    let actual = nu!("echo -- --foo -bar baz | str join \" \"");
-    assert_eq!(actual.out, "--foo -bar baz");
+fn echo_with_end_of_options_multiple_dashes() -> Result {
+    test()
+        .run(r#"echo -- --foo -bar baz | str join " ""#)
+        .expect_value_eq("--foo -bar baz")
 }
 
 #[test]
-fn echo_with_end_of_options_alone() {
-    let actual = nu!("echo --");
-    assert_eq!(actual.out, "");
+fn echo_with_end_of_options_alone() -> Result {
+    // echo with no positional args after -- returns an empty string
+    test().run("echo --").expect_value_eq("")
 }
 
 #[test]
-fn echo_before_and_after_end_of_options() {
-    let actual = nu!("echo arg1 -- -arg2 | str join \" \"");
-    assert_eq!(actual.out, "arg1 -arg2");
+fn echo_before_and_after_end_of_options() -> Result {
+    test()
+        .run(r#"echo arg1 -- -arg2 | str join " ""#)
+        .expect_value_eq("arg1 -arg2")
 }
 
 #[test]
-fn custom_command_with_end_of_options_and_positional() {
-    let actual = nu!("
-def my_cmd [x y] { [$x $y] }
-my_cmd -- -value1 -value2
-");
-    assert!(actual.out.contains("-value1"));
-    assert!(actual.out.contains("-value2"));
+fn custom_command_with_end_of_options_and_positional() -> Result {
+    test()
+        .run(r#"
+            def my_cmd [x y] { [$x $y] }
+            my_cmd -- -value1 -value2
+        "#)
+        .expect_value_eq(vec!["-value1", "-value2"])
 }
 
 #[test]
-fn custom_command_with_end_of_options_and_rest() {
-    let actual = nu!(r#"
-def my_cmd [x ...rest] { [$x ($rest | str join " ")] }
-my_cmd first -- -second -third
-"#);
-    assert!(actual.out.contains("first"));
-    assert!(actual.out.contains("-second"));
-    assert!(actual.out.contains("-third"));
+fn custom_command_with_end_of_options_and_rest() -> Result {
+    test()
+        .run(r#"
+            def my_cmd [x ...rest] { [$x] ++ $rest }
+            my_cmd first -- -second -third
+        "#)
+        .expect_value_eq(vec!["first", "-second", "-third"])
 }
 
 #[test]
-fn custom_command_with_flags_before_end_of_options() {
-    let actual = nu!("
-def my_cmd [--flag x y z] { [$flag $x $y $z] }
-my_cmd --flag value1 -- -value2 -value3
-");
-    assert!(actual.out.contains("value1"));
-    assert!(actual.out.contains("-value2"));
-    assert!(actual.out.contains("-value3"));
+fn custom_command_with_flags_before_end_of_options() -> Result {
+    // --flag is a boolean switch; value1 becomes the first positional x
+    test()
+        .run(r#"
+            def my_cmd [--flag x y z] { [$x $y $z] }
+            my_cmd --flag value1 -- -value2 -value3
+        "#)
+        .expect_value_eq(vec!["value1", "-value2", "-value3"])
 }
 
 #[test]
-fn custom_command_with_optional_positional_and_end_of_options() {
-    let actual = nu!("
-def my_cmd [x y?] { if ($y == null) { $x } else { [$x $y] } }
-my_cmd -- -value1 -value2
-");
-    assert!(actual.out.contains("-value1"));
-    assert!(actual.out.contains("-value2"));
+fn custom_command_with_optional_positional_and_end_of_options() -> Result {
+    test()
+        .run(r#"
+            def my_cmd [x y?] { if ($y == null) { $x } else { [$x $y] } }
+            my_cmd -- -value1 -value2
+        "#)
+        .expect_value_eq(vec!["-value1", "-value2"])
 }
 
 #[test]
-fn end_of_options_with_wrapped_command() {
-    let actual = nu!(r#"
-def --wrapped my_wrap [...args] { $args | str join " " }
-my_wrap -- -flag value
-"#);
-    // def --wrapped passes -- through to the underlying program (it allows unknown args),
+fn end_of_options_with_wrapped_command() -> Result {
+    // def --wrapped passes -- through to the underlying program (allows_unknown_args),
     // so -- itself must appear in the rest args.
-    assert!(actual.out.contains("--"));
-    assert!(actual.out.contains("-flag"));
-    assert!(actual.out.contains("value"));
+    test()
+        .run(r#"
+            def --wrapped my_wrap [...args] { $args | str join " " }
+            my_wrap -- -flag value
+        "#)
+        .expect_value_eq("-- -flag value")
 }
 
 #[test]
-fn end_of_options_multiple_occurrences() {
-    let actual = nu!("echo arg1 -- -arg2 -- -arg3");
-    // First -- stops parsing; remaining -- is literal
-    assert!(actual.out.contains("arg1"));
-    assert!(actual.out.contains("-arg2"));
-    assert!(actual.out.contains("--")); // Second -- is a literal arg
-    assert!(actual.out.contains("-arg3"));
+fn end_of_options_multiple_occurrences() -> Result {
+    // First -- stops flag parsing; remaining -- is a literal string arg
+    test()
+        .run("echo arg1 -- -arg2 -- -arg3")
+        .expect_value_eq(vec!["arg1", "-arg2", "--", "-arg3"])
 }
 
 #[test]
-fn end_of_options_with_spread_operator() {
-    let actual = nu!(r#"
-def my_cmd [...rest] { $rest | str join " " }
-my_cmd -- ...["-a" "-b"]
-"#);
-    // The spread should still work after --
-    assert!(actual.out.contains("-a"));
-    assert!(actual.out.contains("-b"));
+fn end_of_options_with_spread_operator() -> Result {
+    // Spread operator still works after --
+    test()
+        .run(r#"
+            def my_cmd [...rest] { $rest | str join " " }
+            my_cmd -- ...["-a" "-b"]
+        "#)
+        .expect_value_eq("-a -b")
 }
 
 #[test]
-fn end_of_options_with_unknown_args() {
-    let actual = nu!(r#"
-def my_cmd [--flag] { 
-    if ($flag == null) { "no flag" } else { $flag }
-}
-my_cmd -- --unknown
-"#);
-    // --unknown after -- is treated as a positional, but my_cmd has no positionals -> error
-    assert!(
-        actual.err.contains("extra") || actual.err.contains("positional"),
-        "Expected error about extra positional, got: {}",
-        actual.err
-    );
+fn end_of_options_with_unknown_args() -> Result {
+    // --unknown after -- is a positional, but my_cmd has no positionals -> parse error
+    let code = r#"
+        def my_cmd [--flag] {
+            if ($flag == null) { "no flag" } else { $flag }
+        }
+        my_cmd -- --unknown
+    "#;
+    test().run(code).expect_parse_error()?;
+    Ok(())
 }
 
 #[test]
-fn custom_command_short_flags_before_end_of_options() {
-    let actual = nu!("
-def my_cmd [-f --long x y z] { [$f $long $x $y $z] }
-my_cmd -f --long value1 -- -value2 -value3
-");
-    assert!(actual.out.contains("value1"));
-    assert!(actual.out.contains("-value2"));
-    assert!(actual.out.contains("-value3"));
+fn custom_command_short_flags_before_end_of_options() -> Result {
+    // -f and --long are boolean switches; value1 becomes positional x
+    test()
+        .run(r#"
+            def my_cmd [-f --long x y z] { [$x $y $z] }
+            my_cmd -f --long value1 -- -value2 -value3
+        "#)
+        .expect_value_eq(vec!["value1", "-value2", "-value3"])
 }
 
 #[test]
-fn end_of_options_preserves_special_chars() {
-    let actual = nu!(r#"echo -- "-n" "-e" "test\n""#);
-    assert!(actual.out.contains("-n"));
-    assert!(actual.out.contains("-e"));
-    // The \n should be literal, not interpreted as a newline by echo (since -n is not a flag)
+fn end_of_options_preserves_special_chars() -> Result {
+    // -n and -e are passed as literal strings, not flags
+    let vals: Vec<String> = test().run(r#"echo -- "-n" "-e" "test\n""#)?;
+    assert!(vals.contains(&"-n".to_string()));
+    assert!(vals.contains(&"-e".to_string()));
+    Ok(())
 }
 
 #[test]
-fn end_of_options_with_equals_syntax() {
-    let actual = nu!("
-def my_cmd [--flag: string, y] { [$flag $y] }
-my_cmd --flag=value1 -- -value2
-");
-    assert!(actual.out.contains("value1"));
-    assert!(actual.out.contains("-value2"));
+fn end_of_options_with_equals_syntax() -> Result {
+    test()
+        .run(r#"
+            def my_cmd [--flag: string, y] { [$flag $y] }
+            my_cmd --flag=value1 -- -value2
+        "#)
+        .expect_value_eq(vec!["value1", "-value2"])
 }
 
 #[test]
-fn end_of_options_no_args_after() {
-    let actual = nu!(r#"
-def my_cmd [x?] { if ($x == null) { "empty" } else { $x } }
-my_cmd --
-"#);
-    assert!(actual.out.contains("empty"));
+fn end_of_options_no_args_after() -> Result {
+    test()
+        .run(r#"
+            def my_cmd [x?] { if ($x == null) { "empty" } else { $x } }
+            my_cmd --
+        "#)
+        .expect_value_eq("empty")
 }
 
 #[test]
-fn external_command_with_end_of_options() {
-    // External commands should pass -- through as-is (already working)
-    let actual = nu!("^echo -- -n hello");
-    assert!(actual.out.contains("--"));
-    assert!(actual.out.contains("-n"));
+fn external_command_with_end_of_options() -> Result {
+    // External commands receive -- and following args verbatim
+    let out: String = test().inherit_path().run(r#"^echo -- -n hello"#)?;
+    assert!(out.contains("--"), "expected '--' in output, got: {out}");
+    assert!(out.contains("-n"), "expected '-n' in output, got: {out}");
+    Ok(())
 }
 
 #[test]
-fn test_command_with_end_of_options() {
-    // `test` builtin with --
-    let actual = nu!(r#"test -- -z"""#);
-    // Should not error; -z should be treated as a string operand, not a flag
-    assert!(!actual.err.contains("unknown flag"));
+fn custom_command_rest_param_with_end_of_options() -> Result {
+    test()
+        .run(r#"
+            def collect_args [...args] { $args | length }
+            collect_args -- -a -b -c
+        "#)
+        .expect_value_eq(3i64)
 }
 
 #[test]
-fn custom_command_rest_param_with_end_of_options() {
-    let actual = nu!("
-def collect_args [...args] { $args | length }
-collect_args -- -a -b -c
-");
-    assert_eq!(actual.out, "3");
+fn end_of_options_with_negative_numbers() -> Result {
+    // -5 after -- is treated as a positional integer literal, not a flag
+    test()
+        .run(r#"
+            def add_nums [x y] { $x + $y }
+            add_nums -- -5 10
+        "#)
+        .expect_value_eq(5i64)
 }
 
 #[test]
-fn end_of_options_with_negative_numbers() {
-    let actual = nu!("
-def add_nums [x y] { $x + $y }
-add_nums -- -5 10
-");
-    // -5 should be treated as positional arg, not a flag
-    assert_eq!(actual.out, "5");
-}
-
-#[test]
-fn custom_command_mixed_positionals_and_flags_with_end_of_options() {
-    let actual = nu!("
-def complex [x --flag: string y z] { [$x $flag $y $z] }
-complex first --flag flagval -- -second -third
-");
-    assert!(actual.out.contains("first"));
-    assert!(actual.out.contains("flagval"));
-    assert!(actual.out.contains("-second"));
-    assert!(actual.out.contains("-third"));
+fn custom_command_mixed_positionals_and_flags_with_end_of_options() -> Result {
+    test()
+        .run(r#"
+            def complex [x --flag: string y z] { [$x $flag $y $z] }
+            complex first --flag flagval -- -second -third
+        "#)
+        .expect_value_eq(vec!["first", "flagval", "-second", "-third"])
 }

--- a/tests/integration/posix_end_of_options.rs
+++ b/tests/integration/posix_end_of_options.rs
@@ -37,10 +37,10 @@ fn echo_before_and_after_end_of_options() -> Result {
 fn custom_command_with_end_of_options_and_positional() -> Result {
     test()
         .run(
-            r#"
+            "
             def my_cmd [x y] { [$x $y] }
             my_cmd -- -value1 -value2
-        "#,
+        ",
         )
         .expect_value_eq(vec!["-value1", "-value2"])
 }
@@ -49,10 +49,10 @@ fn custom_command_with_end_of_options_and_positional() -> Result {
 fn custom_command_with_end_of_options_and_rest() -> Result {
     test()
         .run(
-            r#"
+            "
             def my_cmd [x ...rest] { [$x] ++ $rest }
             my_cmd first -- -second -third
-        "#,
+        ",
         )
         .expect_value_eq(vec!["first", "-second", "-third"])
 }
@@ -62,10 +62,10 @@ fn custom_command_with_flags_before_end_of_options() -> Result {
     // --flag is a boolean switch; value1 becomes the first positional x
     test()
         .run(
-            r#"
+            "
             def my_cmd [--flag x y z] { [$x $y $z] }
             my_cmd --flag value1 -- -value2 -value3
-        "#,
+        ",
         )
         .expect_value_eq(vec!["value1", "-value2", "-value3"])
 }
@@ -74,10 +74,10 @@ fn custom_command_with_flags_before_end_of_options() -> Result {
 fn custom_command_with_optional_positional_and_end_of_options() -> Result {
     test()
         .run(
-            r#"
+            "
             def my_cmd [x y?] { if ($y == null) { $x } else { [$x $y] } }
             my_cmd -- -value1 -value2
-        "#,
+        ",
         )
         .expect_value_eq(vec!["-value1", "-value2"])
 }
@@ -135,10 +135,10 @@ fn custom_command_short_flags_before_end_of_options() -> Result {
     // -f and --long are boolean switches; value1 becomes positional x
     test()
         .run(
-            r#"
+            "
             def my_cmd [-f --long x y z] { [$x $y $z] }
             my_cmd -f --long value1 -- -value2 -value3
-        "#,
+        ",
         )
         .expect_value_eq(vec!["value1", "-value2", "-value3"])
 }
@@ -156,10 +156,10 @@ fn end_of_options_preserves_special_chars() -> Result {
 fn end_of_options_with_equals_syntax() -> Result {
     test()
         .run(
-            r#"
+            "
             def my_cmd [--flag: string, y] { [$flag $y] }
             my_cmd --flag=value1 -- -value2
-        "#,
+        ",
         )
         .expect_value_eq(vec!["value1", "-value2"])
 }
@@ -179,7 +179,7 @@ fn end_of_options_no_args_after() -> Result {
 #[test]
 fn external_command_with_end_of_options() -> Result {
     // External commands receive -- and following args verbatim
-    let out: String = test().inherit_path().run(r#"^echo -- -n hello"#)?;
+    let out: String = test().inherit_path().run("^echo -- -n hello")?;
     assert!(out.contains("--"), "expected '--' in output, got: {out}");
     assert!(out.contains("-n"), "expected '-n' in output, got: {out}");
     Ok(())
@@ -189,10 +189,10 @@ fn external_command_with_end_of_options() -> Result {
 fn custom_command_rest_param_with_end_of_options() -> Result {
     test()
         .run(
-            r#"
+            "
             def collect_args [...args] { $args | length }
             collect_args -- -a -b -c
-        "#,
+        ",
         )
         .expect_value_eq(3i64)
 }
@@ -202,10 +202,10 @@ fn end_of_options_with_negative_numbers() -> Result {
     // -5 after -- is treated as a positional integer literal, not a flag
     test()
         .run(
-            r#"
+            "
             def add_nums [x y] { $x + $y }
             add_nums -- -5 10
-        "#,
+        ",
         )
         .expect_value_eq(5i64)
 }
@@ -214,10 +214,10 @@ fn end_of_options_with_negative_numbers() -> Result {
 fn custom_command_mixed_positionals_and_flags_with_end_of_options() -> Result {
     test()
         .run(
-            r#"
+            "
             def complex [x --flag: string y z] { [$x $flag $y $z] }
             complex first --flag flagval -- -second -third
-        "#,
+        ",
         )
         .expect_value_eq(vec!["first", "flagval", "-second", "-third"])
 }

--- a/tests/integration/posix_end_of_options.rs
+++ b/tests/integration/posix_end_of_options.rs
@@ -9,14 +9,14 @@ use nu_test_support::prelude::*;
 #[test]
 fn echo_with_end_of_options_stops_flag_parsing() -> Result {
     test()
-        .run(r#"echo -- -n hello"#)
+        .run("echo -- -n hello")
         .expect_value_eq(["-n", "hello"])
 }
 
 #[test]
 fn echo_with_end_of_options_multiple_dashes() -> Result {
     test()
-        .run(r#"echo -- --foo -bar baz"#)
+        .run("echo -- --foo -bar baz")
         .expect_value_eq(["--foo", "-bar", "baz"])
 }
 
@@ -29,7 +29,7 @@ fn echo_with_end_of_options_alone() -> Result {
 #[test]
 fn echo_before_and_after_end_of_options() -> Result {
     test()
-        .run(r#"echo arg1 -- -arg2"#)
+        .run("echo arg1 -- -arg2")
         .expect_value_eq(["arg1", "-arg2"])
 }
 
@@ -88,10 +88,10 @@ fn end_of_options_with_wrapped_command() -> Result {
     // so -- itself must appear in the rest args.
     test()
         .run(
-            r#"
+            "
             def --wrapped my_wrap [...args] { $args }
             my_wrap -- -flag value
-        "#,
+        ",
         )
         .expect_value_eq(["--", "-flag", "value"])
 }

--- a/tests/integration/posix_end_of_options.rs
+++ b/tests/integration/posix_end_of_options.rs
@@ -9,15 +9,15 @@ use nu_test_support::prelude::*;
 #[test]
 fn echo_with_end_of_options_stops_flag_parsing() -> Result {
     test()
-        .run(r#"echo -- -n hello | str join " ""#)
-        .expect_value_eq("-n hello")
+        .run(r#"echo -- -n hello"#)
+        .expect_value_eq(["-n", "hello"])
 }
 
 #[test]
 fn echo_with_end_of_options_multiple_dashes() -> Result {
     test()
-        .run(r#"echo -- --foo -bar baz | str join " ""#)
-        .expect_value_eq("--foo -bar baz")
+        .run(r#"echo -- --foo -bar baz"#)
+        .expect_value_eq(["--foo", "-bar", "baz"])
 }
 
 #[test]
@@ -29,8 +29,8 @@ fn echo_with_end_of_options_alone() -> Result {
 #[test]
 fn echo_before_and_after_end_of_options() -> Result {
     test()
-        .run(r#"echo arg1 -- -arg2 | str join " ""#)
-        .expect_value_eq("arg1 -arg2")
+        .run(r#"echo arg1 -- -arg2"#)
+        .expect_value_eq(["arg1", "-arg2"])
 }
 
 #[test]
@@ -89,11 +89,11 @@ fn end_of_options_with_wrapped_command() -> Result {
     test()
         .run(
             r#"
-            def --wrapped my_wrap [...args] { $args | str join " " }
+            def --wrapped my_wrap [...args] { $args }
             my_wrap -- -flag value
         "#,
         )
-        .expect_value_eq("-- -flag value")
+        .expect_value_eq(["--", "-flag", "value"])
 }
 
 #[test]
@@ -110,11 +110,11 @@ fn end_of_options_with_spread_operator() -> Result {
     test()
         .run(
             r#"
-            def my_cmd [...rest] { $rest | str join " " }
+            def my_cmd [...rest] { $rest }
             my_cmd -- ...["-a" "-b"]
         "#,
         )
-        .expect_value_eq("-a -b")
+        .expect_value_eq(["-a", "-b"])
 }
 
 #[test]


### PR DESCRIPTION
## Description
We've tried this before. Let's try it again!

This PR implements POSIX [Guideline 10](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02) — the `--` end-of-options delimiter — for all nushell internal commands:

> *The first `--` argument that is not an option-argument should be accepted as a delimiter indicating the end of options. Any following arguments should be treated as operands, even if they begin with the `-` character.*

During parsing we now check for exactly `b"--"` *before* attempting any flag-name parsing, returning `EndOfOptions` immediately when detected.

- For built-ins and custom commands: `--` is consumed and all subsequent spans fall through to existing positional parsing.
- For known external commands (declared with `extern`): `--` is not consumed and passes through as a regular argument to the external program, since external binaries handle their own argument parsing.

## User-facing changes (Release notes)

### Added POSIX-style `--` option parsing for Nushell commands

Nushell now supports the POSIX `--` end-of-options delimiter for built-in commands, custom commands, and `def --wrapped` commands.

When `--` appears in a command invocation, it stops all flag parsing. Any arguments after `--` are treated as positional operands, even if they start with `-` or `--`. The `--` token itself is consumed and does not appear in the command's arguments.

```nushell
# Pass dash-prefixed values as positional args, not flags
def greet [--upper, name] {
    if $upper { $name | str upcase } else { $name }
}
greet -- -Alice   # -Alice is now a positional, not an unknown flag
# returns -Alice

# Useful for passing flag-like values to rest parameters
def process [...args] { $args }
process -- --verbose -x foo   # -- consumed; args = ["--verbose", "-x", "foo"]
# returns
# ╭───┬───────────╮
# │ 0 │ --verbose │
# │ 1 │ -x        │
# │ 2 │ foo       │
# ╰───┴───────────╯

# Works with def --wrapped too
def --wrapped my-git [...args] { print ...$args }
my-git commit -- -m "my message"   # -- NOT consumed; -m passed as operand
# returns
# commit
# --
# -m
# my message
```

For `extern`-declared known external commands, `--` continues to be passed through to the external binary unchanged (as those programs manage their own argument parsing).
## Additional notes
See tests added in `tests/integration/posix_end_of_options.rs` for more examples

Closes #10939
Related to #7898
Related to #11897
Related to #16223