### PR TITLE
save ~100 tokens in evaluate_tool.md instructions

### DIFF
--- a/crates/nu-mcp/src/evaluate_tool.md
+++ b/crates/nu-mcp/src/evaluate_tool.md
@@ -18,36 +18,36 @@ Command Equivalents to Bash:
 
 | Bash Command | Nushell Command | Description |
 |--------------|-----------------|-------------|
-| `mkdir -p <path>` | `mkdir <path>` | Creates the given path, creating parents as necessary |
-| `> <path>`  | `o> <path>` | Save command output to a file |
-| `>> <path>` | `o>> <path>` | Append command output to a file |
-| `> /dev/null` | `ignore` | Discard command output |
-| `> /dev/null 2>&1` | `o+e>\| ignore` | Discard command output, including stderr |
-| `command 2>&1` | `command o+e>\| ...` | Redirect stderr to stdout (use `o+e>` or `out+err>`) |
-| `cmd1 \| tee log.txt \| cmd2` | `cmd1 \| tee { save log.txt } \| cmd2` | Tee command output to a log file |
-| `command \| head -5` | `command \| first 5` | Limit the output to the first 5 rows of an internal command (see also last and skip) |
-| `cat <path>` | `open --raw <path>` | Display the contents of the given file |
-| `cat <(<command1>) <(<command2>)` | `[(command1), (command2)] \| str join` | Concatenate the outputs of command1 and command2 |
-| `cat <path> <(<command>)` | `[(open --raw <path>), (command)] \| str join` | Concatenate the contents of the given file and output of command |
-| `for f in *.md; do echo $f; done` | `ls *.md \| each { $in.name }` | Iterate over a list and return results |
-| `for i in $(seq 1 10); do echo $i; done` | `for i in 1..10 { print $i }` | Iterate over a list and run a command on results |
-| `cp <source> <dest>` | `cp <source> <dest>` | Copy file to new location |
-| `rm -rf <path>` | `rm -r <path>` | Recursively removes the given path |
-| `date -d <date>` | `"<date>" \| into datetime -f <format>` | Parse a date (format documentation) |
-| `sed` | `str replace` | Find and replace a pattern in a string |
-| `grep <pattern>` | `where $it =~ <substring>` or `find <substring>` | Filter strings that contain the substring |
-| `command1 && command2` | `command1; command2` | Run a command, and if it's successful run a second |
-| `stat $(which git)` | `stat ...(which git).path` | Use command output as argument for other command |
-| `echo /tmp/$RANDOM` | `$"/tmp/(random int)"` | Use command output in a string |
-| `cargo b --jobs=$(nproc)` | `cargo b $"--jobs=(sys cpu \| length)"` | Use command output in an option |
-| `echo $PATH` | `$env.PATH (Non-Windows) or $env.Path (Windows)` | See the current path |
-| `echo $?` | `$env.LAST_EXIT_CODE` | See the exit status of the last executed command |
-| `export` | `$env` | List the current environment variables |
-| `FOO=BAR ./bin` | `FOO=BAR ./bin` | Update environment for a command |
-| `echo $FOO` | `$env.FOO` | Use environment variables |
-| `echo ${FOO:-fallback}` | `$env.FOO? \| default "ABC"` | Use a fallback in place of an unset variable |
-| `type FOO` | `which FOO` | Display information about a command (builtin, alias, or executable) |
-| `\` | `( <command> )` | A command can span multiple lines when wrapped with ( and ) |
+| mkdir -p <path> | mkdir <path> | Creates the given path, creating parents as necessary |
+| > <path>  | o> <path> | Save command output to a file |
+| >> <path> | o>> <path> | Append command output to a file |
+| > /dev/null | ignore | Discard command output |
+| > /dev/null 2>&1 | o+e>\| ignore | Discard command output, including stderr |
+| command 2>&1 | command o+e>\| ... | Redirect stderr to stdout (use o+e> or out+err>) |
+| cmd1 \| tee log.txt \| cmd2 | cmd1 \| tee { save log.txt } \| cmd2 | Tee command output to a log file |
+| command \| head -5 | command \| first 5 | Limit the output to the first 5 rows of an internal command (see also last and skip) |
+| cat <path> | open --raw <path> | Display the contents of the given file |
+| cat <(<command1>) <(<command2>) | [(command1), (command2)] \| str join | Concatenate the outputs of command1 and command2 |
+| cat <path> <(<command>) | [(open --raw <path>), (command)] \| str join | Concatenate the contents of the given file and output of command |
+| for f in *.md; do echo $f; done | ls *.md \| each { $in.name } | Iterate over a list and return results |
+| for i in $(seq 1 10); do echo $i; done | for i in 1..10 { print $i } | Iterate over a list and run a command on results |
+| cp <source> <dest> | cp <source> <dest> | Copy file to new location |
+| rm -rf <path> | rm -r <path> | Recursively removes the given path |
+| date -d <date> | "<date>" \| into datetime -f <format> | Parse a date (format documentation) |
+| sed | str replace | Find and replace a pattern in a string |
+| grep <pattern> | where $it =~ <substring> or find <substring> | Filter strings that contain the substring |
+| command1 && command2 | command1; command2 | Run a command, and if it's successful run a second |
+| stat $(which git) | stat ...(which git).path | Use command output as argument for other command |
+| echo /tmp/$RANDOM | $"/tmp/(random int)" | Use command output in a string |
+| cargo b --jobs=$(nproc) | cargo b $"--jobs=(sys cpu \| length)" | Use command output in an option |
+| echo $PATH | $env.PATH (Non-Windows) or $env.Path (Windows) | See the current path |
+| echo $? | $env.LAST_EXIT_CODE | See the exit status of the last executed command |
+| export | $env | List the current environment variables |
+| FOO=BAR ./bin | FOO=BAR ./bin | Update environment for a command |
+| echo $FOO | $env.FOO | Use environment variables |
+| echo ${FOO:-fallback} | $env.FOO? \| default "ABC" | Use a fallback in place of an unset variable |
+| type FOO | which FOO | Display information about a command (builtin, alias, or executable) |
+| \ | ( <command> ) | A command can span multiple lines when wrapped with ( and ) |
 
 If the polars commands are available, prefer it for working with parquet, jsonl, ndjson, csv files, and avro files.
 It is much more efficient than the other Nushell commands or other non-nushell commands.


### PR DESCRIPTION
## Description

Save ~100 tokens in the `evaluate_tool.md` instructions by stripping out backtick characters from the `Command Equivalents to Bash` table. We don't need to make text pretty when it's just agent instructions. In the context of being fed to an LLM, backticks serve little purpose, maybe you can argue they serve to disambiguate surrounding prose text from command syntax. But, in the context of this table, the first 2 columns are *only* commands with no prose, so they do not need disambiguation.

## User-facing changes (Release notes)

Small improvement in token-efficiency for the `nu --mcp` agent tool instructions.