### PR TITLE
Submodules are no longer implicitly imported

### DIFF
--- a/crates/nu-lsp/src/completion.rs
+++ b/crates/nu-lsp/src/completion.rs
@@ -408,6 +408,26 @@ mod tests {
             "kind": 6
         }
     ]))]
+    #[case::use_submodule("use.nu", (20, 4), None, serde_json::json!([
+        {
+            "label": "dirs",
+            "labelDetails": { "description": "custom" },
+            "textEdit": {
+                "newText": "dirs ",
+                "range": { "start": { "character": 0, "line": 20 }, "end": { "character": 4, "line": 20 } }
+            },
+            "kind": 2
+        },
+        {
+            "label": "dirs next",
+            "labelDetails": { "description": "custom" },
+            "textEdit": {
+                "newText": "dirs next ",
+                "range": { "start": { "character": 0, "line": 20 }, "end": { "character": 4, "line": 20 } }
+            },
+            "kind": 2
+        },
+    ]))]
     #[case::command_basic("command.nu", (0, 6), None, serde_json::json!([
         { "label": "config n foo bar", "detail": DETAIL_STR, "kind": 2 },
         {

--- a/crates/nu-protocol/src/module.rs
+++ b/crates/nu-protocol/src/module.rs
@@ -131,31 +131,6 @@ impl Module {
             let mut const_rows = vec![];
             let mut errors = vec![];
 
-            for (_, id) in &self.submodules {
-                let submodule = working_set.get_module(*id);
-                let span = submodule.span.or(self.span).unwrap_or(backup_span);
-
-                let (sub_results, sub_errors) = submodule.resolve_import_pattern(
-                    working_set,
-                    *id,
-                    &[],
-                    None,
-                    span,
-                    imported_modules,
-                );
-                errors.extend(sub_errors);
-
-                for (sub_name, sub_decl_id) in sub_results.decls {
-                    let mut new_name = final_name.clone();
-                    new_name.push(b' ');
-                    new_name.extend(sub_name);
-
-                    decls.push((new_name, sub_decl_id));
-                }
-
-                const_rows.extend(sub_results.constant_values);
-            }
-
             decls.extend(self.decls_with_head(&final_name));
 
             for (name, var_id) in self.consts() {

--- a/crates/nu-std/std-rfc/mod.nu
+++ b/crates/nu-std/std-rfc/mod.nu
@@ -1,12 +1,12 @@
 export use conversions *
 export use tables *
 export use path *
-export module url
-export module str
-export module iter
-export module random
-export module xml
-export module pb
+export use url
+export use str
+export use iter
+export use random
+export use xml
+export use pb
 
 # kv module depends on sqlite feature, which may not be available in some builds
 const kv_module = if ("sqlite" in (version).features) { "std-rfc/kv" } else { null }

--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -4,31 +4,20 @@
 export use std/util *
 
 # std submodules
-export module std/assert
-export module std/bench
-export module std/dt
-export module std/formats
-export module std/help
-export module std/input
-export module std/iter
-export module std/log
-export module std/math
-export module std/xml
-export module std/config
-export module std/testing
-export module std/random
-
-# Load main dirs command and all subcommands
-export use std/dirs main
-export module dirs {
-  export use std/dirs [
-    add
-    drop
-    next
-    prev
-    goto
-  ]
-}
+export use std/assert
+export use std/bench
+export use std/dt
+export use std/formats
+export use std/help
+export use std/input
+export use std/iter
+export use std/log
+export use std/math
+export use std/xml
+export use std/config
+export use std/testing
+export use std/random
+export use std/dirs
 
 # Workaround for #13403 to load export-env blocks from submodules
 export-env {

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -10,9 +10,9 @@ const MODULE_SETUP: &str = "
             export const E = 'e'
             export module bacon {
                 export const viking = 'eats'
-                export module none {}
-            }
-        }
+                export module none {}; export use none
+            }; export use bacon
+        }; export use eggs
     }
 ";
 

--- a/tests/fixtures/lsp/completion/use.nu
+++ b/tests/fixtures/lsp/completion/use.nu
@@ -6,3 +6,16 @@ export use std-rf
 
 use std null_d
 use 🤔🐘 [ foo, ]
+
+export module dirs {
+  export def main [] {}
+  export def next [] {}
+
+  export module shells-aliases {
+    export alias shells = main
+    export alias n = next
+  }
+}
+
+use dirs
+dirs

--- a/tests/fixtures/lsp/workspace/foo.nu
+++ b/tests/fixtures/lsp/workspace/foo.nu
@@ -9,8 +9,8 @@ export  def "foo str" [] { "foo" }
 export module "mod name" {
   export module "sub module" {
     export def "cmd name long" [] { }
-  }
-}
+  }; export use "sub module"
+}; export use "mod name"
 
 # cmt
 export module cst_mod {
@@ -19,15 +19,15 @@ export module cst_mod {
     # sub sub cmt
     export module "sub sub module" {
       export const var_name = "const value"
-    }
-  }
+    }; export use "sub sub module"
+  }; export use "sub module"
 
   @category foo
   export  def module_attribute_foo [] { }
 
   @complete external
   export extern module_attribute_baz []
-}
+}; export use cst_mod
 
 @category foo
 export def block_attribute_foo [] { }

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -785,45 +785,40 @@ fn nested_list_export_works() {
     assert_eq!(actual.out, "bacon");
 }
 
-#[test]
-fn reload_submodules() {
+#[rstest]
+#[case(
+    &[
+        "use voice.nu",
+        r#""export def cat [] {'woem'}" | save -f animals.nu"#,
+        "use voice.nu",
+        "(voice animals cat) == 'woem'",
+    ]
+)]
+#[case(
+    &[
+        "use voice.nu",
+        r#""export def cat [] {'meow'}" | save -f animals.nu"#,
+        // should also verify something unchanged if `use voice`.
+        "use voice",
+        "(voice animals cat) == 'woem'",
+    ]
+)]
+#[case(
+    &[
+        "use voice.nu animals cat",
+        r#""export def cat [] {'woem'}" | save -f animals.nu"#,
+        "use voice.nu animals cat",
+        "(cat) == 'woem'",
+    ]
+)]
+fn reload_submodules(#[case] inp: &[&str]) {
     Playground::setup("reload_submodule_changed_file", |dirs, sandbox| {
         sandbox.with_files(&[
             FileWithContent("voice.nu", "export module animals.nu"),
             FileWithContent("animals.nu", "export def cat [] { 'meow'}"),
         ]);
 
-        let inp = [
-            "use voice.nu",
-            r#""export def cat [] {'woem'}" | save -f animals.nu"#,
-            "use voice.nu",
-            "(voice animals cat) == 'woem'",
-        ];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
-        assert_eq!(actual.out, "true");
-
-        // should also verify something unchanged if `use voice`.
-        let inp = [
-            "use voice.nu",
-            r#""export def cat [] {'meow'}" | save -f animals.nu"#,
-            "use voice",
-            "(voice animals cat) == 'woem'",
-        ];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
-        assert_eq!(actual.out, "true");
-
-        // should also works if we use members directly.
-        sandbox.with_files(&[
-            FileWithContent("voice.nu", "export module animals.nu"),
-            FileWithContent("animals.nu", "export def cat [] { 'meow'}"),
-        ]);
-        let inp = [
-            "use voice.nu animals cat",
-            r#""export def cat [] {'woem'}" | save -f animals.nu"#,
-            "use voice.nu animals cat",
-            "(cat) == 'woem'",
-        ];
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
+        let actual = nu!(cwd: dirs.test(), nu_repl_code(inp));
         assert_eq!(actual.out, "true");
     });
 }

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -1,6 +1,6 @@
 use nu_test_support::fs::Stub::{FileWithContent, FileWithContentToBeTrimmed};
 use nu_test_support::playground::Playground;
-use nu_test_support::prelude::{Result, TestResultExt, test};
+use nu_test_support::prelude::*;
 use nu_test_support::{nu, nu_repl_code};
 use pretty_assertions::assert_eq;
 use rstest::rstest;
@@ -669,54 +669,21 @@ fn deep_import_aliased_external_args(
     assert_eq!(actual.out, "bar");
 }
 
-#[test]
-fn module_dir() {
-    let import = "use samples/spam";
-
-    let inp = &[import, "spam"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual.out, "spam");
-
-    let inp = &[import, "spam foo"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual.out, "foo");
-
-    let inp = &[import, "spam bar"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual.out, "bar");
-
-    let inp = &[import, "spam foo baz"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual.out, "foobaz");
-
-    let inp = &[import, "spam bar baz"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual.out, "barbaz");
-
-    let inp = &[import, "spam baz"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual.out, "spambaz");
-}
-
-#[test]
-fn module_dir_deep() {
-    let import = "use samples/spam";
-
-    let inp = &[import, "spam bacon"];
-    let actual_repl = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual_repl.out, "bacon");
-
-    let inp = &[import, "spam bacon foo"];
-    let actual_repl = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual_repl.out, "bacon foo");
-
-    let inp = &[import, "spam bacon beans"];
-    let actual_repl = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual_repl.out, "beans");
-
-    let inp = &[import, "spam bacon beans foo"];
-    let actual_repl = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual_repl.out, "beans foo");
+#[rstest]
+#[case("spam", "spam")]
+#[case("spam foo", "foo")]
+#[case("spam bar", "bar")]
+#[case("spam foo baz", "foobaz")]
+#[case("spam bar baz", "barbaz")]
+#[case("spam baz", "spambaz")]
+#[case::deep("spam bacon", "bacon")]
+#[case::deep("spam bacon foo", "bacon foo")]
+#[case::deep("spam bacon beans", "beans")]
+#[case::deep("spam bacon beans foo", "beans foo")]
+fn module_dir(#[case] code: &str, #[case] expected: impl IntoValue) -> Result {
+    let mut tester = test().cwd("tests/modules");
+    let () = tester.run("use samples/spam")?;
+    tester.run(code).expect_value_eq(expected)
 }
 
 #[test]

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -791,8 +791,9 @@ fn nested_list_export_works() {
         "use voice.nu",
         r#""export def cat [] {'woem'}" | save -f animals.nu"#,
         "use voice.nu",
-        "(voice animals cat) == 'woem'",
-    ]
+    ],
+    "voice animals cat",
+    "woem"
 )]
 #[case(
     &[
@@ -800,27 +801,36 @@ fn nested_list_export_works() {
         r#""export def cat [] {'meow'}" | save -f animals.nu"#,
         // should also verify something unchanged if `use voice`.
         "use voice",
-        "(voice animals cat) == 'woem'",
-    ]
+    ],
+    "voice animals cat",
+    "woem"
 )]
 #[case(
     &[
         "use voice.nu animals cat",
         r#""export def cat [] {'woem'}" | save -f animals.nu"#,
         "use voice.nu animals cat",
-        "(cat) == 'woem'",
-    ]
+    ],
+    "cat",
+    "woem"
 )]
-fn reload_submodules(#[case] inp: &[&str]) {
+fn reload_submodules(
+    #[case] setup: &[&str],
+    #[case] code: &str,
+    #[case] expected: impl IntoValue,
+) -> Result {
     Playground::setup("reload_submodule_changed_file", |dirs, sandbox| {
         sandbox.with_files(&[
             FileWithContent("voice.nu", "export module animals.nu; export use animals"),
             FileWithContent("animals.nu", "export def cat [] { 'meow'}"),
         ]);
 
-        let actual = nu!(cwd: dirs.test(), nu_repl_code(inp));
-        assert_eq!(actual.out, "true");
-    });
+        let mut tester = test().cwd(dirs.test());
+        for line in setup {
+            let () = tester.run(line)?;
+        }
+        tester.run(code).expect_value_eq(expected)
+    })
 }
 
 #[test]

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -814,7 +814,7 @@ fn nested_list_export_works() {
 fn reload_submodules(#[case] inp: &[&str]) {
     Playground::setup("reload_submodule_changed_file", |dirs, sandbox| {
         sandbox.with_files(&[
-            FileWithContent("voice.nu", "export module animals.nu"),
+            FileWithContent("voice.nu", "export module animals.nu; export use animals"),
             FileWithContent("animals.nu", "export def cat [] { 'meow'}"),
         ]);
 

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -803,7 +803,7 @@ fn nested_list_export_works() {
         "use voice",
     ],
     "voice animals cat",
-    "woem"
+    "meow"
 )]
 #[case(
     &[

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -624,8 +624,8 @@ fn deep_import_patterns() {
                 export module beans {
                     export def foo [] { 'foo' };
                     export def bar [] { 'bar' }
-                };
-            };
+                }; export use beans
+            }; export use eggs
         }
     ";
 
@@ -661,8 +661,8 @@ fn deep_import_aliased_external_args(
             export module eggs {
                 export module beans {
                     export alias foo = ^echo
-                }
-            }
+                }; export use beans
+            }; export use eggs
         }
     ";
     let actual = nu!(format!("{module_decl}; {input}"));

--- a/tests/modules/samples/spam/bacon/beans/mod.nu
+++ b/tests/modules/samples/spam/bacon/beans/mod.nu
@@ -1,4 +1,4 @@
-export module foo.nu
+export module foo.nu; export use foo
 
 export def test [] { 'test' }
 

--- a/tests/modules/samples/spam/bacon/mod.nu
+++ b/tests/modules/samples/spam/bacon/mod.nu
@@ -1,5 +1,5 @@
-export module foo.nu
-export module beans
+export module foo.nu; export use foo
+export module beans; export use beans
 
 export def test [] { 'test' }
 

--- a/tests/modules/samples/spam/mod.nu
+++ b/tests/modules/samples/spam/mod.nu
@@ -1,7 +1,7 @@
-export module eggs.nu
-export module foo.nu
-export module bar.nu
-export module bacon
+export module eggs.nu; export use eggs
+export module foo.nu; export use foo
+export module bar.nu; export use bar
+export module bacon; export use bacon  
 
 export def main [] { 'spam' }
 

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -1,8 +1,9 @@
 use nu_test_support::fs::Stub::{FileWithContent, FileWithContentToBeTrimmed};
 use nu_test_support::playground::Playground;
-use nu_test_support::prelude::{Result, TestResultExt, test};
+use nu_test_support::prelude::*;
 use nu_test_support::{nu, nu_repl_code};
 use pretty_assertions::assert_eq;
+use rstest::rstest;
 
 #[test]
 fn add_overlay() {
@@ -1585,33 +1586,17 @@ fn overlay_use_module_dir() {
     assert_eq!(actual.out, "spambaz");
 }
 
-#[test]
-fn overlay_use_module_dir_prefix() {
-    let import = "overlay use samples/spam --prefix";
-
-    let inp = &[import, "spam"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual.out, "spam");
-
-    let inp = &[import, "spam foo"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual.out, "foo");
-
-    let inp = &[import, "spam bar"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual.out, "bar");
-
-    let inp = &[import, "spam foo baz"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual.out, "foobaz");
-
-    let inp = &[import, "spam bar baz"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual.out, "barbaz");
-
-    let inp = &[import, "spam baz"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
-    assert_eq!(actual.out, "spambaz");
+#[rstest]
+#[case("spam", "spam")]
+#[case("spam foo", "foo")]
+#[case("spam bar", "bar")]
+#[case("spam foo baz", "foobaz")]
+#[case("spam bar baz", "barbaz")]
+#[case("spam baz", "spambaz")]
+fn overlay_use_module_dir_prefix(#[case] code: &str, #[case] expected: impl IntoValue) -> Result {
+    let mut tester = test().cwd("tests/modules");
+    let () = tester.run("overlay use samples/spam --prefix")?;
+    tester.run(code).expect_value_eq(expected)
 }
 
 #[test]


### PR DESCRIPTION
## Description

Currently, importing a module also imports its exported sub-modules.
```nushell
use std/dirs

dirs_  # completion triggered
# => dirs
# => dirs add
# => dirs drop
# => dirs goto
# => dirs next
# => dirs prev
# => dirs shells-aliases dexit
# => dirs shells-aliases enter
# => dirs shells-aliases g
# => dirs shells-aliases n
# => dirs shells-aliases p
# => dirs shells-aliases shells
```
This is unexpected (and really annoying).

Also, while it imports the sub-module's definitions, it does not run the sub-module's `export-env` block.

With this PR:
```nushell
use std/dirs

dirs_  # completion triggered
# => dirs
# => dirs add
# => dirs drop
# => dirs goto
# => dirs next
# => dirs prev
```

To use the aliases, one just needs to `use std/dirs shells-aliases *`

## User-facing changes (Release notes)

Importing a module no longer implicitly imports its exported sub-modules.

```nushell
export module foo {
    export def bar [] {}

    export module sub {
        export def baz [] {}
    }
}

use foo
foo bar      # valid
foo sub baz  # invalid, `sub` is not implicitly imported
```

To have your modules keep the old behavior, you will need to export the modules contents explicitly:
```nushell
export module foo {
    export def bar [] {}

    export module sub {
        export def baz [] {}
    }
    export use sub
}

use foo
foo bar      # valid
foo sub baz  # valid
```
> [!NOTE]
> `use`ing a module inside another module does *not* run the imported module's `export-env` block.
> (See [`export-env` runs only when the use call is evaluated](https://www.nushell.sh/book/modules/creating_modules.html#export-env-runs-only-when-the-use-call-is-evaluated))
> Thus, explicit `use`s as recommended above will not run `export-env` blocks, which is inline with how the previous implicit imports worked.