### PR TITLE
fix(parser): a regression of parse_unit_value where `[.foons]` not return early

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3230,7 +3230,7 @@ pub fn parse_unit_value<'res>(
 ) -> Option<ParseUnitResult<'res>> {
     if bytes.len() < 2
         || !(bytes[0].is_ascii_digit()
-            || bytes[0] == b'.'
+            || (bytes[0] == b'.' && bytes[1].is_ascii_digit())
             || (bytes[0] == b'-' && bytes[1].is_ascii_digit()))
     {
         return None;

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -340,6 +340,11 @@ fn list_quotes_with_equals() -> TestResult {
 }
 
 #[test]
+fn list_raw_string_unit_value_like() -> TestResult {
+    run_test("[.foons] | get 0", ".foons")
+}
+
+#[test]
 fn record_quotes_with_equals() -> TestResult {
     run_test(r#"{"a=":b} | get a="#, "b")?;
     run_test(r#"{"=a":b} | get =a"#, "b")?;


### PR DESCRIPTION
## Description

Fixes a regression introduced by #17923

## User-facing changes (Release notes)

Fixed a regression where lists like `[.foons]` will cause parser error.