### PR TITLE
add context for the `idx search` command

### DIFF
--- a/crates/nu-command/src/filesystem/idx/export.rs
+++ b/crates/nu-command/src/filesystem/idx/export.rs
@@ -29,7 +29,7 @@ impl Command for IdxExport {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Save the current idx index to disk",
+            description: "Save the current idx index to disk.",
             example: "idx export ~/my-index.db",
             result: None,
         }]

--- a/crates/nu-command/src/filesystem/idx/files.rs
+++ b/crates/nu-command/src/filesystem/idx/files.rs
@@ -27,12 +27,12 @@ impl Command for IdxFiles {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "List all indexed files",
+                description: "List all indexed files.",
                 example: "idx files",
                 result: None,
             },
             Example {
-                description: "Fuzzy-match indexed files by query",
+                description: "Fuzzy-match indexed files by query.",
                 example: "idx files main",
                 result: None,
             },

--- a/crates/nu-command/src/filesystem/idx/find.rs
+++ b/crates/nu-command/src/filesystem/idx/find.rs
@@ -36,17 +36,17 @@ impl Command for IdxFind {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Fuzzy search for files and directories matching 'main'",
+                description: "Fuzzy search for files and directories matching 'main'.",
                 example: "idx find main",
                 result: None,
             },
             Example {
-                description: "Search only files with verbose scoring output",
+                description: "Search only files with verbose scoring output.",
                 example: "idx find config --files --verbose",
                 result: None,
             },
             Example {
-                description: "Search only directories, limited to top 10 results",
+                description: "Search only directories, limited to top 10 results.",
                 example: "idx find src --dirs --limit 10",
                 result: None,
             },

--- a/crates/nu-command/src/filesystem/idx/import.rs
+++ b/crates/nu-command/src/filesystem/idx/import.rs
@@ -35,7 +35,7 @@ impl Command for IdxImport {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Restore an idx index from a snapshot on disk",
+            description: "Restore an idx index from a snapshot on disk.",
             example: "idx import ~/my-index.db",
             result: None,
         }]

--- a/crates/nu-command/src/filesystem/idx/init.rs
+++ b/crates/nu-command/src/filesystem/idx/init.rs
@@ -47,17 +47,17 @@ impl Command for IdxInit {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Initialize idx for the current directory",
+                description: "Initialize idx for the current directory.",
                 example: "idx init .",
                 result: None,
             },
             Example {
-                description: "Initialize idx and wait for the initial scan to complete",
+                description: "Initialize idx and wait for the initial scan to complete.",
                 example: "idx init . --wait",
                 result: None,
             },
             Example {
-                description: "Initialize idx without filesystem watching",
+                description: "Initialize idx without filesystem watching.",
                 example: "idx init . --no-watch",
                 result: None,
             },

--- a/crates/nu-command/src/filesystem/idx/search.rs
+++ b/crates/nu-command/src/filesystem/idx/search.rs
@@ -48,22 +48,22 @@ impl Command for IdxSearch {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Search indexed file contents for a plain text pattern",
+                description: "Search indexed file contents for a plain text pattern.",
                 example: "idx search hello",
                 result: None,
             },
             Example {
-                description: "Search using a regular expression",
+                description: "Search using a regular expression.",
                 example: "idx search --regex 'fn \\w+'",
                 result: None,
             },
             Example {
-                description: "Search with multiple patterns simultaneously",
+                description: "Search with multiple patterns simultaneously.",
                 example: "idx search TODO FIXME HACK",
                 result: None,
             },
             Example {
-                description: "Include 2 lines of context before and 5 lines after each match",
+                description: "Include 2 lines of context before and 5 lines after each match.",
                 example: "idx search error -2..5",
                 result: None,
             },

--- a/crates/nu-command/src/filesystem/idx/search.rs
+++ b/crates/nu-command/src/filesystem/idx/search.rs
@@ -1,6 +1,8 @@
 use super::state::stream_grep;
 use fff_search::GrepMode;
 use nu_engine::command_prelude::*;
+use nu_protocol::Range;
+use std::ops::Bound;
 
 #[derive(Clone)]
 pub struct IdxSearch;
@@ -24,6 +26,12 @@ impl Command for IdxSearch {
                 SyntaxShape::Int,
                 "Maximum number of matches to collect.",
                 Some('l'),
+            )
+            .named(
+                "context",
+                SyntaxShape::Range,
+                "Number of lines of context to include before and after each match. Negative value for before-context, positive value for after-context in range format -3..5.",
+                Some('c'),
             )
             .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::record())))])
             .category(Category::FileSystem)
@@ -52,6 +60,11 @@ impl Command for IdxSearch {
             Example {
                 description: "Search with multiple patterns simultaneously",
                 example: "idx search TODO FIXME HACK",
+                result: None,
+            },
+            Example {
+                description: "Include 2 lines of context before and 5 lines after each match",
+                example: "idx search error -2..5",
                 result: None,
             },
         ]
@@ -97,7 +110,74 @@ impl Command for IdxSearch {
             GrepMode::PlainText
         };
 
+        let context_range: Option<Range> = call.get_flag(engine_state, stack, "context")?;
+        let (before_context, after_context) = match context_range {
+            Some(Range::IntRange(r)) => {
+                // Reject three-part ranges like -3..1..5 (explicit step != 1)
+                if r.step() != 1 {
+                    return Err(ShellError::UnsupportedInput {
+                        msg: "Context range must not have an explicit step (e.g. use -3..5, not -3..1..5)".into(),
+                        input: "value originates from here".into(),
+                        msg_span: call.head,
+                        input_span: call.head,
+                    });
+                }
+
+                let start = r.start();
+                if start > 0 {
+                    return Err(ShellError::UnsupportedInput {
+                        msg: "Context range start must be <= 0 (use a negative value for before-context, e.g. -3..5)".into(),
+                        input: "value originates from here".into(),
+                        msg_span: call.head,
+                        input_span: call.head,
+                    });
+                }
+
+                let end_val = match r.end() {
+                    Bound::Included(e) | Bound::Excluded(e) => e,
+                    Bound::Unbounded => {
+                        return Err(ShellError::UnsupportedInput {
+                            msg: "Context range must have a bounded end (use a positive value for after-context, e.g. -3..5)".into(),
+                            input: "value originates from here".into(),
+                            msg_span: call.head,
+                            input_span: call.head,
+                        });
+                    }
+                };
+
+                if end_val < 0 {
+                    return Err(ShellError::UnsupportedInput {
+                        msg: "Context range end must be >= 0 (use a positive value for after-context, e.g. -3..5)".into(),
+                        input: "value originates from here".into(),
+                        msg_span: call.head,
+                        input_span: call.head,
+                    });
+                }
+
+                let before = start.unsigned_abs() as usize;
+                let after = end_val as usize;
+                (before, after)
+            }
+            Some(Range::FloatRange(_)) => {
+                return Err(ShellError::UnsupportedInput {
+                    msg: "Float ranges are not supported for context".into(),
+                    input: "value originates from here".into(),
+                    msg_span: call.head,
+                    input_span: call.head,
+                });
+            }
+            None => (0, 0),
+        };
+
         let signals = engine_state.signals();
-        stream_grep(&patterns, mode, limit, call.head, signals)
+        stream_grep(
+            &patterns,
+            mode,
+            limit,
+            call.head,
+            before_context,
+            after_context,
+            signals,
+        )
     }
 }

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -1856,6 +1856,8 @@ pub fn stream_grep(
     mode: GrepMode,
     page_limit: usize,
     span: Span,
+    before_context: usize,
+    after_context: usize,
     signals: &Signals,
 ) -> Result<PipelineData, ShellError> {
     let snapshot = require_runtime(span)?;
@@ -1866,6 +1868,8 @@ pub fn stream_grep(
     let options = GrepSearchOptions {
         mode,
         page_limit,
+        before_context,
+        after_context,
         ..Default::default()
     };
 
@@ -1922,31 +1926,46 @@ pub fn stream_grep(
             })
             .collect::<Vec<_>>();
 
-        Value::record(
-            [
-                ("path".to_string(), Value::string(path, span)),
-                (
-                    "line_number".to_string(),
-                    Value::int(i64::try_from(item.line_number).unwrap_or(i64::MAX), span),
-                ),
-                (
-                    "column".to_string(),
-                    Value::int(usize_to_i64(item.col), span),
-                ),
-                (
-                    "byte_offset".to_string(),
-                    Value::int(i64::try_from(item.byte_offset).unwrap_or(i64::MAX), span),
-                ),
-                (
-                    "line".to_string(),
-                    Value::string(item.line_content.clone(), span),
-                ),
-                ("matches".to_string(), Value::list(offsets, span)),
-            ]
-            .into_iter()
-            .collect(),
-            span,
-        )
+        let mut cols: Vec<(String, Value)> = vec![
+            ("path".to_string(), Value::string(path, span)),
+            (
+                "line_number".to_string(),
+                Value::int(i64::try_from(item.line_number).unwrap_or(i64::MAX), span),
+            ),
+            (
+                "column".to_string(),
+                Value::int(usize_to_i64(item.col), span),
+            ),
+            (
+                "byte_offset".to_string(),
+                Value::int(i64::try_from(item.byte_offset).unwrap_or(i64::MAX), span),
+            ),
+            (
+                "line".to_string(),
+                Value::string(item.line_content.clone(), span),
+            ),
+            ("matches".to_string(), Value::list(offsets, span)),
+        ];
+
+        if !item.context_before.is_empty() || !item.context_after.is_empty() {
+            let context = item
+                .context_before
+                .iter()
+                .map(|l| Value::string(l.clone(), span))
+                .chain(std::iter::once(Value::string(
+                    item.line_content.clone(),
+                    span,
+                )))
+                .chain(
+                    item.context_after
+                        .iter()
+                        .map(|l| Value::string(l.clone(), span)),
+                )
+                .collect::<Vec<_>>();
+            cols.push(("with_context".to_string(), Value::list(context, span)));
+        }
+
+        Value::record(cols.into_iter().collect(), span)
     });
 
     Ok(PipelineData::ListStream(

--- a/crates/nu-command/src/filesystem/idx/status.rs
+++ b/crates/nu-command/src/filesystem/idx/status.rs
@@ -21,7 +21,7 @@ impl Command for IdxStatus {
 
     fn examples(&self) -> Vec<Example<'_>> {
         vec![Example {
-            description: "Show the current idx runtime status",
+            description: "Show the current idx runtime status.",
             example: "idx status",
             result: None,
         }]


### PR DESCRIPTION
## Description

This PR add the ability to have a "before_context" and "after_context" in the `idx search` command by using the `--context/-c` parameter and a range.

## User-facing changes (Release notes)
### Added `--context` support to `idx search`
Add context to your `idx search` queries by using `--context/-c` and a nushell range. The range has to be in the form of negative_number..positive_number where negative_number is the before lines to show and the positive_number is the after lines to show in the `with_context` record key.

<img width="2504" height="1007" alt="Screenshot 2026-06-08 at 10-15-31" src="https://github.com/user-attachments/assets/eb5d08f6-5028-4fe3-945c-825bd8898624" />

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->