### PR TITLE
Refactor type checking code.

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -6,7 +6,7 @@ use nu_parser::{lex, lite_parse, parse, parse_block};
 use nu_plugin_core::{Encoder, EncodingType};
 use nu_plugin_protocol::{PluginCallResponse, PluginOutput};
 use nu_protocol::{
-    PipelineData, Signals, Span, Spanned, Type, Value,
+    PipelineData, Signals, Span, Spanned, Type, TypeSet, Value,
     engine::{EngineState, Stack, StateWorkingSet},
 };
 use nu_std::load_standard_library;
@@ -672,7 +672,7 @@ fn bench_type_widen_simple() -> impl IntoBenchmarks {
     [benchmark_fn("type_widen_simple", move |bench| {
         let a = a.clone();
         let b = b.clone();
-        bench.iter(move || black_box(a.clone().widen(b.clone())))
+        bench.iter(move || black_box(a.clone().union(b.clone())))
     })]
 }
 
@@ -682,7 +682,7 @@ fn bench_type_widen_large_records() -> impl IntoBenchmarks {
     [benchmark_fn("type_widen_large_records", move |bench| {
         let rec1 = rec1.clone();
         let rec2 = rec2.clone();
-        bench.iter(move || black_box(rec1.clone().widen(rec2.clone())))
+        bench.iter(move || black_box(rec1.clone().union(rec2.clone())))
     })]
 }
 
@@ -700,20 +700,20 @@ fn bench_type_widen_large_oneof() -> impl IntoBenchmarks {
     [benchmark_fn("type_widen_large_oneof", move |bench| {
         let one = one.clone();
         let two = two.clone();
-        bench.iter(move || black_box(one.clone().widen(two.clone())))
+        bench.iter(move || black_box(one.clone().union(two.clone())))
     })]
 }
 
 fn bench_type_widen_chain() -> impl IntoBenchmarks {
     let mut t = Type::String;
     for _ in 0..100 {
-        t = t.widen(Type::Int);
+        t = t.union(Type::Int);
     }
     [benchmark_fn("type_widen_chain", move |bench| {
         let t = t.clone();
         bench.iter(move || {
             let mut tmp = t.clone();
-            tmp = tmp.widen(Type::Int);
+            tmp = tmp.union(Type::Int);
             black_box(tmp)
         })
     })]

--- a/crates/nu-cli/src/completions/cell_path_completions.rs
+++ b/crates/nu-cli/src/completions/cell_path_completions.rs
@@ -158,7 +158,6 @@ fn get_suggestions_by_value(
 fn get_suggestions_by_type(ty: &Type, current_span: reedline::Span) -> Vec<SemanticSuggestion> {
     match ty {
         Type::Record(columns) | Type::Table(columns) => columns
-            .fields
             .iter()
             .map(|(name, ty)| SemanticSuggestion {
                 suggestion: Suggestion {

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -1,7 +1,8 @@
 use itertools::Itertools;
 use nu_engine::{command_prelude::*, compile};
 use nu_protocol::{
-    Range, ast::Block, debugger::WithoutDebug, engine::StateWorkingSet, report_shell_error,
+    CompareTypes, Range, ast::Block, debugger::WithoutDebug, engine::StateWorkingSet,
+    report_shell_error,
 };
 use std::{
     sync::Arc,

--- a/crates/nu-cmd-lang/tests/commands/describe.rs
+++ b/crates/nu-cmd-lang/tests/commands/describe.rs
@@ -36,6 +36,6 @@ fn test_oneof_flattening_in_describe_glob_string() {
 fn test_oneof_flattening_in_describe_glob_string_reverse_order() {
     let result =
         nu!("do { let g: glob = \"*.rs\"; [ {content: \"README.rs\"} {content: $g} ] | describe }");
-    assert!(result.out.contains("table<content: oneof<string, glob>>"));
+    assert_eq!("table<content: oneof<string, glob>>", result.out);
     assert!(!result.out.contains("oneof<oneof<"));
 }

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -43,7 +43,7 @@ impl Command for Rm {
                             ("deleted".to_string(), Type::Bool),
                             (
                                 "error".to_string(),
-                                Type::OneOf([Type::Nothing, Type::String].into()),
+                                Type::one_of(vec![Type::Nothing, Type::String]),
                             ),
                         ]
                         .into(),

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -43,7 +43,7 @@ impl Command for Rm {
                             ("deleted".to_string(), Type::Bool),
                             (
                                 "error".to_string(),
-                                Type::one_of(vec![Type::Nothing, Type::String]),
+                                Type::one_of([Type::Nothing, Type::String]),
                             ),
                         ]
                         .into(),

--- a/crates/nu-command/src/filesystem/umkdir.rs
+++ b/crates/nu-command/src/filesystem/umkdir.rs
@@ -51,7 +51,7 @@ impl Command for UMkdir {
                             ("created".to_string(), Type::Bool),
                             (
                                 "error".to_string(),
-                                Type::OneOf([Type::Nothing, Type::String].into()),
+                                Type::one_of([Type::Nothing, Type::String]),
                             ),
                         ]
                         .into(),

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -67,13 +67,10 @@ impl Command for Watch {
                     Type::Table(
                         vec![
                             ("operation".into(), Type::String),
-                            (
-                                "path".into(),
-                                Type::OneOf([Type::String, Type::Nothing].into()),
-                            ),
+                            ("path".into(), Type::one_of([Type::String, Type::Nothing])),
                             (
                                 "new_path".into(),
-                                Type::OneOf([Type::String, Type::Nothing].into()),
+                                Type::one_of([Type::String, Type::Nothing]),
                             ),
                         ]
                         .into(),

--- a/crates/nu-command/src/filters/sort.rs
+++ b/crates/nu-command/src/filters/sort.rs
@@ -168,7 +168,6 @@ impl Command for Sort {
                 let mut vec = value.into_list().expect("matched list above");
                 if let Type::Table(cols) = r#type {
                     let columns: Vec<Comparator> = cols
-                        .fields
                         .iter()
                         .map(|col| {
                             vec![PathMember::string(

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -48,14 +48,8 @@ where
         Signature::build(self.name())
             .category(Category::Hash)
             .input_output_types(vec![
-                (
-                    Type::String,
-                    Type::OneOf(Box::new([Type::String, Type::Binary])),
-                ),
-                (
-                    Type::Binary,
-                    Type::OneOf(Box::new([Type::String, Type::Binary])),
-                ),
+                (Type::String, Type::one_of([Type::String, Type::Binary])),
+                (Type::Binary, Type::one_of([Type::String, Type::Binary])),
                 (Type::table(), Type::table()),
                 (Type::record(), Type::record()),
             ])

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -2,8 +2,8 @@
 use crate::get_full_help;
 use crate::{EvalBlockWithEarlyReturnFn, eval_ir::eval_ir_block};
 use nu_protocol::{
-    BlockId, Config, ENV_VARIABLE_ID, IntoPipelineData, PipelineData, PipelineExecutionData,
-    ShellError, Signature, Span, Value, VarId,
+    BlockId, CompareTypes, Config, ENV_VARIABLE_ID, IntoPipelineData, PipelineData,
+    PipelineExecutionData, ShellError, Signature, Span, Value, VarId,
     ast::{Assignment, Block, Call, Expr, Expression, ExternalArgument, PathMember},
     debugger::{DebugContext, WithDebug, WithoutDebug},
     engine::{Closure, EngineState, EnvName, EnvVars, Stack},

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -4,9 +4,9 @@ use nu_path::{dots::expand_ndots_safe, expand_path, expand_path_with, expand_til
 #[cfg(feature = "os")]
 use nu_protocol::process::check_exit_status_future;
 use nu_protocol::{
-    DeclId, ENV_VARIABLE_ID, Flag, IntoPipelineData, IntoSpanned, ListStream, OutDest,
-    PipelineData, PipelineExecutionData, PositionalArg, Range, Record, RegId, ShellError, Signals,
-    Signature, Span, Spanned, Type, Value, VarId,
+    CompareTypes, DeclId, ENV_VARIABLE_ID, Flag, IntoPipelineData, IntoSpanned, ListStream,
+    OutDest, PipelineData, PipelineExecutionData, PositionalArg, Range, Record, RegId, ShellError,
+    Signals, Signature, Span, Spanned, Type, Value, VarId,
     ast::{Bits, Block, Boolean, CellPath, Comparison, Math, Operator},
     combined_type_string,
     debugger::DebugContext,
@@ -15,8 +15,7 @@ use nu_protocol::{
         StateWorkingSet,
     },
     ir::{Call, DataSlice, Instruction, IrAstRef, IrBlock, Literal, RedirectMode},
-    shell_error::generic::GenericError,
-    shell_error::io::IoError,
+    shell_error::{generic::GenericError, io::IoError},
 };
 use nu_utils::IgnoreCaseExt;
 

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1573,7 +1573,7 @@ fn check_input_types(
     // Check if the input type is compatible with *any* of the command's possible input types
     if io_types
         .iter()
-        .any(|(command_type, _)| input.is_subtype_of(command_type))
+        .any(|(command_type, _)| input.is_assignable_to(command_type))
     {
         return Ok(());
     }

--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -27,8 +27,8 @@ use crate::{
 use itertools::Itertools;
 use log::trace;
 use nu_protocol::{
-    ParseError, PositionalArg, Signature, Span, SyntaxShape, Type, VarId, ast::*,
-    engine::StateWorkingSet,
+    CompareTypes, ParseError, PositionalArg, Signature, Span, SyntaxShape, Type, TypeSet, VarId,
+    ast::*, engine::StateWorkingSet,
 };
 use std::{collections::HashMap, sync::Arc};
 
@@ -173,7 +173,7 @@ pub fn parse_list_expression(
                 };
 
                 contained_type = match contained_type {
-                    Some(ctype) => Some(ctype.widen(ty)),
+                    Some(ctype) => Some(ctype.union(ty)),
                     None => Some(ty),
                 };
 

--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -1893,7 +1893,7 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
             match &inner.ty {
                 Type::Record(inner_fields) => {
                     if let Some(fields) = &mut field_types {
-                        for (field, ty) in inner_fields.fields.as_ref() {
+                        for (field, ty) in inner_fields.iter() {
                             fields.push((field.clone(), ty.clone()));
                         }
                     }

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -1,5 +1,5 @@
 use nu_protocol::{
-    CollectionColumns, ParseError, Span, Type,
+    CollectionColumns, CompareTypes, ParseError, Span, Type,
     ast::{Assignment, Block, Comparison, Expr, Expression, Math, Operator, Pipeline, Range},
     combined_type_string,
     engine::StateWorkingSet,
@@ -42,67 +42,47 @@ fn type_error(
 }
 
 pub fn type_compatible(lhs: &Type, rhs: &Type) -> bool {
-    // Structural subtyping
-    let is_compatible = |expected: &CollectionColumns<Type>, found: &CollectionColumns<Type>| {
-        if expected.fields.is_empty() || found.fields.is_empty() {
-            // We treat an incoming empty table/record type as compatible for typechecking purposes
-            // It is the responsibility of the runtime to reject if necessary
-            true
-        } else if expected.fields.len() > found.fields.len() {
-            false
-        } else {
-            expected.fields.iter().all(|(col_x, ty_x)| {
-                if let Some((_, ty_y)) = found.fields.iter().find(|(col_y, _)| col_x == col_y) {
-                    type_compatible(ty_x, ty_y)
-                } else {
-                    false
-                }
-            })
-        }
-    };
+    fn is_columns_compatible(lhs: &CollectionColumns<Type>, rhs: &CollectionColumns<Type>) -> bool {
+        lhs.is_any() || rhs.is_any() || rhs.is_subtype_of(lhs)
+    }
 
     match (lhs, rhs) {
-        (Type::List(c), Type::List(d)) => type_compatible(c, d),
-        (Type::List(c), Type::Table(table_fields)) => {
-            if matches!(**c, Type::Any) {
-                return true;
-            }
-
-            if let Type::Record(fields) = &**c {
-                is_compatible(fields, table_fields)
-            } else {
-                false
-            }
+        (Type::Table(lhs_cols), Type::List(rhs_ty))
+            if let Type::Record(rhs_cols) = rhs_ty.as_ref() =>
+        {
+            is_columns_compatible(lhs_cols, rhs_cols)
         }
-        (Type::Table(table_fields), Type::List(c)) => {
-            if matches!(**c, Type::Any) {
-                return true;
-            }
-
-            if let Type::Record(fields) = &**c {
-                is_compatible(table_fields, fields)
-            } else {
-                false
-            }
+        (Type::List(lhs_ty), Type::Table(rhs_cols))
+            if let Type::Record(lhs_cols) = lhs_ty.as_ref() =>
+        {
+            is_columns_compatible(lhs_cols, rhs_cols)
         }
-        (Type::Number, Type::Int) => true,
-        (Type::Int, Type::Number) => true,
-        (Type::Number, Type::Float) => true,
-        (Type::Float, Type::Number) => true,
-        (Type::Closure, Type::Block) => true,
-        (Type::Any, _) => true,
-        (_, Type::Any) => true,
         (Type::Record(lhs), Type::Record(rhs)) | (Type::Table(lhs), Type::Table(rhs)) => {
-            is_compatible(lhs, rhs)
+            is_columns_compatible(lhs, rhs)
         }
+        // glob string compatibility is one way
         (Type::Glob, Type::String) => true,
-        (Type::CellPath, other) => {
-            other.is_subtype_of(&Type::CellPath) || Type::CellPath.is_subtype_of(other)
+        (Type::String, Type::Glob) => false,
+        (Type::OneOf(lhs_tys), Type::OneOf(rhs_tys)) => {
+            match (lhs_tys.is_empty(), rhs_tys.is_empty()) {
+                (_, true) => true,
+                (true, _) => false,
+                _ => rhs_tys
+                    .iter()
+                    .any(|rhs_ty| lhs_tys.iter().any(|lhs_ty| type_compatible(lhs_ty, rhs_ty))),
+            }
         }
-        (Type::OneOf(types), u) | (u, Type::OneOf(types)) => {
-            types.iter().any(|t| type_compatible(t, u))
+        (Type::OneOf(lhs_tys), rhs_ty) => {
+            lhs_tys.iter().any(|lhs_ty| type_compatible(lhs_ty, rhs_ty))
         }
-        (lhs, rhs) => lhs == rhs,
+        (lhs_ty, Type::OneOf(rhs_tys)) => {
+            if rhs_tys.is_empty() {
+                true
+            } else {
+                rhs_tys.iter().any(|rhs_ty| type_compatible(lhs_ty, rhs_ty))
+            }
+        }
+        (lhs, rhs) => rhs.compare_types(lhs).is_some(),
     }
 }
 

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -1,5 +1,5 @@
 use nu_protocol::{
-    CollectionColumns, CompareTypes, ParseError, Span, Type,
+    CompareTypes, ParseError, Span, Type,
     ast::{Assignment, Block, Comparison, Expr, Expression, Math, Operator, Pipeline, Range},
     combined_type_string,
     engine::StateWorkingSet,
@@ -41,49 +41,8 @@ fn type_error(
     (Type::Any, Some(err))
 }
 
-pub fn type_compatible(lhs: &Type, rhs: &Type) -> bool {
-    fn is_columns_compatible(lhs: &CollectionColumns<Type>, rhs: &CollectionColumns<Type>) -> bool {
-        lhs.is_any() || rhs.is_any() || rhs.is_subtype_of(lhs)
-    }
-
-    match (lhs, rhs) {
-        (Type::Table(lhs_cols), Type::List(rhs_ty))
-            if let Type::Record(rhs_cols) = rhs_ty.as_ref() =>
-        {
-            is_columns_compatible(lhs_cols, rhs_cols)
-        }
-        (Type::List(lhs_ty), Type::Table(rhs_cols))
-            if let Type::Record(lhs_cols) = lhs_ty.as_ref() =>
-        {
-            is_columns_compatible(lhs_cols, rhs_cols)
-        }
-        (Type::Record(lhs), Type::Record(rhs)) | (Type::Table(lhs), Type::Table(rhs)) => {
-            is_columns_compatible(lhs, rhs)
-        }
-        // glob string compatibility is one way
-        (Type::Glob, Type::String) => true,
-        (Type::String, Type::Glob) => false,
-        (Type::OneOf(lhs_tys), Type::OneOf(rhs_tys)) => {
-            match (lhs_tys.is_empty(), rhs_tys.is_empty()) {
-                (_, true) => true,
-                (true, _) => false,
-                _ => rhs_tys
-                    .iter()
-                    .any(|rhs_ty| lhs_tys.iter().any(|lhs_ty| type_compatible(lhs_ty, rhs_ty))),
-            }
-        }
-        (Type::OneOf(lhs_tys), rhs_ty) => {
-            lhs_tys.iter().any(|lhs_ty| type_compatible(lhs_ty, rhs_ty))
-        }
-        (lhs_ty, Type::OneOf(rhs_tys)) => {
-            if rhs_tys.is_empty() {
-                true
-            } else {
-                rhs_tys.iter().any(|rhs_ty| type_compatible(lhs_ty, rhs_ty))
-            }
-        }
-        (lhs, rhs) => rhs.compare_types(lhs).is_some(),
-    }
+pub fn type_compatible(dst: &Type, src: &Type) -> bool {
+    src.is_assignable_to(dst)
 }
 
 // TODO: rework type checking for Custom values

--- a/crates/nu-protocol/src/collection_columns.rs
+++ b/crates/nu-protocol/src/collection_columns.rs
@@ -22,7 +22,7 @@ use crate::SyntaxShape;
 ///
 /// Type widening (union) for [`Type`]:
 /// ```rust
-/// # use nu_protocol::{CollectionColumns, Type};
+/// # use nu_protocol::{CollectionColumns, Type, TypeSet};
 /// let foo = CollectionColumns::from(vec![
 ///     ("a".to_string(), Type::Int),
 ///     ("b".to_string(), Type::String),
@@ -33,7 +33,7 @@ use crate::SyntaxShape;
 ///     ("c".to_string(), Type::Date),
 /// ]);
 /// assert_eq!(
-///     foo.widen(bar),
+///     foo.union(bar),
 ///     CollectionColumns::from(vec![
 ///         ("a".to_string(), Type::Number),
 ///         ("b".to_string(), Type::OneOf([Type::String, Type::Int].into())),
@@ -87,11 +87,6 @@ impl<T> CollectionColumns<T>
 where
     T: TypeSet + Clone,
 {
-    /// prefer `TypeSet::union`
-    pub fn widen(self, other: Self) -> Self {
-        <Self as TypeSet>::union(self, other)
-    }
-
     fn widen_fields(lhs: Box<[(String, T)]>, rhs: Box<[(String, T)]>) -> Box<[(String, T)]> {
         if lhs.is_empty() || rhs.is_empty() {
             return [].into();

--- a/crates/nu-protocol/src/collection_columns.rs
+++ b/crates/nu-protocol/src/collection_columns.rs
@@ -182,6 +182,11 @@ where
     fn is_any(&self) -> bool {
         self.fields.is_empty()
     }
+
+    fn is_assignable_to(&self, dst: &Self) -> bool {
+        let src = self;
+        src.is_any() || dst.is_any() || src.is_subtype_of(dst)
+    }
 }
 
 impl<T> TypeSet for CollectionColumns<T>

--- a/crates/nu-protocol/src/collection_columns.rs
+++ b/crates/nu-protocol/src/collection_columns.rs
@@ -1,4 +1,4 @@
-use crate::Type;
+use crate::{CompareTypes, Type, TypeRelation};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -130,6 +130,65 @@ impl CollectionColumns<Type> {
                 })
                 .collect()
         }
+    }
+}
+
+impl<T> CompareTypes for CollectionColumns<T>
+where
+    T: CompareTypes,
+{
+    fn compare_types(&self, other: &Self) -> Option<TypeRelation> {
+        let self_fields = self.fields.as_ref();
+        let other_fields = other.fields.as_ref();
+
+        // Handle the simplest cases
+        match (self_fields, other_fields) {
+            ([], []) => return Some(TypeRelation::Equal),
+            ([], _) => return Some(TypeRelation::Supertype),
+            (_, []) => return Some(TypeRelation::Subtype),
+            _ => (),
+        }
+
+        let lhs_super = match self.fields.len().cmp(&other_fields.len()) {
+            std::cmp::Ordering::Less => true,
+            std::cmp::Ordering::Greater => false,
+            std::cmp::Ordering::Equal => {
+                // start neutral
+                let mut state = TypeRelation::Equal;
+                for (name, lhs_ty) in self_fields {
+                    let (_, rhs_ty) = other_fields.iter().find(|(o_name, _)| o_name == name)?;
+                    if lhs_ty.is_any() || rhs_ty.is_any() {
+                        continue;
+                    }
+                    state = state.combine(lhs_ty.compare_types(rhs_ty)?)?;
+                }
+
+                return Some(state);
+            }
+        };
+
+        let (super_ty, sub_ty) = match lhs_super {
+            true => (self_fields, other_fields),
+            false => (other_fields, self_fields),
+        };
+
+        for (name, super_elem_ty) in super_ty {
+            let (_, sub_elem_ty) = sub_ty.iter().find(|(o_name, _)| o_name == name)?;
+            match super_elem_ty.compare_types(sub_elem_ty)? {
+                TypeRelation::Equal | TypeRelation::Supertype => (),
+                TypeRelation::Subtype => return None,
+            }
+        }
+
+        Some(match lhs_super {
+            true => TypeRelation::Supertype,
+            false => TypeRelation::Subtype,
+        })
+    }
+
+    /// Our type system uses the empty record as both the bottom and the top type of records
+    fn is_any(&self) -> bool {
+        self.fields.is_empty()
     }
 }
 

--- a/crates/nu-protocol/src/collection_columns.rs
+++ b/crates/nu-protocol/src/collection_columns.rs
@@ -43,21 +43,44 @@ use crate::SyntaxShape;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash, Ord, PartialOrd)]
 #[serde(transparent)]
 pub struct CollectionColumns<T> {
-    pub fields: Box<[(String, T)]>,
+    fields: Box<[(String, T)]>,
 }
 
 impl<T> CollectionColumns<T> {
     pub fn map<U>(&self, f: impl Fn(&T) -> U) -> CollectionColumns<U> {
-        let Self { fields } = self;
-        CollectionColumns {
-            fields: fields.into_iter().map(|(k, v)| (k.clone(), f(v))).collect(),
-        }
+        self.iter().map(|(k, v)| (k.clone(), f(v))).collect()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(String, T)> {
+        self.into_iter()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.fields.is_empty()
     }
 }
 
 impl<T> CollectionColumns<T> {
     pub fn new(fields: Box<[(String, T)]>) -> Self {
         Self { fields }
+    }
+}
+
+impl<T> IntoIterator for CollectionColumns<T> {
+    type Item = (String, T);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.fields.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a CollectionColumns<T> {
+    type Item = &'a (String, T);
+    type IntoIter = std::slice::Iter<'a, (String, T)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.fields.iter()
     }
 }
 
@@ -71,9 +94,7 @@ impl<T> FromIterator<(String, T)> for CollectionColumns<T> {
 
 impl<T> From<Vec<(String, T)>> for CollectionColumns<T> {
     fn from(value: Vec<(String, T)>) -> Self {
-        Self {
-            fields: value.into_boxed_slice(),
-        }
+        value.into_boxed_slice().into()
     }
 }
 

--- a/crates/nu-protocol/src/collection_columns.rs
+++ b/crates/nu-protocol/src/collection_columns.rs
@@ -64,6 +64,12 @@ impl<T> CollectionColumns<T> {
     pub fn new(fields: Box<[(String, T)]>) -> Self {
         Self { fields }
     }
+
+    pub fn get<'s>(&'s self, key: &'_ str) -> Option<&'s T> {
+        self.iter()
+            .find(|(name, _)| name == key)
+            .map(|(_, val)| val)
+    }
 }
 
 impl<T> IntoIterator for CollectionColumns<T> {
@@ -146,51 +152,54 @@ where
     T: CompareTypes,
 {
     fn compare_types(&self, other: &Self) -> Option<TypeRelation> {
-        let self_fields = self.fields.as_ref();
-        let other_fields = other.fields.as_ref();
+        // for structural subtyping, each field in a type is a "requirement". less
+        // fields in the type => less requirements => is supertype of more types
+        // e.g.: `{a: any, b: any}` is a supertype of `{a: any, b: any, c: any}`
+        //
+        // for `self` to be a subtype of `other`:
+        // - `self` must have all fields required by `other`. extra fields in `self` are irrelevant
+        // - for field `a` in `other`, `self.a` must be a subtype of `other.a`
 
-        // Handle the simplest cases
-        match (self_fields, other_fields) {
-            ([], []) => return Some(TypeRelation::Equal),
-            ([], _) => return Some(TypeRelation::Supertype),
-            (_, []) => return Some(TypeRelation::Subtype),
-            _ => (),
+        match (self.is_empty(), other.is_empty()) {
+            (true, true) => return Some(TypeRelation::Equal),
+            (true, false) => return Some(TypeRelation::Supertype),
+            (false, true) => return Some(TypeRelation::Subtype),
+            (false, false) => (),
         }
 
-        let lhs_super = match self.fields.len().cmp(&other_fields.len()) {
-            std::cmp::Ordering::Less => true,
-            std::cmp::Ordering::Greater => false,
-            std::cmp::Ordering::Equal => {
-                // start neutral
-                let mut state = TypeRelation::Equal;
-                for (name, lhs_ty) in self_fields {
-                    let (_, rhs_ty) = other_fields.iter().find(|(o_name, _)| o_name == name)?;
+        // NOTE[1]: with regards to number of columns `lhs` <= `rhs`
+        let (flipped, eq, (lhs, rhs)) = match self.fields.len().cmp(&other.fields.len()) {
+            std::cmp::Ordering::Less => (false, false, (self, other)),
+            std::cmp::Ordering::Equal => (false, true, (self, other)),
+            std::cmp::Ordering::Greater => (true, false, (other, self)),
+        };
+
+        let start = match eq {
+            true => TypeRelation::Equal,
+            false => TypeRelation::Supertype,
+        };
+
+        let out = lhs
+            .iter()
+            .map(|(lhs_key, lhs_ty)| match rhs.get(lhs_key) {
+                Some(rhs_ty) => {
                     if lhs_ty.is_any() || rhs_ty.is_any() {
-                        continue;
+                        // Not really" equal", just used to continue without affecting the outcome.
+                        Some(TypeRelation::Equal)
+                    } else {
+                        lhs_ty.compare_types(rhs_ty)
                     }
-                    state = state.combine(lhs_ty.compare_types(rhs_ty)?)?;
                 }
+                // if `lhs` has a field `rhs` doesn't despite having at most the same number of
+                // columns as `rhs` (see NOTE[1]) then the sets of their keys are disjoint. they
+                // can't have a subtyping relation
+                None => None,
+            })
+            .try_fold(start, |acc, e| acc.combine(e?))?;
 
-                return Some(state);
-            }
-        };
-
-        let (super_ty, sub_ty) = match lhs_super {
-            true => (self_fields, other_fields),
-            false => (other_fields, self_fields),
-        };
-
-        for (name, super_elem_ty) in super_ty {
-            let (_, sub_elem_ty) = sub_ty.iter().find(|(o_name, _)| o_name == name)?;
-            match super_elem_ty.compare_types(sub_elem_ty)? {
-                TypeRelation::Equal | TypeRelation::Supertype => (),
-                TypeRelation::Subtype => return None,
-            }
-        }
-
-        Some(match lhs_super {
-            true => TypeRelation::Supertype,
-            false => TypeRelation::Subtype,
+        Some(match flipped {
+            true => out.reverse(),
+            false => out,
         })
     }
 
@@ -254,19 +263,40 @@ where
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
+    use rstest::rstest;
 
     use super::*;
     use crate::Type;
 
-    #[test]
-    fn equal_size() {
-        let param_ty: CollectionColumns<Type> =
-            vec![("foo".into(), Type::one_of([Type::Int, Type::Nothing]))].into();
-        let arg_ty: CollectionColumns<Type> = vec![("foo".into(), Type::Int)].into();
+    #[rstest]
+    #[case(Some(TypeRelation::Equal), [], [])]
+    #[case(Some(TypeRelation::Equal),
+        [("a", Type::Int)],
+        [("a", Type::Int)],
+    )]
+    #[case(None,
+        [("a", Type::Int)],
+        [("b", Type::Int)],
+    )]
+    #[case(Some(TypeRelation::Supertype),
+        [("a", Type::Int), ("b", Type::Int)],
+        [("a", Type::Int), ("b", Type::Int), ("c", Type::Int)],
+    )]
+    fn relations(
+        #[case] expected: Option<TypeRelation>,
+        #[case] lhs: impl IntoIterator<Item = (&'static str, Type)>,
+        #[case] rhs: impl IntoIterator<Item = (&'static str, Type)>,
+    ) {
+        let lhs = lhs
+            .into_iter()
+            .map(|(k, ty)| (k.to_owned(), ty))
+            .collect::<CollectionColumns<Type>>();
+        let rhs = rhs
+            .into_iter()
+            .map(|(k, ty)| (k.to_owned(), ty))
+            .collect::<CollectionColumns<Type>>();
 
-        assert_eq!(
-            param_ty.compare_types(&arg_ty),
-            Some(TypeRelation::Supertype)
-        );
+        assert_eq!(lhs.compare_types(&rhs), expected);
+        assert_eq!(rhs.compare_types(&lhs), expected.map(TypeRelation::reverse));
     }
 }

--- a/crates/nu-protocol/src/collection_columns.rs
+++ b/crates/nu-protocol/src/collection_columns.rs
@@ -229,3 +229,23 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::Type;
+
+    #[test]
+    fn equal_size() {
+        let param_ty: CollectionColumns<Type> =
+            vec![("foo".into(), Type::one_of([Type::Int, Type::Nothing]))].into();
+        let arg_ty: CollectionColumns<Type> = vec![("foo".into(), Type::Int)].into();
+
+        assert_eq!(
+            param_ty.compare_types(&arg_ty),
+            Some(TypeRelation::Supertype)
+        );
+    }
+}

--- a/crates/nu-protocol/src/collection_columns.rs
+++ b/crates/nu-protocol/src/collection_columns.rs
@@ -55,8 +55,12 @@ impl<T> CollectionColumns<T> {
         self.into_iter()
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.fields.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.fields.len()
     }
 }
 

--- a/crates/nu-protocol/src/collection_columns.rs
+++ b/crates/nu-protocol/src/collection_columns.rs
@@ -1,4 +1,4 @@
-use crate::{CompareTypes, Type, TypeRelation};
+use crate::{CompareTypes, TypeRelation, TypeSet};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -83,24 +83,16 @@ impl<T> From<Box<[(String, T)]>> for CollectionColumns<T> {
     }
 }
 
-impl CollectionColumns<Type> {
+impl<T> CollectionColumns<T>
+where
+    T: TypeSet + Clone,
+{
+    /// prefer `TypeSet::union`
     pub fn widen(self, other: Self) -> Self {
-        let Self {
-            fields: self_fields,
-        } = self;
-        let Self {
-            fields: other_fields,
-        } = other;
-
-        Self {
-            fields: Self::widen_fields(self_fields, other_fields),
-        }
+        <Self as TypeSet>::union(self, other)
     }
 
-    fn widen_fields(
-        lhs: Box<[(String, Type)]>,
-        rhs: Box<[(String, Type)]>,
-    ) -> Box<[(String, Type)]> {
+    fn widen_fields(lhs: Box<[(String, T)]>, rhs: Box<[(String, T)]>) -> Box<[(String, T)]> {
         if lhs.is_empty() || rhs.is_empty() {
             return [].into();
         }
@@ -115,10 +107,10 @@ impl CollectionColumns<Type> {
         const MAP_THRESH: usize = 16;
         if big.len() > MAP_THRESH {
             use std::collections::HashMap;
-            let mut big_map: HashMap<String, Type> = big.into_iter().collect();
+            let mut big_map: HashMap<String, T> = big.into_iter().collect();
             small
                 .into_iter()
-                .filter_map(|(col, typ)| big_map.remove(&col).map(|b_typ| (col, typ.widen(b_typ))))
+                .filter_map(|(col, typ)| big_map.remove(&col).map(|b_typ| (col, typ.union(b_typ))))
                 .collect()
         } else {
             small
@@ -126,7 +118,7 @@ impl CollectionColumns<Type> {
                 .filter_map(|(col, typ)| {
                     big.iter()
                         .find_map(|(b_col, b_typ)| (&col == b_col).then(|| b_typ.clone()))
-                        .map(|b_typ| (col, typ.widen(b_typ)))
+                        .map(|b_typ| (col, typ.union(b_typ)))
                 })
                 .collect()
         }
@@ -189,6 +181,24 @@ where
     /// Our type system uses the empty record as both the bottom and the top type of records
     fn is_any(&self) -> bool {
         self.fields.is_empty()
+    }
+}
+
+impl<T> TypeSet for CollectionColumns<T>
+where
+    T: TypeSet + Clone,
+{
+    fn union(self, other: Self) -> Self {
+        let Self {
+            fields: self_fields,
+        } = self;
+        let Self {
+            fields: other_fields,
+        } = other;
+
+        Self {
+            fields: Self::widen_fields(self_fields, other_fields),
+        }
     }
 }
 

--- a/crates/nu-protocol/src/collection_columns.rs
+++ b/crates/nu-protocol/src/collection_columns.rs
@@ -151,6 +151,25 @@ where
     }
 }
 
+fn element_comparison_helper<T, F, O>(
+    lhs: &CollectionColumns<T>,
+    rhs: &CollectionColumns<T>,
+    f: F,
+) -> impl Iterator<Item = Option<O>>
+where
+    T: CompareTypes,
+    F: Fn(&T, &T) -> Option<O>,
+{
+    lhs.iter()
+        .map(move |(lhs_key, lhs_ty)| match rhs.get(lhs_key) {
+            Some(rhs_ty) => f(lhs_ty, rhs_ty),
+            // if `lhs` has a field `rhs` doesn't despite having at most the same number of
+            // columns as `rhs` (see NOTE[1]) then the sets of their keys are disjoint. they
+            // can't have a subtyping relation
+            None => None,
+        })
+}
+
 impl<T> CompareTypes for CollectionColumns<T>
 where
     T: CompareTypes,
@@ -183,23 +202,15 @@ where
             false => TypeRelation::Supertype,
         };
 
-        let out = lhs
-            .iter()
-            .map(|(lhs_key, lhs_ty)| match rhs.get(lhs_key) {
-                Some(rhs_ty) => {
-                    if lhs_ty.is_any() || rhs_ty.is_any() {
-                        // Not really" equal", just used to continue without affecting the outcome.
-                        Some(TypeRelation::Equal)
-                    } else {
-                        lhs_ty.compare_types(rhs_ty)
-                    }
-                }
-                // if `lhs` has a field `rhs` doesn't despite having at most the same number of
-                // columns as `rhs` (see NOTE[1]) then the sets of their keys are disjoint. they
-                // can't have a subtyping relation
-                None => None,
-            })
-            .try_fold(start, |acc, e| acc.combine(e?))?;
+        let out = element_comparison_helper(lhs, rhs, |lhs_ty, rhs_ty| {
+            if lhs_ty.is_any() || rhs_ty.is_any() {
+                // Not really" equal", just used to continue without affecting the outcome.
+                Some(TypeRelation::Equal)
+            } else {
+                lhs_ty.compare_types(rhs_ty)
+            }
+        })
+        .try_fold(start, |acc, e| acc.combine(e?))?;
 
         Some(match flipped {
             true => out.reverse(),
@@ -214,7 +225,13 @@ where
 
     fn is_assignable_to(&self, dst: &Self) -> bool {
         let src = self;
-        src.is_any() || dst.is_any() || src.is_subtype_of(dst)
+
+        (src.is_any() || dst.is_any())
+            || element_comparison_helper(dst, src, |dst_ty, src_ty| {
+                Some(src_ty.is_assignable_to(dst_ty))
+            })
+            .try_fold(true, |acc, e| Some(acc && (e?)))
+            .unwrap_or(false)
     }
 }
 
@@ -286,6 +303,10 @@ mod tests {
         [("a", Type::Int), ("b", Type::Int)],
         [("a", Type::Int), ("b", Type::Int), ("c", Type::Int)],
     )]
+    #[case(None,
+        [("name", Type::String), ("attrs", Type::list(Type::Any)), ("desc", Type::String)],
+        [("attrs", Type::list(Type::String)), ("desc", Type::String)],
+    )]
     fn relations(
         #[case] expected: Option<TypeRelation>,
         #[case] lhs: impl IntoIterator<Item = (&'static str, Type)>,
@@ -302,5 +323,27 @@ mod tests {
 
         assert_eq!(lhs.compare_types(&rhs), expected);
         assert_eq!(rhs.compare_types(&lhs), expected.map(TypeRelation::reverse));
+    }
+
+    #[rstest]
+    #[case(true,
+        [("name", Type::String), ("attrs", Type::list(Type::Any)), ("desc", Type::String)],
+        [("attrs", Type::list(Type::String)), ("desc", Type::String)],
+    )]
+    fn is_assignable_to(
+        #[case] expected: bool,
+        #[case] src: impl IntoIterator<Item = (&'static str, Type)>,
+        #[case] dst: impl IntoIterator<Item = (&'static str, Type)>,
+    ) {
+        let src = src
+            .into_iter()
+            .map(|(k, ty)| (k.to_owned(), ty))
+            .collect::<CollectionColumns<Type>>();
+        let dst = dst
+            .into_iter()
+            .map(|(k, ty)| (k.to_owned(), ty))
+            .collect::<CollectionColumns<Type>>();
+
+        assert_eq!(src.is_assignable_to(&dst), expected)
     }
 }

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -36,6 +36,7 @@ mod signature;
 pub mod span;
 mod syntax_shape;
 mod ty;
+mod ty_relation;
 mod value;
 
 pub use alias::*;
@@ -58,6 +59,7 @@ pub use signature::*;
 pub use span::*;
 pub use syntax_shape::*;
 pub use ty::*;
+pub use ty_relation::*;
 pub use value::*;
 
 pub use nu_derive_value::*;

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -26,6 +26,7 @@ mod id;
 pub mod ir;
 mod lev_distance;
 mod module;
+mod one_of;
 pub mod parser_path;
 mod pipeline;
 #[cfg(feature = "plugin")]
@@ -52,6 +53,7 @@ pub use example::*;
 pub use id::*;
 pub use lev_distance::levenshtein_distance;
 pub use module::*;
+pub use one_of::*;
 pub use pipeline::*;
 #[cfg(feature = "plugin")]
 pub use plugin::*;

--- a/crates/nu-protocol/src/one_of.rs
+++ b/crates/nu-protocol/src/one_of.rs
@@ -20,7 +20,7 @@ impl OneOf {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Type> {
-        self.items.iter()
+        self.into_iter()
     }
 
     fn add_ty_inner(this: &mut Vec<Type>, mut ty: Type) {
@@ -63,6 +63,15 @@ impl IntoIterator for OneOf {
     }
 }
 
+impl<'a> IntoIterator for &'a OneOf {
+    type Item = &'a Type;
+    type IntoIter = std::slice::Iter<'a, Type>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter()
+    }
+}
+
 impl FromIterator<Type> for OneOf {
     fn from_iter<I: IntoIterator<Item = Type>>(iter: I) -> Self {
         let mut vec = Vec::new();
@@ -91,37 +100,29 @@ impl TypeSet for OneOf {
 
 impl CompareTypes for OneOf {
     fn compare_types(&self, other: &Self) -> Option<TypeRelation> {
-        let self_items = self.items.as_ref();
-        let other_items = other.items.as_ref();
-
-        // Handle the simplest cases
-        match (self_items, other_items) {
-            ([], []) => return Some(TypeRelation::Equal),
-            ([], _) => return Some(TypeRelation::Subtype),
-            (_, []) => return Some(TypeRelation::Supertype),
-            _ => (),
-        }
-
-        // iterate the shorter list to reduce quadratic behaviour
-        let ((small, big), flipped) = if self_items.len() <= other_items.len() {
-            ((self_items, other_items), false)
-        } else {
-            ((other_items, self_items), true)
-        };
-
-        for s_ty in small {
-            let _ = big.iter().find(|b_ty| {
-                matches!(
-                    s_ty.compare_types(*b_ty),
-                    Some(TypeRelation::Subtype | TypeRelation::Equal)
-                )
-            })?;
-        }
-
-        Some(match flipped {
-            false => TypeRelation::Subtype,
-            true => TypeRelation::Supertype,
+        Some(match (self.is_empty(), other.is_empty()) {
+            (true, true) => TypeRelation::Equal,
+            (true, false) => TypeRelation::Subtype,
+            (false, true) => TypeRelation::Supertype,
+            (false, false) => match (self.is_subtype_of(other), self.is_supertype_of(other)) {
+                (true, true) => TypeRelation::Equal,
+                (true, false) => TypeRelation::Subtype,
+                (false, true) => TypeRelation::Supertype,
+                (false, false) => return None,
+            },
         })
+    }
+
+    fn is_subtype_of(&self, other: &Self) -> bool {
+        match (self.is_empty(), other.is_empty()) {
+            (true, _) => true,
+            (_, true) => false,
+            _ => self.iter().all(|ty| ty.is_subtype_of(other)),
+        }
+    }
+
+    fn is_supertype_of(&self, other: &Self) -> bool {
+        other.is_subtype_of(self)
     }
 
     fn is_assignable_to(&self, dst: &Self) -> bool {
@@ -139,22 +140,32 @@ impl CompareTypes for OneOf {
 
 impl CompareTypes<Type> for OneOf {
     fn compare_types(&self, other: &Type) -> Option<TypeRelation> {
-        match other {
+        Some(match other {
+            Type::OneOf(other) => return self.compare_types(other),
+            Type::Any => TypeRelation::Subtype,
             // `oneof<>` is an uninhibited type, so it's kind of like our bottom type
-            _ if self.is_empty() => Some(TypeRelation::Subtype),
-            Type::Any => Some(TypeRelation::Subtype),
-            Type::OneOf(other) => self.compare_types(other),
-            _ => self
-                .items
-                .iter()
-                .any(|self_ty| {
-                    matches!(
-                        self_ty.compare_types(other),
-                        Some(TypeRelation::Supertype | TypeRelation::Equal)
-                    )
-                })
-                .then_some(TypeRelation::Supertype),
-        }
+            _ if self.is_empty() => TypeRelation::Subtype,
+            _ => match (self.is_subtype_of(other), self.is_supertype_of(other)) {
+                (true, true) => TypeRelation::Equal,
+                (true, false) => TypeRelation::Subtype,
+                (false, true) => TypeRelation::Supertype,
+                (false, false) => return None,
+            },
+        })
+    }
+
+    fn is_subtype_of(&self, other: &Type) -> bool {
+        let sub_tys = self;
+        let super_ty = other;
+        sub_tys.iter().all(|sub_ty| sub_ty.is_subtype_of(super_ty))
+    }
+
+    fn is_supertype_of(&self, other: &Type) -> bool {
+        let super_tys = self;
+        let sub_ty = other;
+        super_tys
+            .iter()
+            .any(|super_ty| super_ty.is_supertype_of(sub_ty))
     }
 
     fn is_assignable_to(&self, dst: &Type) -> bool {
@@ -170,7 +181,22 @@ impl CompareTypes<Type> for OneOf {
 
 impl CompareTypes<OneOf> for Type {
     fn compare_types(&self, other: &OneOf) -> Option<TypeRelation> {
-        other.compare_types(self).map(TypeRelation::reverse)
+        Some(
+            match (self.is_subtype_of(other), self.is_supertype_of(other)) {
+                (true, true) => TypeRelation::Equal,
+                (true, false) => TypeRelation::Subtype,
+                (false, true) => TypeRelation::Supertype,
+                (false, false) => return None,
+            },
+        )
+    }
+
+    fn is_subtype_of(&self, other: &OneOf) -> bool {
+        other.is_supertype_of(self)
+    }
+
+    fn is_supertype_of(&self, other: &OneOf) -> bool {
+        other.is_subtype_of(self)
     }
 
     fn is_assignable_to(&self, dst: &OneOf) -> bool {

--- a/crates/nu-protocol/src/one_of.rs
+++ b/crates/nu-protocol/src/one_of.rs
@@ -1,0 +1,168 @@
+use std::fmt::Display;
+
+use crate::{CompareTypes, Type, TypeRelation, TypeSet};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Hash, Ord, PartialOrd)]
+#[serde(transparent)]
+pub struct OneOf {
+    items: Box<[Type]>,
+}
+
+impl OneOf {
+    pub fn add_ty(self, ty: Type) -> Self {
+        let OneOf { items } = self;
+        let mut items = items.into_vec();
+        Self::add_ty_inner(&mut items, ty);
+        Self {
+            items: items.into(),
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Type> {
+        self.items.iter()
+    }
+
+    fn add_ty_inner(this: &mut Vec<Type>, mut ty: Type) {
+        // handle nested unions first
+        if let Type::OneOf(inner) = ty {
+            for sub_t in inner.items {
+                Self::add_ty_inner(this, sub_t);
+            }
+            return;
+        }
+
+        for this_ty in this.iter_mut() {
+            let one = std::mem::replace(this_ty, Type::Any);
+            match Type::flat_widen(one, ty) {
+                Ok(new_wide) => {
+                    *this_ty = new_wide;
+                    return;
+                }
+                Err((old_one, old_ty)) => {
+                    *this_ty = old_one;
+                    ty = old_ty;
+                }
+            }
+        }
+
+        this.push(ty);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+impl IntoIterator for OneOf {
+    type Item = Type;
+    type IntoIter = std::vec::IntoIter<Type>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_iter()
+    }
+}
+
+impl FromIterator<Type> for OneOf {
+    fn from_iter<I: IntoIterator<Item = Type>>(iter: I) -> Self {
+        let mut vec = Vec::new();
+        for ty in iter {
+            Self::add_ty_inner(&mut vec, ty);
+        }
+        Self { items: vec.into() }
+    }
+}
+
+impl TypeSet for OneOf {
+    fn union(self, other: Self) -> Self {
+        let OneOf { items: ts } = self;
+        let OneOf { items: us } = other;
+        let (big, small) = match ts.len() >= us.len() {
+            true => (ts, us),
+            false => (us, ts),
+        };
+        let mut out = big.into_vec();
+        for t in small {
+            Self::add_ty_inner(&mut out, t);
+        }
+        Self { items: out.into() }
+    }
+}
+
+impl CompareTypes for OneOf {
+    fn compare_types(&self, other: &Self) -> Option<TypeRelation> {
+        let self_items = self.items.as_ref();
+        let other_items = other.items.as_ref();
+
+        // Handle the simplest cases
+        match (self_items, other_items) {
+            ([], []) => return Some(TypeRelation::Equal),
+            ([], _) => return Some(TypeRelation::Subtype),
+            (_, []) => return Some(TypeRelation::Supertype),
+            _ => (),
+        }
+
+        // iterate the shorter list to reduce quadratic behaviour
+        let ((small, big), flipped) = if self_items.len() <= other_items.len() {
+            ((self_items, other_items), false)
+        } else {
+            ((other_items, self_items), true)
+        };
+
+        for s_ty in small {
+            let _ = big.iter().find(|b_ty| {
+                matches!(
+                    s_ty.compare_types(*b_ty),
+                    Some(TypeRelation::Subtype | TypeRelation::Equal)
+                )
+            })?;
+        }
+
+        Some(match flipped {
+            false => TypeRelation::Subtype,
+            true => TypeRelation::Supertype,
+        })
+    }
+}
+
+impl CompareTypes<Type> for OneOf {
+    fn compare_types(&self, other: &Type) -> Option<TypeRelation> {
+        match other {
+            // `oneof<>` is an uninhibited type, so it's kind of like our bottom type
+            _ if self.is_empty() => Some(TypeRelation::Subtype),
+            Type::Any => Some(TypeRelation::Subtype),
+            Type::OneOf(other) => self.compare_types(other),
+            _ => self
+                .items
+                .iter()
+                .any(|self_ty| {
+                    matches!(
+                        self_ty.compare_types(other),
+                        Some(TypeRelation::Supertype | TypeRelation::Equal)
+                    )
+                })
+                .then_some(TypeRelation::Supertype),
+        }
+    }
+}
+
+impl CompareTypes<OneOf> for Type {
+    fn compare_types(&self, other: &OneOf) -> Option<TypeRelation> {
+        other.compare_types(self).map(TypeRelation::reverse)
+    }
+}
+
+impl Display for OneOf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let types = self.items.as_ref();
+        write!(f, "oneof")?;
+        let [first, rest @ ..] = types else {
+            return Ok(());
+        };
+        write!(f, "<{first}")?;
+        for t in rest {
+            write!(f, ", {t}")?;
+        }
+        f.write_str(">")
+    }
+}

--- a/crates/nu-protocol/src/one_of.rs
+++ b/crates/nu-protocol/src/one_of.rs
@@ -123,6 +123,18 @@ impl CompareTypes for OneOf {
             true => TypeRelation::Supertype,
         })
     }
+
+    fn is_assignable_to(&self, dst: &Self) -> bool {
+        let dst_tys = dst;
+        let src_tys = self;
+        match (dst_tys.is_empty(), src_tys.is_empty()) {
+            (_, true) => true,
+            (true, _) => false,
+            _ => src_tys
+                .iter()
+                .any(|src_ty| dst_tys.iter().any(|dst_ty| src_ty.is_assignable_to(dst_ty))),
+        }
+    }
 }
 
 impl CompareTypes<Type> for OneOf {
@@ -144,11 +156,26 @@ impl CompareTypes<Type> for OneOf {
                 .then_some(TypeRelation::Supertype),
         }
     }
+
+    fn is_assignable_to(&self, dst: &Type) -> bool {
+        let src = self;
+
+        if src.is_empty() {
+            true
+        } else {
+            src.iter().any(|src_ty| src_ty.is_assignable_to(dst))
+        }
+    }
 }
 
 impl CompareTypes<OneOf> for Type {
     fn compare_types(&self, other: &OneOf) -> Option<TypeRelation> {
         other.compare_types(self).map(TypeRelation::reverse)
+    }
+
+    fn is_assignable_to(&self, dst: &OneOf) -> bool {
+        let src = self;
+        dst.iter().any(|dst_ty| src.is_assignable_to(dst_ty))
     }
 }
 

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -175,24 +175,6 @@ impl PipelineData {
         }
     }
 
-    /// Determine if the `PipelineData` is a [subtype](https://en.wikipedia.org/wiki/Subtyping) of `other`.
-    ///
-    /// This check makes no effort to collect a stream, so it may be a different result
-    /// than would be returned by calling [`Value::is_subtype_of()`] on the result of
-    /// [`.into_value()`](Self::into_value).
-    ///
-    /// A `ListStream` acts the same as an empty list type: it is a subtype of any [`list`](Type::List)
-    /// or [`table`](Type::Table) type. After converting to a value, it may become a more specific type.
-    /// For example, a `ListStream` is a subtype of `list<int>` and `list<string>`.
-    /// If calling [`.into_value()`](Self::into_value) results in a `list<int>`,
-    /// then the value would not be a subtype of `list<string>`, in contrast to the original `ListStream`.
-    ///
-    /// A `ByteStream` is a subtype of [`string`](Type::String) if it is coercible into a string.
-    /// Likewise, a `ByteStream` is a subtype of [`binary`](Type::Binary) if it is coercible into a binary value.
-    pub fn is_assignable_to(&self, dst: &Type) -> bool {
-        <Self as CompareTypes<Type>>::is_assignable_to(self, dst)
-    }
-
     pub fn into_value(self, span: Span) -> Result<Value, ShellError> {
         match self {
             PipelineData::Empty => Ok(Value::nothing(span)),
@@ -906,6 +888,20 @@ impl CompareTypes<Type> for PipelineData {
         self.get_type().compare_types(other)
     }
 
+    /// Determine if the `PipelineData` can be assigned to `other`.
+    ///
+    /// This check makes no effort to collect a stream, so it may be a different result
+    /// than would be returned by calling [`Value::is_subtype_of()`] on the result of
+    /// [`.into_value()`](Self::into_value).
+    ///
+    /// A `ListStream` acts the same as an empty list type: it is a subtype of any [`list`](Type::List)
+    /// or [`table`](Type::Table) type. After converting to a value, it may become a more specific type.
+    /// For example, a `ListStream` is a subtype of `list<int>` and `list<string>`.
+    /// If calling [`.into_value()`](Self::into_value) results in a `list<int>`,
+    /// then the value would not be a subtype of `list<string>`, in contrast to the original `ListStream`.
+    ///
+    /// A `ByteStream` is a subtype of [`string`](Type::String) if it is coercible into a string.
+    /// Likewise, a `ByteStream` is a subtype of [`binary`](Type::Binary) if it is coercible into a binary value.
     fn is_assignable_to(&self, dst: &Type) -> bool {
         self.get_type().is_assignable_to(dst)
     }

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "os")]
 use crate::process::ExitStatusGuard;
 use crate::{
-    ByteStream, ByteStreamSource, ByteStreamType, Config, ListStream, OutDest, PipelineMetadata,
-    Range, ShellError, Signals, Span, Type, Value,
+    ByteStream, ByteStreamSource, ByteStreamType, CompareTypes, Config, ListStream, OutDest,
+    PipelineMetadata, Range, ShellError, Signals, Span, Type, TypeRelation, Value,
     ast::{Call, PathMember},
     engine::{EngineState, Stack},
     shell_error::{generic::GenericError, io::IoError},
@@ -189,31 +189,8 @@ impl PipelineData {
     ///
     /// A `ByteStream` is a subtype of [`string`](Type::String) if it is coercible into a string.
     /// Likewise, a `ByteStream` is a subtype of [`binary`](Type::Binary) if it is coercible into a binary value.
-    pub fn is_subtype_of(&self, other: &Type) -> bool {
-        match (self, other) {
-            (_, Type::Any) => true,
-            (data, Type::OneOf(oneof)) => oneof.iter().any(|t| data.is_subtype_of(t)),
-            (PipelineData::Empty, Type::Nothing) => true,
-            (PipelineData::Value(val, ..), ty) => val.is_subtype_of(ty),
-
-            // a list stream could be a list with any type, including a table
-            (PipelineData::ListStream(..), Type::List(..) | Type::Table(..)) => true,
-
-            (PipelineData::ByteStream(stream, ..), Type::String)
-                if stream.type_().is_string_coercible() =>
-            {
-                true
-            }
-            (PipelineData::ByteStream(stream, ..), Type::Binary)
-                if stream.type_().is_binary_coercible() =>
-            {
-                true
-            }
-
-            (PipelineData::Empty, _) => false,
-            (PipelineData::ListStream(..), _) => false,
-            (PipelineData::ByteStream(..), _) => false,
-        }
+    pub fn is_assignable_to(&self, dst: &Type) -> bool {
+        <Self as CompareTypes<Type>>::is_assignable_to(self, dst)
     }
 
     pub fn into_value(self, span: Span) -> Result<Value, ShellError> {
@@ -921,6 +898,16 @@ impl PipelineData {
                 }
             },
         }
+    }
+}
+
+impl CompareTypes<Type> for PipelineData {
+    fn compare_types(&self, other: &Type) -> Option<TypeRelation> {
+        self.get_type().compare_types(other)
+    }
+
+    fn is_assignable_to(&self, dst: &Type) -> bool {
+        self.get_type().is_assignable_to(dst)
     }
 }
 

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -268,8 +268,6 @@ impl Type {
 impl CompareTypes for Type {
     fn compare_types(&self, other: &Self) -> Option<TypeRelation> {
         match (self, other) {
-            (t, u) if t == u => Some(TypeRelation::Equal),
-
             (_, Type::Any) => Some(TypeRelation::Subtype),
             (Type::Any, _) => Some(TypeRelation::Supertype),
 
@@ -310,6 +308,8 @@ impl CompareTypes for Type {
             (Type::OneOf(lhs_oneof), Type::OneOf(rhs_oneof)) => lhs_oneof.compare_types(rhs_oneof),
             (Type::OneOf(lhs_oneof), rhs) => lhs_oneof.compare_types(rhs),
             (lhs, Type::OneOf(rhs_oneof)) => lhs.compare_types(rhs_oneof),
+
+            (t, u) if t == u => Some(TypeRelation::Equal),
 
             _ => None,
         }

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -296,18 +296,13 @@ impl CompareTypes for Type {
                 this.compare_types(that)
             }
 
-            (Type::Table(_), Type::List(list_elem)) if matches!(**list_elem, Type::Any) => {
-                Some(TypeRelation::Subtype)
-            }
-            (Type::List(list_elem), Type::Table(_)) if matches!(**list_elem, Type::Any) => {
-                Some(TypeRelation::Supertype)
-            }
-
             (Type::Table(table_cols), Type::List(list_elem)) => match list_elem.as_ref() {
+                Type::Any => Some(TypeRelation::Subtype),
                 Type::Record(record_cols) => table_cols.compare_types(record_cols),
                 _ => None,
             },
             (Type::List(list_elem), Type::Table(table_cols)) => match list_elem.as_ref() {
+                Type::Any => Some(TypeRelation::Supertype),
                 Type::Record(record_cols) => record_cols.compare_types(table_cols),
                 _ => None,
             },

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -1,4 +1,4 @@
-use crate::{CollectionColumns, CompareTypes, SyntaxShape, TypeRelation, ast::PathMember};
+use crate::{CollectionColumns, CompareTypes, SyntaxShape, TypeRelation, TypeSet, ast::PathMember};
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, fmt::Display};
 #[cfg(test)]
@@ -143,125 +143,56 @@ impl Type {
 
     /// Returns supertype of arguments without creating a `oneof`, or falling back to `any` (unless one or both of the arguments are `any`)
     fn flat_widen(lhs: Type, rhs: Type) -> Result<Type, (Type, Type)> {
-        // Fast-paths that don't require cloning.
-        if lhs == rhs {
-            return Ok(lhs);
-        }
+        // handle special cases and hot paths
+        let (lhs, rhs) = match (lhs, rhs) {
+            // disjoint glob/string pair. We don't want to consume lhs/rhs here because subsequent code still needs them.
+            tys @ (Type::Glob, Type::String) | tys @ (Type::String, Type::Glob) => return Err(tys),
+            // primitive number hierarchy is extremely common
+            (Type::Int, Type::Float) | (Type::Float, Type::Int) => return Ok(Type::Number),
+            tys => tys,
+        };
 
-        // Any value yields the top type.
-        if matches!(lhs, Type::Any) || matches!(rhs, Type::Any) {
-            return Ok(Type::Any);
-        }
-
-        // primitive number hierarchy is extremely common; handle it before any more expensive logic (including subtype checks) to keep
-        // `type_widen_simple` fast.
-        if matches!(lhs, Type::Int | Type::Float | Type::Number)
-            && matches!(rhs, Type::Int | Type::Float | Type::Number)
-        {
-            return Ok(Type::Number);
-        }
-
-        // disjoint glob/string pair. We don't want to consume lhs/rhs here because subsequent code still needs them.
-        if (matches!(lhs, Type::Glob) && matches!(rhs, Type::String))
-            || (matches!(lhs, Type::String) && matches!(rhs, Type::Glob))
-        {
-            return Err((lhs, rhs));
-        }
-
-        // structural collections; clones are unavoidable because we need owned data for the result, but we only clone
-        // the inner vectors, not the entire `Type` twice.
-        match (&lhs, &rhs) {
-            (Type::Record(this), Type::Record(that)) => {
-                return Ok(Type::Record(this.clone().widen(that.clone())));
+        // widen structural collections without checking for subtyping
+        let (lhs, rhs) = match (lhs, rhs) {
+            (Type::Record(lhs), Type::Record(rhs)) => {
+                return Ok(Type::Record(lhs.union(rhs)));
             }
-            (Type::Table(this), Type::Table(that)) => {
-                return Ok(Type::Table(this.clone().widen(that.clone())));
+            (Type::Table(lhs), Type::Table(rhs)) => {
+                return Ok(Type::Table(lhs.union(rhs)));
             }
-
-            (Type::List(_list_item), Type::Table(_table))
-            | (Type::Table(_table), Type::List(_list_item)) => {
-                // `lhs` and `rhs` are still owned, so we can match on the original values once again to avoid needless cloning.
-                let item = match (lhs, rhs) {
-                    (Type::List(list_item), Type::Table(table)) => match *list_item {
-                        Type::Record(record) => Type::Record(record.widen(table)),
-                        list_item => Type::one_of([list_item, Type::Record(table)]),
-                    },
-                    (Type::Table(table), Type::List(list_item)) => match *list_item {
-                        Type::Record(record) => Type::Record(record.widen(table)),
-                        list_item => Type::one_of([list_item, Type::Record(table)]),
-                    },
-                    _ => unreachable!(),
-                };
-                return Ok(Type::List(Box::new(item)));
+            // We're choosing to lose some information by preferring
+            // - `list<oneof<T, record>>` over
+            // - `oneof<list<T>, table>`
+            (Type::List(list_elem), Type::Table(table_cols))
+            | (Type::Table(table_cols), Type::List(list_elem)) => {
+                return Ok(Type::list(list_elem.union(Type::Record(table_cols))));
             }
-
+            // We're choosing to lose some information by preferring
+            // - `list<oneof<T, U>>` over
+            // - `oneof<list<T>, list<U>>`
             (Type::List(lhs), Type::List(rhs)) => {
-                // We have to take ownership of the inner types, so clone here.
-                let lhs_inner = lhs.clone();
-                let rhs_inner = rhs.clone();
-                return Ok(Type::list(lhs_inner.widen(*rhs_inner)));
+                return Ok(Type::list(lhs.union(*rhs)));
             }
-
-            _ => {}
-        }
+            tys => tys,
+        };
 
         // If one type is already a subtype of the other, we can skip all of the heavier logic below.
-        if lhs.is_subtype_of(&rhs) {
-            return Ok(rhs);
+        match lhs.compare_types(&rhs) {
+            Some(rel) => Ok(match rel {
+                TypeRelation::Subtype => rhs,
+                TypeRelation::Equal => lhs,
+                TypeRelation::Supertype => lhs,
+            }),
+            // Fallback - the two types are unrelated. Move them out so that callers don't have to clone again.
+            _ => Err((lhs, rhs)),
         }
-        if rhs.is_subtype_of(&lhs) {
-            return Ok(lhs);
-        }
-
-        // Fallback - the two types are unrelated. Move them out so that callers don't have to clone again.
-        Err((lhs, rhs))
     }
 
     /// Returns the supertype between `self` and `other`, or `Type::Any` if they're unrelated
+    ///
+    /// prefer `TypeSet::union`
     pub fn widen(self, other: Type) -> Type {
-        // defensive fast-path: if one value is already a subtype of the other, return the supertype immediately.
-        //
-        // A subtle exception: a list-of-records is considered a subtype of a table with matching columns.
-        fn shortcut_allowed(lhs: &Type, rhs: &Type) -> bool {
-            !matches!(
-                (lhs, rhs),
-                (Type::List(_), Type::Table(_)) | (Type::Table(_), Type::List(_))
-            )
-        }
-
-        // only shortcut when the relationship is one-way; for pairs like glob/string `is_subtype_of` returns true both ways,
-        // and we must not collapse them to a single type.
-        if self.is_subtype_of(&other)
-            && !other.is_subtype_of(&self)
-            && shortcut_allowed(&self, &other)
-        {
-            return other;
-        }
-
-        let tu = match Self::flat_widen(self, other) {
-            Ok(t) => return t,
-            Err(tu) => tu,
-        };
-
-        match tu {
-            (Type::OneOf(ts), Type::OneOf(us)) => {
-                let (big, small) = match ts.len() >= us.len() {
-                    true => (ts, us),
-                    false => (us, ts),
-                };
-                let mut out = big.into_vec();
-                for t in small.into_iter() {
-                    Self::oneof_add_widen(&mut out, t);
-                }
-                Type::one_of(out)
-            }
-            (Type::OneOf(oneof), t) | (t, Type::OneOf(oneof)) => {
-                let mut out = oneof.into_vec();
-                Self::oneof_add_widen(&mut out, t);
-                Type::one_of(out)
-            }
-            (this, other) => Type::one_of([this, other]),
-        }
+        <Self as TypeSet>::union(self, other)
     }
 
     /// Adds a type to a OneOf union, flattening nested OneOfs, deduplicating, and attempting to widen existing types.
@@ -313,7 +244,7 @@ impl Type {
     pub fn supertype_of(it: impl IntoIterator<Item = Type>) -> Option<Self> {
         let mut it = it.into_iter();
         it.next().and_then(|head| {
-            it.try_fold(head, |acc, e| match acc.widen(e) {
+            it.try_fold(head, |acc, e| match acc.union(e) {
                 Type::Any => None,
                 r => Some(r),
             })
@@ -501,6 +432,35 @@ impl CompareTypes for Type {
     }
 }
 
+impl TypeSet for Type {
+    fn union(self, other: Self) -> Self {
+        let (lhs, rhs) = match Self::flat_widen(self, other) {
+            Ok(t) => return t,
+            Err(tys) => tys,
+        };
+
+        match (lhs, rhs) {
+            (Type::OneOf(ts), Type::OneOf(us)) => {
+                let (big, small) = match ts.len() >= us.len() {
+                    true => (ts, us),
+                    false => (us, ts),
+                };
+                let mut out = big.into_vec();
+                for t in small.into_iter() {
+                    Self::oneof_add_widen(&mut out, t);
+                }
+                Type::one_of(out)
+            }
+            (Type::OneOf(oneof), t) | (t, Type::OneOf(oneof)) => {
+                let mut out = oneof.into_vec();
+                Self::oneof_add_widen(&mut out, t);
+                Type::one_of(out)
+            }
+            (this, other) => Type::one_of([this, other]),
+        }
+    }
+}
+
 impl Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -636,7 +596,7 @@ mod tests {
         fn test_widen_flattens_oneof() {
             let a = Type::one_of([Type::String, Type::Int]);
             let b = Type::one_of([Type::Float, Type::Bool]);
-            let widened = a.widen(b);
+            let widened = a.union(b);
             if let Type::OneOf(types) = widened {
                 let types_vec = types.to_vec();
                 assert_eq!(types_vec.len(), 3);
@@ -672,12 +632,12 @@ mod tests {
         fn test_widen_subtype_shortcut() {
             // widening a union that already covers the new type should return the original union unchanged.
             let union = Type::one_of([Type::String, Type::Number]);
-            let result = union.clone().widen(Type::Int);
+            let result = union.clone().union(Type::Int);
             assert_eq!(result, union);
 
             // symmetric case where the left side is the subtype
             let union2 = Type::one_of([Type::Int, Type::String]);
-            let result2 = Type::Int.widen(union2.clone());
+            let result2 = Type::Int.union(union2.clone());
             assert_eq!(result2, union2);
         }
 
@@ -686,7 +646,7 @@ mod tests {
             // repeatedly widen the same type pair
             let mut t = Type::String;
             for _ in 0..100 {
-                t = t.widen(Type::Int);
+                t = t.union(Type::Int);
             }
             let expected = Type::one_of([Type::String, Type::Int]);
             assert_eq!(t, expected);
@@ -700,14 +660,14 @@ mod tests {
             )));
             let table = Type::Table(vec![("a".to_string(), Type::Int)].into());
 
-            let widened = list_record.clone().widen(table.clone());
+            let widened = list_record.clone().union(table.clone());
             let expected = Type::List(Box::new(Type::Record(
                 vec![("a".to_string(), Type::Int)].into(),
             )));
             assert_eq!(widened, expected);
 
             // and the other way around
-            let widened2 = table.widen(list_record.clone());
+            let widened2 = table.union(list_record.clone());
             assert_eq!(widened2, expected);
         }
 
@@ -715,8 +675,8 @@ mod tests {
         fn test_glob_string_union() {
             let g = Type::Glob;
             let s = Type::String;
-            let w1 = g.clone().widen(s.clone());
-            let w2 = s.clone().widen(g.clone());
+            let w1 = g.clone().union(s.clone());
+            let w2 = s.clone().union(g.clone());
             let expected1 = Type::one_of([Type::Glob, Type::String]);
             let expected2 = Type::one_of([Type::String, Type::Glob]);
             assert_eq!(w1, expected1);

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -45,11 +45,14 @@ fn follow_cell_path_recursive<'a>(
         return Some(current);
     };
     match (current.as_ref(), first) {
-        (Type::Record(columns), PathMember::String { val, .. }) => {
-            let idx = columns.fields.iter().position(|(name, _)| name == val)?;
+        (Type::Record(_), PathMember::String { val, .. }) => {
             let next = match current {
-                Cow::Borrowed(Type::Record(f)) => Cow::Borrowed(&f.fields[idx].1),
-                Cow::Owned(Type::Record(f)) => Cow::Owned(f.fields[idx].1.to_owned()),
+                Cow::Borrowed(Type::Record(f)) => {
+                    Cow::Borrowed(&f.iter().find(|(name, _)| name == val)?.1)
+                }
+                Cow::Owned(Type::Record(f)) => {
+                    Cow::Owned(f.into_iter().find(|(name, _)| name == val)?.1)
+                }
                 _ => unreachable!(),
             };
             follow_cell_path_recursive(next, path_members)
@@ -62,7 +65,7 @@ fn follow_cell_path_recursive<'a>(
 
         // Table to List (String)
         (Type::Table(columns), PathMember::String { val, .. }) => {
-            let (_, sub_type) = columns.fields.iter().find(|(name, _)| name == val)?;
+            let (_, sub_type) = columns.iter().find(|(name, _)| name == val)?;
             let list_type = Type::List(Box::new(sub_type.clone()));
             follow_cell_path_recursive(Cow::Owned(list_type), path_members)
         }

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -345,6 +345,32 @@ impl CompareTypes for Type {
     fn is_any(&self) -> bool {
         matches!(self, Type::Any)
     }
+
+    fn is_assignable_to(&self, dst: &Self) -> bool {
+        let src = self;
+        match (dst, src) {
+            (Type::Table(dst_cols), Type::List(src_ty))
+                if let Type::Record(src_cols) = src_ty.as_ref() =>
+            {
+                src_cols.is_assignable_to(dst_cols)
+            }
+            (Type::List(dst_ty), Type::Table(src_cols))
+                if let Type::Record(dst_cols) = dst_ty.as_ref() =>
+            {
+                src_cols.is_assignable_to(dst_cols)
+            }
+            (Type::Record(dst_cols), Type::Record(src_cols))
+            | (Type::Table(dst_cols), Type::Table(src_cols)) => src_cols.is_assignable_to(dst_cols),
+            // strings can be coerced globs
+            (Type::Glob, Type::String) => true,
+            // but not the other way around
+            (Type::String, Type::Glob) => false,
+            (Type::OneOf(dst_tys), Type::OneOf(src_tys)) => src_tys.is_assignable_to(dst_tys),
+            (Type::OneOf(dst_tys), src_ty) => src_ty.is_assignable_to(dst_tys),
+            (dst_ty, Type::OneOf(src_tys)) => src_tys.is_assignable_to(dst_ty),
+            (lhs, rhs) => rhs.compare_types(lhs).is_some(),
+        }
+    }
 }
 
 impl TypeSet for Type {

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -307,15 +307,6 @@ impl CompareTypes for Type {
                 _ => None,
             },
 
-            (Type::OneOf(oneof), Type::CellPath) => oneof
-                .iter()
-                .all(|t| {
-                    matches!(
-                        t.compare_types(&Type::CellPath),
-                        Some(TypeRelation::Subtype | TypeRelation::Equal)
-                    )
-                })
-                .then_some(TypeRelation::Subtype),
             (Type::OneOf(lhs_oneof), Type::OneOf(rhs_oneof)) => lhs_oneof.compare_types(rhs_oneof),
             (Type::OneOf(lhs_oneof), rhs) => lhs_oneof.compare_types(rhs),
             (lhs, Type::OneOf(rhs_oneof)) => lhs.compare_types(rhs_oneof),

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -180,7 +180,8 @@ impl Type {
         }
     }
 
-    /// Returns the supertype of all types within `it`. Short-circuits on, and falls back to, `Type::Any`.
+    /// Returns a supertype of all types within `it` *that is not `Any`*.
+    /// If `it` contains `Type::Any`, short circuits and returns `None`.
     pub fn supertype_of(it: impl IntoIterator<Item = Type>) -> Option<Self> {
         let mut it = it.into_iter();
         it.next().and_then(|head| {

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -1,4 +1,4 @@
-use crate::{CollectionColumns, SyntaxShape, ast::PathMember};
+use crate::{CollectionColumns, CompareTypes, SyntaxShape, TypeRelation, ast::PathMember};
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, fmt::Display};
 #[cfg(test)]
@@ -138,53 +138,7 @@ impl Type {
     /// If you have a concrete [`Value`](crate::Value) or [`PipelineData`](crate::PipelineData),
     /// you should use their respective `is_subtype_of` methods instead.
     pub fn is_subtype_of(&self, other: &Type) -> bool {
-        // Structural subtyping
-        let is_subtype_collection =
-            |this: &CollectionColumns<Type>, that: &CollectionColumns<Type>| {
-                let (this, that) = (this.fields.as_ref(), that.fields.as_ref());
-                if this.is_empty() || that.is_empty() {
-                    true
-                } else if this.len() < that.len() {
-                    false
-                } else {
-                    that.iter().all(|(col_y, ty_y)| {
-                        if let Some((_, ty_x)) = this.iter().find(|(col_x, _)| col_x == col_y) {
-                            ty_x.is_subtype_of(ty_y)
-                        } else {
-                            false
-                        }
-                    })
-                }
-            };
-
-        match (self, other) {
-            (t, u) if t == u => true,
-            (_, Type::Any) => true,
-            // We want `get`/`select`/etc to accept string and int values, so it's convenient to
-            // use them with variables, without having to explicitly convert them into cell-paths
-            (Type::String | Type::Int, Type::CellPath) => true,
-            (Type::OneOf(oneof), Type::CellPath) => {
-                oneof.iter().all(|t| t.is_subtype_of(&Type::CellPath))
-            }
-            (Type::Float | Type::Int, Type::Number) => true,
-            (Type::Glob, Type::String) | (Type::String, Type::Glob) => true,
-            (Type::List(t), Type::List(u)) if t.is_subtype_of(u) => true, // List is covariant
-            (Type::Record(this), Type::Record(that)) | (Type::Table(this), Type::Table(that)) => {
-                is_subtype_collection(this, that)
-            }
-            (Type::Table(_), Type::List(that)) if matches!(**that, Type::Any) => true,
-            (Type::Table(this), Type::List(that)) => {
-                matches!(that.as_ref(), Type::Record(that) if is_subtype_collection(this, that))
-            }
-            (Type::List(this), Type::Table(that)) => {
-                matches!(this.as_ref(), Type::Record(this) if is_subtype_collection(this, that))
-            }
-            (Type::OneOf(this), that @ Type::OneOf(_)) => {
-                this.iter().all(|t| t.is_subtype_of(that))
-            }
-            (this, Type::OneOf(that)) => that.iter().any(|t| this.is_subtype_of(t)),
-            _ => false,
-        }
+        <Self as CompareTypes>::is_subtype_of(self, other)
     }
 
     /// Returns supertype of arguments without creating a `oneof`, or falling back to `any` (unless one or both of the arguments are `any`)
@@ -440,6 +394,113 @@ impl Type {
     }
 }
 
+impl CompareTypes for Type {
+    fn compare_types(&self, other: &Self) -> Option<TypeRelation> {
+        match (self, other) {
+            (t, u) if t == u => Some(TypeRelation::Equal),
+
+            (_, Type::Any) => Some(TypeRelation::Subtype),
+            (Type::Any, _) => Some(TypeRelation::Supertype),
+
+            // I don't know how this was decided but this is the behavior that was present in the
+            // parser
+            (Type::Closure, Type::Block) => Some(TypeRelation::Supertype),
+            (Type::Block, Type::Closure) => Some(TypeRelation::Subtype),
+
+            // We want `get`/`select`/etc to accept string and int values, so it's convenient to
+            // use them with variables, without having to explicitly convert them into cell-paths
+            (Type::String | Type::Int, Type::CellPath) => Some(TypeRelation::Subtype),
+            (Type::CellPath, Type::String | Type::Int) => Some(TypeRelation::Supertype),
+
+            (Type::Float | Type::Int, Type::Number) => Some(TypeRelation::Subtype),
+            (Type::Number, Type::Float | Type::Int) => Some(TypeRelation::Supertype),
+
+            (Type::Glob, Type::String) => Some(TypeRelation::Supertype),
+            (Type::String, Type::Glob) => Some(TypeRelation::Subtype),
+
+            // List is covariant
+            (Type::List(t), Type::List(u)) => t.compare_types(u),
+
+            (Type::Record(this), Type::Record(that)) | (Type::Table(this), Type::Table(that)) => {
+                this.compare_types(that)
+            }
+
+            (Type::Table(_), Type::List(list_elem)) if matches!(**list_elem, Type::Any) => {
+                Some(TypeRelation::Subtype)
+            }
+            (Type::List(list_elem), Type::Table(_)) if matches!(**list_elem, Type::Any) => {
+                Some(TypeRelation::Supertype)
+            }
+
+            (Type::Table(table_cols), Type::List(list_elem)) => match list_elem.as_ref() {
+                Type::Record(record_cols) => table_cols.compare_types(record_cols),
+                _ => None,
+            },
+            (Type::List(list_elem), Type::Table(table_cols)) => match list_elem.as_ref() {
+                Type::Record(record_cols) => record_cols.compare_types(table_cols),
+                _ => None,
+            },
+
+            (Type::OneOf(oneof), Type::CellPath) => oneof
+                .iter()
+                .all(|t| {
+                    matches!(
+                        t.compare_types(&Type::CellPath),
+                        Some(TypeRelation::Subtype | TypeRelation::Equal)
+                    )
+                })
+                .then_some(TypeRelation::Subtype),
+            (Type::OneOf(lhs_list), Type::OneOf(rhs_list)) => {
+                // iterate the shorter list to reduce quadratic behaviour
+                let ((small, big), flipped) = if lhs_list.len() <= rhs_list.len() {
+                    ((lhs_list, rhs_list), false)
+                } else {
+                    ((rhs_list, lhs_list), true)
+                };
+
+                for s_ty in small {
+                    let _ = big.iter().find(|b_ty| {
+                        matches!(
+                            s_ty.compare_types(b_ty),
+                            Some(TypeRelation::Subtype | TypeRelation::Equal)
+                        )
+                    })?;
+                }
+
+                Some(match flipped {
+                    false => TypeRelation::Subtype,
+                    true => TypeRelation::Supertype,
+                })
+            }
+
+            (Type::OneOf(lhs_tys), rhs) => lhs_tys
+                .iter()
+                .any(|lhs_ty| {
+                    matches!(
+                        lhs_ty.compare_types(rhs),
+                        Some(TypeRelation::Supertype | TypeRelation::Equal)
+                    )
+                })
+                .then_some(TypeRelation::Supertype),
+            (lhs, Type::OneOf(rhs_tys)) => rhs_tys
+                .iter()
+                .any(|rhs_ty| {
+                    matches!(
+                        lhs.compare_types(rhs_ty),
+                        Some(TypeRelation::Subtype | TypeRelation::Equal)
+                    )
+                })
+                .then_some(TypeRelation::Subtype),
+
+            _ => None,
+        }
+    }
+
+    fn is_any(&self) -> bool {
+        matches!(self, Type::Any)
+    }
+}
+
 impl Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -511,7 +572,7 @@ pub fn combined_type_string(types: &[Type], join_word: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::Type;
+    use super::*;
     use strum::IntoEnumIterator;
 
     mod subtype_relation {

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -461,6 +461,22 @@ mod tests {
         }
     }
 
+    mod oneof {
+        use super::*;
+
+        #[test]
+        fn oneof_lhs() {
+            let rel = Type::one_of([Type::Int, Type::Nothing]).compare_types(&Type::Int);
+            assert_eq!(rel, Some(TypeRelation::Supertype));
+        }
+
+        #[test]
+        fn oneof_rhs() {
+            let rel = Type::Int.compare_types(&Type::one_of([Type::Int, Type::Nothing]));
+            assert_eq!(rel, Some(TypeRelation::Subtype));
+        }
+    }
+
     mod oneof_flattening {
         use super::*;
 
@@ -473,10 +489,9 @@ mod tests {
             ]);
             if let Type::OneOf(oneof) = nested {
                 let types_vec: Vec<Type> = oneof.into_iter().collect();
-                assert_eq!(types_vec.len(), 4);
+                assert_eq!(types_vec.len(), 3);
                 assert!(types_vec.contains(&Type::String));
-                assert!(types_vec.contains(&Type::Int));
-                assert!(types_vec.contains(&Type::Float));
+                assert!(types_vec.contains(&Type::Number));
                 assert!(types_vec.contains(&Type::Bool));
             } else {
                 panic!("Expected OneOf");

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -354,6 +354,7 @@ impl CompareTypes for Type {
             (Type::OneOf(dst_tys), Type::OneOf(src_tys)) => src_tys.is_assignable_to(dst_tys),
             (Type::OneOf(dst_tys), src_ty) => src_ty.is_assignable_to(dst_tys),
             (dst_ty, Type::OneOf(src_tys)) => src_tys.is_assignable_to(dst_ty),
+            (lhs, rhs @ Type::CellPath) => rhs.is_subtype_of(lhs),
             (lhs, rhs) => rhs.compare_types(lhs).is_some(),
         }
     }

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -130,15 +130,6 @@ impl Type {
         Self::Custom(name.into())
     }
 
-    /// Determine of the [`Type`] is a [subtype](https://en.wikipedia.org/wiki/Subtyping) of `other`.
-    ///
-    /// This should only be used at parse-time.
-    /// If you have a concrete [`Value`](crate::Value) or [`PipelineData`](crate::PipelineData),
-    /// you should use their respective `is_subtype_of` methods instead.
-    pub fn is_subtype_of(&self, other: &Type) -> bool {
-        <Self as CompareTypes>::is_subtype_of(self, other)
-    }
-
     /// Returns supertype of arguments without creating a `oneof`, or falling back to `any` (unless one or both of the arguments are `any`)
     pub(crate) fn flat_widen(lhs: Type, rhs: Type) -> Result<Type, (Type, Type)> {
         // handle special cases and hot paths
@@ -184,13 +175,6 @@ impl Type {
             // Fallback - the two types are unrelated. Move them out so that callers don't have to clone again.
             _ => Err((lhs, rhs)),
         }
-    }
-
-    /// Returns the supertype between `self` and `other`, or `Type::Any` if they're unrelated
-    ///
-    /// prefer `TypeSet::union`
-    pub fn widen(self, other: Type) -> Type {
-        <Self as TypeSet>::union(self, other)
     }
 
     /// Returns the supertype of all types within `it`. Short-circuits on, and falls back to, `Type::Any`.
@@ -340,6 +324,19 @@ impl CompareTypes for Type {
 
             _ => None,
         }
+    }
+
+    /// Determine of the [`Type`] is a [subtype](https://en.wikipedia.org/wiki/Subtyping) of `other`.
+    ///
+    /// This should only be used at parse-time.
+    /// If you have a concrete [`Value`](crate::Value) or [`PipelineData`](crate::PipelineData),
+    /// you should use their respective `is_subtype_of` methods instead.
+    // This is identical to this method's default implementation. Written here to attach doccomment.
+    fn is_subtype_of(&self, other: &Self) -> bool {
+        matches!(
+            self.compare_types(other),
+            Some(TypeRelation::Subtype | TypeRelation::Equal)
+        )
     }
 
     fn is_any(&self) -> bool {

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -1,4 +1,6 @@
-use crate::{CollectionColumns, CompareTypes, SyntaxShape, TypeRelation, TypeSet, ast::PathMember};
+use crate::{
+    CollectionColumns, CompareTypes, OneOf, SyntaxShape, TypeRelation, TypeSet, ast::PathMember,
+};
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, fmt::Display};
 #[cfg(test)]
@@ -27,7 +29,7 @@ pub enum Type {
     /// Supertype of Int and Float. Equivalent to `oneof<int, float>`
     Number,
     /// Supertype of all types it contains.
-    OneOf(Box<[Type]>),
+    OneOf(OneOf),
     Range,
     Record(CollectionColumns<Type>),
     String,
@@ -113,11 +115,7 @@ impl Type {
     /// Creates a OneOf type from an iterator of types.
     /// Flattens any nested OneOf types and removes duplicates.
     pub fn one_of(types: impl IntoIterator<Item = Type>) -> Self {
-        let mut flattened = Vec::new();
-        for t in types {
-            Self::oneof_add(&mut flattened, t);
-        }
-        Self::OneOf(flattened.into())
+        Self::OneOf(OneOf::from_iter(types))
     }
 
     pub fn record() -> Self {
@@ -142,7 +140,7 @@ impl Type {
     }
 
     /// Returns supertype of arguments without creating a `oneof`, or falling back to `any` (unless one or both of the arguments are `any`)
-    fn flat_widen(lhs: Type, rhs: Type) -> Result<Type, (Type, Type)> {
+    pub(crate) fn flat_widen(lhs: Type, rhs: Type) -> Result<Type, (Type, Type)> {
         // handle special cases and hot paths
         let (lhs, rhs) = match (lhs, rhs) {
             // disjoint glob/string pair. We don't want to consume lhs/rhs here because subsequent code still needs them.
@@ -193,51 +191,6 @@ impl Type {
     /// prefer `TypeSet::union`
     pub fn widen(self, other: Type) -> Type {
         <Self as TypeSet>::union(self, other)
-    }
-
-    /// Adds a type to a OneOf union, flattening nested OneOfs, deduplicating, and attempting to widen existing types.
-    fn oneof_add_widen(oneof: &mut Vec<Type>, mut t: Type) {
-        // handle nested unions first
-        if let Type::OneOf(inner) = t {
-            for sub_t in inner.into_vec() {
-                Self::oneof_add_widen(oneof, sub_t);
-            }
-            return;
-        }
-
-        let mut i = 0;
-        while i < oneof.len() {
-            let one = std::mem::replace(&mut oneof[i], Type::Any);
-            match Self::flat_widen(one, t) {
-                Ok(one_t) => {
-                    oneof[i] = one_t;
-                    return;
-                }
-                Err((one_old, t_old)) => {
-                    oneof[i] = one_old;
-                    t = t_old; // `t` is mutable here
-                    i += 1;
-                }
-            }
-        }
-
-        oneof.push(t);
-    }
-
-    /// Adds a type to a OneOf union, flattening nested OneOfs and deduplicating.
-    fn oneof_add(oneof: &mut Vec<Type>, t: Type) {
-        match t {
-            Type::OneOf(inner) => {
-                for sub_t in inner.into_vec() {
-                    Self::oneof_add(oneof, sub_t);
-                }
-            }
-            t => {
-                if !oneof.contains(&t) {
-                    oneof.push(t);
-                }
-            }
-        }
     }
 
     /// Returns the supertype of all types within `it`. Short-circuits on, and falls back to, `Type::Any`.
@@ -350,7 +303,7 @@ impl CompareTypes for Type {
             (Type::String, Type::Glob) => Some(TypeRelation::Subtype),
 
             // List is covariant
-            (Type::List(t), Type::List(u)) => t.compare_types(u),
+            (Type::List(t), Type::List(u)) => t.compare_types(u.as_ref()),
 
             (Type::Record(this), Type::Record(that)) | (Type::Table(this), Type::Table(that)) => {
                 this.compare_types(that)
@@ -381,47 +334,9 @@ impl CompareTypes for Type {
                     )
                 })
                 .then_some(TypeRelation::Subtype),
-            (Type::OneOf(lhs_list), Type::OneOf(rhs_list)) => {
-                // iterate the shorter list to reduce quadratic behaviour
-                let ((small, big), flipped) = if lhs_list.len() <= rhs_list.len() {
-                    ((lhs_list, rhs_list), false)
-                } else {
-                    ((rhs_list, lhs_list), true)
-                };
-
-                for s_ty in small {
-                    let _ = big.iter().find(|b_ty| {
-                        matches!(
-                            s_ty.compare_types(b_ty),
-                            Some(TypeRelation::Subtype | TypeRelation::Equal)
-                        )
-                    })?;
-                }
-
-                Some(match flipped {
-                    false => TypeRelation::Subtype,
-                    true => TypeRelation::Supertype,
-                })
-            }
-
-            (Type::OneOf(lhs_tys), rhs) => lhs_tys
-                .iter()
-                .any(|lhs_ty| {
-                    matches!(
-                        lhs_ty.compare_types(rhs),
-                        Some(TypeRelation::Supertype | TypeRelation::Equal)
-                    )
-                })
-                .then_some(TypeRelation::Supertype),
-            (lhs, Type::OneOf(rhs_tys)) => rhs_tys
-                .iter()
-                .any(|rhs_ty| {
-                    matches!(
-                        lhs.compare_types(rhs_ty),
-                        Some(TypeRelation::Subtype | TypeRelation::Equal)
-                    )
-                })
-                .then_some(TypeRelation::Subtype),
+            (Type::OneOf(lhs_oneof), Type::OneOf(rhs_oneof)) => lhs_oneof.compare_types(rhs_oneof),
+            (Type::OneOf(lhs_oneof), rhs) => lhs_oneof.compare_types(rhs),
+            (lhs, Type::OneOf(rhs_oneof)) => lhs.compare_types(rhs_oneof),
 
             _ => None,
         }
@@ -440,22 +355,8 @@ impl TypeSet for Type {
         };
 
         match (lhs, rhs) {
-            (Type::OneOf(ts), Type::OneOf(us)) => {
-                let (big, small) = match ts.len() >= us.len() {
-                    true => (ts, us),
-                    false => (us, ts),
-                };
-                let mut out = big.into_vec();
-                for t in small.into_iter() {
-                    Self::oneof_add_widen(&mut out, t);
-                }
-                Type::one_of(out)
-            }
-            (Type::OneOf(oneof), t) | (t, Type::OneOf(oneof)) => {
-                let mut out = oneof.into_vec();
-                Self::oneof_add_widen(&mut out, t);
-                Type::one_of(out)
-            }
+            (Type::OneOf(ts), Type::OneOf(us)) => Type::OneOf(ts.union(us)),
+            (Type::OneOf(oneof), t) | (t, Type::OneOf(oneof)) => Type::OneOf(oneof.add_ty(t)),
             (this, other) => Type::one_of([this, other]),
         }
     }
@@ -479,17 +380,7 @@ impl Display for Type {
             Type::List(l) => write!(f, "list<{l}>"),
             Type::Nothing => write!(f, "nothing"),
             Type::Number => write!(f, "number"),
-            Type::OneOf(types) => {
-                write!(f, "oneof")?;
-                let [first, rest @ ..] = &**types else {
-                    return Ok(());
-                };
-                write!(f, "<{first}")?;
-                for t in rest {
-                    write!(f, ", {t}")?;
-                }
-                f.write_str(">")
-            }
+            Type::OneOf(oneof) => write!(f, "{oneof}"),
             Type::String => write!(f, "string"),
             Type::Any => write!(f, "any"),
             Type::Error => write!(f, "error"),

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -471,8 +471,8 @@ mod tests {
                 Type::one_of([Type::Int, Type::Float]),
                 Type::Bool,
             ]);
-            if let Type::OneOf(types) = nested {
-                let types_vec = types.to_vec();
+            if let Type::OneOf(oneof) = nested {
+                let types_vec: Vec<Type> = oneof.into_iter().collect();
                 assert_eq!(types_vec.len(), 4);
                 assert!(types_vec.contains(&Type::String));
                 assert!(types_vec.contains(&Type::Int));
@@ -488,8 +488,8 @@ mod tests {
             let a = Type::one_of([Type::String, Type::Int]);
             let b = Type::one_of([Type::Float, Type::Bool]);
             let widened = a.union(b);
-            if let Type::OneOf(types) = widened {
-                let types_vec = types.to_vec();
+            if let Type::OneOf(oneof) = widened {
+                let types_vec: Vec<Type> = oneof.into_iter().collect();
                 assert_eq!(types_vec.len(), 3);
                 assert!(types_vec.contains(&Type::String));
                 assert!(types_vec.contains(&Type::Number)); // Int + Float -> Number
@@ -504,8 +504,8 @@ mod tests {
             let record_type =
                 Type::Record(vec![("content".to_string(), Type::list(Type::String))].into());
             let oneof = Type::one_of([Type::String, record_type.clone(), record_type.clone()]);
-            if let Type::OneOf(types) = oneof {
-                let types_vec = types.to_vec();
+            if let Type::OneOf(oneof) = oneof {
+                let types_vec: Vec<Type> = oneof.into_iter().collect();
                 assert_eq!(types_vec.len(), 2);
                 assert!(types_vec.contains(&Type::String));
                 assert!(types_vec.contains(&record_type));

--- a/crates/nu-protocol/src/ty_relation.rs
+++ b/crates/nu-protocol/src/ty_relation.rs
@@ -66,6 +66,14 @@ pub trait CompareTypes<Rhs = Self> {
         )
     }
 
+    /// Returns `true` if `self` is equal to or is a *strict* supertype of `other`
+    fn is_supertype_of(&self, other: &Rhs) -> bool {
+        matches!(
+            self.compare_types(other),
+            Some(TypeRelation::Supertype | TypeRelation::Equal)
+        )
+    }
+
     /// Allows having an "escape hatch".
     ///
     /// Due to not having separate top and bottom types, and treating `any` as both, we need to be
@@ -78,6 +86,13 @@ pub trait CompareTypes<Rhs = Self> {
     /// - `int <: list`???
     fn is_any(&self) -> bool {
         false
+    }
+
+    /// Equivalent to [`CompareTypes::is_subtype_of`] by default.
+    ///
+    /// Exists as a separate method to allow relaxing requirements when needed.
+    fn is_assignable_to(&self, dst: &Rhs) -> bool {
+        self.is_subtype_of(dst)
     }
 }
 

--- a/crates/nu-protocol/src/ty_relation.rs
+++ b/crates/nu-protocol/src/ty_relation.rs
@@ -43,9 +43,18 @@ impl TypeRelation {
 
 /// Trait for comparisons corresponding to subtyping relations.
 ///
+/// `<:` and `:>` are used to mean "is subtype of" and "is supertype of" respectively.
+/// `<<:` and `:>>` are used as their "strict" counterparts (no equality).
+///
 /// Implementations must be:
 /// - *Transitive*: if `a <: b` and `b <: c`, then `a <: c`
-/// - *Antisymmetric*: if `a <: b`, then `b :> a`
+/// - *Dual*: if `a <: b`, then `b :> a`
+/// - *Antisymmetric*:
+///   - if `a <<: b`, then `b <<: a` can't be true
+///   - if `a <: b` and `b <: a`, then `a == b`
+///
+/// Output of [`Self::is_subtype_of`] and [`Self::is_supertype_of`] must be consistent with
+/// [`Self::compare_types`]
 ///
 /// The `Rhs` type parameter is to allow comparing the runtime type of a value with static types,
 /// without going through intermediate steps.
@@ -59,6 +68,8 @@ pub trait CompareTypes<Rhs = Self> {
     fn compare_types(&self, other: &Rhs) -> Option<TypeRelation>;
 
     /// Returns `true` if `self` is equal to or is a *strict* subtype of `other`
+    ///
+    /// Converse of [`Self::is_supertype_of`]
     fn is_subtype_of(&self, other: &Rhs) -> bool {
         matches!(
             self.compare_types(other),
@@ -67,6 +78,8 @@ pub trait CompareTypes<Rhs = Self> {
     }
 
     /// Returns `true` if `self` is equal to or is a *strict* supertype of `other`
+    ///
+    /// Converse of [`Self::is_subtype_of`]
     fn is_supertype_of(&self, other: &Rhs) -> bool {
         matches!(
             self.compare_types(other),

--- a/crates/nu-protocol/src/ty_relation.rs
+++ b/crates/nu-protocol/src/ty_relation.rs
@@ -16,7 +16,7 @@ impl TypeRelation {
         }
     }
 
-    /// Badly named
+    /// Combines two partial relation results.
     ///
     /// While computing the relation of two types, sometimes it has to be done in multiple steps,
     /// e.g. `oneof`, `record`.

--- a/crates/nu-protocol/src/ty_relation.rs
+++ b/crates/nu-protocol/src/ty_relation.rs
@@ -1,0 +1,93 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeRelation {
+    /// Strict subtype
+    Subtype,
+    Equal,
+    /// Strict supertype
+    Supertype,
+}
+
+impl TypeRelation {
+    pub fn reverse(self) -> Self {
+        match self {
+            Self::Subtype => Self::Supertype,
+            Self::Equal => Self::Equal,
+            Self::Supertype => Self::Subtype,
+        }
+    }
+
+    /// Badly named
+    ///
+    /// While computing the relation of two types, sometimes it has to be done in multiple steps,
+    /// e.g. `oneof`, `record`.
+    /// -   In both cases, one may start with [`Self::Equal`] before processing any type parameters.
+    /// -   If both types are empty (e.g. `record<>` with no columns, `oneof<>` with no variants),
+    ///     [`Self::Equal`] is the correct result without requiring further checks.
+    /// -   As items are checked, the result of these checks may not form a coherent result.
+    ///     e.g.: `lhs = record<a: int, b: int>` and `rhs = record<a: int, c: int>`
+    ///     -   both `lhs` and `rhs` have an `a: int` column. `lhs` and `rhs` might be [Equal](Self::Equal)
+    ///     -   `lhs` has a `b: int` column, which `rhs` does not. This makes `lhs` the more
+    ///         specific type between the two, thus `lhs` might be a [Subtype](Self::Subtype) of `rhs`
+    ///     -   `lhs` does not have a `b: int` column, which `rhs` does. This makes `rhs` the more
+    ///         specific type between the two, thus `lhs` might be a [Supertype](Self::Supertype) of `rhs`
+    /// -   If there are conflicting results, returns [`None`]
+    pub fn combine(self, other: Self) -> Option<Self> {
+        match (self, other) {
+            (s, Self::Equal) | (Self::Equal, s) => Some(s),
+            (Self::Subtype, Self::Subtype) => Some(Self::Subtype),
+            (Self::Supertype, Self::Supertype) => Some(Self::Supertype),
+            _ => None,
+        }
+    }
+}
+
+/// Trait for comparisons corresponding to subtyping relations.
+///
+/// Implementations must be:
+/// - *Transitive*: if `a <: b` and `b <: c`, then `a <: c`
+/// - *Antisymmetric*: if `a <: b`, then `b :> a`
+///
+/// The `Rhs` type parameter is to allow comparing the runtime type of a value with static types,
+/// without going through intermediate steps.
+/// Instead of `Value::get_type(&val).compare_types(&ty)`, which might require allocations for the
+/// intermediate `Type`, one can use `Value::compare_types(&val, &ty)`
+pub trait CompareTypes<Rhs = Self> {
+    /// Compares types and returns their relation with regards to subtyping.
+    ///
+    /// - Returns `Some` if types are equal, or one type is a subtype of the other.
+    /// - Returns `None` if neither type is equal to or is subtype of the other.
+    fn compare_types(&self, other: &Rhs) -> Option<TypeRelation>;
+
+    /// Returns `true` if `self` is equal to or is a *strict* subtype of `other`
+    fn is_subtype_of(&self, other: &Rhs) -> bool {
+        matches!(
+            self.compare_types(other),
+            Some(TypeRelation::Subtype | TypeRelation::Equal)
+        )
+    }
+
+    /// Allows having an "escape hatch".
+    ///
+    /// Due to not having separate top and bottom types, and treating `any` as both, we need to be
+    /// especially lax in some situations to keep things convenient and backwards compatible.
+    ///
+    /// We can't treat `any` as a bottom type in [`CompareTypes::compare_types`] as due to
+    /// reflexivity it would imply all types are subtypes of all other types:
+    /// - `any` as top type: `int <: any`
+    /// - `any` as *bottom* type: `any <: list`
+    /// - `int <: list`???
+    fn is_any(&self) -> bool {
+        false
+    }
+}
+
+/// Trait for set operations on types.
+pub trait TypeSet {
+    /// Returns the narrowest common supertype of the given types.
+    #[doc(alias = "widen")]
+    fn union(self, other: Self) -> Self;
+
+    // // no actual use case yet. this is just where it should be when/if it's implemented
+    // #[doc(alias = "narrow")]
+    // fn intersection(self, other: Self) -> Option<Self>;
+}

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -623,7 +623,7 @@ where
     }
 
     fn expected_type() -> Type {
-        Type::one_of(vec![A::expected_type(), B::expected_type()])
+        Type::one_of([A::expected_type(), B::expected_type()])
     }
 }
 

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -623,7 +623,7 @@ where
     }
 
     fn expected_type() -> Type {
-        Type::OneOf(vec![A::expected_type(), B::expected_type()].into())
+        Type::one_of(vec![A::expected_type(), B::expected_type()])
     }
 }
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -5422,9 +5422,7 @@ mod tests {
             assert_eq!(list_of_floats.get_type(), Type::List(Box::new(Type::Float)));
             assert_eq!(
                 list_of_ints_and_floats_and_bools.get_type(),
-                Type::List(Box::new(Type::OneOf(
-                    vec![Type::Number, Type::Bool].into_boxed_slice()
-                )))
+                Type::List(Box::new(Type::one_of([Type::Number, Type::Bool])))
             );
             assert_eq!(
                 list_of_ints_and_floats.get_type(),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -5436,6 +5436,7 @@ mod tests {
 
         use super::*;
 
+        #[track_caller]
         fn assert_subtype_equivalent(value: &Value, ty: &Type) {
             assert_eq!(value.is_subtype_of(ty), value.get_type().is_subtype_of(ty));
         }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1049,23 +1049,6 @@ impl Value {
         }
     }
 
-    /// Determine of the [`Value`] is a [subtype](https://en.wikipedia.org/wiki/Subtyping) of `other`
-    ///
-    /// If you have a [`Value`], this method should always be used over chaining [`Value::get_type`] with [`Type::is_subtype_of`](crate::Type::is_subtype_of).
-    ///
-    /// This method is able to leverage that information encoded in a `Value` to provide more accurate
-    /// type comparison than if one were to collect the type into [`Type`](crate::Type) value with [`Value::get_type`].
-    ///
-    /// Empty lists are considered subtypes of all `list<T>` types.
-    ///
-    /// Lists of mixed records where some column is present in all record is a subtype of `table<column>`.
-    /// For example, `[{a: 1, b: 2}, {a: 1}]` is a subtype of `table<a: int>` (but not `table<a: int, b: int>`).
-    ///
-    /// See also: [`PipelineData::is_subtype_of`](crate::PipelineData::is_subtype_of)
-    pub fn is_subtype_of(&self, other: &Type) -> bool {
-        <Self as CompareTypes<Type>>::is_subtype_of(self, other)
-    }
-
     pub fn get_data_by_key(&self, name: &str) -> Option<Value> {
         let span = self.span();
         match self {
@@ -2200,6 +2183,27 @@ impl CompareTypes<Type> for Value {
             },
             val => val.get_type().compare_types(other),
         }
+    }
+
+    /// Determine if the [`Value`] is a [subtype](https://en.wikipedia.org/wiki/Subtyping) of `other`
+    ///
+    /// If you have a [`Value`], this method should always be used over chaining [`Value::get_type`] with [`Type::is_subtype_of`].
+    ///
+    /// This method is able to leverage that information encoded in a `Value` to provide more accurate
+    /// type comparison than if one were to collect the type into [`Type`] value with [`Value::get_type`].
+    ///
+    /// Empty lists are considered subtypes of all `list<T>` types.
+    ///
+    /// Lists of mixed records where some column is present in all record is a subtype of `table<column>`.
+    /// For example, `[{a: 1, b: 2}, {a: 1}]` is a subtype of `table<a: int>` (but not `table<a: int, b: int>`).
+    ///
+    /// See also: [`PipelineData::is_subtype_of`](crate::PipelineData::is_subtype_of)
+    // This is identical to this method's default implementation. Written here to attach doccomment.
+    fn is_subtype_of(&self, other: &Type) -> bool {
+        matches!(
+            self.compare_types(other),
+            Some(TypeRelation::Subtype | TypeRelation::Equal)
+        )
     }
 }
 
@@ -5432,7 +5436,7 @@ mod tests {
     }
 
     mod is_subtype {
-        use crate::Type;
+        use crate::{CompareTypes, Type};
 
         use super::*;
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -21,7 +21,7 @@ pub use range::{FloatRange, IntRange, Range};
 pub use record::Record;
 
 use crate::{
-    BlockId, CollectionColumns, Config, ShellError, Signals, Span, Type,
+    BlockId, CompareTypes, Config, ShellError, Signals, Span, Type, TypeRelation,
     ast::{Bits, Boolean, CellPath, Comparison, Math, Operator, PathMember},
     did_you_mean,
     engine::{Closure, EngineState},
@@ -1063,52 +1063,7 @@ impl Value {
     ///
     /// See also: [`PipelineData::is_subtype_of`](crate::PipelineData::is_subtype_of)
     pub fn is_subtype_of(&self, other: &Type) -> bool {
-        // records are structurally typed
-        let record_compatible = |val: &Value, other: &CollectionColumns<Type>| match val {
-            Value::Record { val, .. } => other
-                .fields
-                .iter()
-                .all(|(key, ty)| val.get(key).is_some_and(|inner| inner.is_subtype_of(ty))),
-            _ => false,
-        };
-
-        // All cases matched explicitly to ensure this does not accidentally allocate `Type` if any composite types are introduced in the future
-        match (self, other) {
-            (_, Type::Any) => true,
-            (val, Type::OneOf(types)) => types.iter().any(|t| val.is_subtype_of(t)),
-
-            // `Type` allocation for scalar types is trivial
-            (
-                Value::Bool { .. }
-                | Value::Int { .. }
-                | Value::Float { .. }
-                | Value::String { .. }
-                | Value::Glob { .. }
-                | Value::Filesize { .. }
-                | Value::Duration { .. }
-                | Value::Date { .. }
-                | Value::Range { .. }
-                | Value::Closure { .. }
-                | Value::Error { .. }
-                | Value::Binary { .. }
-                | Value::CellPath { .. }
-                | Value::Nothing { .. },
-                _,
-            ) => self.get_type().is_subtype_of(other),
-
-            // matching composite types
-            (val @ Value::Record { .. }, Type::Record(inner)) => record_compatible(val, inner),
-            (Value::List { vals, .. }, Type::List(inner)) => {
-                vals.iter().all(|val| val.is_subtype_of(inner))
-            }
-            (Value::List { vals, .. }, Type::Table(inner)) => {
-                vals.iter().all(|val| record_compatible(val, inner))
-            }
-            (Value::Custom { val, .. }, Type::Custom(inner)) => val.type_name() == **inner,
-
-            // non-matching composite types
-            (Value::Record { .. } | Value::List { .. } | Value::Custom { .. }, _) => false,
-        }
+        <Self as CompareTypes<Type>>::is_subtype_of(self, other)
     }
 
     pub fn get_data_by_key(&self, name: &str) -> Option<Value> {
@@ -2207,6 +2162,43 @@ impl Value {
                 *s = Some(engine_state.signals().clone());
             }
             _ => (),
+        }
+    }
+}
+
+impl CompareTypes<Type> for Value {
+    fn compare_types(&self, other: &Type) -> Option<TypeRelation> {
+        match other {
+            Type::Any => return Some(TypeRelation::Subtype),
+            Type::OneOf(oneof) => {
+                return oneof
+                    .iter()
+                    .any(|ty| self.is_subtype_of(ty))
+                    .then_some(TypeRelation::Subtype);
+            }
+            _ => (),
+        }
+
+        match self {
+            Value::List { vals, .. } => match other {
+                Type::List(ty) if let Type::Any = ty.as_ref() => Some(TypeRelation::Subtype),
+                Type::List(ty) => {
+                    let ty = ty.as_ref();
+                    vals.iter()
+                        .map(|val| val.compare_types(ty))
+                        .try_fold(TypeRelation::Equal, |acc, e| acc.combine(e?))
+                }
+                Type::Table(cols) => vals
+                    .iter()
+                    .map(|val| val.as_record().ok().and_then(|rec| rec.compare_types(cols)))
+                    .try_fold(TypeRelation::Equal, |acc, e| acc.combine(e?)),
+                _ => None,
+            },
+            Value::Record { val, .. } => match other {
+                Type::Record(cols) => val.compare_types(cols),
+                _ => None,
+            },
+            val => val.get_type().compare_types(other),
         }
     }
 }

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -550,20 +550,18 @@ impl Record {
 
 impl CompareTypes<CollectionColumns<Type>> for Record {
     fn compare_types(&self, other: &CollectionColumns<Type>) -> Option<TypeRelation> {
-        let values = self.inner.as_slice();
-        let tys = other.fields.as_ref();
-
-        // Handle the simplest cases
-        match (values, tys) {
-            ([], []) => return Some(TypeRelation::Equal),
-            ([], _) => return Some(TypeRelation::Supertype),
-            (_, []) => return Some(TypeRelation::Subtype),
-            _ => (),
+        match (self.is_empty(), other.is_empty()) {
+            (true, true) => return Some(TypeRelation::Equal),
+            (true, false) => return Some(TypeRelation::Supertype),
+            (false, true) => return Some(TypeRelation::Subtype),
+            (false, false) => {}
         }
 
-        tys.iter()
+        other
+            .iter()
             .map(|(ty_name, ty)| {
-                match values.iter().find(|(val_name, _)| val_name == ty_name) {
+                let found = self.inner.iter().find(|(val_name, _)| val_name == ty_name);
+                match found {
                     Some((_, val)) => val.compare_types(ty),
                     // If the record value does not have a column specified in the type, then the
                     // record's type might be a supertype of `other`

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -560,9 +560,8 @@ impl CompareTypes<CollectionColumns<Type>> for Record {
         other
             .iter()
             .map(|(ty_name, ty)| {
-                let found = self.inner.iter().find(|(val_name, _)| val_name == ty_name);
-                match found {
-                    Some((_, val)) => val.compare_types(ty),
+                match self.get(ty_name) {
+                    Some(val) => val.compare_types(ty),
                     // If the record value does not have a column specified in the type, then the
                     // record's type might be a supertype of `other`
                     None => Some(TypeRelation::Supertype),

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::{
-    ShellError, Span, Value,
+    CollectionColumns, CompareTypes, ShellError, Span, Type, TypeRelation, Value,
     casing::{CaseInsensitive, CaseSensitive, CaseSensitivity, Casing, WrapCased},
 };
 
@@ -545,6 +545,32 @@ impl Record {
     /// ```
     pub fn sort_cols(&mut self) {
         self.inner.sort_by(|(k1, _), (k2, _)| k1.cmp(k2))
+    }
+}
+
+impl CompareTypes<CollectionColumns<Type>> for Record {
+    fn compare_types(&self, other: &CollectionColumns<Type>) -> Option<TypeRelation> {
+        let values = self.inner.as_slice();
+        let tys = other.fields.as_ref();
+
+        // Handle the simplest cases
+        match (values, tys) {
+            ([], []) => return Some(TypeRelation::Equal),
+            ([], _) => return Some(TypeRelation::Supertype),
+            (_, []) => return Some(TypeRelation::Subtype),
+            _ => (),
+        }
+
+        tys.iter()
+            .map(|(ty_name, ty)| {
+                match values.iter().find(|(val_name, _)| val_name == ty_name) {
+                    Some((_, val)) => val.compare_types(ty),
+                    // If the record value does not have a column specified in the type, then the
+                    // record's type might be a supertype of `other`
+                    None => Some(TypeRelation::Supertype),
+                }
+            })
+            .try_fold(TypeRelation::Equal, |acc, e| acc.combine(e?))
     }
 }
 

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -557,17 +557,57 @@ impl CompareTypes<CollectionColumns<Type>> for Record {
             (false, false) => {}
         }
 
-        other
-            .iter()
-            .map(|(ty_name, ty)| {
-                match self.get(ty_name) {
-                    Some(val) => val.compare_types(ty),
-                    // If the record value does not have a column specified in the type, then the
-                    // record's type might be a supertype of `other`
-                    None => Some(TypeRelation::Supertype),
-                }
-            })
-            .try_fold(TypeRelation::Equal, |acc, e| acc.combine(e?))
+        let (flipped, eq) = match self.len().cmp(&other.len()) {
+            std::cmp::Ordering::Less => (false, false),
+            std::cmp::Ordering::Equal => (false, true),
+            std::cmp::Ordering::Greater => (true, false),
+        };
+
+        let start = match eq {
+            true => TypeRelation::Equal,
+            false => TypeRelation::Supertype,
+        };
+
+        if flipped {
+            let lhs = other;
+            let rhs = self;
+            lhs.iter()
+                .map(|(lhs_key, lhs_ty)| {
+                    match rhs.get(lhs_key) {
+                        Some(rhs_val) => {
+                            if CompareTypes::<Type>::is_any(lhs_ty) || rhs_val.is_any() {
+                                // Not really" equal", just used to continue without affecting the outcome.
+                                Some(TypeRelation::Equal)
+                            } else {
+                                // `CompareTypes<Value> for Type` is not implemented
+                                // lhs_ty.compare_types(rhs_val)
+                                rhs_val.compare_types(lhs_ty).map(TypeRelation::reverse)
+                            }
+                        }
+                        None => None,
+                    }
+                })
+                .try_fold(start, |acc, e| acc.combine(e?))
+                .map(TypeRelation::reverse)
+        } else {
+            let lhs = self;
+            let rhs = other;
+            lhs.iter()
+                .map(|(lhs_key, lhs_val)| {
+                    match rhs.get(lhs_key) {
+                        Some(rhs_ty) => {
+                            if lhs_val.is_any() || CompareTypes::<Type>::is_any(rhs_ty) {
+                                // Not really" equal", just used to continue without affecting the outcome.
+                                Some(TypeRelation::Equal)
+                            } else {
+                                lhs_val.compare_types(rhs_ty)
+                            }
+                        }
+                        None => None,
+                    }
+                })
+                .try_fold(start, |acc, e| acc.combine(e?))
+        }
     }
 }
 

--- a/tests/repl/tests.rs
+++ b/tests/repl/tests.rs
@@ -7,6 +7,7 @@ use tempfile::NamedTempFile;
 
 pub type TestResult = Result<(), Box<dyn std::error::Error>>;
 
+#[track_caller]
 pub fn run_test_with_env(input: &str, expected: &str, env: &HashMap<&str, &str>) -> TestResult {
     let mut file = NamedTempFile::new()?;
     let name = file.path();
@@ -41,6 +42,7 @@ pub fn run_test(input: &str, expected: &str) -> TestResult {
 }
 
 #[cfg(test)]
+#[track_caller]
 pub fn run_test_std(input: &str, expected: &str) -> TestResult {
     let mut file = NamedTempFile::new()?;
     let name = file.path();
@@ -77,6 +79,7 @@ fn run_cmd_and_assert(mut cmd: Command, expected: &str) -> TestResult {
 }
 
 #[cfg(test)]
+#[track_caller]
 pub fn run_test_contains(input: &str, expected: &str) -> TestResult {
     let mut file = NamedTempFile::new()?;
     let name = file.path();
@@ -105,6 +108,7 @@ pub fn run_test_contains(input: &str, expected: &str) -> TestResult {
 }
 
 #[cfg(test)]
+#[track_caller]
 pub fn test_ide_contains(input: &str, ide_commands: &[&str], expected: &str) -> TestResult {
     let mut file = NamedTempFile::new()?;
     let name = file.path();
@@ -136,6 +140,7 @@ pub fn test_ide_contains(input: &str, ide_commands: &[&str], expected: &str) -> 
 }
 
 #[cfg(test)]
+#[track_caller]
 pub fn fail_test(input: &str, expected: &str) -> TestResult {
     let mut file = NamedTempFile::new()?;
     let name = file.path();


### PR DESCRIPTION
## Description

- Moved `Type::OneOf` related code to a separate `OneOf` struct.
- Added `CompareTypes` trait and `TypeRelation` enum describing the subtyping relation between types.
- Added `TypeSet` for type union (widening) operations.

All the type checking code being scattered in different places and having subtle differences depending on the use case was frustrating to work with.

Also, `oneof<>` (our only uninhibited type, so it could be considered the bottom type) had some inconsistencies and unexpected behavior, which are now fixed. I'm not putting this in the release notes because:
- `oneof<>` is extremely niche with the only use being adding a parameter to a command which can never be passed
- `oneof<>`, the empty type set, exist more or less as an emergent property of how our type system is implemented. It's not a deliberate bottom type, and we do not guarantee anything about it
- until the #18212 is merged, it will continue to have incorrect behaviors
  ```nushell
  # this should, and does type check
  # this command can never be called, `$param` is required but will not accept any value
  def foo [param: oneof<>] {
      let x: oneof<> = $param
  }

  # this should NOT, and yet does type check
  # this command can be called, but only without an argument
  def bar [param?: oneof<>] {
      # at runtime `$param` can only ever be `null` and thus
      # should be rejected by the parser in the following assignment
      # unfortunately, `$param`'s type is not expanded to include `nothing`
      # and causes parse time type checking to consider this assigment correct,
      # only to fail at runtime (if `enforce-runtime-annotations` is enabled)
      let x: oneof<> = $param
  }
  ```

## User-facing changes (Release notes)
N/A