### PR TITLE
Reduce the size of the release binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -433,10 +433,12 @@ sqlite = [
   "reedline/sqlite",
 ]
 
+# Reduce release binary size and improve runtime performance at the cost of longer compile times
 [profile.release]
-opt-level = "s"     # Optimize for size
-strip = "debuginfo"
-lto = "thin"
+codegen-units = 1
+lto = true # "fat"
+panic = "abort"
+strip = true # "symbols"
 
 # build with `cargo build --profile profiling`
 # to analyze performance with tooling like linux perf


### PR DESCRIPTION
## Description
I stumbled on these comments while reading about the [proposed blockers for the 1.0 release](https://github.com/nushell/nushell/issues/18297):

> The biggest problem I see is that the nushell core nu-command is extremely big for a shell

> Don't forget nu take 30-50 MiB where bash takes only 5MiB

Source: https://github.com/nushell/nushell/issues/18297#issuecomment-4576977436, https://github.com/nushell/nushell/issues/18297#issuecomment-4578494838

In the long term I think we should focus on making changes to the actual codebase in order to decrease the size of the release binaries by removing unneeded dependencies and bloat that doesn't need to be there. However, I figured it'd be wise to start from the low-hanging fruit by configuring the compile flags, which, as far as I'm able to tell, haven't really been tuned yet.

I've personally set the following arguments inside my config.toml file that Cargo uses for each release build:

```
[profile.release]
codegen-units = 1
lto = true
panic = "abort"
strip = true
```

These are mostly (/solely) based off of https://github.com/johnthagen/min-sized-rust with some trial and error added on top. With these flags set, I'm able to reduce the size of the release binary from 69.1 MB all the way down to 31.5 MB when having these settings set globally, while also potentially making the binary itself faster during runtime. By setting these values for our Cargo.toml only (as is done in this PR), the binary size was reduced to 44.6 MB.

The changes are better explained in the repository linked above and in the [official documentation](https://doc.rust-lang.org/cargo/reference/profiles.html), but in short:
- Codegen units were reduced to the minimum of 1 instead of the default of 16 set by Cargo. This change reduces the size of the binaries and should also increase the runtime performance with the tradeoff of increased compile time.
- LTO was changed to "fat"/true from "thin", which Nushell had set previously. According to the official documentation, "thin" [is similar to "fat", but takes substantially less time to run while still achieving performance gains similar to "fat"](https://doc.rust-lang.org/cargo/reference/profiles.html#lto).
- Panic was set to "abort" rather than the alternative of "unwind". We shouldn't have release builds panic anyway, so it shouldn't matter whether we have unwinding enabled or not on panics.
- Strip is set to true, which is equivalent to "symbols". Previously Nushell had set this to a less aggressive value of "debuginfo". Once again, there's no reason not to strip all debugging information from a release binary.
- Opt-level isn't set explicitly, which makes it fall back to the value of 3. This didn't seem to have a huge impact on the binary size anyway when comparing it to those built with the value set to "s" or "z".

I tested all of the changes individually on my X86_64 non-musl Linux machine and was able to confirm that they all reduced the binary size compared to the original/fallback values.

At first I wanted to open a discussion for these changes, but it seems like we already had one somewhat related to this subject https://github.com/nushell/nushell/discussions/16547, yet it seems like nothing was done even though the same configuration options were discussed in that thread. As such I figured I should open a draft PR for this to gather some feedback and see if this is something we can do.

## User-facing changes (Release notes)
Reduce release binary size and improve runtime performance at the cost of longer compile times.