### PR TITLE
allow dc-glob to expand tilde

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -352,7 +352,9 @@ fn run_dc_glob(
         interrupt: engine_state.signals().interrupt_flag(),
     };
     let cwd_for_matches = cwd.as_std_path().to_path_buf();
-    let glob_pattern = nu_path::expand_tilde(glob_pattern).to_string_lossy().to_string();
+    let glob_pattern = nu_path::expand_tilde(glob_pattern)
+        .to_string_lossy()
+        .to_string();
 
     let matches =
         nu_glob::dc_glob::glob_with(cwd.as_std_path(), &glob_pattern, &options).map_err(|err| {
@@ -679,7 +681,9 @@ fn run_debug_subcommand(
                         span,
                     ))
                 })?;
-            let expanded_pattern = nu_path::expand_tilde(&pattern.item).to_string_lossy().to_string();
+            let expanded_pattern = nu_path::expand_tilde(&pattern.item)
+                .to_string_lossy()
+                .to_string();
             let out = nu_glob::dc_glob::glob_with(
                 relative_to,
                 &expanded_pattern,

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -352,9 +352,10 @@ fn run_dc_glob(
         interrupt: engine_state.signals().interrupt_flag(),
     };
     let cwd_for_matches = cwd.as_std_path().to_path_buf();
+    let glob_pattern = nu_path::expand_tilde(glob_pattern).to_string_lossy().to_string();
 
     let matches =
-        nu_glob::dc_glob::glob_with(cwd.as_std_path(), glob_pattern, &options).map_err(|err| {
+        nu_glob::dc_glob::glob_with(cwd.as_std_path(), &glob_pattern, &options).map_err(|err| {
             ShellError::Generic(GenericError::new(
                 "error with glob pattern",
                 err.to_string(),
@@ -678,9 +679,10 @@ fn run_debug_subcommand(
                         span,
                     ))
                 })?;
+            let expanded_pattern = nu_path::expand_tilde(&pattern.item).to_string_lossy().to_string();
             let out = nu_glob::dc_glob::glob_with(
                 relative_to,
-                &pattern.item,
+                &expanded_pattern,
                 &nu_glob::dc_glob::GlobWalkOptions::default(),
             )
             .map_err(|err| {


### PR DESCRIPTION
## Description

This PR fixes a bug where the new experimental-option `dc-glob` wouldn't expand `~` properly in the `glob` command. Now it does.

<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
While using experimental option `dc-glob`, `glob` expands `~` as expected now.
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->