### PR TITLE
Support reedline's verb-based edit commands in keybindings (Reedlines #1100)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.48.0"
-source = "git+https://github.com/nushell/reedline?branch=main#bab11cfda424c940bf681c4864d1c1cd51199984"
+source = "git+https://github.com/nushell/reedline?branch=main#e148b103bd3a74ee62f7546c31b43c547fee2bfe"
 dependencies = [
  "arboard",
  "chrono",

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -1555,12 +1555,24 @@ pub(crate) fn display_edit_command(edit: EditCommandDiscriminants) -> Option<&'s
         ECD::CopyAroundPair => "CopyAroundPair left: <char>, right <char>",
         ECD::CutTextObject => "CutTextObject scope: <string>, object_type: <string>",
         ECD::CopyTextObject => "CopyTextObject scope: <string>, object_type: <string>",
-        ECD::Move => "Move motion: <string>, + motion fields",
-        ECD::Extend => "Extend motion: <string>, + motion fields",
-        ECD::Erase => "Erase motion: <string>, + motion fields",
-        ECD::Cut => "Cut motion: <string>, granularity?: <string>, + motion fields",
-        ECD::Copy => "Copy motion: <string>, granularity?: <string>, + motion fields",
-        ECD::Change => "Change motion: <string>, granularity?: <string>, + motion fields",
+        ECD::Move => {
+            "Move motion: <string>, direction: <string>, word_kind?: <string>, edge?: <string>, char?: <char>, stop?: <string>"
+        }
+        ECD::Extend => {
+            "Extend motion: <string>, direction: <string>, word_kind?: <string>, edge?: <string>, char?: <char>, stop?: <string>"
+        }
+        ECD::Erase => {
+            "Erase motion: <string>, direction: <string>, word_kind?: <string>, edge?: <string>, char?: <char>, stop?: <string>"
+        }
+        ECD::Cut => {
+            "Cut motion: <string>, direction: <string>, word_kind?: <string>, edge?: <string>, char?: <char>, stop?: <string>, granularity?: <string>"
+        }
+        ECD::Copy => {
+            "Copy motion: <string>, direction: <string>, word_kind?: <string>, edge?: <string>, char?: <char>, stop?: <string>, granularity?: <string>"
+        }
+        ECD::Change => {
+            "Change motion: <string>, direction: <string>, word_kind?: <string>, edge?: <string>, char?: <char>, stop?: <string>, granularity?: <string>"
+        }
         ECD::ReplaceChars => return None,
     })
 }
@@ -1590,39 +1602,33 @@ fn parse_text_object(
     config: &Config,
     span: Span,
 ) -> Result<TextObject, ShellError> {
-    let scope_value = extract_value("scope", record, span)?;
-    let scope_str = scope_value
-        .to_expanded_string("", config)
-        .to_ascii_lowercase();
-    let scope = match scope_str.as_str() {
-        "inner" => TextObjectScope::Inner,
-        "around" => TextObjectScope::Around,
-        str => {
-            return Err(ShellError::InvalidValue {
-                valid: "'inner' or 'around'".into(),
-                actual: format!("'{str}'"),
-                span: scope_value.span(),
-            });
-        }
-    };
+    let scope = extract_enum_field(
+        "scope",
+        record,
+        config,
+        span,
+        "'inner' or 'around'",
+        |name| match name {
+            "inner" => Some(TextObjectScope::Inner),
+            "around" => Some(TextObjectScope::Around),
+            _ => None,
+        },
+    )?;
 
-    let type_value = extract_value("object_type", record, span)?;
-    let type_str = type_value
-        .to_expanded_string("", config)
-        .to_ascii_lowercase();
-    let object_type = match type_str.as_str() {
-        "word" => TextObjectType::Word,
-        "bigword" => TextObjectType::BigWord,
-        "brackets" | "bracket" => TextObjectType::Brackets,
-        "quote" | "quotes" => TextObjectType::Quote,
-        str => {
-            return Err(ShellError::InvalidValue {
-                valid: "'word', 'bigword', 'brackets', or 'quote'".into(),
-                actual: format!("'{str}'"),
-                span: type_value.span(),
-            });
-        }
-    };
+    let object_type = extract_enum_field(
+        "object_type",
+        record,
+        config,
+        span,
+        "'word', 'bigword', 'brackets', or 'quote'",
+        |name| match name {
+            "word" => Some(TextObjectType::Word),
+            "bigword" => Some(TextObjectType::BigWord),
+            "brackets" | "bracket" => Some(TextObjectType::Brackets),
+            "quote" | "quotes" => Some(TextObjectType::Quote),
+            _ => None,
+        },
+    )?;
 
     Ok(TextObject { scope, object_type })
 }
@@ -1661,25 +1667,28 @@ fn parse_direction(record: &Record, config: &Config, span: Span) -> Result<Direc
     )
 }
 
-/// Operator span granularity; defaults to char-wise like `Granularity::default()`.
+/// Operator span granularity; an absent field falls back to
+/// `Granularity::default()` (char-wise).
 fn parse_granularity(
     record: &Record,
     config: &Config,
     span: Span,
 ) -> Result<Granularity, ShellError> {
-    let Ok(value) = extract_value("granularity", record, span) else {
-        return Ok(Granularity::CharWise);
-    };
-    let name = value.to_expanded_string("", config).to_ascii_lowercase();
-    match name.as_str() {
-        "charwise" => Ok(Granularity::CharWise),
-        "linewise" => Ok(Granularity::LineWise),
-        _ => Err(ShellError::InvalidValue {
-            valid: "'charwise' or 'linewise'".into(),
-            actual: format!("'{name}'"),
-            span: value.span(),
-        }),
+    if !record.contains("granularity") {
+        return Ok(Granularity::default());
     }
+    extract_enum_field(
+        "granularity",
+        record,
+        config,
+        span,
+        "'charwise' or 'linewise'",
+        |name| match name {
+            "charwise" => Some(Granularity::CharWise),
+            "linewise" => Some(Granularity::LineWise),
+            _ => None,
+        },
+    )
 }
 
 /// Parse a [`MotionTarget`] from the flat fields of an edit-command record.
@@ -1687,6 +1696,9 @@ fn parse_granularity(
 /// `motion` selects the variant; the remaining fields supply its data —
 /// `direction` (forward/backward), `word_kind` (small/big), `edge` (start/end),
 /// `char`, and `stop` (on/before).
+///
+/// `MotionTarget::Offset` is intentionally not exposed; `MoveToPosition`
+/// already covers absolute cursor positions.
 fn parse_motion_target(
     record: &Record,
     config: &Config,

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -12,10 +12,11 @@ use nu_protocol::{
     extract_value,
 };
 use reedline::{
-    ColumnarMenu, DescriptionMenu, DescriptionMode, EditCommand, EditCommandDiscriminants, IdeMenu,
-    Keybindings, ListMenu, MenuBuilder, PromptEditModeDiscriminants, Reedline, ReedlineEvent,
-    ReedlineEventDiscriminants, ReedlineMenu, TextObject, TextObjectScope, TextObjectType,
-    TraversalDirection, default_emacs_keybindings, default_vi_insert_keybindings,
+    ColumnarMenu, DescriptionMenu, DescriptionMode, Direction, EditCommand,
+    EditCommandDiscriminants, FindStop, Granularity, IdeMenu, Keybindings, ListMenu, MenuBuilder,
+    MotionTarget, PromptEditModeDiscriminants, Reedline, ReedlineEvent, ReedlineEventDiscriminants,
+    ReedlineMenu, TextObject, TextObjectScope, TextObjectType, TraversalDirection, WordEdge,
+    WordKind, default_emacs_keybindings, default_vi_insert_keybindings,
     default_vi_normal_keybindings,
 };
 use std::{str::FromStr, sync::Arc};
@@ -1418,6 +1419,23 @@ fn edit_from_record(
         Ok(ECD::CutTextObject) => EditCommand::CutTextObject {
             text_object: parse_text_object(record, config, span)?,
         },
+        // The verb commands take a `MotionTarget` (and, for the operators, a
+        // `Granularity`) parsed from the same record. See `parse_motion_target`.
+        Ok(ECD::Move) => EditCommand::Move(parse_motion_target(record, config, span)?),
+        Ok(ECD::Extend) => EditCommand::Extend(parse_motion_target(record, config, span)?),
+        Ok(ECD::Erase) => EditCommand::Erase(parse_motion_target(record, config, span)?),
+        Ok(ECD::Cut) => EditCommand::Cut {
+            target: parse_motion_target(record, config, span)?,
+            granularity: parse_granularity(record, config, span)?,
+        },
+        Ok(ECD::Copy) => EditCommand::Copy {
+            target: parse_motion_target(record, config, span)?,
+            granularity: parse_granularity(record, config, span)?,
+        },
+        Ok(ECD::Change) => EditCommand::Change {
+            target: parse_motion_target(record, config, span)?,
+            granularity: parse_granularity(record, config, span)?,
+        },
         // `EditCommand::ReplaceChars` - Internal hack not sanely implementable as a
         // standalone binding
         Ok(ECD::ReplaceChars) | Err(_) => {
@@ -1537,6 +1555,12 @@ pub(crate) fn display_edit_command(edit: EditCommandDiscriminants) -> Option<&'s
         ECD::CopyAroundPair => "CopyAroundPair left: <char>, right <char>",
         ECD::CutTextObject => "CutTextObject scope: <string>, object_type: <string>",
         ECD::CopyTextObject => "CopyTextObject scope: <string>, object_type: <string>",
+        ECD::Move => "Move motion: <string>, + motion fields",
+        ECD::Extend => "Extend motion: <string>, + motion fields",
+        ECD::Erase => "Erase motion: <string>, + motion fields",
+        ECD::Cut => "Cut motion: <string>, granularity?: <string>, + motion fields",
+        ECD::Copy => "Copy motion: <string>, granularity?: <string>, + motion fields",
+        ECD::Change => "Change motion: <string>, granularity?: <string>, + motion fields",
         ECD::ReplaceChars => return None,
     })
 }
@@ -1603,6 +1627,133 @@ fn parse_text_object(
     Ok(TextObject { scope, object_type })
 }
 
+/// Read a lowercased string field from `record` and map it to an enum value,
+/// erroring with `valid` if the field is missing or unrecognized.
+fn extract_enum_field<T>(
+    field: &'static str,
+    record: &Record,
+    config: &Config,
+    span: Span,
+    valid: &str,
+    parse: impl Fn(&str) -> Option<T>,
+) -> Result<T, ShellError> {
+    let value = extract_value(field, record, span)?;
+    let name = value.to_expanded_string("", config).to_ascii_lowercase();
+    parse(&name).ok_or_else(|| ShellError::InvalidValue {
+        valid: valid.into(),
+        actual: format!("'{name}'"),
+        span: value.span(),
+    })
+}
+
+fn parse_direction(record: &Record, config: &Config, span: Span) -> Result<Direction, ShellError> {
+    extract_enum_field(
+        "direction",
+        record,
+        config,
+        span,
+        "'forward' or 'backward'",
+        |name| match name {
+            "forward" => Some(Direction::Forward),
+            "backward" => Some(Direction::Backward),
+            _ => None,
+        },
+    )
+}
+
+/// Operator span granularity; defaults to char-wise like `Granularity::default()`.
+fn parse_granularity(
+    record: &Record,
+    config: &Config,
+    span: Span,
+) -> Result<Granularity, ShellError> {
+    let Ok(value) = extract_value("granularity", record, span) else {
+        return Ok(Granularity::CharWise);
+    };
+    let name = value.to_expanded_string("", config).to_ascii_lowercase();
+    match name.as_str() {
+        "charwise" => Ok(Granularity::CharWise),
+        "linewise" => Ok(Granularity::LineWise),
+        _ => Err(ShellError::InvalidValue {
+            valid: "'charwise' or 'linewise'".into(),
+            actual: format!("'{name}'"),
+            span: value.span(),
+        }),
+    }
+}
+
+/// Parse a [`MotionTarget`] from the flat fields of an edit-command record.
+///
+/// `motion` selects the variant; the remaining fields supply its data —
+/// `direction` (forward/backward), `word_kind` (small/big), `edge` (start/end),
+/// `char`, and `stop` (on/before).
+fn parse_motion_target(
+    record: &Record,
+    config: &Config,
+    span: Span,
+) -> Result<MotionTarget, ShellError> {
+    let motion_value = extract_value("motion", record, span)?;
+    let motion = motion_value
+        .to_expanded_string("", config)
+        .to_ascii_lowercase();
+    let target = match motion.as_str() {
+        "grapheme" => MotionTarget::Grapheme(parse_direction(record, config, span)?),
+        "word" => MotionTarget::Word {
+            kind: extract_enum_field(
+                "word_kind",
+                record,
+                config,
+                span,
+                "'small' or 'big'",
+                |name| match name {
+                    "small" => Some(WordKind::Small),
+                    "big" => Some(WordKind::Big),
+                    _ => None,
+                },
+            )?,
+            edge: extract_enum_field("edge", record, config, span, "'start' or 'end'", |name| {
+                match name {
+                    "start" => Some(WordEdge::Start),
+                    "end" => Some(WordEdge::End),
+                    _ => None,
+                }
+            })?,
+            direction: parse_direction(record, config, span)?,
+        },
+        "lineedge" => MotionTarget::LineEdge(parse_direction(record, config, span)?),
+        "bufferedge" => MotionTarget::BufferEdge(parse_direction(record, config, span)?),
+        "line" => MotionTarget::Line(parse_direction(record, config, span)?),
+        "find" => {
+            let ch = extract_char(extract_value("char", record, span)?)?;
+            MotionTarget::Find {
+                ch,
+                direction: parse_direction(record, config, span)?,
+                stop: extract_enum_field(
+                    "stop",
+                    record,
+                    config,
+                    span,
+                    "'on' or 'before'",
+                    |name| match name {
+                        "on" => Some(FindStop::On),
+                        "before" => Some(FindStop::Before),
+                        _ => None,
+                    },
+                )?,
+            }
+        }
+        other => {
+            return Err(ShellError::InvalidValue {
+                valid: "a motion: 'grapheme', 'word', 'lineedge', 'bufferedge', 'line', or 'find'"
+                    .into(),
+                actual: format!("'{other}'"),
+                span: motion_value.span(),
+            });
+        }
+    };
+    Ok(target)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -1642,6 +1793,74 @@ mod test {
         assert_eq!(
             parsed_event,
             Some(ReedlineEvent::Edit(vec![EditCommand::Clear]))
+        );
+    }
+
+    #[test]
+    fn test_edit_move_motion() {
+        let event = Value::test_record(record! {
+            "edit" => Value::test_string("Move"),
+            "motion" => Value::test_string("grapheme"),
+            "direction" => Value::test_string("backward"),
+        });
+        let config = Config::default();
+
+        let parsed_event = parse_event(&event, &config).unwrap();
+        assert_eq!(
+            parsed_event,
+            Some(ReedlineEvent::Edit(vec![EditCommand::Move(
+                MotionTarget::Grapheme(Direction::Backward)
+            )]))
+        );
+    }
+
+    #[test]
+    fn test_edit_cut_word_linewise() {
+        let event = Value::test_record(record! {
+            "edit" => Value::test_string("Cut"),
+            "motion" => Value::test_string("word"),
+            "word_kind" => Value::test_string("big"),
+            "edge" => Value::test_string("end"),
+            "direction" => Value::test_string("forward"),
+            "granularity" => Value::test_string("linewise"),
+        });
+        let config = Config::default();
+
+        let parsed_event = parse_event(&event, &config).unwrap();
+        assert_eq!(
+            parsed_event,
+            Some(ReedlineEvent::Edit(vec![EditCommand::Cut {
+                target: MotionTarget::Word {
+                    kind: WordKind::Big,
+                    edge: WordEdge::End,
+                    direction: Direction::Forward,
+                },
+                granularity: Granularity::LineWise,
+            }]))
+        );
+    }
+
+    #[test]
+    fn test_edit_find_motion() {
+        let event = Value::test_record(record! {
+            "edit" => Value::test_string("Erase"),
+            "motion" => Value::test_string("find"),
+            "char" => Value::test_string("x"),
+            "direction" => Value::test_string("forward"),
+            "stop" => Value::test_string("before"),
+        });
+        let config = Config::default();
+
+        let parsed_event = parse_event(&event, &config).unwrap();
+        assert_eq!(
+            parsed_event,
+            Some(ReedlineEvent::Edit(vec![EditCommand::Erase(
+                MotionTarget::Find {
+                    ch: 'x',
+                    direction: Direction::Forward,
+                    stop: FindStop::Before,
+                }
+            )]))
         );
     }
 


### PR DESCRIPTION
## Description
Reedline's motion-unification refactor (Reedline PR 1100) introduced six verb-based `EditCommand`s (`Move`, `Extend`, `Cut`, `Copy`, `Change`, and `Erase`) each operating on a `MotionTarget`.
These broke nu-cli's exhaustive keybinding matches, so this PR bumps the pinned reedline revision past the refactor and wires the new commands into keybinding parsing instead of rejecting them:

- an `edit` event record now accepts the six verbs with a `motion` field (`grapheme`, `word`, `line`, `lineedge`, `bufferedge`, `find`) and its parameters: `direction` (`forward`/`backward`), `word_kind` (`small`/`big`), `edge` (`start`/`end`), and `char` + `stop` (`on`/`before`) for `find`
- `cut`, `copy`, and `change` additionally accept an optional `granularity` (`charwise`/`linewise`, defaulting to reedline's char-wise)
- `keybindings list` documents the new commands with their full field lists
- string→enum field parsing goes through a shared `extract_enum_field` helper (also adopted by the existing
`parse_text_object`), so all motion fields share one error path
- `MotionTarget::Offset` is intentionally not exposed; `MoveToPosition` already covers absolute positions

Example:
```nushell
$env.config.keybindings ++= [{
    name: erase_to_x
    modifier: control
    keycode: char_e
    mode: emacs
    event: { edit: erase, motion: find, char: "x", direction: forward, stop: before }
}]
```

## User-facing changes (Release notes)
Keybinding `edit` events now support reedline's verb-based edit commands (`move`, `extend`, `cut`, `copy`, `change`, `erase`) combined with a `motion` and its parameters, enabling vi-style operator/motion keybindings to be expressed directly in config. The new commands and their fields are discoverable via `keybindings list`.