### PR TITLE
non-blocking completions

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -157,7 +157,7 @@ type PendingRx = Arc<Mutex<Option<mpsc::Receiver<()>>>>;
 #[derive(Clone)]
 pub struct NuCompleter {
     engine_state: Arc<EngineState>,
-    stack: Stack,
+    stack: Arc<Stack>,
     cache: CompletionCache,
     pending_rx: PendingRx,
 }
@@ -190,7 +190,7 @@ impl NuCompleter {
     pub fn new(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
         Self {
             engine_state,
-            stack: Stack::with_parent(stack).reset_out_dest().collect_value(),
+            stack,
             cache: Arc::new(Mutex::new(HashMap::new())),
             pending_rx: Arc::new(Mutex::new(None)),
         }
@@ -199,13 +199,15 @@ impl NuCompleter {
     fn new_for_background(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
         Self {
             engine_state,
-            stack: Stack::with_parent(stack)
-                .reset_out_dest()
-                // We never want to write to the terminal
-                .suppress_output()
-                // We don't want races with reedlines own
-                .suppress_stdin()
-                .collect_value(),
+            stack: Arc::new(
+                Stack::with_parent(stack)
+                    .reset_out_dest()
+                    // We never want to write to the terminal
+                    .suppress_output()
+                    // We don't want races with reedlines own
+                    .suppress_stdin()
+                    .collect_value(),
+            ),
             cache: Arc::new(Mutex::new(HashMap::new())),
             pending_rx: Arc::new(Mutex::new(None)),
         }
@@ -639,7 +641,6 @@ impl NuCompleter {
                         }
 
                         // resort to external completer set in config
-                        // resort to external completer set in config
                         let completion = self
                             .engine_state
                             .get_config()
@@ -830,12 +831,12 @@ impl ReedlineCompleter for NuCompleter {
         }
 
         let engine_state = self.engine_state.clone();
-        let stack = Arc::new(self.stack.clone());
+        let stack = self.stack.clone();
         let cache = self.cache.clone();
         let line_owned = line.to_string();
 
         thread::spawn(move || {
-            let completer = NuCompleter::new_background(engine_state, stack);
+            let completer = NuCompleter::new_for_background(engine_state, stack);
             let suggestions: Vec<Suggestion> = completer
                 .fetch_completions_at(&line_owned, pos)
                 .into_iter()
@@ -971,7 +972,7 @@ mod completer_tests {
             nu_cmd_lang::create_default_context(),
         ));
         let stack = Arc::new(Stack::new());
-        let bg = NuCompleter::new_background(engine_state, stack);
+        let bg = NuCompleter::new_for_background(engine_state, stack);
 
         assert!(
             matches!(bg.stack.stdout(), OutDest::Value),

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -144,22 +144,55 @@ fn strip_placeholder_if_any<'a>(
     (new_span, prefix)
 }
 
-struct CachedCompletion {
-    suggestions: Vec<Suggestion>,
-    timestamp: Instant,
+/// Cache key and worker message identity: (line buffer, cursor byte offset).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CompletionQuery {
+    line: String,
+    pos: usize,
 }
 
-type CompletionCache = Arc<Mutex<HashMap<(String, usize), CachedCompletion>>>;
-/// Shared slot for the background-thread signal channel receiver.
-/// Wrapped in Arc<Mutex<>> so NuCompleter stays Clone.
-type PendingRx = Arc<Mutex<Option<mpsc::Receiver<()>>>>;
+struct CacheEntry {
+    suggestions: Vec<Suggestion>,
+    at: Instant,
+}
 
-#[derive(Clone)]
+/// Reedline-side handle to the single background worker for this completer.
+///
+/// `pending` is the latest enqueued request; the worker may only wake reedline
+/// when it finishes that generation (stale ready signals are drained/ignored).
+struct CompletionWorker {
+    request_tx: mpsc::Sender<(CompletionQuery, u64)>,
+    ready_rx: mpsc::Receiver<u64>,
+    next_generation: u64,
+    /// `(query, generation)` still awaited from the worker, if any.
+    pending: Option<(CompletionQuery, u64)>,
+}
+
+/// Isolate a stack for completion evaluation.
+///
+/// Completions may run arbitrary code; output is always captured so it cannot
+/// corrupt reedline / LSP. Background workers also null child stdin and detach
+/// from the terminal (via `Stack::suppress_stdin`) so subprocesses cannot race
+/// the line editor.
+fn isolated_stack(parent: Arc<Stack>, background: bool) -> Arc<Stack> {
+    let stack = Stack::with_parent(parent)
+        .reset_out_dest()
+        .suppress_output()
+        .collect_value();
+    Arc::new(if background {
+        stack.suppress_stdin()
+    } else {
+        stack
+    })
+}
+
 pub struct NuCompleter {
     engine_state: Arc<EngineState>,
     stack: Arc<Stack>,
-    cache: CompletionCache,
-    pending_rx: PendingRx,
+    /// Shared with the background worker; reedline thread only.
+    cache: Arc<Mutex<HashMap<CompletionQuery, CacheEntry>>>,
+    /// Lazily spawned on the first cache miss; reedline thread only (no lock).
+    worker: Option<CompletionWorker>,
 }
 
 /// Common arguments required for Completer
@@ -188,28 +221,20 @@ impl Context<'_> {
 
 impl NuCompleter {
     pub fn new(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
+        Self::with_stack(engine_state, isolated_stack(stack, false))
+    }
+
+    /// Background worker: same isolation as [`Self::new`], plus suppressed stdin.
+    fn for_background(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
+        Self::with_stack(engine_state, isolated_stack(stack, true))
+    }
+
+    fn with_stack(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
         Self {
             engine_state,
             stack,
             cache: Arc::new(Mutex::new(HashMap::new())),
-            pending_rx: Arc::new(Mutex::new(None)),
-        }
-    }
-
-    fn new_for_background(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
-        Self {
-            engine_state,
-            stack: Arc::new(
-                Stack::with_parent(stack)
-                    .reset_out_dest()
-                    // We never want to write to the terminal
-                    .suppress_output()
-                    // We don't want races with reedlines own
-                    .suppress_stdin()
-                    .collect_value(),
-            ),
-            cache: Arc::new(Mutex::new(HashMap::new())),
-            pending_rx: Arc::new(Mutex::new(None)),
+            worker: None,
         }
     }
 
@@ -792,7 +817,7 @@ impl NuCompleter {
 
         completer.fetch(
             ctx.working_set,
-            &self.stack,
+            self.stack.as_ref(),
             String::from_utf8_lossy(ctx.prefix),
             ctx.span,
             ctx.offset,
@@ -808,221 +833,281 @@ struct CommandCompletionOptions {
     quote_internals: bool,
 }
 
+impl NuCompleter {
+    fn cached(&self, query: &CompletionQuery) -> Option<Vec<Suggestion>> {
+        let cache = self.cache.lock().ok()?;
+        let entry = cache.get(query)?;
+        (entry.at.elapsed() < CACHE_TTL).then(|| entry.suggestions.clone())
+    }
+
+    /// Spawn the long-lived worker. Takes field refs so callers can hold
+    /// `&mut self.worker` while building it.
+    fn spawn_worker(
+        engine_state: &Arc<EngineState>,
+        stack: &Arc<Stack>,
+        cache: &Arc<Mutex<HashMap<CompletionQuery, CacheEntry>>>,
+    ) -> CompletionWorker {
+        let (request_tx, request_rx) = mpsc::channel::<(CompletionQuery, u64)>();
+        let (ready_tx, ready_rx) = mpsc::channel::<u64>();
+
+        let completer = NuCompleter::for_background(engine_state.clone(), Arc::clone(stack));
+        let cache = Arc::clone(cache);
+
+        thread::spawn(move || {
+            let mut queued = None;
+            loop {
+                // Prefer a request that arrived during the previous compute;
+                // otherwise block for the next one.
+                let (query, generation) = match queued.take().or_else(|| request_rx.recv().ok()) {
+                    Some(req) => req,
+                    None => return,
+                };
+
+                // Coalesce: only the latest query is worth computing.
+                let mut latest = (query, generation);
+                while let Ok(newer) = request_rx.try_recv() {
+                    latest = newer;
+                }
+                let (query, generation) = latest;
+
+                let suggestions: Vec<Suggestion> = completer
+                    .fetch_completions_at(&query.line, query.pos)
+                    .into_iter()
+                    .map(|s| s.suggestion)
+                    .collect();
+
+                if let Ok(mut guard) = cache.lock() {
+                    guard.retain(|_, e| e.at.elapsed() < CACHE_TTL);
+                    guard.insert(
+                        query,
+                        CacheEntry {
+                            suggestions,
+                            at: Instant::now(),
+                        },
+                    );
+                }
+
+                // If more work arrived while we computed, process it next and
+                // do NOT signal ready!
+                match request_rx.try_recv() {
+                    Ok(newer) => queued = Some(newer),
+                    Err(mpsc::TryRecvError::Empty) => {
+                        if ready_tx.send(generation).is_err() {
+                            return;
+                        }
+                    }
+                    Err(mpsc::TryRecvError::Disconnected) => return,
+                }
+            }
+        });
+
+        CompletionWorker {
+            request_tx,
+            ready_rx,
+            next_generation: 0,
+            pending: None,
+        }
+    }
+}
+
 impl ReedlineCompleter for NuCompleter {
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
-        let key = (line.to_string(), pos);
+        let query = CompletionQuery {
+            line: line.to_string(),
+            pos,
+        };
 
-        // Return immediately if the cache has a fresh result for this query.
-        if let Some(suggestions) = get_from_cache(self, &key) {
+        if let Some(suggestions) = self.cached(&query) {
+            if let Some(worker) = self.worker.as_mut()
+                && worker.pending.as_ref().is_some_and(|(q, _)| q == &query)
+            {
+                worker.pending = None;
+            }
             return suggestions;
         }
 
-        // If the cache misses: alert the background thread and instantly return empty.
-        // Reedline will call `check_pending` / `complete` again to pick up the
-        // results and repaint.
-        let (tx, rx) = mpsc::channel();
-        {
-            let Ok(mut pending_guard) = self.pending_rx.lock() else {
-                // If the mutex is poisoned,
-                // return empty results and pray the next call goes smoothly.
-                return vec![];
-            };
-            pending_guard.replace(rx);
-        }
-
-        let engine_state = self.engine_state.clone();
-        let stack = self.stack.clone();
-        let cache = self.cache.clone();
-        let line_owned = line.to_string();
-
-        thread::spawn(move || {
-            let completer = NuCompleter::new_for_background(engine_state, stack);
-            let suggestions: Vec<Suggestion> = completer
-                .fetch_completions_at(&line_owned, pos)
-                .into_iter()
-                .map(|s| s.suggestion)
-                .collect();
-
-            if let Ok(mut guard) = cache.lock() {
-                guard.insert(
-                    key,
-                    CachedCompletion {
-                        suggestions,
-                        timestamp: Instant::now(),
-                    },
-                );
-            }
-
-            // Results are in the cache!
-            let _ = tx.send(());
+        let worker = self.worker.get_or_insert_with(|| {
+            Self::spawn_worker(&self.engine_state, &self.stack, &self.cache)
         });
 
-        fn get_from_cache(
-            completer: &NuCompleter,
-            key: &(String, usize),
-        ) -> Option<Vec<Suggestion>> {
-            let cache = completer.cache.lock().ok()?;
-            let entry = cache.get(key)?;
+        // Already waiting on this exact query.
+        if worker.pending.as_ref().is_some_and(|(q, _)| q == &query) {
+            return vec![];
+        }
 
-            if entry.timestamp.elapsed() < CACHE_TTL {
-                Some(entry.suggestions.clone())
-            } else {
-                None
-            }
+        worker.next_generation = worker.next_generation.wrapping_add(1);
+        let generation = worker.next_generation;
+
+        if worker.request_tx.send((query.clone(), generation)).is_ok() {
+            worker.pending = Some((query, generation));
+        } else {
+            worker.pending = None;
         }
 
         vec![]
     }
 
     fn has_pending(&mut self) -> bool {
-        self.pending_rx.lock().is_ok_and(|g| g.is_some())
+        self.worker.as_ref().is_some_and(|w| w.pending.is_some())
     }
 
     fn check_pending(&mut self) -> bool {
-        let Ok(mut guard) = self.pending_rx.lock() else {
-            return false;
-        };
-        let Some(rx) = guard.as_ref() else {
+        let Some(worker) = self.worker.as_mut() else {
             return false;
         };
 
-        match rx.try_recv() {
-            Ok(()) => {
-                *guard = None;
-                true
-            }
-            Err(mpsc::TryRecvError::Empty) => false,
-            Err(mpsc::TryRecvError::Disconnected) => {
-                *guard = None;
-                false
+        let Some(expected) = worker.pending.as_ref().map(|(_, generation)| *generation) else {
+            // Drain any late signals so the channel does not fill up.
+            while worker.ready_rx.try_recv().is_ok() {}
+            return false;
+        };
+
+        let mut matched = false;
+        while let Ok(generation) = worker.ready_rx.try_recv() {
+            if generation == expected {
+                matched = true;
             }
         }
+
+        if matched {
+            worker.pending = None;
+        }
+        matched
     }
 }
 
 #[cfg(test)]
 mod completer_tests {
     use super::*;
+    use nu_protocol::OutDest;
+
+    fn test_engine() -> Arc<EngineState> {
+        let mut engine =
+            nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
+        let delta = StateWorkingSet::new(&engine).render();
+        engine.merge_delta(delta).expect("merge_delta");
+        Arc::new(engine)
+    }
+
+    /// Poll like reedline until the latest request is ready (or fail the test).
+    fn wait_for(completer: &mut NuCompleter, line: &str, pos: usize) -> Vec<Suggestion> {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            if completer.check_pending() {
+                return completer.complete(line, pos);
+            }
+            assert!(
+                Instant::now() < deadline,
+                "background completion timed out for {line:?}"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
 
     #[test]
-    fn test_non_blocking_completion_cache() {
-        let mut engine_state =
-            nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
+    fn non_blocking_complete_fills_cache() {
+        let mut completer = NuCompleter::new(test_engine(), Arc::new(Stack::new()));
 
-        let delta = {
-            let working_set = nu_protocol::engine::StateWorkingSet::new(&engine_state);
-            working_set.render()
-        };
-
-        let result = engine_state.merge_delta(delta);
-        assert!(
-            result.is_ok(),
-            "Error merging delta: {:?}",
-            result.err().unwrap()
-        );
-
-        let mut completer = NuCompleter::new(engine_state.into(), Arc::new(Stack::new()));
-
-        // Get expected results via the direct (non-cached) path.
-        let expected: Vec<Suggestion> = completer
+        let expected: Vec<_> = completer
             .fetch_completions_at("ls | c", 6)
             .into_iter()
             .map(|s| s.suggestion)
             .collect();
-        assert!(!expected.is_empty(), "expected non-empty results");
-        assert!(
-            expected.iter().any(|s| s.value == "cd"),
-            "should contain cd"
-        );
+        assert!(expected.iter().any(|s| s.value == "cd"));
 
-        let first = completer.complete("ls | c", 6);
-        assert!(
-            first.is_empty(),
-            "first call should return empty (cache miss)"
-        );
-        assert!(completer.has_pending(), "should have pending completion");
+        assert!(completer.complete("ls | c", 6).is_empty());
+        assert!(completer.has_pending());
 
-        // Simulate reedline's polling loop: call check_pending() until results arrive,
-        // then call complete() to retrieve them from the cache.
-        let second = loop {
-            if completer.check_pending() {
-                break completer.complete("ls | c", 6);
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        };
-
-        assert_eq!(
-            expected.len(),
-            second.len(),
-            "cached result should match direct result"
-        );
+        let cached = wait_for(&mut completer, "ls | c", 6);
+        assert_eq!(expected.len(), cached.len());
         for s in &expected {
             assert!(
-                second.iter().any(|x| x.value == s.value),
-                "cached result should contain '{}'",
+                cached.iter().any(|x| x.value == s.value),
+                "missing {}",
                 s.value
             );
         }
     }
 
-    /// Verifies that the background completion stack NEVER inherits the live terminal's
-    /// stdout/stderr.
+    /// Only the latest enqueued generation may return true from `check_pending`.
     #[test]
-    fn test_background_completer_suppresses_output() {
-        use nu_protocol::OutDest;
+    fn only_latest_generation_wakes_pending() {
+        let mut engine =
+            nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
+        let setup = r#"
+            $env.config.completions.external = {
+                enable: true
+                completer: {|spans|
+                    sleep 80ms
+                    [{value: $"got-($spans | last)"}]
+                }
+            }
+        "#;
+        let mut stack = Stack::new();
+        let mut working_set = StateWorkingSet::new(&engine);
+        let block = parse(&mut working_set, None, setup.as_bytes(), false);
+        assert!(working_set.parse_errors.is_empty());
+        engine
+            .merge_delta(working_set.render())
+            .expect("merge setup");
+        nu_engine::eval_block::<nu_protocol::debugger::WithoutDebug>(
+            &engine,
+            &mut stack,
+            &block,
+            nu_protocol::PipelineData::empty(),
+        )
+        .expect("eval setup");
 
-        let engine_state = Arc::new(nu_command::add_shell_command_context(
-            nu_cmd_lang::create_default_context(),
-        ));
-        let stack = Arc::new(Stack::new());
-        let bg = NuCompleter::new_for_background(engine_state, stack);
+        let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+        let first = "somecmd a";
+        let second = "somecmd ab";
 
-        assert!(
-            matches!(bg.stack.stdout(), OutDest::Value),
-            "background completer stdout should be collected"
-        );
-        assert!(
-            matches!(bg.stack.stderr(), OutDest::Null),
-            "background completer stderr should be Null"
-        );
+        assert!(completer.complete(first, first.len()).is_empty());
+        // Let the worker start first before superseding it.
+        thread::sleep(Duration::from_millis(20));
+        assert!(completer.complete(second, second.len()).is_empty());
+        assert!(completer.has_pending());
 
-        assert!(
-            bg.stack.suppress_stdin,
-            "background completer must suppress child-process stdin"
-        );
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut premature_wakes = 0;
+        let result = loop {
+            if completer.check_pending() {
+                let suggestions = completer.complete(second, second.len());
+                if suggestions.is_empty() {
+                    premature_wakes += 1;
+                    assert!(completer.has_pending());
+                } else {
+                    break suggestions;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "latest completion never ready (premature_wakes={premature_wakes})"
+            );
+            thread::sleep(Duration::from_millis(10));
+        };
 
-        // foreground completer is chill with stdin
-        let fg = NuCompleter::new(
-            Arc::new(nu_command::add_shell_command_context(
-                nu_cmd_lang::create_default_context(),
-            )),
-            Arc::new(Stack::new()),
-        );
-        assert!(
-            !fg.stack.suppress_stdin,
-            "foreground completer must not suppress stdin"
-        );
+        assert_eq!(premature_wakes, 0);
+        assert!(result.iter().any(|s| s.value == "got-ab"), "{result:?}");
+    }
+
+    #[test]
+    fn isolation_contracts() {
+        let engine = test_engine();
+        let bg = NuCompleter::for_background(engine.clone(), Arc::new(Stack::new()));
+        assert!(matches!(bg.stack.stdout(), OutDest::Value));
+        assert!(matches!(bg.stack.stderr(), OutDest::Null));
+        assert!(bg.stack.suppress_stdin);
+
+        let fg = NuCompleter::new(engine, Arc::new(Stack::new()));
+        assert!(matches!(fg.stack.stdout(), OutDest::Value));
+        assert!(matches!(fg.stack.stderr(), OutDest::Null));
+        assert!(!fg.stack.suppress_stdin);
     }
 
     #[test]
     fn test_completion_helper() {
-        let mut engine_state =
-            nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
-
-        // Custom additions
-        let delta = {
-            let working_set = nu_protocol::engine::StateWorkingSet::new(&engine_state);
-            working_set.render()
-        };
-
-        let result = engine_state.merge_delta(delta);
-        assert!(
-            result.is_ok(),
-            "Error merging delta: {:?}",
-            result.err().unwrap()
-        );
-
-        let completer = NuCompleter::new(engine_state.into(), Arc::new(Stack::new()));
+        let completer = NuCompleter::new(test_engine(), Arc::new(Stack::new()));
         let dataset = [
             ("1 bit-sh", true, "b", vec!["bit-shl", "bit-shr"]),
             ("1.0 bit-sh", false, "b", vec![]),

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -1165,54 +1165,41 @@ mod completer_tests {
         assert!(fresh.iter().any(|s| s.value == "config"));
     }
 
-    /// Only the latest enqueued generation may return true from `check_pending`.
+    /// A superseded in-flight generation must never wake `check_pending`; only
+    /// the latest enqueued generation may.
     #[test]
     fn only_latest_generation_wakes_pending() {
-        // A private directory of gate files shared with the completer closure.
-        // Instead of racing on sleep durations, the worker announces when it
-        // begins a token and blocks until the test releases it, so each
-        // generation finishes exactly when we say so.
-        let gate_dir = std::env::temp_dir().join(format!(
-            "nu-completion-generation-test-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0),
-        ));
-        std::fs::create_dir_all(&gate_dir).expect("create gate dir");
-        let gate = gate_dir.to_string_lossy().replace('\\', "/");
+        // The external completer runs on the worker thread. For each token it
+        // touches `started-<token>` and then blocks until `release-<token>`
+        // appears, letting the test drive exactly when each generation finishes
+        // instead of racing on sleeps.
+        let gate = std::env::temp_dir().join(format!("nu-gen-test-{}", std::process::id()));
+        std::fs::create_dir_all(&gate).expect("create gate dir");
+        let gate_str = gate.to_string_lossy().replace('\\', "/");
 
-        let setup = format!(
-            r#"
-            $env.config.completions.external = {{
-                enable: true
-                completer: {{|spans|
-                    let token = ($spans | last)
-                    touch ('{gate}' | path join $"started-($token)")
-                    while not ('{gate}' | path join $"release-($token)" | path exists) {{
-                        sleep 10ms
-                    }}
-                    [{{value: $"got-($token)"}}]
-                }}
-            }}
-            "#
-        );
         let mut engine =
             nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
         let mut stack = Stack::new();
-        // `merge_env` (below) requires a valid `$env.PWD`; it can't be set from
-        // script, so seed it directly on the stack.
+        // `merge_env` needs a valid `$env.PWD`, which can't be set from script.
         stack.add_env_var(
             "PWD".to_string(),
-            nu_protocol::Value::string(&gate, nu_protocol::Span::unknown()),
+            nu_protocol::Value::string(&gate_str, nu_protocol::Span::unknown()),
+        );
+        let setup = format!(
+            r#"$env.config.completions.external = {{
+                enable: true
+                completer: {{|spans|
+                    let t = $spans | last
+                    touch ('{gate_str}' | path join $"started-($t)")
+                    while not ('{gate_str}' | path join $"release-($t)" | path exists) {{ sleep 10ms }}
+                    [{{value: $"got-($t)"}}]
+                }}
+            }}"#
         );
         let mut working_set = StateWorkingSet::new(&engine);
         let block = parse(&mut working_set, None, setup.as_bytes(), false);
         assert!(working_set.parse_errors.is_empty());
-        engine
-            .merge_delta(working_set.render())
-            .expect("merge setup");
+        engine.merge_delta(working_set.render()).expect("merge");
         nu_engine::eval_block::<nu_protocol::debugger::WithoutDebug>(
             &engine,
             &mut stack,
@@ -1220,61 +1207,45 @@ mod completer_tests {
             nu_protocol::PipelineData::empty(),
         )
         .expect("eval setup");
-        // Propagate `$env.config` (the external completer) into the permanent
-        // state the completer reads via `engine_state.get_config()`.
         engine.merge_env(&mut stack).expect("merge env");
 
-        // Gate helpers, keyed by the token the closure reports.
-        let started = |token: &str| gate_dir.join(format!("started-{token}"));
-        let release = |token: &str| {
-            std::fs::write(gate_dir.join(format!("release-{token}")), b"").expect("release token");
-        };
-        let wait_for_file = |path: std::path::PathBuf| {
+        let started = |t: &str| gate.join(format!("started-{t}"));
+        let release =
+            |t: &str| std::fs::write(gate.join(format!("release-{t}")), b"").expect("release");
+        let await_file = |p: std::path::PathBuf| {
             let deadline = Instant::now() + Duration::from_secs(30);
-            while !path.exists() {
-                assert!(Instant::now() < deadline, "timed out waiting for {path:?}");
+            while !p.exists() {
+                assert!(Instant::now() < deadline, "timed out waiting for {p:?}");
                 thread::sleep(Duration::from_millis(5));
             }
         };
 
         let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
-        let first = "somecmd a";
-        let second = "somecmd ab";
 
-        // Enqueue `first` and wait until the worker is actually computing it.
-        assert!(completer.complete(first, first.len()).is_empty());
-        assert!(completer.has_pending());
-        wait_for_file(started("a"));
+        // Enqueue gen1 and wait until the worker is actually computing it, so
+        // gen2 can't be coalesced in before gen1 starts.
+        assert!(completer.complete("somecmd a", 9).is_empty());
+        await_file(started("a"));
 
-        // Supersede with `second` while `first` is still in flight.
-        assert!(completer.complete(second, second.len()).is_empty());
-        assert!(completer.has_pending());
+        // Supersede with gen2 while gen1 is still blocked.
+        assert!(completer.complete("somecmd ab", 10).is_empty());
 
-        // Let `first` finish. Because `second` is already queued, the worker
-        // must move straight on to it without signaling the stale generation.
+        // Let gen1 finish. Because gen2 is already queued, the worker moves
+        // straight to it without signaling gen1's stale generation.
         release("a");
-        wait_for_file(started("ab"));
-
-        // `first` has now completed, yet `check_pending` must stay false: only
-        // the latest generation is allowed to wake it.
+        await_file(started("ab"));
         assert!(
             !completer.check_pending(),
             "a superseded generation woke check_pending"
         );
         assert!(completer.has_pending());
 
-        // Releasing `second` finally wakes the latest generation, which yields
-        // the latest result.
+        // gen2 finishing wakes the latest generation with the latest result.
         release("ab");
-        let deadline = Instant::now() + Duration::from_secs(30);
-        while !completer.check_pending() {
-            assert!(Instant::now() < deadline, "latest completion never ready");
-            thread::sleep(Duration::from_millis(5));
-        }
-        let result = completer.complete(second, second.len());
+        let result = wait_for(&mut completer, "somecmd ab", 10);
         assert!(result.iter().any(|s| s.value == "got-ab"), "{result:?}");
 
-        let _ = std::fs::remove_dir_all(&gate_dir);
+        let _ = std::fs::remove_dir_all(&gate);
     }
 
     #[test]

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -809,10 +809,83 @@ struct CommandCompletionOptions {
 
 impl ReedlineCompleter for NuCompleter {
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
-        self.fetch_completions_at(line, pos)
-            .into_iter()
-            .map(|s| s.suggestion)
-            .collect()
+        let key = format!("{line}|{pos}");
+
+        // Return immediately if the cache has a fresh result for this query.
+        if let Some(suggestions) = get_from_cache(self, &key) {
+            return suggestions;
+        }
+
+        // If the cache misses: alert the background thread and instantly return empty.
+        // Reedline will call `check_pending` / `complete` again to pick up the
+        // results and repaint.
+        let (tx, rx) = mpsc::channel();
+        self.pending_rx.lock().expect("Lock poisoned").replace(rx);
+
+        let engine_state = self.engine_state.clone();
+        let stack = Arc::new(self.stack.clone());
+        let cache = self.cache.clone();
+        let line_owned = line.to_string();
+
+        thread::spawn(move || {
+            let completer = NuCompleter::new_background(engine_state, stack);
+            let suggestions: Vec<Suggestion> = completer
+                .fetch_completions_at(&line_owned, pos)
+                .into_iter()
+                .map(|s| s.suggestion)
+                .collect();
+
+            if let Ok(mut guard) = cache.lock() {
+                guard.insert(
+                    key,
+                    CachedCompletion {
+                        suggestions,
+                        timestamp: Instant::now(),
+                    },
+                );
+            }
+
+            // Results are in the cache!
+            let _ = tx.send(());
+        });
+
+        fn get_from_cache(completor: &NuCompleter, key: &str) -> Option<Vec<Suggestion>> {
+            let cache = completor.cache.lock().ok()?;
+            let entry = cache.get(key)?;
+
+            if entry.timestamp.elapsed() < CACHE_TTL {
+                Some(entry.suggestions.clone())
+            } else {
+                None
+            }
+        }
+
+        vec![]
+    }
+
+    fn has_pending(&mut self) -> bool {
+        self.pending_rx.lock().is_ok_and(|g| g.is_some())
+    }
+
+    fn check_pending(&mut self) -> bool {
+        let Ok(mut guard) = self.pending_rx.lock() else {
+            return false;
+        };
+        let Some(rx) = guard.as_ref() else {
+            return false;
+        };
+
+        match rx.try_recv() {
+            Ok(()) => {
+                *guard = None;
+                true
+            }
+            Err(mpsc::TryRecvError::Empty) => false,
+            Err(mpsc::TryRecvError::Disconnected) => {
+                *guard = None;
+                false
+            }
+        }
     }
 }
 

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -196,7 +196,7 @@ impl NuCompleter {
         }
     }
 
-    fn new_background(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
+    fn new_for_background(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
         Self {
             engine_state,
             stack: Stack::with_parent(stack)

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -9,9 +9,15 @@ use nu_protocol::{
     ast::{Argument, Block, Expr, Expression, PipelineRedirection, RedirectionTarget, Traverse},
     engine::{ArgType, EngineState, Stack, StateWorkingSet},
 };
+use nu_utils::time::Instant;
 use reedline::{Completer as ReedlineCompleter, Suggestion};
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread;
+use std::time::Duration;
 use std::{borrow::Cow, ops::ControlFlow};
+
+const CACHE_TTL: Duration = Duration::from_secs(5);
 
 use super::{StaticCompletion, custom_completions::CommandWideCompletion};
 
@@ -138,10 +144,22 @@ fn strip_placeholder_if_any<'a>(
     (new_span, prefix)
 }
 
+struct CachedCompletion {
+    suggestions: Vec<Suggestion>,
+    timestamp: Instant,
+}
+
+type CompletionCache = Arc<Mutex<HashMap<String, CachedCompletion>>>;
+/// Shared slot for the background-thread signal channel receiver.
+/// Wrapped in Arc<Mutex<>> so NuCompleter stays Clone.
+type PendingRx = Arc<Mutex<Option<mpsc::Receiver<()>>>>;
+
 #[derive(Clone)]
 pub struct NuCompleter {
     engine_state: Arc<EngineState>,
     stack: Stack,
+    cache: CompletionCache,
+    pending_rx: PendingRx,
 }
 
 /// Common arguments required for Completer
@@ -173,6 +191,23 @@ impl NuCompleter {
         Self {
             engine_state,
             stack: Stack::with_parent(stack).reset_out_dest().collect_value(),
+            cache: Arc::new(Mutex::new(HashMap::new())),
+            pending_rx: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn new_background(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
+        Self {
+            engine_state,
+            stack: Stack::with_parent(stack)
+                .reset_out_dest()
+                // We never want to write to the terminal
+                .suppress_output()
+                // We don't want races with reedlines own
+                .suppress_stdin()
+                .collect_value(),
+            cache: Arc::new(Mutex::new(HashMap::new())),
+            pending_rx: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -603,6 +638,7 @@ impl NuCompleter {
                             }
                         }
 
+                        // resort to external completer set in config
                         // resort to external completer set in config
                         let completion = self
                             .engine_state

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -894,6 +894,106 @@ mod completer_tests {
     use super::*;
 
     #[test]
+    fn test_non_blocking_completion_cache() {
+        let mut engine_state =
+            nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
+
+        let delta = {
+            let working_set = nu_protocol::engine::StateWorkingSet::new(&engine_state);
+            working_set.render()
+        };
+
+        let result = engine_state.merge_delta(delta);
+        assert!(
+            result.is_ok(),
+            "Error merging delta: {:?}",
+            result.err().unwrap()
+        );
+
+        let mut completer = NuCompleter::new(engine_state.into(), Arc::new(Stack::new()));
+
+        // Get expected results via the direct (non-cached) path.
+        let expected: Vec<Suggestion> = completer
+            .fetch_completions_at("ls | c", 6)
+            .into_iter()
+            .map(|s| s.suggestion)
+            .collect();
+        assert!(!expected.is_empty(), "expected non-empty results");
+        assert!(
+            expected.iter().any(|s| s.value == "cd"),
+            "should contain cd"
+        );
+
+        let first = completer.complete("ls | c", 6);
+        assert!(
+            first.is_empty(),
+            "first call should return empty (cache miss)"
+        );
+        assert!(completer.has_pending(), "should have pending completion");
+
+        // Simulate reedline's polling loop: call check_pending() until results arrive,
+        // then call complete() to retrieve them from the cache.
+        let second = loop {
+            if completer.check_pending() {
+                break completer.complete("ls | c", 6);
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        };
+
+        assert_eq!(
+            expected.len(),
+            second.len(),
+            "cached result should match direct result"
+        );
+        for s in &expected {
+            assert!(
+                second.iter().any(|x| x.value == s.value),
+                "cached result should contain '{}'",
+                s.value
+            );
+        }
+    }
+
+    /// Verifies that the background completion stack NEVER inherits the live terminal's
+    /// stdout/stderr.
+    #[test]
+    fn test_background_completer_suppresses_output() {
+        use nu_protocol::OutDest;
+
+        let engine_state = Arc::new(nu_command::add_shell_command_context(
+            nu_cmd_lang::create_default_context(),
+        ));
+        let stack = Arc::new(Stack::new());
+        let bg = NuCompleter::new_background(engine_state, stack);
+
+        assert!(
+            matches!(bg.stack.stdout(), OutDest::Value),
+            "background completer stdout should be collected"
+        );
+        assert!(
+            matches!(bg.stack.stderr(), OutDest::Null),
+            "background completer stderr should be Null"
+        );
+
+        assert!(
+            bg.stack.suppress_stdin,
+            "background completer must suppress child-process stdin"
+        );
+
+        // foreground completer is chill with stdin
+        let fg = NuCompleter::new(
+            Arc::new(nu_command::add_shell_command_context(
+                nu_cmd_lang::create_default_context(),
+            )),
+            Arc::new(Stack::new()),
+        );
+        assert!(
+            !fg.stack.suppress_stdin,
+            "foreground completer must not suppress stdin"
+        );
+    }
+
+    #[test]
     fn test_completion_helper() {
         let mut engine_state =
             nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -1,7 +1,7 @@
 use crate::completions::{
     ArgValueCompletion, AttributableCompletion, AttributeCompletion, CellPathCompletion,
     CommandCompletion, Completer, CompletionOptions, CustomCompletion, FileCompletion,
-    FlagCompletion, OperatorCompletion, VariableCompletion, base::SemanticSuggestion,
+    FlagCompletion, NuMatcher, OperatorCompletion, VariableCompletion, base::SemanticSuggestion,
 };
 use nu_parser::parse;
 use nu_protocol::{
@@ -11,11 +11,11 @@ use nu_protocol::{
 };
 use nu_utils::time::Instant;
 use reedline::{Completer as ReedlineCompleter, Suggestion};
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::Duration;
 use std::{borrow::Cow, ops::ControlFlow};
+use std::{collections::HashMap, path::is_separator};
 
 const CACHE_TTL: Duration = Duration::from_secs(5);
 
@@ -148,7 +148,27 @@ fn strip_placeholder_if_any<'a>(
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct CompletionQuery {
     line: String,
-    pos: usize,
+    current_position: usize,
+}
+
+impl CompletionQuery {
+    /// Returns the buffer text up to the cursor.
+    /// This represents the only portion of the text that completion depends on.
+    fn input_text(&self) -> &str {
+        let fallback = &self.line; // full buffer is where cursor is
+
+        self.line.get(..self.current_position).unwrap_or(fallback)
+    }
+
+    /// Determines if this query is a strict narrowing of a previous query,
+    /// meaning the base's results are a superset that can be filtered in place.
+    fn strictly_narrows(&self, base_query: &CompletionQuery) -> bool {
+        let Some(appended) = self.input_text().strip_prefix(base_query.input_text()) else {
+            return false;
+        };
+
+        !appended.is_empty() && !appended.contains(|c: char| c.is_whitespace() || is_separator(c))
+    }
 }
 
 struct CacheEntry {
@@ -834,10 +854,90 @@ struct CommandCompletionOptions {
 }
 
 impl NuCompleter {
+    const EMPTY: Vec<Suggestion> = vec![];
+
     fn cached(&self, query: &CompletionQuery) -> Option<Vec<Suggestion>> {
         let cache = self.cache.lock().ok()?;
         let entry = cache.get(query)?;
         (entry.at.elapsed() < CACHE_TTL).then(|| entry.suggestions.clone())
+    }
+
+    /// Best-effort suggestions for a cache miss: reuse the freshest still-valid
+    /// cache entry that `query` narrows,
+    /// filtered down to the longer prefix the user has since typed.
+    fn stale_fallback(&self, query: &CompletionQuery) -> Vec<Suggestion> {
+        self.narrow(self.fetch_closest_cached_suggestions(query), query)
+    }
+
+    /// Safely locks the cache and extracts the suggestions from the tightest valid superset.
+    fn fetch_closest_cached_suggestions(&self, query: &CompletionQuery) -> Vec<Suggestion> {
+        let Ok(cache) = self.cache.lock() else {
+            return Self::EMPTY;
+        };
+
+        cache
+            .iter()
+            .filter(|(base_query, cache_entry)| {
+                cache_entry.at.elapsed() < CACHE_TTL && query.strictly_narrows(base_query)
+            })
+            // Prefer the closest superset: most already typed = tightest existing filter
+            .max_by_key(|(base_query, _)| base_query.current_position)
+            .map(|(_, cache_entry)| cache_entry.suggestions.clone())
+            .unwrap_or_default()
+    }
+
+    /// Re-filters a superset of suggestions to match the current query.
+    fn narrow(&self, suggestions: Vec<Suggestion>, query: &CompletionQuery) -> Vec<Suggestion> {
+        let Some((reference_span, search_token)) = suggestions.first().and_then(|suggestion| {
+            let span = suggestion.span;
+            let token = query.input_text().get(span.start..)?;
+            Some((span, token))
+        }) else {
+            // Bail if there are no suggestions, or the span exceeds the input length.
+            return Self::EMPTY;
+        };
+
+        // Stretch the span from the original start point to the user's current cursor position.
+        let updated_span = reedline::Span::new(reference_span.start, query.current_position);
+        let options = self.build_completion_options();
+        let mut matcher = NuMatcher::new(search_token, &options, true);
+
+        // If the spans that produced past suggestions mirror the ones that produced this one, they're fit as matches.
+        for mut suggestion in suggestions
+            .into_iter()
+            .filter(|suggestion| suggestion.span == reference_span)
+        {
+            suggestion.span = updated_span;
+            // Owned because `suggestion` is moved into the matcher on the same line.
+            let haystack = suggestion.display_value().to_string();
+            matcher.add(haystack, suggestion);
+        }
+
+        Self::extract_matcher_results(matcher)
+    }
+
+    /// Constructs completion options from the engine state configuration.
+    fn build_completion_options(&self) -> CompletionOptions {
+        let configuration = self.engine_state.get_config();
+
+        CompletionOptions {
+            case_sensitive: configuration.completions.case_sensitive,
+            match_algorithm: configuration.completions.algorithm.into(),
+            sort: configuration.completions.sort,
+            match_description: false,
+        }
+    }
+
+    /// Maps the raw matcher output back into finalized `Suggestion` objects.
+    fn extract_matcher_results(matcher: NuMatcher<Suggestion>) -> Vec<Suggestion> {
+        matcher
+            .results()
+            .into_iter()
+            .map(|(mut suggestion, match_indices)| {
+                suggestion.match_indices = Some(match_indices);
+                suggestion
+            })
+            .collect()
     }
 
     /// Spawn the long-lived worker. Takes field refs so callers can hold
@@ -871,7 +971,7 @@ impl NuCompleter {
                 let (query, generation) = latest;
 
                 let suggestions: Vec<Suggestion> = completer
-                    .fetch_completions_at(&query.line, query.pos)
+                    .fetch_completions_at(&query.line, query.current_position)
                     .into_iter()
                     .map(|s| s.suggestion)
                     .collect();
@@ -914,7 +1014,7 @@ impl ReedlineCompleter for NuCompleter {
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
         let query = CompletionQuery {
             line: line.to_string(),
-            pos,
+            current_position: pos,
         };
 
         if let Some(suggestions) = self.cached(&query) {
@@ -926,13 +1026,16 @@ impl ReedlineCompleter for NuCompleter {
             return suggestions;
         }
 
+        // Cache miss: keep the menu populated with the last shown results
+        let fallback = self.stale_fallback(&query);
+
         let worker = self.worker.get_or_insert_with(|| {
             Self::spawn_worker(&self.engine_state, &self.stack, &self.cache)
         });
 
-        // Already waiting on this exact query.
+        // Already waiting on this exact query; keep showing the fallback.
         if worker.pending.as_ref().is_some_and(|(q, _)| q == &query) {
-            return vec![];
+            return fallback;
         }
 
         worker.next_generation = worker.next_generation.wrapping_add(1);
@@ -944,7 +1047,7 @@ impl ReedlineCompleter for NuCompleter {
             worker.pending = None;
         }
 
-        vec![]
+        fallback
     }
 
     fn has_pending(&mut self) -> bool {
@@ -1029,21 +1132,81 @@ mod completer_tests {
         }
     }
 
+    /// A cache miss while typing more of the same token narrows the previously
+    /// shown results in place instead of returning an empty ("NO RECORDS FOUND")
+    /// menu while the background worker recomputes.
+    #[test]
+    fn cache_miss_narrows_previous_results() {
+        let mut completer = NuCompleter::new(test_engine(), Arc::new(Stack::new()));
+
+        // Prime the cache with the results for `ls | c`.
+        assert!(completer.complete("ls | c", 6).is_empty());
+        let primed = wait_for(&mut completer, "ls | c", 6);
+        assert!(primed.iter().any(|s| s.value == "config"));
+        assert!(primed.iter().any(|s| s.value == "cd"));
+
+        // Typing another char is a cache miss, but the menu should immediately
+        // narrow the cached results rather than flashing empty.
+        let narrowed = completer.complete("ls | co", 7);
+        assert!(
+            !narrowed.is_empty(),
+            "expected stale fallback, got empty menu"
+        );
+        assert!(narrowed.iter().any(|s| s.value == "config"));
+        assert!(narrowed.iter().any(|s| s.value == "const"));
+        assert!(!narrowed.iter().any(|s| s.value == "cd"));
+        // Spans are re-anchored to cover the freshly typed token.
+        for s in &narrowed {
+            assert_eq!(s.span.end, 7, "span not re-anchored for {}", s.value);
+        }
+
+        // The accurate async result still lands afterwards.
+        let fresh = wait_for(&mut completer, "ls | co", 7);
+        assert!(fresh.iter().any(|s| s.value == "config"));
+    }
+
     /// Only the latest enqueued generation may return true from `check_pending`.
     #[test]
     fn only_latest_generation_wakes_pending() {
+        // A private directory of gate files shared with the completer closure.
+        // Instead of racing on sleep durations, the worker announces when it
+        // begins a token and blocks until the test releases it, so each
+        // generation finishes exactly when we say so.
+        let gate_dir = std::env::temp_dir().join(format!(
+            "nu-completion-generation-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
+        std::fs::create_dir_all(&gate_dir).expect("create gate dir");
+        let gate = gate_dir.to_string_lossy().replace('\\', "/");
+
+        let setup = format!(
+            r#"
+            $env.config.completions.external = {{
+                enable: true
+                completer: {{|spans|
+                    let token = ($spans | last)
+                    touch ('{gate}' | path join $"started-($token)")
+                    while not ('{gate}' | path join $"release-($token)" | path exists) {{
+                        sleep 10ms
+                    }}
+                    [{{value: $"got-($token)"}}]
+                }}
+            }}
+            "#
+        );
         let mut engine =
             nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
-        let setup = r#"
-            $env.config.completions.external = {
-                enable: true
-                completer: {|spans|
-                    sleep 80ms
-                    [{value: $"got-($spans | last)"}]
-                }
-            }
-        "#;
         let mut stack = Stack::new();
+        // `merge_env` (below) requires a valid `$env.PWD`; it can't be set from
+        // script, so seed it directly on the stack.
+        stack.add_env_var(
+            "PWD".to_string(),
+            nu_protocol::Value::string(&gate, nu_protocol::Span::unknown()),
+        );
         let mut working_set = StateWorkingSet::new(&engine);
         let block = parse(&mut working_set, None, setup.as_bytes(), false);
         assert!(working_set.parse_errors.is_empty());
@@ -1057,38 +1220,61 @@ mod completer_tests {
             nu_protocol::PipelineData::empty(),
         )
         .expect("eval setup");
+        // Propagate `$env.config` (the external completer) into the permanent
+        // state the completer reads via `engine_state.get_config()`.
+        engine.merge_env(&mut stack).expect("merge env");
+
+        // Gate helpers, keyed by the token the closure reports.
+        let started = |token: &str| gate_dir.join(format!("started-{token}"));
+        let release = |token: &str| {
+            std::fs::write(gate_dir.join(format!("release-{token}")), b"").expect("release token");
+        };
+        let wait_for_file = |path: std::path::PathBuf| {
+            let deadline = Instant::now() + Duration::from_secs(30);
+            while !path.exists() {
+                assert!(Instant::now() < deadline, "timed out waiting for {path:?}");
+                thread::sleep(Duration::from_millis(5));
+            }
+        };
 
         let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
         let first = "somecmd a";
         let second = "somecmd ab";
 
+        // Enqueue `first` and wait until the worker is actually computing it.
         assert!(completer.complete(first, first.len()).is_empty());
-        // Let the worker start first before superseding it.
-        thread::sleep(Duration::from_millis(20));
+        assert!(completer.has_pending());
+        wait_for_file(started("a"));
+
+        // Supersede with `second` while `first` is still in flight.
         assert!(completer.complete(second, second.len()).is_empty());
         assert!(completer.has_pending());
 
-        let deadline = Instant::now() + Duration::from_secs(30);
-        let mut premature_wakes = 0;
-        let result = loop {
-            if completer.check_pending() {
-                let suggestions = completer.complete(second, second.len());
-                if suggestions.is_empty() {
-                    premature_wakes += 1;
-                    assert!(completer.has_pending());
-                } else {
-                    break suggestions;
-                }
-            }
-            assert!(
-                Instant::now() < deadline,
-                "latest completion never ready (premature_wakes={premature_wakes})"
-            );
-            thread::sleep(Duration::from_millis(10));
-        };
+        // Let `first` finish. Because `second` is already queued, the worker
+        // must move straight on to it without signaling the stale generation.
+        release("a");
+        wait_for_file(started("ab"));
 
-        assert_eq!(premature_wakes, 0);
+        // `first` has now completed, yet `check_pending` must stay false: only
+        // the latest generation is allowed to wake it.
+        assert!(
+            !completer.check_pending(),
+            "a superseded generation woke check_pending"
+        );
+        assert!(completer.has_pending());
+
+        // Releasing `second` finally wakes the latest generation, which yields
+        // the latest result.
+        release("ab");
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !completer.check_pending() {
+            assert!(Instant::now() < deadline, "latest completion never ready");
+            thread::sleep(Duration::from_millis(5));
+        }
+        let result = completer.complete(second, second.len());
         assert!(result.iter().any(|s| s.value == "got-ab"), "{result:?}");
+
+        let _ = std::fs::remove_dir_all(&gate_dir);
     }
 
     #[test]

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -149,7 +149,7 @@ struct CachedCompletion {
     timestamp: Instant,
 }
 
-type CompletionCache = Arc<Mutex<HashMap<String, CachedCompletion>>>;
+type CompletionCache = Arc<Mutex<HashMap<(String, usize), CachedCompletion>>>;
 /// Shared slot for the background-thread signal channel receiver.
 /// Wrapped in Arc<Mutex<>> so NuCompleter stays Clone.
 type PendingRx = Arc<Mutex<Option<mpsc::Receiver<()>>>>;
@@ -810,7 +810,7 @@ struct CommandCompletionOptions {
 
 impl ReedlineCompleter for NuCompleter {
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
-        let key = format!("{line}|{pos}");
+        let key = (line.to_string(), pos);
 
         // Return immediately if the cache has a fresh result for this query.
         if let Some(suggestions) = get_from_cache(self, &key) {
@@ -857,7 +857,10 @@ impl ReedlineCompleter for NuCompleter {
             let _ = tx.send(());
         });
 
-        fn get_from_cache(completer: &NuCompleter, key: &str) -> Option<Vec<Suggestion>> {
+        fn get_from_cache(
+            completer: &NuCompleter,
+            key: &(String, usize),
+        ) -> Option<Vec<Suggestion>> {
             let cache = completer.cache.lock().ok()?;
             let entry = cache.get(key)?;
 

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -820,7 +820,14 @@ impl ReedlineCompleter for NuCompleter {
         // Reedline will call `check_pending` / `complete` again to pick up the
         // results and repaint.
         let (tx, rx) = mpsc::channel();
-        self.pending_rx.lock().expect("Lock poisoned").replace(rx);
+        {
+            let Ok(mut pending_guard) = self.pending_rx.lock() else {
+                // If the mutex is poisoned,
+                // return empty results and pray the next call goes smoothly.
+                return vec![];
+            };
+            pending_guard.replace(rx);
+        }
 
         let engine_state = self.engine_state.clone();
         let stack = Arc::new(self.stack.clone());

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -849,8 +849,8 @@ impl ReedlineCompleter for NuCompleter {
             let _ = tx.send(());
         });
 
-        fn get_from_cache(completor: &NuCompleter, key: &str) -> Option<Vec<Suggestion>> {
-            let cache = completor.cache.lock().ok()?;
+        fn get_from_cache(completer: &NuCompleter, key: &str) -> Option<Vec<Suggestion>> {
+            let cache = completer.cache.lock().ok()?;
             let entry = cache.get(key)?;
 
             if entry.timestamp.elapsed() < CACHE_TTL {

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -458,7 +458,9 @@ fn convert_whole_command_completion_results(
                     .with_inner([err]),
                 )
             );
-            return Some(vec![]);
+            // Error does not equal empty success: fall back so file completion
+            // still runs when an external completer fails.
+            return None;
         }
     };
 

--- a/crates/nu-cli/src/completions/mod.rs
+++ b/crates/nu-cli/src/completions/mod.rs
@@ -25,7 +25,7 @@ pub use base::{Completer, SemanticSuggestion};
 pub use cell_path_completions::CellPathCompletion;
 pub use command_completions::CommandCompletion;
 pub use completer::NuCompleter;
-pub use completion_options::{CompletionOptions, MatchAlgorithm};
+pub use completion_options::{CompletionOptions, MatchAlgorithm, NuMatcher};
 pub use custom_completions::CustomCompletion;
 pub use directory_completions::DirectoryCompletion;
 pub use dotnu_completions::DotNuCompletion;

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1143,7 +1143,7 @@ fn exportable_completions() {
     match_suggestions(&vec!["foo"], &suggestions);
 
     let completion_str = "use 🤔🐘 b";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["bar"], &suggestions);
     assert_eq!(suggestions[0].description, Some("meow\nmeow".into()));
 }
@@ -2989,7 +2989,7 @@ fn custom_value_cell_path_completions() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let completion_str = "$v.";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected = ["major", "minor", "patch", "pre", "build"];
     let received: Vec<_> = suggestions.iter().map(|s| s.value.as_str()).collect();
     assert!(

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -488,7 +488,7 @@ fn custom_completions_wraps_builtin_commandline_complete() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "my-ls test";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(
         &vec![
             "test",
@@ -518,7 +518,7 @@ fn custom_completions_wraps_builtin_commandline_complete_path() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "my-ls te";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(
         &vec![
             "`te st.txt`",
@@ -890,12 +890,12 @@ fn which_command_quoted_completions() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     // Commands with spaces
     let completion_str = "which \"detect";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["detect", "\"detect columns\"", "\"detect type\""];
     match_suggestions(&expected, &suggestions);
     // Commands with quotes
     let completion_str = "which foo";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec![
         r#""foo's""#,
         r#""foo\"b\"a'r""#,

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -37,7 +37,10 @@ pub trait CompleterExt {
 impl CompleterExt for NuCompleter {
     fn complete_and_wait(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
         let suggestions = self.complete(line, pos);
-        if !suggestions.is_empty() || !self.has_pending() {
+
+        // With nothing pending, `suggestions` is the settled result (a cache hit
+        // or a genuine empty).
+        if !self.has_pending() {
             return suggestions;
         }
 

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -26,6 +26,31 @@ use support::{
     file, folder, match_suggestions, match_suggestions_by_string, new_engine,
 };
 
+/// Extension trait for test completions.
+///
+/// Since the background completion kicks off a thread and immediately returns an empty vector
+/// on a cache miss, integration tests that don't spin the `reedline` event loop will fail.
+/// This helper simulates the loop synchronously so the legacy integration tests require minimal modification
+pub trait CompleterExt {
+    fn complete_and_wait(&mut self, line: &str, pos: usize) -> Vec<Suggestion>;
+}
+
+impl CompleterExt for NuCompleter {
+    fn complete_and_wait(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+        let mut suggestions = self.complete(line, pos);
+        if suggestions.is_empty() && self.has_pending() {
+            loop {
+                if self.check_pending() {
+                    suggestions = self.complete(line, pos);
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+        }
+        suggestions
+    }
+}
+
 // Match a list of suggestions with the content of a directory.
 // This helper is for DotNutCompletion, so actually it only retrieves
 // *.nu files and subdirectories.

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1,5 +1,8 @@
 pub mod support;
 
+use core::time::Duration;
+
+use nu_utils::time::Instant;
 use std::{
     collections::HashMap,
     fs::{ReadDir, read_dir},
@@ -26,28 +29,31 @@ use support::{
     file, folder, match_suggestions, match_suggestions_by_string, new_engine,
 };
 
-/// Extension trait for test completions.
-///
-/// Since the background completion kicks off a thread and immediately returns an empty vector
-/// on a cache miss, integration tests that don't spin the `reedline` event loop will fail.
-/// This helper simulates the loop synchronously so the legacy integration tests require minimal modification
+/// Sync wrapper for the async reedline completion path used by integration tests.
 pub trait CompleterExt {
     fn complete_and_wait(&mut self, line: &str, pos: usize) -> Vec<Suggestion>;
 }
 
 impl CompleterExt for NuCompleter {
     fn complete_and_wait(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
-        let mut suggestions = self.complete(line, pos);
-        if suggestions.is_empty() && self.has_pending() {
-            loop {
-                if self.check_pending() {
-                    suggestions = self.complete(line, pos);
-                    break;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(10));
-            }
+        let suggestions = self.complete(line, pos);
+        if !suggestions.is_empty() || !self.has_pending() {
+            return suggestions;
         }
-        suggestions
+
+        const WINDOW: Duration = std::time::Duration::from_secs(30);
+
+        let deadline = Instant::now() + WINDOW;
+        loop {
+            if self.check_pending() {
+                return self.complete(line, pos);
+            }
+            assert!(
+                Instant::now() < deadline,
+                "complete_and_wait timed out for {line:?}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
     }
 }
 
@@ -185,6 +191,27 @@ fn custom_completer_with_options(
     assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
 
     NuCompleter::new(Arc::new(engine), Arc::new(stack))
+}
+
+/// External completer errors must fall back to file completion (not empty menu).
+#[test]
+fn external_completer_error_falls_back_to_file_completion() {
+    let (_, _, mut engine, mut stack) = new_engine();
+    let record = r#"
+        $env.config.completions.external = {
+            enable: true
+            completer: {|spans| error make {msg: "simulated completer failure"} }
+        }
+    "#;
+    assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let suggestions = completer.complete_and_wait("somecmd test", 12);
+    let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
+    assert!(
+        values.iter().any(|v| v.starts_with("test")),
+        "expected file-completion fallback, got: {values:?}"
+    );
 }
 
 #[fixture]

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -246,7 +246,7 @@ fn misc_command_argument_completions(
     #[case] pos: Option<usize>,
     #[case] expected: Vec<&str>,
 ) {
-    let suggestions = completer.complete(input, pos.unwrap_or(input.len()));
+    let suggestions = completer.complete_and_wait(input, pos.unwrap_or(input.len()));
     match_suggestions(&expected, &suggestions);
 }
 
@@ -261,7 +261,7 @@ fn misc_custom_completions(
     #[case] pos: Option<usize>,
     #[case] expected: Vec<&str>,
 ) {
-    let suggestions = completer_strings.complete(input, pos.unwrap_or(input.len()));
+    let suggestions = completer_strings.complete_and_wait(input, pos.unwrap_or(input.len()));
     match_suggestions(&expected, &suggestions);
 }
 
@@ -279,11 +279,11 @@ fn customcompletions_override_options() {
 
     // sort: true should force sorting
     let expected: Vec<_> = vec!["Abcdef", "Foo Abcdef"];
-    let suggestions = completer.complete("my-command Abcd", 15);
+    let suggestions = completer.complete_and_wait("my-command Abcd", 15);
     match_suggestions(&expected, &suggestions);
 
     // Custom options should make case-sensitive
-    let suggestions = completer.complete("my-command aBcD", 15);
+    let suggestions = completer.complete_and_wait("my-command aBcD", 15);
     assert!(suggestions.is_empty());
 }
 
@@ -298,12 +298,12 @@ fn customcompletions_inherit_options() {
     );
 
     // Make sure matching is fuzzy
-    let suggestions = completer.complete("my-command Acd", 14);
+    let suggestions = completer.complete_and_wait("my-command Acd", 14);
     let expected: Vec<_> = vec!["Acd Bar", "Abcdef", "Foo Abcdef"];
     match_suggestions(&expected, &suggestions);
 
     // Custom options should make matching case insensitive
-    let suggestions = completer.complete("my-command acd", 14);
+    let suggestions = completer.complete_and_wait("my-command acd", 14);
     match_suggestions(&expected, &suggestions);
 }
 
@@ -315,7 +315,7 @@ fn customcompletions_no_sort() {
            sort: false"#,
         &["zzzfoo", "foo", "not matched", "abcfoo"],
     );
-    let suggestions = completer.complete("my-command foo", 14);
+    let suggestions = completer.complete_and_wait("my-command foo", 14);
     let expected_items = vec!["zzzfoo", "foo", "abcfoo"];
     let expected_inds = vec![
         Some(vec![3, 4, 5]),
@@ -339,7 +339,7 @@ fn customcompletions_no_filter() {
         "filter: false",
         &["zzzfoo", "foo", "not matched", "abcfoo"],
     );
-    let suggestions = completer.complete("my-command foo", 14);
+    let suggestions = completer.complete_and_wait("my-command foo", 14);
     let expected_items = vec!["zzzfoo", "foo", "not matched", "abcfoo"];
     match_suggestions(&expected_items, &suggestions);
 }
@@ -364,7 +364,7 @@ fn custom_completions_override_span(
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "foo | my-command foobar";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["foobarbaz"], &suggestions);
     let (start, end) = expected_span;
     assert_eq!(Span::new(start, end), suggestions[0].span);
@@ -389,7 +389,7 @@ fn custom_completions_override_display_value() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "my-command sir";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["first", "second"], &suggestions);
 }
 
@@ -413,7 +413,7 @@ fn custom_completions_filter_by_description() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "my-command warm";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["red", "green"], &suggestions);
 }
 
@@ -434,7 +434,7 @@ fn custom_completions_match_description_disabled_by_default() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "my-command warm";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&Vec::<&str>::new(), &suggestions);
 }
 
@@ -450,7 +450,7 @@ fn custom_completions_strip_ansi_from_values() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "my-command ";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["bar", "baz", "foo"], &suggestions);
 }
 
@@ -466,7 +466,7 @@ fn custom_completions_strip_ansi_from_record_values() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "my-command ";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["magenta_dir", "plain_dir"], &suggestions);
 }
 
@@ -643,7 +643,7 @@ fn command_argument_completions(
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     // `pos` defaults to `input.len()` if set to None
     let span_end = pos.unwrap_or(input.len());
-    let suggestions = completer.complete(input, span_end);
+    let suggestions = completer.complete_and_wait(input, span_end);
     match_suggestions_by_string(&expected, &suggestions);
 
     let last_res = suggestions.last().unwrap();
@@ -677,7 +677,7 @@ fn custom_completion_for_list_typed_argument(
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     // `pos` defaults to `input.len()` if set to None
     let span_end = pos.unwrap_or(input.len());
-    let suggestions = completer.complete(input, span_end);
+    let suggestions = completer.complete_and_wait(input, span_end);
     match_suggestions(&expected, &suggestions);
 }
 
@@ -693,7 +693,7 @@ fn list_completions_defined_inline() {
         ] { }
 
         say ";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
 
     // including only subcommand completions
     let expected: Vec<_> = vec!["cat", "dog"];
@@ -712,7 +712,7 @@ fn list_completions_extern() {
         ]
 
         say ";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
 
     // including only subcommand completions
     let expected: Vec<_> = vec!["cat", "dog"];
@@ -735,7 +735,7 @@ fn list_completions_from_constant_and_allows_record() {
         ] { }
 
         say "#;
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
 
     // including only subcommand completions
     let expected: Vec<_> = vec!["cat", "dog"];
@@ -773,7 +773,7 @@ fn external_commands() {
         Arc::new(nu_protocol::engine::Stack::new()),
     );
     let completion_str = "ls; ^sleep";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     #[cfg(windows)]
     let expected: Vec<_> = vec!["sleep.exe"];
     #[cfg(not(windows))]
@@ -781,7 +781,7 @@ fn external_commands() {
     match_suggestions(&expected, &suggestions);
 
     let completion_str = "sleep";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     #[cfg(windows)]
     let expected: Vec<_> = vec!["sleep", "sleep.exe"];
     #[cfg(not(windows))]
@@ -789,14 +789,14 @@ fn external_commands() {
     match_suggestions(&expected, &suggestions);
 
     let completion_str = "ls; %sl";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["sleep", "slice"];
     match_suggestions(&expected, &suggestions);
 
     #[cfg(windows)]
     {
         let completion_str = "scri";
-        let suggestions = completer.complete(completion_str, completion_str.len());
+        let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
         let expected: Vec<_> = vec!["script.ps1"];
         match_suggestions(&expected, &suggestions);
     }
@@ -813,7 +813,7 @@ fn percent_completion_only_shows_builtins() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "%sli";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["slice"];
     match_suggestions(&expected, &suggestions);
 }
@@ -826,7 +826,7 @@ fn percent_completion_includes_shadowed_builtin() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "%ls";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["ls"];
     match_suggestions(&expected, &suggestions);
 }
@@ -843,7 +843,7 @@ fn external_commands_disabled() {
     let stack = nu_protocol::engine::Stack::new();
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "ls; ^sleep";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     #[cfg(windows)]
     let expected: Vec<_> = vec!["sleep.exe"];
     #[cfg(not(windows))]
@@ -851,7 +851,7 @@ fn external_commands_disabled() {
     match_suggestions(&expected, &suggestions);
 
     let completion_str = "sleep";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["sleep"];
     match_suggestions(&expected, &suggestions);
 }
@@ -866,12 +866,12 @@ fn which_command_completions() {
     );
     // flags
     let completion_str = "which --all";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["--all"];
     match_suggestions(&expected, &suggestions);
     // commands
     let completion_str = "which sleep";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     #[cfg(windows)]
     let expected: Vec<_> = vec!["sleep", "sleep.exe"];
     #[cfg(not(windows))]
@@ -911,7 +911,7 @@ fn hide_env_completions() {
     let (_, _, engine, stack) = new_engine();
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "hide-env T";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected = vec!["TEST"];
     match_suggestions(&expected, &suggestions);
 }
@@ -927,7 +927,7 @@ fn customcompletions_invalid() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let completion_str = "my-command foo";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     assert!(suggestions.is_empty());
 }
 
@@ -939,7 +939,7 @@ fn dont_use_dotnu_completions() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     // Test nested nu script
     let completion_str = "go work use `./dir_module/";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
 
     // including a plaintext file
     let expected: Vec<_> = vec![
@@ -960,7 +960,7 @@ fn dotnu_completions() {
 
     // Flags should still be working
     let completion_str = "overlay use --";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
 
     match_suggestions(&vec!["--help", "--prefix", "--reload"], &suggestions);
 
@@ -969,7 +969,7 @@ fn dotnu_completions() {
     let completion_str = "use `.\\dir_module\\";
     #[cfg(not(windows))]
     let completion_str = "use `./dir_module/";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
 
     match_suggestions(
         &vec![
@@ -990,7 +990,7 @@ fn dotnu_completions() {
     let completion_str = "use `.\\dir_module\\sub module\\`";
     #[cfg(not(windows))]
     let completion_str = "use `./dir_module/sub module/`";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
 
     match_suggestions(
         &vec![
@@ -1030,7 +1030,7 @@ fn dotnu_completions() {
 
     // Test source completion
     let completion_str = "source-env ";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
 
     match_suggestions(&expected, &suggestions);
 
@@ -1038,13 +1038,13 @@ fn dotnu_completions() {
     expected.insert(0, "std-rfc");
     expected.insert(0, "std");
     let completion_str = "use ";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
 
     match_suggestions(&expected, &suggestions);
 
     // Test overlay use completion
     let completion_str = "overlay use ";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
 
     match_suggestions(&expected, &suggestions);
 
@@ -1053,18 +1053,18 @@ fn dotnu_completions() {
     {
         let completion_str = "use \\";
         let dir_content = read_dir("\\").unwrap();
-        let suggestions = completer.complete(completion_str, completion_str.len());
+        let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
         match_dir_content_for_dotnu(dir_content, &suggestions);
     }
 
     let completion_str = "use /";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let dir_content = read_dir("/").unwrap();
     match_dir_content_for_dotnu(dir_content, &suggestions);
 
     let completion_str = "use ~";
     let dir_content = read_dir(expand_tilde("~")).unwrap();
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_dir_content_for_dotnu(dir_content, &suggestions);
 }
 
@@ -1081,7 +1081,7 @@ fn module_name_completions() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "use 🤔";
 
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["🤔🐘"], &suggestions);
 
     assert_eq!(
@@ -1098,11 +1098,11 @@ fn dotnu_stdlib_completions() {
 
     // `export  use` should be recognized as command `export use`
     let completion_str = "export  use std/ass";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["std/assert"], &suggestions);
 
     let completion_str = "use \"std";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["std", "std-rfc"], &suggestions);
 }
 
@@ -1123,23 +1123,23 @@ fn exportable_completions() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let completion_str = "use std null";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["null-device", "null_device"], &suggestions);
 
     let completion_str = "export use std/assert eq";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["equal"], &suggestions);
 
     let completion_str = "use std/assert \"not eq";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["\"not equal\""], &suggestions);
 
     let completion_str = "use std/math [E, `TAU";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["TAU"], &suggestions);
 
     let completion_str = "use 🤔🐘 'foo";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["foo"], &suggestions);
 
     let completion_str = "use 🤔🐘 b";
@@ -1155,28 +1155,28 @@ fn dotnu_completions_const_nu_lib_dirs() {
 
     // file in `lib-dir1/`, set by `const NU_LIB_DIRS`
     let completion_str = "use xyzz";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["xyzzy.nu"], &suggestions);
 
     // file in `lib-dir2/`, set by `$env.NU_LIB_DIRS`
     let completion_str = "use asdf";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["asdf.nu"], &suggestions);
 
     // file in `lib-dir3/`, set by both, should not replicate
     let completion_str = "use spam";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["spam.nu"], &suggestions);
 
     // if `./` specified by user, file in `lib-dir*` should be ignored
     #[cfg(windows)]
     {
         let completion_str = "use .\\asdf";
-        let suggestions = completer.complete(completion_str, completion_str.len());
+        let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
         match_suggestions(&vec![".\\asdf.nu"], &suggestions);
     }
     let completion_str = "use ./asdf";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&vec!["./asdf.nu"], &suggestions);
 }
 
@@ -1323,7 +1323,7 @@ fn command_wide_completion_external() {
 
         gh alias one two"#;
 
-    let suggestions = completer.complete(sample, sample.len());
+    let suggestions = completer.complete_and_wait(sample, sample.len());
     let expected = vec!["gh", "alias", "one", "two"];
     match_suggestions(&expected, &suggestions);
 }
@@ -1345,7 +1345,7 @@ fn command_wide_completion_custom(#[case] return_code: &str) {
 
         foo bar baz"#);
 
-    let suggestions = completer.complete(&sample, sample.len());
+    let suggestions = completer.complete_and_wait(&sample, sample.len());
     let expected = vec!["foo", "bar", "baz", "some", "more"];
     match_suggestions(&expected, &suggestions);
 }
@@ -1369,7 +1369,7 @@ fn command_wide_completion_wrapped_untyped_equals_flag_value() {
 
         wt switch --base=rel"#;
 
-    let suggestions = completer.complete(sample, sample.len());
+    let suggestions = completer.complete_and_wait(sample, sample.len());
     let expected = vec!["--base=releases/4.x.x", "--base=main"];
     match_suggestions(&expected, &suggestions);
 }
@@ -1408,7 +1408,7 @@ fn command_wide_completion_fallback(#[case] code: &str) {
 
     let sample = /* lang=nu */ "foo bar completions";
 
-    let suggestions = completer.complete(sample, sample.len());
+    let suggestions = completer.complete_and_wait(sample, sample.len());
     let expected = vec![folder("completions")];
     match_suggestions_by_string(&expected, &suggestions);
 }
@@ -1435,7 +1435,7 @@ fn parameter_completion_overrides_command_wide_completion() {
 
         cmd one "#;
 
-    let suggestions = completer.complete(sample, sample.len());
+    let suggestions = completer.complete_and_wait(sample, sample.len());
     let expected = vec!["bar", "specific"];
     match_suggestions(&expected, &suggestions);
 }
@@ -1466,7 +1466,7 @@ fn command_wide_completion_flag_completion() {
 
         cmd -"#;
 
-    let suggestions = completer.complete(sample, sample.len());
+    let suggestions = completer.complete_and_wait(sample, sample.len());
     let expected = vec!["--flag", "--switch", "-f", "-s", "--with", "--external"];
     match_suggestions(&expected, &suggestions);
 
@@ -1476,7 +1476,8 @@ fn command_wide_completion_flag_completion() {
 
     // flag value completion
     let input_for_flag_value = format!("{sample}-flag ");
-    let suggestions = completer.complete(&input_for_flag_value, input_for_flag_value.len());
+    let suggestions =
+        completer.complete_and_wait(&input_for_flag_value, input_for_flag_value.len());
     let expected = vec!["command", "wide", "--with", "--external"];
     match_suggestions(&expected, &suggestions);
 
@@ -1485,7 +1486,8 @@ fn command_wide_completion_flag_completion() {
     assert_eq!(span.end, input_for_flag_value.len());
 
     let input_for_flag_value = format!("{sample}-flag=wi");
-    let suggestions = completer.complete(&input_for_flag_value, input_for_flag_value.len());
+    let suggestions =
+        completer.complete_and_wait(&input_for_flag_value, input_for_flag_value.len());
     let expected = vec!["wide"];
     match_suggestions(&expected, &suggestions);
 
@@ -1504,7 +1506,7 @@ fn file_completions() {
 
     // Test completions for the current folder
     let target_dir = format!("cp {dir_str}{MAIN_SEPARATOR}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [
@@ -1523,7 +1525,7 @@ fn file_completions() {
     {
         let separator = '/';
         let target_dir = format!("cp {dir_str}{separator}");
-        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+        let slash_suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
         let expected_slash_paths: Vec<_> = expected_paths
             .iter()
@@ -1538,7 +1540,7 @@ fn file_completions() {
 
     // Test completions for the current folder even with parts before the autocomplet
     let target_dir = format!("cp somefile.txt {dir_str}{MAIN_SEPARATOR}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [
@@ -1557,7 +1559,7 @@ fn file_completions() {
     {
         let separator = '/';
         let target_dir = format!("cp somefile.txt {dir_str}{separator}");
-        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+        let slash_suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
         let expected_slash_paths: Vec<_> = expected_paths
             .iter()
@@ -1572,7 +1574,7 @@ fn file_completions() {
 
     // Test completions for a file
     let target_dir = format!("cp {}", folder(dir.join("another")));
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [file(dir.join("another").join("newfile"))];
@@ -1582,14 +1584,14 @@ fn file_completions() {
 
     // Test completions for hidden files
     let target_dir = format!("ls {}", file(dir.join(".hidden_folder").join(".")));
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     let expected_paths = [file(dir.join(".hidden_folder").join(".hidden_subfile"))];
 
     #[cfg(windows)]
     {
         let target_dir = format!("ls {}/.", folder(dir.join(".hidden_folder")));
-        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+        let slash_suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
         let expected_slash: Vec<_> = expected_paths
             .iter()
@@ -1603,7 +1605,7 @@ fn file_completions() {
     match_suggestions_by_string(&expected_paths, &suggestions);
 
     // Don't suggest files as fallback when no directories match for commands expecting directories
-    let suggestions = completer.complete("cd n", 4);
+    let suggestions = completer.complete_and_wait("cd n", 4);
     let expected_paths: Vec<_> = vec![];
 
     // Match the results
@@ -1622,7 +1624,7 @@ fn custom_command_rest_any_args_file_completions() {
 
     // Test completions for the current folder
     let target_dir = format!("list {dir_str}{MAIN_SEPARATOR}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [
@@ -1642,7 +1644,7 @@ fn custom_command_rest_any_args_file_completions() {
 
     // Test completions for the current folder even with parts before the autocomplet
     let target_dir = format!("list somefile.txt {dir_str}{MAIN_SEPARATOR}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [
@@ -1662,7 +1664,7 @@ fn custom_command_rest_any_args_file_completions() {
 
     // Test completions for a file
     let target_dir = format!("list {}", folder(dir.join("another")));
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [file(dir.join("another").join("newfile"))];
@@ -1672,7 +1674,7 @@ fn custom_command_rest_any_args_file_completions() {
 
     // Test completions for hidden files
     let target_dir = format!("list {}", file(dir.join(".hidden_folder").join(".")));
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     let expected_paths = [file(dir.join(".hidden_folder").join(".hidden_subfile"))];
 
@@ -1701,42 +1703,42 @@ fn file_completions_with_mixed_separators() {
         .collect();
 
     let target_dir = format!("ls {dir_str}/lib-dir1/");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     match_suggestions_by_string(&expected_slash_paths, &suggestions);
 
     let target_dir = format!("cp {dir_str}\\lib-dir1/");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     match_suggestions_by_string(&expected_slash_paths, &suggestions);
 
     let target_dir = format!("ls {dir_str}/lib-dir1\\/");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     match_suggestions_by_string(&expected_slash_paths, &suggestions);
 
     let target_dir = format!("ls {dir_str}\\lib-dir1\\/");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     match_suggestions_by_string(&expected_slash_paths, &suggestions);
 
     let target_dir = format!("ls {dir_str}\\lib-dir1\\");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     match_suggestions_by_string(&expected_paths, &suggestions);
 
     let target_dir = format!("ls {dir_str}/lib-dir1\\");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     match_suggestions_by_string(&expected_paths, &suggestions);
 
     let target_dir = format!("ls {dir_str}/lib-dir1/\\");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     match_suggestions_by_string(&expected_paths, &suggestions);
 
     let target_dir = format!("ls {dir_str}\\lib-dir1/\\");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     match_suggestions_by_string(&expected_paths, &suggestions);
 }
@@ -1751,7 +1753,7 @@ fn partial_completions() {
 
     // Test completions for a folder's name
     let target_dir = format!("cd {}", file(dir.join("pa")));
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [
@@ -1769,7 +1771,7 @@ fn partial_completions() {
     // and are present under directories whose names begin with "pa"
     let dir_str = file(dir.join("pa").join("h"));
     let target_dir = format!("cp {dir_str}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [
@@ -1790,7 +1792,7 @@ fn partial_completions() {
     // Test completion for all files under directories whose names begin with "pa"
     let dir_str = folder(dir.join("pa"));
     let target_dir = format!("ls {dir_str}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [
@@ -1813,7 +1815,7 @@ fn partial_completions() {
     // Test completion for a single file
     let dir_str = file(dir.join("fi").join("so"));
     let target_dir = format!("rm {dir_str}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [file(dir.join("final_partial").join("somefile"))];
@@ -1824,7 +1826,7 @@ fn partial_completions() {
     // Test completion where there is a sneaky `..` in the path
     let dir_str = file(dir.join("par").join("..").join("fi").join("so"));
     let target_dir = format!("rm {dir_str}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [
@@ -1869,7 +1871,7 @@ fn partial_completions() {
     // Test completion for all files under directories whose names begin with "pa"
     let file_str = file(dir.join("partial-a").join("have"));
     let target_file = format!("rm {file_str}");
-    let suggestions = completer.complete(&target_file, target_file.len());
+    let suggestions = completer.complete_and_wait(&target_file, target_file.len());
 
     // Create the expected values
     let expected_paths = [
@@ -1883,7 +1885,7 @@ fn partial_completions() {
     // Test completion for all files under directories whose names begin with "pa"
     let file_str = file(dir.join("partial-a").join("have_ext."));
     let file_dir = format!("rm {file_str}");
-    let suggestions = completer.complete(&file_dir, file_dir.len());
+    let suggestions = completer.complete_and_wait(&file_dir, file_dir.len());
 
     // Create the expected values
     let expected_paths = [
@@ -1909,7 +1911,7 @@ fn partial_completion_with_dot_expansions() {
             .join("so"),
     );
     let target_dir = format!("rm {dir_str}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [
@@ -1964,7 +1966,7 @@ fn command_ls_with_filecompletion() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let target_dir = "ls ";
-    let suggestions = completer.complete(target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<_> = vec![
@@ -1994,7 +1996,7 @@ fn command_ls_with_filecompletion() {
     match_suggestions(&expected_paths, &suggestions);
 
     let target_dir = "ls custom_completion.";
-    let suggestions = completer.complete(target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(target_dir, target_dir.len());
 
     let expected_paths: Vec<_> = vec!["custom_completion.nu"];
 
@@ -2008,7 +2010,7 @@ fn command_open_with_filecompletion() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let target_dir = "open ";
-    let suggestions = completer.complete(target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<_> = vec![
@@ -2038,7 +2040,7 @@ fn command_open_with_filecompletion() {
     match_suggestions(&expected_paths, &suggestions);
 
     let target_dir = "open custom_completion.";
-    let suggestions = completer.complete(target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(target_dir, target_dir.len());
 
     let expected_paths: Vec<_> = vec!["custom_completion.nu"];
 
@@ -2052,7 +2054,7 @@ fn command_rm_with_globcompletion() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let target_dir = "rm ";
-    let suggestions = completer.complete(target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<_> = vec![
@@ -2089,7 +2091,7 @@ fn command_cp_with_globcompletion() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let target_dir = "cp ";
-    let suggestions = completer.complete(target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<_> = vec![
@@ -2126,7 +2128,7 @@ fn command_save_with_filecompletion() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let target_dir = "save ";
-    let suggestions = completer.complete(target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<_> = vec![
@@ -2163,7 +2165,7 @@ fn command_touch_with_filecompletion() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let target_dir = "touch ";
-    let suggestions = completer.complete(target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<_> = vec![
@@ -2200,7 +2202,7 @@ fn command_watch_with_filecompletion() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let target_dir = "watch ";
-    let suggestions = completer.complete(target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<_> = vec![
@@ -2245,7 +2247,7 @@ fn subcommand_vs_external_completer() {
     let mut subcommand_completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let prefix = "fod br";
-    let suggestions = subcommand_completer.complete(prefix, prefix.len());
+    let suggestions = subcommand_completer.complete_and_wait(prefix, prefix.len());
     match_suggestions(
         &vec![
             "external",
@@ -2257,7 +2259,7 @@ fn subcommand_vs_external_completer() {
     );
 
     let prefix = "foot bar";
-    let suggestions = subcommand_completer.complete(prefix, prefix.len());
+    let suggestions = subcommand_completer.complete_and_wait(prefix, prefix.len());
     match_suggestions(&vec!["external", "foo-test-command bar"], &suggestions);
 }
 
@@ -2324,7 +2326,7 @@ fn file_completion_quoted_match_indices(
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
-    let suggestions = completer.complete(typed, typed.len());
+    let suggestions = completer.complete_and_wait(typed, typed.len());
 
     #[cfg(not(windows))]
     let use_forward_slashes = true;
@@ -2358,7 +2360,7 @@ fn file_completion_quoted_match_indices(
     {
         if typed.contains('/') {
             let typed = typed.replace("/", "\\");
-            let suggestions = completer.complete(typed.as_str(), typed.len());
+            let suggestions = completer.complete_and_wait(typed.as_str(), typed.len());
             assert_eq!(
                 expected
                     .into_iter()
@@ -2387,7 +2389,7 @@ fn flag_completions() {
     // Instantiate a new completer
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     // Test completions for the 'ls' flags
-    let suggestions = completer.complete("ls -", 4);
+    let suggestions = completer.complete_and_wait("ls -", 4);
     assert_eq!(18, suggestions.len());
     let expected: Vec<_> = vec![
         "--all",
@@ -2413,7 +2415,7 @@ fn flag_completions() {
     match_suggestions(&expected, &suggestions);
 
     // https://github.com/nushell/nushell/issues/16375
-    let suggestions = completer.complete("table -", 7);
+    let suggestions = completer.complete_and_wait("table -", 7);
     assert_eq!(22, suggestions.len());
 }
 
@@ -2437,7 +2439,7 @@ fn attribute_completions() {
     // Instantiate a new completer
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     // Test completions for the 'ls' flags
-    let suggestions = completer.complete("@", 1);
+    let suggestions = completer.complete_and_wait("@", 1);
 
     // Match results
     match_suggestions_by_string(&attribute_names, &suggestions);
@@ -2451,7 +2453,7 @@ fn attributable_completions() {
     // Instantiate a new completer
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     // Test completions for the 'ls' flags
-    let suggestions = completer.complete("@example; ", 10);
+    let suggestions = completer.complete_and_wait("@example; ", 10);
 
     let expected: Vec<_> = vec!["def", "export def", "export extern", "extern"];
 
@@ -2472,7 +2474,7 @@ fn folder_with_directorycompletions() {
 
     // Test completions for the current folder
     let target_dir = format!("cd {dir_str}{MAIN_SEPARATOR}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [
@@ -2487,7 +2489,7 @@ fn folder_with_directorycompletions() {
     #[cfg(windows)]
     {
         let target_dir = format!("cd {dir_str}/");
-        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+        let slash_suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
         let expected_slash_paths: Vec<_> = expected_paths
             .iter()
@@ -2517,7 +2519,7 @@ fn folder_with_directorycompletions_with_dots() {
 
     // Test completions for the current folder
     let target_dir = format!("cd {dir_str}{MAIN_SEPARATOR}..{MAIN_SEPARATOR}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [folder(
@@ -2530,7 +2532,7 @@ fn folder_with_directorycompletions_with_dots() {
     #[cfg(windows)]
     {
         let target_dir = format!("cd {dir_str}/../");
-        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+        let slash_suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
         let expected_slash_paths: Vec<_> = expected_paths
             .iter()
@@ -2560,7 +2562,7 @@ fn folder_with_directorycompletions_with_three_trailing_dots() {
 
     // Test completions for the current folder
     let target_dir = format!("cd {dir_str}{MAIN_SEPARATOR}...{MAIN_SEPARATOR}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths = [
@@ -2605,7 +2607,7 @@ fn folder_with_directorycompletions_with_three_trailing_dots() {
     #[cfg(windows)]
     {
         let target_dir = format!("cd {dir_str}/.../");
-        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+        let slash_suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
         let expected_slash_paths: Vec<_> = expected_paths
             .iter()
@@ -2635,7 +2637,7 @@ fn folder_with_directorycompletions_do_not_collapse_dots() {
 
     // Test completions for the current folder
     let target_dir = format!("cd {dir_str}{MAIN_SEPARATOR}..{MAIN_SEPARATOR}..{MAIN_SEPARATOR}");
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
     // Create the expected values
     let expected_paths: Vec<_> = vec![
@@ -2686,7 +2688,7 @@ fn folder_with_directorycompletions_do_not_collapse_dots() {
     #[cfg(windows)]
     {
         let target_dir = format!("cd {dir_str}/../../");
-        let slash_suggestions = completer.complete(&target_dir, target_dir.len());
+        let slash_suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
 
         let expected_slash_paths: Vec<_> = expected_paths
             .iter()
@@ -2713,7 +2715,7 @@ fn variables_completions() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     // Test completions for $nu
-    let suggestions = completer.complete("$nu.", 4);
+    let suggestions = completer.complete_and_wait("$nu.", 4);
 
     let expected: Vec<_> = vec![
         "cache-dir",
@@ -2746,7 +2748,7 @@ fn variables_completions() {
     match_suggestions(&expected, &suggestions);
 
     // Test completions for $nu.h (filter)
-    let suggestions = completer.complete("$nu.h", 5);
+    let suggestions = completer.complete_and_wait("$nu.h", 5);
 
     assert_eq!(3, suggestions.len());
 
@@ -2756,14 +2758,14 @@ fn variables_completions() {
     match_suggestions(&expected, &suggestions);
 
     // Test completions for $nu.os-info
-    let suggestions = completer.complete("$nu.os-info.", 12);
+    let suggestions = completer.complete_and_wait("$nu.os-info.", 12);
     assert_eq!(4, suggestions.len());
     let expected: Vec<_> = vec!["arch", "family", "kernel_version", "name"];
     // Match results
     match_suggestions(&expected, &suggestions);
 
     // Test completions for custom var
-    let suggestions = completer.complete("$actor.", 7);
+    let suggestions = completer.complete_and_wait("$actor.", 7);
 
     assert_eq!(2, suggestions.len());
 
@@ -2773,7 +2775,7 @@ fn variables_completions() {
     match_suggestions(&expected, &suggestions);
 
     // Test completions for custom var (filtering)
-    let suggestions = completer.complete("$actor.n", 8);
+    let suggestions = completer.complete_and_wait("$actor.n", 8);
 
     assert_eq!(1, suggestions.len());
 
@@ -2783,7 +2785,7 @@ fn variables_completions() {
     match_suggestions(&expected, &suggestions);
 
     // Test completions for $env
-    let suggestions = completer.complete("$env.", 5);
+    let suggestions = completer.complete_and_wait("$env.", 5);
 
     assert_eq!(3, suggestions.len());
 
@@ -2796,7 +2798,7 @@ fn variables_completions() {
     match_suggestions(&expected, &suggestions);
 
     // Test completions for $env
-    let suggestions = completer.complete("$env.T", 6);
+    let suggestions = completer.complete_and_wait("$env.T", 6);
 
     assert_eq!(1, suggestions.len());
 
@@ -2805,7 +2807,7 @@ fn variables_completions() {
     // Match results
     match_suggestions(&expected, &suggestions);
 
-    let suggestions = completer.complete("$", 1);
+    let suggestions = completer.complete_and_wait("$", 1);
     let expected: Vec<_> = vec!["$actor", "$env", "$in", "$nu"];
 
     match_suggestions(&expected, &suggestions);
@@ -2817,38 +2819,38 @@ fn local_variable_completion() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let completion_str = "def test [foo?: string, --foo1: bool, ...foo2] { let foo3 = true; $foo";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
 
     // https://github.com/nushell/nushell/issues/15291
     let expected: Vec<_> = vec!["$foo", "$foo1", "$foo2", "$foo3"];
     match_suggestions(&expected, &suggestions);
 
     let completion_str = "if true { let foo = true; $foo";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["$foo"];
     match_suggestions(&expected, &suggestions);
 
     let completion_str = "if true {let foo1 = 1} else {let foo = true; $foo";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["$foo"];
     match_suggestions(&expected, &suggestions);
 
     let completion_str = "for foo in [1] { let foo1 = true; $foo";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["$foo", "$foo1"];
     match_suggestions(&expected, &suggestions);
 
     let completion_str = "for foo in [1] { let foo1 = true }; $foo";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     assert!(suggestions.is_empty());
 
     let completion_str = "(let foo = true; $foo";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["$foo"];
     match_suggestions(&expected, &suggestions);
 
     let completion_str = "match {a: {b: 3}} {{a: {b: $foo}} => $foo";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["$foo"];
     match_suggestions(&expected, &suggestions);
 }
@@ -2865,7 +2867,7 @@ fn unlet_variable_current_stack_not_in_completions() {
 
     // Verify myvar IS available before unlet
     let mut completer = NuCompleter::new(Arc::new(engine.clone()), Arc::new(stack.clone()));
-    let suggestions = completer.complete("$my", 3);
+    let suggestions = completer.complete_and_wait("$my", 3);
     assert!(
         suggestions.iter().any(|s| s.value == "$myvar"),
         "Expected $myvar to be in completions before unlet"
@@ -2877,7 +2879,7 @@ fn unlet_variable_current_stack_not_in_completions() {
 
     // Verify myvar is NOT available after unlet
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
-    let suggestions = completer.complete("$my", 3);
+    let suggestions = completer.complete_and_wait("$my", 3);
     assert!(
         !suggestions.iter().any(|s| s.value == "$myvar"),
         "Expected $myvar to NOT be in completions after unlet"
@@ -2906,7 +2908,7 @@ fn unlet_variable_parent_stack_not_in_completions() {
     // Verify myvar is NOT available in child stack completions
     // (the parent's deletions should be propagated via parent_deletions check)
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(child_stack));
-    let suggestions = completer.complete("$my", 3);
+    let suggestions = completer.complete_and_wait("$my", 3);
     assert!(
         !suggestions.iter().any(|s| s.value == "$myvar"),
         "Expected $myvar to NOT be in completions in child stack after parent unlet"
@@ -2937,7 +2939,7 @@ fn unlet_variable_grandparent_stack_not_in_completions() {
 
     // Verify myvar is NOT available in grandchild stack completions
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(grandchild_stack));
-    let suggestions = completer.complete("$my", 3);
+    let suggestions = completer.complete_and_wait("$my", 3);
     assert!(
         !suggestions.iter().any(|s| s.value == "$myvar"),
         "Expected $myvar to NOT be in completions in grandchild stack after grandparent unlet"
@@ -2957,7 +2959,7 @@ fn record_cell_path_completions(#[case] input: &str) {
     assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
-    let suggestions = completer.complete(input, input.len());
+    let suggestions = completer.complete_and_wait(input, input.len());
     let expected = ["a"].into();
     match_suggestions(&expected, &suggestions);
 }
@@ -2975,7 +2977,7 @@ fn table_cell_path_completions(#[case] input: &str, #[case] expected: Vec<&str>)
     assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
-    let suggestions = completer.complete(input, input.len());
+    let suggestions = completer.complete_and_wait(input, input.len());
     match_suggestions(&expected, &suggestions);
 }
 
@@ -3014,16 +3016,16 @@ fn quoted_cell_path_completions() {
         "\"|\"",
     ];
     let completion_str = "$foo.";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&expected, &suggestions);
 
     let expected: Vec<_> = vec!["\"foo bar\"", "\"foo\\\\\\\\\\\"bar\\\"\""];
     let completion_str = "$foo.`foo";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&expected, &suggestions);
 
     let completion_str = "$foo.foo";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     match_suggestions(&expected, &suggestions);
 }
 
@@ -3037,7 +3039,7 @@ fn alias_of_command_and_flags() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
-    let suggestions = completer.complete("ll t", 4);
+    let suggestions = completer.complete_and_wait("ll t", 4);
     #[cfg(windows)]
     let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink\\", "test_b\\"];
     #[cfg(not(windows))]
@@ -3056,7 +3058,7 @@ fn alias_of_basic_command() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
-    let suggestions = completer.complete("ll t", 4);
+    let suggestions = completer.complete_and_wait("ll t", 4);
     #[cfg(windows)]
     let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink\\", "test_b\\"];
     #[cfg(not(windows))]
@@ -3078,7 +3080,7 @@ fn alias_of_another_alias() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
-    let suggestions = completer.complete("lf t", 4);
+    let suggestions = completer.complete_and_wait("lf t", 4);
     #[cfg(windows)]
     let expected_paths: Vec<_> = vec!["test_a\\", "test_a_symlink\\", "test_b\\"];
     #[cfg(not(windows))]
@@ -3124,7 +3126,7 @@ fn run_external_completion_within_pwd(
     // Instantiate a new completer
     let mut completer = NuCompleter::new(Arc::new(engine_state), Arc::new(stack));
 
-    completer.complete(input, input.len())
+    completer.complete_and_wait(input, input.len())
 }
 
 fn run_external_completion(completer: &str, input: &str) -> Vec<Suggestion> {
@@ -3138,7 +3140,7 @@ fn unknown_command_completion() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let target_dir = "thiscommanddoesnotexist ";
-    let suggestions = completer.complete(target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(target_dir, target_dir.len());
 
     #[cfg(windows)]
     let expected_paths: Vec<_> = vec![
@@ -3174,7 +3176,7 @@ fn filecompletions_triggers_after_cursor() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
-    let suggestions = completer.complete("cp   test_c", 3);
+    let suggestions = completer.complete_and_wait("cp   test_c", 3);
 
     #[cfg(windows)]
     let expected_paths: Vec<_> = vec![
@@ -3211,11 +3213,11 @@ fn filecompletions_for_redirection_target() {
 
     let expected = vec!["`dir with space/bar baz`", "`dir with space/foo`"];
     let command = "(echo 'foo' o+e> `dir with space/`";
-    let suggestions = completer.complete(command, command.len());
+    let suggestions = completer.complete_and_wait(command, command.len());
     match_suggestions(&expected, &suggestions);
 
     let command = "echo 'foo' o> foo e> `dir with space/`";
-    let suggestions = completer.complete(command, command.len());
+    let suggestions = completer.complete_and_wait(command, command.len());
     match_suggestions(&expected, &suggestions);
 }
 
@@ -3243,7 +3245,7 @@ fn extern_custom_completion(
     #[case] input: &str,
     #[case] answer: &str,
 ) {
-    let suggestions = extern_completer.complete(input, input.len());
+    let suggestions = extern_completer.complete_and_wait(input, input.len());
     let expected = match answer {
         "animal" => vec!["cat", "dog", "eel"],
         "fruit" => vec!["apple", "banana"],
@@ -3264,7 +3266,7 @@ fn custom_completer_triggers_cursor_before_word(
     #[case] position: usize,
     #[case] extra: Vec<&str>,
 ) {
-    let suggestions = custom_completer.complete("cmd foo  bar ", position);
+    let suggestions = custom_completer.complete_and_wait("cmd foo  bar ", position);
     let mut expected: Vec<_> = vec!["cmd", "foo"];
     expected.extend(extra);
     match_suggestions(&expected, &suggestions);
@@ -3272,7 +3274,7 @@ fn custom_completer_triggers_cursor_before_word(
 
 #[rstest]
 fn sort_fuzzy_completions_in_alphabetical_order(mut fuzzy_alpha_sort_completer: NuCompleter) {
-    let suggestions = fuzzy_alpha_sort_completer.complete("ls nu", 5);
+    let suggestions = fuzzy_alpha_sort_completer.complete_and_wait("ls nu", 5);
     // Even though "nushell" is a better match, it should come second because
     // the completions should be sorted in alphabetical order
     match_suggestions(&vec!["custom_completion.nu", "nushell"], &suggestions);
@@ -3286,7 +3288,7 @@ fn exact_match() {
 
     // Troll case to test if exact match logic works case insensitively
     let target_dir = format!("open {}", folder(dir.join("pArTiAL")));
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
     match_suggestions(
         &vec![
             file(dir.join("partial").join("hello.txt")).as_str(),
@@ -3296,7 +3298,7 @@ fn exact_match() {
     );
 
     let target_dir = format!("open {}", file(dir.join("partial").join("h")));
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
     match_suggestions(
         &vec![
             file(dir.join("partial").join("hello.txt")).as_str(),
@@ -3308,7 +3310,7 @@ fn exact_match() {
     // Even though "hol" is an exact match, the first component ("part") wasn't an
     // exact match, so we include partial-a/hola
     let target_dir = format!("open {}", file(dir.join("part").join("hol")));
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
     match_suggestions(
         &vec![
             folder(dir.join("partial").join("hol")).as_str(),
@@ -3319,7 +3321,7 @@ fn exact_match() {
 
     // Exact match behavior shouldn't be enabled if the path has no slashes
     let target_dir = format!("open {}", file(dir.join("partial")));
-    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let suggestions = completer.complete_and_wait(&target_dir, target_dir.len());
     assert!(suggestions.len() > 1);
 }
 
@@ -3344,7 +3346,7 @@ fn exact_match_case_insensitive() {
                 folder(dir.join("aa").join("foo")).as_str(),
                 folder(dir.join("aaa").join("foo")).as_str(),
             ],
-            &completer.complete(&target, target.len()),
+            &completer.complete_and_wait(&target, target.len()),
         );
     });
 }
@@ -3358,12 +3360,12 @@ fn alias_offset_bug_7648() {
     assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack).is_ok());
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
-    let suggestions = completer.complete("e", 1);
+    let suggestions = completer.complete_and_wait("e", 1);
     assert!(!suggestions.is_empty());
 
     // Make sure completion in complicated external head expression still works
     let input = "^(ls | e";
-    let suggestions = completer.complete(input, input.len());
+    let suggestions = completer.complete_and_wait(input, input.len());
     assert!(!suggestions.is_empty());
 }
 
@@ -3376,153 +3378,155 @@ fn alias_offset_bug_7754() {
     assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack).is_ok());
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
-    let suggestions = completer.complete("ll -a | c", 9);
+    let suggestions = completer.complete_and_wait("ll -a | c", 9);
     assert!(!suggestions.is_empty());
 }
 
 #[rstest]
 fn operator_completions(mut custom_completer: NuCompleter) {
-    let suggestions = custom_completer.complete("1 ", 2);
+    let suggestions = custom_completer.complete_and_wait("1 ", 2);
     // == != > < >= <= in not-in
     // + - * / // mod **
     // 5 bit-xxx
     assert_eq!(20, suggestions.len());
-    let suggestions = custom_completer.complete("1 bit-s", 7);
+    let suggestions = custom_completer.complete_and_wait("1 bit-s", 7);
     let expected: Vec<_> = vec!["bit-shl", "bit-shr"];
     match_suggestions(&expected, &suggestions);
 
-    let suggestions = custom_completer.complete("'str' ", 6);
+    let suggestions = custom_completer.complete_and_wait("'str' ", 6);
     // == != > < >= <= in not-in
     // has not-has starts-with not-starts-with ends-with not-ends-with
     // =~ !~ like not-like ++
     assert_eq!(19, suggestions.len());
-    let suggestions = custom_completer.complete("'str' +", 7);
+    let suggestions = custom_completer.complete_and_wait("'str' +", 7);
     let expected: Vec<_> = vec!["++"];
     match_suggestions(&expected, &suggestions);
 
-    let suggestions = custom_completer.complete("1ms ", 4);
+    let suggestions = custom_completer.complete_and_wait("1ms ", 4);
     // == != > < >= <= in not-in
     // + - * / // mod
     assert_eq!(14, suggestions.len());
-    let suggestions = custom_completer.complete("1ms /", 5);
+    let suggestions = custom_completer.complete_and_wait("1ms /", 5);
     let expected: Vec<_> = vec!["/", "//"];
     match_suggestions(&expected, &suggestions);
 
-    let suggestions = custom_completer.complete("..2 ", 4);
+    let suggestions = custom_completer.complete_and_wait("..2 ", 4);
     // == != in not-in has not-has
     assert_eq!(6, suggestions.len());
-    let suggestions = custom_completer.complete("..2 h", 5);
+    let suggestions = custom_completer.complete_and_wait("..2 h", 5);
     let expected: Vec<_> = vec!["has"];
     match_suggestions(&expected, &suggestions);
 
-    let suggestions = custom_completer.complete("[[];[]] ", 8);
+    let suggestions = custom_completer.complete_and_wait("[[];[]] ", 8);
     // == != in not-in has not-has ++
     assert_eq!(7, suggestions.len());
-    let suggestions = custom_completer.complete("[[];[]] h", 9);
+    let suggestions = custom_completer.complete_and_wait("[[];[]] h", 9);
     let expected: Vec<_> = vec!["has"];
     match_suggestions(&expected, &suggestions);
 
-    let suggestions = custom_completer.complete("(date now) ", 11);
+    let suggestions = custom_completer.complete_and_wait("(date now) ", 11);
     // == != > < >= <= in not-in
     assert_eq!(8, suggestions.len());
-    let suggestions = custom_completer.complete("(date now) <", 12);
+    let suggestions = custom_completer.complete_and_wait("(date now) <", 12);
     let expected: Vec<_> = vec!["<", "<="];
     match_suggestions(&expected, &suggestions);
 
     // default operators for all types
     let expected: Vec<_> = vec!["!=", "==", "in", "not-in"];
-    let suggestions = custom_completer.complete("{1} ", 4);
+    let suggestions = custom_completer.complete_and_wait("{1} ", 4);
     match_suggestions(&expected, &suggestions);
-    let suggestions = custom_completer.complete("null ", 5);
+    let suggestions = custom_completer.complete_and_wait("null ", 5);
     match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn cell_path_operator_completions(mut custom_completer: NuCompleter) {
-    let suggestions = custom_completer.complete("[1].0 ", 6);
+    let suggestions = custom_completer.complete_and_wait("[1].0 ", 6);
     // == != > < >= <= in not-in
     // + - * / // mod **
     // 5 bit-xxx
     assert_eq!(20, suggestions.len());
-    let suggestions = custom_completer.complete("[1].0 bit-s", 11);
+    let suggestions = custom_completer.complete_and_wait("[1].0 bit-s", 11);
     let expected: Vec<_> = vec!["bit-shl", "bit-shr"];
     match_suggestions(&expected, &suggestions);
 
-    let suggestions = custom_completer.complete("{'foo': [1, 1kb]}.foo.1 ", 24);
+    let suggestions = custom_completer.complete_and_wait("{'foo': [1, 1kb]}.foo.1 ", 24);
     // == != > < >= <= in not-in
     // + - * / // mod
     assert_eq!(14, suggestions.len());
-    let suggestions = custom_completer.complete("{'foo': [1, 1kb]}.foo.1 mo", 26);
+    let suggestions = custom_completer.complete_and_wait("{'foo': [1, 1kb]}.foo.1 mo", 26);
     let expected: Vec<_> = vec!["mod"];
     match_suggestions(&expected, &suggestions);
 
-    let suggestions = custom_completer.complete("const f = {'foo': [1, '1']}; $f.foo.1 ", 38);
+    let suggestions =
+        custom_completer.complete_and_wait("const f = {'foo': [1, '1']}; $f.foo.1 ", 38);
     // == != > < >= <= in not-in
     // has not-has starts-with not-starts-with ends-with not-ends-with
     // =~ !~ like not-like ++
     assert_eq!(19, suggestions.len());
-    let suggestions = custom_completer.complete("const f = {'foo': [1, '1']}; $f.foo.1 ++", 40);
+    let suggestions =
+        custom_completer.complete_and_wait("const f = {'foo': [1, '1']}; $f.foo.1 ++", 40);
     let expected: Vec<_> = vec!["++"];
     match_suggestions(&expected, &suggestions);
 }
 
 #[rstest]
 fn assignment_operator_completions(mut custom_completer: NuCompleter) {
-    let suggestions = custom_completer.complete("mut foo = ''; $foo ", 19);
+    let suggestions = custom_completer.complete_and_wait("mut foo = ''; $foo ", 19);
     // == != > < >= <= in not-in
     // has not-has starts-with not-starts-with ends-with not-ends-with
     // =~ !~ like not-like ++
     // = ++=
     assert_eq!(21, suggestions.len());
-    let suggestions = custom_completer.complete("mut foo = ''; $foo ++", 21);
+    let suggestions = custom_completer.complete_and_wait("mut foo = ''; $foo ++", 21);
     let expected: Vec<_> = vec!["++", "++="];
     match_suggestions(&expected, &suggestions);
 
     // == != > < >= <= in not-in
     // =
-    let suggestions = custom_completer.complete("mut foo = date now; $foo ", 25);
+    let suggestions = custom_completer.complete_and_wait("mut foo = date now; $foo ", 25);
     assert_eq!(9, suggestions.len());
-    let suggestions = custom_completer.complete("mut foo = date now; $foo =", 26);
+    let suggestions = custom_completer.complete_and_wait("mut foo = date now; $foo =", 26);
     let expected: Vec<_> = vec!["=", "=="];
     match_suggestions(&expected, &suggestions);
 
-    let suggestions = custom_completer.complete("mut foo = date now; $foo ", 25);
+    let suggestions = custom_completer.complete_and_wait("mut foo = date now; $foo ", 25);
     // == != > < >= <= in not-in
     // =
     assert_eq!(9, suggestions.len());
-    let suggestions = custom_completer.complete("mut foo = date now; $foo =", 26);
+    let suggestions = custom_completer.complete_and_wait("mut foo = date now; $foo =", 26);
     let expected: Vec<_> = vec!["=", "=="];
     match_suggestions(&expected, &suggestions);
 
-    let suggestions = custom_completer.complete("mut foo = 1ms; $foo ", 20);
+    let suggestions = custom_completer.complete_and_wait("mut foo = 1ms; $foo ", 20);
     // == != > < >= <= in not-in
     // + - * / // mod
     // = += -= *= /=
     assert_eq!(19, suggestions.len());
-    let suggestions = custom_completer.complete("mut foo = 1ms; $foo +", 21);
+    let suggestions = custom_completer.complete_and_wait("mut foo = 1ms; $foo +", 21);
     let expected: Vec<_> = vec!["+", "+="];
     match_suggestions(&expected, &suggestions);
 
     // default operators for all mutables
     let expected: Vec<_> = vec!["!=", "=", "==", "in", "not-in"];
-    let suggestions = custom_completer.complete("mut foo = null; $foo ", 21);
+    let suggestions = custom_completer.complete_and_wait("mut foo = null; $foo ", 21);
     match_suggestions(&expected, &suggestions);
 
     // $env should be considered mutable
-    let suggestions = custom_completer.complete("$env.config.keybindings ", 24);
+    let suggestions = custom_completer.complete_and_wait("$env.config.keybindings ", 24);
     // == != in not-in
     // has not-has ++=
     // = ++=
     assert_eq!(9, suggestions.len());
     let expected: Vec<_> = vec!["++", "++="];
-    let suggestions = custom_completer.complete("$env.config.keybindings +", 25);
+    let suggestions = custom_completer.complete_and_wait("$env.config.keybindings +", 25);
     match_suggestions(&expected, &suggestions);
 
     // all operators for type any
-    let suggestions = custom_completer.complete("ls | where name ", 16);
+    let suggestions = custom_completer.complete_and_wait("ls | where name ", 16);
     assert_eq!(32, suggestions.len());
     let expected: Vec<_> = vec!["starts-with"];
-    let suggestions = custom_completer.complete("ls | where name starts", 22);
+    let suggestions = custom_completer.complete_and_wait("ls | where name starts", 22);
     match_suggestions(&expected, &suggestions);
 }
 
@@ -3534,14 +3538,14 @@ fn cellpath_assignment_operator_completions() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "$foo.foo.1 ";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     // == != > < >= <= in not-in
     // has not-has starts-with not-starts-with ends-with not-ends-with
     // =~ !~ like not-like ++
     // = ++=
     assert_eq!(21, suggestions.len());
     let completion_str = "$foo.foo.1 ++";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["++", "++="];
     match_suggestions(&expected, &suggestions);
 
@@ -3551,12 +3555,12 @@ fn cellpath_assignment_operator_completions() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "$foo.foo.1 ";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     // == != > < >= <= in not-in
     // =
     assert_eq!(9, suggestions.len());
     let completion_str = "$foo.foo.1 =";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["=", "=="];
     match_suggestions(&expected, &suggestions);
 }
@@ -3573,7 +3577,7 @@ fn alias_expansion_for_external_completions() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "example_alias extra_arg";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec!["example_cmd", "arg1", "arg2", "extra_arg"];
     match_suggestions(&expected, &suggestions);
 }
@@ -3590,7 +3594,7 @@ fn nested_alias_expansion_for_external_completions() {
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let completion_str = "nested_alias extra_arg";
-    let suggestions = completer.complete(completion_str, completion_str.len());
+    let suggestions = completer.complete_and_wait(completion_str, completion_str.len());
     let expected: Vec<_> = vec![
         "example_cmd",
         "arg1",
@@ -3605,20 +3609,22 @@ fn nested_alias_expansion_for_external_completions() {
 #[ignore]
 #[rstest]
 fn type_inferenced_operator_completions(mut custom_completer: NuCompleter) {
-    let suggestions = custom_completer.complete("let f = {'foo': [1, '1']}; $f.foo.1 ", 36);
+    let suggestions =
+        custom_completer.complete_and_wait("let f = {'foo': [1, '1']}; $f.foo.1 ", 36);
     // == != > < >= <= in not-in
     // has not-has starts-with not-starts-with ends-with not-ends-with
     // =~ !~ like not-like ++
     assert_eq!(19, suggestions.len());
-    let suggestions = custom_completer.complete("const f = {'foo': [1, '1']}; $f.foo.1 ++", 38);
+    let suggestions =
+        custom_completer.complete_and_wait("const f = {'foo': [1, '1']}; $f.foo.1 ++", 38);
     let expected: Vec<_> = vec!["++"];
     match_suggestions(&expected, &suggestions);
 
-    let suggestions = custom_completer.complete("mut foo = [(date now)]; $foo.0 ", 31);
+    let suggestions = custom_completer.complete_and_wait("mut foo = [(date now)]; $foo.0 ", 31);
     // == != > < >= <= in not-in
     // =
     assert_eq!(9, suggestions.len());
-    let suggestions = custom_completer.complete("mut foo = [(date now)]; $foo.0 =", 32);
+    let suggestions = custom_completer.complete_and_wait("mut foo = [(date now)]; $foo.0 =", 32);
     let expected: Vec<_> = vec!["=", "=="];
     match_suggestions(&expected, &suggestions);
 }
@@ -3659,7 +3665,7 @@ fn suggestion_match_indices(
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let input = format!("def foo [a: string@[{options}]] {{}}; foo {pattern}");
-    let suggestions = completer.complete(&input, input.len());
+    let suggestions = completer.complete_and_wait(&input, input.len());
 
     assert_eq!(suggestions.len(), expected_values.len());
     assert_eq!(suggestions.len(), expected_indices.len());
@@ -3683,11 +3689,11 @@ fn clip_subcommands_show_before_and_after_use() {
 
     // Before `use` — built-in `clip copy` should be present
     let mut completer = NuCompleter::new(Arc::new(engine.clone()), Arc::new(stack.clone()));
-    let suggestions = completer.complete("clip ", 5);
+    let suggestions = completer.complete_and_wait("clip ", 5);
     assert!(suggestions.iter().any(|s| s.value == "clip copy"));
 
     // Also check the no-space case (`clip`) returns subcommands
-    let suggestions_no_space = completer.complete("clip", 4);
+    let suggestions_no_space = completer.complete_and_wait("clip", 4);
     assert!(suggestions_no_space.iter().any(|s| s.value == "clip copy"));
 
     // After `use std/clip` — completions should still include `clip copy`
@@ -3695,10 +3701,10 @@ fn clip_subcommands_show_before_and_after_use() {
     assert!(load_standard_library(&mut engine).is_ok());
     assert!(support::merge_input("use std/clip".as_bytes(), &mut engine, &mut stack).is_ok());
     let mut completer2 = NuCompleter::new(Arc::new(engine), Arc::new(stack));
-    let suggestions2 = completer2.complete("clip ", 5);
+    let suggestions2 = completer2.complete_and_wait("clip ", 5);
     assert!(suggestions2.iter().any(|s| s.value == "clip copy"));
 
     // And the no-space case after `use`
-    let suggestions2_no_space = completer2.complete("clip", 4);
+    let suggestions2_no_space = completer2.complete_and_wait("clip", 4);
     assert!(suggestions2_no_space.iter().any(|s| s.value == "clip copy"));
 }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -932,25 +932,29 @@ mod background_isolation_tests {
     fn test_detached_process_removes_console() {
         let mut cmd = Command::new("cmd");
 
-        // `chcp` with no args queries the console code page via the console API.
-        // It succeeds when a console is attached and fails when there is none.
+        // We deliberately use only cmd built-ins (no external .exe/.com) to avoid
+        // Windows auto-allocating a console for console-subsystem children
+        // This would produce a false "has_console" result even
+        // when DETACHED_PROCESS is working correctly.
         cmd.args([
             "/c",
-            "(chcp >NUL 2>&1) && echo has_console || echo no_console",
+            "(echo.>CON 2>NUL && echo has_console) || echo no_console",
         ])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null());
+        .stderr(Stdio::piped()); // Capture instead of null so we can show diagnostics 
 
         prepare_background_command(&mut cmd);
 
         let output = cmd.output().expect("cmd should run");
-        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
         assert_eq!(
-            stdout.trim(),
-            "no_console",
-            "subprocess should have no console after DETACHED_PROCESS; \
-             if it has one a completer could call SetConsoleMode and corrupt reedline's state"
+            stdout, "no_console",
+            "Subprocess should have no console after DETACHED_PROCESS.\n\
+         stderr was: {stderr}"
         );
     }
 }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -7,11 +7,11 @@ use nu_protocol::{
     process::{ChildProcess, PostWaitCallback},
     shell_error::io::IoError,
 };
+#[cfg(unix)]
+use nu_system::prepare_background_command;
 use nu_system::{ForegroundChild, kill_by_pid};
 use nu_utils::IgnoreCaseExt;
 use pathdiff::diff_paths;
-#[cfg(unix)]
-use std::os::unix::process::CommandExt as UnixCommandExt;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 use std::{
@@ -264,20 +264,8 @@ If you create a custom command with this name, that will be used instead."
                 // and cause bad EIO).
                 if engine_state.is_mcp || stack.suppress_stdin {
                     command.stdin(Stdio::null());
-
-                    // Without the new session, the subprocess can still open
-                    // /dev/tty directly, change terminal settings (tcsetattr), and
-                    // corrupt the pty state.
                     #[cfg(unix)]
-                    unsafe {
-                        command.pre_exec(|| {
-                            // setsid() initiates a new session without a
-                            // controlling terminal, so /dev/tty will fail to open.
-                            // Skip EPERM: we may already be a session leader.
-                            let _ = nix::unistd::setsid();
-                            Ok(())
-                        });
-                    }
+                    prepare_background_command(&mut command);
                 } else {
                     command.stdin(Stdio::inherit());
                 }
@@ -849,7 +837,7 @@ mod test {
 ///      corrupt reedline's raw-mode terminal, causing EIO on the next read.
 #[cfg(all(test, unix))]
 mod background_isolation_tests {
-    use std::os::unix::process::CommandExt as UnixCommandExt;
+    use nu_system::prepare_background_command;
     use std::process::{Command, Stdio};
     use std::time::Duration;
 
@@ -900,14 +888,7 @@ mod background_isolation_tests {
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
 
-        // This is what the setsid pre_exec in run_external.rs does when
-        // stack.suppress_stdin is true.
-        unsafe {
-            cmd.pre_exec(|| {
-                let _ = nix::unistd::setsid();
-                Ok(())
-            });
-        }
+        prepare_background_command(&mut cmd);
 
         let output = cmd.output().expect("sh should run");
         let stdout = String::from_utf8_lossy(&output.stdout);

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -829,7 +829,7 @@ mod test {
 
 /// Tests for the background-completion terminal-isolation fix.
 ///
-/// When `stack.suppress_stdin` is set (used by `NuCompleter::new_background`),
+/// When `stack.suppress_stdin` is set (used by `NuCompleter::new_for_background`),
 /// subprocesses must:
 ///   1. Receive /dev/null for stdin – so they can't steal keystrokes.
 ///   2. Run in a new session (setsid) – so opening /dev/tty fails.

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -10,6 +10,8 @@ use nu_protocol::{
 use nu_system::{ForegroundChild, kill_by_pid};
 use nu_utils::IgnoreCaseExt;
 use pathdiff::diff_paths;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt as UnixCommandExt;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 use std::{
@@ -256,13 +258,26 @@ If you create a custom command with this name, that will be used instead."
                 }
             },
             PipelineData::Empty => {
-                // MCP servers run non-interactively - use null stdin to prevent commands
-                // from hanging when they prompt for passwords or other input.
-                // In the future, this may become a more general option (e.g., no_stdin)
-                // but needs more testing first. See:
-                // https://github.com/nushell/nushell/pull/17161#discussion_r2761243143
-                if engine_state.is_mcp {
+                // Use null stdin when running non-interactively (MCP) or when the
+                // caller explicitly requests it (mainly background completion threads,
+                // where inheriting the terminal could race with reedline's reads
+                // and cause bad EIO).
+                if engine_state.is_mcp || stack.suppress_stdin {
                     command.stdin(Stdio::null());
+
+                    // Without the new session, the subprocess can still open
+                    // /dev/tty directly, change terminal settings (tcsetattr), and
+                    // corrupt the pty state.
+                    #[cfg(unix)]
+                    unsafe {
+                        command.pre_exec(|| {
+                            // setsid() initiates a new session without a
+                            // controlling terminal, so /dev/tty will fail to open.
+                            // Skip EPERM: we may already be a session leader.
+                            let _ = nix::unistd::setsid();
+                            Ok(())
+                        });
+                    }
                 } else {
                     command.stdin(Stdio::inherit());
                 }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -828,32 +828,32 @@ mod test {
 ///
 /// When `stack.suppress_stdin` is set (used by `NuCompleter::new_for_background`),
 /// subprocesses must:
-///   1. Receive /dev/null for stdin – so they can't steal keystrokes.
-///   2. Run in a new session (setsid) – so opening /dev/tty fails.
-///      Without setsid, tools like carapace can call tcsetattr on /dev/tty and
-///      corrupt reedline's raw-mode terminal, causing EIO on the next read.
-#[cfg(all(test, unix))]
+///   1. Receive a null device for stdin so they can't steal keystrokes.
+///   2. Be isolated from the parent's terminal/console so tools like carapace
+///      cannot call tcsetattr (Unix) or SetConsoleMode (Windows) and corrupt
+///      reedline's raw-mode state.
+#[cfg(test)]
 mod background_isolation_tests {
     use nu_system::prepare_background_command;
     use std::process::{Command, Stdio};
     use std::time::Duration;
 
-    /// A subprocess whose stdin is /dev/null should see EOF immediately – it
-    /// must not block waiting for terminal input.  Blocking would indicate that
+    /// A subprocess whose stdin is the null device should see EOF immediately –
+    /// it must not block waiting for terminal input. Blocking would indicate that
     /// suppress_stdin isn't working and the subprocess still holds the terminal.
+    #[cfg(unix)]
     #[test]
     fn test_suppress_stdin_gives_eof_not_terminal() {
-        // "read line" will return immediately with exit code 1 when stdin is
-        // /dev/null (EOF), but block indefinitely if stdin is the terminal.
+        // "read line" returns immediately with exit code 1 when stdin is
+        // /dev/null (EOF), but blocks indefinitely if stdin is the terminal.
         let child = Command::new("sh")
             .args(["-c", "read line; echo exit:$?"])
-            .stdin(Stdio::null()) // suppress_stdin effect
+            .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()
             .expect("sh should spawn");
 
-        // Give the process 2 s; if it's blocking on terminal it won't finish.
         let start = nu_utils::time::Instant::now();
         let output = child.wait_with_output().expect("wait failed");
         assert!(
@@ -861,7 +861,32 @@ mod background_isolation_tests {
             "subprocess blocked – stdin was not /dev/null"
         );
         let stdout = String::from_utf8_lossy(&output.stdout);
-        // exit code 1 means read returned EOF (stdin was /dev/null)
+        assert!(
+            stdout.contains("exit:1"),
+            "expected EOF on stdin, got: {stdout}"
+        );
+    }
+
+    /// On Windows, `set /p` reads a line from stdin. With NUL for stdin it
+    /// returns immediately with ERRORLEVEL 1 (EOF), but blocks on a terminal.
+    #[cfg(windows)]
+    #[test]
+    fn test_suppress_stdin_gives_eof_not_terminal() {
+        let child = Command::new("cmd")
+            .args(["/c", "set /p x= && echo exit:0 || echo exit:1"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("cmd should spawn");
+
+        let start = nu_utils::time::Instant::now();
+        let output = child.wait_with_output().expect("wait failed");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "subprocess blocked... stdin was not NUL"
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
             stdout.contains("exit:1"),
             "expected EOF on stdin, got: {stdout}"
@@ -871,6 +896,7 @@ mod background_isolation_tests {
     /// A subprocess spawned via setsid() must not be able to open /dev/tty.
     /// If it CAN open /dev/tty it can call tcsetattr and corrupt reedline's
     /// terminal state, causing EIO ("Input/output error") on the next read.
+    #[cfg(unix)]
     #[test]
     fn test_setsid_removes_controlling_terminal() {
         let mut cmd = Command::new("sh");
@@ -894,6 +920,37 @@ mod background_isolation_tests {
             "no_tty",
             "subprocess should have no controlling terminal after setsid(); \
              if it has one it can corrupt reedline's terminal mode and cause EIO"
+        );
+    }
+
+    /// A subprocess launched with DETACHED_PROCESS has no console attached, so
+    /// cmd's built-in `chcp` (which queries the console code page) MUST fail.
+    /// If `chcp` succeeds it would be bad as the child has inherited the parent's console and a
+    /// completer could call SetConsoleMode to corrupt reedline's state.
+    #[cfg(windows)]
+    #[test]
+    fn test_detached_process_removes_console() {
+        let mut cmd = Command::new("cmd");
+
+        // `chcp` with no args queries the console code page via the console API.
+        // It succeeds when a console is attached and fails when there is none.
+        cmd.args([
+            "/c",
+            "(chcp >NUL 2>&1) && echo has_console || echo no_console",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+
+        prepare_background_command(&mut cmd);
+
+        let output = cmd.output().expect("cmd should run");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(
+            stdout.trim(),
+            "no_console",
+            "subprocess should have no console after DETACHED_PROCESS; \
+             if it has one a completer could call SetConsoleMode and corrupt reedline's state"
         );
     }
 }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -256,10 +256,7 @@ If you create a custom command with this name, that will be used instead."
                 }
             },
             PipelineData::Empty => {
-                // Use null stdin when running non-interactively (MCP) or when the
-                // caller explicitly requests it (mainly background completion threads,
-                // where inheriting the terminal could race with reedline's reads
-                // and cause bad EIO).
+                // MCP and background completions must not inherit the live terminal.
                 if engine_state.is_mcp || stack.suppress_stdin {
                     command.stdin(Stdio::null());
                     prepare_background_command(&mut command);
@@ -284,7 +281,9 @@ If you create a custom command with this name, that will be used instead."
         #[cfg(unix)]
         let child = ForegroundChild::spawn(
             command,
-            engine_state.is_interactive,
+            // `suppress_stdin` children are already detached; do not also take
+            // the foreground pgrp from the completion thread.
+            engine_state.is_interactive && !stack.suppress_stdin,
             engine_state.is_background_job(),
             &engine_state.pipeline_externals_state,
         );
@@ -824,137 +823,56 @@ mod test {
     }
 }
 
-/// Tests for the background-completion terminal-isolation fix.
-///
-/// When `stack.suppress_stdin` is set (used by `NuCompleter::new_for_background`),
-/// subprocesses must:
-///   1. Receive a null device for stdin so they can't steal keystrokes.
-///   2. Be isolated from the parent's terminal/console so tools like carapace
-///      cannot call tcsetattr (Unix) or SetConsoleMode (Windows) and corrupt
-///      reedline's raw-mode state.
+/// `prepare_background_command` must detach from the controlling terminal/console
+/// so completer subprocesses cannot rewrite reedline's raw-mode state.
 #[cfg(test)]
 mod background_isolation_tests {
     use nu_system::prepare_background_command;
     use std::process::{Command, Stdio};
-    use std::time::Duration;
 
-    /// A subprocess whose stdin is the null device should see EOF immediately –
-    /// it must not block waiting for terminal input. Blocking would indicate that
-    /// suppress_stdin isn't working and the subprocess still holds the terminal.
     #[cfg(unix)]
     #[test]
-    fn test_suppress_stdin_gives_eof_not_terminal() {
-        // "read line" returns immediately with exit code 1 when stdin is
-        // /dev/null (EOF), but blocks indefinitely if stdin is the terminal.
-        let child = Command::new("sh")
-            .args(["-c", "read line; echo exit:$?"])
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("sh should spawn");
-
-        let start = nu_utils::time::Instant::now();
-        let output = child.wait_with_output().expect("wait failed");
-        assert!(
-            start.elapsed() < Duration::from_secs(2),
-            "subprocess blocked – stdin was not /dev/null"
-        );
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(
-            stdout.contains("exit:1"),
-            "expected EOF on stdin, got: {stdout}"
-        );
-    }
-
-    /// On Windows, `set /p` reads a line from stdin. With NUL for stdin it
-    /// returns immediately with ERRORLEVEL 1 (EOF), but blocks on a terminal.
-    #[cfg(windows)]
-    #[test]
-    fn test_suppress_stdin_gives_eof_not_terminal() {
-        let child = Command::new("cmd")
-            .args(["/c", "set /p x= && echo exit:0 || echo exit:1"])
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("cmd should spawn");
-
-        let start = nu_utils::time::Instant::now();
-        let output = child.wait_with_output().expect("wait failed");
-        assert!(
-            start.elapsed() < Duration::from_secs(2),
-            "subprocess blocked... stdin was not NUL"
-        );
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(
-            stdout.contains("exit:1"),
-            "expected EOF on stdin, got: {stdout}"
-        );
-    }
-
-    /// A subprocess spawned via setsid() must not be able to open /dev/tty.
-    /// If it CAN open /dev/tty it can call tcsetattr and corrupt reedline's
-    /// terminal state, causing EIO ("Input/output error") on the next read.
-    #[cfg(unix)]
-    #[test]
-    fn test_setsid_removes_controlling_terminal() {
+    fn setsid_removes_controlling_terminal() {
         let mut cmd = Command::new("sh");
+        // Subshell so a failed redirect does not exit before the `||` branch.
         cmd.args([
             "-c",
-            // Try to open /dev/tty; if it succeeds write "has_tty", else "no_tty".
-            // Use a subshell so that a failed exec redirect (which exits the
-            // shell on both bash and dash) doesn't silence the outer || branch.
             "(exec 3>/dev/tty) 2>/dev/null && echo has_tty || echo no_tty",
         ])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
-
         prepare_background_command(&mut cmd);
 
         let output = cmd.output().expect("sh should run");
-        let stdout = String::from_utf8_lossy(&output.stdout);
         assert_eq!(
-            stdout.trim(),
+            String::from_utf8_lossy(&output.stdout).trim(),
             "no_tty",
-            "subprocess should have no controlling terminal after setsid(); \
-             if it has one it can corrupt reedline's terminal mode and cause EIO"
+            "child must not retain a controlling terminal after setsid"
         );
     }
 
-    /// A subprocess launched with DETACHED_PROCESS has no console attached, so
-    /// cmd's built-in `chcp` (which queries the console code page) MUST fail.
-    /// If `chcp` succeeds it would be bad as the child has inherited the parent's console and a
-    /// completer could call SetConsoleMode to corrupt reedline's state.
     #[cfg(windows)]
     #[test]
-    fn test_detached_process_removes_console() {
+    fn detached_process_removes_console() {
+        // Use only cmd built-ins — console-subsystem .exe children can get a
+        // fresh console even with DETACHED_PROCESS, which would false-positive.
         let mut cmd = Command::new("cmd");
-
-        // We deliberately use only cmd built-ins (no external .exe/.com) to avoid
-        // Windows auto-allocating a console for console-subsystem children
-        // This would produce a false "has_console" result even
-        // when DETACHED_PROCESS is working correctly.
         cmd.args([
             "/c",
             "(echo.>CON 2>NUL && echo has_console) || echo no_console",
         ])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped()); // Capture instead of null so we can show diagnostics 
-
+        .stderr(Stdio::piped());
         prepare_background_command(&mut cmd);
 
         let output = cmd.output().expect("cmd should run");
-
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         let stderr = String::from_utf8_lossy(&output.stderr);
-
         assert_eq!(
             stdout, "no_console",
-            "Subprocess should have no console after DETACHED_PROCESS.\n\
-         stderr was: {stderr}"
+            "child must not retain a console after DETACHED_PROCESS; stderr={stderr}"
         );
     }
 }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -838,3 +838,84 @@ mod test {
         assert_eq!(buf, b"foo");
     }
 }
+
+/// Tests for the background-completion terminal-isolation fix.
+///
+/// When `stack.suppress_stdin` is set (used by `NuCompleter::new_background`),
+/// subprocesses must:
+///   1. Receive /dev/null for stdin – so they can't steal keystrokes.
+///   2. Run in a new session (setsid) – so opening /dev/tty fails.
+///      Without setsid, tools like carapace can call tcsetattr on /dev/tty and
+///      corrupt reedline's raw-mode terminal, causing EIO on the next read.
+#[cfg(all(test, unix))]
+mod background_isolation_tests {
+    use std::os::unix::process::CommandExt as UnixCommandExt;
+    use std::process::{Command, Stdio};
+    use std::time::Duration;
+
+    /// A subprocess whose stdin is /dev/null should see EOF immediately – it
+    /// must not block waiting for terminal input.  Blocking would indicate that
+    /// suppress_stdin isn't working and the subprocess still holds the terminal.
+    #[test]
+    fn test_suppress_stdin_gives_eof_not_terminal() {
+        // "read line" will return immediately with exit code 1 when stdin is
+        // /dev/null (EOF), but block indefinitely if stdin is the terminal.
+        let child = Command::new("sh")
+            .args(["-c", "read line; echo exit:$?"])
+            .stdin(Stdio::null()) // suppress_stdin effect
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("sh should spawn");
+
+        // Give the process 2 s; if it's blocking on terminal it won't finish.
+        let start = nu_utils::time::Instant::now();
+        let output = child.wait_with_output().expect("wait failed");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "subprocess blocked – stdin was not /dev/null"
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        // exit code 1 means read returned EOF (stdin was /dev/null)
+        assert!(
+            stdout.contains("exit:1"),
+            "expected EOF on stdin, got: {stdout}"
+        );
+    }
+
+    /// A subprocess spawned via setsid() must not be able to open /dev/tty.
+    /// If it CAN open /dev/tty it can call tcsetattr and corrupt reedline's
+    /// terminal state, causing EIO ("Input/output error") on the next read.
+    #[test]
+    fn test_setsid_removes_controlling_terminal() {
+        let mut cmd = Command::new("sh");
+        cmd.args([
+            "-c",
+            // Try to open /dev/tty; if it succeeds write "has_tty", else "no_tty".
+            // Use a subshell so that a failed exec redirect (which exits the
+            // shell on both bash and dash) doesn't silence the outer || branch.
+            "(exec 3>/dev/tty) 2>/dev/null && echo has_tty || echo no_tty",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+
+        // This is what the setsid pre_exec in run_external.rs does when
+        // stack.suppress_stdin is true.
+        unsafe {
+            cmd.pre_exec(|| {
+                let _ = nix::unistd::setsid();
+                Ok(())
+            });
+        }
+
+        let output = cmd.output().expect("sh should run");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(
+            stdout.trim(),
+            "no_tty",
+            "subprocess should have no controlling terminal after setsid(); \
+             if it has one it can corrupt reedline's terminal mode and cause EIO"
+        );
+    }
+}

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -7,9 +7,7 @@ use nu_protocol::{
     process::{ChildProcess, PostWaitCallback},
     shell_error::io::IoError,
 };
-#[cfg(unix)]
-use nu_system::prepare_background_command;
-use nu_system::{ForegroundChild, kill_by_pid};
+use nu_system::{ForegroundChild, kill_by_pid, prepare_background_command};
 use nu_utils::IgnoreCaseExt;
 use pathdiff::diff_paths;
 #[cfg(windows)]
@@ -264,7 +262,6 @@ If you create a custom command with this name, that will be used instead."
                 // and cause bad EIO).
                 if engine_state.is_mcp || stack.suppress_stdin {
                     command.stdin(Stdio::null());
-                    #[cfg(unix)]
                     prepare_background_command(&mut command);
                 } else {
                     command.stdin(Stdio::inherit());

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -65,6 +65,9 @@ pub struct Stack {
     /// Locally updated config. Use [`.get_config()`](Self::get_config) to access correctly.
     pub config: Option<Arc<Config>>,
     pub(crate) out_dest: StackOutDest,
+    /// When `true`, external processes spawned with `PipelineData::Empty` input
+    /// receive `/dev/null` for stdin instead of inheriting the terminal.
+    pub suppress_stdin: bool,
 }
 
 impl Default for Stack {
@@ -97,6 +100,7 @@ impl Stack {
             deletions: vec![],
             config: None,
             out_dest: StackOutDest::new(),
+            suppress_stdin: false,
         }
     }
 
@@ -120,6 +124,7 @@ impl Stack {
             deletions: vec![],
             config: parent.config.clone(),
             out_dest: parent.out_dest.clone(),
+            suppress_stdin: parent.suppress_stdin,
             parent_stack: Some(parent),
         }
     }
@@ -393,6 +398,7 @@ impl Stack {
             deletions: vec![],
             config: self.config.clone(),
             out_dest: self.out_dest.clone(),
+            suppress_stdin: self.suppress_stdin,
         }
     }
 
@@ -429,6 +435,7 @@ impl Stack {
             deletions: vec![],
             config: self.config.clone(),
             out_dest: self.out_dest.clone(),
+            suppress_stdin: self.suppress_stdin,
         }
     }
 
@@ -863,6 +870,29 @@ impl Stack {
     /// (which is why this function does not take `&mut self`).
     pub fn reset_out_dest(mut self) -> Self {
         self.out_dest = StackOutDest::new();
+        self
+    }
+
+    /// Redirects stdout and stderr to [`OutDest::Null`], discarding all output.
+    ///
+    /// Use this for background evaluation tasks (e.g., completion) that must
+    /// never write to the terminal while reedline owns it.
+    pub fn suppress_output(mut self) -> Self {
+        self.out_dest.stdout = OutDest::Null;
+        self.out_dest.stderr = OutDest::Null;
+        self
+    }
+
+    /// Causes external processes spawned with empty input to receive
+    /// `/dev/null` for stdin instead of inheriting the terminal.
+    ///
+    /// Use this together with [`suppress_output`](Self::suppress_output) for
+    /// background tasks (e.g. completion threads).  Without it, subprocesses
+    /// spawned by closure-based completers (carapace, fish_complete, etc.)
+    /// inherit the live terminal fd and can race with reedline's reads,
+    /// causing `Input/output error` (EIO).
+    pub fn suppress_stdin(mut self) -> Self {
+        self.suppress_stdin = true;
         self
     }
 

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -12,13 +12,11 @@ use std::{io::IsTerminal, sync::atomic::Ordering};
 #[cfg(unix)]
 pub use child_pgroup::stdin_fd;
 
-/// Prepare a command to run in background isolation: no controlling terminal,
-/// so tools like carapace cannot call `tcsetattr` on `/dev/tty` and corrupt
-/// reedline's terminal state. (bad)
+/// Detach `command` from the parent's controlling terminal/console.
 ///
-/// Call this before spawning the command. This caller is responsible for also
-/// redirecting stdin to `/dev/null` so the subprocess cannot steal keystrokes.
-/// Will fall through to nothing on WASM and friends, which is O.K
+/// Used for background completion subprocesses so they cannot call
+/// `tcsetattr` / `SetConsoleMode` and corrupt reedline. Caller must also
+/// redirect stdin to null. No-op on platforms without a process API.
 pub fn prepare_background_command(command: &mut Command) {
     #[cfg(unix)]
     child_pgroup::prepare_isolated_command(command);
@@ -26,8 +24,7 @@ pub fn prepare_background_command(command: &mut Command) {
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        // disables opening CONIN$/CONOUT$ the call-ability of SetConsoleMode
-        // basically setsid() from Unix.
+        // DETACHED_PROCESS: no console to no SetConsoleMode (Unix setsid analogue).
         const DETACHED_PROCESS: u32 = 0x0000_0008;
         command.creation_flags(DETACHED_PROCESS);
     }
@@ -389,25 +386,17 @@ mod child_pgroup {
         unsafe { BorrowedFd::borrow_raw(nix::libc::STDIN_FILENO) }
     }
 
-    /// Isolate `command` from the parent's controlling terminal so it cannot call
-    /// `tcsetattr` on `/dev/tty` and corrupt reedline's raw-mode state.
+    /// `setsid` in `pre_exec`: new session, no controlling terminal.
     ///
-    /// The caller is responsible for also redirecting stdin to `/dev/null` so
-    /// the subprocess cannot steal keystrokes.
-    ///
-    /// Disclaimer: this is NOT just [`prepare_command`] with `background = true`!
-    /// This calls `setsid` to start a brand-new session with no controlling terminal at
-    /// all. It also skips the signal-handler resets that [`prepare_command`] applies, since
-    /// the completions don't participate in job control.
+    /// Not the same as [`prepare_command`] with `background = true` (that only
+    /// skips `tcsetpgrp`; this fully detaches). Completions skip job-control
+    /// signal resets intentionally.
     pub fn prepare_isolated_command(command: &mut Command) {
-        // SAFETY: `setsid` is async-signal-safe per [POSIX signal-safety(7)](https://man7.org/linux/man-pages/man7/signal-safety.7.html), so
-        // it is legal to call from the `pre_exec` hook that runs after `fork`
-        // as long as it hits before `exec`.
+        // SAFETY: `setsid` is async-signal-safe (POSIX signal-safety(7)); legal
+        // in `pre_exec` between fork and exec.
         unsafe {
             command.pre_exec(|| {
-                // Creates a new session without a controlling terminal, so
-                // `/dev/tty` will fail to open.  Ignore EPERM as we may
-                // already be a session leader.
+                // Ignore EPERM if we are already a session leader.
                 let _ = unistd::setsid();
                 Ok(())
             });

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -10,6 +10,8 @@ use crate::ExitStatus;
 use std::{io::IsTerminal, sync::atomic::Ordering};
 
 #[cfg(unix)]
+pub use child_pgroup::prepare_background_command;
+#[cfg(unix)]
 pub use child_pgroup::stdin_fd;
 
 #[cfg(unix)]
@@ -420,6 +422,27 @@ mod child_pgroup {
 
         if !background {
             let _ = unistd::tcsetpgrp(unsafe { stdin_fd() }, pgrp);
+        }
+    }
+
+    /// Prepare a command to run in background isolation: no controlling terminal,
+    /// so tools like carapace cannot call `tcsetattr` on `/dev/tty` and corrupt
+    /// reedline's terminal state. (bad)
+    ///
+    /// Call this before spawning the command. This caller is responsible for also
+    /// redirecting stdin to `/dev/null` so the subprocess cannot steal keystrokes.
+    pub fn prepare_background_command(command: &mut Command) {
+        // // SAFETY: `setsid` is async-signal-safe per [POSIX signal-safety(7)](https://man7.org/linux/man-pages/man7/signal-safety.7.html), so
+        // it is legal to call from the `pre_exec` hook that runs after `fork`
+        // as long as it hits before `exec`.
+        unsafe {
+            command.pre_exec(|| {
+                // Creates a new session without a controlling terminal, so
+                // `/dev/tty` will fail to open.  Ignore EPERM as we may
+                // already be a session leader.
+                let _ = unistd::setsid();
+                Ok(())
+            });
         }
     }
 

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -21,23 +21,7 @@ pub use child_pgroup::stdin_fd;
 /// Will fall through to nothing on WASM and friends, which is O.K
 pub fn prepare_background_command(command: &mut Command) {
     #[cfg(unix)]
-    {
-        use nix::unistd;
-        use std::os::unix::process::CommandExt;
-
-        // SAFETY: `setsid` is async-signal-safe per [POSIX signal-safety(7)](https://man7.org/linux/man-pages/man7/signal-safety.7.html), so
-        // it is legal to call from the `pre_exec` hook that runs after `fork`
-        // as long as it hits before `exec`.
-        unsafe {
-            command.pre_exec(|| {
-                // Creates a new session without a controlling terminal, so
-                // `/dev/tty` will fail to open.  Ignore EPERM as we may
-                // already be a session leader.
-                let _ = unistd::setsid();
-                Ok(())
-            });
-        }
-    }
+    child_pgroup::prepare_isolated_command(command);
 
     #[cfg(windows)]
     {
@@ -403,6 +387,31 @@ mod child_pgroup {
     /// interface.
     pub unsafe fn stdin_fd() -> impl AsFd {
         unsafe { BorrowedFd::borrow_raw(nix::libc::STDIN_FILENO) }
+    }
+
+    /// Isolate `command` from the parent's controlling terminal so it cannot call
+    /// `tcsetattr` on `/dev/tty` and corrupt reedline's raw-mode state.
+    ///
+    /// The caller is responsible for also redirecting stdin to `/dev/null` so
+    /// the subprocess cannot steal keystrokes.
+    ///
+    /// Disclaimer: this is NOT just [`prepare_command`] with `background = true`!
+    /// This calls `setsid` to start a brand-new session with no controlling terminal at
+    /// all. It also skips the signal-handler resets that [`prepare_command`] applies, since
+    /// the completions don't participate in job control.
+    pub fn prepare_isolated_command(command: &mut Command) {
+        // SAFETY: `setsid` is async-signal-safe per [POSIX signal-safety(7)](https://man7.org/linux/man-pages/man7/signal-safety.7.html), so
+        // it is legal to call from the `pre_exec` hook that runs after `fork`
+        // as long as it hits before `exec`.
+        unsafe {
+            command.pre_exec(|| {
+                // Creates a new session without a controlling terminal, so
+                // `/dev/tty` will fail to open.  Ignore EPERM as we may
+                // already be a session leader.
+                let _ = unistd::setsid();
+                Ok(())
+            });
+        }
     }
 
     pub fn prepare_command(external_command: &mut Command, existing_pgrp: u32, background: bool) {

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -10,9 +10,44 @@ use crate::ExitStatus;
 use std::{io::IsTerminal, sync::atomic::Ordering};
 
 #[cfg(unix)]
-pub use child_pgroup::prepare_background_command;
-#[cfg(unix)]
 pub use child_pgroup::stdin_fd;
+
+/// Prepare a command to run in background isolation: no controlling terminal,
+/// so tools like carapace cannot call `tcsetattr` on `/dev/tty` and corrupt
+/// reedline's terminal state. (bad)
+///
+/// Call this before spawning the command. This caller is responsible for also
+/// redirecting stdin to `/dev/null` so the subprocess cannot steal keystrokes.
+/// Will fall through to nothing on WASM and friends, which is O.K
+pub fn prepare_background_command(command: &mut Command) {
+    #[cfg(unix)]
+    {
+        use nix::unistd;
+        use std::os::unix::process::CommandExt;
+
+        // SAFETY: `setsid` is async-signal-safe per [POSIX signal-safety(7)](https://man7.org/linux/man-pages/man7/signal-safety.7.html), so
+        // it is legal to call from the `pre_exec` hook that runs after `fork`
+        // as long as it hits before `exec`.
+        unsafe {
+            command.pre_exec(|| {
+                // Creates a new session without a controlling terminal, so
+                // `/dev/tty` will fail to open.  Ignore EPERM as we may
+                // already be a session leader.
+                let _ = unistd::setsid();
+                Ok(())
+            });
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // disables opening CONIN$/CONOUT$ the call-ability of SetConsoleMode
+        // basically setsid() from Unix.
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        command.creation_flags(DETACHED_PROCESS);
+    }
+}
 
 #[cfg(unix)]
 use nix::{sys::signal, sys::wait, unistd::Pid};
@@ -422,27 +457,6 @@ mod child_pgroup {
 
         if !background {
             let _ = unistd::tcsetpgrp(unsafe { stdin_fd() }, pgrp);
-        }
-    }
-
-    /// Prepare a command to run in background isolation: no controlling terminal,
-    /// so tools like carapace cannot call `tcsetattr` on `/dev/tty` and corrupt
-    /// reedline's terminal state. (bad)
-    ///
-    /// Call this before spawning the command. This caller is responsible for also
-    /// redirecting stdin to `/dev/null` so the subprocess cannot steal keystrokes.
-    pub fn prepare_background_command(command: &mut Command) {
-        // // SAFETY: `setsid` is async-signal-safe per [POSIX signal-safety(7)](https://man7.org/linux/man-pages/man7/signal-safety.7.html), so
-        // it is legal to call from the `pre_exec` hook that runs after `fork`
-        // as long as it hits before `exec`.
-        unsafe {
-            command.pre_exec(|| {
-                // Creates a new session without a controlling terminal, so
-                // `/dev/tty` will fail to open.  Ignore EPERM as we may
-                // already be a session leader.
-                let _ = unistd::setsid();
-                Ok(())
-            });
         }
     }
 

--- a/crates/nu-system/src/lib.rs
+++ b/crates/nu-system/src/lib.rs
@@ -27,6 +27,8 @@ mod windows;
 
 pub use self::exit_status::ExitStatus;
 #[cfg(unix)]
+pub use self::foreground::prepare_background_command;
+#[cfg(unix)]
 pub use self::foreground::stdin_fd;
 pub use self::foreground::{
     ForegroundChild, ForegroundGuard, ForegroundWaitStatus, UnfreezeHandle,

--- a/crates/nu-system/src/lib.rs
+++ b/crates/nu-system/src/lib.rs
@@ -26,7 +26,6 @@ mod unix;
 mod windows;
 
 pub use self::exit_status::ExitStatus;
-#[cfg(unix)]
 pub use self::foreground::prepare_background_command;
 #[cfg(unix)]
 pub use self::foreground::stdin_fd;


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

- in this PR, I made completions non-blocking by default. this means that for very expensive computations (git checkout for example), inputting text is lag-free.
- it includes tests (including a trait to integrate easily into existing ones)
- it works on a very simple always-on cache model. this means that entries will always be returned instantly. when new results are discovered, the completions are repainted.
- the worst case for the model is that no results are returned in the first pass, but this is equivalent to the existing behavior without blocking input.

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
- Drastically improves completion UX, and eliminates any resentment towards completions as I had begun to develop, finding it better to just memorize input to avoid a long terminal freeze.
## Additional notes
<!--
Optional.

Examples:
- fixes nushell/reedline#123
- closes nushell/reedline#456
- related nushell/reedline#789

Anything else reviewers should know.
Remove this section if not needed.
-->

https://github.com/user-attachments/assets/f95ce7d8-765a-4190-a14a-cd7d0108febb

See relevant PR for reedline: https://github.com/nushell/reedline/pull/1093

