### PR TITLE
allow ctrl+c to work better on `from json`

### DIFF
--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -761,7 +761,7 @@ pub fn convert_sqlite_value_to_nu_value(
         ValueRef::Real(f) => Value::float(f, span),
         ValueRef::Text(buf) => match (std::str::from_utf8(buf), decl_type) {
             (Ok(txt), Some(DeclType::Json | DeclType::Jsonb)) => {
-                match crate::try_json_str_to_value(txt, span, false) {
+                match crate::try_json_str_to_value(txt, span, false, &Signals::empty()) {
                     Ok(val) => val,
                     Err(err) => Value::error(err, span),
                 }

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -2,8 +2,9 @@ use std::io::{BufRead, Cursor};
 
 use nu_engine::command_prelude::*;
 use nu_protocol::{
-    ListStream, Signals,
+    DEFAULT_ERROR_CONTEXT, ListStream, Signals,
     shell_error::{generic::GenericError, io::IoError},
+    truncated_source_window,
 };
 
 #[derive(Clone)]
@@ -99,7 +100,7 @@ impl Command for FromJson {
                 {
                     if let Some(reader) = stream.reader() {
                         Ok(PipelineData::list_stream(
-                            read_json_lines(reader, span, strict, Signals::empty()),
+                            read_json_lines(reader, span, strict, engine_state.signals().clone()),
                             metadata,
                         ))
                     } else {
@@ -121,8 +122,10 @@ impl Command for FromJson {
                 return Ok(Value::nothing(span).into_pipeline_data());
             }
 
-            Ok(try_str_to_value(&string_input, span, strict)?
-                .into_pipeline_data_with_metadata(metadata))
+            Ok(
+                try_str_to_value(&string_input, span, strict, engine_state.signals())?
+                    .into_pipeline_data_with_metadata(metadata),
+            )
         }
     }
 }
@@ -134,27 +137,34 @@ fn read_json_lines(
     strict: bool,
     signals: Signals,
 ) -> ListStream {
+    let iter_signals = signals.clone();
     let iter = input
         .lines()
         .filter(|line| line.as_ref().is_ok_and(|line| !line.trim().is_empty()) || line.is_err())
         .map(move |line| {
             let line = line.map_err(|err| IoError::new(err, span, None))?;
-            try_str_to_value(&line, span, strict)
+            try_str_to_value(&line, span, strict, &iter_signals)
         })
         .map(move |result| result.unwrap_or_else(|err| Value::error(err, span)));
 
     ListStream::new(iter, span, signals)
 }
 
-pub fn try_str_to_value(input: &str, span: Span, strict: bool) -> Result<Value, ShellError> {
+pub fn try_str_to_value(
+    input: &str,
+    span: Span,
+    strict: bool,
+    signals: &Signals,
+) -> Result<Value, ShellError> {
     match strict {
         true => try_str_to_value_impl(
             input,
             span,
+            signals,
             |s| serde_json::from_str(s),
             |err| err.is_syntax().then_some((err.line(), err.column())),
         ),
-        false => try_str_to_value_impl(input, span, nu_json::from_str, |err| match err {
+        false => try_str_to_value_impl(input, span, signals, nu_json::from_str, |err| match err {
             nu_json::Error::Syntax(_, row, col) => Some((*row, *col)),
             _ => None,
         }),
@@ -165,6 +175,7 @@ pub fn try_str_to_value(input: &str, span: Span, strict: bool) -> Result<Value, 
 fn try_str_to_value_impl<E: std::error::Error>(
     input: &str,
     span: Span,
+    signals: &Signals,
     parser: impl Fn(&str) -> Result<nu_json::Value, E>,
     on_syntax_err: impl Fn(&E) -> Option<(usize, usize)>,
 ) -> Result<Value, ShellError> {
@@ -173,7 +184,9 @@ fn try_str_to_value_impl<E: std::error::Error>(
         Err(err) => match on_syntax_err(&err) {
             Some((row, col)) => {
                 let label = err.to_string();
-                let label_span = Span::from_row_column(row, col, input);
+                let byte_span = Span::try_from_row_column(row, col, input, &span, signals)?;
+                let (src, label_span) =
+                    truncated_source_window(input, byte_span, DEFAULT_ERROR_CONTEXT);
                 Err(ShellError::Generic(
                     GenericError::new(
                         "Error while parsing JSON text",
@@ -181,7 +194,7 @@ fn try_str_to_value_impl<E: std::error::Error>(
                         span,
                     )
                     .with_inner([ShellError::OutsideSpannedLabeledError {
-                        src: input.into(),
+                        src,
                         error: "Error while parsing JSON text".into(),
                         msg: label,
                         span: label_span,
@@ -205,5 +218,81 @@ mod test {
     #[test]
     fn test_examples() -> nu_test_support::Result {
         nu_test_support::test().examples(FromJson)
+    }
+
+    #[test]
+    fn json_error_source_is_bounded() {
+        // Build a large string (~100KB) with an error near the end
+        let mut valid_part = String::new();
+        valid_part.push('[');
+        for i in 0..2000 {
+            use std::fmt::Write;
+            write!(&mut valid_part, r#""line {i}","#).unwrap();
+        }
+        // Malformed at the end
+        valid_part.push_str("broken]"); // no closing quote
+
+        let signals = Signals::empty();
+        let result = try_str_to_value(&valid_part, Span::test_data(), true, &signals);
+        assert!(result.is_err(), "should fail to parse");
+
+        let err = result.unwrap_err();
+        match &err {
+            ShellError::Generic(GenericError { inner, .. }) => {
+                let inner_err = inner.first().expect("should have inner error");
+                match inner_err {
+                    ShellError::OutsideSpannedLabeledError { src, .. } => {
+                        // src should be bounded well under the 100KB input
+                        assert!(
+                            src.len() < 20_000,
+                            "error source should be bounded, got {} bytes",
+                            src.len()
+                        );
+                    }
+                    other => panic!("expected OutsideSpannedLabeledError, got {other:?}"),
+                }
+            }
+            other => panic!("expected Generic error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_error_source_not_entire_file() {
+        // With a ~50KB input, the error src should be far smaller
+        let mut input = String::with_capacity(50_000);
+        input.push('[');
+        input.push_str(&"0,".repeat(10_000));
+        input.push_str(":]"); // syntax error: `:]` instead of `]`
+
+        let signals = Signals::empty();
+        let result = try_str_to_value(&input, Span::test_data(), true, &signals);
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        match &err {
+            ShellError::Generic(GenericError { inner, .. }) => {
+                let inner_err = inner.first().expect("should have inner error");
+                match inner_err {
+                    ShellError::OutsideSpannedLabeledError { src, .. } => {
+                        // src should be a window around the error, not the whole 50KB
+                        assert!(
+                            src.len() < 20_000,
+                            "error source should be bounded, got {} bytes",
+                            src.len()
+                        );
+                    }
+                    other => panic!("expected OutsideSpannedLabeledError, got {other:?}"),
+                }
+            }
+            other => panic!("expected Generic error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_parse_success_not_affected() {
+        let input = r#"{"a": 1, "b": [2, 3]}"#;
+        let signals = Signals::empty();
+        let result = try_str_to_value(input, Span::test_data(), true, &signals);
+        assert!(result.is_ok(), "valid JSON should still parse");
     }
 }

--- a/crates/nu-command/src/formats/from/kdl.rs
+++ b/crates/nu-command/src/formats/from/kdl.rs
@@ -1,7 +1,9 @@
 use crate::formats::{KDL_CANONICAL_METADATA_KEY, KDL_CANONICAL_METADATA_VALUE};
 use kdl::{KdlDocument, KdlError, KdlNode, KdlValue};
 use nu_engine::command_prelude::*;
-use nu_protocol::shell_error::generic::GenericError;
+use nu_protocol::{
+    DEFAULT_ERROR_CONTEXT, shell_error::generic::GenericError, truncated_source_window,
+};
 use num_traits::ToPrimitive;
 
 #[derive(Clone)]
@@ -129,8 +131,13 @@ fn parse_kdl_document_with_diagnostics(input: &str, span: Span) -> Result<KdlDoc
 
 fn kdl_error_to_shell_error(input: &str, span: Span, err: &KdlError) -> ShellError {
     if let Some(diagnostic) = err.diagnostics.first() {
-        let label_span = span_from_kdl_diagnostic(input, diagnostic);
         let diagnostic_message = kdl_diagnostics_message(&err.diagnostics);
+        let byte_offset = diagnostic.span.offset();
+        let (src, label_span) = truncated_source_window(
+            input,
+            Span::new(byte_offset, byte_offset),
+            DEFAULT_ERROR_CONTEXT,
+        );
 
         return ShellError::Generic(
             GenericError::new(
@@ -139,7 +146,7 @@ fn kdl_error_to_shell_error(input: &str, span: Span, err: &KdlError) -> ShellErr
                 span,
             )
             .with_inner([ShellError::OutsideSpannedLabeledError {
-                src: input.into(),
+                src,
                 error: "Error while parsing KDL text".into(),
                 msg: diagnostic_message,
                 span: label_span,
@@ -172,31 +179,6 @@ fn kdl_diagnostics_message(diagnostics: &[kdl::KdlDiagnostic]) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n\n")
-}
-
-fn span_from_kdl_diagnostic(input: &str, diagnostic: &kdl::KdlDiagnostic) -> Span {
-    let (row, col) = row_col_from_byte_offset(input, diagnostic.span.offset());
-    Span::from_row_column(row, col, input)
-}
-
-fn row_col_from_byte_offset(input: &str, offset: usize) -> (usize, usize) {
-    let mut row = 1;
-    let mut col = 1;
-
-    for (byte_index, ch) in input.char_indices() {
-        if byte_index >= offset {
-            break;
-        }
-
-        if ch == '\n' {
-            row += 1;
-            col = 1;
-        } else {
-            col += 1;
-        }
-    }
-
-    (row, col)
 }
 
 fn kdl_diagnostic_message(diagnostic: &kdl::KdlDiagnostic) -> String {
@@ -535,5 +517,44 @@ mod test {
                 .expect("missing message text"),
             Value::string("hello\nworld", span)
         );
+    }
+
+    #[test]
+    fn kdl_error_source_is_bounded() {
+        let mut input = String::with_capacity(50_000);
+        for _ in 0..2000 {
+            input.push_str("node1 key=1; ");
+        }
+        input.push_str("node2 \"unclosed"); // Syntax error: unclosed string
+
+        let result = parse_kdl_document_with_diagnostics(&input, Span::test_data());
+        assert!(result.is_err(), "should fail to parse");
+
+        let err = result.unwrap_err();
+        match &err {
+            ShellError::Generic(GenericError { inner, .. }) => {
+                let inner_err = inner.first().expect("should have inner error");
+                match inner_err {
+                    ShellError::OutsideSpannedLabeledError { src, .. } => {
+                        assert!(
+                            src.len() < 20_000,
+                            "error source should be bounded, got {} bytes",
+                            src.len()
+                        );
+                    }
+                    other => panic!("expected OutsideSpannedLabeledError, got {other:?}"),
+                }
+            }
+            other => panic!("expected Generic error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kdl_parse_success_not_affected() {
+        let result = parse_kdl_document_with_diagnostics(
+            r#"node1 key=1; node2 key="val""#,
+            Span::test_data(),
+        );
+        assert!(result.is_ok(), "valid KDL should still parse");
     }
 }

--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -1,7 +1,9 @@
 use crate::formats::nu_xml_format::{COLUMN_ATTRS_NAME, COLUMN_CONTENT_NAME, COLUMN_TAG_NAME};
 use indexmap::IndexMap;
 use nu_engine::command_prelude::*;
-use nu_protocol::shell_error::generic::GenericError;
+use nu_protocol::{
+    DEFAULT_ERROR_CONTEXT, Signals, shell_error::generic::GenericError, truncated_source_window,
+};
 
 use roxmltree::{NodeType, ParsingOptions, TextPos};
 
@@ -63,7 +65,7 @@ string. This way content of every tag is always a table and is easier to parse"#
             keep_processing_instructions,
             allow_dtd,
         };
-        from_xml(input, &info)
+        from_xml(input, &info, engine_state.signals())
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -216,70 +218,114 @@ fn from_xml_string_to_value(s: &str, info: &ParsingInfo) -> Result<Value, roxmlt
     Ok(from_document_to_value(&parsed, info))
 }
 
-fn from_xml(input: PipelineData, info: &ParsingInfo) -> Result<PipelineData, ShellError> {
+fn from_xml(
+    input: PipelineData,
+    info: &ParsingInfo,
+    signals: &Signals,
+) -> Result<PipelineData, ShellError> {
     let (concat_string, span, metadata) = input.collect_string_strict(info.span)?;
 
     match from_xml_string_to_value(&concat_string, info) {
         Ok(x) => {
             Ok(x.into_pipeline_data_with_metadata(metadata.map(|md| md.with_content_type(None))))
         }
-        Err(err) => Err(process_xml_parse_error(concat_string, err, span)),
+        Err(err) => Err(process_xml_parse_error(concat_string, err, span, signals)),
     }
 }
 
-fn process_xml_parse_error(source: String, err: roxmltree::Error, span: Span) -> ShellError {
+fn process_xml_parse_error(
+    source: impl AsRef<str>,
+    err: roxmltree::Error,
+    span: Span,
+    signals: &Signals,
+) -> ShellError {
+    let source = source.as_ref();
     match err {
-        roxmltree::Error::InvalidXmlPrefixUri(pos) => make_xml_error_spanned(
+        roxmltree::Error::InvalidXmlPrefixUri(pos) => make_xml_err(
+            source,
+            span,
+            signals,
             "The `xmlns:xml` attribute must have an <http://www.w3.org/XML/1998/namespace> URI.",
-            source,
             pos,
         ),
-        roxmltree::Error::UnexpectedXmlUri(pos) => make_xml_error_spanned(
+        roxmltree::Error::UnexpectedXmlUri(pos) => make_xml_err(
+            source,
+            span,
+            signals,
             "Only the xmlns:xml attribute can have the http://www.w3.org/XML/1998/namespace  URI.",
-            source,
             pos,
         ),
-        roxmltree::Error::UnexpectedXmlnsUri(pos) => make_xml_error_spanned(
+        roxmltree::Error::UnexpectedXmlnsUri(pos) => make_xml_err(
+            source,
+            span,
+            signals,
             "The http://www.w3.org/2000/xmlns/  URI must not be declared.",
-            source,
             pos,
         ),
-        roxmltree::Error::InvalidElementNamePrefix(pos) => {
-            make_xml_error_spanned("xmlns can't be used as an element prefix.", source, pos)
-        }
-        roxmltree::Error::DuplicatedNamespace(namespace, pos) => make_xml_error_spanned(
+        roxmltree::Error::InvalidElementNamePrefix(pos) => make_xml_err(
+            source,
+            span,
+            signals,
+            "xmlns can't be used as an element prefix.",
+            pos,
+        ),
+        roxmltree::Error::DuplicatedNamespace(namespace, pos) => make_xml_err(
+            source,
+            span,
+            signals,
             format!("Namespace {namespace} was already defined on this element."),
-            source,
             pos,
         ),
-        roxmltree::Error::UnknownNamespace(prefix, pos) => {
-            make_xml_error_spanned(format!("Unknown prefix {prefix}"), source, pos)
-        }
-        roxmltree::Error::UnexpectedCloseTag(expected, actual, pos) => make_xml_error_spanned(
+        roxmltree::Error::UnknownNamespace(prefix, pos) => make_xml_err(
+            source,
+            span,
+            signals,
+            format!("Unknown prefix {prefix}"),
+            pos,
+        ),
+        roxmltree::Error::UnexpectedCloseTag(expected, actual, pos) => make_xml_err(
+            source,
+            span,
+            signals,
             format!("Unexpected close tag {actual}, expected {expected}"),
-            source,
             pos,
         ),
-        roxmltree::Error::UnexpectedEntityCloseTag(pos) => {
-            make_xml_error_spanned("Entity value starts with a close tag.", source, pos)
-        }
-        roxmltree::Error::UnknownEntityReference(entity, pos) => make_xml_error_spanned(
-            format!("Reference to unknown entity {entity} (was not defined in the DTD)"),
+        roxmltree::Error::UnexpectedEntityCloseTag(pos) => make_xml_err(
             source,
+            span,
+            signals,
+            "Entity value starts with a close tag.",
+            pos,
+        ),
+        roxmltree::Error::UnknownEntityReference(entity, pos) => make_xml_err(
+            source,
+            span,
+            signals,
+            format!("Reference to unknown entity {entity} (was not defined in the DTD)"),
             pos,
         ),
         roxmltree::Error::MalformedEntityReference(pos) => {
-            make_xml_error_spanned("Malformed entity reference.", source, pos)
+            make_xml_err(source, span, signals, "Malformed entity reference.", pos)
         }
-        roxmltree::Error::EntityReferenceLoop(pos) => {
-            make_xml_error_spanned("Possible entity reference loop.", source, pos)
-        }
-        roxmltree::Error::InvalidAttributeValue(pos) => {
-            make_xml_error_spanned("Attribute value cannot have a < character.", source, pos)
-        }
-        roxmltree::Error::DuplicatedAttribute(attribute, pos) => make_xml_error_spanned(
-            format!("Element has a duplicated attribute: {attribute}"),
+        roxmltree::Error::EntityReferenceLoop(pos) => make_xml_err(
             source,
+            span,
+            signals,
+            "Possible entity reference loop.",
+            pos,
+        ),
+        roxmltree::Error::InvalidAttributeValue(pos) => make_xml_err(
+            source,
+            span,
+            signals,
+            "Attribute value cannot have a < character.",
+            pos,
+        ),
+        roxmltree::Error::DuplicatedAttribute(attribute, pos) => make_xml_err(
+            source,
+            span,
+            signals,
+            format!("Element has a duplicated attribute: {attribute}"),
             pos,
         ),
         roxmltree::Error::NoRootNode => {
@@ -295,56 +341,76 @@ fn process_xml_parse_error(source: String, err: roxmltree::Error, span: Span) ->
         roxmltree::Error::NodesLimitReached => make_xml_error("Node limit was reached.", span),
         roxmltree::Error::AttributesLimitReached => make_xml_error("Attribute limit reached", span),
         roxmltree::Error::NamespacesLimitReached => make_xml_error("Namespace limit reached", span),
-        roxmltree::Error::UnexpectedDeclaration(pos) => make_xml_error_spanned(
+        roxmltree::Error::UnexpectedDeclaration(pos) => make_xml_err(
+            source,
+            span,
+            signals,
             "An XML document can have only one XML declaration and it must be at the start of the document.",
-            source,
             pos,
         ),
-        roxmltree::Error::InvalidName(pos) => make_xml_error_spanned("Invalid name.", source, pos),
-        roxmltree::Error::NonXmlChar(_, pos) => make_xml_error_spanned(
+        roxmltree::Error::InvalidName(pos) => {
+            make_xml_err(source, span, signals, "Invalid name.", pos)
+        }
+        roxmltree::Error::NonXmlChar(_, pos) => make_xml_err(
+            source,
+            span,
+            signals,
             "Non-XML character found. Valid characters are: <https://www.w3.org/TR/xml/#char32>",
-            source,
             pos,
         ),
-        roxmltree::Error::InvalidChar(expected, actual, pos) => make_xml_error_spanned(
+        roxmltree::Error::InvalidChar(expected, actual, pos) => make_xml_err(
+            source,
+            span,
+            signals,
             format!(
                 "Unexpected character {}, expected {}",
                 actual as char, expected as char
             ),
-            source,
             pos,
         ),
-        roxmltree::Error::InvalidChar2(expected, actual, pos) => make_xml_error_spanned(
+        roxmltree::Error::InvalidChar2(expected, actual, pos) => make_xml_err(
+            source,
+            span,
+            signals,
             format!(
                 "Unexpected character {}, expected {}",
                 actual as char, expected
             ),
-            source,
             pos,
         ),
-        roxmltree::Error::InvalidString(_, pos) => {
-            make_xml_error_spanned("Invalid/unexpected string in XML.", source, pos)
-        }
+        roxmltree::Error::InvalidString(_, pos) => make_xml_err(
+            source,
+            span,
+            signals,
+            "Invalid/unexpected string in XML.",
+            pos,
+        ),
         roxmltree::Error::InvalidExternalID(pos) => {
-            make_xml_error_spanned("Invalid ExternalID in the DTD.", source, pos)
+            make_xml_err(source, span, signals, "Invalid ExternalID in the DTD.", pos)
         }
-        roxmltree::Error::EntityResolver(pos, msg) => make_xml_error_spanned(
-            format!("Resolving the given entity yielded an error: {}.", msg),
+        roxmltree::Error::EntityResolver(pos, msg) => make_xml_err(
             source,
+            span,
+            signals,
+            format!("Resolving the given entity yielded an error: {msg}."),
             pos,
         ),
-        roxmltree::Error::InvalidComment(pos) => make_xml_error_spanned(
+        roxmltree::Error::InvalidComment(pos) => make_xml_err(
+            source,
+            span,
+            signals,
             "A comment cannot contain `--` or end with `-`.",
-            source,
             pos,
         ),
-        roxmltree::Error::InvalidCharacterData(pos) => make_xml_error_spanned(
-            "Character Data node contains an invalid data. Currently, only `]]>` is not allowed.",
+        roxmltree::Error::InvalidCharacterData(pos) => make_xml_err(
             source,
+            span,
+            signals,
+            "Character Data node contains an invalid data. Currently, only `]]>` is not allowed.",
             pos,
         ),
         roxmltree::Error::UnknownToken(pos) => {
-            make_xml_error_spanned("Unknown token in XML.", source, pos)
+            make_xml_err(source, span, signals, "Unknown token in XML.", pos)
         }
         roxmltree::Error::UnexpectedEndOfStream => {
             make_xml_error("Unexpected end of stream while parsing XML.", span)
@@ -352,18 +418,30 @@ fn process_xml_parse_error(source: String, err: roxmltree::Error, span: Span) ->
     }
 }
 
-fn make_xml_error(msg: impl Into<String>, span: Span) -> ShellError {
-    ShellError::Generic(GenericError::new("Failed to parse XML", msg.into(), span))
+fn make_xml_err(
+    source: &str,
+    span: Span,
+    signals: &Signals,
+    msg: impl Into<String>,
+    pos: TextPos,
+) -> ShellError {
+    match Span::try_from_row_column(pos.row as usize, pos.col as usize, source, &span, signals) {
+        Ok(byte_span) => {
+            let (src, label_span) =
+                truncated_source_window(source, byte_span, DEFAULT_ERROR_CONTEXT);
+            ShellError::OutsideSpannedLabeledError {
+                src,
+                error: "Failed to parse XML".into(),
+                msg: msg.into(),
+                span: label_span,
+            }
+        }
+        Err(e) => e,
+    }
 }
 
-fn make_xml_error_spanned(msg: impl Into<String>, src: String, pos: TextPos) -> ShellError {
-    let span = Span::from_row_column(pos.row as usize, pos.col as usize, &src);
-    ShellError::OutsideSpannedLabeledError {
-        src,
-        error: "Failed to parse XML".into(),
-        msg: msg.into(),
-        span,
-    }
+fn make_xml_error(msg: impl Into<String>, span: Span) -> ShellError {
+    ShellError::Generic(GenericError::new("Failed to parse XML", msg.into(), span))
 }
 
 #[cfg(test)]
@@ -371,6 +449,7 @@ mod tests {
     use crate::Metadata;
     use crate::MetadataSet;
     use crate::Reject;
+    use roxmltree::ParsingOptions;
 
     use super::*;
 
@@ -564,5 +643,57 @@ mod tests {
             ),
             result.expect("There should be a result")
         )
+    }
+
+    #[test]
+    fn xml_error_source_is_bounded() {
+        // Build a large valid XML with an error near the end
+        let mut input = String::from("<root>");
+        for _ in 0..5000 {
+            input.push_str("<item>value</item>");
+        }
+        input.push_str("<bad"); // Unclosed tag at the end (error)
+
+        let signals = Signals::empty();
+        let parse_result = roxmltree::Document::parse_with_options(
+            &input,
+            ParsingOptions {
+                allow_dtd: true,
+                ..Default::default()
+            },
+        );
+        assert!(parse_result.is_err(), "should fail to parse");
+
+        let err = process_xml_parse_error(
+            &input,
+            parse_result.unwrap_err(),
+            Span::test_data(),
+            &signals,
+        );
+        match &err {
+            ShellError::OutsideSpannedLabeledError { src, .. } => {
+                assert!(
+                    src.len() < 20_000,
+                    "error source should be bounded, got {} bytes",
+                    src.len()
+                );
+            }
+            ShellError::Generic(_) => (), // Generic errors without source are also OK
+            other => panic!("expected OutsideSpannedLabeledError or Generic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn xml_parse_success_not_affected() {
+        let result = from_xml_string_to_value(
+            r#"<?xml version="1.0"?><root><item>value</item></root>"#,
+            &ParsingInfo {
+                span: Span::test_data(),
+                keep_comments: false,
+                keep_processing_instructions: false,
+                allow_dtd: false,
+            },
+        );
+        assert!(result.is_ok(), "valid XML should still parse");
     }
 }

--- a/crates/nu-command/src/platform/clip/paste.rs
+++ b/crates/nu-command/src/platform/clip/paste.rs
@@ -3,7 +3,7 @@ use crate::{
     platform::clip::get_config::get_clip_config_with_plugin_fallback, try_json_str_to_value,
 };
 use nu_engine::command_prelude::*;
-use nu_protocol::{Config, shell_error::generic::GenericError};
+use nu_protocol::{Config, Signals, shell_error::generic::GenericError};
 
 #[derive(Clone)]
 pub struct ClipPaste;
@@ -53,7 +53,7 @@ impl Command for ClipPaste {
 
         let trimmed = text.trim_start();
         if trimmed.starts_with('{') || trimmed.starts_with('[') || trimmed.starts_with('"') {
-            return match try_json_str_to_value(trimmed, call.head, false) {
+            return match try_json_str_to_value(trimmed, call.head, false, &Signals::empty()) {
                 Ok(value) => Ok(value.into_pipeline_data()),
                 Err(_) => Ok(Value::string(text, call.head).into_pipeline_data()),
             };

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -426,3 +426,259 @@ impl From<IoError> for LabeledError {
         Self::from_diagnostic(&err)
     }
 }
+
+/// Default number of context bytes on each side of an error span when truncating source
+/// for diagnostics.
+pub const DEFAULT_ERROR_CONTEXT: usize = 4096;
+
+/// Truncates a source string to a bounded window around an error span.
+///
+/// Takes `context` bytes on each side of the error location. Returns the
+/// truncated source and an adjusted span that is relative to the truncated window.
+/// This prevents unbounded memory usage when error diagnostics embed large source files.
+///
+/// Slicing is safe on multi-byte UTF-8: window boundaries are adjusted to char boundaries.
+///
+/// For multi-line inputs the window expands to the nearest line boundaries so that line
+/// numbers in the diagnostic output are consistent. For single-line (minified) inputs
+/// with a large requested context, the window is clamped to a smaller focused snippet
+/// since a wall of unbroken text is not helpful.
+///
+/// Use with `Span::try_from_row_column` when you only have (row, col) from the parser,
+/// or directly when you already have the byte offset from the parser.
+pub fn truncated_source_window(input: &str, byte_span: Span, context: usize) -> (String, Span) {
+    let mid = (byte_span.start + byte_span.end) / 2;
+
+    // Detect single-line (minified) input.  When the caller asks for a large context
+    // but the input has no newlines nearby, a wall of unbroken text is useless — clamp
+    // to a tight window focused on the error location.
+    const TIGHT_CONTEXT: usize = 128;
+    let is_single_line = if context > TIGHT_CONTEXT {
+        let probe_start = input.floor_char_boundary(mid.saturating_sub(TIGHT_CONTEXT));
+        let probe_end = input.ceil_char_boundary(input.len().min(mid + TIGHT_CONTEXT));
+        !input[probe_start..probe_end].contains('\n')
+    } else {
+        false
+    };
+    let effective = if is_single_line {
+        TIGHT_CONTEXT
+    } else {
+        context
+    };
+
+    let mut window_start = mid.saturating_sub(effective);
+    let mut window_end = input.len().min(mid + effective);
+
+    // Adjust to char boundaries to avoid panicking on multi-byte UTF-8
+    window_start = input.floor_char_boundary(window_start);
+    window_end = input.ceil_char_boundary(window_end);
+
+    if !is_single_line && context > TIGHT_CONTEXT {
+        // Multi-line with large context: round to nearest line boundaries for
+        // proper line-number display.  Guard against blowing up by 2x context.
+        window_start = if let Some(pos) = input[..window_start].rfind('\n') {
+            let line_start = pos + 1;
+            if window_start - line_start <= context * 2 {
+                line_start
+            } else {
+                window_start
+            }
+        } else {
+            window_start
+        };
+        window_end = if let Some(pos) = input[window_end..].find('\n') {
+            let line_end = window_end + pos + 1;
+            if line_end - window_end <= context * 2 {
+                line_end
+            } else {
+                window_end
+            }
+        } else {
+            window_end
+        };
+    }
+
+    let truncated = input[window_start..window_end].to_string();
+    let adjusted_span = Span::new(
+        byte_span.start.saturating_sub(window_start),
+        byte_span.end.saturating_sub(window_start),
+    );
+    (truncated, adjusted_span)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncated_source_window_middle() {
+        // 40 bytes of padding on each side, "ERROR" spanning bytes 40..45
+        // mid = (40+45)/2 = 42
+        // window_start = 42-8 = 34, window_end = min(85,42+8) = 50
+        let input = format!("{:a<40}ERROR{:b<40}", "", "");
+        assert_eq!(input.len(), 85);
+        let byte_span = Span::new(40, 45);
+        let (src, span) = truncated_source_window(&input, byte_span, 8);
+        assert!(
+            src.contains("ERROR"),
+            "truncated source should contain the error"
+        );
+        assert_eq!(span.start, 6, "40 - 34 = 6");
+        assert_eq!(span.end, 11, "45 - 34 = 11");
+    }
+
+    #[test]
+    fn truncated_source_window_near_start() {
+        // mid = (0+4)/2 = 2
+        // window_start = 2-8 = 0 (saturated), window_end = min(80, 2+8) = 10
+        let input = format!("{:x<80}", "");
+        let byte_span = Span::new(0, 4);
+        let (src, span) = truncated_source_window(&input, byte_span, 8);
+        assert_eq!(span.start, 0, "0 - 0 = 0");
+        assert_eq!(span.end, 4, "4 - 0 = 4");
+        assert_eq!(src.len(), 10, "window [0, 10) is 10 bytes");
+    }
+
+    #[test]
+    fn truncated_source_window_near_end() {
+        // mid = (76+80)/2 = 78
+        // window_start = 78-8 = 70, window_end = min(80, 78+8) = 80
+        let input = format!("{:x<80}", "");
+        let byte_span = Span::new(76, 80);
+        let (src, span) = truncated_source_window(&input, byte_span, 8);
+        assert_eq!(span.start, 6, "76 - 70 = 6");
+        assert_eq!(span.end, 10, "80 - 70 = 10");
+        assert_eq!(src.len(), 10, "window [70, 80) is 10 bytes");
+    }
+
+    #[test]
+    fn truncated_source_window_small_input() {
+        let input = "small";
+        let byte_span = Span::new(2, 4);
+        let (src, span) = truncated_source_window(input, byte_span, 100);
+        // Input is smaller than context, so window should be the entire input
+        assert_eq!(
+            src, "small",
+            "should be the full input when context > input.len()"
+        );
+        assert_eq!(span.start, 2, "adjusted span start should match original");
+        assert_eq!(span.end, 4, "adjusted span end should match original");
+    }
+
+    #[test]
+    fn truncated_source_window_span_adjustment() {
+        let input = "aaaaaaaaaaERRORbbbbbbbbbb"; // 10 a's, 5 E's, 5 b's = 20 bytes
+        // Error from byte 10 to byte 15 -> "ERROR"
+        let byte_span = Span::new(10, 15);
+        let (src, span) = truncated_source_window(input, byte_span, 5);
+        // Window: mid=12, window_start = 12-5 = 7, window_end = 12+5 = 17
+        // src = input[7..17] = "aaaERRORbb" (3 a's + 5 E's + 2 b's = 10 bytes)
+        assert_eq!(&src, "aaaERRORbb", "window should be 10 bytes");
+        // Adjusted: byte_span.start - window_start = 10-7 = 3
+        assert_eq!(
+            span.start, 3,
+            "adjusted start should be original - window_start"
+        );
+        assert_eq!(
+            span.end, 8,
+            "adjusted end should be original - window_start"
+        );
+        assert_eq!(
+            &src[3..8],
+            "ERROR",
+            "ERROR should be at the right adjusted position"
+        );
+    }
+
+    #[test]
+    fn truncated_source_window_zero_width_span() {
+        let input = "abcdefghijklmnopqrstuvwxyz";
+        let byte_span = Span::new(13, 13); // middle of alphabet
+        let (src, span) = truncated_source_window(input, byte_span, 5);
+        assert_eq!(
+            span.start, span.end,
+            "zero-width span should stay zero-width"
+        );
+        assert!(src.len() <= 11, "window should be bounded");
+    }
+
+    #[test]
+    fn truncated_source_window_multibyte_utf8() {
+        // Chinese chars are 3 bytes each; slicing at arbitrary byte offsets must not panic
+        let input = "你好世界ERROR世界";
+        // "ERROR" starts at byte 12 (4 chars × 3 bytes)
+        let byte_span = Span::new(12, 17);
+        let (src, span) = truncated_source_window(input, byte_span, 3);
+        assert!(
+            src.contains("ERROR"),
+            "window must contain the error region"
+        );
+        assert_eq!(
+            &src[span.start..span.end],
+            "ERROR",
+            "adjusted span must slice correctly"
+        );
+    }
+
+    #[test]
+    fn truncated_source_window_multibyte_utf8_boundary_crossing() {
+        // Force window bounds into the middle of multi-byte chars
+        // "aaaaa" (5 bytes) + "你好世界" (12 bytes) + "ERROR" (5 bytes) + "世界你好" (12 bytes)
+        let input = "aaaaa你好世界ERROR世界你好";
+        // "ERROR" at bytes 17..22
+        let byte_span = Span::new(17, 22);
+        // context=8 should give enough room while crossing multi-byte boundaries
+        let (src, span) = truncated_source_window(input, byte_span, 8);
+        assert!(
+            src.contains("ERROR"),
+            "window must contain the error region"
+        );
+        assert_eq!(&src[span.start..span.end], "ERROR");
+    }
+
+    #[test]
+    fn truncated_source_window_single_line_minified() {
+        // Simulate a minified JSON file: one giant line, error near the end.
+        let mut input = String::new();
+        input.push_str(&"\"key\":\"value\",".repeat(500)); // 14 bytes each
+        let err_byte = input.len(); // byte right after the valid part
+        input.push_str("\"broken"); // syntax error starts here
+        let byte_span = Span::new(err_byte, err_byte + 1); // the opening quote of "broken
+        let (src, span) = truncated_source_window(&input, byte_span, DEFAULT_ERROR_CONTEXT);
+        // The window should be tight (no wall of text) for single-line input.
+        assert!(
+            src.len() < 1000,
+            "single-line window should be tight, got {} bytes",
+            src.len()
+        );
+        assert_eq!(
+            &src[span.start..span.end],
+            "\"",
+            "should point at the opening quote"
+        );
+    }
+
+    #[test]
+    fn truncated_source_window_multiline_uses_full_context() {
+        // Multi-line input should get the full context window with line boundaries.
+        let mut input = String::new();
+        for i in 0..200 {
+            use std::fmt::Write;
+            writeln!(&mut input, "line {i}").unwrap();
+        }
+        input.push_str("ERROR here\nlast line");
+        // "ERROR here" starts at some point in the file
+        let err_offset = input.find("ERROR").expect("ERROR should be in input");
+        let byte_span = Span::new(err_offset, err_offset + 5);
+        // Use a generous context to show it's not truncated to tight window
+        let (src, span) = truncated_source_window(&input, byte_span, DEFAULT_ERROR_CONTEXT);
+        // Multi-line: should contain the whole lines around the error, not tight
+        assert!(
+            src.len() > 1000,
+            "multi-line window should be large, got {} bytes",
+            src.len()
+        );
+        assert!(src.contains("ERROR"), "should contain the error region");
+        assert_eq!(&src[span.start..span.end], "ERROR");
+    }
+}

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -567,13 +567,18 @@ mod tests {
 
     #[test]
     fn truncated_source_window_span_adjustment() {
-        let input = "aaaaaaaaaaERRORbbbbbbbbbb"; // 10 a's, 5 E's, 5 b's = 20 bytes
-        // Error from byte 10 to byte 15 -> "ERROR"
+        // Use XXXXX as the error marker to avoid typos-tool false
+        // positives on an error-word adjacent to other characters.
+        let input = "aaaaaaaaaaXXXXXbbbbbbbbbb"; // 10 a's, 5 X's, 10 b's = 25 bytes
+        // Error from byte 10 to byte 15 -> "XXXXX"
         let byte_span = Span::new(10, 15);
         let (src, span) = truncated_source_window(input, byte_span, 5);
         // Window: mid=12, window_start = 12-5 = 7, window_end = 12+5 = 17
-        // src = input[7..17] = "aaaERRORbb" (3 a's + 5 E's + 2 b's = 10 bytes)
-        assert_eq!(&src, "aaaERRORbb", "window should be 10 bytes");
+        // src = input[7..17] = "aaaXXXXXbb" (3 a's + 5 X's + 2 b's = 10 bytes)
+        assert_eq!(src.len(), 10, "window should be 10 bytes");
+        assert!(src.starts_with("aaa"), "window should start with aaa");
+        assert!(src.ends_with("bb"), "window should end with bb");
+        assert!(src.contains("XXXXX"), "window should contain the error marker");
         // Adjusted: byte_span.start - window_start = 10-7 = 3
         assert_eq!(
             span.start, 3,
@@ -585,8 +590,8 @@ mod tests {
         );
         assert_eq!(
             &src[3..8],
-            "ERROR",
-            "ERROR should be at the right adjusted position"
+            "XXXXX",
+            "error marker should be at the right adjusted position"
         );
     }
 

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -578,7 +578,10 @@ mod tests {
         assert_eq!(src.len(), 10, "window should be 10 bytes");
         assert!(src.starts_with("aaa"), "window should start with aaa");
         assert!(src.ends_with("bb"), "window should end with bb");
-        assert!(src.contains("XXXXX"), "window should contain the error marker");
+        assert!(
+            src.contains("XXXXX"),
+            "window should contain the error marker"
+        );
         // Adjusted: byte_span.start - window_start = 10-7 = 3
         assert_eq!(
             span.start, 3,

--- a/crates/nu-protocol/src/errors/mod.rs
+++ b/crates/nu-protocol/src/errors/mod.rs
@@ -13,7 +13,9 @@ pub mod shell_warning;
 pub use chained_error::ChainedError;
 pub use compile_error::CompileError;
 pub use config::{ConfigError, ConfigWarning};
-pub use labeled_error::{ErrorLabel, ErrorSource, LabeledError};
+pub use labeled_error::{
+    DEFAULT_ERROR_CONTEXT, ErrorLabel, ErrorSource, LabeledError, truncated_source_window,
+};
 pub use parse_error::{DidYouMean, ParseError};
 pub use parse_warning::ParseWarning;
 pub use report_error::{

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -595,22 +595,39 @@ impl ByteStream {
     ///
     /// Any trailing new lines are kept in the returned [`Vec`].
     pub fn into_bytes(self) -> Result<Vec<u8>, ShellError> {
-        // todo!() ctrlc
-        let from_io_error = IoError::factory(self.span, None);
+        let span = self.span;
+        let signals = self.signals;
+        let from_io_error = IoError::factory(span, None);
         match self.stream {
             ByteStreamSource::Read(mut read) => {
                 let mut buf = Vec::new();
-                read.read_to_end(&mut buf).map_err(|err| {
-                    match ShellErrorBridge::try_from(err) {
-                        Ok(ShellErrorBridge(err)) => err,
-                        Err(err) => ShellError::Io(from_io_error(err)),
+                let mut chunk = [0; DEFAULT_BUF_SIZE];
+                loop {
+                    signals.check(&span)?;
+                    match read.read(&mut chunk) {
+                        Ok(0) => break,
+                        Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                        Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                        Err(e) => match ShellErrorBridge::try_from(e) {
+                            Ok(ShellErrorBridge(e)) => return Err(e),
+                            Err(e) => return Err(ShellError::Io(from_io_error(e))),
+                        },
                     }
-                })?;
+                }
                 Ok(buf)
             }
             ByteStreamSource::File(mut file) => {
                 let mut buf = Vec::new();
-                file.read_to_end(&mut buf).map_err(&from_io_error)?;
+                let mut chunk = [0; DEFAULT_BUF_SIZE];
+                loop {
+                    signals.check(&span)?;
+                    match file.read(&mut chunk) {
+                        Ok(0) => break,
+                        Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                        Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                        Err(e) => return Err(ShellError::Io(from_io_error(e))),
+                    }
+                }
                 Ok(buf)
             }
             #[cfg(feature = "os")]

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -1,6 +1,6 @@
 //! [`Span`] to point to sections of source code and the [`Spanned`] wrapper type
 use crate::shell_error::generic::GenericError;
-use crate::{FromValue, IntoValue, ShellError, SpanId, Value, record};
+use crate::{FromValue, IntoValue, ShellError, Signals, SpanId, Value, record};
 use miette::SourceSpan;
 use serde::{Deserialize, Serialize};
 use std::{fmt, ops::Deref};
@@ -264,6 +264,39 @@ impl Span {
         }
     }
 
+    /// Like [`from_row_column`] but checks for signal interruption during scanning.
+    ///
+    /// Signal check interval: every 16384 bytes.
+    /// Returns a span covering at least one byte so it is visible in error diagnostics.
+    pub fn try_from_row_column(
+        row: usize,
+        col: usize,
+        contents: &str,
+        span: &Span,
+        signals: &Signals,
+    ) -> Result<Span, ShellError> {
+        let mut cur_row = 1;
+        let mut cur_col = 1;
+
+        for (offset, curr_byte) in contents.bytes().enumerate() {
+            if offset > 0 && offset % 16384 == 0 {
+                signals.check(span)?;
+            }
+            if curr_byte == b'\n' {
+                cur_row += 1;
+                cur_col = 1;
+            } else if cur_row >= row && cur_col >= col {
+                // Return a span covering at least one byte for visible error highlighting
+                let end = contents.len().min(offset + 1);
+                return Ok(Span::new(offset, end));
+            } else {
+                cur_col += 1;
+            }
+        }
+
+        Ok(Span::new(contents.len(), contents.len()))
+    }
+
     /// Returns the minimal [`Span`] that encompasses both of the given spans.
     ///
     /// The two `Spans` can overlap in the middle,
@@ -404,5 +437,96 @@ impl<T, E> ErrSpan for Result<T, E> {
 
     fn err_span(self, span: Span) -> Self::Result {
         self.map_err(|err| err.into_spanned(span))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Signals;
+    use std::sync::{Arc, atomic::AtomicBool};
+
+    /// Span from a matched position now covers at least one byte for visible error highlighting.
+    /// Both `start` and `end` indicate that `start == end - 1`.
+
+    #[test]
+    fn try_from_row_column_first_line() {
+        let input = "hello\nworld\nfoo";
+        let signals = Signals::empty();
+        let result = Span::try_from_row_column(1, 3, input, &Span::unknown(), &signals);
+        assert_eq!(result, Ok(Span::new(2, 3))); // 'l' in "hello" at index 2..3
+    }
+
+    #[test]
+    fn try_from_row_column_second_line() {
+        let input = "hello\nworld\nfoo";
+        let signals = Signals::empty();
+        let result = Span::try_from_row_column(2, 1, input, &Span::unknown(), &signals);
+        assert_eq!(result, Ok(Span::new(6, 7))); // 'w' in "world" at index 6..7
+    }
+
+    #[test]
+    fn try_from_row_column_last_char() {
+        let input = "hello\nworld\nfoo";
+        let signals = Signals::empty();
+        // "foo" starts at index 12, third char 'o' at index 14
+        let result = Span::try_from_row_column(3, 3, input, &Span::unknown(), &signals);
+        assert_eq!(result, Ok(Span::new(14, 15)));
+    }
+
+    #[test]
+    fn try_from_row_column_beyond_input() {
+        let input = "hi";
+        let signals = Signals::empty();
+        // Asking for a row beyond the input should return the end
+        let result = Span::try_from_row_column(10, 1, input, &Span::unknown(), &signals);
+        assert_eq!(result, Ok(Span::new(2, 2))); // end of input
+    }
+
+    #[test]
+    fn try_from_row_column_interrupted_triggers_error() {
+        // Input long enough to trigger the 16384-byte signal check
+        let flag = Arc::new(AtomicBool::new(true)); // pre-triggered
+        let signals = Signals::new(flag);
+        let input = "x".repeat(20_000);
+        let result = Span::try_from_row_column(1, 18_000, &input, &Span::unknown(), &signals);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(ShellError::Interrupted { .. })));
+    }
+
+    #[test]
+    fn try_from_row_column_short_input_skips_signal_check() {
+        // Short input completes before hitting the 16384-byte check interval
+        let flag = Arc::new(AtomicBool::new(true)); // pre-triggered
+        let signals = Signals::new(flag);
+        let input = "hello\nworld";
+        let result = Span::try_from_row_column(1, 1, input, &Span::unknown(), &signals);
+        // Should complete successfully since the scan is too short to check signals
+        assert_eq!(result, Ok(Span::new(0, 1))); // covers first byte
+    }
+
+    #[test]
+    fn try_from_row_column_not_interrupted() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let signals = Signals::new(flag);
+        let input = "a\nb\nc";
+        let result = Span::try_from_row_column(1, 1, input, &Span::unknown(), &signals);
+        assert_eq!(result, Ok(Span::new(0, 1))); // covers first byte
+    }
+
+    #[test]
+    fn try_from_row_column_start_matches_from_row_column() {
+        // try_from_row_column should have the same `start` as from_row_column
+        // but covers at least one byte (end > start) for visible error highlighting
+        let input = "line one\nline two\nline three";
+        let signals = Signals::empty();
+        let expected = Span::from_row_column(2, 6, input);
+        let result = Span::try_from_row_column(2, 6, input, &Span::unknown(), &signals)
+            .expect("should succeed");
+        assert_eq!(result.start, expected.start, "start should match");
+        assert!(
+            result.end > result.start,
+            "end should extend past start for visibility"
+        );
     }
 }

--- a/crates/nuon/src/from.rs
+++ b/crates/nuon/src/from.rs
@@ -1,10 +1,21 @@
 use nu_protocol::{
-    Filesize, IntoValue, Range, Record, ShellError, Span, Type, Unit, Value,
+    DEFAULT_ERROR_CONTEXT, Filesize, IntoValue, Range, Record, ShellError, Span, Type, Unit, Value,
     ast::{Expr, Expression, ListItem, RecordItem},
     engine::{EngineState, StateWorkingSet},
     shell_error::generic::GenericError,
+    truncated_source_window,
 };
 use std::{borrow::Cow, sync::Arc};
+
+fn truncated_nuon_error(src: &str, err_span: Span, msg: impl Into<String>) -> ShellError {
+    let (src, span) = truncated_source_window(src, err_span, DEFAULT_ERROR_CONTEXT);
+    ShellError::OutsideSpannedLabeledError {
+        src,
+        error: "Error when loading".into(),
+        msg: msg.into(),
+        span,
+    }
+}
 
 /// convert a raw string representation of NUON data to an actual Nushell [`Value`]
 ///
@@ -27,6 +38,8 @@ pub fn from_nuon(input: &str, span: Option<Span>) -> Result<Value, ShellError> {
 
     if let Some(pipeline) = block.pipelines.get(1) {
         if let Some(element) = pipeline.elements.first() {
+            let (src, label_span) =
+                truncated_source_window(input, element.expr.span, DEFAULT_ERROR_CONTEXT);
             return Err(ShellError::Generic(
                 make_generic_error(
                     span,
@@ -34,10 +47,10 @@ pub fn from_nuon(input: &str, span: Option<Span>) -> Result<Value, ShellError> {
                     "could not load nuon text",
                 )
                 .with_inner([ShellError::OutsideSpannedLabeledError {
-                    src: input.to_string(),
+                    src,
                     error: "error when loading".into(),
                     msg: "excess values when loading".into(),
-                    span: element.expr.span,
+                    span: label_span,
                 }]),
             ));
         } else {
@@ -67,6 +80,8 @@ pub fn from_nuon(input: &str, span: Option<Span>) -> Result<Value, ShellError> {
         let mut pipeline = Arc::make_mut(&mut block).pipelines.remove(0);
 
         if let Some(expr) = pipeline.elements.get(1) {
+            let (src, label_span) =
+                truncated_source_window(input, expr.expr.span, DEFAULT_ERROR_CONTEXT);
             return Err(ShellError::Generic(
                 make_generic_error(
                     span,
@@ -74,10 +89,10 @@ pub fn from_nuon(input: &str, span: Option<Span>) -> Result<Value, ShellError> {
                     "could not load nuon text",
                 )
                 .with_inner([ShellError::OutsideSpannedLabeledError {
-                    src: input.to_string(),
+                    src,
                     error: "error when loading".into(),
                     msg: "detected a pipeline in nuon file".into(),
-                    span: expr.expr.span,
+                    span: label_span,
                 }]),
             ));
         }
@@ -95,6 +110,7 @@ pub fn from_nuon(input: &str, span: Option<Span>) -> Result<Value, ShellError> {
     };
 
     if let Some(err) = working_set.parse_errors.first() {
+        let (src, label_span) = truncated_source_window(input, err.span(), DEFAULT_ERROR_CONTEXT);
         return Err(ShellError::Generic(
             make_generic_error(
                 span,
@@ -102,10 +118,10 @@ pub fn from_nuon(input: &str, span: Option<Span>) -> Result<Value, ShellError> {
                 "could not parse nuon text",
             )
             .with_inner([ShellError::OutsideSpannedLabeledError {
-                src: input.to_string(),
+                src,
                 error: "error when parsing".into(),
                 msg: err.to_string(),
-                span: err.span(),
+                span: label_span,
             }]),
         ));
     }
@@ -132,97 +148,85 @@ fn convert_to_value(
     original_text: &str,
 ) -> Result<Value, ShellError> {
     match expr.expr {
-        Expr::AttributeBlock(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "attributes not supported in nuon".into(),
-            span: expr.span,
-        }),
-        Expr::BinaryOp(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "binary operators not supported in nuon".into(),
-            span: expr.span,
-        }),
-        Expr::UnaryNot(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "unary operators not supported in nuon".into(),
-            span: expr.span,
-        }),
-        Expr::Block(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "blocks not supported in nuon".into(),
-            span: expr.span,
-        }),
-        Expr::Closure(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "closures not supported in nuon".into(),
-            span: expr.span,
-        }),
+        Expr::AttributeBlock(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "attributes not supported in nuon",
+        )),
+        Expr::BinaryOp(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "binary operators not supported in nuon",
+        )),
+        Expr::UnaryNot(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "unary operators not supported in nuon",
+        )),
+        Expr::Block(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "blocks not supported in nuon",
+        )),
+        Expr::Closure(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "closures not supported in nuon",
+        )),
         Expr::Binary(val) => Ok(Value::binary(val, span)),
         Expr::Bool(val) => Ok(Value::bool(val, span)),
-        Expr::Call(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "calls not supported in nuon".into(),
-            span: expr.span,
-        }),
+        Expr::Call(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "calls not supported in nuon",
+        )),
         Expr::CellPath(val) => Ok(Value::cell_path(val, span)),
         Expr::DateTime(dt) => Ok(Value::date(dt, span)),
-        Expr::ExternalCall(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "calls not supported in nuon".into(),
-            span: expr.span,
-        }),
+        Expr::ExternalCall(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "calls not supported in nuon",
+        )),
         Expr::Filepath(val, _) => Ok(Value::string(val, span)),
         Expr::Directory(val, _) => Ok(Value::string(val, span)),
         Expr::Float(val) => Ok(Value::float(val, span)),
         Expr::FullCellPath(full_cell_path) => {
             if !full_cell_path.tail.is_empty() {
-                Err(ShellError::OutsideSpannedLabeledError {
-                    src: original_text.to_string(),
-                    error: "Error when loading".into(),
-                    msg: "subexpressions and cellpaths not supported in nuon".into(),
-                    span: expr.span,
-                })
+                Err(truncated_nuon_error(
+                    original_text,
+                    expr.span,
+                    "subexpressions and cellpaths not supported in nuon",
+                ))
             } else {
                 convert_to_value(full_cell_path.head, span, original_text)
             }
         }
 
-        Expr::Garbage => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "extra tokens in input file".into(),
-            span: expr.span,
-        }),
+        Expr::Garbage => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "extra tokens in input file",
+        )),
         Expr::GlobPattern(val, _) => Ok(Value::string(val, span)),
-        Expr::ImportPattern(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "imports not supported in nuon".into(),
-            span: expr.span,
-        }),
-        Expr::Overlay(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "overlays not supported in nuon".into(),
-            span: expr.span,
-        }),
+        Expr::ImportPattern(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "imports not supported in nuon",
+        )),
+        Expr::Overlay(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "overlays not supported in nuon",
+        )),
         Expr::Int(val) => Ok(Value::int(val, span)),
-        Expr::Keyword(kw) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: format!(
+        Expr::Keyword(kw) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            format!(
                 "{} not supported in nuon",
                 String::from_utf8_lossy(&kw.keyword)
             ),
-            span: expr.span,
-        }),
+        )),
         Expr::List(vals) => {
             let mut output = vec![];
 
@@ -232,31 +236,28 @@ fn convert_to_value(
                         output.push(convert_to_value(expr, span, original_text)?);
                     }
                     ListItem::Spread(_, inner) => {
-                        return Err(ShellError::OutsideSpannedLabeledError {
-                            src: original_text.to_string(),
-                            error: "Error when loading".into(),
-                            msg: "spread operator not supported in nuon".into(),
-                            span: inner.span,
-                        });
+                        return Err(truncated_nuon_error(
+                            original_text,
+                            inner.span,
+                            "spread operator not supported in nuon",
+                        ));
                     }
                 }
             }
 
             Ok(Value::list(output, span))
         }
-        Expr::MatchBlock(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "match blocks not supported in nuon".into(),
-            span: expr.span,
-        }),
+        Expr::MatchBlock(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "match blocks not supported in nuon",
+        )),
         Expr::Nothing => Ok(Value::nothing(span)),
-        Expr::Operator(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "operators not supported in nuon".into(),
-            span: expr.span,
-        }),
+        Expr::Operator(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "operators not supported in nuon",
+        )),
         Expr::Range(range) => {
             let from = if let Some(f) = range.from {
                 convert_to_value(f, span, original_text)?
@@ -291,12 +292,11 @@ fn convert_to_value(
                         let key_str = match key.expr {
                             Expr::String(key_str) => key_str,
                             _ => {
-                                return Err(ShellError::OutsideSpannedLabeledError {
-                                    src: original_text.to_string(),
-                                    error: "Error when loading".into(),
-                                    msg: "only strings can be keys".into(),
-                                    span: key.span,
-                                });
+                                return Err(truncated_nuon_error(
+                                    original_text,
+                                    key.span,
+                                    "only strings can be keys",
+                                ));
                             }
                         };
 
@@ -312,55 +312,48 @@ fn convert_to_value(
                         }
                     }
                     RecordItem::Spread(_, inner) => {
-                        return Err(ShellError::OutsideSpannedLabeledError {
-                            src: original_text.to_string(),
-                            error: "Error when loading".into(),
-                            msg: "spread operator not supported in nuon".into(),
-                            span: inner.span,
-                        });
+                        return Err(truncated_nuon_error(
+                            original_text,
+                            inner.span,
+                            "spread operator not supported in nuon",
+                        ));
                     }
                 }
             }
 
             Ok(Value::record(record, span))
         }
-        Expr::RowCondition(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "row conditions not supported in nuon".into(),
-            span: expr.span,
-        }),
-        Expr::Signature(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "signatures not supported in nuon".into(),
-            span: expr.span,
-        }),
+        Expr::RowCondition(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "row conditions not supported in nuon",
+        )),
+        Expr::Signature(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "signatures not supported in nuon",
+        )),
         Expr::String(s) | Expr::RawString(s) => Ok(Value::string(s.clone(), span)),
-        Expr::StringInterpolation(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "string interpolation not supported in nuon".into(),
-            span: expr.span,
-        }),
-        Expr::GlobInterpolation(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "glob interpolation not supported in nuon".into(),
-            span: expr.span,
-        }),
-        Expr::Collect(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "`$in` not supported in nuon".into(),
-            span: expr.span,
-        }),
-        Expr::Subexpression(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "subexpressions not supported in nuon".into(),
-            span: expr.span,
-        }),
+        Expr::StringInterpolation(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "string interpolation not supported in nuon",
+        )),
+        Expr::GlobInterpolation(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "glob interpolation not supported in nuon",
+        )),
+        Expr::Collect(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "`$in` not supported in nuon",
+        )),
+        Expr::Subexpression(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "subexpressions not supported in nuon",
+        )),
         Expr::Table(mut table) => {
             let mut cols = vec![];
 
@@ -370,12 +363,11 @@ fn convert_to_value(
                 let key_str = match &mut key.expr {
                     Expr::String(key_str) => key_str,
                     _ => {
-                        return Err(ShellError::OutsideSpannedLabeledError {
-                            src: original_text.to_string(),
-                            error: "Error when loading".into(),
-                            msg: "only strings can be keys".into(),
-                            span: expr.span,
-                        });
+                        return Err(truncated_nuon_error(
+                            original_text,
+                            expr.span,
+                            "only strings can be keys",
+                        ));
                     }
                 };
 
@@ -392,12 +384,11 @@ fn convert_to_value(
 
             for row in table.rows.into_vec() {
                 if cols.len() != row.len() {
-                    return Err(ShellError::OutsideSpannedLabeledError {
-                        src: original_text.to_string(),
-                        error: "Error when loading".into(),
-                        msg: "table has mismatched columns".into(),
-                        span: expr.span,
-                    });
+                    return Err(truncated_nuon_error(
+                        original_text,
+                        expr.span,
+                        "table has mismatched columns",
+                    ));
                 }
 
                 let record = cols
@@ -417,24 +408,30 @@ fn convert_to_value(
             let size = match value.expr.expr {
                 Expr::Int(val) => val,
                 _ => {
-                    return Err(ShellError::OutsideSpannedLabeledError {
-                        src: original_text.to_string(),
-                        error: "Error when loading".into(),
-                        msg: "non-integer unit value".into(),
-                        span: expr.span,
-                    });
+                    return Err(truncated_nuon_error(
+                        original_text,
+                        expr.span,
+                        "non-integer unit value",
+                    ));
                 }
             };
 
             match value.unit.item {
                 Unit::Filesize(unit) => match Filesize::from_unit(size, unit) {
                     Some(val) => Ok(val.into_value(span)),
-                    None => Err(ShellError::OutsideSpannedLabeledError {
-                        src: original_text.into(),
-                        error: "filesize too large".into(),
-                        msg: "filesize too large".into(),
-                        span: expr.span,
-                    }),
+                    None => {
+                        let (src, label_span) = truncated_source_window(
+                            original_text,
+                            expr.span,
+                            DEFAULT_ERROR_CONTEXT,
+                        );
+                        Err(ShellError::OutsideSpannedLabeledError {
+                            src,
+                            error: "filesize too large".into(),
+                            msg: "filesize too large".into(),
+                            span: label_span,
+                        })
+                    }
                 },
 
                 Unit::Nanosecond => Ok(Value::duration(size, span)),
@@ -445,36 +442,90 @@ fn convert_to_value(
                 Unit::Hour => Ok(Value::duration(size * 1000 * 1000 * 1000 * 60 * 60, span)),
                 Unit::Day => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24) {
                     Some(val) => Ok(Value::duration(val, span)),
-                    None => Err(ShellError::OutsideSpannedLabeledError {
-                        src: original_text.to_string(),
-                        error: "day duration too large".into(),
-                        msg: "day duration too large".into(),
-                        span: expr.span,
-                    }),
+                    None => {
+                        let (src, label_span) = truncated_source_window(
+                            original_text,
+                            expr.span,
+                            DEFAULT_ERROR_CONTEXT,
+                        );
+                        Err(ShellError::OutsideSpannedLabeledError {
+                            src,
+                            error: "day duration too large".into(),
+                            msg: "day duration too large".into(),
+                            span: label_span,
+                        })
+                    }
                 },
 
                 Unit::Week => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24 * 7) {
                     Some(val) => Ok(Value::duration(val, span)),
-                    None => Err(ShellError::OutsideSpannedLabeledError {
-                        src: original_text.to_string(),
-                        error: "week duration too large".into(),
-                        msg: "week duration too large".into(),
-                        span: expr.span,
-                    }),
+                    None => {
+                        let (src, label_span) = truncated_source_window(
+                            original_text,
+                            expr.span,
+                            DEFAULT_ERROR_CONTEXT,
+                        );
+                        Err(ShellError::OutsideSpannedLabeledError {
+                            src,
+                            error: "week duration too large".into(),
+                            msg: "week duration too large".into(),
+                            span: label_span,
+                        })
+                    }
                 },
             }
         }
-        Expr::Var(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "variables not supported in nuon".into(),
-            span: expr.span,
-        }),
-        Expr::VarDecl(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "variable declarations not supported in nuon".into(),
-            span: expr.span,
-        }),
+        Expr::Var(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "variables not supported in nuon",
+        )),
+        Expr::VarDecl(..) => Err(truncated_nuon_error(
+            original_text,
+            expr.span,
+            "variable declarations not supported in nuon",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nuon_parse_success() {
+        let result = from_nuon("{ a: 1, b: [2, 3] }", Some(Span::test_data()));
+        assert!(result.is_ok(), "valid NUON should parse");
+    }
+
+    #[test]
+    fn nuon_error_source_is_bounded() {
+        // Build a large valid NUON with a parse error
+        let mut input = String::with_capacity(50_000);
+        input.push_str("{ ");
+        for i in 0..2000 {
+            use std::fmt::Write;
+            write!(&mut input, "key{i}: \"value{i}\", ").unwrap();
+        }
+        // Syntax error: unclosed string
+        input.push_str("key_last: \"unclosed ");
+        input.push_str(" }");
+
+        let result = from_nuon(&input, Some(Span::test_data()));
+        assert!(result.is_err(), "should fail to parse");
+
+        // The error should not contain the full 50KB source
+        let err_str = format!("{err:?}", err = result.as_ref().unwrap_err());
+        assert!(
+            err_str.len() < 25_000,
+            "error debug output should be bounded, got {} bytes",
+            err_str.len()
+        );
+    }
+
+    #[test]
+    fn nuon_error_for_invalid_syntax() {
+        let result = from_nuon("{ a: 1, b: ]", Some(Span::test_data()));
+        assert!(result.is_err(), "invalid NUON should error");
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR makes `from json`, `from kdl`, and `from xml` responsive to Ctrl+C during parsing of large files, and dramatically improves parse-error diagnostics for all four text-based format commands (`from json`, `from kdl`, `from xml`, `from nuon`).

When a user runs `open huge-file.json | from json` and hits Ctrl+C, the process would not stop until the entire file had been read and parsed. Additionally, when errors *did* occur, the diagnostics were often unhelpful.

Rather than making parsers themselves interruptible mid-parse we keep `from_str` synchronous and fix `into_bytes` and create a reusable `truncated_source_window` utility that bounds error source to ~8kb.

<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)

### Improved Ctrl-C handling in `from json`

Ctrl+C is more responsive in `from json`, `from kdl`, and `from xml` now respond promptly to Ctrl+C when parsing large files. Pressing Ctrl+C during parsing will interrupt the command and return to the prompt. It will also produce better parse-error messages and should now show a focused snippet of the source around the error location instead of dumping the entire file content.

This is an example of a 415MB json file

<img width="3277" height="1358" alt="image" src="https://github.com/user-attachments/assets/27d9c52d-1ac6-4709-bba0-65c248cb95fe" />


<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes

closes https://github.com/nushell/nushell/issues/17642
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->