### PR TITLE
refactor(parser): consolidate spread operator checking logic

### DIFF
--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -1,14 +1,14 @@
 use crate::{
     lite_parser::LiteCommand,
-    parse_helpers::{PERCENT_FORCED_BUILTIN_PARSER_INFO, garbage},
+    parse_helpers::{PERCENT_FORCED_BUILTIN_PARSER_INFO, extract_spread_list, garbage},
     parse_source::find_dirs_var,
     type_check::type_compatible,
 };
 use log::trace;
 use nu_engine::DIR_VAR_PARSER_INFO;
 use nu_protocol::{
-    DeclId, Flag, ParseError, PositionalArg, ShellError, Signature, Span, Spanned, SyntaxShape,
-    Type,
+    DeclId, Flag, IntoSpanned, ParseError, PositionalArg, ShellError, Signature, Span, Spanned,
+    SyntaxShape, Type,
     ast::*,
     did_you_mean,
     engine::{CommandType, StateWorkingSet},
@@ -321,13 +321,10 @@ fn is_quoted(bytes: &[u8]) -> bool {
 fn parse_external_arg(working_set: &mut StateWorkingSet, span: Span) -> ExternalArgument {
     let contents = working_set.get_span_contents(span);
 
-    if contents.len() > 3
-        && contents.starts_with(b"...")
-        && (contents[3] == b'$' || contents[3] == b'[' || contents[3] == b'(')
-    {
+    if let Some(Spanned { item: _, span }) = extract_spread_list(contents.into_spanned(span)) {
         ExternalArgument::Spread(crate::parser::parse_value(
             working_set,
-            Span::new(span.start + 3, span.end),
+            span,
             &SyntaxShape::List(Box::new(SyntaxShape::Any)),
         ))
     } else {
@@ -1121,9 +1118,10 @@ pub fn parse_internal_call(
         {
             let contents = working_set.get_span_contents(spans[spans_idx]);
 
-            if contents.len() > 3
-                && contents.starts_with(b"...")
-                && (contents[3] == b'$' || contents[3] == b'[' || contents[3] == b'(')
+            if let Some(Spanned {
+                span: spread_arg_span,
+                ..
+            }) = extract_spread_list(contents.into_spanned(spans[spans_idx]))
             {
                 if signature.rest_positional.is_none() && !signature.allows_unknown_args {
                     working_set.error(ParseError::UnexpectedSpreadArg(
@@ -1150,7 +1148,7 @@ pub fn parse_internal_call(
                     // Parse list of arguments to be spread
                     let args = crate::parser::parse_value(
                         working_set,
-                        Span::new(arg_span.start + 3, arg_span.end),
+                        spread_arg_span,
                         &SyntaxShape::List(Box::new(rest_shape)),
                     );
 
@@ -1359,13 +1357,12 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
             // argument so runtime dispatch can forward it without flattening first.
             for arg_span in resolution_spans.iter().skip(head_idx + 1) {
                 let contents = working_set.get_span_contents(*arg_span);
-                if contents.len() > 3
-                    && contents.starts_with(b"...")
-                    && (contents[3] == b'$' || contents[3] == b'[' || contents[3] == b'(')
+                if let Some(Spanned { span: arg_span, .. }) =
+                    extract_spread_list(contents.into_spanned(*arg_span))
                 {
                     let spread_expr = crate::parser::parse_value(
                         working_set,
-                        Span::new(arg_span.start + 3, arg_span.end),
+                        arg_span,
                         &SyntaxShape::List(Box::new(SyntaxShape::Any)),
                     );
                     call.arguments.push(Argument::Spread(spread_expr));

--- a/crates/nu-parser/src/parse_def.rs
+++ b/crates/nu-parser/src/parse_def.rs
@@ -1,7 +1,7 @@
 use crate::{
     known_external::KnownExternal,
     lite_parser::LiteCommand,
-    parse_helpers::garbage,
+    parse_helpers::{SPREAD_OPERATOR, garbage},
     parse_pipelines::redirecting_builtin_error,
     parser::{
         ArgumentParsingLevel, CallKind, ParsedInternalCall, compile_block_with_id, parse_attribute,
@@ -23,7 +23,7 @@ use nu_protocol::{
 
 fn rest_param_is_type_annotated(signature_source: &[u8], rest_name: &str) -> bool {
     let mut needle = Vec::with_capacity(rest_name.len() + 3);
-    needle.extend_from_slice(b"...");
+    needle.extend_from_slice(SPREAD_OPERATOR);
     needle.extend_from_slice(rest_name.as_bytes());
 
     if signature_source.len() < needle.len() {

--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -4,7 +4,10 @@ use crate::{
     Token, TokenContents,
     lex::{LexState, is_assignment_operator, lex, lex_n_tokens},
     lite_parser::{LiteCommand, lite_parse},
-    parse_helpers::{PERCENT_FORCED_BUILTIN_PARSER_INFO, garbage, garbage_pipeline},
+    parse_helpers::{
+        PERCENT_FORCED_BUILTIN_PARSER_INFO, extract_spread_list, extract_spread_record, garbage,
+        garbage_pipeline,
+    },
     parse_keywords::{
         is_unaliasable_parser_keyword, parse_alias, parse_attribute_block, parse_const, parse_def,
         parse_export_env, parse_export_in_block, parse_extern, parse_for, parse_hide,
@@ -27,8 +30,8 @@ use crate::{
 use itertools::Itertools;
 use log::trace;
 use nu_protocol::{
-    CompareTypes, ParseError, PositionalArg, Signature, Span, SyntaxShape, Type, TypeSet, VarId,
-    ast::*, engine::StateWorkingSet,
+    CompareTypes, IntoSpanned, ParseError, PositionalArg, Signature, Span, Spanned, SyntaxShape,
+    Type, TypeSet, VarId, ast::*, engine::StateWorkingSet,
 };
 use std::{collections::HashMap, sync::Arc};
 
@@ -142,13 +145,13 @@ pub fn parse_list_expression(
             while spans_idx < command.parts.len() {
                 let curr_span = command.parts[spans_idx];
                 let curr_tok = working_set.get_span_contents(curr_span);
-                let (arg, ty) = if curr_tok.starts_with(b"...")
-                    && curr_tok.len() > 3
-                    && (curr_tok[3] == b'$' || curr_tok[3] == b'[' || curr_tok[3] == b'(')
+                let (arg, ty) = if let Some(Spanned {
+                    span: trimmed_span, ..
+                }) = extract_spread_list(curr_tok.into_spanned(curr_span))
                 {
                     // Parse the spread operator
                     // Remove "..." before parsing argument to spread operator
-                    command.parts[spans_idx] = Span::new(curr_span.start + 3, curr_span.end);
+                    command.parts[spans_idx] = trimmed_span;
                     let spread_arg = parse_multispan_value(
                         working_set,
                         &command.parts,
@@ -1840,10 +1843,7 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
             .expect("should have gotten 1 token")
             .span;
         let contents = working_set.get_span_contents(span);
-        if contents.len() > 3
-            && contents.starts_with(b"...")
-            && (contents[3] == b'$' || contents[3] == b'{' || contents[3] == b'(')
-        {
+        if extract_spread_record(contents.into_spanned(span)).is_some() {
             // This was a spread operator, so there's no value
             continue;
         }
@@ -1878,16 +1878,10 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
     while idx < tokens.len() {
         let curr_span = tokens[idx].span;
         let curr_tok = working_set.get_span_contents(curr_span);
-        if curr_tok.starts_with(b"...")
-            && curr_tok.len() > 3
-            && (curr_tok[3] == b'$' || curr_tok[3] == b'{' || curr_tok[3] == b'(')
+        if let Some(Spanned { span, .. }) = extract_spread_record(curr_tok.into_spanned(curr_span))
         {
             // Parse spread operator
-            let inner = parse_value(
-                working_set,
-                Span::new(curr_span.start + 3, curr_span.end),
-                &SyntaxShape::record(),
-            );
+            let inner = parse_value(working_set, span, &SyntaxShape::record());
             idx += 1;
 
             match &inner.ty {

--- a/crates/nu-parser/src/parse_helpers.rs
+++ b/crates/nu-parser/src/parse_helpers.rs
@@ -1,6 +1,34 @@
-use nu_protocol::{Span, ast::*, engine::StateWorkingSet};
+use nu_protocol::{Span, Spanned, ast::*, engine::StateWorkingSet};
 
 pub(crate) const PERCENT_FORCED_BUILTIN_PARSER_INFO: &str = "percent_forced_builtin";
+
+/// three dots b"..."
+pub(crate) const SPREAD_OPERATOR: &[u8; 3] = b"...";
+
+/// three dots "..."
+pub(crate) const SPREAD_OPERATOR_STR: &str = "...";
+
+#[inline]
+fn extract_spread_value(
+    delim: u8,
+    Spanned { item, mut span }: Spanned<&[u8]>,
+) -> Option<Spanned<&[u8]>> {
+    let item = item.strip_prefix(SPREAD_OPERATOR)?;
+    span.start += SPREAD_OPERATOR.len();
+    match item {
+        [b'$' | b'(', ..] => Some(Spanned { item, span }),
+        [head, ..] if *head == delim => Some(Spanned { item, span }),
+        _ => None,
+    }
+}
+
+pub(crate) fn extract_spread_list(spanned: Spanned<&[u8]>) -> Option<Spanned<&[u8]>> {
+    extract_spread_value(b'[', spanned)
+}
+
+pub(crate) fn extract_spread_record(spanned: Spanned<&[u8]>) -> Option<Spanned<&[u8]>> {
+    extract_spread_value(b'{', spanned)
+}
 
 pub fn garbage(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     Expression::garbage(working_set, span)

--- a/crates/nu-parser/src/parse_literals.rs
+++ b/crates/nu-parser/src/parse_literals.rs
@@ -3,15 +3,17 @@
 use crate::{
     Token, TokenContents,
     lex::lex,
-    parse_helpers::{garbage, is_variable, trim_quotes},
+    parse_helpers::{
+        SPREAD_OPERATOR_STR, extract_spread_record, garbage, is_variable, trim_quotes,
+    },
     parse_pipelines::parse_block,
     type_check::check_range_types,
 };
 use itertools::Itertools;
 use log::trace;
 use nu_protocol::{
-    DidYouMean, FilesizeUnit, ParseError, Span, Spanned, SyntaxShape, Type, Unit, VarId, ast::*,
-    casing::Casing, engine::StateWorkingSet,
+    DidYouMean, FilesizeUnit, IntoSpanned, ParseError, Span, Spanned, SyntaxShape, Type, Unit,
+    VarId, ast::*, casing::Casing, engine::StateWorkingSet,
 };
 use std::sync::Arc;
 
@@ -233,7 +235,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Option<Expr
         return None;
     };
 
-    if token.starts_with("...") {
+    if token.starts_with(SPREAD_OPERATOR_STR) {
         working_set.error(ParseError::Expected(
             "range operator ('..'), got spread ('...')",
             span,
@@ -570,9 +572,7 @@ pub fn parse_brace_expr(
                 SyntaxShape::MatchBlock => parse_match_block_expression(working_set, span),
                 // For edge case of `{}.foo?`, #17896
                 _ if second_bytes == b"}" => parse_full_cell_path(working_set, None, span),
-                _ if second_bytes.starts_with(b"...")
-                    && second_bytes.get(3).is_some_and(|c| b"${(".contains(c)) =>
-                {
+                _ if extract_spread_record(second_bytes.into_spanned(second.span)).is_some() => {
                     parse_record(working_set, span)
                 }
                 SyntaxShape::Any => parse_closure_expression(working_set, shape, span),

--- a/crates/nu-parser/src/parse_signatures.rs
+++ b/crates/nu-parser/src/parse_signatures.rs
@@ -6,7 +6,7 @@ use crate::parse_literals::parse_full_cell_path;
 use crate::{
     Token, TokenContents,
     lex::lex_signature,
-    parse_helpers::{garbage, is_variable},
+    parse_helpers::{SPREAD_OPERATOR, garbage, is_variable},
     parse_shape_specs::{parse_completer, parse_shape_name, parse_type},
     type_check::type_compatible,
 };
@@ -888,7 +888,7 @@ pub fn parse_signature_helper(
                                 parse_mode = ParseMode::Arg;
                             }
                             // Rest param
-                            else if let Some(contents) = contents.strip_prefix(b"...") {
+                            else if let Some(contents) = contents.strip_prefix(SPREAD_OPERATOR) {
                                 let name = String::from_utf8_lossy(contents).to_string();
                                 let contents_vec: Vec<u8> = contents.to_vec();
 


### PR DESCRIPTION
## Description
Pretty straightforward.

The pattern I used here, having helper functions handle spans too with a signature like `Spanned<&[u8]> -> Spanned<&[u8]>` might be useful for other places too.

## User-facing changes (Release notes)
N/A