### PR TITLE
fix(use): module descriptions should be properly formatted

### DIFF
--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -41,13 +41,15 @@ impl Completer for DotNuCompletion {
 
         for (module_name_bytes, module_id) in modules_map.into_iter() {
             let value = String::from_utf8_lossy(module_name_bytes).to_string();
-            let description = working_set.get_module_comments(*module_id).map(|spans| {
-                spans
-                    .iter()
-                    .map(|sp| String::from_utf8_lossy(working_set.get_span_contents(*sp)).into())
-                    .collect::<Vec<String>>()
-                    .join("\n")
-            });
+            // TODO: this is a quickfix. just like `help modules`, this constructs the module
+            // description from scratch each time. we should construct module descriptions when the
+            // module is first parsed and store it for later use (like we do with custom commands)
+            // TODO: we need to provide descriptions not just for modules that are already in scope,
+            // but for modules that haven't been imported yet.
+            // (importing a new file like `use foo.nu`)
+            let description = working_set
+                .get_module_comments(*module_id)
+                .map(|spans| working_set.build_desc(spans).0);
 
             matcher.add_semantic_suggestion(SemanticSuggestion {
                 suggestion: Suggestion {

--- a/crates/nu-cli/src/completions/exportable_completions.rs
+++ b/crates/nu-cli/src/completions/exportable_completions.rs
@@ -77,18 +77,14 @@ impl Completer for ExportableCompletion<'_> {
         for (name, module_id) in &module.submodules {
             let name = String::from_utf8_lossy(name).to_string();
             if let Some(match_indices) = matcher.check_match(&name) {
-                let comments = working_set.get_module_comments(*module_id).map(|spans| {
-                    spans
-                        .iter()
-                        .map(|sp| {
-                            String::from_utf8_lossy(working_set.get_span_contents(*sp)).into()
-                        })
-                        .collect::<Vec<String>>()
-                });
+                let (desc, extra) = working_set
+                    .get_module_comments(*module_id)
+                    .map(|spans| working_set.build_desc(spans))
+                    .unzip();
                 add_suggestion(
                     wrapped_name(name),
-                    Some("Submodule".into()),
-                    comments,
+                    desc.or_else(|| Some("Submodule".into())),
+                    extra.map(|s| vec![s]),
                     match_indices,
                     SuggestionKind::Module,
                 );

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1044,7 +1044,7 @@ fn module_name_completions() {
 
     assert_eq!(
         suggestions[0].description,
-        Some("# module comment\n# another comment".into())
+        Some("module comment\nanother comment".into())
     );
 }
 

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1069,6 +1069,11 @@ fn exportable_completions() {
     let (_, _, mut engine, mut stack) = new_dotnu_engine();
     let code = r#"export module "🤔🐘" {
         export const foo = "🤔🐘";
+        # meow
+        # meow
+        #
+        # woem
+        export module bar {}
     }"#;
     assert!(support::merge_input(code.as_bytes(), &mut engine, &mut stack).is_ok());
     assert!(load_standard_library(&mut engine).is_ok());
@@ -1094,6 +1099,11 @@ fn exportable_completions() {
     let completion_str = "use 🤔🐘 'foo";
     let suggestions = completer.complete(completion_str, completion_str.len());
     match_suggestions(&vec!["foo"], &suggestions);
+
+    let completion_str = "use 🤔🐘 b";
+    let suggestions = completer.complete(completion_str, completion_str.len());
+    match_suggestions(&vec!["bar"], &suggestions);
+    assert_eq!(suggestions[0].description, Some("meow\nmeow".into()));
 }
 
 #[test]

--- a/crates/nu-lsp/src/hover.rs
+++ b/crates/nu-lsp/src/hover.rs
@@ -186,13 +186,12 @@ impl LanguageServer {
                 false,
             )),
             Id::Module(module_id, _) => {
-                let description = working_set
-                    .get_module_comments(module_id)?
-                    .iter()
-                    .map(|sp| String::from_utf8_lossy(working_set.get_span_contents(*sp)).into())
-                    .collect::<Vec<String>>()
-                    .join("\n");
-                markdown_hover(description)
+                let (mut desc, extra) = working_set
+                    .get_module_comments(module_id)
+                    .map(|spans| working_set.build_desc(spans))?;
+                desc.push_str("\n\n");
+                desc.push_str(&extra);
+                markdown_hover(desc)
             }
             Id::Value(t) => markdown_hover(format!("`{t}`")),
             Id::External(cmd) => {
@@ -306,9 +305,9 @@ mod hover_tests {
     #[case::use_record("hover/use.nu", (0, 19), "```\nrecord<foo: list<oneof<int, record<bar: int>>>>\n``` \n---\nimmutable", true)]
     #[case::use_function("hover/use.nu", (0, 22), "\n---\n### Usage \n```nu\n  foo {flags}\n```\n\n### Flags", true)]
     #[case::cell_path("workspace/baz.nu", (8, 42), "```\nstring\n```\n---\nconst value", false)]
-    #[case::module_first("workspace/foo.nu", (15, 15), "# cmt", false)]
-    #[case::module_second("workspace/foo.nu", (17, 27), "# sub cmt", false)]
-    #[case::module_third("workspace/foo.nu", (19, 33), "# sub sub cmt", false)]
+    #[case::module_first("workspace/foo.nu", (15, 15), "cmt", false)]
+    #[case::module_second("workspace/foo.nu", (17, 27), "sub cmt", false)]
+    #[case::module_third("workspace/foo.nu", (21, 33), "sub sub cmt\n\nextra", false)]
     fn hover_on_exportable(
         #[case] filename: &str,
         #[case] cursor: (u32, u32),

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -1085,18 +1085,18 @@ mod tests {
     )]
     // Regression tests for https://github.com/nushell/nushell/pull/16696
     #[case::export_def_with_attributes(
-        "workspace/foo.nu", (25, 3),
+        "workspace/foo.nu", (27, 3),
         serde_json::json!([
             make_highlight(0, 0, 0, 10),
             make_highlight(6, 0, 6, 11),
             make_highlight(10, 4, 10, 14),
-            make_highlight(25, 2, 25, 13),
-            make_highlight(32, 0, 32, 10),
+            make_highlight(27, 2, 27, 13),
+            make_highlight(34, 0, 34, 10),
         ])
     )]
     #[case::export_extern_with_attributes(
-        "workspace/foo.nu", (28, 3),
-        serde_json::json!([make_highlight(28, 2, 28, 15), make_highlight(35, 0, 35, 13)])
+        "workspace/foo.nu", (30, 3),
+        serde_json::json!([make_highlight(30, 2, 30, 15), make_highlight(37, 0, 37, 13)])
     )]
     fn document_highlight_request(
         #[case] filename: &str,

--- a/tests/fixtures/lsp/workspace/foo.nu
+++ b/tests/fixtures/lsp/workspace/foo.nu
@@ -17,6 +17,8 @@ export module cst_mod {
   # sub cmt
   export module "sub module" {
     # sub sub cmt
+    #
+    # extra
     export module "sub sub module" {
       export const var_name = "const value"
     }; export use "sub sub module"


### PR DESCRIPTION
## User-facing changes (Release notes)
### Improved module descriptions in completions and LSP hovers
Descriptions of module completions for `use` were previously not formatted. Instead of what you would get from `help modules ...`, the descriptions were the modules' doc comment *as it appeared* in the file (`#` and leading indent not removed).

Before:
```
> use c
      ╭───────╮ ╭─────────────────────────────────────────────╮
      │clip   │ │# Commands for interacting with the system   │
      ╰───────╯ │clipboard # # > These commands require your  │
                │terminal to support OSC 52 # > Terminal      │
                │multiplexers such as screen, tmux, zellij etc│
                │may interfere with this command              │
                ╰─────────────────────────────────────────────╯
```

After:
```
> use c
      ╭───────╮ ╭────────────────────────────────────────╮
      │clip   │ │Commands for interacting with the system│
      ╰───────╯ │clipboard                               │
                ╰────────────────────────────────────────╯
```