### PR TITLE
Make experimental option `enforce-runtime-annotations` opt out

### DIFF
--- a/crates/nu-experimental/src/options/enforce_runtime_annotations.rs
+++ b/crates/nu-experimental/src/options/enforce_runtime_annotations.rs
@@ -13,7 +13,7 @@ impl ExperimentalOptionMarker for EnforceRuntimeAnnotations {
     const DESCRIPTION: &'static str = "\
         Enforce type checking of let assignments at runtime such that \
         invalid type conversion errors propagate the same way they would for predefined values.";
-    const STATUS: Status = Status::OptIn;
+    const STATUS: Status = Status::OptOut;
     const SINCE: Version = (0, 107, 1);
     const ISSUE: u32 = 16832;
 }


### PR DESCRIPTION
## Description

We need to move forward with this at some point, having CI run with it on is a good starting point.

If any problems pop up we can rebase this branch on `main` as they are fixed.

## User-facing changes (Release notes)

### Promoted `enforce-runtime-annotations` to opt-out

In Nushell 0.108.0, [`enforce-runtime-annotations`](https://www.nushell.sh/blog/2025-10-15-nushell_v0_108_0.html#enforce-assignment-type-annotations-at-runtime-16079-toc) experimental option was added. With this release `enforce-runtime-annotations` is promoted to being opt-out, meaning that by default this experimental option is enabled now.

This option enforces type checking of let assignments at runtime, catching type errors that might have been missed in parse time type checking due to insufficient type information.

If you experience any trouble with this, you can disable it via the command-line argument:
```nushell
nu --experimental-options '[enforce-runtime-annotations=false]'
```
or via the environment variable:
```nushell
NU_EXPERIMENTAL_OPTIONS="enforce-runtime-annotations=false" nu
```