### PR TITLE
fix: use new highlighter api for better abbr expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7182,8 +7182,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201e8e0160cbe7bb5eb2caccf281e178e77fac95115ab31a2c29edc5593603c8"
+source = "git+https://github.com/nushell/reedline?branch=main#bab11cfda424c940bf681c4864d1c1cd51199984"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -461,7 +461,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # nu-ansi-term = { git = "https://github.com/nushell/nu-ansi-term.git", branch = "main" }
 
 # Run all benchmarks with `cargo bench`

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -8,7 +8,7 @@ use nu_protocol::{
     ast::{Block, Expr, Expression, PipelineRedirection, RecordItem},
     engine::{EngineState, Stack, StateWorkingSet},
 };
-use reedline::{Highlighter, StyledText};
+use reedline::{AbbrExpandContext, Highlighter, StyledText};
 use std::sync::{Arc, Mutex};
 
 struct HighlightCache {
@@ -44,7 +44,7 @@ impl Highlighter for NuHighlighter {
         result.text
     }
 
-    fn is_inside_string_literal(&self, line: &str, cursor: usize) -> bool {
+    fn should_expand_abbr(&self, line: &str, cursor: usize, context: AbbrExpandContext) -> bool {
         let (global_span_offset, shapes) = match self
             .cache
             .lock()
@@ -65,15 +65,21 @@ impl Highlighter for NuHighlighter {
         };
 
         let global_cursor = cursor + global_span_offset;
-        shapes.iter().any(|(span, shape)| {
+        !shapes.iter().any(|(span, shape)| {
             span.contains(global_cursor)
-                && matches!(
-                    shape,
-                    FlatShape::String
-                        | FlatShape::RawString
-                        | FlatShape::StringInterpolation
-                        | FlatShape::ExternalArg
-                )
+                && match context {
+                    AbbrExpandContext::WordAbbreviation => matches!(
+                        shape,
+                        FlatShape::String
+                            | FlatShape::RawString
+                            | FlatShape::StringInterpolation
+                            | FlatShape::ExternalArg
+                    ),
+                    AbbrExpandContext::BangExpansion => matches!(
+                        shape,
+                        FlatShape::String | FlatShape::RawString | FlatShape::StringInterpolation
+                    ),
+                }
         })
     }
 }
@@ -586,7 +592,7 @@ fn get_char_length(c: char) -> usize {
 mod tests {
     use super::NuHighlighter;
     use nu_protocol::engine::{EngineState, Stack};
-    use reedline::Highlighter;
+    use reedline::{AbbrExpandContext, Highlighter};
     use rstest::rstest;
     use std::sync::Arc;
 
@@ -596,41 +602,74 @@ mod tests {
 
     #[rstest]
     // 4-byte emoji
-    #[case("\"hello 🎉\" hi", 7, true)] // first byte of 🎉
-    #[case("\"hello 🎉\" hi", 9, true)] // third byte of 🎉
-    #[case("\"hello 🎉\" hi", 13, false)] // after closing quote
+    #[case("\"hello 🎉\" hi", 7, false)] // first byte of 🎉
+    #[case("\"hello 🎉\" hi", 9, false)] // third byte of 🎉
+    #[case("\"hello 🎉\" hi", 13, true)] // after closing quote
     // 8-byte zwj emoji
-    #[case("\"hello 🤝🏿\" hi", 9, true)] // inside 🤝
-    #[case("\"hello 🤝🏿\" hi", 11, true)] // first byte of 🏿
-    #[case("\"hello 🤝🏿\" hi", 13, true)] // inside 🏿
-    #[case("\"hello 🤝🏿\" hi", 17, false)] // after closing quote
+    #[case("\"hello 🤝🏿\" hi", 9, false)] // inside 🤝
+    #[case("\"hello 🤝🏿\" hi", 11, false)] // first byte of 🏿
+    #[case("\"hello 🤝🏿\" hi", 13, false)] // inside 🏿
+    #[case("\"hello 🤝🏿\" hi", 17, true)] // after closing quote
     // 3-byte unicode
-    #[case("\"こんにちは\" hi", 2, true)] // inside こ
-    #[case("\"こんにちは\" hi", 5, true)] // inside ん
-    #[case("\"こんにちは\" hi", 13, true)] // start of は
-    #[case("\"こんにちは\" hi", 18, false)] // after closing quote
+    #[case("\"こんにちは\" hi", 2, false)] // inside こ
+    #[case("\"こんにちは\" hi", 5, false)] // inside ん
+    #[case("\"こんにちは\" hi", 13, false)] // start of は
+    #[case("\"こんにちは\" hi", 18, true)] // after closing quote
     // raw string
-    #[case("r#'hello'# hi", 4, true)] // inside 'e'
-    #[case("r#'hello'# hi", 11, false)] // after closing #
+    #[case("r#'hello'# hi", 4, false)] // inside 'e'
+    #[case("r#'hello'# hi", 11, true)] // after closing #
     // string interpolation
-    #[case("$\"hello\" hi", 0, true)] // $ — opening StringInterpolation span (0..2)
-    #[case("$\"hello\" hi", 4, true)] // inside literal 'hello'
-    #[case("$\"hello\" hi", 9, false)] // after closing quote
+    #[case("$\"hello\" hi", 0, false)] // $ — opening StringInterpolation span (0..2)
+    #[case("$\"hello\" hi", 4, false)] // inside literal 'hello'
+    #[case("$\"hello\" hi", 9, true)] // after closing quote
     // no string
-    #[case("1 + 2", 0, false)]
-    #[case("1 + 2", 2, false)]
-    // ExternalArg is treated as a string literal to suppress abbreviation expansion in external commands
-    #[case("ls -la", 0, false)] // on 'ls'  — FlatShape::External
-    #[case("ls -la", 3, true)] // on '-la' — FlatShape::ExternalArg
-    #[case("bash -c \"echo hello\"", 0, false)] // on 'bash'            — FlatShape::External
-    #[case("bash -c \"echo hello\"", 5, true)] // on '-c'              — FlatShape::ExternalArg
-    #[case("bash -c \"echo hello\"", 10, true)] // inside "echo hello"  — FlatShape::ExternalArg
-    fn test_is_inside_string_literal(
+    #[case("1 + 2", 0, true)]
+    #[case("1 + 2", 2, true)]
+    // suppress abbreviation expansion in external commands
+    #[case("ls -la", 0, true)] // on 'ls'  — FlatShape::External
+    #[case("ls -la", 3, false)] // on '-la' — FlatShape::ExternalArg
+    #[case("bash -c \"echo hello\"", 0, true)] // on 'bash'            — FlatShape::External
+    #[case("bash -c \"echo hello\"", 5, false)] // on '-c'              — FlatShape::ExternalArg
+    #[case("bash -c \"echo hello\"", 10, false)] // inside "echo hello"  — FlatShape::ExternalArg
+    fn test_should_expand_word_abbr(
         #[case] line: &str,
         #[case] cursor: usize,
         #[case] expected: bool,
     ) {
         let h = make_highlighter();
-        assert_eq!(h.is_inside_string_literal(line, cursor), expected);
+        assert_eq!(
+            h.should_expand_abbr(line, cursor, AbbrExpandContext::WordAbbreviation),
+            expected
+        );
+    }
+
+    #[rstest]
+    // bare bang expressions allow expansion
+    #[case("!!", 0, true)]
+    #[case("!!", 1, true)]
+    #[case("!ls", 0, true)]
+    #[case("!ls", 2, true)]
+    #[case("!-1", 1, true)]
+    // bang inside string literals suppresses expansion
+    #[case("\"!!\"", 1, false)]
+    #[case("\"!ls\"", 2, false)]
+    #[case("r#'!!'#", 3, false)]
+    #[case("$\"!!\"", 2, false)]
+    // bang as external arg does not suppress expansion
+    #[case("bash -c !!", 9, true)]
+    #[case("bash -c !ls", 9, true)]
+    // bang inside a string that is itself an external arg — shape is ExternalArg, not String.
+    // currently there is no way to avoid this
+    #[case("echo \"hi !!\"", 9, true)]
+    fn test_should_expand_abbr_bang(
+        #[case] line: &str,
+        #[case] cursor: usize,
+        #[case] expected: bool,
+    ) {
+        let h = make_highlighter();
+        assert_eq!(
+            h.should_expand_abbr(line, cursor, AbbrExpandContext::BangExpansion),
+            expected
+        );
     }
 }

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -647,11 +647,11 @@ mod tests {
     #[case("!ls", 0, true)]
     #[case("!ls", 2, true)]
     #[case("!-1", 1, true)]
-    // bang inside string literals suppresses expansion
-    #[case("\"!!\"", 1, false)]
-    #[case("\"!ls\"", 2, false)]
-    #[case("r#'!!'#", 3, false)]
-    #[case("$\"!!\"", 2, false)]
+    // bang inside string literals does not suppress expansion
+    #[case("\"!!\"", 1, true)]
+    #[case("\"!ls\"", 2, true)]
+    #[case("r#'!!'#", 3, true)]
+    #[case("$\"!!\"", 2, true)]
     // bang as external arg does not suppress expansion
     #[case("bash -c !!", 9, true)]
     #[case("bash -c !ls", 9, true)]

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -75,10 +75,7 @@ impl Highlighter for NuHighlighter {
                             | FlatShape::StringInterpolation
                             | FlatShape::ExternalArg
                     ),
-                    AbbrExpandContext::BangExpansion => matches!(
-                        shape,
-                        FlatShape::String | FlatShape::RawString | FlatShape::StringInterpolation
-                    ),
+                    AbbrExpandContext::BangExpansion => false,
                 }
         })
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
- fixes #18315 

sorry been busy this week so i was delayed getting this up @fdncred 

note that for internal calls such as `echo` the expansion 'bug' described in #18315 would still occur since the bang expression is parsed as a string which we've marked as a non-expansion condition. not sure if/how we want to get around that.

also, running `cargo update -p reedline` isn't updating reedline to the latest commit -- any help there?