### PR TITLE
fix: avoid SIGABRT from broken stdout/stderr on parent exit

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -33,7 +33,7 @@ use nu_protocol::{
 use nu_utils::time::Instant;
 use nu_utils::{
     filesystem::{PermissionResult, have_permission},
-    perf, stderr_write_all_and_flush,
+    perf, stderr_write_all_and_flush, stdout_write_all_and_flush,
 };
 #[cfg(feature = "sqlite")]
 use reedline::SqliteBackedHistory;
@@ -807,7 +807,8 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
                 shell_integration.osc133,
             );
 
-            println!();
+            // Don't use `println!`: it panics on a broken stdout (parent terminal closed).
+            let _ = stdout_write_all_and_flush("\n");
 
             cleanup_exit((), engine_state, 0);
 

--- a/crates/nu-mcp/src/lib.rs
+++ b/crates/nu-mcp/src/lib.rs
@@ -46,6 +46,10 @@ pub fn initialize_mcp_server(
         .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::DEBUG.into()))
         .with_writer(std::io::stderr)
         .with_ansi(false)
+        // The MCP host owns our stderr pipe and closes it on exit. Once closed, every
+        // event write returns `Err(BrokenPipe)`, and the default fallback runs `eprintln!`, which
+        // panics on a broken pipe.
+        .log_internal_errors(false)
         .try_init()
     {
         tracing::debug!("tracing subscriber already initialized: {err}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ use run::{run_commands, run_file, run_repl};
 use signals::ctrlc_protection;
 use std::{
     borrow::Cow,
+    io::Write,
     path::{PathBuf, absolute},
     str::FromStr,
     sync::Arc,
@@ -71,14 +72,63 @@ fn current_dir_from_environment() -> PathBuf {
     }
 }
 
+/// Mirror of miette's private `Panic` diagnostic so we keep the
+/// `RUST_BACKTRACE=1` help text and backtrace rendering when reporting a panic.
+#[derive(Debug)]
+struct Panic(String);
+
+impl std::fmt::Display for Panic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let backtrace = std::backtrace::Backtrace::capture();
+        if backtrace.status() == std::backtrace::BacktraceStatus::Captured {
+            write!(f, "{}\n{backtrace}", self.0)
+        } else {
+            write!(f, "{}", self.0)
+        }
+    }
+}
+
+impl std::error::Error for Panic {}
+
+impl miette::Diagnostic for Panic {
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        Some(Box::new(
+            "set the `RUST_BACKTRACE=1` environment variable to display a backtrace.",
+        ))
+    }
+}
+
 fn main() -> Result<()> {
     let entire_start_time = nu_utils::time::Instant::now();
     let mut start_time = nu_utils::time::Instant::now();
-    miette::set_panic_hook();
-    let miette_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |x| {
-        crossterm::terminal::disable_raw_mode().expect("unable to disable raw mode");
-        miette_hook(x);
+    // Replicated from `miette::set_panic_hook`, but writes via `writeln!(io::stderr(), …)`
+    // instead of `eprintln!`. `eprintln!`/`println!` panic on a broken stderr/stdout
+    // (parent terminal/pty closed), so when our parent (Codex, Ghostty, an MCP host, …)
+    // exits and closes our pipes, the original hook re-panics from inside the panic
+    // handler — and Rust escalates the double-panic to `abort()`, producing a crash
+    // report for what should be a clean shutdown.
+    std::panic::set_hook(Box::new(|info| {
+        use miette::Context;
+
+        // Best-effort terminal restore; never panic from inside the hook.
+        let _ = crossterm::terminal::disable_raw_mode();
+
+        let mut message = "Something went wrong".to_string();
+        let payload = info.payload();
+        if let Some(msg) = payload.downcast_ref::<&str>() {
+            message = (*msg).to_string();
+        } else if let Some(msg) = payload.downcast_ref::<String>() {
+            message.clone_from(msg);
+        }
+
+        let mut report: miette::Result<()> = Err(Panic(message).into());
+        if let Some(loc) = info.location() {
+            report = report
+                .with_context(|| format!("at {}:{}:{}", loc.file(), loc.line(), loc.column()));
+        }
+        if let Err(err) = report.with_context(|| "Main thread panicked.".to_string()) {
+            let _ = writeln!(std::io::stderr(), "Error: {err:?}");
+        }
     }));
 
     let engine_state = EngineState::new();


### PR DESCRIPTION
## Description

Don't use macros to print to STDOUT or STDERR in key places, which will panic if the file descriptor is closed.

Fixes #18427

## User-facing changes (Release notes)

Don't SIGABRT when closing your terminal or using nu as an MCP server.

## Additional notes

When the parent process (Ghostty, Codex, any MCP host) closes the pipe attached to nu's stdout/stderr, std's `print!`/`eprintln!` panic on the broken-pipe write. miette's installed panic hook then calls `eprintln!` itself, which panics again on the still-broken pipe — a panic inside a panic hook is a hard abort(), so the process dies with SIGABRT instead of exiting cleanly.

I had to inline miette's panic reporting in the panic hook, as it uses `eprintln!` which causes the process to `abort` (as it's already panicking).