### PR TITLE
refactor exit logic

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -12,7 +12,7 @@ use crate::{
     prompt_update,
     reedline_config::{KeybindingsMode, add_menus, create_keybindings},
     syntax_highlight::NoOpHighlighter,
-    util::eval_source,
+    util::{eval_source, evaluate_source},
 };
 use crossterm::cursor::SetCursorStyle;
 use log::{error, trace, warn};
@@ -21,13 +21,13 @@ use nu_cmd_base::util::get_editor;
 use nu_color_config::StyleComputer;
 use nu_engine::env_to_strings;
 use nu_engine::exit::cleanup_exit;
-use nu_parser::{lex, parse, trim_quotes_str};
+use nu_parser::{lex, trim_quotes_str};
 use nu_protocol::shell_error::io::IoError;
 use nu_protocol::{BannerKind, ShellIntegrationConfig, shell_error};
 use nu_protocol::{
     Config, HistoryConfig, HistoryFileFormat, PipelineData, ShellError, Span, Spanned, Value,
     config::NuCursorShape,
-    engine::{EngineState, Stack, StateWorkingSet},
+    engine::{EngineState, Stack},
     report_shell_error,
 };
 use nu_utils::time::Instant;
@@ -1053,40 +1053,32 @@ fn do_run_cmd(
 ) -> Reedline {
     trace!("eval source: {s}");
 
-    let mut cmds = s.split_whitespace();
-
     let had_warning_before = engine_state.exit_warning_given.load(Ordering::SeqCst);
-
-    if let Some("exit") = cmds.next() {
-        let mut working_set = StateWorkingSet::new(engine_state);
-        let _ = parse(&mut working_set, None, s.as_bytes(), false);
-
-        if working_set.parse_errors.is_empty() {
-            match cmds.next() {
-                Some(s) => {
-                    if let Ok(n) = s.parse::<i32>() {
-                        return cleanup_exit(line_editor, engine_state, n);
-                    }
-                }
-                None => {
-                    return cleanup_exit(line_editor, engine_state, 0);
-                }
-            }
-        }
-    }
 
     if shell_integration_osc2 {
         run_shell_integration_osc2(Some(s), engine_state, stack, use_color);
     }
 
-    eval_source(
+    match evaluate_source(
         engine_state,
         stack,
         s.as_bytes(),
         &format!("repl_entry #{entry_num}"),
         PipelineData::empty(),
         false,
-    );
+    ) {
+        Err(ShellError::Exit { code, .. }) => {
+            return cleanup_exit(line_editor, engine_state, code);
+        }
+        Err(err) => {
+            report_shell_error(Some(stack), engine_state, &err);
+            stack.set_last_error(&err);
+        }
+        Ok(failed) => {
+            let code: i32 = failed.into();
+            stack.set_last_exit_code(code, Span::unknown());
+        }
+    }
 
     // if there was a warning before, and we got to this point, it means
     // the possible call to cleanup_exit did not occur.

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -254,6 +254,9 @@ pub fn eval_source(
             code
         }
         Err(err) => {
+            if let ShellError::Exit { code, .. } = &err {
+                std::process::exit(*code)
+            }
             report_shell_error(Some(stack), engine_state, &err);
             let code = err.exit_code();
             stack.set_last_error(&err);
@@ -279,7 +282,7 @@ pub fn eval_source(
     exit_code
 }
 
-fn evaluate_source(
+pub(crate) fn evaluate_source(
     engine_state: &mut EngineState,
     stack: &mut Stack,
     source: &[u8],

--- a/crates/nu-command/src/shells/exit.rs
+++ b/crates/nu-command/src/shells/exit.rs
@@ -1,7 +1,4 @@
-use nu_engine::{
-    command_prelude::*,
-    exit::{cleanup, cleanup_exit},
-};
+use nu_engine::{command_prelude::*, exit::cleanup};
 
 #[derive(Clone)]
 pub struct Exit;
@@ -44,12 +41,21 @@ impl Command for Exit {
         let exit_code = exit_code.map_or(0, |it| it as i32);
 
         if abort {
-            cleanup_exit((), engine_state, exit_code);
-            Ok(Value::nothing(call.head).into_pipeline_data())
+            if cleanup((), engine_state).is_some() {
+                Ok(Value::nothing(call.head).into_pipeline_data())
+            } else {
+                Err(ShellError::Exit {
+                    code: exit_code,
+                    abort: true,
+                })
+            }
         } else if cleanup((), engine_state).is_some() {
             Ok(Value::nothing(call.head).into_pipeline_data())
         } else {
-            Err(ShellError::Exit { code: exit_code })
+            Err(ShellError::Exit {
+                code: exit_code,
+                abort: false,
+            })
         }
     }
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -507,9 +507,6 @@ pub fn eval_block<D: DebugContext>(
     input: PipelineData,
 ) -> Result<PipelineExecutionData, ShellError> {
     let result = eval_ir_block::<D>(engine_state, stack, block, input);
-    if let Err(ShellError::Exit { code }) = &result {
-        std::process::exit(*code)
-    }
     if let Err(err) = &result {
         stack.set_last_error(err);
     }
@@ -526,7 +523,6 @@ pub fn eval_block_with_early_return<D: DebugContext>(
         Err(ShellError::Return { span: _, value }) => Ok(PipelineExecutionData::from(
             PipelineData::value(*value, None),
         )),
-        Err(ShellError::Exit { code }) => std::process::exit(code),
         x => x,
     }
 }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -280,7 +280,7 @@ fn eval_ir_block_impl<D: DebugContext>(
             Err(err @ (ShellError::Continue { .. } | ShellError::Break { .. })) => {
                 return Err(err);
             }
-            Err(err @ (ShellError::Return { .. } | ShellError::Exit { .. })) => {
+            Err(err @ (ShellError::Return { .. } | ShellError::Exit { abort: false, .. })) => {
                 if let Some(always_run_handler) =
                     ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
                 {
@@ -293,6 +293,9 @@ fn eval_ir_block_impl<D: DebugContext>(
                     // These block control related errors should be passed through
                     return Err(err);
                 }
+            }
+            Err(err @ ShellError::Exit { abort: true, .. }) => {
+                return Err(err);
             }
             Err(err) => {
                 #[cfg(unix)]

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1170,7 +1170,7 @@ pub enum ShellError {
             "This shouldn't happen. Please file an issue: https://github.com/nushell/nushell/issues"
         )
     )]
-    Exit { code: i32 },
+    Exit { code: i32, abort: bool },
 
     /// The code being executed called itself too many times.
     ///

--- a/src/run.rs
+++ b/src/run.rs
@@ -7,7 +7,7 @@ use log::trace;
 use nu_cli::read_plugin_file;
 use nu_cli::{EvaluateCommandsOpts, evaluate_commands, evaluate_file, evaluate_repl};
 use nu_protocol::{
-    PipelineData, Spanned,
+    PipelineData, ShellError, Spanned,
     engine::{EngineState, Stack},
     report_shell_error,
 };
@@ -103,6 +103,9 @@ pub(crate) fn run_commands(
     perf!("evaluate_commands", start_time, use_color);
 
     if let Err(err) = result {
+        if let ShellError::Exit { code, .. } = &err {
+            std::process::exit(*code)
+        }
         report_shell_error(Some(&stack), engine_state, &err);
         std::process::exit(err.exit_code().unwrap_or(0));
     }
@@ -175,6 +178,9 @@ pub(crate) fn run_file(
     perf!("evaluate_file", start_time, use_color);
 
     if let Err(err) = result {
+        if let ShellError::Exit { code, .. } = &err {
+            std::process::exit(*code)
+        }
         report_shell_error(Some(&stack), engine_state, &err);
         std::process::exit(err.exit_code().unwrap_or(0));
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
Removed an exception on the repl that intercepted `exit` followed by an optional int and exited nushell directly. This was to `drop` the reedline object before exiting in order to restore the cursor (#9314), but it wouldn't work if the `exit` was after a pipeline, or inside a custom command, etc.

Now, the cursor restoring should happen regardless of how you call `exit` and it will also remove the confusing behavior when you shadow `exit` with a custom command, as that would be ignored when typing `exit` but not `print test ; exit` for example.

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
Typing `exit` in the repl will no longer use a different logic and will call the `exit` command normally. Furthermore, any invocation of `exit` (e.g. inside a keybind of custom command) will restore the terminal cursor to the state it was before rather than only in the aforementioned case.

<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->