### PR TITLE
Allow polars selectors as input for all commands that accept expressions as input.

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/cumulative.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/cumulative.rs
@@ -78,6 +78,10 @@ impl PluginCommand for Cumulative {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/implode.rs
@@ -28,10 +28,16 @@ impl PluginCommand for ExprImplode {
                 "Maintains the order of the original values in the list",
                 Some('o'),
             )
-            .input_output_type(
-                PolarsPluginType::NuExpression.into(),
-                PolarsPluginType::NuExpression.into(),
-            )
+            .input_output_types(vec![
+                (
+                    PolarsPluginType::NuExpression.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -63,7 +69,10 @@ impl PluginCommand for ExprImplode {
         let value = input.into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),
-            _ => Err(cant_convert_err(&value, &[PolarsPluginType::NuExpression])),
+            _ => Err(cant_convert_err(
+                &value,
+                &[PolarsPluginType::NuExpression, PolarsPluginType::NuSelector],
+            )),
         }
         .map_err(LabeledError::from)
         .map(|pd| pd.set_metadata(metadata))

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/max.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/max.rs
@@ -30,6 +30,10 @@ impl PluginCommand for ExprMax {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -108,6 +112,7 @@ impl PluginCommand for ExprMax {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/mean.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/mean.rs
@@ -30,6 +30,10 @@ impl PluginCommand for ExprMean {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -108,6 +112,7 @@ impl PluginCommand for ExprMean {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/median.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/median.rs
@@ -31,6 +31,10 @@ impl PluginCommand for LazyMedian {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -112,6 +116,7 @@ impl PluginCommand for LazyMedian {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/min.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/min.rs
@@ -30,6 +30,10 @@ impl PluginCommand for ExprMin {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -108,6 +112,7 @@ impl PluginCommand for ExprMin {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/n_unique.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/n_unique.rs
@@ -32,6 +32,10 @@ impl PluginCommand for NUnique {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -93,6 +97,7 @@ impl PluginCommand for NUnique {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/over.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/over.rs
@@ -31,10 +31,16 @@ impl PluginCommand for Over {
                 SyntaxShape::Any,
                 "Expression(s) that define the partition window.",
             )
-            .input_output_type(
-                PolarsPluginType::NuExpression.into(),
-                PolarsPluginType::NuExpression.into(),
-            )
+            .input_output_types(vec![
+                (
+                    PolarsPluginType::NuExpression.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+            ])
             .category(Category::Custom("lazyframe".into()))
     }
 
@@ -108,7 +114,7 @@ impl PluginCommand for Over {
             }
             _ => Err(cant_convert_err(
                 &input_value,
-                &[PolarsPluginType::NuExpression],
+                &[PolarsPluginType::NuExpression, PolarsPluginType::NuSelector],
             )),
         }
         .map_err(LabeledError::from)

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/quantile.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/quantile.rs
@@ -38,6 +38,10 @@ impl PluginCommand for LazyQuantile {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -125,6 +129,7 @@ impl PluginCommand for LazyQuantile {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/std.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/std.rs
@@ -30,6 +30,10 @@ impl PluginCommand for ExprStd {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -100,6 +104,7 @@ impl PluginCommand for ExprStd {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/sum.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/sum.rs
@@ -30,6 +30,10 @@ impl PluginCommand for ExprSum {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -108,6 +112,7 @@ impl PluginCommand for ExprSum {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/aggregation/var.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/aggregation/var.rs
@@ -31,6 +31,10 @@ impl PluginCommand for ExprVar {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -101,6 +105,7 @@ impl PluginCommand for ExprVar {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/is_not_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/is_not_null.rs
@@ -32,6 +32,10 @@ impl PluginCommand for IsNotNull {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -100,6 +104,7 @@ impl PluginCommand for IsNotNull {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/is_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/is_null.rs
@@ -34,6 +34,10 @@ impl PluginCommand for IsNull {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -102,6 +106,7 @@ impl PluginCommand for IsNull {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/boolean/when.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/boolean/when.rs
@@ -41,9 +41,10 @@ impl PluginCommand for ExprWhen {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
-                // FIXME Type::Any input added to disable pipeline input type checking, as run-time checks can raise undesirable type errors
-                // which aren't caught by the parser. see https://github.com/nushell/nushell/pull/14922 for more details
-                (Type::Any, PolarsPluginType::NuExpression.into()),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("expression".into()))
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/data/cast.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/cast.rs
@@ -35,6 +35,10 @@ impl PluginCommand for CastDF {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),

--- a/crates/nu_plugin_polars/src/dataframe/command/data/entropy.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/entropy.rs
@@ -39,10 +39,16 @@ impl PluginCommand for Entropy {
                 "Normalize pk if it doesn’t sum to 1. Default to true.",
                 None,
             )
-            .input_output_types(vec![(
-                PolarsPluginType::NuExpression.into(),
-                PolarsPluginType::NuExpression.into(),
-            )])
+            .input_output_types(vec![
+                (
+                    PolarsPluginType::NuExpression.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -90,7 +96,10 @@ impl PluginCommand for Entropy {
         let value = input.into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),
-            _ => Err(cant_convert_err(&value, &[PolarsPluginType::NuExpression])),
+            _ => Err(cant_convert_err(
+                &value,
+                &[PolarsPluginType::NuExpression, PolarsPluginType::NuSelector],
+            )),
         }
         .map_err(LabeledError::from)
         .map(|pd| pd.set_metadata(metadata))

--- a/crates/nu_plugin_polars/src/dataframe/command/data/explode.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/explode.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use crate::PolarsPlugin;
 use crate::dataframe::values::{Column, NuDataFrame, NuExpression, NuLazyFrame};
-use crate::values::{CustomValueSupport, NuSelector, PolarsPluginObject, PolarsPluginType};
+use crate::values::{
+    CustomValueSupport, NuSelector, PolarsPluginObject, PolarsPluginType, cant_convert_err,
+};
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
@@ -36,6 +38,10 @@ impl PluginCommand for LazyExplode {
             .input_output_types(vec![
                 (
                     PolarsPluginType::NuExpression.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
+                    PolarsPluginType::NuSelector.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
@@ -158,12 +164,15 @@ pub(crate) fn explode(
         PolarsPluginObject::NuExpression(expr) => {
             explode_expr(plugin, engine, call, expr, explode_options)
         }
-        _ => Err(ShellError::CantConvert {
-            to_type: "dataframe or expression".into(),
-            from_type: value.get_type().to_string(),
-            span: call.head,
-            help: None,
-        }),
+        _ => Err(cant_convert_err(
+            &value,
+            &[
+                PolarsPluginType::NuDataFrame,
+                PolarsPluginType::NuLazyFrame,
+                PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
+            ],
+        )),
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/command/data/fill_nan.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/fill_nan.rs
@@ -38,6 +38,14 @@ impl PluginCommand for LazyFillNA {
                     PolarsPluginType::NuLazyFrame.into(),
                     PolarsPluginType::NuLazyFrame.into(),
                 ),
+                (
+                    PolarsPluginType::NuExpression.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("lazyframe".into()))
     }
@@ -123,6 +131,7 @@ impl PluginCommand for LazyFillNA {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/data/fill_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/fill_null.rs
@@ -42,6 +42,10 @@ impl PluginCommand for LazyFillNull {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("lazyframe".into()))
     }
@@ -119,6 +123,7 @@ impl PluginCommand for LazyFillNull {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/data/filter.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/filter.rs
@@ -43,6 +43,10 @@ impl PluginCommand for LazyFilter {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("lazyframe".into()))
     }
@@ -173,9 +177,11 @@ impl PluginCommand for LazyFilter {
             _ => Err(cant_convert_err(
                 &pipeline_value,
                 &[
-                    // PolarsPluginType::NuDataFrame,
+                    PolarsPluginType::NuDataFrame,
+                    PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuLazyGroupBy,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/data/first.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/first.rs
@@ -40,6 +40,10 @@ impl PluginCommand for FirstDF {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),

--- a/crates/nu_plugin_polars/src/dataframe/command/data/flatten.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/flatten.rs
@@ -38,6 +38,10 @@ impl PluginCommand for LazyFlatten {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),

--- a/crates/nu_plugin_polars/src/dataframe/command/data/last.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/last.rs
@@ -38,6 +38,10 @@ impl PluginCommand for LastDF {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),

--- a/crates/nu_plugin_polars/src/dataframe/command/data/replace.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/replace.rs
@@ -54,10 +54,16 @@ impl PluginCommand for Replace {
                 "Data type of the resulting expression. If set to `null` (default), the data type is determined automatically based on the other inputs.",
                 Some('t'),
             )
-            .input_output_type(
-                PolarsPluginType::NuExpression.into(),
-                PolarsPluginType::NuExpression.into(),
-            )
+            .input_output_types(vec![
+                (
+                    PolarsPluginType::NuExpression.into(),
+                    PolarsPluginType::NuExpression.into()
+                ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into()
+                )
+             ])
             .category(Category::Custom("expression".into()))
     }
 

--- a/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/shift.rs
@@ -49,6 +49,10 @@ impl PluginCommand for Shift {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe or lazyframe".into()))
     }
@@ -168,6 +172,7 @@ impl PluginCommand for Shift {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyGroupBy,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/data/unique.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/unique.rs
@@ -60,6 +60,10 @@ impl PluginCommand for Unique {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe or lazyframe".into()))
     }
@@ -203,6 +207,7 @@ impl PluginCommand for Unique {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyGroupBy,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/as_date.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/as_date.rs
@@ -54,6 +54,10 @@ impl PluginCommand for AsDate {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -228,6 +232,7 @@ fn command(
                 PolarsPluginType::NuDataFrame,
                 PolarsPluginType::NuLazyFrame,
                 PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
             ],
         )),
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/as_datetime.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/as_datetime.rs
@@ -66,6 +66,10 @@ impl PluginCommand for AsDateTime {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .required("format", SyntaxShape::String, "Formatting date time string.")
             .switch("not-exact", "The format string may be contained in the date (e.g. foo-2021-01-01-bar could match 2021-01-01).", Some('n'))
@@ -336,6 +340,7 @@ fn command(
                 PolarsPluginType::NuDataFrame,
                 PolarsPluginType::NuLazyFrame,
                 PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
             ],
         )),
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/datepart.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/datepart.rs
@@ -39,10 +39,16 @@ impl PluginCommand for ExprDatePart {
                 SyntaxShape::String,
                 "Part of the date to capture.  Possible values are year, quarter, month, week, weekday, day, hour, minute, second, millisecond, microsecond, nanosecond.",
             )
-            .input_output_type(
-                PolarsPluginType::NuExpression.into(),
-                PolarsPluginType::NuExpression.into(),
-            )
+            .input_output_types(vec![
+                (
+                    PolarsPluginType::NuExpression.into(),
+                    PolarsPluginType::NuExpression.into()
+                ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into()
+                ),
+            ])
             .category(Category::Custom("expression".into()))
     }
 

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_day.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_day.rs
@@ -43,6 +43,10 @@ impl PluginCommand for GetDay {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -123,6 +127,7 @@ fn command(
                 PolarsPluginType::NuDataFrame,
                 PolarsPluginType::NuLazyFrame,
                 PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
             ],
         )),
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_hour.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_hour.rs
@@ -45,6 +45,10 @@ impl PluginCommand for GetHour {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -131,6 +135,7 @@ fn command(
                 PolarsPluginType::NuDataFrame,
                 PolarsPluginType::NuLazyFrame,
                 PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
             ],
         )),
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_minute.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_minute.rs
@@ -43,6 +43,10 @@ impl PluginCommand for GetMinute {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -115,6 +119,7 @@ fn command(
                 PolarsPluginType::NuDataFrame,
                 PolarsPluginType::NuLazyFrame,
                 PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
             ],
         )),
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_month.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_month.rs
@@ -43,6 +43,10 @@ impl PluginCommand for GetMonth {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -115,6 +119,7 @@ fn command(
                 PolarsPluginType::NuDataFrame,
                 PolarsPluginType::NuLazyFrame,
                 PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
             ],
         )),
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_nanosecond.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_nanosecond.rs
@@ -43,6 +43,10 @@ impl PluginCommand for GetNanosecond {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -115,6 +119,7 @@ fn command(
                 PolarsPluginType::NuDataFrame,
                 PolarsPluginType::NuLazyFrame,
                 PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
             ],
         )),
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_ordinal.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_ordinal.rs
@@ -43,6 +43,10 @@ impl PluginCommand for GetOrdinal {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -115,6 +119,7 @@ fn command(
                 PolarsPluginType::NuDataFrame,
                 PolarsPluginType::NuLazyFrame,
                 PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
             ],
         )),
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_second.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_second.rs
@@ -43,6 +43,10 @@ impl PluginCommand for GetSecond {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -115,6 +119,7 @@ fn command(
                 PolarsPluginType::NuDataFrame,
                 PolarsPluginType::NuLazyFrame,
                 PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
             ],
         )),
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_week.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_week.rs
@@ -43,6 +43,10 @@ impl PluginCommand for GetWeek {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -115,6 +119,7 @@ fn command(
                 PolarsPluginType::NuDataFrame,
                 PolarsPluginType::NuLazyFrame,
                 PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
             ],
         )),
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_weekday.rs
@@ -43,6 +43,10 @@ impl PluginCommand for GetWeekDay {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -115,6 +119,7 @@ fn command(
                 PolarsPluginType::NuDataFrame,
                 PolarsPluginType::NuLazyFrame,
                 PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
             ],
         )),
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/get_year.rs
@@ -43,6 +43,10 @@ impl PluginCommand for GetYear {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -115,6 +119,7 @@ fn command(
                 PolarsPluginType::NuDataFrame,
                 PolarsPluginType::NuLazyFrame,
                 PolarsPluginType::NuExpression,
+                PolarsPluginType::NuSelector,
             ],
         )),
     }

--- a/crates/nu_plugin_polars/src/dataframe/command/datetime/strftime.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/datetime/strftime.rs
@@ -37,6 +37,10 @@ impl PluginCommand for StrFTime {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -114,6 +118,7 @@ impl PluginCommand for StrFTime {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/integer/to_decimal.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/integer/to_decimal.rs
@@ -37,10 +37,16 @@ impl PluginCommand for ToDecimal {
                 SyntaxShape::Int,
                 "Number of decimal points to infer.",
             )
-            .input_output_type(
-                PolarsPluginType::NuExpression.into(),
-                PolarsPluginType::NuExpression.into(),
-            )
+            .input_output_types(vec![
+                (
+                    PolarsPluginType::NuExpression.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -71,7 +77,10 @@ impl PluginCommand for ToDecimal {
         let value = input.into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command(plugin, engine, call, expr),
-            _ => Err(cant_convert_err(&value, &[PolarsPluginType::NuExpression])),
+            _ => Err(cant_convert_err(
+                &value,
+                &[PolarsPluginType::NuExpression, PolarsPluginType::NuSelector],
+            )),
         }
         .map_err(LabeledError::from)
         .map(|pd| pd.set_metadata(metadata))

--- a/crates/nu_plugin_polars/src/dataframe/command/integer/to_integer.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/integer/to_integer.rs
@@ -43,10 +43,16 @@ impl PluginCommand for ToInteger {
                 SyntaxShape::Any,
                 "Data type to cast to (defaults is i64).",
                 )
-            .input_output_type(
-                PolarsPluginType::NuExpression.into(),
-                PolarsPluginType::NuExpression.into(),
-            )
+            .input_output_types(vec![
+                (
+                    PolarsPluginType::NuExpression.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+            ])
             .category(Category::Custom("dataframe".into()))
     }
 
@@ -77,7 +83,10 @@ impl PluginCommand for ToInteger {
         let value = input.into_value(call.head)?;
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuExpression(expr) => command(plugin, engine, call, expr),
-            _ => Err(cant_convert_err(&value, &[PolarsPluginType::NuExpression])),
+            _ => Err(cant_convert_err(
+                &value,
+                &[PolarsPluginType::NuExpression, PolarsPluginType::NuSelector],
+            )),
         }
         .map_err(LabeledError::from)
         .map(|pd| pd.set_metadata(metadata))

--- a/crates/nu_plugin_polars/src/dataframe/command/string/contains.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/contains.rs
@@ -41,6 +41,10 @@ impl PluginCommand for Contains {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -121,6 +125,7 @@ impl PluginCommand for Contains {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_join.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_join.rs
@@ -39,6 +39,10 @@ impl PluginCommand for StrJoin {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -107,7 +111,10 @@ impl PluginCommand for StrJoin {
                 command_df(plugin, engine, call, lazy.collect(call.head)?)
             }
             PolarsPluginObject::NuExpression(expr) => command_expr(plugin, engine, call, expr),
-            _ => Err(cant_convert_err(&value, &[PolarsPluginType::NuExpression])),
+            _ => Err(cant_convert_err(
+                &value,
+                &[PolarsPluginType::NuExpression, PolarsPluginType::NuSelector],
+            )),
         }
         .map_err(LabeledError::from)
         .map(|pd| pd.set_metadata(metadata))

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_lengths.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_lengths.rs
@@ -41,6 +41,10 @@ impl PluginCommand for StrLengths {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -110,6 +114,7 @@ impl PluginCommand for StrLengths {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_replace.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_replace.rs
@@ -55,6 +55,10 @@ impl PluginCommand for StrReplace {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -120,6 +124,7 @@ impl PluginCommand for StrReplace {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_replace_all.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_replace_all.rs
@@ -55,6 +55,10 @@ impl PluginCommand for StrReplaceAll {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -124,6 +128,7 @@ impl PluginCommand for StrReplaceAll {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/string/str_slice.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/str_slice.rs
@@ -41,6 +41,10 @@ impl PluginCommand for StrSlice {
                     PolarsPluginType::NuExpression.into(),
                 ),
                 (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
+                (
                     PolarsPluginType::NuDataFrame.into(),
                     PolarsPluginType::NuDataFrame.into(),
                 ),
@@ -138,6 +142,7 @@ impl PluginCommand for StrSlice {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/string/to_lowercase.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/to_lowercase.rs
@@ -43,6 +43,10 @@ impl PluginCommand for ToLowerCase {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -109,6 +113,7 @@ impl PluginCommand for ToLowerCase {
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
                     PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }

--- a/crates/nu_plugin_polars/src/dataframe/command/string/to_uppercase.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/string/to_uppercase.rs
@@ -47,6 +47,10 @@ impl PluginCommand for ToUpperCase {
                     PolarsPluginType::NuExpression.into(),
                     PolarsPluginType::NuExpression.into(),
                 ),
+                (
+                    PolarsPluginType::NuSelector.into(),
+                    PolarsPluginType::NuExpression.into(),
+                ),
             ])
             .category(Category::Custom("dataframe".into()))
     }
@@ -112,7 +116,7 @@ impl PluginCommand for ToUpperCase {
                 &[
                     PolarsPluginType::NuDataFrame,
                     PolarsPluginType::NuLazyFrame,
-                    PolarsPluginType::NuExpression,
+                    PolarsPluginType::NuSelector,
                 ],
             )),
         }


### PR DESCRIPTION
## Description
Many commands would not work with selectors do to the input_output_types not being updated. This updates all commands that allows expression inputs to also accept a selector.

## User-facing changes (Release notes)
All commands that can accept a polars expression can now accept a polars selector as input