### PR TITLE
Add `--full-reparse/-f` to `run` command

### DIFF
--- a/crates/nu-command/src/misc/run.rs
+++ b/crates/nu-command/src/misc/run.rs
@@ -213,7 +213,7 @@ impl Command for Run {
             },
             Example {
                 description: "Always reload and reparse a script before each invocation.",
-                example: "watch . -g *.nu | each -f { run --full-reparse test.nu }",
+                example: "watch . -g *.nu | each -f { run --full-reparse ./test.nu }",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/misc/run.rs
+++ b/crates/nu-command/src/misc/run.rs
@@ -1,8 +1,14 @@
 use nu_engine::{
     CallEval, command_prelude::*, get_eval_block_with_early_return, get_eval_expression,
 };
+use nu_parser::{find_main_block_id_in_script, parse};
 use nu_path::{absolute_with, is_windows_device_path};
-use nu_protocol::{BlockId, Value, engine::CommandType, shell_error::io::IoError};
+use nu_protocol::{
+    BlockId, Value,
+    ast::Block,
+    engine::{CommandType, StateWorkingSet},
+    shell_error::{generic::GenericError, io::IoError},
+};
 use std::sync::Arc;
 
 /// Run a script file in an isolated scope as part of a pipeline.
@@ -26,6 +32,11 @@ impl Command for Run {
                 "arguments",
                 SyntaxShape::Any,
                 "Arguments to pass to the script's `def main` if it exists.",
+            )
+            .switch(
+                "full-reparse",
+                "Reload and reparse the script on every invocation instead of using parser-cached blocks.",
+                Some('f'),
             )
             .allows_unknown_args()
             .category(Category::Core)
@@ -60,12 +71,8 @@ impl Command for Run {
         // Parser-time metadata tells us exactly which script block was compiled for this call.
         // We intentionally execute that precompiled block instead of reparsing at runtime.
         //
-        // - `block_id`: block compiled from the resolved script file
-        // - `block_id_name`: script file path string captured at parse time
-        let block_id: i64 = call.req_parser_info(engine_state, stack, "block_id")?;
         let block_id_name: String = call.req_parser_info(engine_state, stack, "block_id_name")?;
-        let block_id = BlockId::new(block_id as usize);
-        let block = engine_state.get_block(block_id).clone();
+        let full_reparse = call.get_parser_info(stack, "full_reparse").is_some();
 
         // Resolve the script path to an absolute path for consistent `CURRENT_FILE` / `FILE_PWD`
         // behavior. Device paths on Windows are already absolute-like and must be preserved.
@@ -87,6 +94,34 @@ impl Command for Run {
             path
         };
 
+        let mut full_reparse_engine_state = None;
+        let (block, main_block) = if full_reparse {
+            let (reparsed_engine_state, reparsed_block, reparsed_main_block_id) =
+                parse_run_script_fresh(engine_state, &file_path, call.head)?;
+            let reparsed_main_block =
+                reparsed_main_block_id.map(|id| reparsed_engine_state.get_block(id).clone());
+            full_reparse_engine_state = Some(reparsed_engine_state);
+            (reparsed_block, reparsed_main_block)
+        } else {
+            // - `block_id`: block compiled from the resolved script file
+            let block_id: i64 = call.req_parser_info(engine_state, stack, "block_id")?;
+            let block_id = BlockId::new(block_id as usize);
+            let block = engine_state.get_block(block_id).clone();
+            let main_block = if call.get_parser_info(stack, "main_block_id").is_some() {
+                let main_block_id: i64 =
+                    call.req_parser_info(engine_state, stack, "main_block_id")?;
+                Some(
+                    engine_state
+                        .get_block(BlockId::new(main_block_id as usize))
+                        .clone(),
+                )
+            } else {
+                None
+            };
+            (block, main_block)
+        };
+        let eval_engine_state = full_reparse_engine_state.as_ref().unwrap_or(engine_state);
+
         // Stash caller values so we can restore them after execution. `run` should expose file
         // context to the script, but must not leak modified values back to the caller.
         let old_file_pwd = stack.get_env_var(engine_state, "FILE_PWD").cloned();
@@ -102,20 +137,13 @@ impl Command for Run {
             Value::string(file_path.to_string_lossy(), call.head),
         );
 
-        let eval_block_with_early_return = get_eval_block_with_early_return(engine_state);
+        let eval_block_with_early_return = get_eval_block_with_early_return(eval_engine_state);
         let return_result = (|| {
             // If parser metadata includes a `main` entrypoint, invoke that specific declaration.
             // Otherwise evaluate the full script block as a pipeline transform.
-            if call.get_parser_info(stack, "main_block_id").is_some() {
-                // These IDs are parser-scoped to the resolved script and avoid cross-script `main`
-                // lookup collisions from ambient declarations.
-                let main_block_id: i64 =
-                    call.req_parser_info(engine_state, stack, "main_block_id")?;
-                let main_block = engine_state
-                    .get_block(BlockId::new(main_block_id as usize))
-                    .clone();
+            if let Some(main_block) = main_block.clone() {
                 let signature = (*main_block.signature).clone();
-                let callee_stack = stack.gather_captures(engine_state, &main_block.captures);
+                let callee_stack = stack.gather_captures(eval_engine_state, &main_block.captures);
                 let mut call_eval = CallEval::new(
                     callee_stack,
                     call.head,
@@ -126,7 +154,7 @@ impl Command for Run {
                 // Forward remaining run arguments (`run file.nu ...args`) to `main`.
                 // This helper normalizes long/short flags and supports AST+IR call representations
                 // while delegating actual binding/type validation to CallEval.
-                bind_main_arguments(engine_state, stack, call, &signature, &mut call_eval)?;
+                bind_main_arguments(eval_engine_state, stack, call, &signature, &mut call_eval)?;
                 call_eval.finalize_for_signature(&signature)?;
 
                 // Execute a signature-stripped copy of `main` after manually binding all
@@ -137,14 +165,14 @@ impl Command for Run {
                 let mut executable_main_block = (*main_block).clone();
                 *executable_main_block.signature = Signature::new("main");
 
-                call_eval.run_prebound(engine_state, &executable_main_block, input)
+                call_eval.run_prebound(eval_engine_state, &executable_main_block, input)
             } else {
                 // No explicit `main`: execute the script block directly in an isolated child stack.
                 // Parent scope values remain readable via stack parenting, but script mutations do
                 // not leak back to the caller.
                 let parent_stack = Arc::new(stack.clone());
                 let mut callee_stack = Stack::with_parent(parent_stack);
-                eval_block_with_early_return(engine_state, &mut callee_stack, &block, input)
+                eval_block_with_early_return(eval_engine_state, &mut callee_stack, &block, input)
                     .map(|p| p.body)
             }
         })();
@@ -183,8 +211,58 @@ impl Command for Run {
                 example: "ls | run process.nu | select name size",
                 result: None,
             },
+            Example {
+                description: "Always reload and reparse a script before each invocation.",
+                example: "watch . -g *.nu | each -f { run --full-reparse test.nu }",
+                result: None,
+            },
         ]
     }
+}
+
+/// Reload, reparse, and compile a script file against a cloned engine state.
+///
+/// This is used by `run --full-reparse` to bypass parser-time script caching while keeping
+/// declaration resolution and execution isolated from the caller's engine state.
+///
+/// Parse errors are surfaced at runtime as `ShellError::Generic`, which is an intentional behavior
+/// difference from parse-time `run` compilation.
+fn parse_run_script_fresh(
+    engine_state: &EngineState,
+    file_path: &std::path::Path,
+    call_head: Span,
+) -> Result<(EngineState, Arc<Block>, Option<BlockId>), ShellError> {
+    let contents = std::fs::read(file_path)
+        .map_err(|err| IoError::new(err, call_head, file_path.to_path_buf()))?;
+    let mut full_reparse_engine_state = engine_state.clone();
+    let mut working_set = StateWorkingSet::new(&full_reparse_engine_state);
+    working_set
+        .files
+        .push(file_path.to_path_buf(), call_head)
+        .map_err(|err| GenericError::new("Failed to parse script", err.to_string(), call_head))?;
+
+    let filename = file_path.to_string_lossy();
+    let script_block = parse(&mut working_set, Some(filename.as_ref()), &contents, false);
+    let script_main_block_id = find_main_block_id_in_script(&working_set, &script_block);
+    working_set.files.pop();
+
+    if let Some(parse_error) = working_set.parse_errors.first() {
+        return Err(GenericError::new(
+            "Failed to parse script",
+            parse_error.to_string(),
+            call_head,
+        )
+        .into());
+    }
+
+    let delta = working_set.render();
+    full_reparse_engine_state.merge_delta(delta)?;
+
+    Ok((
+        full_reparse_engine_state,
+        script_block,
+        script_main_block_id,
+    ))
 }
 
 /// Parse a source token that looks like a long or short named flag.

--- a/crates/nu-command/tests/commands/run.rs
+++ b/crates/nu-command/tests/commands/run.rs
@@ -559,3 +559,48 @@ fn run_full_reparse_forwards_main_arguments_and_flags() {
         },
     );
 }
+
+#[test]
+fn run_script_exporting_run_does_not_override_builtin_run_in_repl_session() -> Result {
+    Playground::setup(
+        "run_script_exporting_run_does_not_override_builtin_run_in_repl_session",
+        |dirs, sandbox| {
+            sandbox.mkdir("toolkit");
+            sandbox.with_files(&[
+                FileWithContentToBeTrimmed(
+                    "toolkit/wrappers.nu",
+                    "
+                    export def run [--experimental-options: string] {
+                        'toolkit run'
+                    }
+                ",
+                ),
+                FileWithContentToBeTrimmed(
+                    "toolkit/mod.nu",
+                    "
+                    export use wrappers.nu *
+
+                    export def main [] {
+                        'toolkit main'
+                    }
+                ",
+                ),
+                FileWithContentToBeTrimmed(
+                    "toolkit.nu",
+                    "
+                    export use toolkit *
+
+                    export def main [] {
+                        help toolkit
+                        'ok'
+                    }
+                ",
+                ),
+            ]);
+
+            let mut tester = test().cwd(dirs.test());
+            tester.run("run toolkit.nu").expect_value_eq("ok")?;
+            tester.run("run toolkit.nu").expect_value_eq("ok")
+        },
+    )
+}

--- a/crates/nu-command/tests/commands/run.rs
+++ b/crates/nu-command/tests/commands/run.rs
@@ -433,3 +433,129 @@ fn run_main_script_tracks_file_edits_in_repl_session() -> Result {
         },
     )
 }
+
+#[test]
+fn run_main_script_in_reused_closure_keeps_cached_parse_by_default() -> Result {
+    Playground::setup(
+        "run_main_script_in_reused_closure_keeps_cached_parse_by_default",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "run-edit.nu",
+                "
+                def main [] {
+                    'hello'
+                }
+            ",
+            )]);
+
+            let mut tester = test().cwd(dirs.test());
+            tester.run::<()>("let runner = { run run-edit.nu }")?;
+            tester.run("do $runner").expect_value_eq("hello")?;
+            tester.run::<()>(r#"'def main [] { "hello world" }' | save --force run-edit.nu"#)?;
+            tester.run("do $runner").expect_value_eq("hello")
+        },
+    )
+}
+
+#[test]
+fn run_main_script_in_reused_closure_reloads_with_full_reparse() -> Result {
+    Playground::setup(
+        "run_main_script_in_reused_closure_reloads_with_full_reparse",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "run-edit.nu",
+                "
+                def main [] {
+                    'hello'
+                }
+            ",
+            )]);
+
+            let mut tester = test().cwd(dirs.test());
+            tester.run::<()>("let runner = { run --full-reparse run-edit.nu }")?;
+            tester.run("do $runner").expect_value_eq("hello")?;
+            tester.run::<()>(r#"'def main [] { "hello world" }' | save --force run-edit.nu"#)?;
+            tester.run("do $runner").expect_value_eq("hello world")?;
+            tester.run::<()>(r#"'def main [] { "hello again" }' | save --force run-edit.nu"#)?;
+            tester.run("do $runner").expect_value_eq("hello again")
+        },
+    )
+}
+
+#[test]
+fn run_script_without_main_tracks_file_edits_with_full_reparse() -> Result {
+    Playground::setup(
+        "run_script_without_main_tracks_file_edits_with_full_reparse",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "run-no-main.nu",
+                "
+                str upcase
+            ",
+            )]);
+
+            let mut tester = test().cwd(dirs.test());
+            tester
+                .run(r#""hello" | run --full-reparse run-no-main.nu"#)
+                .expect_value_eq("HELLO")?;
+            tester.run::<()>("'str downcase' | save --force run-no-main.nu")?;
+            tester
+                .run(r#""HELLO" | run --full-reparse run-no-main.nu"#)
+                .expect_value_eq("hello")
+        },
+    )
+}
+
+#[test]
+fn run_full_reparse_recovers_after_script_parse_error() -> Result {
+    Playground::setup(
+        "run_full_reparse_recovers_after_script_parse_error",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "run-edit.nu",
+                "
+                def main [] {
+                    'ok'
+                }
+            ",
+            )]);
+
+            let mut tester = test().cwd(dirs.test());
+            tester
+                .run("run --full-reparse run-edit.nu")
+                .expect_value_eq("ok")?;
+            tester.run::<()>("'def main [ {' | save --force run-edit.nu")?;
+            let _ = tester
+                .run("run --full-reparse run-edit.nu")
+                .expect_shell_error()?;
+            tester.run::<()>(r#"'def main [] { "ok again" }' | save --force run-edit.nu"#)?;
+            tester
+                .run("run --full-reparse run-edit.nu")
+                .expect_value_eq("ok again")
+        },
+    )
+}
+
+#[test]
+fn run_full_reparse_forwards_main_arguments_and_flags() {
+    Playground::setup(
+        "run_full_reparse_forwards_main_arguments_and_flags",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "format.nu",
+                "
+                def main [value: string, --char(-c): string] {
+                    $\"($in) ($value) ($char)\"
+                }
+            ",
+            )]);
+
+            let actual = nu!(
+                cwd: dirs.test(),
+                r#""hello" | run --full-reparse format.nu "arg" -c "!" "#
+            );
+            assert_eq!(actual.out, "hello arg !");
+            assert!(actual.err.is_empty());
+        },
+    );
+}

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3813,6 +3813,7 @@ pub fn parse_run(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
 /// - `"block_id"` — the compiled script block
 /// - `"block_id_name"` — the resolved file path (for `CURRENT_FILE` / `FILE_PWD`)
 /// - `"main_block_id"` — the `def main` block inside the script, if one exists
+/// - `"full_reparse"` — present when `run --full-reparse` is set (runtime reparses script each call)
 /// - `"noop"` — present when the filename argument is `null` (pipeline pass-through)
 fn parse_run_expr_internal(
     working_set: &mut StateWorkingSet,
@@ -3847,6 +3848,18 @@ fn parse_run_expr_internal(
             if call_kind == CallKind::Help {
                 return Expression::new(working_set, Expr::Call(call), Span::concat(spans), output);
             }
+
+            let do_full_reparse = match has_flag_const(working_set, &call, "full-reparse") {
+                Ok(value) => value,
+                Err(()) => {
+                    return Expression::new(
+                        working_set,
+                        Expr::Call(call),
+                        Span::concat(spans),
+                        output,
+                    );
+                }
+            };
 
             // Get the script filename (first positional argument)
             let first_expr = call.positional_iter().next();
@@ -3892,6 +3905,29 @@ fn parse_run_expr_internal(
                 };
 
                 if let Some(path) = find_in_dirs(&filename, working_set, &cwd, Some(LIB_DIRS_VAR)) {
+                    if do_full_reparse {
+                        let mut call_with_block = call;
+                        call_with_block.set_parser_info(
+                            "block_id_name".to_string(),
+                            Expression::new(
+                                working_set,
+                                Expr::Filepath(path.path_buf().display().to_string(), false),
+                                spans[1],
+                                Type::String,
+                            ),
+                        );
+                        call_with_block.set_parser_info(
+                            "full_reparse".to_string(),
+                            Expression::new(working_set, Expr::Bool(true), spans[1], Type::Bool),
+                        );
+                        return Expression::new(
+                            working_set,
+                            Expr::Call(call_with_block),
+                            Span::concat(spans),
+                            Type::Any,
+                        );
+                    }
+
                     if let Some(contents) = path.read(working_set) {
                         // Add the file to the stack of files being processed.
                         if let Err(e) = working_set.files.push(path.clone().path_buf(), spans[1]) {
@@ -3985,7 +4021,7 @@ fn parse_run_expr_internal(
 ///
 /// Returns `None` if the script contains no such definition, which causes `run` to execute the
 /// script block directly instead of dispatching through the `main` entrypoint.
-fn find_main_block_id_in_script(
+pub fn find_main_block_id_in_script(
     working_set: &StateWorkingSet<'_>,
     script_block: &Block,
 ) -> Option<BlockId> {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3805,6 +3805,15 @@ pub fn parse_run(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
     Pipeline::from_vec(vec![expr])
 }
 
+fn find_keyword_decl_by_name(working_set: &StateWorkingSet, name: &[u8]) -> Option<DeclId> {
+    (0..working_set.num_decls())
+        .map(DeclId::new)
+        .find(|decl_id| {
+            let decl = working_set.get_decl(*decl_id);
+            decl.name().as_bytes() == name && decl.is_keyword()
+        })
+}
+
 /// Core parser for a `run` expression.
 ///
 /// Resolves the script filename at parse time, reads and compiles the script into a [`Block`],
@@ -3829,7 +3838,9 @@ fn parse_run_expr_internal(
             return garbage(working_set, Span::concat(spans));
         }
 
-        if let Some(decl_id) = working_set.find_decl(name) {
+        if let Some(decl_id) =
+            find_keyword_decl_by_name(working_set, name).or_else(|| working_set.find_decl(name))
+        {
             #[allow(deprecated)]
             let cwd = working_set.get_cwd();
 
@@ -3935,7 +3946,7 @@ fn parse_run_expr_internal(
                             return garbage(working_set, Span::concat(spans));
                         }
 
-                        // Parse the script as a non-scoped block
+                        // Parse the script as a non-scoped block.
                         let mut block = parse(
                             working_set,
                             Some(&path.path().to_string_lossy()),


### PR DESCRIPTION
## Description

This PR fixes 2 bugs in the `run` command.
1. It allows for a user to use `run` in non-caching mode by specifying `run --full-reparse/-f`. This is good for situations like this `watch . -g *.nu | where path ends-with test.nu | each -f {  run -f test.nu  }` when a user is editing `test.nu` over and over again. However, one should be careful because `test.nu` could be looked up from other viable locations. It's better to use something like `./test.nu`. I actually ran into this while testing.
2. It fixes a bug where the decl lookup wasn't correct so `nu -n` and then `run toolkit.nu` would only work once when you should be able to `run toolkit.nu` many times in the repl.

## User-facing changes (Release notes)

- `watch . -g *.nu | where path ends-with test.nu | each -f {  run -f ./test.nu }` now works.
- `nu -n` then `run toolkit.nu` then `run toolkit.nu` now works, previously it didn't allow running it more than once due to a bug in caching.