### PR TITLE
Polars upgrade 0.54

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,12 +82,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774ffdfeac16e9b4d75e41225dc2545d9c2082a0634b5d7f6f70e168546eecb1"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,18 +1102,17 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "pure-rust-locales",
  "serde",
  "wasm-bindgen",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4431,7 +4424,7 @@ dependencies = [
  "reedline",
  "rstest",
  "strum",
- "sysinfo",
+ "sysinfo 0.38.4",
  "tempfile",
  "unicode-segmentation",
  "uuid",
@@ -4616,7 +4609,7 @@ dependencies = [
  "serde_yaml 0.9.34+deprecated",
  "sha2",
  "strum",
- "sysinfo",
+ "sysinfo 0.38.4",
  "tabled",
  "tempfile",
  "titlecase",
@@ -4978,7 +4971,7 @@ dependencies = [
  "ntapi",
  "nu-utils",
  "procfs",
- "sysinfo",
+ "sysinfo 0.38.4",
  "uucore",
  "web-time",
  "windows 0.62.2",
@@ -5975,9 +5968,9 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899852b723e563dc3cbdc7ea833b14ec44e61309f55df29ba86d45cfd6bc141a"
+checksum = "77310b662567e0930bacde83ae055afb4093a9ca9f992ef084949db42f8e9b4a"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
@@ -5999,9 +5992,9 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f672743a042b72ace4f88b29f8205ab200b29c5ac976c0560899680c07d2d09"
+checksum = "fdbec6a6ba17db2bd9344b73e44b85faec0f03067c35ceacfe0ad93ae17c864d"
 dependencies = [
  "atoi_simd",
  "avro-schema",
@@ -6044,22 +6037,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "polars-buffer"
-version = "0.53.0"
+name = "polars-async"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7011424c3a79ca9c1272c7b4f5fe98695d3bed45595e37bb23c16a2978c80c"
+checksum = "3f029955433c73de482acab05239f09c9adc01cefc3504bb5b611db8a266bb02"
+dependencies = [
+ "atomic-waker",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "parking_lot",
+ "pin-project-lite",
+ "polars-config",
+ "polars-error",
+ "polars-utils",
+ "rand 0.9.2",
+ "slotmap",
+ "tokio",
+]
+
+[[package]]
+name = "polars-buffer"
+version = "0.54.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df18eff8121cb2e09073a676a5891ff01421cc3e0133f990219a14a3641b6bd"
 dependencies = [
  "bytemuck",
  "either",
+ "polars-utils",
  "serde",
  "version_check",
 ]
 
 [[package]]
 name = "polars-compute"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a32eca8e08ac4cc5de2ac3996d2b38567bba72cdb19bbfd94c370193ed51dd"
+checksum = "0d06223aba6642d6f7d3e3742dae5c1d962dc20871a7ab7691adac16d10167a3"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -6082,10 +6096,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "polars-core"
-version = "0.53.0"
+name = "polars-config"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726296966d04268ee9679c2062af2d06c83c7a87379be471defe616b244c5029"
+checksum = "a908dddfd87ca12f6c91a0f9ead4e4c880858a31083df95a251a171eec9a8bca"
+dependencies = [
+ "polars-error",
+ "serde",
+]
+
+[[package]]
+name = "polars-core"
+version = "0.54.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf1813183e704069c2ecef4604ae10d37c007470adb429c82a1fe0186038a04"
 dependencies = [
  "bitflags 2.11.0",
  "boxcar",
@@ -6100,8 +6124,10 @@ dependencies = [
  "itoa",
  "num-traits",
  "polars-arrow",
+ "polars-async",
  "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-dtype",
  "polars-error",
  "polars-row",
@@ -6114,6 +6140,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum_macros",
+ "tokio",
  "uuid",
  "version_check",
  "xxhash-rust",
@@ -6121,9 +6148,9 @@ dependencies = [
 
 [[package]]
 name = "polars-dtype"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51976dc46d42cd1e7ca252a9e3bdc90c63b0bfa7030047ebaf5250c2b7838fa6"
+checksum = "d0f4bdad2ba2f7856366cfae5942531c7274c08eb97383b35354897244dc47a9"
 dependencies = [
  "boxcar",
  "hashbrown 0.16.1",
@@ -6136,9 +6163,9 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c13126f8baebc13dadf26a80dcf69a607977fc8a67b18671ad2cefc713a7bdd"
+checksum = "1e71cf279424064e3a55301cb54747472e3db57fed33aa49dae45aaed147b631"
 dependencies = [
  "avro-schema",
  "object_store",
@@ -6151,9 +6178,9 @@ dependencies = [
 
 [[package]]
 name = "polars-expr"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2151f54b0ae5d6b86c3c47df0898ff90edfe774807823f742f36e44973d51ea1"
+checksum = "3ee67b7a1e044d30b150fc1b05fde86c81a9af73e8aeca5fe5c4c91f4873c0d7"
 dependencies = [
  "bitflags 2.11.0",
  "chrono-tz",
@@ -6179,9 +6206,9 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059724d7762d7332cbc225e6504d996091b28fa1337716e06e5a81d9e54a34ad"
+checksum = "25b122c9693dc093d64aaed781f819cc6cd244f02125e9394932243631c83149"
 dependencies = [
  "async-trait",
  "atoi_simd",
@@ -6190,6 +6217,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "fast-float2",
+ "fastrand",
  "flate2",
  "fs4",
  "futures",
@@ -6201,10 +6229,12 @@ dependencies = [
  "memmap2",
  "num-traits",
  "object_store",
+ "parking_lot",
  "percent-encoding",
  "polars-arrow",
  "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-core",
  "polars-error",
  "polars-json",
@@ -6212,6 +6242,7 @@ dependencies = [
  "polars-schema",
  "polars-time",
  "polars-utils",
+ "rand 0.9.2",
  "rayon",
  "regex",
  "reqwest",
@@ -6226,9 +6257,9 @@ dependencies = [
 
 [[package]]
 name = "polars-json"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55581d4cc8f4122cae92d12aec997e6713ac483871391a7db09501604007be4b"
+checksum = "20a65f3d2d3d3bcd22c5861e8dbbc18c7588f79ff53934c795814cde301c143e"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -6248,9 +6279,9 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e1e24d4db8c349e9576564cfff47a3f08bb831dba9168f6599be178bc725e8"
+checksum = "71a384f58299be750a9e85aa7473a680224f051172d02ce31b10aab74834ad68"
 dependencies = [
  "bitflags 2.11.0",
  "chrono",
@@ -6260,6 +6291,7 @@ dependencies = [
  "polars-arrow",
  "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-core",
  "polars-expr",
  "polars-io",
@@ -6277,9 +6309,9 @@ dependencies = [
 
 [[package]]
 name = "polars-mem-engine"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394e4cd90186043d4051ce118e90794afbe81ac5eb9a51e358a56728e8ebde3"
+checksum = "4b9432f4e6c50dbafd7f3affe7cc7482bdae0535e2f9cc49b5908ea304782aae"
 dependencies = [
  "memmap2",
  "polars-arrow",
@@ -6298,10 +6330,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "polars-ops"
-version = "0.53.0"
+name = "polars-ooc"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e47b2d9b3627662650da0a8c76ce5101ed1c61b104cb2b3663e0dc711571b12"
+checksum = "5e344e934bd4e42ef1f38c061936bda8bf13d08e14305391fc21a7ccf56a795b"
+dependencies = [
+ "async-trait",
+ "boxcar",
+ "libc",
+ "polars-async",
+ "polars-config",
+ "polars-core",
+ "polars-io",
+ "polars-utils",
+ "thread_local",
+ "tokio",
+]
+
+[[package]]
+name = "polars-ops"
+version = "0.54.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a0920cb63afbce5889b402fbb55bd7f660c655c4183a42c79daf8ff8646eb4"
 dependencies = [
  "argminmax",
  "base64",
@@ -6339,9 +6389,9 @@ dependencies = [
 
 [[package]]
 name = "polars-parquet"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436bae3e89438cafe69400e7567057d7d9820d21ac9a4f69a33b413f2666f03d"
+checksum = "7474e149d7b85b223efa80ad7aec709bc000d3754e2656786fdef81aef76990c"
 dependencies = [
  "async-stream",
  "base64",
@@ -6356,6 +6406,7 @@ dependencies = [
  "polars-arrow",
  "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-error",
  "polars-parquet-format",
  "polars-utils",
@@ -6379,9 +6430,9 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7930d5ae1d006179e65f01af57c859307b5875a4cc078dc75257250b9ae5162"
+checksum = "aa2568dfd0f952eddf2a6622c603e3d9b0e7fc2f20585de30d1b2a849c129008"
 dependencies = [
  "bitflags 2.11.0",
  "blake3",
@@ -6392,12 +6443,14 @@ dependencies = [
  "either",
  "futures",
  "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "memmap2",
  "num-traits",
  "percent-encoding",
  "polars-arrow",
  "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-core",
  "polars-error",
  "polars-io",
@@ -6419,9 +6472,9 @@ dependencies = [
 
 [[package]]
 name = "polars-row"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ea1a4554fe06442db1d6229235cd358e8eacba96aed8718f612caf3e3a646"
+checksum = "88ea35e86d918806d895e80a7e21523d998709dbdffeadda1db3ee778101a33f"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -6435,9 +6488,9 @@ dependencies = [
 
 [[package]]
 name = "polars-schema"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d688e73f9156f93cb29350be144c8f1e84c1bc705f00ee7f15eb9706a7971273"
+checksum = "cd98a2a08209fc24cd18be2cf1570fe80cc015d1a433272e85406c537f207f14"
 dependencies = [
  "indexmap 2.14.0",
  "polars-error",
@@ -6448,9 +6501,9 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100415f86069d7e9fbf54737148fc161a7c7316a6a7d375fb6cfc7fc64f570ae"
+checksum = "228fdb8e09e1a218d2d5c3bf6b790e6cc845abae086d70cd4a629e29f2e9c0c1"
 dependencies = [
  "bitflags 2.11.0",
  "hex",
@@ -6468,55 +6521,53 @@ dependencies = [
 
 [[package]]
 name = "polars-stream"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a0c054bdf16efd16bbc587e8d5418ae28464d61afd735513579cd3c338fa70"
+checksum = "2eef15f6caed27f4100d45fb4d525fd969b4379cb35e3de8c0f1b3639a21025a"
 dependencies = [
  "async-channel",
  "async-trait",
- "atomic-waker",
  "bitflags 2.11.0",
  "bytes",
  "chrono-tz",
  "crossbeam-channel",
- "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils",
  "futures",
  "memchr",
- "memmap2",
  "num-traits",
  "parking_lot",
  "percent-encoding",
- "pin-project-lite",
  "polars-arrow",
+ "polars-async",
  "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-core",
  "polars-error",
  "polars-expr",
  "polars-io",
  "polars-json",
  "polars-mem-engine",
+ "polars-ooc",
  "polars-ops",
  "polars-parquet",
  "polars-plan",
  "polars-time",
  "polars-utils",
- "rand 0.9.2",
  "rayon",
  "recursive",
  "serde_json",
  "slotmap",
  "tokio",
+ "uuid",
  "version_check",
 ]
 
 [[package]]
 name = "polars-time"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e80404e1e418c997230e3b2972c3be331f45df8bdd3150fe3bef562c7a332f"
+checksum = "11db712abcbcf105890af0c835da8e72066bf5e61bfa76509d2ebfc6ba031324"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -6538,9 +6589,9 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.53.0"
+version = "0.54.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c97cabf53eb8fbf6050cde3fef8f596c51cc25fd7d55fbde108d815ee6674abf"
+checksum = "75993cefc910963b85e668da4e4413b2496fcd6a087f217c3d259bd868348460"
 dependencies = [
  "argminmax",
  "bincode 2.0.1",
@@ -6550,6 +6601,7 @@ dependencies = [
  "either",
  "flate2",
  "foldhash 0.2.0",
+ "futures",
  "half",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -6557,6 +6609,7 @@ dependencies = [
  "memmap2",
  "num-derive",
  "num-traits",
+ "polars-config",
  "polars-error",
  "rand 0.9.2",
  "raw-cpuid",
@@ -6568,6 +6621,8 @@ dependencies = [
  "serde_stacker",
  "slotmap",
  "stacker",
+ "sysinfo 0.37.2",
+ "tokio",
  "uuid",
  "version_check",
 ]
@@ -8437,6 +8492,20 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
+]
+
+[[package]]
+name = "sysinfo"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
@@ -9897,14 +9966,36 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.3.2",
  "windows-core 0.62.2",
- "windows-future",
- "windows-numerics",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -9930,6 +10021,19 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
@@ -9938,7 +10042,18 @@ dependencies = [
  "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
- "windows-strings",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -9949,7 +10064,7 @@ checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
- "windows-threading",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -10010,6 +10125,16 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
@@ -10029,11 +10154,29 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -10160,6 +10303,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5968,9 +5968,9 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77310b662567e0930bacde83ae055afb4093a9ca9f992ef084949db42f8e9b4a"
+checksum = "82f1f122456ec136102033b13f71905b7c3f01e526642679c86aace9f9cdefde"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
@@ -5992,9 +5992,9 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbec6a6ba17db2bd9344b73e44b85faec0f03067c35ceacfe0ad93ae17c864d"
+checksum = "87d4892d5cc6461bb4a184d18e6fa03a5d316ee1d6de06a33dfa08d479fbc2db"
 dependencies = [
  "atoi_simd",
  "avro-schema",
@@ -6038,9 +6038,9 @@ dependencies = [
 
 [[package]]
 name = "polars-async"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f029955433c73de482acab05239f09c9adc01cefc3504bb5b611db8a266bb02"
+checksum = "91e87f836190486f500b28347436985cc0af29b7a514e53f98840d396ce4d5f5"
 dependencies = [
  "atomic-waker",
  "crossbeam-channel",
@@ -6058,9 +6058,9 @@ dependencies = [
 
 [[package]]
 name = "polars-buffer"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df18eff8121cb2e09073a676a5891ff01421cc3e0133f990219a14a3641b6bd"
+checksum = "e481eeaf33c544ac0dd71a2e375553ca2fdae47b3472a96eaccb6eb43218783d"
 dependencies = [
  "bytemuck",
  "either",
@@ -6071,9 +6071,9 @@ dependencies = [
 
 [[package]]
 name = "polars-compute"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d06223aba6642d6f7d3e3742dae5c1d962dc20871a7ab7691adac16d10167a3"
+checksum = "c55d41642a9ee887ac394c5a310af3256fa8340a86cde2cb624c515aa963461c"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -6097,9 +6097,9 @@ dependencies = [
 
 [[package]]
 name = "polars-config"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a908dddfd87ca12f6c91a0f9ead4e4c880858a31083df95a251a171eec9a8bca"
+checksum = "65af861341b00eac73bcb65423fb5cc3d2322526d6b7561a0ddf094947c38033"
 dependencies = [
  "polars-error",
  "serde",
@@ -6107,9 +6107,9 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf1813183e704069c2ecef4604ae10d37c007470adb429c82a1fe0186038a04"
+checksum = "3e5924fc46306054bae78f9d35ea5e404cf185baa7f170eb55a16ff95191069c"
 dependencies = [
  "bitflags 2.11.0",
  "boxcar",
@@ -6148,9 +6148,9 @@ dependencies = [
 
 [[package]]
 name = "polars-dtype"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f4bdad2ba2f7856366cfae5942531c7274c08eb97383b35354897244dc47a9"
+checksum = "7b65a750bb99ea66be90c8a7e336f6f3a87427a0f7f89d2a40adae98314e9b27"
 dependencies = [
  "boxcar",
  "hashbrown 0.16.1",
@@ -6163,9 +6163,9 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e71cf279424064e3a55301cb54747472e3db57fed33aa49dae45aaed147b631"
+checksum = "e49a75e3406b9b5b4e5ff177877fe0de766e9688fbdb263a7b25f293dc47d61a"
 dependencies = [
  "avro-schema",
  "object_store",
@@ -6178,9 +6178,9 @@ dependencies = [
 
 [[package]]
 name = "polars-expr"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee67b7a1e044d30b150fc1b05fde86c81a9af73e8aeca5fe5c4c91f4873c0d7"
+checksum = "e21fdd37e8d9ef109f13d3454baffa0a57041cf60069123b8a2bd846c8ad0205"
 dependencies = [
  "bitflags 2.11.0",
  "chrono-tz",
@@ -6206,9 +6206,9 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b122c9693dc093d64aaed781f819cc6cd244f02125e9394932243631c83149"
+checksum = "6363a1c44a65fe8d73cce7fe4d77c9b6fea3a0da44007012e755e5b4e65aa078"
 dependencies = [
  "async-trait",
  "atoi_simd",
@@ -6257,9 +6257,9 @@ dependencies = [
 
 [[package]]
 name = "polars-json"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a65f3d2d3d3bcd22c5861e8dbbc18c7588f79ff53934c795814cde301c143e"
+checksum = "1dca6cd170370ef7e189a4c362846c57553843653c3fe65aafe12ca77599987c"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -6279,9 +6279,9 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a384f58299be750a9e85aa7473a680224f051172d02ce31b10aab74834ad68"
+checksum = "809d9590232a37d638337629c18279af97bdb0d17c3d8b2b6bb186e903e8bd5e"
 dependencies = [
  "bitflags 2.11.0",
  "chrono",
@@ -6309,9 +6309,9 @@ dependencies = [
 
 [[package]]
 name = "polars-mem-engine"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9432f4e6c50dbafd7f3affe7cc7482bdae0535e2f9cc49b5908ea304782aae"
+checksum = "f55c6b7d162c506bc8eee82b065fa0399ebcd20b8f08675a534f3d360904ba38"
 dependencies = [
  "memmap2",
  "polars-arrow",
@@ -6331,9 +6331,9 @@ dependencies = [
 
 [[package]]
 name = "polars-ooc"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e344e934bd4e42ef1f38c061936bda8bf13d08e14305391fc21a7ccf56a795b"
+checksum = "78b3eea0b386837b760a97ec9c92df99cbc10f94885cae060fd7100f9b794163"
 dependencies = [
  "async-trait",
  "boxcar",
@@ -6349,9 +6349,9 @@ dependencies = [
 
 [[package]]
 name = "polars-ops"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a0920cb63afbce5889b402fbb55bd7f660c655c4183a42c79daf8ff8646eb4"
+checksum = "cb146490a717ac5ae4ff3a22a5adf3ebae79361f187b1f550f9e24783d7ad765"
 dependencies = [
  "argminmax",
  "base64",
@@ -6389,9 +6389,9 @@ dependencies = [
 
 [[package]]
 name = "polars-parquet"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7474e149d7b85b223efa80ad7aec709bc000d3754e2656786fdef81aef76990c"
+checksum = "fd6b79ba2103c00cbb9c5dd4459ffff1d8ce15286c7a6d376a04c711df20d8b7"
 dependencies = [
  "async-stream",
  "base64",
@@ -6430,9 +6430,9 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2568dfd0f952eddf2a6622c603e3d9b0e7fc2f20585de30d1b2a849c129008"
+checksum = "2f5ccc230515adb10762a8c7b0df03fd88f3328deb5b60e9b1eeb2eceef4d344"
 dependencies = [
  "bitflags 2.11.0",
  "blake3",
@@ -6472,9 +6472,9 @@ dependencies = [
 
 [[package]]
 name = "polars-row"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ea35e86d918806d895e80a7e21523d998709dbdffeadda1db3ee778101a33f"
+checksum = "3d4e3254450024078e10c919ecd3b467bdcfdd5cf386c2ca6eedec89bd4771d2"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -6488,9 +6488,9 @@ dependencies = [
 
 [[package]]
 name = "polars-schema"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd98a2a08209fc24cd18be2cf1570fe80cc015d1a433272e85406c537f207f14"
+checksum = "6f8a0de8951d02576fd0cdcecd9c605a6b6364d3105b7469b8d7874ea34eea2f"
 dependencies = [
  "indexmap 2.14.0",
  "polars-error",
@@ -6501,9 +6501,9 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228fdb8e09e1a218d2d5c3bf6b790e6cc845abae086d70cd4a629e29f2e9c0c1"
+checksum = "b282a6164927eb12774b66b071b773a1573173ae53758e8d4df50389ff06efa2"
 dependencies = [
  "bitflags 2.11.0",
  "hex",
@@ -6521,9 +6521,9 @@ dependencies = [
 
 [[package]]
 name = "polars-stream"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eef15f6caed27f4100d45fb4d525fd969b4379cb35e3de8c0f1b3639a21025a"
+checksum = "cfa8ff4ee21799898579595a0ef2fb728d0a9cac3d061835fb7f7f6dd854734a"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -6565,9 +6565,9 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11db712abcbcf105890af0c835da8e72066bf5e61bfa76509d2ebfc6ba031324"
+checksum = "e1063fe074c4212a54917be604377c6e6bfbc8b6c942a5c57be214e4ccaaafdf"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -6589,9 +6589,9 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75993cefc910963b85e668da4e4413b2496fcd6a087f217c3d259bd868348460"
+checksum = "590b0a94aa8f97992d52f1198600ecc1c1f7cfa03c1b31cae057143455804ac0"
 dependencies = [
  "argminmax",
  "bincode 2.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 authors = ["The Nushell Project Developers"]
 edition = "2024"
-rust-version = "1.94.1"
+rust-version = "1.95.0"
 license = "MIT"
 version = "0.113.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ bytesize = "2.3.1"
 byteyarn = "0.5"
 calamine = "0.35"
 chardetng = "0.1.17"
-chrono = { default-features = false, version = "0.4.41" } # polars is requiring <= 0.4.41
+chrono = { default-features = false, version = "0.4.42" }
 chrono-humanize = "0.2.3"
 chrono-tz = "0.10"
 crossbeam-channel = "0.5.15"

--- a/crates/nu_plugin_polars/Cargo.toml
+++ b/crates/nu_plugin_polars/Cargo.toml
@@ -33,13 +33,13 @@ indexmap = { version = "2.13" }
 num = { version = "0.4" }
 serde = { version = "1.0", features = ["derive"] }
 sqlparser = { version = "~0.61.0" }
-polars-io = { version = "~0.53.0", features = ["avro", "cloud", "aws", "azure", "gcp"] }
-polars-arrow = { version = "~0.53.0" }
-polars-ops = { version = "~0.53.0", features = ["pivot", "cutqcut"] }
-polars-plan = { version = "~0.53.0", features = ["regex"] }
-polars-utils = { version = "~0.53.0" }
-polars-lazy = { version = "~0.53.0" }
-polars-compute = { version = "~0.53.0" }
+polars-io = { version = "~0.54.3", features = ["avro", "cloud", "aws", "azure", "gcp"] }
+polars-arrow = { version = "~0.54.3" }
+polars-ops = { version = "~0.54.3", features = ["pivot", "cutqcut"] }
+polars-plan = { version = "~0.54.3", features = ["regex"] }
+polars-utils = { version = "~0.54.3" }
+polars-lazy = { version = "~0.54.3" }
+polars-compute = { version = "~0.54.3" }
 planus = { version = "~1.1.1" } # Temporarily here to convince cargo not to upgrade planus to 1.2.0
 typetag = "0.2"
 env_logger = "0.11.8"
@@ -103,7 +103,7 @@ features = [
   "trigonometry",
 ]
 optional = false
-version = "=0.53.0"
+version = "=0.54.3"
 
 [dev-dependencies]
 nu-cmd-lang = { workspace = true, features = ["plugin"] }

--- a/crates/nu_plugin_polars/Cargo.toml
+++ b/crates/nu_plugin_polars/Cargo.toml
@@ -33,13 +33,13 @@ indexmap = { version = "2.13" }
 num = { version = "0.4" }
 serde = { version = "1.0", features = ["derive"] }
 sqlparser = { version = "~0.61.0" }
-polars-io = { version = "~0.54.3", features = ["avro", "cloud", "aws", "azure", "gcp"] }
-polars-arrow = { version = "~0.54.3" }
-polars-ops = { version = "~0.54.3", features = ["pivot", "cutqcut"] }
-polars-plan = { version = "~0.54.3", features = ["regex"] }
-polars-utils = { version = "~0.54.3" }
-polars-lazy = { version = "~0.54.3" }
-polars-compute = { version = "~0.54.3" }
+polars-io = { version = "~0.54.4", features = ["avro", "cloud", "aws", "azure", "gcp"] }
+polars-arrow = { version = "~0.54.4" }
+polars-ops = { version = "~0.54.4", features = ["pivot", "cutqcut"] }
+polars-plan = { version = "~0.54.4", features = ["regex"] }
+polars-utils = { version = "~0.54.4" }
+polars-lazy = { version = "~0.54.4" }
+polars-compute = { version = "~0.54.4" }
 planus = { version = "~1.1.1" } # Temporarily here to convince cargo not to upgrade planus to 1.2.0
 typetag = "0.2"
 env_logger = "0.11.8"
@@ -103,7 +103,7 @@ features = [
   "trigonometry",
 ]
 optional = false
-version = "=0.54.3"
+version = "=0.54.4"
 
 [dev-dependencies]
 nu-cmd-lang = { workspace = true, features = ["plugin"] }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/aggregate.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/aggregate.rs
@@ -181,7 +181,7 @@ fn get_col_name(expr: &Expr) -> Option<String> {
             | polars::prelude::AggExpr::First(e)
             | polars::prelude::AggExpr::Last(e)
             | polars::prelude::AggExpr::Mean(e)
-            | polars::prelude::AggExpr::Implode(e)
+            | polars::prelude::AggExpr::Implode { input: e, .. }
             | polars::prelude::AggExpr::Count { input: e, .. }
             | polars::prelude::AggExpr::Sum(e)
             | polars::prelude::AggExpr::AggGroups(e)
@@ -189,8 +189,7 @@ fn get_col_name(expr: &Expr) -> Option<String> {
             | polars::prelude::AggExpr::Var(e, _)
             | polars::prelude::AggExpr::Item { input: e, .. }
             | polars::prelude::AggExpr::FirstNonNull(e)
-            | polars::prelude::AggExpr::LastNonNull(e)
-            | polars::prelude::AggExpr::Quantile { expr: e, .. } => get_col_name(e.as_ref()),
+            | polars::prelude::AggExpr::LastNonNull(e) => get_col_name(e.as_ref()),
         },
         Expr::Filter { input: expr, .. }
         | Expr::Slice { input: expr, .. }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
@@ -23,6 +23,11 @@ impl PluginCommand for ExprImplode {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
+            .switch(
+                "maintain-order",
+                "Maintains the order of the original values in the list",
+                Some('o'),
+            )
             .input_output_type(
                 PolarsPluginType::NuExpression.into(),
                 PolarsPluginType::NuExpression.into(),
@@ -71,7 +76,8 @@ fn command_expr(
     call: &EvaluatedCall,
     expr: NuExpression,
 ) -> Result<PipelineData, ShellError> {
-    let res: NuExpression = expr.into_polars().implode().into();
+    let maintain_order = call.has_flag("maintain-order")?;
+    let res: NuExpression = expr.into_polars().implode(maintain_order).into();
     res.to_pipeline_data(plugin, engine, call.head)
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/is_in.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/is_in.rs
@@ -26,6 +26,11 @@ impl PluginCommand for ExprIsIn {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .required("list", SyntaxShape::Any, "List to check if values are in.")
+            .switch(
+                "maintain-order",
+                "Maintains the order of the original values in the list",
+                Some('o'),
+            )
             .input_output_types(vec![
                 (
                     PolarsPluginType::NuExpression.into(),
@@ -189,6 +194,7 @@ fn command_expr(
     call: &EvaluatedCall,
     expr: NuExpression,
 ) -> Result<PipelineData, ShellError> {
+    let maintain_order = call.has_flag("maintain-order")?;
     let is_in_expr: Expr = call
         .req::<Value>(0)
         .and_then(|ref value| NuExpression::try_from_value(plugin, value))
@@ -215,7 +221,7 @@ fn command_expr(
                     span: call.head,
                 })
             } else {
-                Ok(lit(list).implode())
+                Ok(lit(list).implode(maintain_order))
             }
         })?;
 

--- a/crates/nu_plugin_polars/src/dataframe/command/data/pivot.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/pivot.rs
@@ -4,6 +4,7 @@ use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
 };
 
+use polars::frame::PivotColumnNaming;
 use polars::{
     df,
     frame::DataFrame,
@@ -83,6 +84,11 @@ impl PluginCommand for PivotDF {
             .switch(
                 "stable",
                 "Perform a stable pivot.",
+                None,
+            )
+            .switch(
+                "always-combine-names",
+                "Always combine the values and on-column names.",
                 None,
             )
             .input_output_types(vec![
@@ -294,6 +300,12 @@ fn command_lazy(
         Selector::Wildcard - on.clone() - index.unwrap_or_else(|| Selector::Empty)
     };
 
+    let pivot_column_naming = if call.has_flag("always-combine-names")? {
+        PivotColumnNaming::Combine
+    } else {
+        PivotColumnNaming::Auto
+    };
+
     let result: NuLazyFrame = lazy
         .to_polars()
         .pivot(
@@ -304,6 +316,7 @@ fn command_lazy(
             agg,
             maintain_order,
             separator,
+            pivot_column_naming,
         )
         .into();
 

--- a/crates/nu_plugin_polars/src/dataframe/command/data/replace.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/replace.rs
@@ -137,7 +137,7 @@ impl PluginCommand for Replace {
                 description: "Replace column with different values using a record",
                 example: "[[a]; [1] [1] [2] [2]]
                 | polars into-df
-                | polars select (polars col a | polars replace {1: a, 2: b} --strict --return-dtype str)
+                | polars select (polars col a | polars replace {1: a, 2: b} --default c --strict --return-dtype str)
                 | polars collect",
                 result: Some(
                     NuDataFrame::from(
@@ -177,7 +177,6 @@ impl PluginCommand for Replace {
                 )));
             }
         };
-        // let new_vals: Vec<Value> = call.req(1)?;
 
         let old = values_to_expr(plugin, call.head, old_vals)?;
         let new = values_to_expr(plugin, call.head, new_vals)?;

--- a/crates/nu_plugin_polars/src/dataframe/command/data/sql_expr.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/sql_expr.rs
@@ -143,7 +143,7 @@ fn apply_window_spec(expr: Expr, window_type: Option<&WindowType>) -> Result<Exp
                     .iter()
                     .map(parse_sql_expr)
                     .collect::<Result<Vec<_>>>()?;
-                expr.over(partition_by)
+                expr.over(partition_by)?
                 // Order by and Row range may not be supported at the moment
             }
             // TODO: make NamedWindow work

--- a/crates/nu_plugin_polars/src/dataframe/command/index/set_with_idx.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/index/set_with_idx.rs
@@ -132,7 +132,7 @@ fn command(
                 indices_span,
             ))
         })?
-        .into_iter()
+        .iter()
         .flatten();
 
     let df = NuDataFrame::try_from_pipeline_coerce(plugin, input, call.head)?;

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
@@ -1164,8 +1164,8 @@ fn series_to_values(
                     .map(|ca| {
                         let sublist: Vec<Value> = if let Some(arr) = ca {
                             let dt = DataType::from_arrow_dtype(arr.dtype());
-                            let s = Series::from_chunk_and_dtype("".into(), arr, &dt).map_err(
-                                |e| {
+                            let s =
+                                Series::from_chunk_and_dtype("".into(), arr, &dt).map_err(|e| {
                                     ShellError::Generic(
                                         GenericError::new_internal(
                                             "Error creating series from list values",
@@ -1173,8 +1173,7 @@ fn series_to_values(
                                         )
                                         .with_help(e.to_string()),
                                     )
-                                },
-                            )?;
+                                })?;
                             series_to_values(&s, None, None, span)?
                         } else {
                             // empty item

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
@@ -817,7 +817,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -839,7 +839,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -861,7 +861,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -883,7 +883,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -905,7 +905,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -927,7 +927,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -949,7 +949,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -971,7 +971,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -993,7 +993,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -1015,7 +1015,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -1037,7 +1037,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -1059,7 +1059,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -1073,7 +1073,7 @@ fn series_to_values(
 
             Ok(values)
         }
-        t @ (DataType::Binary | DataType::BinaryOffset) => {
+        DataType::Binary => {
             let make_err = |e: PolarsError| {
                 ShellError::Generic(
                     GenericError::new_internal("Error casting column to binary", "")
@@ -1081,11 +1081,30 @@ fn series_to_values(
                 )
             };
 
-            let it = match t {
-                DataType::Binary => series.binary().map_err(make_err)?.into_iter(),
-                DataType::BinaryOffset => series.binary_offset().map_err(make_err)?.into_iter(),
-                _ => unreachable!(),
+            let it = series.binary().map_err(make_err)?.iter();
+
+            let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
+                Either::Left(it.skip(from_row).take(size))
+            } else {
+                Either::Right(it)
+            }
+            .map(|v| match v {
+                Some(b) => Value::binary(b, span),
+                None => Value::nothing(span),
+            })
+            .collect::<Vec<Value>>();
+
+            Ok(values)
+        }
+        DataType::BinaryOffset => {
+            let make_err = |e: PolarsError| {
+                ShellError::Generic(
+                    GenericError::new_internal("Error casting column to binary offset", "")
+                        .with_help(e.to_string()),
+                )
             };
+
+            let it = series.binary_offset().map_err(make_err)?.iter();
 
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
@@ -1111,7 +1130,7 @@ fn series_to_values(
                         .with_help(format!("Object not supported for conversion: {x}")),
                 )),
                 Some(ca) => {
-                    let it = ca.into_iter();
+                    let it = ca.iter();
                     let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row)
                     {
                         Either::Left(it.skip(from_row).take(size))
@@ -1136,15 +1155,27 @@ fn series_to_values(
                         .with_help(format!("List not supported for conversion: {x}")),
                 )),
                 Some(ca) => {
-                    let it = ca.into_iter();
+                    let it = ca.iter();
                     if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                         Either::Left(it.skip(from_row).take(size))
                     } else {
                         Either::Right(it)
                     }
                     .map(|ca| {
-                        let sublist: Vec<Value> = if let Some(ref s) = ca {
-                            series_to_values(s, None, None, span)?
+                        let sublist: Vec<Value> = if let Some(arr) = ca {
+                            let dt = DataType::from_arrow_dtype(arr.dtype());
+                            let s = Series::from_chunk_and_dtype("".into(), arr, &dt).map_err(
+                                |e| {
+                                    ShellError::Generic(
+                                        GenericError::new_internal(
+                                            "Error creating series from list values",
+                                            "",
+                                        )
+                                        .with_help(e.to_string()),
+                                    )
+                                },
+                            )?;
+                            series_to_values(&s, None, None, span)?
                         } else {
                             // empty item
                             vec![]
@@ -1167,7 +1198,7 @@ fn series_to_values(
                 .clone()
                 .into_physical();
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -1196,7 +1227,7 @@ fn series_to_values(
                 .clone()
                 .into_physical();
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -1226,7 +1257,7 @@ fn series_to_values(
                 .clone()
                 .into_physical();
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {
@@ -1278,7 +1309,7 @@ fn series_to_values(
                 )
             })?;
 
-            let it = casted.into_iter();
+            let it = casted.iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
                 Either::Left(it.skip(from_row).take(size))
             } else {

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_expression/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_expression/mod.rs
@@ -228,7 +228,7 @@ pub fn expr_to_value(expr: &Expr, span: Span) -> Result<Value, ShellError> {
                 | AggExpr::Item { input: expr, .. }
                 | AggExpr::FirstNonNull(expr)
                 | AggExpr::LastNonNull(expr)
-                | AggExpr::Var(expr, _) => expr_to_value(expr.as_ref(), span)
+                | AggExpr::Var(expr, _) => expr_to_value(expr.as_ref(), span),
             };
 
             Ok(Value::record(

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_expression/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_expression/mod.rs
@@ -220,7 +220,7 @@ pub fn expr_to_value(expr: &Expr, span: Span) -> Result<Value, ShellError> {
                 | AggExpr::First(expr)
                 | AggExpr::Last(expr)
                 | AggExpr::Mean(expr)
-                | AggExpr::Implode(expr)
+                | AggExpr::Implode { input: expr, .. }
                 | AggExpr::Count { input: expr, .. }
                 | AggExpr::Sum(expr)
                 | AggExpr::AggGroups(expr)
@@ -228,19 +228,7 @@ pub fn expr_to_value(expr: &Expr, span: Span) -> Result<Value, ShellError> {
                 | AggExpr::Item { input: expr, .. }
                 | AggExpr::FirstNonNull(expr)
                 | AggExpr::LastNonNull(expr)
-                | AggExpr::Var(expr, _) => expr_to_value(expr.as_ref(), span),
-                AggExpr::Quantile {
-                    expr,
-                    quantile,
-                    method,
-                } => Ok(Value::record(
-                    record! {
-                        "expr" => expr_to_value(expr.as_ref(), span)?,
-                        "quantile" => expr_to_value(quantile.as_ref(), span)?,
-                        "method" => Value::string(format!("{method:?}"), span),
-                    },
-                    span,
-                )),
+                | AggExpr::Var(expr, _) => expr_to_value(expr.as_ref(), span)
             };
 
             Ok(Value::record(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -14,4 +14,4 @@ profile = "default"
 # so that we give repo maintainers and package managers a chance to update to a more
 # recent version of rust. However, if there is a "cool new feature" that we want to
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
-channel = "1.94.1"
+channel = "1.95.0"


### PR DESCRIPTION
## Description
Upgrade to polars 0.54

This also upgrades the rust version to 1.95 and the chrono version 0.4.42

## User-facing changes (Release notes)
- `polar implode` now supports the flag `--maintain-order`
- `polars is-in` now supports the flag `--maintain-order`
- `polars pivot` not supports the flag `--always-combine-names`
- `polars replace` requires a `--default <value>` parameter when used with `--strict` and `--return-dtype` if the dtype has changed from the original dtype
