### PR TITLE
fix a problem with glob and rm

### DIFF
--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -903,3 +903,37 @@ fn ls_dc_glob_wildcard_then_literal_metadata_populated() -> Result {
 
     Ok(())
 }
+
+#[test]
+#[exp(nu_experimental::DC_GLOB)]
+fn ls_literal_directory() -> Result {
+    Playground::setup("ls_literal_dir_dc", |dirs, sandbox| {
+        sandbox
+            .within("subdir")
+            .with_files(&[EmptyFile("test.txt")]);
+
+        test()
+            .cwd(dirs.root())
+            .run("ls ls_literal_dir_dc/subdir | length")
+            .expect_value_eq(1)
+            .expect("ls literal directory should list its contents with dc-glob");
+    });
+
+    Ok(())
+}
+
+#[test]
+#[exp(nu_experimental::DC_GLOB)]
+fn ls_literal_empty_directory() -> Result {
+    Playground::setup("ls_literal_empty_dir_dc", |dirs, sandbox| {
+        sandbox.mkdir("emptydir");
+
+        test()
+            .cwd(dirs.root())
+            .run("ls ls_literal_empty_dir_dc/emptydir | length")
+            .expect_value_eq(0)
+            .expect("ls literal empty directory should not error with dc-glob");
+    });
+
+    Ok(())
+}

--- a/crates/nu-command/tests/commands/move_/umv.rs
+++ b/crates/nu-command/tests/commands/move_/umv.rs
@@ -736,3 +736,22 @@ fn mv_verbose_message_mentions_source_and_destination() {
         assert!(!dirs.test().join("before.txt").exists());
     });
 }
+
+#[test]
+#[exp(nu_experimental::DC_GLOB)]
+fn mv_literal_directory() {
+    Playground::setup("mv_literal_dir_dc", |dirs, sandbox| {
+        sandbox
+            .within("subdir")
+            .with_files(&[EmptyFile("test.txt")]);
+        sandbox.mkdir("dest");
+
+        nu!(
+            cwd: dirs.root(),
+            "mv mv_literal_dir_dc/subdir mv_literal_dir_dc/dest"
+        );
+
+        assert!(!dirs.test().join("subdir").exists());
+        assert!(dirs.test().join("dest/subdir/test.txt").exists());
+    })
+}

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -660,3 +660,20 @@ fn rm_already_in_use() {
         assert!(!outcome.status.success())
     })
 }
+
+#[test]
+#[exp(nu_experimental::DC_GLOB)]
+fn removes_literal_directory_with_recursive_flag() {
+    Playground::setup("rm_literal_dir_dc", |dirs, sandbox| {
+        sandbox
+            .within("subdir")
+            .with_files(&[EmptyFile("test.txt")]);
+
+        nu!(
+            cwd: dirs.root(),
+            "rm rm_literal_dir_dc/subdir --recursive"
+        );
+
+        assert!(!dirs.test().join("subdir").exists());
+    })
+}

--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -1391,3 +1391,21 @@ fn test_cp_wildcards() {
         assert!(files_exist_at(&[".a"], dirs.test()));
     });
 }
+
+#[test]
+#[exp(nu_experimental::DC_GLOB)]
+fn cp_literal_directory_with_recursive_flag() {
+    Playground::setup("cp_literal_dir_dc", |dirs, sandbox| {
+        sandbox
+            .within("subdir")
+            .with_files(&[EmptyFile("test.txt")]);
+        sandbox.mkdir("dest");
+
+        nu!(
+            cwd: dirs.root(),
+            "cp cp_literal_dir_dc/subdir cp_literal_dir_dc/dest --recursive"
+        );
+
+        assert!(dirs.test().join("dest/subdir/test.txt").exists());
+    })
+}

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -108,10 +108,12 @@ pub fn glob_from(
 
     if nu_experimental::DC_GLOB.get() {
         let pattern_path = PathBuf::from(&pattern);
-        // If the resolved pattern is an existing non-directory (regular file or symlink to a file),
-        // return it directly. Passing a plain file path to glob_from_interruptible would make the
-        // traversal engine call read_dir() on it, which fails with "Not a directory (os error 20)".
-        if pattern_path.exists() && !pattern_path.is_dir() {
+        // If the resolved pattern is an existing path, return it directly.
+        // Passing a plain path to glob_from_interruptible makes the traversal engine
+        // call read_dir() on it, which either fails with "Not a directory" (for files)
+        // or iterates the directory's contents instead of matching the directory itself
+        // (for directories), both of which produce incorrect empty results.
+        if pattern_path.exists() {
             return Ok((prefix, Box::new(std::iter::once(Ok(pattern_path)))));
         }
 
@@ -173,7 +175,7 @@ mod tests {
     use super::glob_from;
     use nu_protocol::{NuGlob, Signals, Span, Spanned};
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -262,6 +264,62 @@ mod tests {
             remaining < 6000,
             "expected interrupt to stop iteration before full drain; remaining={remaining}"
         );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    #[exp(nu_experimental::DC_GLOB)]
+    fn glob_from_dc_glob_matches_literal_file() {
+        let root = unique_test_dir("literal_file");
+        fs::create_dir_all(&root).expect("failed to create root");
+        let file = root.join("test.txt");
+        write_file(&file);
+
+        let ctrlc = Arc::new(AtomicBool::new(false));
+        let signals = Signals::new(ctrlc);
+        let pattern = Spanned {
+            item: NuGlob::Expand(file.to_string_lossy().to_string()),
+            span: Span::test_data(),
+        };
+
+        let result = glob_from(&pattern, Path::new("/"), Span::test_data(), None, signals);
+        assert!(result.is_ok(), "glob_from failed");
+
+        let (_, mut iter) = result.unwrap();
+        let first = iter.next();
+        assert!(
+            matches!(first, Some(Ok(ref p)) if *p == file),
+            "expected file path itself, got: {first:?}"
+        );
+        assert!(iter.next().is_none(), "expected exactly one result");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    #[exp(nu_experimental::DC_GLOB)]
+    fn glob_from_dc_glob_matches_literal_directory() {
+        let root = unique_test_dir("literal_dir");
+        fs::create_dir_all(&root).expect("failed to create root");
+
+        let ctrlc = Arc::new(AtomicBool::new(false));
+        let signals = Signals::new(ctrlc);
+        let pattern = Spanned {
+            item: NuGlob::Expand(root.to_string_lossy().to_string()),
+            span: Span::test_data(),
+        };
+
+        let result = glob_from(&pattern, Path::new("/"), Span::test_data(), None, signals);
+        assert!(result.is_ok(), "glob_from failed");
+
+        let (_, mut iter) = result.unwrap();
+        let first = iter.next();
+        assert!(
+            matches!(first, Some(Ok(ref p)) if *p == root),
+            "expected directory path itself, got: {first:?}"
+        );
+        assert!(iter.next().is_none(), "expected exactly one result");
 
         let _ = fs::remove_dir_all(&root);
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR fixes another bug found by @Tyarel8 on Discord where globbing was preventing removing of folders.

<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
Fix a bug with dcglob fixing a problem with rm.

<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->