### PR TITLE
pin ratatui-widgets to 0.3.0 to prevent need for --locked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4710,6 +4710,7 @@ dependencies = [
  "nu-table",
  "nu-utils",
  "ratatui",
+ "ratatui-widgets",
  "serde_json",
  "strip-ansi-escapes",
  "tui-tree-widget",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,12 +222,12 @@ rand = "0.10"
 getrandom = "0.4.2" # pick same version that rand requires
 rand_chacha = "0.10"
 ratatui = { version = "0.30", default-features = false, features = [
-  "all-widgets",
   "crossterm",
   "layout-cache",
   "macros",
   #"underline-color" # leave out so we don't bring in termwiz
 ] }
+ratatui-widgets = "=0.3.0"
 rayon = "1.12.0"
 reedline = "0.48.0"
 rmp = "0.8.15"

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -35,6 +35,7 @@ lscolors = { workspace = true, default-features = false, features = [
     "nu-ansi-term",
 ] }
 ratatui = { workspace = true }
+ratatui-widgets = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 strip-ansi-escapes = { workspace = true }
 edtui = { version = "0.11.2", default-features = false, features = [


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description

This PR pins ratatui-widgets to 0.3.0 because 0.3.1 breaks compilation. This change prevents builders from having to use --locked.

<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->