### PR TITLE
add new `random pass` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aegis-password-generator"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9050b1a8122ca1728e5a21d8d310972979f8eb5cde4ba3b968d644f686043af8"
+dependencies = [
+ "rand 0.9.2",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4529,6 +4540,7 @@ dependencies = [
 name = "nu-command"
 version = "0.113.2"
 dependencies = [
+ "aegis-password-generator",
  "alphanumeric-sort",
  "ansi-str",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ nu_plugin_query = { path = "crates/nu_plugin_query", version = "0.113.2", defaul
 nu_plugin_stress_internals = { path = "crates/nu_plugin_stress_internals", version = "0.113.2", default-features = false }
 nuon = { path = "crates/nuon", version = "0.113.2", default-features = false }
 
+aegis-password-generator = "0.1.1"
 alphanumeric-sort = "1.5"
 ansi-str = "0.9"
 anyhow = "1.0.102"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -95,6 +95,7 @@ pathdiff = { workspace = true }
 percent-encoding = { workspace = true }
 print-positions = { workspace = true }
 quick-xml = { workspace = true }
+aegis-password-generator = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true }
 rayon = { workspace = true }
@@ -222,7 +223,7 @@ os = [
 # The dependencies listed below need 'getrandom'.
 # They work with JS (usually with wasm-bindgen) or regular OS support.
 # Hence they are also put under the 'os' feature to avoid repetition.
-js = ["getrandom", "getrandom/wasm_js", "rand", "uuid"]
+js = ["aegis-password-generator", "getrandom", "getrandom/wasm_js", "rand", "uuid"]
 
 # These dependencies require networking capabilities, especially the http
 # interface requires openssl which is not easy to embed into wasm,

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -466,6 +466,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             RandomChars,
             RandomFloat,
             RandomInt,
+            RandomPass,
             RandomUuid,
             RandomBinary
         };

--- a/crates/nu-command/src/random/mod.rs
+++ b/crates/nu-command/src/random/mod.rs
@@ -4,6 +4,7 @@ mod byte_stream;
 mod chars;
 mod float;
 mod int;
+mod pass;
 mod random_;
 mod uuid;
 
@@ -12,5 +13,6 @@ pub use self::bool::RandomBool;
 pub use self::chars::RandomChars;
 pub use self::float::RandomFloat;
 pub use self::int::RandomInt;
+pub use self::pass::RandomPass;
 pub use self::uuid::RandomUuid;
 pub use random_::Random;

--- a/crates/nu-command/src/random/pass.rs
+++ b/crates/nu-command/src/random/pass.rs
@@ -1,0 +1,134 @@
+use aegis_password_generator::types::PasswordConfig;
+use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::generic::GenericError;
+
+const DEFAULT_PASSWORD_LENGTH: usize = 12;
+
+#[derive(Clone)]
+pub struct RandomPass;
+
+impl Command for RandomPass {
+    fn name(&self) -> &str {
+        "random pass"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("random pass")
+            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .allow_variants_without_examples(true)
+            .named(
+                "chars",
+                SyntaxShape::Int,
+                "Length of the generated password (default 12)",
+                Some('c'),
+            )
+            .switch("no-uppercase", "Exclude uppercase letters A-Z", Some('u'))
+            .switch("no-lowercase", "Exclude lowercase letters a-z", Some('l'))
+            .switch("no-numbers", "Exclude numbers 0-9", Some('n'))
+            .switch("no-symbols", "Exclude symbols like !@#$%", Some('s'))
+            .switch(
+                "include-ambiguous",
+                "Include ambiguous characters O, 0, l, 1",
+                None,
+            )
+            .switch(
+                "include-similar",
+                "Include similar characters i, l, 1",
+                None,
+            )
+            .switch(
+                "require-each-type",
+                "Guarantee at least one char from each enabled character type",
+                None,
+            )
+            .category(Category::Random)
+    }
+
+    fn description(&self) -> &str {
+        "Generate a cryptologically secure password"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["password", "generate", "crypto", "secure"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let span = call.head;
+
+        let chars: Option<i64> = call.get_flag(engine_state, stack, "chars")?;
+        let no_uppercase = call.has_flag(engine_state, stack, "no-uppercase")?;
+        let no_lowercase = call.has_flag(engine_state, stack, "no-lowercase")?;
+        let no_numbers = call.has_flag(engine_state, stack, "no-numbers")?;
+        let no_symbols = call.has_flag(engine_state, stack, "no-symbols")?;
+        let include_ambiguous = call.has_flag(engine_state, stack, "include-ambiguous")?;
+        let include_similar = call.has_flag(engine_state, stack, "include-similar")?;
+        let require_each_type = call.has_flag(engine_state, stack, "require-each-type")?;
+
+        let length = chars.map(|c| c as usize).unwrap_or(DEFAULT_PASSWORD_LENGTH);
+
+        let config = PasswordConfig::default()
+            .with_length(length)
+            .with_uppercase(!no_uppercase)
+            .with_lowercase(!no_lowercase)
+            .with_numbers(!no_numbers)
+            .with_symbols(!no_symbols)
+            .with_exclude_ambiguous(!include_ambiguous)
+            .with_exclude_similar(!include_similar)
+            .with_require_each_type(require_each_type);
+
+        match config.generate() {
+            Ok(password) => Ok(Value::string(password, span).into_pipeline_data()),
+            Err(e) => Err(ShellError::Generic(GenericError::new(
+                "Password generation failed",
+                e.to_string(),
+                span,
+            ))),
+        }
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                description: "Generate a 12-character password with defaults",
+                example: "random pass",
+                result: None,
+            },
+            Example {
+                description: "Generate a 20-character password",
+                example: "random pass --chars 20",
+                result: None,
+            },
+            Example {
+                description: "Generate a password without symbols",
+                example: "random pass --no-symbols",
+                result: None,
+            },
+            Example {
+                description: "Generate a password with only uppercase letters and numbers",
+                example: "random pass --no-lowercase --no-symbols",
+                result: None,
+            },
+            Example {
+                description: "Generate a password including ambiguous characters and requiring each type",
+                example: "random pass --include-ambiguous --require-each-type",
+                result: None,
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() -> nu_test_support::Result {
+        nu_test_support::test().examples(RandomPass)
+    }
+}

--- a/crates/nu-command/src/random/pass.rs
+++ b/crates/nu-command/src/random/pass.rs
@@ -19,33 +19,33 @@ impl Command for RandomPass {
             .named(
                 "chars",
                 SyntaxShape::Int,
-                "Length of the generated password (default 12)",
+                "Length of the generated password (default 12).",
                 Some('c'),
             )
-            .switch("no-uppercase", "Exclude uppercase letters A-Z", Some('u'))
-            .switch("no-lowercase", "Exclude lowercase letters a-z", Some('l'))
-            .switch("no-numbers", "Exclude numbers 0-9", Some('n'))
-            .switch("no-symbols", "Exclude symbols like !@#$%", Some('s'))
+            .switch("no-uppercase", "Exclude uppercase letters A-Z.", Some('u'))
+            .switch("no-lowercase", "Exclude lowercase letters a-z.", Some('l'))
+            .switch("no-numbers", "Exclude numbers 0-9.", Some('n'))
+            .switch("no-symbols", "Exclude symbols like !@#$%.", Some('s'))
             .switch(
                 "include-ambiguous",
-                "Include ambiguous characters O, 0, l, 1",
+                "Include ambiguous characters O, 0, l, 1.",
                 None,
             )
             .switch(
                 "include-similar",
-                "Include similar characters i, l, 1",
+                "Include similar characters i, l, 1.",
                 None,
             )
             .switch(
                 "require-each-type",
-                "Guarantee at least one char from each enabled character type",
+                "Guarantee at least one char from each enabled character type.",
                 None,
             )
             .category(Category::Random)
     }
 
     fn description(&self) -> &str {
-        "Generate a cryptologically secure password"
+        "Generate a cryptologically secure password."
     }
 
     fn search_terms(&self) -> Vec<&str> {


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR adds a random password generator called `random pass`.
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)

### Added `random pass` for generating passwords

New command `random pass` generates random passwords.
```nushell
❯ 0..10 | each {random pass}
╭────┬──────────────╮
│  0 │ o(3&BU2EkWv] │
│  1 │ 3~5y9PpXKH-| │
│  2 │ 7Wa6]`q-TR?- │
│  3 │ r|F=5d:.-BZp │
│  4 │ 7ZjM$xg?h^o3 │
│  5 │ CMg.4-NKxy^e │
│  6 │ b8&zy)ZhN}MV │
│  7 │ }Hc#>GpyK%@6 │
│  8 │ KvJOL4VoTgN] │
│  9 │ 7HN!%1A0Vm-X │
│ 10 │ 4|`M&8x%wX@S │
╰────┴──────────────╯
```
`random pass` supports these flags.
```nushell
  -c, --chars <int>: Length of the generated password (default 12)
  -u, --no-uppercase: Exclude uppercase letters A-Z
  -l, --no-lowercase: Exclude lowercase letters a-z
  -n, --no-numbers: Exclude numbers 0-9
  -s, --no-symbols: Exclude symbols like !@#$%
  --include-ambiguous: Include ambiguous characters O, 0, l, 1
  --include-similar: Include similar characters i, l, 1
  --require-each-type: Guarantee at least one char from each enabled character type
```
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->