### PR TITLE
update `ignore` to really ignore :)

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/ignore.rs
+++ b/crates/nu-cmd-lang/src/core_commands/ignore.rs
@@ -1,5 +1,17 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::{ByteStreamSource, OutDest, engine::StateWorkingSet};
+#[cfg(feature = "os")]
+use nu_protocol::{
+    ByteStream, Signals,
+    process::{ChildPipe, check_ok},
+    shell_error::io::IoError,
+    write_all_and_flush,
+};
+use nu_protocol::{OutDest, engine::StateWorkingSet};
+#[cfg(feature = "os")]
+use std::{
+    io::{self, Cursor},
+    thread,
+};
 
 #[derive(Clone)]
 pub struct Ignore;
@@ -10,12 +22,27 @@ impl Command for Ignore {
     }
 
     fn description(&self) -> &str {
-        "Ignore the output of the previous command in the pipeline."
+        "Ignore selected output streams from the previous command in the pipeline."
     }
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("ignore")
-            .input_output_types(vec![(Type::Any, Type::Nothing)])
+            .input_output_types(vec![(Type::Any, Type::Any)])
+            .switch(
+                "stderr",
+                "Consume all stderr output and allow stdout output through.",
+                Some('e'),
+            )
+            .switch(
+                "stdout",
+                "Consume all stdout output and allow stderr output through.",
+                Some('o'),
+            )
+            .switch(
+                "show-errors",
+                "Allow errors through and set $env.LAST_EXIT_CODE (internal failures use 1).",
+                Some('x'),
+            )
             .category(Category::Core)
     }
 
@@ -29,42 +56,284 @@ impl Command for Ignore {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
-        _call: &Call,
-        mut input: PipelineData,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        if let PipelineData::ByteStream(stream, _) = &mut input {
-            #[cfg(feature = "os")]
-            if let ByteStreamSource::Child(child) = stream.source_mut() {
-                child.ignore_error(true);
+        let consume_stderr = call.has_flag(engine_state, stack, "stderr")?;
+        let consume_stdout = call.has_flag(engine_state, stack, "stdout")? || !consume_stderr;
+        let show_errors = call.has_flag(engine_state, stack, "show-errors")?;
+        let span = call.head;
+
+        match input {
+            PipelineData::ByteStream(stream, metadata) => {
+                #[cfg(feature = "os")]
+                {
+                    let stream_type = stream.type_();
+                    match stream.into_child() {
+                        Ok(child) => handle_external_child(
+                            engine_state,
+                            stack,
+                            span,
+                            child,
+                            stream_type,
+                            metadata,
+                            consume_stdout,
+                            consume_stderr,
+                            show_errors,
+                        ),
+                        Err(stream) => {
+                            if !consume_stdout {
+                                if show_errors {
+                                    stack.set_last_exit_code(0, span);
+                                }
+                                return Ok(PipelineData::byte_stream(stream, metadata));
+                            }
+
+                            match stream.drain() {
+                                Ok(()) => {
+                                    if show_errors {
+                                        stack.set_last_exit_code(0, span);
+                                    }
+                                    Ok(PipelineData::empty())
+                                }
+                                Err(err) => {
+                                    if show_errors {
+                                        stack.set_last_exit_code(1, span);
+                                    }
+                                    Err(err)
+                                }
+                            }
+                        }
+                    }
+                }
+                #[cfg(not(feature = "os"))]
+                {
+                    if !consume_stdout {
+                        return Ok(PipelineData::byte_stream(stream, metadata));
+                    }
+                    match stream.drain() {
+                        Ok(()) => Ok(PipelineData::empty()),
+                        Err(err) => Err(err),
+                    }
+                }
+            }
+            PipelineData::Value(Value::Error { error, .. }, _) => {
+                if consume_stderr {
+                    if show_errors {
+                        stack.set_last_exit_code(1, span);
+                        Err(*error)
+                    } else {
+                        Ok(PipelineData::empty())
+                    }
+                } else {
+                    if show_errors {
+                        stack.set_last_exit_code(1, span);
+                    }
+                    Err(*error)
+                }
+            }
+            input => {
+                if !consume_stdout {
+                    if show_errors {
+                        stack.set_last_exit_code(0, span);
+                    }
+                    return Ok(input);
+                }
+
+                match input.drain() {
+                    Ok(()) => {
+                        if show_errors {
+                            stack.set_last_exit_code(0, span);
+                        }
+                        Ok(PipelineData::empty())
+                    }
+                    Err(err) => {
+                        if show_errors {
+                            stack.set_last_exit_code(1, span);
+                        }
+                        Err(err)
+                    }
+                }
             }
         }
-        input.drain()?;
-        Ok(PipelineData::empty())
     }
 
     fn run_const(
         &self,
-        _working_set: &StateWorkingSet,
-        _call: &Call,
+        working_set: &StateWorkingSet,
+        call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        input.drain()?;
-        Ok(PipelineData::empty())
+        let consume_stderr = call.has_flag_const(working_set, "stderr")?;
+        let consume_stdout = call.has_flag_const(working_set, "stdout")? || !consume_stderr;
+
+        if consume_stderr && matches!(&input, PipelineData::Value(Value::Error { .. }, _)) {
+            return Ok(PipelineData::empty());
+        }
+
+        if consume_stdout {
+            input.drain()?;
+            Ok(PipelineData::empty())
+        } else {
+            Ok(input)
+        }
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![Example {
-            description: "Ignore the output of an echo command.",
-            example: "echo done | ignore",
-            result: Some(Value::nothing(Span::test_data())),
-        }]
+        vec![
+            Example {
+                description: "Ignore all stdout output (default behavior).",
+                example: "echo done | ignore",
+                result: Some(Value::nothing(Span::test_data())),
+            },
+            Example {
+                description: "Consume stderr and allow stdout through.",
+                example: "echo done | ignore --stderr",
+                result: Some(Value::test_string("done")),
+            },
+            Example {
+                description: "Consume stdout while keeping stderr visible.",
+                example: "$'done' | ignore --stdout",
+                result: Some(Value::nothing(Span::test_data())),
+            },
+            Example {
+                description: "Show internal errors and read the resulting exit code.",
+                example: "try { error make {msg: 'boom'} | ignore --show-errors } catch { $env.LAST_EXIT_CODE }",
+                result: Some(Value::test_int(1)),
+            },
+        ]
     }
 
     fn pipe_redirection(&self) -> (Option<OutDest>, Option<OutDest>) {
-        (Some(OutDest::Null), None)
+        (Some(OutDest::PipeSeparate), Some(OutDest::PipeSeparate))
     }
+}
+
+#[cfg(feature = "os")]
+#[expect(clippy::too_many_arguments)]
+/// Handle external child-process output/error behavior for `ignore`.
+fn handle_external_child(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    span: Span,
+    mut child: nu_protocol::process::ChildProcess,
+    stream_type: nu_protocol::ByteStreamType,
+    metadata: Option<nu_protocol::PipelineMetadata>,
+    consume_stdout: bool,
+    consume_stderr: bool,
+    show_errors: bool,
+) -> Result<PipelineData, ShellError> {
+    child.ignore_error(!show_errors);
+
+    // Preserve streaming when stdout should pass through and errors remain suppressed.
+    if !consume_stdout && !show_errors {
+        if consume_stderr && let Some(stderr) = child.stderr.take() {
+            consume_child_pipe_on_thread(stderr, span)?;
+        }
+
+        return Ok(PipelineData::byte_stream(
+            ByteStream::child(child, span),
+            metadata,
+        ));
+    }
+
+    // Once we need exit status enforcement or selective stderr replay, we must collect the
+    // process output before deciding what to forward.
+    let output = match child.wait_with_output() {
+        Ok(output) => output,
+        Err(err) => {
+            if show_errors {
+                stack.set_last_exit_code(1, span);
+            }
+            return Err(err);
+        }
+    };
+
+    if !consume_stderr && let Some(stderr) = output.stderr.as_deref() {
+        write_to_out_dest(stderr, stack.stderr(), span, false, engine_state.signals())?;
+    }
+
+    let stdout = output.stdout.unwrap_or_default();
+    let exit_status = output.exit_status;
+
+    if show_errors {
+        let exit_code = exit_status.code();
+        stack.set_last_exit_code(exit_code, span);
+
+        if let Err(err) = check_ok(exit_status, false, span) {
+            if !consume_stdout && !stdout.is_empty() {
+                write_to_out_dest(&stdout, stack.stdout(), span, true, engine_state.signals())?;
+            }
+            return Err(err);
+        }
+    }
+
+    if !consume_stdout && !stdout.is_empty() {
+        let stream = ByteStream::read(
+            Cursor::new(stdout),
+            span,
+            engine_state.signals().clone(),
+            stream_type,
+        );
+        return Ok(PipelineData::byte_stream(stream, metadata));
+    }
+
+    Ok(PipelineData::empty())
+}
+
+#[cfg(feature = "os")]
+/// Write collected bytes to the requested output destination.
+fn write_to_out_dest(
+    bytes: &[u8],
+    out_dest: &OutDest,
+    span: Span,
+    stdout_fallback: bool,
+    signals: &Signals,
+) -> Result<(), ShellError> {
+    if bytes.is_empty() {
+        return Ok(());
+    }
+
+    match out_dest {
+        OutDest::Null => Ok(()),
+        OutDest::File(file) => {
+            let mut file = file.as_ref();
+            write_all_and_flush(bytes, &mut file, "file", Some(span), signals)
+        }
+        OutDest::Print
+        | OutDest::Inherit
+        | OutDest::Pipe
+        | OutDest::PipeSeparate
+        | OutDest::Value => {
+            if stdout_fallback {
+                let mut stdout = io::stdout();
+                write_all_and_flush(bytes, &mut stdout, "stdout", Some(span), signals)
+            } else {
+                let mut stderr = io::stderr();
+                write_all_and_flush(bytes, &mut stderr, "stderr", Some(span), signals)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "os")]
+/// Consume a child pipe on a detached thread so the child process cannot block on a full stderr
+/// buffer when `ignore` is passing stdout through.
+fn consume_child_pipe_on_thread(pipe: ChildPipe, span: Span) -> Result<(), ShellError> {
+    thread::Builder::new()
+        .name("ignore stderr consumer".into())
+        .spawn(move || {
+            let mut sink = io::sink();
+            match pipe {
+                ChildPipe::Pipe(mut pipe) => io::copy(&mut pipe, &mut sink),
+                ChildPipe::Tee(mut tee) => io::copy(&mut tee, &mut sink),
+            }?;
+            Ok::<(), io::Error>(())
+        })
+        .map_err(|err| ShellError::Io(IoError::new(err, span, None)))?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/tests/commands/ignore.rs
+++ b/crates/nu-command/tests/commands/ignore.rs
@@ -1,4 +1,4 @@
-use nu_test_support::prelude::*;
+use nu_test_support::{nu, prelude::*};
 use std::fs;
 
 #[test]
@@ -15,4 +15,87 @@ fn ignore_still_causes_stream_to_be_consumed_fully() -> Result {
         assert_eq!(file_content, "foobar");
         Ok(())
     })
+}
+
+#[test]
+fn ignore_default_consumes_stdout_and_keeps_stderr() {
+    let actual = nu!(
+        r#"with-env { FOO: "message" } { nu --testbin echo_env_mixed out-err FOO FOO | ignore }"#
+    );
+
+    assert_eq!(actual.out, "");
+    assert_eq!(actual.err, "message\n");
+}
+
+#[test]
+fn ignore_stderr_consumes_stderr_and_allows_stdout() {
+    let actual = nu!(
+        r#"with-env { FOO: "message" } { nu --testbin echo_env_mixed out-err FOO FOO | ignore --stderr }"#
+    );
+
+    assert_eq!(actual.out, "message");
+    assert_eq!(actual.err, "");
+}
+
+#[test]
+fn ignore_stderr_allows_stdout_to_continue_in_pipeline() {
+    let actual = nu!(
+        r#"with-env { FOO: "message" } { nu --testbin echo_env_mixed out-err FOO FOO | ignore --stderr | str upcase }"#
+    );
+
+    assert_eq!(actual.out, "MESSAGE");
+    assert_eq!(actual.err, "");
+}
+
+#[test]
+fn ignore_with_stdout_and_stderr_consumes_both_streams() {
+    let actual = nu!(
+        r#"with-env { FOO: "message" } { nu --testbin echo_env_mixed out-err FOO FOO | ignore --stdout --stderr }"#
+    );
+
+    assert_eq!(actual.out, "");
+    assert_eq!(actual.err, "");
+}
+
+#[test]
+fn ignore_show_errors_allows_external_failures_and_sets_exit_code() {
+    let actual =
+        nu!("try { nu --testbin fail 42 | ignore --show-errors } catch { $env.LAST_EXIT_CODE }");
+
+    assert_eq!(actual.out, "42");
+}
+
+#[test]
+fn ignore_show_errors_sets_internal_failure_exit_code_to_one() {
+    let actual = nu!(
+        "try { error make {msg: 'boom'} | ignore --show-errors } catch { $env.LAST_EXIT_CODE }"
+    );
+
+    assert_eq!(actual.out, "1");
+}
+
+#[test]
+fn ignore_stderr_with_show_errors_sets_internal_failure_exit_code_to_one() {
+    let actual = nu!(
+        "try { error make {msg: 'boom'} | ignore --stderr --show-errors } catch { $env.LAST_EXIT_CODE }"
+    );
+
+    assert_eq!(actual.out, "1");
+}
+
+#[test]
+fn ignore_without_show_errors_does_not_set_last_exit_code() {
+    let actual = nu!(
+        "if ('LAST_EXIT_CODE' in ($env | columns)) { hide-env LAST_EXIT_CODE }; nu --testbin fail 42 | ignore; print done; $env | get --optional LAST_EXIT_CODE"
+    );
+
+    assert_eq!(actual.out, "done");
+}
+
+#[test]
+fn ignore_stderr_suppresses_internal_errors() {
+    let actual = nu!("ls this_path_does_not_exist_12345 | ignore --stderr");
+
+    assert_eq!(actual.out, "");
+    assert_eq!(actual.err, "");
 }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1230,6 +1230,12 @@ fn eval_call<D: DebugContext>(
 
     let args_len = caller_stack.arguments.get_len(*args_base);
     let decl = engine_state.get_decl(decl_id);
+    // Commands such as `ignore --stderr` need errors as pipeline values so they can decide
+    // whether to suppress or rethrow.
+    let stderr_pipe_separate = matches!(
+        redirect_err.as_ref(),
+        Some(Redirection::Pipe(OutDest::PipeSeparate))
+    );
 
     // Set up redirect modes
     let mut caller_stack = caller_stack.push_redirection(redirect_out.take(), redirect_err.take());
@@ -1270,7 +1276,16 @@ fn eval_call<D: DebugContext>(
 
             result
         } else {
-            check_input_types(&input, &decl.signature(), head)?;
+            // `ignore` intentionally handles upstream error values at command level.
+            // Skip early input-error propagation for the built-in `ignore` command so
+            // `run()` can apply `--stderr`/`--show-errors` semantics.
+            let allow_error_input = matches!(input, PipelineData::Value(Value::Error { .. }, ..))
+                && engine_state
+                    .find_decl(b"ignore", &[])
+                    .is_some_and(|ignore_decl_id| ignore_decl_id == decl_id);
+            if !allow_error_input {
+                check_input_types(&input, &decl.signature(), head)?;
+            }
             // FIXME: precalculate this and save it somewhere
             let span = Span::merge_many(
                 std::iter::once(head).chain(
@@ -1307,7 +1322,10 @@ fn eval_call<D: DebugContext>(
     ctx.redirect_out = None;
     ctx.redirect_err = None;
 
-    result
+    match result {
+        Err(err) if stderr_pipe_separate => Ok(PipelineData::Value(Value::error(err, head), None)),
+        result => result,
+    }
 }
 
 fn find_named_var_id(


### PR DESCRIPTION
## Description
This PR expands `ignore` so callers can explicitly control which streams (stderr, stdout) are consumed and when errors should be surfaced and update `$env.LAST_EXIT_CODE`.

## User-facing changes (Release notes)
### Added stream and error controls to `ignore`
Update the `ignore` command with flags to control whether stderr, stdout, or both get consumed and if errors are show which update `$env.LAST_EXIT_CODE`. This should work on internal and external commands.

Existing behavior is the default when no new flags are provided to avoid breaking changes.

- Added `--stderr` (`-e`) to consume stderr while allowing stdout to pass through.
- Added `--stdout` (`-o`) to consume stdout while allowing stderr output through.
- Added `--show-errors` (`-x`) to show external/internal errors and set `$env.LAST_EXIT_CODE` (external exit code for external failures, `1` for internal failures).



## Additional notes
Closes #17849
Closes #18203

Related #15802
Related #12643