### PR TITLE
fix(table): alignments of `expand` and `header_on_separator`

### DIFF
--- a/crates/nu-command/tests/commands/table.rs
+++ b/crates/nu-command/tests/commands/table.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::playground::Playground;
 use nu_test_support::prelude::*;
@@ -4104,19 +4105,76 @@ fn table_expand_big_header() {
     );
 }
 
-#[test]
-fn table_missing_value() {
-    let actual = nu!("[{foo: null} {} {}] | table");
-    assert_eq!(
-        actual.out,
-        "╭───┬─────╮\
-         │ # │ foo │\
-         ├───┼─────┤\
-         │ 0 │     │\
-         │ 1 │  ❎ │\
-         │ 2 │  ❎ │\
-         ╰───┴─────╯",
-    )
+#[rstest]
+fn table_missing_value(#[values(false, true)] expand: bool) -> Result {
+    let mut tester = test();
+    let data: Value = tester.run("[{foo: '____________________'} {} {}]")?;
+    let () = tester.run_with_data("let expand = $in", expand)?;
+    let rendered: String = tester.run_with_data("table --expand=$expand | ansi strip", data)?;
+    pretty_assertions::assert_str_eq!(
+        rendered,
+        "╭───┬──────────────────────╮\n\
+         │ # │         foo          │\n\
+         ├───┼──────────────────────┤\n\
+         │ 0 │ ____________________ │\n\
+         │ 1 │          ❎          │\n\
+         │ 2 │          ❎          │\n\
+         ╰───┴──────────────────────╯\n",
+    );
+    Ok(())
+}
+
+#[rstest]
+#[case::off(false, 3)]
+#[case::on(true, 1)]
+fn horizontal_alignment_with_header_on_separator(
+    #[case] header_on_separator: bool,
+    #[case] skip: usize,
+    #[values(false, true)] expand: bool,
+) -> Result {
+    let mut tester = test();
+
+    let () = tester.run("$env.config.footer_mode = 'never'")?;
+    let () = tester.run_with_data(
+        "$env.config.table.header_on_separator = $in",
+        header_on_separator,
+    )?;
+    let () = tester.run_with_data("let expand = $in", expand)?;
+
+    let data: Value = {
+        let code = r#"[
+            { align:      "_", val: "__________" }
+            { align:   "left", val:         "a"  }
+            { align:  "right", val:           0  }
+            { align:   "left", val:         "a"  }
+            { align: "center",                   }
+            { align:   "left", val:         "a"  }
+            { align: "center",                   }
+            { align:  "right", val:           0  }
+        ]"#;
+        tester.run(code)?
+    };
+
+    let rendered: String = tester.run_with_data("table --expand=$expand | ansi strip", data)?;
+    let trimmed = {
+        let mut positions = rendered.as_bytes().iter().positions(|b| *b == b'\n');
+        let start = positions.nth(skip - 1).unwrap() + 1;
+        let end = positions.nth_back(1).unwrap() + 1;
+        &rendered[start..end]
+    };
+
+    let expected = "\
+        │ 0 │ _      │ __________ │\n\
+        │ 1 │ left   │ a          │\n\
+        │ 2 │ right  │          0 │\n\
+        │ 3 │ left   │ a          │\n\
+        │ 4 │ center │     ❎     │\n\
+        │ 5 │ left   │ a          │\n\
+        │ 6 │ center │     ❎     │\n\
+        │ 7 │ right  │          0 │\n";
+
+    pretty_assertions::assert_str_eq!(trimmed, expected);
+    Ok(())
 }
 
 #[test]

--- a/crates/nu-table/src/common.rs
+++ b/crates/nu-table/src/common.rs
@@ -124,16 +124,6 @@ pub fn get_value_style(value: &Value, config: &Config, style_computer: &StyleCom
     }
 }
 
-pub fn get_empty_style(text: String, style_computer: &StyleComputer) -> NuText {
-    (
-        text,
-        TextStyle::with_style(
-            Alignment::Right,
-            style_computer.compute("empty", &Value::nothing(Span::unknown())),
-        ),
-    )
-}
-
 fn make_styled_value(
     text: String,
     value: &Value,

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -512,9 +512,7 @@ fn remove_header(t: &mut NuTable) -> HeadInfo {
             let to = Position::new(row - 1, col);
 
             let alignment = *t.styles.cfg.get_alignment_horizontal(from);
-            if alignment != t.styles.alignments.data {
-                t.styles.cfg.set_alignment_horizontal(to.into(), alignment);
-            }
+            t.styles.cfg.set_alignment_horizontal(to.into(), alignment);
 
             let color = t.styles.cfg.get_color(from);
             if let Some(color) = color

--- a/crates/nu-table/src/types/general.rs
+++ b/crates/nu-table/src/types/general.rs
@@ -6,7 +6,7 @@ use crate::{
     NuRecordsValue, NuTable, StringResult, TableOpts, TableOutput, TableResult, clean_charset,
     colorize_space,
     common::{
-        INDEX_COLUMN_NAME, NuText, check_value, configure_table, get_empty_style, get_header_style,
+        INDEX_COLUMN_NAME, NuText, check_value, configure_table, error_sign, get_header_style,
         get_index_style, get_value_style, nu_value_to_string_colored,
     },
     types::has_index,
@@ -208,7 +208,7 @@ fn get_string_value_with_header(item: &Value, header: &str, opts: &TableOpts) ->
     match item {
         Value::Record { val, .. } => match val.get(header) {
             Some(value) => get_string_value(value, opts),
-            None => get_empty_style(
+            None => error_sign(
                 opts.config.table.missing_value_symbol.clone(),
                 &opts.style_computer,
             ),


### PR DESCRIPTION
## Description

I first noticed that the cell right below a missing value would be incorrectly aligned.
After some testing I narrowed the preconditions to:
- `header_on_separator` is `true`
- the value below the *missing value* is a *string*
  - instead of a missing value, it can be any type with non standard alignment (e.g. numbers are right aligned)
  - the affected values are not limited to string, any type with the default alignment is affected

Another bug that surfaced during testing was the alignment of the missing value symbol differed between `expand=false` (right aligned) and `expand=true` (center aligned).

This PR fixes those issues.

## User-facing changes (Release notes)

### Fixed table alignment with `header_on_separator`

Alignment issues in `table` when `header_on_separator` is on are fixed:

<table>
<tr> <th>Before</th> <th>After</th> </tr>
<tr>
<td width="500">

```
╭─#─┬─align──┬────val─────╮
│ 0 │ _      │ __________ │
│ 1 │ left   │ a          │
│ 2 │ right  │          0 │
│ 3 │ left   │          a │
│ 4 │ center │     ❎     │
│ 5 │ left   │     a      │
│ 6 │ center │     ❎     │
│ 7 │ right  │          0 │
╰───┴────────┴────────────╯
```

</td>
<td width="500">

```
╭─#─┬─align──┬────val─────╮
│ 0 │ _      │ __________ │
│ 1 │ left   │ a          │
│ 2 │ right  │          0 │
│ 3 │ left   │ a          │
│ 4 │ center │     ❎     │
│ 5 │ left   │ a          │
│ 6 │ center │     ❎     │
│ 7 │ right  │          0 │
╰───┴────────┴────────────╯
```

</td>
</tr>
</table>


## Additional notes

- `Itertools` is imported in the tests for the `.positions()` method.