### PR TITLE
Fix/stor return type

### DIFF
--- a/crates/nu-command/src/stor/open.rs
+++ b/crates/nu-command/src/stor/open.rs
@@ -12,10 +12,7 @@ impl Command for StorOpen {
 
     fn signature(&self) -> Signature {
         Signature::build("stor open")
-            .input_output_types(vec![(
-                Type::Nothing,
-                Type::Custom("sqlite-in-memory".into()),
-            )])
+            .input_output_types(vec![(Type::Nothing, Type::Custom("SQLiteDatabase".into()))])
             .allow_variants_without_examples(true)
             .category(Category::Database)
     }

--- a/crates/nu-command/src/stor/open.rs
+++ b/crates/nu-command/src/stor/open.rs
@@ -65,9 +65,18 @@ impl Command for StorOpen {
 #[cfg(test)]
 mod test {
     use super::*;
+    use nu_test_support::Result;
+    use nu_test_support::prelude::*;
 
     #[test]
-    fn test_examples() -> nu_test_support::Result {
-        nu_test_support::test().examples(StorOpen)
+    fn test_examples() -> Result {
+        test().examples(StorOpen)
+    }
+
+    #[test]
+    #[exp(nu_experimental::ENFORCE_RUNTIME_ANNOTATIONS)]
+    fn correct_return_ty() -> Result {
+        let () = test().run("let db = stor open")?;
+        Ok(())
     }
 }


### PR DESCRIPTION
## User-facing changes (Release notes)
### Fixed stor open return type
`stor open` returns the custom value `SQLiteDatabase`, yet it's signature had `sqlite-in-memory` as the return type. This causes problems with the `enforce-runtime-annotations` experimental option:
```nushell
let db = stor open
# Error: nu::shell::cant_convert
# 
#   × Can't convert to sqlite-in-memory.
#    ╭─[repl_entry #1:1:10]
#  1 │ let db = stor open 
#    ·          ────┬────
#    ·              ╰── can't convert SQLiteDatabase to sqlite-in-memory
#    ╰────
```

The return type has been corrected to `SQLiteDatabase`.

## Additional notes
- related #16832 