### PR TITLE
Fix ANSI-aware truncation in `input list` (#18310)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4525,6 +4525,7 @@ name = "nu-command"
 version = "0.113.2"
 dependencies = [
  "alphanumeric-sort",
+ "ansi-str",
  "arboard",
  "base64",
  "bracoxide",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -24,6 +24,7 @@ harness = false
 workspace = true
 
 [dependencies]
+ansi-str = { workspace = true }
 nu-ansi-term.workspace = true
 nu-cmd-base.workspace = true
 nu-color-config.workspace = true

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -1,3 +1,4 @@
+use ansi_str::AnsiStr;
 use crossterm::{
     cursor::{Hide, MoveDown, MoveToColumn, MoveUp, Show},
     event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
@@ -16,6 +17,7 @@ use nu_protocol::engine::Closure;
 use nu_protocol::{Config, ListStream, TableMode, shell_error::io::IoError};
 use nu_table::common::nu_value_to_string;
 use std::{
+    borrow::Cow,
     collections::HashSet,
     io::{self, Stderr, Write},
 };
@@ -63,6 +65,42 @@ const DEFAULT_TABLE_COLUMN_SEPARATOR: char = '│';
 const INITIAL_STREAM_ITEMS: usize = 80;
 const STREAM_LOAD_BATCH: usize = 50;
 const STREAM_PREFETCH_MARGIN: usize = 2;
+
+fn visible_text_width(text: &str) -> usize {
+    nu_utils::strip_ansi_unlikely(text).width()
+}
+
+fn visible_prefix_byte_len(text: &str, target_width: usize) -> usize {
+    let mut current_width = 0;
+    let mut end_pos = 0;
+
+    for (byte_pos, c) in text.char_indices() {
+        let char_width = UnicodeWidthChar::width(c).unwrap_or(0);
+        if current_width + char_width > target_width {
+            break;
+        }
+        end_pos = byte_pos + c.len_utf8();
+        current_width += char_width;
+    }
+
+    end_pos
+}
+
+fn truncate_ansi_aware_text(text: &str, available_width: usize) -> Cow<'_, str> {
+    let stripped = nu_utils::strip_ansi_unlikely(text);
+
+    if stripped.width() <= available_width {
+        Cow::Borrowed(text)
+    } else if available_width <= 1 {
+        Cow::Borrowed("…")
+    } else {
+        let target_width = available_width - 1;
+        let end_pos = visible_prefix_byte_len(stripped.as_ref(), target_width);
+        let mut truncated = text.ansi_cut(..end_pos).into_owned();
+        truncated.push('…');
+        Cow::Owned(truncated)
+    }
+}
 
 /// Maps TableMode to the appropriate vertical separator character
 fn table_mode_to_separator(mode: TableMode) -> char {
@@ -3263,31 +3301,8 @@ impl<'a> SelectWidget<'a> {
         prefix_width: usize,
     ) -> io::Result<()> {
         let available_width = (self.term_width as usize).saturating_sub(prefix_width);
-        let text_width = UnicodeWidthStr::width(text);
-
-        if text_width <= available_width {
-            // Text fits, render as-is
-            execute!(stderr, Print(text))?;
-        } else if available_width <= 1 {
-            // Only room for ellipsis
-            execute!(stderr, Print("…"))?;
-        } else {
-            // Find the substring that fits in available_width - 1 (reserve 1 for ellipsis)
-            let target_width = available_width - 1;
-            let mut current_width = 0;
-            let mut end_pos = 0;
-
-            for (byte_pos, c) in text.char_indices() {
-                let char_width = UnicodeWidthChar::width(c).unwrap_or(0);
-                if current_width + char_width > target_width {
-                    break;
-                }
-                end_pos = byte_pos + c.len_utf8();
-                current_width += char_width;
-            }
-            execute!(stderr, Print(&text[..end_pos]))?;
-            execute!(stderr, Print("…"))?;
-        }
+        let text = truncate_ansi_aware_text(text, available_width);
+        execute!(stderr, Print(text.as_ref()))?;
         Ok(())
     }
 
@@ -3301,7 +3316,7 @@ impl<'a> SelectWidget<'a> {
         prefix_width: usize,
     ) -> io::Result<()> {
         let available_width = (self.term_width as usize).saturating_sub(prefix_width);
-        let text_width = UnicodeWidthStr::width(text);
+        let text_width = visible_text_width(text);
 
         // Reusable single-char buffer for styled output (avoids allocation per char)
         let mut char_buf = [0u8; 4];
@@ -3980,6 +3995,31 @@ mod test {
         assert_eq!(w.cursor, 1);
 
         Ok(())
+    }
+
+    #[test]
+    fn ansi_styled_text_that_visibly_fits_is_not_truncated() {
+        let text = "\u{1b}[1;37mabcdef\u{1b}[0m";
+
+        let rendered = truncate_ansi_aware_text(text, 6);
+
+        assert_eq!(
+            nu_utils::strip_ansi_unlikely(rendered.as_ref()).as_ref(),
+            "abcdef"
+        );
+        assert!(!rendered.contains('…'));
+    }
+
+    #[test]
+    fn ansi_styled_text_truncates_by_visible_width() {
+        let text = "\u{1b}[1;37mabcdef\u{1b}[0m";
+
+        let rendered = truncate_ansi_aware_text(text, 4);
+
+        assert_eq!(
+            nu_utils::strip_ansi_unlikely(rendered.as_ref()).as_ref(),
+            "abc…"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #18310.

`input list` now measures rendered item width after stripping ANSI escape sequences before deciding whether to add an ellipsis. When truncation is needed, it cuts by the visible stripped prefix through `ansi-str`, so formatted options keep their styling without counting escape bytes as terminal columns.

## User-facing changes (Release notes)

Fixed `input list --fuzzy` truncating ANSI-styled options too early because formatting escape sequences were counted as visible width.

## Additional notes

Verification:
- `cargo test -p nu-command ansi_styled_text`
- `cargo test -p nu-command platform::input::list::test`
- `toolkit fmt`
- `toolkit clippy`
- `git diff --check`
- `toolkit test stdlib`

A full `toolkit check pr` run completed `fmt`, all clippy phases, and the main test suites through `nu-command`, including the new tests. It then failed in unchanged `nu-lsp` completion tests with receive timeouts at `crates/nu-lsp/src/lib.rs:583` (`case_12_use_module`, `case_13_use_null_device`, `case_14_use_foo`, and `case_15_use_submodule`). The failing `nu-lsp` cases pass when rerun individually or outside the full parallel run.