### PR TITLE
Fix simple Clippy error

### DIFF
--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -181,7 +181,7 @@ fn from_xlsx(
                 .headers()
                 .unwrap_or_else(|| vec!["".to_string(); sheet_width])
                 .into_iter()
-                .zip(default_headers.into_iter())
+                .zip(default_headers)
                 .map(
                     |(name, default)| {
                         if name.is_empty() { default } else { name }


### PR DESCRIPTION
## Description
Fixes the following error
```
error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
```
when running `^cargo clippy`, `toolkit clippy`, or `toolkit pr check`, which stops the later command.

## User-facing changes (Release notes)
N/A