### PR TITLE
fix flatten not renaming for later parent conflicting columns

### DIFF
--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -152,10 +152,40 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
 
     match item {
         Value::Record { val, .. } => {
+            let val = val.into_owned();
+            let retained_outer_columns: Vec<String> = if columns.is_empty() {
+                vec![]
+            } else {
+                val.iter()
+                    .filter_map(|(column, value)| {
+                        let column_requested =
+                            columns.iter().find(|c| c.to_column_name() == *column);
+                        let need_flatten = column_requested.is_some();
+
+                        let will_flatten = match value {
+                            Value::Record { .. } => need_flatten,
+                            Value::List { vals, .. } => {
+                                if all && vals.iter().all(|value| value.as_record().is_ok()) {
+                                    need_flatten
+                                } else {
+                                    matches!(
+                                        column_requested
+                                            .and_then(|cell_path| cell_path.members.first()),
+                                        Some(PathMember::String { .. })
+                                    )
+                                }
+                            }
+                            _ => false,
+                        };
+
+                        (!will_flatten).then_some(column.clone())
+                    })
+                    .collect()
+            };
             let mut out = IndexMap::<String, Value>::new();
             let mut inner_table = None;
 
-            for (column_index, (column, value)) in val.into_owned().into_iter().enumerate() {
+            for (column_index, (column, value)) in val.into_iter().enumerate() {
                 let column_requested = columns.iter().find(|c| c.to_column_name() == column);
                 let need_flatten = { columns.is_empty() || column_requested.is_some() };
                 let span = value.span();
@@ -164,7 +194,9 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                     Value::Record { ref val, .. } => {
                         if need_flatten {
                             for (col, val) in val.clone().into_owned() {
-                                if out.contains_key(&col) {
+                                if out.contains_key(&col)
+                                    || retained_outer_columns.iter().any(|column| column == &col)
+                                {
                                     out.insert(format!("{column}_{col}"), val);
                                 } else {
                                     out.insert(col, val);
@@ -268,7 +300,9 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                             // this can avoid output column order changed.
                             if index == parent_column_index {
                                 for (col, val) in &inner_record {
-                                    if record.contains(col) {
+                                    if record.contains(col)
+                                        || (!columns.is_empty() && out.contains_key(col))
+                                    {
                                         record.push(
                                             format!("{parent_column_name}_{col}"),
                                             val.clone(),
@@ -286,7 +320,9 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                         // the flattened column may be the last column in the original table.
                         if index == parent_column_index {
                             for (col, val) in inner_record {
-                                if record.contains(&col) {
+                                if record.contains(&col)
+                                    || (!columns.is_empty() && out.contains_key(&col))
+                                {
                                     record.push(format!("{parent_column_name}_{col}"), val);
                                 } else {
                                     record.push(col, val);

--- a/crates/nu-command/tests/commands/flatten.rs
+++ b/crates/nu-command/tests/commands/flatten.rs
@@ -112,6 +112,20 @@ fn flatten_row_columns_having_same_column_names_flats_separately() {
 }
 
 #[test]
+fn flatten_nested_table_renames_conflicting_column_after_flattened_column() {
+    let actual = nu!("[[b, a]; [[[a]; [9]], 1]] | flatten --all b | to nuon");
+
+    assert_eq!(actual.out, "[[b_a, a]; [9, 1]]");
+}
+
+#[test]
+fn flatten_nested_record_renames_conflicting_column_after_flattened_column() {
+    let actual = nu!("{b: {a: 9}, a: 1} | flatten b | to nuon");
+
+    assert_eq!(actual.out, "[[b_a, a]; [9, 1]]");
+}
+
+#[test]
 fn flatten_table_columns_explicitly() {
     let sample = r#"
                 [


### PR DESCRIPTION
## Description
Currently `flatten` only checked columns already inserted into the output record, so a parent column appearing after the nested column was invisible during `rename`.  

It's fixed by creating a `retained_outer_columns` which is a precomputed list of outer record columns that will still exist after flatten finishes

This borrows the idea from #17816 but changes a little bit.

## User-facing changes (Release notes)

### Improved conflicting column names in `flatten`

This pr fixes flatten renaming column behavior
### Before
```
> [[b, a]; [[[a]; [9]], 1]] | flatten -a b  # Renaming does not happens
╭───┬───╮
│ # │ a │
├───┼───┤
│ 0 │ 9 │
╰───┴───╯
```

### After
```
>  [[b, a]; [[[a]; [9]], 1]] | flatten -a b
╭───┬─────┬───╮
│ # │ b_a │ a │
├───┼─────┼───┤
│ 0 │   9 │ 1 │
╰───┴─────┴───╯
```

## Additional notes
Fixes: #13271