### PR TITLE
Update REPL loop to synchronize cursor position and buffer contents

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -539,6 +539,13 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
     perf!("reset signals", start_time, use_color);
 
     start_time = Instant::now();
+
+    // Juhan said to do this :)
+    let mut repl = engine_state.repl_state.lock().expect("repl state mutex");
+    repl.cursor_pos = line_editor.current_insertion_point();
+    repl.buffer = line_editor.current_buffer_contents().to_string();
+    drop(repl);
+
     // Check all the environment variables they ask for
     // fire the "env_change" hook
     if let Err(error) = hook::eval_env_change_hook(


### PR DESCRIPTION
## Description

This PR fixes #18300 as a patch-release regression fix. @Juhan280 was out of town and pointed us to the exact REPL state update needed for this patch.

In #18119, REPL hooks (`pre_prompt` / `env_change`) were allowed to modify the commandline, but the REPL state was not synchronized in `loop_iteration` before those hooks run. As a result, `commandline edit` in REPL no longer updated the visible prompt buffer.

The fix updates `engine_state.repl_state` (buffer and cursor position) from `line_editor` at the start of each loop iteration, before `env_change` and `pre_prompt` hooks execute. This restores expected `commandline edit` behavior in REPL while keeping the #18119 hook behavior.

## User-facing changes (Release notes)

Fixed a regression where `commandline edit` did not update the commandline in REPL on 0.113.0. `commandline edit` now correctly updates the visible prompt buffer again.

## Additional notes

Closes #18300.

Related #18119.
