### PR TITLE
also use experimental_options env variable when loading config

### DIFF
--- a/src/experimental_options.rs
+++ b/src/experimental_options.rs
@@ -76,10 +76,13 @@ pub fn load(engine_state: &EngineState, cli_args: &NushellCliArgs, has_script: b
 
 // Disable experimental options when not loading config files (for NU_EXPERIMENTAL_OPTIONS env).
 fn should_disable_experimental_options(has_script: bool, cli_args: &NushellCliArgs) -> bool {
-    cli_args.no_config_file.is_some()
-        || (has_script && cli_args.config_file.is_none() && cli_args.env_file.is_none())
-        || (cli_args.commands.is_some()
-            && cli_args.login_shell.is_none()
-            && cli_args.config_file.is_none()
-            && cli_args.env_file.is_none())
+    let no_config_flag = cli_args.no_config_file.is_some();
+    let running_script_without_config =
+        has_script && cli_args.config_file.is_none() && cli_args.env_file.is_none();
+    let running_command_without_config = cli_args.commands.is_some()
+        && cli_args.login_shell.is_none()
+        && cli_args.config_file.is_none()
+        && cli_args.env_file.is_none();
+
+    no_config_flag || running_script_without_config || running_command_without_config
 }

--- a/src/experimental_options.rs
+++ b/src/experimental_options.rs
@@ -77,5 +77,8 @@ pub fn load(engine_state: &EngineState, cli_args: &NushellCliArgs, has_script: b
 fn should_disable_experimental_options(has_script: bool, cli_args: &NushellCliArgs) -> bool {
     has_script
         || cli_args.no_config_file.is_some()
-        || (cli_args.commands.is_some() && cli_args.login_shell.is_none())
+        || (cli_args.commands.is_some()
+            && cli_args.login_shell.is_none()
+            && cli_args.config_file.is_none()
+            && cli_args.env_file.is_none())
 }

--- a/src/experimental_options.rs
+++ b/src/experimental_options.rs
@@ -76,8 +76,6 @@ pub fn load(engine_state: &EngineState, cli_args: &NushellCliArgs, has_script: b
 
 fn should_disable_experimental_options(has_script: bool, cli_args: &NushellCliArgs) -> bool {
     has_script
-        || cli_args.commands.is_some()
-        || cli_args.execute.is_some()
         || cli_args.no_config_file.is_some()
-        || cli_args.login_shell.is_some()
+        || (cli_args.commands.is_some() && cli_args.login_shell.is_none())
 }

--- a/src/experimental_options.rs
+++ b/src/experimental_options.rs
@@ -74,9 +74,10 @@ pub fn load(engine_state: &EngineState, cli_args: &NushellCliArgs, has_script: b
     }
 }
 
+// Disable experimental options when not loading config files (for NU_EXPERIMENTAL_OPTIONS env).
 fn should_disable_experimental_options(has_script: bool, cli_args: &NushellCliArgs) -> bool {
-    has_script
-        || cli_args.no_config_file.is_some()
+    cli_args.no_config_file.is_some()
+        || (has_script && cli_args.config_file.is_none() && cli_args.env_file.is_none())
         || (cli_args.commands.is_some()
             && cli_args.login_shell.is_none()
             && cli_args.config_file.is_none()


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
Changed so that `NU_EXPERIMENTAL_OPTIONS` environment variable will be used when calling nushell with config like with `nu -e command` or `nu -l -c command`. I think it makes sense to use the env by default when nushell is loading config since it can depend on the experimental options and error otherwise. If you don't want to for some reason you can hide the env or change it.

## User-facing changes (Release notes)
If the `NU_EXPERIMENTAL_OPTIONS` environment variable is set, it will be used when running nushell with the `--login` or `--execute` flags since they also load config.


<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->