### PR TITLE
patching for windows globbing was in the wrong place

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -268,10 +268,6 @@ impl Command for Glob {
             });
         }
 
-        // paths starting with drive letters must be escaped on Windows
-        #[cfg(windows)]
-        let glob_pattern = patch_windows_glob_pattern(glob_pattern, glob_span)?;
-
         if glob_pattern.is_empty() {
             return Err(ShellError::Generic(
                 GenericError::new(
@@ -297,20 +293,26 @@ impl Command for Glob {
                 no_symlinks,
                 span,
             ),
-            false => run_legacy_glob(
-                engine_state,
-                stack,
-                &glob_pattern,
-                depth,
-                follow_symlinks,
-                not_patterns,
-                glob_span,
-                not_pattern_span,
-                no_dirs,
-                no_files,
-                no_symlinks,
-                span,
-            ),
+            false => {
+                // paths starting with drive letters must be escaped for wax on Windows
+                #[cfg(windows)]
+                let glob_pattern = patch_windows_glob_pattern(glob_pattern, glob_span)?;
+
+                run_legacy_glob(
+                    engine_state,
+                    stack,
+                    &glob_pattern,
+                    depth,
+                    follow_symlinks,
+                    not_patterns,
+                    glob_span,
+                    not_pattern_span,
+                    no_dirs,
+                    no_files,
+                    no_symlinks,
+                    span,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

I missed an issue specific to windows. Patching the windows path is only required for wax and not dc-glob.

## User-facing changes (Release notes)
Works better with Windows now for things like `glob c:\apps\*`.
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->