### PR TITLE
docs: add binary data examples to hash md5/sha256

### DIFF
--- a/crates/nu-command/src/hash/md5.rs
+++ b/crates/nu-command/src/hash/md5.rs
@@ -31,6 +31,11 @@ impl HashDigest for Md5 {
                 )),
             },
             Example {
+                description: "Return the md5 hash of binary data",
+                example: "0x[deadbeef] | hash md5",
+                result: None,
+            },
+            Example {
                 description: "Return the md5 hash of a file's contents",
                 example: "open ./nu_0_24_1_windows.zip | hash md5",
                 result: None,

--- a/crates/nu-command/src/hash/sha256.rs
+++ b/crates/nu-command/src/hash/sha256.rs
@@ -32,6 +32,11 @@ impl HashDigest for Sha256 {
                 )),
             },
             Example {
+                description: "Return the sha256 hash of binary data",
+                example: "0x[deadbeef] | hash sha256",
+                result: None,
+            },
+            Example {
                 description: "Return the sha256 hash of a file's contents",
                 example: "open ./nu_0_24_1_windows.zip | hash sha256",
                 result: None,


### PR DESCRIPTION
## Description

This PR adds examples showing that `hash md5` and `hash sha256` accept binary data, not just strings.

The new examples use `0x[deadbeef]` input so the command help and generated examples make binary input support clearer.

## User-facing changes (Release notes)

Improved `hash md5` and `hash sha256` help examples to show hashing binary data.

## Additional notes

Addresses #9573, sub-item: `hash md5`/`hash sha256` help text.
