### PR TITLE
feat: add --coerce for def

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -21,7 +21,7 @@ impl Command for Def {
             .required("block", SyntaxShape::Closure(None), "The body of the command, a list of instructions inside {}.")
             .switch("env", "Keep the environment defined inside the command.", None)
             .switch("wrapped", "Treat unknown flags and arguments as strings (requires ...rest-like parameter in signature).", None)
-            .switch("coerce", "Like --wrapped, but respects '--'.", Some('c'))
+            .switch("coerce", "Like --wrapped, but respects '--'.", None)
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -21,6 +21,7 @@ impl Command for Def {
             .required("block", SyntaxShape::Closure(None), "The body of the command, a list of instructions inside {}.")
             .switch("env", "Keep the environment defined inside the command.", None)
             .switch("wrapped", "Treat unknown flags and arguments as strings (requires ...rest-like parameter in signature).", None)
+            .switch("coerce", "Like --wrapped, but respects '--'.", Some('c'))
             .category(Category::Core)
     }
 

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -967,12 +967,20 @@ pub fn parse_internal_call(
             match flag_parse_result {
                 LongFlagParseResult::EndOfOptions => {
                     if signature.allows_unknown_args {
-                        // For commands that pass through unknown args (extern, def --wrapped,
-                        // exec, etc.), -- must be forwarded to the underlying program.
-                        // Directly add -- as an unknown arg, then advance past it.
-                        let arg = parse_unknown_arg(working_set, arg_span, &signature);
-                        call.add_unknown(arg);
-                        spans_idx += 1;
+                        if signature.respects_end_of_options {
+                            // def --coerce:
+                            // consume '--' and switch to positional-only mode,
+                            // while still allowing unknown args afterwards.
+                            end_of_options = true;
+                            spans_idx += 1;
+                        } else {
+                            // Existing behaviour for extern/exec/def --wrapped:
+                            // forward '--' to the wrapped command.
+                            let arg = parse_unknown_arg(working_set, arg_span, &signature);
+                            call.add_unknown(arg);
+                            spans_idx += 1;
+                        }
+
                         continue;
                     } else {
                         // For regular commands, consume -- and switch to positional-only mode.

--- a/crates/nu-parser/src/parse_def.rs
+++ b/crates/nu-parser/src/parse_def.rs
@@ -113,7 +113,11 @@ pub fn parse_def_predecl(working_set: &mut StateWorkingSet, spans: &[Span]) {
     let mut allow_unknown_args = false;
 
     for span in spans {
-        if working_set.get_span_contents(*span) == b"--wrapped" && def_type_name == b"def" {
+        let contents = working_set.get_span_contents(*span);
+
+        if (contents == b"--wrapped" || contents == b"--coerce" || contents == b"-c")
+            && def_type_name == b"def"
+        {
             allow_unknown_args = true;
         }
     }
@@ -516,6 +520,12 @@ fn parse_def_inner(
         return garbage_result(working_set);
     };
 
+    let Ok(has_coerce) = has_flag_const(working_set, &call, "coerce") else {
+        return garbage_result(working_set);
+    };
+
+    let passthrough_mode = has_wrapped || has_coerce;
+
     let [name_expr, sig_expr, block_expr] = call
         .positional_iter()
         .next_array()
@@ -550,14 +560,24 @@ fn parse_def_inner(
 
     if let (Some(mut signature), Some(block_id)) = (sig_expr.as_signature(), block_expr.as_block())
     {
-        if has_wrapped {
+        if passthrough_mode {
             let Some(rest) = signature.rest_positional.as_mut() else {
+                let help = match (has_wrapped, has_coerce) {
+                    (_, true) => {
+                        "Usage: def --coerce (-c) must have a ...rest-like positional argument. Add '...rest' to the command's signature."
+                    }
+
+                    (true, false) => {
+                        "Usage: def --wrapped must have a ...rest-like positional argument. Add '...rest' to the command's signature."
+                    }
+
+                    _ => unreachable!(),
+                };
+
                 working_set.error(ParseError::MissingPositional(
                     "...rest-like positional argument".to_string(),
                     name_expr.span,
-                    "def --wrapped must have a ...rest-like positional argument. \
-                            Add '...rest: string' to the command's signature."
-                        .to_string(),
+                    help.into(),
                 ));
 
                 return (
@@ -598,12 +618,15 @@ fn parse_def_inner(
 
         if let Some(decl_id) = working_set.find_predecl(name.as_bytes()) {
             signature.name.clone_from(&name);
-            if !has_wrapped {
+
+            if !passthrough_mode {
                 *signature = signature.add_help();
             }
+
             signature.description = desc;
             signature.extra_description = extra_desc;
-            signature.allows_unknown_args = has_wrapped;
+            signature.allows_unknown_args = passthrough_mode;
+            signature.respects_end_of_options = has_coerce;
 
             let (attribute_vals, examples) =
                 handle_special_attributes(attributes, working_set, &mut signature);

--- a/crates/nu-parser/src/parse_def.rs
+++ b/crates/nu-parser/src/parse_def.rs
@@ -115,7 +115,7 @@ pub fn parse_def_predecl(working_set: &mut StateWorkingSet, spans: &[Span]) {
     for span in spans {
         let contents = working_set.get_span_contents(*span);
 
-        if (contents == b"--wrapped" || contents == b"--coerce" || contents == b"-c")
+        if (contents == b"--wrapped" || contents == b"--coerce")
             && def_type_name == b"def"
         {
             allow_unknown_args = true;
@@ -564,7 +564,7 @@ fn parse_def_inner(
             let Some(rest) = signature.rest_positional.as_mut() else {
                 let help = match (has_wrapped, has_coerce) {
                     (_, true) => {
-                        "Usage: def --coerce (-c) must have a ...rest-like positional argument. Add '...rest' to the command's signature."
+                        "Usage: def --coerce must have a ...rest-like positional argument. Add '...rest' to the command's signature."
                     }
 
                     (true, false) => {

--- a/crates/nu-parser/src/parse_def.rs
+++ b/crates/nu-parser/src/parse_def.rs
@@ -115,9 +115,7 @@ pub fn parse_def_predecl(working_set: &mut StateWorkingSet, spans: &[Span]) {
     for span in spans {
         let contents = working_set.get_span_contents(*span);
 
-        if (contents == b"--wrapped" || contents == b"--coerce")
-            && def_type_name == b"def"
-        {
+        if (contents == b"--wrapped" || contents == b"--coerce") && def_type_name == b"def" {
             allow_unknown_args = true;
         }
     }

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -326,6 +326,7 @@ pub struct Signature {
     pub is_filter: bool,
     pub creates_scope: bool,
     pub allows_unknown_args: bool,
+    pub respects_end_of_options: bool,
     pub complete: Option<CommandWideCompleter>,
     // Signature category used to classify commands stored in the list of declarations
     pub category: Category,
@@ -362,6 +363,7 @@ impl Signature {
             creates_scope: false,
             category: Category::Default,
             allows_unknown_args: false,
+            respects_end_of_options: false,
             complete: None,
         }
     }

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -326,6 +326,7 @@ pub struct Signature {
     pub is_filter: bool,
     pub creates_scope: bool,
     pub allows_unknown_args: bool,
+    #[serde(default)]
     pub respects_end_of_options: bool,
     pub complete: Option<CommandWideCompleter>,
     // Signature category used to classify commands stored in the list of declarations


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
Adds a `--coerce` which behavior is like `--wrapped` but respects `--`.
## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
Now this is possible:
```nushell
def --coerce example [--my-flag: string ...rest] { $rest | each { {type: ($in | describe) value: $in} } | print; print $"--my-flag='($my_flag)'" }
example --my-flag="hi" -- true false 001 --my-flag="goodbye"
┌───┬────────┬───────────────────┐
│ # │  type  │       value       │
├───┼────────┼───────────────────┤
│ 0 │ string │ true              │
├───┼────────┼───────────────────┤
│ 1 │ string │ false             │
├───┼────────┼───────────────────┤
│ 2 │ string │ 001               │
├───┼────────┼───────────────────┤
│ 3 │ string │ --my-flag=goodbye │
└───┴────────┴───────────────────┘
--my-flag='hi'
```
## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
Closes #18399 