### PR TITLE
http: use the response body for the error message

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -880,6 +880,8 @@ pub fn request_add_custom_headers<B>(
 
 fn handle_status_error(span: Span, requested_url: &str, response: &mut Response) -> ShellError {
     let msg = if response.header("content-type") == Some("application/json") {
+        // We use a json response as a heuristic to mean the body will contain a relevant error message.
+        // This can be widened if the assumption is wrong.
         response
             .body_mut()
             .read_to_string()

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -13,7 +13,6 @@ use base64::{
     engine::{GeneralPurpose, general_purpose::PAD},
 };
 use dns_lookup::LookupErrorKind;
-use http::StatusCode;
 use log::error;
 use multipart_rs::MultipartWriter;
 use nu_engine::command_prelude::*;
@@ -879,36 +878,25 @@ pub fn request_add_custom_headers<B>(
     Ok(request)
 }
 
-fn handle_status_error(span: Span, requested_url: &str, status: StatusCode) -> ShellError {
-    match status {
-        StatusCode::MOVED_PERMANENTLY => ShellError::NetworkFailure {
-            msg: format!("Resource moved permanently (301): {requested_url:?}"),
-            span,
-        },
-        StatusCode::BAD_REQUEST => ShellError::NetworkFailure {
-            msg: format!("Bad request (400) to {requested_url:?}"),
-            span,
-        },
-        StatusCode::FORBIDDEN => ShellError::NetworkFailure {
-            msg: format!("Access forbidden (403) to {requested_url:?}"),
-            span,
-        },
-        StatusCode::NOT_FOUND => ShellError::NetworkFailure {
-            msg: format!("Requested file not found (404): {requested_url:?}"),
-            span,
-        },
-        StatusCode::REQUEST_TIMEOUT => ShellError::NetworkFailure {
-            msg: format!("Request timeout (408): {requested_url:?}"),
-            span,
-        },
-        c => ShellError::NetworkFailure {
-            msg: format!(
-                "Cannot make request to {:?}. Error is {:?}",
-                requested_url,
-                c.to_string()
-            ),
-            span,
-        },
+fn handle_status_error(span: Span, requested_url: &str, response: &mut Response) -> ShellError {
+    let response_body = if response.header("content-type") == Some("application/json") {
+        response
+            .body_mut()
+            .read_to_string()
+            .unwrap_or("Cannot read body".to_string())
+    } else {
+        response
+            .status()
+            .canonical_reason()
+            .unwrap_or("")
+            .to_string()
+    };
+    ShellError::HttpError {
+        code: response.status().as_u16(),
+        reason: response.status().canonical_reason().unwrap_or(""),
+        url: requested_url.to_string(),
+        response: response_body,
+        span,
     }
 }
 
@@ -1058,7 +1046,7 @@ pub fn check_response_redirection(
 }
 
 pub(crate) fn handle_response_status(
-    resp: &Response,
+    resp: &mut Response,
     redirect_mode: RedirectMode,
     requested_url: &str,
     span: Span,
@@ -1072,7 +1060,7 @@ pub(crate) fn handle_response_status(
     if is_success {
         Ok(())
     } else {
-        Err(handle_status_error(span, requested_url, resp.status()))
+        Err(handle_status_error(span, requested_url, resp))
     }
 }
 
@@ -1094,7 +1082,7 @@ pub(crate) fn request_handle_response(
         redirect_mode,
         flags,
     }: RequestMetadata,
-    resp: Response,
+    mut resp: Response,
 ) -> Result<PipelineData, ShellError> {
     // #response_to_buffer moves "resp" making it impossible to read headers later.
     // Wrapping it into a closure to call when needed
@@ -1115,7 +1103,7 @@ pub(crate) fn request_handle_response(
         }
     };
     handle_response_status(
-        &resp,
+        &mut resp,
         redirect_mode,
         requested_url,
         span,

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -879,7 +879,7 @@ pub fn request_add_custom_headers<B>(
 }
 
 fn handle_status_error(span: Span, requested_url: &str, response: &mut Response) -> ShellError {
-    let response_body = if response.header("content-type") == Some("application/json") {
+    let msg = if response.header("content-type") == Some("application/json") {
         response
             .body_mut()
             .read_to_string()
@@ -895,7 +895,7 @@ fn handle_status_error(span: Span, requested_url: &str, response: &mut Response)
         code: response.status().as_u16(),
         reason: response.status().canonical_reason().unwrap_or(""),
         url: requested_url.to_string(),
-        response: response_body,
+        msg,
         span,
     }
 }

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -203,7 +203,7 @@ fn helper(
 
     let (response, request_headers) =
         send_request_no_body(request, request_span, call.head, signals);
-    let response = response?;
+    let mut response = response?;
     check_response_redirection(redirect_mode, span, &response)?;
 
     if args.full {
@@ -229,7 +229,7 @@ fn helper(
     }
 
     handle_response_status(
-        &response,
+        &mut response,
         redirect_mode,
         &requested_url,
         span,

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -199,7 +199,7 @@ fn helper(
     let (response, request_headers) =
         send_request_no_body(request, request_span, call.head, engine_state.signals());
 
-    let response = response?;
+    let mut response = response?;
     check_response_redirection(redirect_mode, span, &response)?;
 
     if args.full {
@@ -226,7 +226,7 @@ fn helper(
 
     let response_headers = extract_response_headers(&response);
     handle_response_status(
-        &response,
+        &mut response,
         redirect_mode,
         &requested_url,
         span,

--- a/crates/nu-command/tests/commands/network/http/delete.rs
+++ b/crates/nu-command/tests/commands/network/http/delete.rs
@@ -27,8 +27,8 @@ fn http_delete_failed_due_to_server_error() -> Result {
     let code = format!("http delete {url}", url = server.url());
     let err = test().run(code).expect_error()?;
     match err {
-        ShellError::NetworkFailure { msg, .. } => {
-            assert_contains("Bad request (400)", msg);
+        ShellError::HttpError { msg, .. } => {
+            assert_contains("Bad Request", msg);
             Ok(())
         }
         err => Err(err.into()),

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -20,8 +20,8 @@ fn http_get_failed_due_to_server_error() -> Result {
         .run_with_data("http get $in", server.url())
         .expect_shell_error()?;
     match err {
-        ShellError::NetworkFailure { msg, .. } => {
-            assert_contains("Bad request (400)", msg);
+        ShellError::HttpError { msg, .. } => {
+            assert_contains("Bad Request", msg);
             Ok(())
         }
         err => Err(err.into()),

--- a/crates/nu-command/tests/commands/network/http/head.rs
+++ b/crates/nu-command/tests/commands/network/http/head.rs
@@ -23,8 +23,8 @@ fn http_head_failed_due_to_server_error() -> Result {
     let code = format!("http head {url}", url = server.url());
     let err = test().run(code).expect_shell_error()?;
     match err {
-        ShellError::NetworkFailure { msg, .. } => {
-            assert_contains("Bad request (400)", msg);
+        ShellError::HttpError { msg, .. } => {
+            assert_contains("Bad Request", msg);
             Ok(())
         }
         err => Err(err.into()),

--- a/crates/nu-command/tests/commands/network/http/options.rs
+++ b/crates/nu-command/tests/commands/network/http/options.rs
@@ -79,8 +79,8 @@ fn http_options_failed_due_to_server_error() -> Result {
         .expect_shell_error()?;
 
     match err {
-        ShellError::NetworkFailure { msg, .. } => {
-            assert_contains("Bad request (400)", msg);
+        ShellError::HttpError { msg, .. } => {
+            assert_contains("Bad Request", msg);
             Ok(())
         }
         err => Err(err.into()),

--- a/crates/nu-command/tests/commands/network/http/patch.rs
+++ b/crates/nu-command/tests/commands/network/http/patch.rs
@@ -31,8 +31,8 @@ fn http_patch_failed_due_to_server_error() -> Result {
         .run_with_data(code, server.url())
         .expect_shell_error()?;
     match err {
-        ShellError::NetworkFailure { msg, .. } => {
-            assert_contains("Bad request (400)", msg);
+        ShellError::HttpError { msg, .. } => {
+            assert_contains("Bad Request", msg);
             Ok(())
         }
         err => Err(err.into()),
@@ -69,8 +69,8 @@ fn http_patch_failed_due_to_unexpected_body() -> Result {
         .expect_shell_error()?;
 
     match err {
-        ShellError::NetworkFailure { msg, .. } => {
-            assert_contains("Cannot make request", msg);
+        ShellError::HttpError { msg, .. } => {
+            assert_contains("Not Implemented", msg);
             Ok(())
         }
         err => Err(err.into()),

--- a/crates/nu-command/tests/commands/network/http/post.rs
+++ b/crates/nu-command/tests/commands/network/http/post.rs
@@ -30,8 +30,8 @@ fn http_post_failed_due_to_server_error() -> Result {
         .run_with_data(code, server.url())
         .expect_shell_error()?;
     match err {
-        ShellError::NetworkFailure { msg, .. } => {
-            assert_contains("Bad request (400)", msg);
+        ShellError::HttpError { msg, .. } => {
+            assert_contains("Bad Request", msg);
             Ok(())
         }
         err => Err(err.into()),
@@ -68,8 +68,8 @@ fn http_post_failed_due_to_unexpected_body() -> Result {
         .expect_shell_error()?;
 
     match err {
-        ShellError::NetworkFailure { msg, .. } => {
-            assert_contains("Cannot make request", msg);
+        ShellError::HttpError { msg, .. } => {
+            assert_contains("Not Implemented", msg);
             Ok(())
         }
         err => Err(err.into()),

--- a/crates/nu-command/tests/commands/network/http/put.rs
+++ b/crates/nu-command/tests/commands/network/http/put.rs
@@ -31,8 +31,8 @@ fn http_put_failed_due_to_server_error() -> Result {
         .run_with_data(code, server.url())
         .expect_shell_error()?;
     match err {
-        ShellError::NetworkFailure { msg, .. } => {
-            assert_contains("Bad request (400)", msg);
+        ShellError::HttpError { msg, .. } => {
+            assert_contains("Bad Request", msg);
             Ok(())
         }
         err => Err(err.into()),
@@ -69,8 +69,8 @@ fn http_put_failed_due_to_unexpected_body() -> Result {
         .expect_shell_error()?;
 
     match err {
-        ShellError::NetworkFailure { msg, .. } => {
-            assert_contains("Cannot make request", msg);
+        ShellError::HttpError { msg, .. } => {
+            assert_contains("Not Implemented", msg);
             Ok(())
         }
         err => Err(err.into()),

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -832,8 +832,8 @@ pub enum ShellError {
         code: u16,
         reason: &'static str,
         url: String,
-        response: String,
-        #[label("{response}")]
+        msg: String,
+        #[label("{msg}")]
         span: Span,
     },
 

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -821,6 +821,22 @@ pub enum ShellError {
         span: Span,
     },
 
+    /// An HTTP request return an error code.
+    ///
+    /// ## Resolution
+    ///
+    /// Check the response body for more details.
+    #[error("HTTP Error {code} ({reason}): {url}")]
+    #[diagnostic(code(nu::shell::http_error))]
+    HttpError {
+        code: u16,
+        reason: &'static str,
+        url: String,
+        response: String,
+        #[label("{response}")]
+        span: Span,
+    },
+
     #[error(transparent)]
     #[diagnostic(transparent)]
     Network(#[from] network::NetworkError),


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

When a failure occurs with an external API, the body of the response usually contains information about the error.

This commit uses that body as the error message when such an error occurs, so the user gets immediate feedback instead of a generic message about getting a 400. This is especially useful during interactive use when experimenting with an API.

This behaviour is only enabled when the response is application/json, as a proxy for "is an API, and the body is likely to be relevant".

Before: 
<img width="697" height="146" alt="image" src="https://github.com/user-attachments/assets/a44ef0e7-2940-41fb-b97f-f38275a79539" />

After:
<img width="732" height="323" alt="image" src="https://github.com/user-attachments/assets/4d8f68e9-fe52-4440-8342-5c9d4cb5d755" />

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
The http commands now use the response body as error message when getting an error response.

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
Fixes #15091