### PR TITLE
Expose `NuTester` internals

### DIFF
--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -115,9 +115,10 @@ pub fn test() -> NuTester {
 /// `NuTester` owns an [`EngineState`] and [`Stack`] that are reused across invocations.
 /// Configuration methods update the engine state before execution.
 #[derive(Clone)]
+#[non_exhaustive] // Ensure this type is only generated using `test()`, `new()` or `default()`.
 pub struct NuTester {
-    engine_state: EngineState,
-    stack: Stack,
+    pub engine_state: EngineState,
+    pub stack: Stack,
 }
 
 impl Default for NuTester {


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
This PR exposes the internals of `NuTester` allowing to test more complicated situations that require access to the engine state and/or the stack. The struct is marked as `non_exhaustive` to ensure that a new `NuTester` instance is still created using the provided methods. Modifying the internals of the tester may mess something up but since this testing code, this should be fine. Also all the easy methods are still available to use.

/cc @132ikl 

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
n/a

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
- related #18349