### PR TITLE
Support reedline menu input/output modes and list description position

### DIFF
--- a/crates/nu-cli/src/menus/menu_completions.rs
+++ b/crates/nu-cli/src/menus/menu_completions.rs
@@ -4,7 +4,7 @@ use nu_protocol::{
     debugger::WithoutDebug,
     engine::{EngineState, Stack},
 };
-use reedline::{Completer, Suggestion, menu_functions::parse_selection_char};
+use reedline::{Completer, InputMode, Suggestion, menu_functions::parse_selection_char};
 use std::sync::Arc;
 
 const SELECTION_CHAR: char = '!';
@@ -14,7 +14,7 @@ pub struct NuMenuCompleter {
     span: Span,
     stack: Stack,
     engine_state: Arc<EngineState>,
-    only_buffer_difference: bool,
+    input_mode: InputMode,
 }
 
 impl NuMenuCompleter {
@@ -23,14 +23,14 @@ impl NuMenuCompleter {
         span: Span,
         stack: Stack,
         engine_state: Arc<EngineState>,
-        only_buffer_difference: bool,
+        input_mode: InputMode,
     ) -> Self {
         Self {
             block_id,
             span,
             stack: stack.reset_out_dest().collect_value(),
             engine_state,
-            only_buffer_difference,
+            input_mode,
         }
     }
 }
@@ -61,10 +61,29 @@ impl Completer for NuMenuCompleter {
             .map(|p| p.body);
 
         if let Ok(values) = res.and_then(|data| data.into_value(self.span)) {
-            convert_to_suggestions(values, line, pos, self.only_buffer_difference)
+            convert_to_suggestions(values, line, pos, self.input_mode)
         } else {
             Vec::new()
         }
+    }
+}
+
+/// Replacement span used when the menu source doesn't provide one, matching
+/// what reedline feeds the completer in each input mode.
+fn default_span(line: &str, pos: usize, input_mode: InputMode) -> reedline::Span {
+    match input_mode {
+        // `line` is only the text typed since the menu opened; replace it in place
+        InputMode::Diff => reedline::Span {
+            start: pos - line.len(),
+            end: pos,
+        },
+        // CursorPrefix (buffer up to cursor), FullBuffer (entire buffer), and
+        // any future mode (`InputMode` is non_exhaustive): the suggestion
+        // replaces everything the completer received
+        _ => reedline::Span {
+            start: 0,
+            end: line.len(),
+        },
     }
 }
 
@@ -72,7 +91,7 @@ fn convert_to_suggestions(
     value: Value,
     line: &str,
     pos: usize,
-    only_buffer_difference: bool,
+    input_mode: InputMode,
 ) -> Vec<Suggestion> {
     match value {
         Value::Record { val, .. } => {
@@ -97,32 +116,10 @@ fn convert_to_suggestions(
                                 end: end as usize,
                             }
                         }
-                        _ => reedline::Span {
-                            start: if only_buffer_difference {
-                                pos - line.len()
-                            } else {
-                                0
-                            },
-                            end: if only_buffer_difference {
-                                pos
-                            } else {
-                                line.len()
-                            },
-                        },
+                        _ => default_span(line, pos, input_mode),
                     }
                 }
-                _ => reedline::Span {
-                    start: if only_buffer_difference {
-                        pos - line.len()
-                    } else {
-                        0
-                    },
-                    end: if only_buffer_difference {
-                        pos
-                    } else {
-                        line.len()
-                    },
-                },
+                _ => default_span(line, pos, input_mode),
             };
 
             let extra = match val.get("extra") {
@@ -150,22 +147,11 @@ fn convert_to_suggestions(
         }
         Value::List { vals, .. } => vals
             .into_iter()
-            .flat_map(|val| convert_to_suggestions(val, line, pos, only_buffer_difference))
+            .flat_map(|val| convert_to_suggestions(val, line, pos, input_mode))
             .collect(),
         _ => vec![Suggestion {
             value: format!("Not a record: {value:?}"),
-            span: reedline::Span {
-                start: if only_buffer_difference {
-                    pos - line.len()
-                } else {
-                    0
-                },
-                end: if only_buffer_difference {
-                    pos
-                } else {
-                    line.len()
-                },
-            },
+            span: default_span(line, pos, input_mode),
             ..Suggestion::default()
         }],
     }

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -12,12 +12,12 @@ use nu_protocol::{
     extract_value,
 };
 use reedline::{
-    ColumnarMenu, DescriptionMenu, DescriptionMode, Direction, EditCommand,
-    EditCommandDiscriminants, FindStop, Granularity, IdeMenu, Keybindings, ListMenu, MenuBuilder,
-    MotionTarget, PromptEditModeDiscriminants, Reedline, ReedlineEvent, ReedlineEventDiscriminants,
-    ReedlineMenu, TextObject, TextObjectScope, TextObjectType, TraversalDirection, WordEdge,
-    WordKind, default_emacs_keybindings, default_vi_insert_keybindings,
-    default_vi_normal_keybindings,
+    ColumnarMenu, DescriptionMenu, DescriptionMode, DescriptionPosition, Direction, EditCommand,
+    EditCommandDiscriminants, FindStop, Granularity, IdeMenu, InputMode, Keybindings, ListMenu,
+    MenuBuilder, MotionTarget, OutputMode, PromptEditModeDiscriminants, Reedline, ReedlineEvent,
+    ReedlineEventDiscriminants, ReedlineMenu, TextObject, TextObjectScope, TextObjectType,
+    TraversalDirection, WordEdge, WordKind, default_emacs_keybindings,
+    default_vi_insert_keybindings, default_vi_normal_keybindings,
 };
 use std::{str::FromStr, sync::Arc};
 
@@ -254,6 +254,76 @@ fn set_menu_style<M: MenuBuilder>(mut menu: M, style: &Value) -> M {
     menu
 }
 
+fn parse_input_mode(value: &Value, config: &Config) -> Result<InputMode, ShellError> {
+    match value
+        .to_expanded_string("", config)
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "diff" => Ok(InputMode::Diff),
+        "cursor_prefix" => Ok(InputMode::CursorPrefix),
+        "full_buffer" => Ok(InputMode::FullBuffer),
+        other => Err(ShellError::InvalidValue {
+            valid: "'diff', 'cursor_prefix', or 'full_buffer'".into(),
+            actual: format!("'{other}'"),
+            span: value.span(),
+        }),
+    }
+}
+
+fn parse_output_mode(value: &Value, config: &Config) -> Result<OutputMode, ShellError> {
+    match value
+        .to_expanded_string("", config)
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "suggested_span" => Ok(OutputMode::SuggestedSpan),
+        "full_buffer" => Ok(OutputMode::FullBuffer),
+        "extend_to_end" => Ok(OutputMode::ExtendToEnd),
+        other => Err(ShellError::InvalidValue {
+            valid: "'suggested_span', 'full_buffer', or 'extend_to_end'".into(),
+            actual: format!("'{other}'"),
+            span: value.span(),
+        }),
+    }
+}
+
+fn parse_description_position(
+    value: &Value,
+    config: &Config,
+) -> Result<DescriptionPosition, ShellError> {
+    match value
+        .to_expanded_string("", config)
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "before" => Ok(DescriptionPosition::Before),
+        "after" => Ok(DescriptionPosition::After),
+        other => Err(ShellError::InvalidValue {
+            valid: "'before' or 'after'".into(),
+            actual: format!("'{other}'"),
+            span: value.span(),
+        }),
+    }
+}
+
+/// Apply the optional general menu modes from reedline #1071. Both default to
+/// unset, preserving existing behavior; `input_mode` supersedes
+/// `only_buffer_difference` when present.
+fn apply_buffer_modes<M: MenuBuilder>(
+    mut menu: M,
+    parsed: &ParsedMenu,
+    config: &Config,
+) -> Result<M, ShellError> {
+    if let Some(value) = &parsed.input_mode {
+        menu = menu.with_input_mode(parse_input_mode(value, config)?);
+    }
+    if let Some(value) = &parsed.output_mode {
+        menu = menu.with_output_mode(parse_output_mode(value, config)?);
+    }
+    Ok(menu)
+}
+
 // Adds a columnar menu to the editor engine
 pub(crate) fn add_columnar_menu(
     line_editor: Reedline,
@@ -316,6 +386,7 @@ pub(crate) fn add_columnar_menu(
 
     let only_buffer_difference = menu.only_buffer_difference.as_bool()?;
     columnar_menu = columnar_menu.with_only_buffer_difference(only_buffer_difference);
+    columnar_menu = apply_buffer_modes(columnar_menu, menu, config)?;
 
     let completer = if let Some(closure) = &menu.source {
         let menu_completer = NuMenuCompleter::new(
@@ -356,6 +427,13 @@ pub(crate) fn add_list_menu(
             }
             Err(_) => list_menu,
         };
+
+        list_menu = match extract_value("description_position", val, span) {
+            Ok(position) => {
+                list_menu.with_description_position(parse_description_position(position, &config)?)
+            }
+            Err(_) => list_menu,
+        };
     }
 
     list_menu = set_menu_style(list_menu, &menu.style);
@@ -365,6 +443,7 @@ pub(crate) fn add_list_menu(
 
     let only_buffer_difference = menu.only_buffer_difference.as_bool()?;
     list_menu = list_menu.with_only_buffer_difference(only_buffer_difference);
+    list_menu = apply_buffer_modes(list_menu, menu, &config)?;
 
     let completer = if let Some(closure) = &menu.source {
         let menu_completer = NuMenuCompleter::new(
@@ -539,6 +618,7 @@ pub(crate) fn add_ide_menu(
 
     let only_buffer_difference = menu.only_buffer_difference.as_bool()?;
     ide_menu = ide_menu.with_only_buffer_difference(only_buffer_difference);
+    ide_menu = apply_buffer_modes(ide_menu, menu, &config)?;
 
     let completer = if let Some(closure) = &menu.source {
         let menu_completer = NuMenuCompleter::new(
@@ -620,6 +700,7 @@ pub(crate) fn add_description_menu(
 
     let only_buffer_difference = menu.only_buffer_difference.as_bool()?;
     description_menu = description_menu.with_only_buffer_difference(only_buffer_difference);
+    description_menu = apply_buffer_modes(description_menu, menu, &config)?;
 
     let completer = if let Some(closure) = &menu.source {
         let menu_completer = NuMenuCompleter::new(
@@ -1874,6 +1955,48 @@ mod test {
                 }
             )]))
         );
+    }
+
+    #[test]
+    fn test_parse_input_mode() {
+        let config = Config::default();
+        assert!(matches!(
+            parse_input_mode(&Value::test_string("full_buffer"), &config),
+            Ok(InputMode::FullBuffer)
+        ));
+        assert!(matches!(
+            parse_input_mode(&Value::test_string("diff"), &config),
+            Ok(InputMode::Diff)
+        ));
+        assert!(parse_input_mode(&Value::test_string("nope"), &config).is_err());
+    }
+
+    #[test]
+    fn test_parse_output_mode() {
+        let config = Config::default();
+        assert!(matches!(
+            parse_output_mode(&Value::test_string("extend_to_end"), &config),
+            Ok(OutputMode::ExtendToEnd)
+        ));
+        assert!(matches!(
+            parse_output_mode(&Value::test_string("suggested_span"), &config),
+            Ok(OutputMode::SuggestedSpan)
+        ));
+        assert!(parse_output_mode(&Value::test_string("nope"), &config).is_err());
+    }
+
+    #[test]
+    fn test_parse_description_position() {
+        let config = Config::default();
+        assert!(matches!(
+            parse_description_position(&Value::test_string("after"), &config),
+            Ok(DescriptionPosition::After)
+        ));
+        assert!(matches!(
+            parse_description_position(&Value::test_string("before"), &config),
+            Ok(DescriptionPosition::Before)
+        ));
+        assert!(parse_description_position(&Value::test_string("nope"), &config).is_err());
     }
 
     #[test]

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -307,17 +307,34 @@ fn parse_description_position(
     }
 }
 
-/// Apply the optional general menu modes from reedline #1071. Both default to
-/// unset, preserving existing behavior; `input_mode` supersedes
-/// `only_buffer_difference` when present.
-fn apply_buffer_modes<M: MenuBuilder>(
+/// Resolve the menu's effective reedline `InputMode` from the optional
+/// `input_mode` and legacy `only_buffer_difference` fields. The result drives
+/// both the reedline menu and `NuMenuCompleter`'s span math, so it must be
+/// resolved exactly once, here.
+fn resolve_input_mode(menu: &ParsedMenu, config: &Config) -> Result<InputMode, ShellError> {
+    match (&menu.input_mode, &menu.only_buffer_difference) {
+        (Some(input_mode), _) => parse_input_mode(input_mode, config),
+        (None, Some(only_buffer_difference)) => {
+            if only_buffer_difference.as_bool()? {
+                Ok(InputMode::Diff)
+            } else {
+                Ok(InputMode::CursorPrefix)
+            }
+        }
+        (None, None) => Err(ShellError::MissingRequiredColumn {
+            column: "input_mode (or only_buffer_difference)",
+            span: menu.name.span(),
+        }),
+    }
+}
+
+/// Apply the optional reedline #1071 `output_mode`. Unset preserves
+/// reedline's default (`suggested_span`).
+fn apply_output_mode<M: MenuBuilder>(
     mut menu: M,
     parsed: &ParsedMenu,
     config: &Config,
 ) -> Result<M, ShellError> {
-    if let Some(value) = &parsed.input_mode {
-        menu = menu.with_input_mode(parse_input_mode(value, config)?);
-    }
     if let Some(value) = &parsed.output_mode {
         menu = menu.with_output_mode(parse_output_mode(value, config)?);
     }
@@ -384,9 +401,9 @@ pub(crate) fn add_columnar_menu(
     let marker = menu.marker.to_expanded_string("", config);
     columnar_menu = columnar_menu.with_marker(&marker);
 
-    let only_buffer_difference = menu.only_buffer_difference.as_bool()?;
-    columnar_menu = columnar_menu.with_only_buffer_difference(only_buffer_difference);
-    columnar_menu = apply_buffer_modes(columnar_menu, menu, config)?;
+    let input_mode = resolve_input_mode(menu, config)?;
+    columnar_menu = columnar_menu.with_input_mode(input_mode);
+    columnar_menu = apply_output_mode(columnar_menu, menu, config)?;
 
     let completer = if let Some(closure) = &menu.source {
         let menu_completer = NuMenuCompleter::new(
@@ -394,7 +411,7 @@ pub(crate) fn add_columnar_menu(
             span,
             stack.captures_to_stack(closure.captures.clone()),
             engine_state,
-            only_buffer_difference,
+            input_mode,
         );
         ReedlineMenu::WithCompleter {
             menu: Box::new(columnar_menu),
@@ -441,9 +458,9 @@ pub(crate) fn add_list_menu(
     let marker = menu.marker.to_expanded_string("", &config);
     list_menu = list_menu.with_marker(&marker);
 
-    let only_buffer_difference = menu.only_buffer_difference.as_bool()?;
-    list_menu = list_menu.with_only_buffer_difference(only_buffer_difference);
-    list_menu = apply_buffer_modes(list_menu, menu, &config)?;
+    let input_mode = resolve_input_mode(menu, &config)?;
+    list_menu = list_menu.with_input_mode(input_mode);
+    list_menu = apply_output_mode(list_menu, menu, &config)?;
 
     let completer = if let Some(closure) = &menu.source {
         let menu_completer = NuMenuCompleter::new(
@@ -451,7 +468,7 @@ pub(crate) fn add_list_menu(
             span,
             stack.captures_to_stack(closure.captures.clone()),
             engine_state,
-            only_buffer_difference,
+            input_mode,
         );
         ReedlineMenu::WithCompleter {
             menu: Box::new(list_menu),
@@ -616,9 +633,9 @@ pub(crate) fn add_ide_menu(
     let marker = menu.marker.to_expanded_string("", &config);
     ide_menu = ide_menu.with_marker(&marker);
 
-    let only_buffer_difference = menu.only_buffer_difference.as_bool()?;
-    ide_menu = ide_menu.with_only_buffer_difference(only_buffer_difference);
-    ide_menu = apply_buffer_modes(ide_menu, menu, &config)?;
+    let input_mode = resolve_input_mode(menu, &config)?;
+    ide_menu = ide_menu.with_input_mode(input_mode);
+    ide_menu = apply_output_mode(ide_menu, menu, &config)?;
 
     let completer = if let Some(closure) = &menu.source {
         let menu_completer = NuMenuCompleter::new(
@@ -626,7 +643,7 @@ pub(crate) fn add_ide_menu(
             span,
             stack.captures_to_stack(closure.captures.clone()),
             engine_state,
-            only_buffer_difference,
+            input_mode,
         );
         ReedlineMenu::WithCompleter {
             menu: Box::new(ide_menu),
@@ -698,9 +715,9 @@ pub(crate) fn add_description_menu(
     let marker = menu.marker.to_expanded_string("", &config);
     description_menu = description_menu.with_marker(&marker);
 
-    let only_buffer_difference = menu.only_buffer_difference.as_bool()?;
-    description_menu = description_menu.with_only_buffer_difference(only_buffer_difference);
-    description_menu = apply_buffer_modes(description_menu, menu, &config)?;
+    let input_mode = resolve_input_mode(menu, &config)?;
+    description_menu = description_menu.with_input_mode(input_mode);
+    description_menu = apply_output_mode(description_menu, menu, &config)?;
 
     let completer = if let Some(closure) = &menu.source {
         let menu_completer = NuMenuCompleter::new(
@@ -708,7 +725,7 @@ pub(crate) fn add_description_menu(
             span,
             stack.captures_to_stack(closure.captures.clone()),
             engine_state,
-            only_buffer_difference,
+            input_mode,
         );
         ReedlineMenu::WithCompleter {
             menu: Box::new(description_menu),
@@ -1969,6 +1986,61 @@ mod test {
             Ok(InputMode::Diff)
         ));
         assert!(parse_input_mode(&Value::test_string("nope"), &config).is_err());
+    }
+
+    fn test_menu(input_mode: Option<Value>, only_buffer_difference: Option<Value>) -> ParsedMenu {
+        ParsedMenu {
+            name: Value::test_string("test_menu"),
+            marker: Value::test_string("| "),
+            only_buffer_difference,
+            input_mode,
+            output_mode: None,
+            style: Value::test_nothing(),
+            r#type: Value::test_nothing(),
+            source: None,
+        }
+    }
+
+    #[test]
+    fn test_resolve_input_mode() {
+        let config = Config::default();
+
+        // input_mode alone
+        assert!(matches!(
+            resolve_input_mode(
+                &test_menu(Some(Value::test_string("full_buffer")), None),
+                &config
+            ),
+            Ok(InputMode::FullBuffer)
+        ));
+
+        // input_mode supersedes a conflicting legacy flag
+        assert!(matches!(
+            resolve_input_mode(
+                &test_menu(
+                    Some(Value::test_string("diff")),
+                    Some(Value::test_bool(false))
+                ),
+                &config
+            ),
+            Ok(InputMode::Diff)
+        ));
+
+        // legacy flag alone maps to the equivalent mode
+        assert!(matches!(
+            resolve_input_mode(&test_menu(None, Some(Value::test_bool(true))), &config),
+            Ok(InputMode::Diff)
+        ));
+        assert!(matches!(
+            resolve_input_mode(&test_menu(None, Some(Value::test_bool(false))), &config),
+            Ok(InputMode::CursorPrefix)
+        ));
+
+        // neither field set is a config error
+        assert!(matches!(
+            resolve_input_mode(&test_menu(None, None), &config),
+            Err(ShellError::MissingRequiredColumn { .. })
+        ));
     }
 
     #[test]

--- a/crates/nu-protocol/src/config/reedline.rs
+++ b/crates/nu-protocol/src/config/reedline.rs
@@ -18,6 +18,11 @@ pub struct ParsedMenu {
     pub name: Value,
     pub marker: Value,
     pub only_buffer_difference: Value,
+    /// Optional reedline `InputMode` ("diff" / "cursor_prefix" / "full_buffer").
+    /// Supersedes `only_buffer_difference` when set; absent keeps current behavior.
+    pub input_mode: Option<Value>,
+    /// Optional reedline `OutputMode` ("suggested_span" / "full_buffer" / "extend_to_end").
+    pub output_mode: Option<Value>,
     pub style: Value,
     pub r#type: Value,
     pub source: Option<Closure>,

--- a/crates/nu-protocol/src/config/reedline.rs
+++ b/crates/nu-protocol/src/config/reedline.rs
@@ -17,7 +17,9 @@ pub struct ParsedKeybinding {
 pub struct ParsedMenu {
     pub name: Value,
     pub marker: Value,
-    pub only_buffer_difference: Value,
+    /// Legacy two-state input behavior. Required unless `input_mode` is set,
+    /// which supersedes it.
+    pub only_buffer_difference: Option<Value>,
     /// Optional reedline `InputMode` ("diff" / "cursor_prefix" / "full_buffer").
     /// Supersedes `only_buffer_difference` when set; absent keeps current behavior.
     pub input_mode: Option<Value>,

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -622,6 +622,10 @@ $env.config.abbreviations = {}
 # Menus may also set output_mode: "suggested_span", "full_buffer", or
 # "extend_to_end" -- how an accepted suggestion replaces the buffer.
 # Unset is equivalent to "suggested_span".
+#
+# List-layout menus accept description_position: "before" or "after" in their
+# `type` record, controlling whether an entry's description is shown before or
+# after its value. Unset keeps reedline's default.
 # Default: []
 $env.config.menus = []
 
@@ -654,6 +658,23 @@ $env.config.menus = []
 #         columns: 4
 #         col_width: 20
 #         col_padding: 2
+#     }
+#     style: {
+#         text: green
+#         selected_text: green_reverse
+#         description_text: yellow
+#     }
+# }]
+
+# Example: A list menu placing descriptions after each entry:
+# $env.config.menus ++= [{
+#     name: history_menu
+#     input_mode: diff
+#     marker: "? "
+#     type: {
+#         layout: list
+#         page_size: 10
+#         description_position: after
 #     }
 #     style: {
 #         text: green

--- a/crates/nu-utils/src/default_files/doc_config.nu
+++ b/crates/nu-utils/src/default_files/doc_config.nu
@@ -609,6 +609,19 @@ $env.config.abbreviations = {}
 # menus (list): Menu configurations for Reedline.
 # Menus are typically activated via keybindings.
 # See https://www.nushell.sh/book/line_editor.html#menus for details.
+#
+# Each menu must declare its input behavior with one of:
+#   input_mode: "diff", "cursor_prefix", or "full_buffer" -- what text the
+#     menu source receives ("diff": only text typed since the menu opened,
+#     "cursor_prefix": the buffer up to the cursor, "full_buffer": the whole
+#     buffer)
+#   only_buffer_difference (legacy): true is equivalent to input_mode "diff",
+#     false to "cursor_prefix"
+# input_mode supersedes only_buffer_difference when both are set.
+#
+# Menus may also set output_mode: "suggested_span", "full_buffer", or
+# "extend_to_end" -- how an accepted suggestion replaces the buffer.
+# Unset is equivalent to "suggested_span".
 # Default: []
 $env.config.menus = []
 
@@ -616,6 +629,25 @@ $env.config.menus = []
 # $env.config.menus ++= [{
 #     name: completion_menu
 #     only_buffer_difference: false
+#     marker: "| "
+#     type: {
+#         layout: columnar
+#         columns: 4
+#         col_width: 20
+#         col_padding: 2
+#     }
+#     style: {
+#         text: green
+#         selected_text: green_reverse
+#         description_text: yellow
+#     }
+# }]
+
+# Example: The same menu using input/output modes instead of the legacy flag:
+# $env.config.menus ++= [{
+#     name: completion_menu
+#     input_mode: cursor_prefix
+#     output_mode: suggested_span
 #     marker: "| "
 #     type: {
 #         layout: columnar


### PR DESCRIPTION
## Description

Reedline recently gained finer-grained control over how completion menus read from and write to the line buffer (the InputMode/OutputMode enums, reedline PR 1071), plus a description_position option for list menus (reedline PR 1044).
This PR exposes all three through Nushell's menu config.

Previously a menu's input behavior was a single boolean, only_buffer_difference. This PR:

- Adds input_mode ("diff" / "cursor_prefix" / "full_buffer"): what slice of the buffer the menu source receives.
- Adds output_mode ("suggested_span" / "full_buffer" / "extend_to_end"): how an accepted suggestion is written back. Unset preserves reedline's default (suggested_span).
- Adds description_position ("before" / "after") to list-layout menus' type record.
- Makes only_buffer_difference optional and keeps it working as a legacy alias(input_mode supersedes it when both are present):
	- true → input_mode: diff,
	- false → input_mode: cursor_prefix.

The effective InputMode is resolved once in resolve_input_mode, then handed to both the reedline menu and NuMenuCompleter, so the completer's span math and the menu can't disagree.
A menu that sets neither input_mode nor only_buffer_difference produces a clear MissingRequiredColumn error.
The built-in default menus continue to use only_buffer_difference, so existing configs are unaffected.

## User-facing changes (Release notes)

Reedline menus can now be configured with input_mode (diff, cursor_prefix, full_buffer) and output_mode (suggested_span, full_buffer, extend_to_end) to control what text the menu reads from the buffer and how an accepted suggestion is written back.
List menus additionally accept description_position (before / after). The existing only_buffer_difference flag still works and is treated as a shorthand (true = diff, false = cursor_prefix).