### PR TITLE
fix(flatten): leading pipe character in a pipeline

### DIFF
--- a/crates/nu-cli/tests/commands/nu_highlight.rs
+++ b/crates/nu-cli/tests/commands/nu_highlight.rs
@@ -19,6 +19,8 @@ use rstest::rstest;
     "^ls e> foo o>| ls",
     "redirection"
 )]
+// https://github.com/nushell/nushell/issues/18369
+#[case::leading_pipe("| ls", "garbage")]
 fn nu_highlight_color_detection(#[case] cmd: &str, #[case] shape: &str) {
     use std::fmt::Write;
 

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -131,6 +131,8 @@ fn flatten_pipeline_element_into(
     pipeline_element: &PipelineElement,
     output: &mut Vec<(Span, FlatShape)>,
 ) {
+    // HACK: `| ls` is considered as valid code,
+    // we should put the pipe in front of the element expression in that case
     if let Some(span) = pipeline_element.pipe
         && span.end <= pipeline_element.expr.span.start
     {

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -131,6 +131,12 @@ fn flatten_pipeline_element_into(
     pipeline_element: &PipelineElement,
     output: &mut Vec<(Span, FlatShape)>,
 ) {
+    if let Some(span) = pipeline_element.pipe
+        && span.end <= pipeline_element.expr.span.start
+    {
+        output.push((span, FlatShape::Garbage));
+    }
+
     flatten_expression_into(working_set, &pipeline_element.expr, output);
 
     if let Some(redirection) = pipeline_element.redirection.as_ref() {
@@ -171,7 +177,9 @@ fn flatten_pipeline_element_into(
     }
 
     // Pipe token should come after redirection
-    if let Some(span) = pipeline_element.pipe {
+    if let Some(span) = pipeline_element.pipe
+        && span.end > pipeline_element.expr.span.start
+    {
         // NOTE: redirection pipes, e.g. `err>|`/`o+e>|` are parsed as both pipe and redirection,
         // we split each of them into 2 shapes here.
         if let Some((last_span, _)) = output.last_mut()


### PR DESCRIPTION
A hacky workaround. @WindSoilder 

## Description

After #17977, each pipe character is associated with the pipe element right before it, however there's an edge case where `| ls` is considered valid nu code while the `|` character bound to the element after it.

This will cause issues during flattening, see #18369.
This PR fixes it by checking the pipe span during flattening.

## User-facing changes (Release notes)

Fixed a bug of AST flattening where leading pipe characters in a block may lead to wrong reedline renderings.

## Additional notes

Closes #18369