### PR TITLE
fixes a bug in the end-of-options functionality

### DIFF
--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -966,20 +966,18 @@ pub fn parse_internal_call(
 
             match flag_parse_result {
                 LongFlagParseResult::EndOfOptions => {
+                    // Switch to positional-only mode so subsequent flags aren't parsed.
+                    end_of_options = true;
+
                     if signature.allows_unknown_args {
                         // For commands that pass through unknown args (extern, def --wrapped,
-                        // exec, etc.), -- must be forwarded to the underlying program.
-                        // Directly add -- as an unknown arg, then advance past it.
+                        // exec, etc.), -- itself must be forwarded to the underlying program.
                         let arg = parse_unknown_arg(working_set, arg_span, &signature);
                         call.add_unknown(arg);
-                        spans_idx += 1;
-                        continue;
-                    } else {
-                        // For regular commands, consume -- and switch to positional-only mode.
-                        end_of_options = true;
-                        spans_idx += 1;
-                        continue;
                     }
+
+                    spans_idx += 1;
+                    continue;
                 }
                 LongFlagParseResult::FoundFlag(long_name, arg) => {
                     // We found a long flag, like --bar

--- a/tests/integration/posix_end_of_options.rs
+++ b/tests/integration/posix_end_of_options.rs
@@ -221,3 +221,27 @@ fn custom_command_mixed_positionals_and_flags_with_end_of_options() -> Result {
         )
         .expect_value_eq(vec!["first", "flagval", "-second", "-third"])
 }
+
+#[test]
+fn wrapped_command_known_flag_after_end_of_options_is_positional() -> Result {
+    // Regression: def --wrapped previously didn't set end_of_options, so known flags
+    // after -- were still parsed as flags and could overwrite values set before --.
+    // Now everything after -- is treated as positional, preserving the pre-- flag value.
+    test()
+        .run(
+            "
+            def --wrapped example [--my-flag: string ...rest] {
+                [$my_flag] ++ $rest
+            }
+            example --my-flag=hi -- true false 001 --my-flag=goodbye
+        ",
+        )
+        .expect_value_eq(vec![
+            "hi",
+            "--",
+            "true",
+            "false",
+            "001",
+            "--my-flag=goodbye",
+        ])
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR fixes a bug in the `end-of-options` `--` functionality when used with `--wrapped`. Previously if `--` was used with a custom command with `--wrapped` the code didn't set `end_of_options = true` properly. So, other --flags=boo would still be passed as flags instead of passing them through.
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
### Fixed a bug in `--` option parsing
Fixed a bug with how `--` was handled with `--wrapped` custom commands. Now you can do things like this:
```nushell
❯ def --wrapped example [--my-flag: string ...rest] {
  let rest = $rest | skip 1  # skip the '--' delimiter
  $rest | each { {type: ($in | describe) value: $in} } | print
  print $"--my-flag='($my_flag)'"
}
❯ example --my-flag="hi" -- true false 001 --my-flag="goodbye"
╭─#─┬──type──┬───────value───────╮
│ 0 │ string │ true              │
│ 1 │ string │ false             │
│ 2 │ string │ 001               │
│ 3 │ string │ --my-flag=goodbye │
╰───┴────────┴───────────────────╯
--my-flag='hi'
```
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
Closes https://github.com/nushell/nushell/issues/18399
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->