### PR TITLE
delete deprecated stdlib copy and paste

### DIFF
--- a/crates/nu-std/std/clip/mod.nu
+++ b/crates/nu-std/std/clip/mod.nu
@@ -3,18 +3,6 @@
 # > These commands require your terminal to support OSC 52
 # > Terminal multiplexers such as screen, tmux, zellij etc may interfere with this command
 
-# @deprecated "Use `clip copy` without `use std/clip`, for OCS 52 copy request use `clip copy52`"
-
-# Copy input to system clipboard (stdlib command deprecated)
-@example "Copy a string to the clipboard" {
-  "Hello" | copy
-}
-export def copy [
-  --ansi (-a)                 # Copy ansi formatting
-]: any -> nothing {
-  $in | copy52 --ansi=$ansi
-}
-
 # Copy input to system clipboard using OSC 52 request
 @example "Copy a string to the clipboard" {
   "Hello" | copy52
@@ -36,16 +24,6 @@ export def copy52 [
   print -n $'(ansi osc)52;c;($text | encode base64)(ansi st)'
 }
 
-# @deprecated "Use `clip paste` without `use std/clip`, for OCS 52 paste request use `clip paste52`"
-
-# Paste contents of system clipboard (stdlib command deprecated)
-@example "Paste a string from the clipboard" {
-  paste
-} --result "Hello"
-export def paste []: [nothing -> string] {
-  paste52
-}
-
 # Paste contents of system clipboard using OSC 52 request
 @example "Paste a string from the clipboard" {
   paste52
@@ -64,8 +42,6 @@ export def paste52 []: [nothing -> string] {
   | decode
 }
 
-# After deprecated commands are removed, prefix will need to be changed to use clip copy or clip copy52.
-
 # Add a prefix to each line of the content to be copied
 @example "Format output for Nushell doc" {
   [1 2 3] | prefix '# => '
@@ -76,7 +52,7 @@ export def paste52 []: [nothing -> string] {
 # => ╰───┴───╯
 # => "
 @example "Format output for Nushell doc and copy it" {
-  ls | prefix '# => ' | copy
+  ls | prefix '# => ' | copy52
 }
 export def "prefix" [prefix: string]: any -> string {
   let input = $in | collect

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -610,7 +610,6 @@ fn main_script_alias_persists() -> Result {
     })
 }
 
-// This test will have to change once clip copy is removed after deprecation time.
 #[test]
 #[exp(nu_experimental::NATIVE_CLIP)]
 fn builtin_commands_can_be_shadowed_and_extended() -> Result {
@@ -619,11 +618,6 @@ fn builtin_commands_can_be_shadowed_and_extended() -> Result {
     let outcome: String = test().run("use std/clip; clip")?;
     assert_contains("clip copy52", &outcome);
     assert_contains("clip prefix", &outcome);
-    assert_contains("clip copy ", &outcome);
-    assert_eq!(outcome.matches("clip copy ").count(), 1);
-
-    let outcome: String = test().run("use std/clip; clip copy --help")?;
-    assert_contains("deprecated", outcome);
 
     Ok(())
 }


### PR DESCRIPTION
## Description
Removed the copy/paste command from stdlib that were deprecated in `0.111.0`. I think it makes sense to remove these sooner rather than later since it can be confusing that they have the exact same name as the ones in the "new" `native-clip` experimental option. 

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
Removed the deprecated `use std/clip` `copy` and `paste` commands, they are now called `copy52` and `paste52` for the ones that use the terminal `OSC 52`, or you can use `clip copy` and `clip paste` from the experimental option `native-clip` that access the system clipboard directly.

<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->