### PR TITLE
fix dc-glob issue with using relative paths vs absolute

### DIFF
--- a/crates/nu-glob/src/dc_glob/globber.rs
+++ b/crates/nu-glob/src/dc_glob/globber.rs
@@ -351,7 +351,13 @@ fn handle_path_candidate<'a>(
     let program = state.program;
     let fast_path = state.fast_path;
 
-    let output_path_candidate = path.strip_prefix(output_relative_to).unwrap_or(path);
+    let output_path_candidate = if program.absolute_prefix.is_some() {
+        path.to_path_buf()
+    } else {
+        path.strip_prefix(output_relative_to)
+            .unwrap_or(path)
+            .to_path_buf()
+    };
     let match_path_candidate = path.strip_prefix(match_relative_to).unwrap_or(path);
     let candidate_depth = if is_parent {
         depth.saturating_sub(1)

--- a/crates/nu-glob/src/dc_glob/mod.rs
+++ b/crates/nu-glob/src/dc_glob/mod.rs
@@ -383,10 +383,10 @@ mod tests {
         let paths = collect_ok_paths(result).expect("failed to collect streamed paths");
 
         assert!(
-            paths
-                .iter()
-                .any(|p| p == &expected_path(&["src", "lib.rs"])),
-            "absolute recursive pattern should include nested files"
+            paths.iter().any(|p| {
+                Path::new(p).is_absolute() && p.ends_with(&expected_path(&["src", "lib.rs"]))
+            }),
+            "absolute recursive pattern should include nested absolute files"
         );
 
         let _ = fs::remove_dir_all(&root);
@@ -930,9 +930,8 @@ mod tests {
 
     #[test]
     fn glob_with_absolute_pattern_literal_then_wildcard() {
-        // Absolute pattern like `<root>/dir/nu*` — same as relative but with
-        // an absolute prefix. Regression guard for Bug #1 with absolute paths.
-        // Results are emitted relative to the traversal start dir.
+        // Absolute pattern like `<root>/dir/nu*` should emit absolute paths,
+        // not paths relative to the current working directory.
         let root = unique_test_dir("absolute_literal_wildcard");
         fs::create_dir_all(&root).expect("failed to create root");
         write_file(&root.join("dir/nu_test1"));
@@ -944,7 +943,8 @@ mod tests {
         let paths = collect_ok_paths(result).expect("failed to collect paths");
 
         assert_eq!(paths.len(), 1);
-        assert_eq!(paths[0], "nu_test1");
+        assert!(Path::new(&paths[0]).is_absolute());
+        assert_eq!(paths[0], format!("{}/dir/nu_test1", root.display()));
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/crates/nu-glob/src/dc_glob/mod.rs
+++ b/crates/nu-glob/src/dc_glob/mod.rs
@@ -946,9 +946,17 @@ mod tests {
         assert!(Path::new(&paths[0]).is_absolute());
 
         #[cfg(windows)]
-        let expected = root.join("dir").join("nu_test1").to_string_lossy().replace('/', "\\");
+        let expected = root
+            .join("dir")
+            .join("nu_test1")
+            .to_string_lossy()
+            .replace('/', "\\");
         #[cfg(not(windows))]
-        let expected = root.join("dir").join("nu_test1").to_string_lossy().into_owned();
+        let expected = root
+            .join("dir")
+            .join("nu_test1")
+            .to_string_lossy()
+            .into_owned();
 
         assert_eq!(paths[0], expected);
 

--- a/crates/nu-glob/src/dc_glob/mod.rs
+++ b/crates/nu-glob/src/dc_glob/mod.rs
@@ -944,7 +944,13 @@ mod tests {
 
         assert_eq!(paths.len(), 1);
         assert!(Path::new(&paths[0]).is_absolute());
-        assert_eq!(paths[0], format!("{}/dir/nu_test1", root.display()));
+
+        #[cfg(windows)]
+        let expected = root.join("dir").join("nu_test1").to_string_lossy().replace('/', "\\");
+        #[cfg(not(windows))]
+        let expected = root.join("dir").join("nu_test1").to_string_lossy().into_owned();
+
+        assert_eq!(paths[0], expected);
 
         let _ = fs::remove_dir_all(&root);
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR fixes another bug reported by @Tyarel8 in Discord where dc-glob was emitting relative path candidates for absolute patterns.
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
glob with dc-glob = true now emits absolute paths when absolute patterns are used. The simple example was doing `glob ~/.cargo/bin/nu*` from within `~/Downloads` and making sure the results start with `/Users/<username>/.cargo/bin/nu`. Previously they incorrectly started with `/Users/<username>/Downloads/nu*` which was completely wrong. Thanks @Tyarel8 !
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->