### PR TITLE
[yaml] upgrade deprecated dependency -> `yaml_serde`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,7 +2552,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_regex",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "signal-hook 0.3.18",
  "socket2 0.5.10",
  "thiserror 1.0.69",
@@ -3743,6 +3743,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "libz-sys"
 version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4620,7 +4626,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "serde_yaml 0.9.34+deprecated",
  "sha2",
  "strum",
  "sysinfo 0.38.4",
@@ -4653,6 +4658,7 @@ dependencies = [
  "win_uds",
  "windows 0.62.2",
  "winreg",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -7979,19 +7985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9258,12 +9251,6 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -10734,6 +10721,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,7 +247,7 @@ semver = "1.0"
 serde = { version = "1.0" }
 serde_json = "1.0.149"
 serde_urlencoded = "0.7.1"
-serde_yaml = "0.9.34"
+yaml_serde = "0.10.4"
 sha2 = "0.10"
 strip-ansi-escapes = "0.2.1"
 strum = "0.27.0"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -113,7 +113,7 @@ scopeguard = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_urlencoded = { workspace = true }
-serde_yaml = { workspace = true }
+yaml_serde = { workspace = true }
 sha2 = { workspace = true }
 strum = { workspace = true }
 sysinfo = { workspace = true }

--- a/crates/nu-command/src/formats/from/yaml.rs
+++ b/crates/nu-command/src/formats/from/yaml.rs
@@ -40,7 +40,7 @@ impl Command for FromYamlLike {
 }
 
 fn convert_yaml_value_to_nu_value(
-    v: &serde_yaml::Value,
+    v: &yaml_serde::Value,
     span: Span,
     val_span: Span,
 ) -> Result<Value, ShellError> {
@@ -51,22 +51,22 @@ fn convert_yaml_value_to_nu_value(
         input_span: val_span,
     };
     Ok(match v {
-        serde_yaml::Value::Bool(b) => Value::bool(*b, span),
-        serde_yaml::Value::Number(n) if n.is_i64() => {
+        yaml_serde::Value::Bool(b) => Value::bool(*b, span),
+        yaml_serde::Value::Number(n) if n.is_i64() => {
             Value::int(n.as_i64().ok_or(err_not_compatible_number)?, span)
         }
-        serde_yaml::Value::Number(n) if n.is_f64() => {
+        yaml_serde::Value::Number(n) if n.is_f64() => {
             Value::float(n.as_f64().ok_or(err_not_compatible_number)?, span)
         }
-        serde_yaml::Value::String(s) => Value::string(s.to_string(), span),
-        serde_yaml::Value::Sequence(a) => {
+        yaml_serde::Value::String(s) => Value::string(s.to_string(), span),
+        yaml_serde::Value::Sequence(a) => {
             let result: Result<Vec<Value>, ShellError> = a
                 .iter()
                 .map(|x| convert_yaml_value_to_nu_value(x, span, val_span))
                 .collect();
             Value::list(result?, span)
         }
-        serde_yaml::Value::Mapping(t) => {
+        yaml_serde::Value::Mapping(t) => {
             // Using an IndexMap ensures consistent ordering
             let mut collected = IndexMap::new();
 
@@ -79,19 +79,19 @@ fn convert_yaml_value_to_nu_value(
                     input_span: val_span,
                 };
                 match (k, v) {
-                    (serde_yaml::Value::Number(k), _) => {
+                    (yaml_serde::Value::Number(k), _) => {
                         collected.insert(
                             k.to_string(),
                             convert_yaml_value_to_nu_value(v, span, val_span)?,
                         );
                     }
-                    (serde_yaml::Value::Bool(k), _) => {
+                    (yaml_serde::Value::Bool(k), _) => {
                         collected.insert(
                             k.to_string(),
                             convert_yaml_value_to_nu_value(v, span, val_span)?,
                         );
                     }
-                    (serde_yaml::Value::String(k), _) => {
+                    (yaml_serde::Value::String(k), _) => {
                         collected.insert(
                             k.clone(),
                             convert_yaml_value_to_nu_value(v, span, val_span)?,
@@ -100,16 +100,16 @@ fn convert_yaml_value_to_nu_value(
                     // Hard-code fix for cases where "v" is a string without quotations with double curly braces
                     // e.g. k = value
                     // value: {{ something }}
-                    // Strangely, serde_yaml returns
+                    // Strangely, yaml_serde returns
                     // "value" -> Mapping(Mapping { map: {Mapping(Mapping { map: {String("something"): Null} }): Null} })
-                    (serde_yaml::Value::Mapping(m), serde_yaml::Value::Null) => {
+                    (yaml_serde::Value::Mapping(m), yaml_serde::Value::Null) => {
                         return m
                             .iter()
                             .take(1)
                             .collect_vec()
                             .first()
                             .and_then(|e| match e {
-                                (serde_yaml::Value::String(s), serde_yaml::Value::Null) => {
+                                (yaml_serde::Value::String(s), yaml_serde::Value::Null) => {
                                     Some(Value::string("{{ ".to_owned() + s.as_str() + " }}", span))
                                 }
                                 _ => None,
@@ -124,30 +124,30 @@ fn convert_yaml_value_to_nu_value(
 
             Value::record(collected.into_iter().collect(), span)
         }
-        serde_yaml::Value::Tagged(t) => {
+        yaml_serde::Value::Tagged(t) => {
             let tag = &t.tag;
 
             match &t.value {
-                serde_yaml::Value::String(s) => {
+                yaml_serde::Value::String(s) => {
                     let val = format!("{tag} {s}").trim().to_string();
                     Value::string(val, span)
                 }
-                serde_yaml::Value::Number(n) => {
+                yaml_serde::Value::Number(n) => {
                     let val = format!("{tag} {n}").trim().to_string();
                     Value::string(val, span)
                 }
-                serde_yaml::Value::Bool(b) => {
+                yaml_serde::Value::Bool(b) => {
                     let val = format!("{tag} {b}").trim().to_string();
                     Value::string(val, span)
                 }
-                serde_yaml::Value::Null => {
+                yaml_serde::Value::Null => {
                     let val = format!("{tag}").trim().to_string();
                     Value::string(val, span)
                 }
                 v => convert_yaml_value_to_nu_value(v, span, val_span)?,
             }
         }
-        serde_yaml::Value::Null => Value::nothing(span),
+        yaml_serde::Value::Null => Value::nothing(span),
         x => unimplemented!("Unsupported YAML case: {:?}", x),
     })
 }
@@ -155,9 +155,9 @@ fn convert_yaml_value_to_nu_value(
 pub fn from_yaml_string_to_value(s: &str, span: Span, val_span: Span) -> Result<Value, ShellError> {
     let mut documents = vec![];
 
-    for document in serde_yaml::Deserializer::from_str(s) {
-        let v: serde_yaml::Value =
-            serde_yaml::Value::deserialize(document).map_err(|x| ShellError::UnsupportedInput {
+    for document in yaml_serde::Deserializer::from_str(s) {
+        let v: yaml_serde::Value =
+            yaml_serde::Value::deserialize(document).map_err(|x| ShellError::UnsupportedInput {
                 msg: format!("Could not load YAML: {x}"),
                 input: "value originates from here".into(),
                 msg_span: span,
@@ -368,8 +368,8 @@ mod test {
         ];
 
         for test_case in test_cases {
-            let doc = serde_yaml::Deserializer::from_str(test_case.input);
-            let v: serde_yaml::Value = serde_yaml::Value::deserialize(doc.last().unwrap()).unwrap();
+            let doc = yaml_serde::Deserializer::from_str(test_case.input);
+            let v: yaml_serde::Value = yaml_serde::Value::deserialize(doc.last().unwrap()).unwrap();
             let result = convert_yaml_value_to_nu_value(&v, Span::test_data(), Span::test_data());
             assert!(result.is_ok());
             assert!(result.ok().unwrap() == test_case.expected.ok().unwrap());

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -59,29 +59,29 @@ pub fn value_to_yaml_value(
     engine_state: &EngineState,
     v: &Value,
     serialize_types: bool,
-) -> Result<serde_yaml::Value, ShellError> {
+) -> Result<yaml_serde::Value, ShellError> {
     Ok(match &v {
-        Value::Bool { val, .. } => serde_yaml::Value::Bool(*val),
-        Value::Int { val, .. } => serde_yaml::Value::Number(serde_yaml::Number::from(*val)),
+        Value::Bool { val, .. } => yaml_serde::Value::Bool(*val),
+        Value::Int { val, .. } => yaml_serde::Value::Number(yaml_serde::Number::from(*val)),
         Value::Filesize { val, .. } => {
-            serde_yaml::Value::Number(serde_yaml::Number::from(val.get()))
+            yaml_serde::Value::Number(yaml_serde::Number::from(val.get()))
         }
-        Value::Duration { val, .. } => serde_yaml::Value::String(val.to_string()),
-        Value::Date { val, .. } => serde_yaml::Value::String(val.to_string()),
-        Value::Range { .. } => serde_yaml::Value::Null,
-        Value::Float { val, .. } => serde_yaml::Value::Number(serde_yaml::Number::from(*val)),
+        Value::Duration { val, .. } => yaml_serde::Value::String(val.to_string()),
+        Value::Date { val, .. } => yaml_serde::Value::String(val.to_string()),
+        Value::Range { .. } => yaml_serde::Value::Null,
+        Value::Float { val, .. } => yaml_serde::Value::Number(yaml_serde::Number::from(*val)),
         Value::String { val, .. } | Value::Glob { val, .. } => {
-            serde_yaml::Value::String(val.clone())
+            yaml_serde::Value::String(val.clone())
         }
         Value::Record { val, .. } => {
-            let mut m = serde_yaml::Mapping::new();
+            let mut m = yaml_serde::Mapping::new();
             for (k, v) in &**val {
                 m.insert(
-                    serde_yaml::Value::String(k.clone()),
+                    yaml_serde::Value::String(k.clone()),
                     value_to_yaml_value(engine_state, v, serialize_types)?,
                 );
             }
-            serde_yaml::Value::Mapping(m)
+            yaml_serde::Value::Mapping(m)
         }
         Value::List { vals, .. } => {
             let mut out = vec![];
@@ -90,7 +90,7 @@ pub fn value_to_yaml_value(
                 out.push(value_to_yaml_value(engine_state, value, serialize_types)?);
             }
 
-            serde_yaml::Value::Sequence(out)
+            yaml_serde::Value::Sequence(out)
         }
         Value::Closure { val, .. } => {
             if serialize_types {
@@ -98,36 +98,36 @@ pub fn value_to_yaml_value(
                 if let Some(span) = block.span {
                     let contents_bytes = engine_state.get_span_contents(span);
                     let contents_string = String::from_utf8_lossy(contents_bytes);
-                    serde_yaml::Value::String(contents_string.to_string())
+                    yaml_serde::Value::String(contents_string.to_string())
                 } else {
-                    serde_yaml::Value::String(format!(
+                    yaml_serde::Value::String(format!(
                         "unable to retrieve block contents for yaml block_id {}",
                         val.block_id.get()
                     ))
                 }
             } else {
-                serde_yaml::Value::Null
+                yaml_serde::Value::Null
             }
         }
-        Value::Nothing { .. } => serde_yaml::Value::Null,
+        Value::Nothing { .. } => yaml_serde::Value::Null,
         Value::Error { error, .. } => return Err(*error.clone()),
-        Value::Binary { val, .. } => serde_yaml::Value::Sequence(
+        Value::Binary { val, .. } => yaml_serde::Value::Sequence(
             val.iter()
-                .map(|x| serde_yaml::Value::Number(serde_yaml::Number::from(*x)))
+                .map(|x| yaml_serde::Value::Number(yaml_serde::Number::from(*x)))
                 .collect(),
         ),
-        Value::CellPath { val, .. } => serde_yaml::Value::Sequence(
+        Value::CellPath { val, .. } => yaml_serde::Value::Sequence(
             val.members
                 .iter()
                 .map(|x| match &x {
-                    PathMember::String { val, .. } => Ok(serde_yaml::Value::String(val.clone())),
+                    PathMember::String { val, .. } => Ok(yaml_serde::Value::String(val.clone())),
                     PathMember::Int { val, .. } => {
-                        Ok(serde_yaml::Value::Number(serde_yaml::Number::from(*val)))
+                        Ok(yaml_serde::Value::Number(yaml_serde::Number::from(*val)))
                     }
                 })
-                .collect::<Result<Vec<serde_yaml::Value>, ShellError>>()?,
+                .collect::<Result<Vec<yaml_serde::Value>, ShellError>>()?,
         ),
-        Value::Custom { .. } => serde_yaml::Value::Null,
+        Value::Custom { .. } => yaml_serde::Value::Null,
     })
 }
 
@@ -220,24 +220,24 @@ fn should_quote_yaml_scalar(string: &str) -> bool {
     needs_quotes_due_to_start(string) || has_plain_ambiguity
 }
 
-fn render_yaml_key(key: &serde_yaml::Value) -> String {
+fn render_yaml_key(key: &yaml_serde::Value) -> String {
     match key {
-        serde_yaml::Value::String(key) if should_quote_yaml_scalar(key) => render_yaml_string(key),
-        serde_yaml::Value::String(key) => key.clone(),
+        yaml_serde::Value::String(key) if should_quote_yaml_scalar(key) => render_yaml_string(key),
+        yaml_serde::Value::String(key) => key.clone(),
         _ => render_inline_yaml_value(key),
     }
 }
 
-fn render_inline_yaml_value(value: &serde_yaml::Value) -> String {
+fn render_inline_yaml_value(value: &yaml_serde::Value) -> String {
     match value {
-        serde_yaml::Value::Null => "null".to_string(),
-        serde_yaml::Value::Bool(value) => value.to_string(),
-        serde_yaml::Value::Number(value) => value.to_string(),
-        serde_yaml::Value::String(value) if should_quote_yaml_scalar(value) => {
+        yaml_serde::Value::Null => "null".to_string(),
+        yaml_serde::Value::Bool(value) => value.to_string(),
+        yaml_serde::Value::Number(value) => value.to_string(),
+        yaml_serde::Value::String(value) if should_quote_yaml_scalar(value) => {
             render_yaml_string(value)
         }
-        serde_yaml::Value::String(value) => value.clone(),
-        serde_yaml::Value::Sequence(values) => {
+        yaml_serde::Value::String(value) => value.clone(),
+        yaml_serde::Value::Sequence(values) => {
             let values = values
                 .iter()
                 .map(render_inline_yaml_value)
@@ -245,7 +245,7 @@ fn render_inline_yaml_value(value: &serde_yaml::Value) -> String {
                 .join(", ");
             format!("[{values}]")
         }
-        serde_yaml::Value::Mapping(entries) => {
+        yaml_serde::Value::Mapping(entries) => {
             let entries = entries
                 .iter()
                 .map(|(key, value)| {
@@ -259,7 +259,7 @@ fn render_inline_yaml_value(value: &serde_yaml::Value) -> String {
                 .join(", ");
             format!("{{{entries}}}")
         }
-        serde_yaml::Value::Tagged(tagged) => {
+        yaml_serde::Value::Tagged(tagged) => {
             format!("{} {}", tagged.tag, render_inline_yaml_value(&tagged.value))
         }
     }
@@ -327,12 +327,12 @@ fn write_yaml_block_scalar(output: &mut String, value: &str, body_indent: usize)
     }
 }
 
-fn is_inline_yaml_value(value: &serde_yaml::Value) -> bool {
+fn is_inline_yaml_value(value: &yaml_serde::Value) -> bool {
     match value {
-        serde_yaml::Value::Sequence(values) => values.is_empty(),
-        serde_yaml::Value::Mapping(entries) => entries.is_empty(),
-        serde_yaml::Value::Tagged(tagged) => is_inline_yaml_value(&tagged.value),
-        serde_yaml::Value::String(value) => !is_yaml_block_scalar_candidate(value),
+        yaml_serde::Value::Sequence(values) => values.is_empty(),
+        yaml_serde::Value::Mapping(entries) => entries.is_empty(),
+        yaml_serde::Value::Tagged(tagged) => is_inline_yaml_value(&tagged.value),
+        yaml_serde::Value::String(value) => !is_yaml_block_scalar_candidate(value),
         _ => true,
     }
 }
@@ -343,19 +343,19 @@ fn write_yaml_indent(output: &mut String, indent: usize) {
     }
 }
 
-fn write_yaml_value(output: &mut String, value: &serde_yaml::Value, indent: usize) {
+fn write_yaml_value(output: &mut String, value: &yaml_serde::Value, indent: usize) {
     match value {
-        serde_yaml::Value::Sequence(values) if !values.is_empty() => {
+        yaml_serde::Value::Sequence(values) if !values.is_empty() => {
             write_yaml_sequence(output, values, indent);
         }
-        serde_yaml::Value::Mapping(entries) if !entries.is_empty() => {
+        yaml_serde::Value::Mapping(entries) if !entries.is_empty() => {
             write_yaml_mapping(output, entries, indent, "");
         }
-        serde_yaml::Value::String(value) if is_yaml_block_scalar_candidate(value) => {
+        yaml_serde::Value::String(value) if is_yaml_block_scalar_candidate(value) => {
             write_yaml_indent(output, indent);
             write_yaml_block_scalar(output, value, indent + 2);
         }
-        serde_yaml::Value::Tagged(tagged) => write_yaml_value(output, &tagged.value, indent),
+        yaml_serde::Value::Tagged(tagged) => write_yaml_value(output, &tagged.value, indent),
         _ => {
             write_yaml_indent(output, indent);
             output.push_str(&render_inline_yaml_value(value));
@@ -364,15 +364,15 @@ fn write_yaml_value(output: &mut String, value: &serde_yaml::Value, indent: usiz
     }
 }
 
-fn write_yaml_sequence(output: &mut String, values: &[serde_yaml::Value], indent: usize) {
+fn write_yaml_sequence(output: &mut String, values: &[yaml_serde::Value], indent: usize) {
     for value in values {
         match value {
-            serde_yaml::Value::String(value) if is_yaml_block_scalar_candidate(value) => {
+            yaml_serde::Value::String(value) if is_yaml_block_scalar_candidate(value) => {
                 write_yaml_indent(output, indent);
                 output.push_str("- ");
                 write_yaml_block_scalar(output, value, indent + 2);
             }
-            serde_yaml::Value::Mapping(entries) if !entries.is_empty() => {
+            yaml_serde::Value::Mapping(entries) if !entries.is_empty() => {
                 write_yaml_mapping(output, entries, indent, "- ");
             }
             value if is_inline_yaml_value(value) => {
@@ -392,7 +392,7 @@ fn write_yaml_sequence(output: &mut String, values: &[serde_yaml::Value], indent
 
 fn write_yaml_mapping(
     output: &mut String,
-    entries: &serde_yaml::Mapping,
+    entries: &yaml_serde::Mapping,
     indent: usize,
     first_prefix: &str,
 ) {
@@ -415,7 +415,7 @@ fn write_yaml_mapping(
 
         output.push_str(&render_yaml_key(key));
 
-        if let serde_yaml::Value::String(value) = value
+        if let yaml_serde::Value::String(value) = value
             && is_yaml_block_scalar_candidate(value)
         {
             output.push_str(": ");
@@ -431,7 +431,7 @@ fn write_yaml_mapping(
     }
 }
 
-fn yaml_value_to_string(value: &serde_yaml::Value) -> String {
+fn yaml_value_to_string(value: &yaml_serde::Value) -> String {
     let mut output = String::new();
     write_yaml_value(&mut output, value, 0);
     output


### PR DESCRIPTION
## Description

As described in #18401, a dependency on the deprecated `serde_yaml` caused an error when serializing, and then deserializing, a string ending in `:`. This library has been deprecated for 2 years, and the more modern `yaml_serde` is a fork that has been managed by the official YAML organization ([yeah, for real](https://crates.io/crates/yaml_serde)).

Because it's a fork, I thought "why not try find/replace all?" After all, I've seen [@jonhoo's serde breakdown](https://www.youtube.com/watch?v=BI_bHCGRgMY). This actually resolved my issue. Dang, maybe rust is easy? I'm surprised. I'm curious to see what happens in CI.

## User-facing changes (Release notes)

None.

Here if you need it. Yay for a 1st Rust PR!