### PR TITLE
refactor: `get_locale_from_env_vars` in `nu-utils`

### DIFF
--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -3,7 +3,6 @@ use chrono::{DateTime, Datelike, Locale, TimeZone};
 use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
 
-use nu_utils::locale::{LOCALE_OVERRIDE_ENV_VAR, get_system_locale_string};
 use std::fmt::{Display, Write};
 
 #[derive(Clone)]
@@ -100,7 +99,7 @@ impl Command for FormatDate {
     ) -> Result<PipelineData, ShellError> {
         let list = call.has_flag(engine_state, stack, "list")?;
         let format = call.opt::<Spanned<String>>(engine_state, stack, 0)?;
-        let locale = get_locale(|name| stack.get_env_var(engine_state, name))?;
+        let locale = get_locale(|name| stack.get_env_var(engine_state, name)?.as_str().ok());
 
         run(engine_state, call, input, list, format, locale)
     }
@@ -113,38 +112,19 @@ impl Command for FormatDate {
     ) -> Result<PipelineData, ShellError> {
         let list = call.has_flag_const(working_set, "list")?;
         let format = call.opt_const::<Spanned<String>>(working_set, 0)?;
-        let locale = get_locale(|name| working_set.get_env_var(name))?;
+        let locale = get_locale(|name| working_set.get_env_var(name)?.as_str().ok());
 
         run(working_set.permanent(), call, input, list, format, locale)
     }
 }
 
-fn get_locale<'a, F>(env_getter: F) -> Result<Locale, ShellError>
+fn get_locale<'a, F>(env_getter: F) -> Locale
 where
-    F: Fn(&str) -> Option<&'a Value> + 'a,
+    F: Fn(&str) -> Option<&'a str> + 'a,
 {
-    // env var preference is documented at https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html
-    // LC_ALL overrides LC_TIME, LC_TIME overrides LANG
-    static LOCALE_VAR_NAMES: &[&str] = &[LOCALE_OVERRIDE_ENV_VAR, "LC_ALL", "LC_TIME", "LANG"];
-
-    // get the locale first so we can use the proper get_env_var functions since this is a const command
-    // we can override the locale by setting $env.NU_TEST_LOCALE_OVERRIDE or $env.LC_TIME
-    let locale_var = LOCALE_VAR_NAMES
-        .iter()
-        .find_map(|name| env_getter(name))
-        .map(Value::as_str)
-        .transpose()?;
-
-    let locale = match locale_var {
-        Some(loc) => (loc.split('.').next())
-            .and_then(|s| Locale::try_from(s).ok())
-            .unwrap_or(Locale::en_US),
-        None => get_system_locale_string()
-            .map(|l| l.replace('-', "_"))
-            .and_then(|s| Locale::try_from(s.as_str()).ok())
-            .unwrap_or(Locale::en_US),
-    };
-    Ok(locale)
+    nu_utils::get_env_locale(Some("LC_TIME"), env_getter)
+        .and_then(|s| Locale::try_from(s.as_ref()).ok())
+        .unwrap_or(Locale::en_US)
 }
 
 fn run(

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -122,7 +122,7 @@ fn get_locale<'a, F>(env_getter: F) -> Locale
 where
     F: Fn(&str) -> Option<&'a str> + 'a,
 {
-    nu_utils::get_env_locale(Some("LC_TIME"), env_getter)
+    nu_utils::get_locale_from_env_vars(Some("LC_TIME"), env_getter)
         .and_then(|s| Locale::try_from(s.as_ref()).ok())
         .unwrap_or(Locale::en_US)
 }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 use chrono::{DateTime, Datelike, Duration, FixedOffset, Local, Locale, TimeZone};
 use chrono_humanize::HumanTime;
 use fancy_regex::Regex;
-use nu_utils::{ObviousFloat, SharedCow, contains_emoji, get_env_locale};
+use nu_utils::{ObviousFloat, SharedCow, contains_emoji, get_locale_from_env_vars};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -953,7 +953,7 @@ impl Value {
         Tz::Offset: Display,
     {
         let mut formatter_buf = String::new();
-        let locale = get_env_locale(Some("LC_TIME"), |name| std::env::var(name).ok())
+        let locale = get_locale_from_env_vars(Some("LC_TIME"), |name| std::env::var(name).ok())
             .and_then(|s| s.as_ref().try_into().ok())
             .unwrap_or(Locale::en_US);
         let format = date_time.format_localized(formatter, locale);

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -28,10 +28,7 @@ use crate::{
 use chrono::{DateTime, Datelike, Duration, FixedOffset, Local, Locale, TimeZone};
 use chrono_humanize::HumanTime;
 use fancy_regex::Regex;
-use nu_utils::{
-    ObviousFloat, SharedCow, contains_emoji,
-    locale::{LOCALE_OVERRIDE_ENV_VAR, get_system_locale_string},
-};
+use nu_utils::{ObviousFloat, SharedCow, contains_emoji, get_env_locale};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -956,20 +953,9 @@ impl Value {
         Tz::Offset: Display,
     {
         let mut formatter_buf = String::new();
-        let locale = if let Ok(l) =
-            std::env::var(LOCALE_OVERRIDE_ENV_VAR).or_else(|_| std::env::var("LC_TIME"))
-        {
-            let locale_str = l.split('.').next().unwrap_or("en_US");
-            locale_str.try_into().unwrap_or(Locale::en_US)
-        } else {
-            // LC_ALL > LC_CTYPE > LANG else en_US
-            get_system_locale_string()
-                .map(|l| l.replace('-', "_")) // `chrono::Locale` needs something like `xx_xx`, rather than `xx-xx`
-                .unwrap_or_else(|| String::from("en_US"))
-                .as_str()
-                .try_into()
-                .unwrap_or(Locale::en_US)
-        };
+        let locale = get_env_locale(Some("LC_TIME"), |name| std::env::var(name).ok())
+            .and_then(|s| s.as_ref().try_into().ok())
+            .unwrap_or(Locale::en_US);
         let format = date_time.format_localized(formatter, locale);
 
         match formatter_buf.write_fmt(format_args!("{format}")) {

--- a/crates/nu-utils/src/lib.rs
+++ b/crates/nu-utils/src/lib.rs
@@ -23,7 +23,7 @@ pub mod sync;
 pub mod time;
 pub mod utils;
 
-pub use locale::get_system_locale;
+pub use locale::{get_env_locale, get_system_locale};
 pub use utils::{
     ConfigFileKind, enable_vt_processing, get_ls_colors, stderr_write_all_and_flush,
     stdout_write_all_and_flush, terminal_size,

--- a/crates/nu-utils/src/lib.rs
+++ b/crates/nu-utils/src/lib.rs
@@ -23,7 +23,7 @@ pub mod sync;
 pub mod time;
 pub mod utils;
 
-pub use locale::{get_env_locale, get_system_locale};
+pub use locale::{get_locale_from_env_vars, get_system_locale};
 pub use utils::{
     ConfigFileKind, enable_vt_processing, get_ls_colors, stderr_write_all_and_flush,
     stdout_write_all_and_flush, terminal_size,

--- a/crates/nu-utils/src/locale.rs
+++ b/crates/nu-utils/src/locale.rs
@@ -52,10 +52,11 @@ pub fn get_system_locale_string() -> Option<String> {
 /// - LANG
 ///
 /// [1]: https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html
-pub fn get_env_locale<'a, F>(locale_for: Option<&str>, env_getter: F) -> Option<Cow<'a, str>>
+pub fn get_env_locale<'a, F, O>(locale_for: Option<&str>, env_getter: F) -> Option<Cow<'a, str>>
 where
     F: 'a,
-    F: Fn(&str) -> Option<&'a str>,
+    F: Fn(&str) -> Option<O>,
+    O: Into<Cow<'a, str>>,
 {
     let mut env_var_names = [LOCALE_OVERRIDE_ENV_VAR, "LC_ALL"]
         .iter()
@@ -63,10 +64,12 @@ where
         .chain(locale_for)
         .chain(["LANG"]);
 
-    env_var_names
-        .find_map(env_getter)
-        .map(|s| s.split('.').next().unwrap_or(s))
-        .map(Cow::Borrowed)
+    let env_var = env_var_names.find_map(env_getter).map(Into::into);
+    env_var
+        .map(|s| match s {
+            Cow::Borrowed(s) => Cow::Borrowed(s.split('.').next().unwrap_or(s)),
+            Cow::Owned(s) => Cow::Owned(s.split('.').next().map(ToOwned::to_owned).unwrap_or(s)),
+        })
         .or_else(|| {
             get_system_locale_string()
                 .map(|l| l.replace('-', "_"))

--- a/crates/nu-utils/src/locale.rs
+++ b/crates/nu-utils/src/locale.rs
@@ -43,16 +43,24 @@ pub fn get_system_locale_string() -> Option<String> {
     sys_locale::get_locale()
 }
 
-/// env var preference is documented in [gettext manual][1]
+/// Get the current locale from environment variables.
 ///
-/// in priority order:
+/// - Checks multiple environment variables.
+/// - Generic over how to read environment variables (can be used to read environment variables from
+///   `StateWorkingSet`, `Stack`, or from process environment variables)
+/// - Allows specifying a locale category (`LC_TIME`, `LC_NUMERIC`, etc.)
+///
+/// Priority order as documented in [`gettext` manual][1]:
 /// - NU_TEST_LOCALE_OVERRIDE
 /// - LC_ALL
-/// - (`locale_for`) LC_xxx, according to selected locale category: LC_CTYPE, LC_NUMERIC, LC_TIME
+/// - `locale_category` (if provided)
 /// - LANG
 ///
 /// [1]: https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html
-pub fn get_env_locale<'a, F, O>(locale_for: Option<&str>, env_getter: F) -> Option<Cow<'a, str>>
+pub fn get_locale_from_env_vars<'a, F, O>(
+    locale_category: Option<&str>,
+    env_getter: F,
+) -> Option<Cow<'a, str>>
 where
     F: 'a,
     F: Fn(&str) -> Option<O>,
@@ -61,7 +69,7 @@ where
     let mut env_var_names = [LOCALE_OVERRIDE_ENV_VAR, "LC_ALL"]
         .iter()
         .copied()
-        .chain(locale_for)
+        .chain(locale_category)
         .chain(["LANG"]);
 
     let env_var = env_var_names.find_map(env_getter).map(Into::into);

--- a/crates/nu-utils/src/locale.rs
+++ b/crates/nu-utils/src/locale.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use num_format::Locale;
 
 pub const LOCALE_OVERRIDE_ENV_VAR: &str = "NU_TEST_LOCALE_OVERRIDE";
@@ -39,4 +41,35 @@ pub fn get_system_locale_string() -> Option<String> {
 #[cfg(not(debug_assertions))]
 pub fn get_system_locale_string() -> Option<String> {
     sys_locale::get_locale()
+}
+
+/// env var preference is documented in [gettext manual][1]
+///
+/// in priority order:
+/// - NU_TEST_LOCALE_OVERRIDE
+/// - LC_ALL
+/// - (`locale_for`) LC_xxx, according to selected locale category: LC_CTYPE, LC_NUMERIC, LC_TIME
+/// - LANG
+///
+/// [1]: https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html
+pub fn get_env_locale<'a, F>(locale_for: Option<&str>, env_getter: F) -> Option<Cow<'a, str>>
+where
+    F: 'a,
+    F: Fn(&str) -> Option<&'a str>,
+{
+    let mut env_var_names = [LOCALE_OVERRIDE_ENV_VAR, "LC_ALL"]
+        .iter()
+        .copied()
+        .chain(locale_for)
+        .chain(["LANG"]);
+
+    env_var_names
+        .find_map(env_getter)
+        .map(|s| s.split('.').next().unwrap_or(s))
+        .map(Cow::Borrowed)
+        .or_else(|| {
+            get_system_locale_string()
+                .map(|l| l.replace('-', "_"))
+                .map(Cow::Owned)
+        })
 }


### PR DESCRIPTION
## Description

Just de-duplicating some code.

## User-facing changes (Release notes)
N/A