### PR TITLE
update custom command `--wrapped` to not always convert to glob

### DIFF
--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -361,6 +361,26 @@ fn def_wrapped_explicit_string_rest_keeps_tilde_literal() {
 }
 
 #[test]
+fn def_wrapped_untyped_rest_bare_word_is_string_type() {
+    // Regression test: `def --wrapped [...rest]` should report bare words as strings, not globs
+    let actual = nu!("def --wrapped foo [...rest] { print ($rest.0 | describe) }; foo test");
+    assert_eq!(actual.out, "string");
+}
+
+#[test]
+fn def_wrapped_untyped_rest_multiple_bare_words() {
+    let actual = nu!("def --wrapped foo [...rest] { print ($rest.2 | describe) }; foo a b c");
+    assert_eq!(actual.out, "string");
+}
+
+#[test]
+fn def_wrapped_untyped_rest_glob_pattern_stays_glob() {
+    // Glob patterns with wildcards should remain as globs
+    let actual = nu!("def --wrapped foo [...rest] { print ($rest.0 | describe) }; foo *.rs");
+    assert_eq!(actual.out, "glob");
+}
+
+#[test]
 fn def_wrapped_dynamic_percent_builtin_preserves_no_arg_defaults() {
     Playground::setup(
         "def_wrapped_dynamic_percent_builtin_preserves_no_arg_defaults",

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -24,10 +24,11 @@ use crate::{
     ENV_CONVERSIONS, convert_env_vars, eval::is_automatic_env_var, eval_block_with_early_return,
 };
 
-/// For `def --wrapped` and `known extern` rest params (`SyntaxShape::ExternalArgument`), expand
-/// tilde and ndots in bare glob values that are not actual glob patterns. This mirrors what
-/// `run-external` does in `eval_external_arguments`, so that `$args | to nuon` returns expanded
-/// paths instead of the raw `~` / `...` tokens.
+/// For `def --wrapped` and `known extern` rest params (`SyntaxShape::ExternalArgument`), convert
+/// non-glob `Value::Glob` values to `Value::String`, expanding tilde and ndots in the process.
+/// This mirrors what `run-external` does in `eval_external_arguments`, so that `$args | to nuon`
+/// returns expanded paths instead of the raw `~` / `...` tokens, while also ensuring that plain
+/// bare-word strings (e.g. `test`) are reported as strings rather than globs.
 fn expand_external_glob_arg(val: Value) -> Value {
     if let Value::Glob {
         val: ref s,
@@ -39,10 +40,7 @@ fn expand_external_glob_arg(val: Value) -> Value {
         && !nu_glob::is_glob(s)
     {
         let expanded = expand_ndots_safe(expand_tilde(s.as_str()));
-        let expanded_str = expanded.to_string_lossy().into_owned();
-        if expanded_str != *s {
-            return Value::string(expanded_str, internal_span);
-        }
+        return Value::string(expanded.to_string_lossy().into_owned(), internal_span);
     }
     val
 }

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -592,7 +592,7 @@ fn percent_dynamic_dispatch_with_mixed_positional_and_spread_args() -> Result {
 #[test]
 fn percent_dynamic_dispatch_in_wrapped_command_forwards_rest_args() -> Result {
     let code = "export def --wrapped builtin [arg1, ...args] { %($arg1) ...$args }; builtin echo hello world | to nuon";
-    test().run(code).expect_value_eq(r#"["hello", "world"]"#)
+    test().run(code).expect_value_eq("[hello, world]")
 }
 
 #[test]


### PR DESCRIPTION
## Description
This PR fixes a bug where `def --wrapped cmd [...rest] {$rest.0 | describe}` was always printing the type as `glob`. I'm not sure that's too much of a problem but with this PR there should be only 3 returns from `cmd` above; `string`, `glob`, `ShellError`. This is because `--wrapped` is specifically intended to pass arguments to externals.

## User-facing changes (Release notes)
Fixed a regression where all custom commands with `--wrapped` where numbers and strings passed to externals as `glob` now everything is passed as `string` or `glob` or creates an error.
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
closes https://github.com/nushell/nushell/issues/18370
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->