### PR TITLE
Add non UTF-8 text support for `url encode`/`url decode`

### DIFF
--- a/crates/nu-command/src/network/url/decode.rs
+++ b/crates/nu-command/src/network/url/decode.rs
@@ -1,8 +1,21 @@
-use nu_cmd_base::input_handler::{CellPathOnlyArgs, operate};
+use std::borrow::Cow;
+
+use nu_cmd_base::input_handler::{CmdArgument, operate};
 use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
 
 use percent_encoding::percent_decode_str;
+
+struct Arguments {
+    cell_paths: Option<Vec<CellPath>>,
+    binary: bool,
+}
+
+impl CmdArgument for Arguments {
+    fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
+        self.cell_paths.take()
+    }
+}
 
 #[derive(Clone)]
 pub struct UrlDecode;
@@ -16,14 +29,24 @@ impl Command for UrlDecode {
         Signature::build("url decode")
             .input_output_types(vec![
                 (Type::String, Type::String),
+                (Type::String, Type::Binary),
                 (
                     Type::List(Box::new(Type::String)),
                     Type::List(Box::new(Type::String)),
+                ),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::Binary)),
                 ),
                 (Type::table(), Type::table()),
                 (Type::record(), Type::record()),
             ])
             .allow_variants_without_examples(true)
+            .switch(
+                "binary",
+                "Return a binary value, to allow decoding non UTF-8 text.",
+                Some('b'),
+            )
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
@@ -48,7 +71,9 @@ impl Command for UrlDecode {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
-        let args = CellPathOnlyArgs::from(cell_paths);
+        let cell_paths = Some(cell_paths).filter(|v| !v.is_empty());
+        let binary = call.has_flag(engine_state, stack, "binary")?;
+        let args = Arguments { cell_paths, binary };
         operate(action, args, input, call.head, engine_state.signals())
     }
 
@@ -75,21 +100,30 @@ impl Command for UrlDecode {
     }
 }
 
-fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
+fn action(input: &Value, args: &Arguments, head: Span) -> Value {
     let input_span = input.span();
     match input {
         Value::String { val, .. } => {
-            let val = percent_decode_str(val).decode_utf8();
-            match val {
-                Ok(val) => Value::string(val, head),
-                Err(e) => Value::error(
-                    ShellError::Generic(GenericError::new(
-                        "Failed to decode string",
-                        e.to_string(),
-                        input_span,
-                    )),
-                    head,
-                ),
+            let percent_decode_str = percent_decode_str(val);
+            match args.binary {
+                true => {
+                    let data: Cow<'_, [u8]> = percent_decode_str.into();
+                    Value::binary(data, head)
+                }
+                false => {
+                    let val = percent_decode_str.decode_utf8();
+                    match val {
+                        Ok(val) => Value::string(val, head),
+                        Err(e) => Value::error(
+                            ShellError::Generic(GenericError::new(
+                                "Failed to decode string",
+                                e.to_string(),
+                                input_span,
+                            )),
+                            head,
+                        ),
+                    }
+                }
             }
         }
         Value::Error { .. } => input.clone(),

--- a/crates/nu-command/src/network/url/decode.rs
+++ b/crates/nu-command/src/network/url/decode.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 
 use nu_cmd_base::input_handler::{CmdArgument, operate};
 use nu_engine::command_prelude::*;
-use nu_protocol::shell_error::generic::GenericError;
 
 use percent_encoding::percent_decode_str;
 
@@ -119,12 +118,14 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                     let val = percent_decode_str.decode_utf8();
                     match val {
                         Ok(val) => Value::string(val, head),
-                        Err(e) => Value::error(
-                            ShellError::Generic(GenericError::new(
-                                "Failed to decode string",
-                                e.to_string(),
-                                input_span,
-                            )),
+                        Err(_) => Value::error(
+                            ShellError::NonUtf8Custom {
+                                msg: "\
+                                    Input is not UTF-8 encoded.\n\
+                                    Try using the `--binary` flag together with `decode`."
+                                    .into(),
+                                span: input_span,
+                            },
                             head,
                         ),
                     }

--- a/crates/nu-command/src/network/url/decode.rs
+++ b/crates/nu-command/src/network/url/decode.rs
@@ -96,6 +96,11 @@ impl Command for UrlDecode {
                     Span::test_data(),
                 )),
             },
+            Example {
+                description: "Decode a percent-encoded iso-8859-1 string.",
+                example: "'%A3%20rates' | url decode --binary | decode iso-8859-1",
+                result: Some(Value::test_string("£ rates")),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -101,6 +101,11 @@ impl Command for UrlEncode {
                     "https%3A%2F%2Fexample%2Ecom%2Ffoo%20bar",
                 )),
             },
+            Example {
+                description: "Encode a iso-8859-1 encoded string.",
+                example: "'£ rates' | encode iso-8859-1 | url encode",
+                result: Some(Value::test_string("%A3%20rates")),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -1,7 +1,21 @@
-use nu_cmd_base::input_handler::{CellPathOnlyArgs, operate};
+use nu_cmd_base::input_handler::{CmdArgument, operate};
 use nu_engine::command_prelude::*;
 
 use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+
+struct Arguments {
+    cell_paths: Option<Vec<CellPath>>,
+    ascii_set: &'static AsciiSet,
+}
+
+static ASCII_SET_ALL: &AsciiSet = NON_ALPHANUMERIC;
+static ASCII_SET_NOT_ALL: &AsciiSet = &NON_ALPHANUMERIC.remove(b'/').remove(b':').remove(b'.');
+
+impl CmdArgument for Arguments {
+    fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
+        self.cell_paths.take()
+    }
+}
 
 #[derive(Clone)]
 pub struct UrlEncode;
@@ -48,12 +62,16 @@ impl Command for UrlEncode {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
-        let args = CellPathOnlyArgs::from(cell_paths);
-        if call.has_flag(engine_state, stack, "all")? {
-            operate(action_all, args, input, call.head, engine_state.signals())
-        } else {
-            operate(action, args, input, call.head, engine_state.signals())
-        }
+        let cell_paths = Some(cell_paths).filter(|v| !v.is_empty());
+        let ascii_set = match call.has_flag(engine_state, stack, "all")? {
+            true => ASCII_SET_ALL,
+            false => ASCII_SET_NOT_ALL,
+        };
+        let args = Arguments {
+            cell_paths,
+            ascii_set,
+        };
+        operate(action, args, input, call.head, engine_state.signals())
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -86,30 +104,11 @@ impl Command for UrlEncode {
     }
 }
 
-fn action_all(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
+fn action(input: &Value, args: &Arguments, head: Span) -> Value {
     match input {
         Value::String { val, .. } => {
-            const FRAGMENT: &AsciiSet = NON_ALPHANUMERIC;
-            Value::string(utf8_percent_encode(val, FRAGMENT).to_string(), head)
-        }
-        Value::Error { .. } => input.clone(),
-        _ => Value::error(
-            ShellError::OnlySupportsThisInputType {
-                exp_input_type: "string".into(),
-                wrong_type: input.get_type().to_string(),
-                dst_span: head,
-                src_span: input.span(),
-            },
-            head,
-        ),
-    }
-}
-
-fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
-    match input {
-        Value::String { val, .. } => {
-            const FRAGMENT: &AsciiSet = &NON_ALPHANUMERIC.remove(b'/').remove(b':').remove(b'.');
-            Value::string(utf8_percent_encode(val, FRAGMENT).to_string(), head)
+            let utf8_percent_encode = utf8_percent_encode(val, args.ascii_set);
+            Value::string(utf8_percent_encode.to_string(), head)
         }
         Value::Error { .. } => input.clone(),
         _ => Value::error(

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -1,7 +1,7 @@
 use nu_cmd_base::input_handler::{CmdArgument, operate};
 use nu_engine::command_prelude::*;
 
-use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, percent_encode, utf8_percent_encode};
 
 struct Arguments {
     cell_paths: Option<Vec<CellPath>>,
@@ -29,7 +29,8 @@ impl Command for UrlEncode {
         Signature::build("url encode")
             .input_output_types(vec![
                 (Type::String, Type::String),
-                (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String))),
+                (Type::Binary, Type::String),
+                (Type::List(Box::new(Type::one_of([Type::String, Type::Binary]))), Type::List(Box::new(Type::String))),
                 (Type::table(), Type::table()),
                 (Type::record(), Type::record()),
             ])
@@ -108,6 +109,10 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
     match input {
         Value::String { val, .. } => {
             let utf8_percent_encode = utf8_percent_encode(val, args.ascii_set);
+            Value::string(utf8_percent_encode.to_string(), head)
+        }
+        Value::Binary { val, .. } => {
+            let utf8_percent_encode = percent_encode(val, args.ascii_set);
             Value::string(utf8_percent_encode.to_string(), head)
         }
         Value::Error { .. } => input.clone(),

--- a/crates/nu-command/tests/commands/url/decode.rs
+++ b/crates/nu-command/tests/commands/url/decode.rs
@@ -15,9 +15,8 @@ fn url_decode_special_characters() -> Result {
 fn url_decode_error_invalid_utf8() -> Result {
     let err = test().run("'%99' | url decode").expect_error()?;
     match err {
-        ShellError::Generic(err) => {
-            assert_eq!(err.error, "Failed to decode string");
-            assert_contains("invalid utf-8 sequence", err.msg);
+        ShellError::NonUtf8Custom { msg, .. } => {
+            assert_contains("--binary", msg);
             Ok(())
         }
         err => Err(err.into()),


### PR DESCRIPTION
## Description

- I wanted to see if I could write a helper command in nu for handling "Content-Disposition" headers as described in #18292
- Researched how it should be [parsed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Disposition#syntax)
- Realize it's not as straightforward as one might expect: [RFC 5987, section-3.2.2](https://datatracker.ietf.org/doc/html/rfc5987#section-3.2.2)
  - `filename="easy peasy.txt"`
  - `filename*=iso-8859-1'en'%A3%20rates.txt` (not so easy :pensive:)
- Try
  ```nushell
  '%A3%20rates' | url decode  # | decode iso-8859-1
  ```
  And fail
  ```
   Error: nu::shell::error
  
    × Failed to decode string
     ╭─[repl_entry #1:1:1]
   1 │ '%A3%20rates' | url decode  # | decode iso-8859-1
     · ──────┬──────
     ·       ╰── invalid utf-8 sequence of 1 bytes from index 0
     ╰────
  ```
- Rejoice :tada:
  ```nushell
  '%A3%20rates' | url decode --binary | decode iso-8859-1
  # => £ rates
  ```

## User-facing changes (Release notes)

- `url encode` can now encode binary input too, adding support for encoding non UTF-8 texts
  ```nushell
  '£ rates' | encode iso-8859-1 | url encode
  # => %A3%20rates
  ```
- `url decode` can now decode inputs that do not evaluate to UTF-8 texts by returning a binary value (only with the `--binary` switch)
  ```nushell
  '%A3%20rates' | url decode --binary | decode iso-8859-1
  # => £ rates
  ```