### PR TITLE
Fix nix flake build (rust toolchain + workspace package version)

### DIFF
--- a/scripts/nix/default.nix
+++ b/scripts/nix/default.nix
@@ -61,6 +61,12 @@ let
   cargoToml = fromTOML (readFile (root + /Cargo.toml));
   # Allow for extra Cargo.toml files to be passed for crates
   extraToml = fromTOML (readFile extraCargo);
+
+  version =
+    if (cargoToml.package.version.workspace or false) then
+      cargoToml.workspace.package.version
+    else
+      cargoToml.package.version;
 in
 rustPlatform.buildRustPackage {
   inherit
@@ -72,8 +78,8 @@ rustPlatform.buildRustPackage {
     checkFlags
     buildType
     checkType
+    version
     ;
-  inherit (cargoToml.package) version;
 
   # Crates will need to build with their Cargo.toml
   src = toSource {

--- a/scripts/nix/flake.lock
+++ b/scripts/nix/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764988672,
-        "narHash": "sha256-FIJtt3Zil89/hLy9i7f0R2xXcJDPc3CeqiiCLfsFV0Y=",
+        "lastModified": 1780370483,
+        "narHash": "sha256-7mDa7OBAaf7MU6ZovT9ENfD62kH911SsSazBb4KTDF0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "086fd19a68e80fcc8a298e9df4674982e4c498a6",
+        "rev": "4a408e1fc99ad517b4cb402fd0de7464f40c05e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
Support `workspace.package.version` since #18286 changed the main crate to inherit version from the workspace. The flake was still expecting `package.version` to be a normal version string which is no longer the case.

Also update rust-overlay in flake.lock to get the newer toolchain that's now required by `rust-toolchain.toml`.

Fixes #18329

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
Fix Nix package evaluation for building from flake.


## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->

I think adding some simple CI checks (maybe in the nightly job?) for the flake would be nice, but didn't want to overload this PR by trying to add that which is often tricky to get right (GitHub Actions = pain 😭).