### PR TITLE
Make `nu-test-support` compile without `os` feature

### DIFF
--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [features]
 os = [
+  "nu-cli",
   "nu-cmd-lang/os",
   "nu-command/os",
   "nu-engine/os",
@@ -30,7 +31,7 @@ rustls-tls = ["nu-command/rustls-tls"]
 nu-cmd-extra.workspace = true
 nu-cmd-lang.workspace = true
 nu-command.workspace = true
-nu-cli.workspace = true
+nu-cli = { workspace = true, optional = true }
 nu-engine.workspace = true
 nu-experimental.workspace = true
 nu-glob.workspace = true

--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -36,8 +36,12 @@ static INITIAL_ENGINE_STATES: KeyedLazyLock<GroupKey, EngineState> = KeyedLazyLo
     // let engine_state = nu_cmd_plugin::add_plugin_command_context(engine_state);
     let engine_state = nu_command::add_shell_command_context(engine_state);
     let engine_state = nu_cmd_extra::add_extra_command_context(engine_state);
-    let mut engine_state = nu_cli::add_cli_context(engine_state);
+    #[cfg(feature = "os")]
+    let engine_state = nu_cli::add_cli_context(engine_state);
     // let engine_state = nu_explore::add_explore_context(engine_state);
+
+    // Make `engine_state` mutable without fiddling with features
+    let mut engine_state = engine_state;
 
     engine_state.generate_nu_constant();
     [


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
While running `cargo test -p nu-heavy-utils` you get a compilation error on `main`. This is because some parts of `nu-test-support` try to compile with the `os` feature and some parts do not. This is happening because of the integration of `nu-cli` in the `NuTester` via #18267.

This PR makes the integration of `nu-cli` optional and behind the `os` feature. This way compiling without the usage of the `os` feature works again.

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
n/a