### PR TITLE
chore: Upgrade to fff 0.9 and reenable watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "fff-grep"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68286213d07412846c0010a0b227b79c08fbc214cf7822f85cabd9e3f36606ae"
+checksum = "e2e3bc72c710fcad66390b4a6f91b04739d8e5d58b808a733bd7775f53c25dd8"
 dependencies = [
  "bstr",
  "memchr",
@@ -2201,15 +2201,15 @@ dependencies = [
 
 [[package]]
 name = "fff-query-parser"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5eb0a0363657b57a3a60d12a76a41f799406514b238123487e54290a6f1a62f"
+checksum = "4c82a1957c0db1c1a2e4b1471e20cf0c41b13fb69f6aea42aec8a2b8ddd03dfd"
 
 [[package]]
 name = "fff-search"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b4517eb8a9b87a46d09e9958f2ddbc036440a9fb5d5ddfc05e6dcf4655ce2"
+checksum = "8202f46b59a35840766815f1c144c71974e8600dcbd2c52f20a00799e36f3a78"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ encoding_rs = "0.8"
 fancy-regex = "0.18"
 filesize = "0.2"
 filetime = "0.2.27"
-fff-search = { version = "=0.8.4", default-features = false }
+fff-search = { version = "=0.9.0", default-features = false }
 fluent = "0.17.0"
 fuzzy-matcher = { version = "^0.3.7" }
 gatekeeper = "3.0.0"

--- a/crates/nu-command/src/filesystem/idx/import.rs
+++ b/crates/nu-command/src/filesystem/idx/import.rs
@@ -16,6 +16,11 @@ impl Command for IdxImport {
                 SyntaxShape::Filepath,
                 "Path to a stored idx snapshot.",
             )
+            .switch(
+                "no-watch",
+                "Disable filesystem watching after import (watching is enabled by default).",
+                None,
+            )
             .input_output_types(vec![(Type::Nothing, Type::record())])
             .category(Category::FileSystem)
     }
@@ -46,8 +51,10 @@ impl Command for IdxImport {
         let path: Spanned<String> = call.req(engine_state, stack, 0)?;
         let cwd = engine_state.cwd(Some(stack))?;
         let abs = nu_path::expand_path_with(path.item, cwd, true);
+        let no_watch = call.has_flag(engine_state, stack, "no-watch")?;
+
         Ok(PipelineData::value(
-            restore_snapshot(abs.as_ref(), call.head)?,
+            restore_snapshot(abs.as_ref(), no_watch, call.head)?,
             None,
         ))
     }

--- a/crates/nu-command/src/filesystem/idx/init.rs
+++ b/crates/nu-command/src/filesystem/idx/init.rs
@@ -18,6 +18,16 @@ impl Command for IdxInit {
                 Some('w'),
             )
             .switch(
+                "no-watch",
+                "Disable filesystem watching after the initial scan (watching is enabled by default).",
+                None,
+            )
+            .switch(
+                "no-content-indexing",
+                "Disable file content indexing (content indexing is enabled by default).",
+                None,
+            )
+            .switch(
                 "follow-symlinks",
                 "Whether to follow symlinks when indexing.",
                 Some('f'),
@@ -31,7 +41,7 @@ impl Command for IdxInit {
     }
 
     fn extra_description(&self) -> &str {
-        "By default idx init returns immediately and indexing continues in the background. Use `idx status` to check when scanning completes. Pass `--wait` to block until the initial scan finishes."
+        "By default idx init returns immediately and indexing continues in the background. Use `idx status` to check when scanning completes. Pass `--wait` to block until the initial scan finishes. Filesystem watching is enabled by default; pass `--no-watch` to disable it."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -46,6 +56,11 @@ impl Command for IdxInit {
                 example: "idx init . --wait",
                 result: None,
             },
+            Example {
+                description: "Initialize idx without filesystem watching",
+                example: "idx init . --no-watch",
+                result: None,
+            },
         ]
     }
 
@@ -58,13 +73,14 @@ impl Command for IdxInit {
     ) -> Result<PipelineData, ShellError> {
         let path: Spanned<String> = call.req(engine_state, stack, 0)?;
         let wait = call.has_flag(engine_state, stack, "wait")?;
+        let no_watch = call.has_flag(engine_state, stack, "no-watch")?;
+        let no_indexing = call.has_flag(engine_state, stack, "no-content-indexing")?;
         let follow = call.has_flag(engine_state, stack, "follow-symlinks")?;
         let cwd = engine_state.cwd(Some(stack))?;
         let abs = nu_path::expand_path_with(path.item, cwd, true);
-        // There is a functionality in fff-search to update the index via watch but it was non-trivial to get working
-        // So, for now, let's always default to watch = false.
-        let watch = false;
-        let status = init_runtime(&abs, watch, wait, follow, call.head)?;
+        let watch = !no_watch;
+        let content_indexing = !no_indexing;
+        let status = init_runtime(&abs, watch, wait, follow, content_indexing, call.head)?;
         Ok(PipelineData::value(status.to_value(call.head), None))
     }
 }

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -437,6 +437,7 @@ pub fn init_runtime(
     watch: bool,
     wait: bool,
     follow_symlinks: bool,
+    enable_content_indexing: bool,
     span: Span,
 ) -> Result<IdxStatus, ShellError> {
     let shared_picker = SharedFilePicker::default();
@@ -447,12 +448,14 @@ pub fn init_runtime(
         shared_frecency,
         FilePickerOptions {
             base_path: path.display().to_string(),
-            enable_mmap_cache: false,
-            enable_content_indexing: false,
-            mode: FFFMode::Ai,
             cache_budget: None,
-            watch,
+            enable_content_indexing,
+            enable_fs_root_scanning: false, // this will error out if executed at /
+            enable_home_dir_scanning: true,
+            enable_mmap_cache: false,
             follow_symlinks,
+            mode: FFFMode::Ai,
+            watch,
         },
     )
     .map_err(|err| fff_error(err, span))?;
@@ -1774,12 +1777,14 @@ pub fn restore_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
         shared_frecency,
         FilePickerOptions {
             base_path: base_path_str.clone(),
-            enable_mmap_cache: false,
-            enable_content_indexing: false,
-            mode: FFFMode::Ai,
             cache_budget: None,
-            watch: false,
+            enable_content_indexing: false,
+            enable_fs_root_scanning: false,
+            enable_home_dir_scanning: true,
+            enable_mmap_cache: false,
             follow_symlinks: false,
+            mode: FFFMode::Ai,
+            watch: false,
         },
     );
 

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -1579,7 +1579,7 @@ pub fn store_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
 /// The restored runtime is immediately queryable by `idx files`, `idx dirs`,
 /// `idx find`, and `idx status` without a filesystem scan.
 #[cfg(feature = "sqlite")]
-pub fn restore_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
+pub fn restore_snapshot(path: &Path, no_watch: bool, span: Span) -> Result<Value, ShellError> {
     // Open SQLite database
     let conn = Connection::open(path).map_err(|err| {
         ShellError::Generic(GenericError::new(
@@ -1784,7 +1784,7 @@ pub fn restore_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
             enable_mmap_cache: false,
             follow_symlinks: false,
             mode: FFFMode::Ai,
-            watch: false,
+            watch: !no_watch,
         },
     );
 

--- a/crates/nu-command/tests/commands/idx.rs
+++ b/crates/nu-command/tests/commands/idx.rs
@@ -32,7 +32,7 @@ fn idx_status_reports_initialized_after_init() -> Result {
 
 #[test]
 #[serial]
-fn idx_status_reports_watch_disabled_by_default() -> Result {
+fn idx_status_reports_watch_enabled_by_default() -> Result {
     Playground::setup(
         "idx_status_reports_watch_enabled_by_default",
         |dirs, sandbox| {
@@ -41,7 +41,7 @@ fn idx_status_reports_watch_disabled_by_default() -> Result {
             test()
                 .cwd(dirs.test())
                 .run("idx init .; idx status | get watch")
-                .expect_value_eq(false)
+                .expect_value_eq(true)
         },
     )
 }


### PR DESCRIPTION
## Description

This PR updates fff to 0.9 and does a little bit of changes to the default config: specifically enable indexing by default which is the main reason fff is so fast, here is an example on the index directory

```sh
idx init .
timeit {idx search MAX_FILE_SIZE}
355ms 288ms 21ms

idx init . --no-content-indexing
timeit {idx search MAX_FILE_SIZE}
4s 874ms 113ms
```

I think if the user is starting the idx command they likely are ready for an additional resources spent on storing the index

> you might be interesting in the upcoming persisted index mode that
does indexing but stores it in the memory mapped file and allowing to restore it between the sessions

@fdncred this PR is simply enabling the watch mode and it just works, I verified on macos and linux - I didn't face any issues

https://github.com/user-attachments/assets/5d890d7a-3c8a-4936-b094-057387f388ad

## User-facing changes (Release notes)
The `idx init` command uses content indexing by default.