### PR TITLE
allow `--context` to be one of int or range

### DIFF
--- a/crates/nu-command/src/filesystem/idx/search.rs
+++ b/crates/nu-command/src/filesystem/idx/search.rs
@@ -29,8 +29,8 @@ impl Command for IdxSearch {
             )
             .named(
                 "context",
-                SyntaxShape::Range,
-                "Number of lines of context to include before and after each match. Negative value for before-context, positive value for after-context in range format -3..5.",
+                SyntaxShape::OneOf(vec![SyntaxShape::Range, SyntaxShape::Int]),
+                "The number of context lines to include before and after each match can be specified as an integer or a range. An integer sets both the before and after context to that number, while a range uses a negative value for lines before and a positive value for lines after (e.g., -3..5).",
                 Some('c'),
             )
             .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::record())))])
@@ -110,63 +110,88 @@ impl Command for IdxSearch {
             GrepMode::PlainText
         };
 
-        let context_range: Option<Range> = call.get_flag(engine_state, stack, "context")?;
-        let (before_context, after_context) = match context_range {
-            Some(Range::IntRange(r)) => {
-                // Reject three-part ranges like -3..1..5 (explicit step != 1)
-                if r.step() != 1 {
-                    return Err(ShellError::UnsupportedInput {
-                        msg: "Context range must not have an explicit step (e.g. use -3..5, not -3..1..5)".into(),
-                        input: "value originates from here".into(),
-                        msg_span: call.head,
-                        input_span: call.head,
-                    });
-                }
-
-                let start = r.start();
-                if start > 0 {
-                    return Err(ShellError::UnsupportedInput {
-                        msg: "Context range start must be <= 0 (use a negative value for before-context, e.g. -3..5)".into(),
-                        input: "value originates from here".into(),
-                        msg_span: call.head,
-                        input_span: call.head,
-                    });
-                }
-
-                let end_val = match r.end() {
-                    Bound::Included(e) | Bound::Excluded(e) => e,
-                    Bound::Unbounded => {
-                        return Err(ShellError::UnsupportedInput {
-                            msg: "Context range must have a bounded end (use a positive value for after-context, e.g. -3..5)".into(),
-                            input: "value originates from here".into(),
-                            msg_span: call.head,
-                            input_span: call.head,
-                        });
-                    }
-                };
-
-                if end_val < 0 {
-                    return Err(ShellError::UnsupportedInput {
-                        msg: "Context range end must be >= 0 (use a positive value for after-context, e.g. -3..5)".into(),
-                        input: "value originates from here".into(),
-                        msg_span: call.head,
-                        input_span: call.head,
-                    });
-                }
-
-                let before = start.unsigned_abs() as usize;
-                let after = end_val as usize;
-                (before, after)
-            }
-            Some(Range::FloatRange(_)) => {
+        let context_param: Option<Value> = call.get_flag(engine_state, stack, "context")?;
+        let (before_context, after_context) = match context_param {
+            Some(Value::Int { val: i, .. }) if i < 0 => {
                 return Err(ShellError::UnsupportedInput {
-                    msg: "Float ranges are not supported for context".into(),
+                    msg: "Context must be specified as an or a range (e.g. -3..5). Negative value for before-context, positive value for after-context.".into(),
                     input: "value originates from here".into(),
                     msg_span: call.head,
                     input_span: call.head,
                 });
             }
-            None => (0, 0),
+            Some(Value::Int { val: n, .. }) => (n as usize, n as usize),
+            Some(Value::Range { val: range, .. }) => {
+                // Valid cases
+                match *range {
+                    Range::IntRange(r) => {
+                        // Reject three-part ranges like -3..1..5 (explicit step != 1)
+                        if r.step() != 1 {
+                            return Err(ShellError::UnsupportedInput {
+                                msg: "Context range must not have an explicit step (e.g. use -3..5, not -3..1..5)".into(),
+                                input: "value originates from here".into(),
+                                msg_span: call.head,
+                                input_span: call.head,
+                            });
+                        }
+
+                        let start = r.start();
+                        if start > 0 {
+                            return Err(ShellError::UnsupportedInput {
+                                msg: "Context range start must be <= 0 (use a negative value for before-context, e.g. -3..5)".into(),
+                                input: "value originates from here".into(),
+                                msg_span: call.head,
+                                input_span: call.head,
+                            });
+                        }
+
+                        let end_val = match r.end() {
+                            Bound::Included(e) | Bound::Excluded(e) => e,
+                            Bound::Unbounded => {
+                                return Err(ShellError::UnsupportedInput {
+                                    msg: "Context range must have a bounded end (use a positive value for after-context, e.g. -3..5)".into(),
+                                    input: "value originates from here".into(),
+                                    msg_span: call.head,
+                                    input_span: call.head,
+                                });
+                            }
+                        };
+
+                        if end_val < 0 {
+                            return Err(ShellError::UnsupportedInput {
+                                msg: "Context range end must be >= 0 (use a positive value for after-context, e.g. -3..5)".into(),
+                                input: "value originates from here".into(),
+                                msg_span: call.head,
+                                input_span: call.head,
+                            });
+                        }
+
+                        let before = start.unsigned_abs() as usize;
+                        let after = end_val as usize;
+                        (before, after)
+                    }
+                    Range::FloatRange(_) => {
+                        return Err(ShellError::UnsupportedInput {
+                            msg: "Float ranges are not supported for context".into(),
+                            input: "value originates from here".into(),
+                            msg_span: call.head,
+                            input_span: call.head,
+                        });
+                    }
+                }
+            }
+            Some(other) => {
+                return Err(ShellError::UnsupportedInput {
+                    msg: format!(
+                        "Context must be an integer or range, but got {}",
+                        other.get_type()
+                    ),
+                    input: "value originates from here".into(),
+                    msg_span: call.head,
+                    input_span: call.head,
+                });
+            }
+            None => (0usize, 0usize),
         };
 
         let signals = engine_state.signals();


### PR DESCRIPTION
## Description
This PR allows the `idx search --context` parameter to be one of `int` or `range`. When supplied by `int` it makes before and after context that number.

## User-facing changes (Release notes)

### Allowed `idx search --context` to accept counts or ranges

This change allows `idx search --context` to be supplied as either an `int` or as a `range`.
<img width="2426" height="1839" alt="Screenshot 2026-06-08 at 13-38-25" src="https://github.com/user-attachments/assets/96392630-7e6d-4a67-9ec0-4299097fa4d0" />

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->