### PR TITLE
Revert "pin ratatui-widgets to 0.3.0 to prevent need for --locked"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4710,7 +4710,6 @@ dependencies = [
  "nu-table",
  "nu-utils",
  "ratatui",
- "ratatui-widgets",
  "serde_json",
  "strip-ansi-escapes",
  "tui-tree-widget",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,12 +222,12 @@ rand = "0.10"
 getrandom = "0.4.2" # pick same version that rand requires
 rand_chacha = "0.10"
 ratatui = { version = "0.30", default-features = false, features = [
+  "all-widgets",
   "crossterm",
   "layout-cache",
   "macros",
   #"underline-color" # leave out so we don't bring in termwiz
 ] }
-ratatui-widgets = "=0.3.0"
 rayon = "1.12.0"
 reedline = "0.48.0"
 rmp = "0.8.15"

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -35,7 +35,6 @@ lscolors = { workspace = true, default-features = false, features = [
     "nu-ansi-term",
 ] }
 ratatui = { workspace = true }
-ratatui-widgets = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 strip-ansi-escapes = { workspace = true }
 edtui = { version = "0.11.2", default-features = false, features = [


### PR DESCRIPTION
Reverts nushell/nushell#18395

I still had to use --locked anyway for other crates so there's no since in doing this if we still have to use it. My compilation tests must of been cached or something when submitting 18395 🤷🏻 