### PR TITLE
Type system improvements

### DIFF
--- a/crates/nu-cmd-lang/tests/commands/describe.rs
+++ b/crates/nu-cmd-lang/tests/commands/describe.rs
@@ -7,7 +7,7 @@ fn test_oneof_flattening_in_describe() {
         nu!("[ ...(0..4 | each { {content:[{content:[any]}]} }), {content:[any]} ] | describe");
     assert_eq!(
         result.out,
-        "table<content: list<oneof<string, record<content: list<string>>>>>"
+        "table<content: oneof<table<content: list<string>>, list<string>>>"
     );
 }
 
@@ -19,7 +19,7 @@ fn test_oneof_flattening_in_describe_reverse_order() {
     assert!(
         result
             .out
-            .contains("table<content: list<oneof<string, record<content: list<string>>")
+            .contains("table<content: oneof<list<string>, table<content: list<string>>>>",)
     );
     assert!(!result.out.contains("oneof<oneof<"));
 }

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -82,7 +82,11 @@ pub fn get_pipeline_elements(
                 (
                     command.name().to_string(),
                     get_arguments(engine_state, stack, call.as_ref(), eval_expression),
-                    command.signature().get_output_type().to_string(),
+                    command
+                        .signature()
+                        .get_output_type(None)
+                        .unwrap_or_default()
+                        .to_string(),
                 )
             } else {
                 ("no-op".to_string(), vec![], expression.ty.to_string())

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -1,3 +1,4 @@
+use nu_protocol::Type;
 use nu_test_support::{fs::Stub::FileWithContentToBeTrimmed, prelude::*};
 
 #[test]
@@ -345,13 +346,11 @@ fn from_csv_text_with_wrong_type_separator() -> Result {
             | from csv --separator ('123' | into int)
         ";
 
-        let outcome = test().cwd(dirs.test()).run(code).expect_error()?;
+        let outcome = test().cwd(dirs.test()).run(code).expect_parse_error()?;
         match outcome {
-            ShellError::CantConvert {
-                to_type, from_type, ..
-            } => {
-                assert_eq!(from_type, "int");
-                assert_eq!(to_type, "string");
+            ParseError::TypeMismatch(expected, got, _) => {
+                assert_eq!(expected, Type::String);
+                assert_eq!(got, Type::Int);
                 Ok(())
             }
             err => Err(err.into()),

--- a/crates/nu-command/tests/format_conversions/tsv.rs
+++ b/crates/nu-command/tests/format_conversions/tsv.rs
@@ -1,3 +1,4 @@
+use nu_protocol::Type;
 use nu_test_support::{fs::Stub::FileWithContentToBeTrimmed, prelude::*};
 
 #[test]
@@ -273,16 +274,15 @@ fn from_tsv_text_with_wrong_type_comment() -> Result {
             | from csv --comment ('123' | into int)
         ";
 
-        let err = test().cwd(dirs.test()).run(code).expect_shell_error()?;
-        let ShellError::CantConvert {
-            from_type, to_type, ..
-        } = err
-        else {
-            return Err(err.into());
-        };
-        assert_eq!(from_type, "int");
-        assert_eq!(to_type, "char");
-        Ok(())
+        let outcome = test().cwd(dirs.test()).run(code).expect_parse_error()?;
+        match outcome {
+            ParseError::TypeMismatch(expected, got, _) => {
+                assert_eq!(expected, Type::String);
+                assert_eq!(got, Type::Int);
+                Ok(())
+            }
+            err => Err(err.into()),
+        }
     })
 }
 

--- a/crates/nu-parser/src/parse_alias.rs
+++ b/crates/nu-parser/src/parse_alias.rs
@@ -106,6 +106,7 @@ pub fn parse_alias(
             rest_spans,
             decl_id,
             ArgumentParsingLevel::Full,
+            None,
         );
 
         working_set
@@ -177,7 +178,7 @@ pub fn parse_alias(
                 && is_math_expression_like(working_set, replacement_spans[0])
             {
                 let starting_error_count = working_set.parse_errors.len();
-                let expr = parse_expression(working_set, replacement_spans);
+                let expr = parse_expression(working_set, replacement_spans, None);
                 working_set.parse_errors.truncate(starting_error_count);
 
                 working_set.error(ParseError::CantAliasExpression(
@@ -190,7 +191,7 @@ pub fn parse_alias(
             let starting_error_count = working_set.parse_errors.len();
             working_set.search_predecls = false;
 
-            let expr = parse_call(working_set, replacement_spans, replacement_spans[0]);
+            let expr = parse_call(working_set, replacement_spans, replacement_spans[0], None);
 
             working_set.search_predecls = true;
 

--- a/crates/nu-parser/src/parse_bindings.rs
+++ b/crates/nu-parser/src/parse_bindings.rs
@@ -16,6 +16,7 @@ use nu_protocol::{
 };
 use std::{collections::HashMap, sync::Arc};
 
+// TODO: handle pipeline input type based inference
 pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline {
     trace!("parsing: let");
 
@@ -98,6 +99,7 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
             &spans[1..],
             decl_id,
             ArgumentParsingLevel::Full,
+            None,
         );
 
         return Pipeline::from_vec(vec![Expression::new(
@@ -240,6 +242,7 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeli
             &spans[1..],
             decl_id,
             ArgumentParsingLevel::Full,
+            None,
         );
 
         return (
@@ -349,6 +352,7 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
             &spans[1..],
             decl_id,
             ArgumentParsingLevel::Full,
+            None,
         );
 
         return Pipeline::from_vec(vec![Expression::new(

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -8,7 +8,7 @@ use log::trace;
 use nu_engine::DIR_VAR_PARSER_INFO;
 use nu_protocol::{
     DeclId, Flag, IntoSpanned, ParseError, PositionalArg, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Type,
+    SyntaxShape, Type, TypeSet,
     ast::*,
     did_you_mean,
     engine::{CommandType, StateWorkingSet},
@@ -882,6 +882,7 @@ pub fn parse_internal_call(
     spans: &[Span],
     decl_id: DeclId,
     arg_parsing_level: ArgumentParsingLevel,
+    input: Option<Type>,
 ) -> ParsedInternalCall {
     trace!("parsing: internal call (decl id: {})", decl_id.get());
 
@@ -892,7 +893,16 @@ pub fn parse_internal_call(
 
     let decl = working_set.get_decl(decl_id);
     let signature = working_set.get_signature(decl);
-    let output = signature.get_output_type();
+    // TODO: Throw an actual error here, instead of leaning on later type checking code
+    //
+    // `Type::Nothing` is added to inputs to allow uses like:
+    // `ls | sort-by { open -r $in.name | lines | length }`
+    // see https://github.com/nushell/nushell/pull/14922
+    // Incorrect behavior this may cause will be handled by
+    // `check_pipeline_type` in crates/nu-parser/src/type_check.rs
+    let output = signature
+        .get_output_type(input.map(|ty| ty.union(Type::Nothing)))
+        .unwrap_or(Type::Error);
 
     let deprecation = decl.deprecation_info();
 

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -357,7 +357,7 @@ pub fn parse_external_call(
 
     let head = if let [b'$' | b'(', ..] = head_contents {
         // the expression is inside external_call, so it's a subexpression
-        let arg = crate::parser::parse_expression(working_set, &[head_span]);
+        let arg = crate::parser::parse_expression(working_set, &[head_span], None);
         Box::new(arg)
     } else {
         Box::new(parse_external_string(working_set, head_span))
@@ -774,7 +774,7 @@ pub fn parse_multispan_value(
 
             // is it subexpression?
             // Not sure, but let's make it not, so the behavior is the same as previous version of nushell.
-            let arg = crate::parser::parse_expression(working_set, &spans[*spans_idx..]);
+            let arg = crate::parser::parse_expression(working_set, &spans[*spans_idx..], None);
             *spans_idx = spans.len().saturating_sub(1);
 
             arg
@@ -1295,7 +1295,12 @@ pub fn parse_internal_call(
     }
 }
 
-pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span) -> Expression {
+pub fn parse_call(
+    working_set: &mut StateWorkingSet,
+    spans: &[Span],
+    head: Span,
+    input: Option<Type>,
+) -> Expression {
     trace!("parsing: call");
     let call_span = Span::concat(spans);
 
@@ -1354,7 +1359,7 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
         if is_dynamic_head {
             trace!("parsing: dynamic percent builtin dispatch");
 
-            let head_expr = crate::parser::parse_expression(working_set, &[head_span]);
+            let head_expr = crate::parser::parse_expression(working_set, &[head_span], input);
 
             // Create a placeholder call; the IR compiler will rewrite this to `run-internal`.
             let mut call = Call::new(call_span);
@@ -1452,6 +1457,7 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
                     &resolution_spans[pos..],
                     decl_id,
                     ArgumentParsingLevel::Full,
+                    input,
                 )
             }
         } else {
@@ -1462,6 +1468,7 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
                 &resolution_spans[pos..],
                 decl_id,
                 ArgumentParsingLevel::Full,
+                input,
             )
         };
 
@@ -1743,6 +1750,7 @@ pub fn parse_attribute(
                     &spans[cmd_end..],
                     decl_id,
                     ArgumentParsingLevel::Full,
+                    None,
                 )
             }
         },
@@ -1754,6 +1762,7 @@ pub fn parse_attribute(
                 &spans[cmd_end..],
                 decl_id,
                 ArgumentParsingLevel::Full,
+                None,
             )
         }
     };

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -882,7 +882,7 @@ pub fn parse_internal_call(
     spans: &[Span],
     decl_id: DeclId,
     arg_parsing_level: ArgumentParsingLevel,
-    input: Option<Type>,
+    input_type: Option<Type>,
 ) -> ParsedInternalCall {
     trace!("parsing: internal call (decl id: {})", decl_id.get());
 
@@ -901,7 +901,7 @@ pub fn parse_internal_call(
     // Incorrect behavior this may cause will be handled by
     // `check_pipeline_type` in crates/nu-parser/src/type_check.rs
     let output = signature
-        .get_output_type(input.map(|ty| ty.union(Type::Nothing)))
+        .get_output_type(input_type.map(|ty| ty.union(Type::Nothing)))
         .unwrap_or(Type::Error);
 
     let deprecation = decl.deprecation_info();
@@ -1299,7 +1299,7 @@ pub fn parse_call(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
     head: Span,
-    input: Option<Type>,
+    input_type: Option<Type>,
 ) -> Expression {
     trace!("parsing: call");
     let call_span = Span::concat(spans);
@@ -1359,7 +1359,7 @@ pub fn parse_call(
         if is_dynamic_head {
             trace!("parsing: dynamic percent builtin dispatch");
 
-            let head_expr = crate::parser::parse_expression(working_set, &[head_span], input);
+            let head_expr = crate::parser::parse_expression(working_set, &[head_span], input_type);
 
             // Create a placeholder call; the IR compiler will rewrite this to `run-internal`.
             let mut call = Call::new(call_span);
@@ -1457,7 +1457,7 @@ pub fn parse_call(
                     &resolution_spans[pos..],
                     decl_id,
                     ArgumentParsingLevel::Full,
-                    input,
+                    input_type,
                 )
             }
         } else {
@@ -1468,7 +1468,7 @@ pub fn parse_call(
                 &resolution_spans[pos..],
                 decl_id,
                 ArgumentParsingLevel::Full,
-                input,
+                input_type,
             )
         };
 

--- a/crates/nu-parser/src/parse_def.rs
+++ b/crates/nu-parser/src/parse_def.rs
@@ -194,6 +194,7 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
         &spans[1..],
         decl_id,
         ArgumentParsingLevel::Full,
+        None,
     );
 
     if working_set
@@ -469,6 +470,7 @@ fn parse_def_inner(
         rest_spans,
         decl_id,
         ArgumentParsingLevel::Full,
+        None,
     );
 
     if working_set
@@ -706,6 +708,7 @@ fn parse_extern_inner(
                 rest_spans,
                 decl_id,
                 ArgumentParsingLevel::Full,
+                None,
             );
             working_set.exit_scope();
 

--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -993,7 +993,7 @@ pub fn parse_assignment_expression(
     }
 
     // Parse the lhs and operator as usual for a math expression
-    let mut lhs = parse_expression(working_set, lhs_spans);
+    let mut lhs = parse_expression(working_set, lhs_spans, None);
     // make sure that lhs is a mutable variable.
     match &lhs.expr {
         Expr::FullCellPath(p) => {
@@ -1235,7 +1235,7 @@ pub fn parse_math_expression(
     if first_span == b"if" || first_span == b"match" {
         // If expression
         if spans.len() > 1 {
-            return parse_call(working_set, spans, spans[0]);
+            return parse_call(working_set, spans, spans[0], None);
         } else {
             working_set.error(ParseError::Expected(
                 "expression",
@@ -1311,7 +1311,7 @@ pub fn parse_math_expression(
         // allow `if` to be a special value for assignment.
 
         if content == b"if" || content == b"match" {
-            let rhs = parse_call(working_set, &spans[idx..], spans[0]);
+            let rhs = parse_call(working_set, &spans[idx..], spans[0], None);
             expr_stack.push(op);
             expr_stack.push(rhs);
             break;
@@ -1435,7 +1435,11 @@ pub fn parse_math_expression(
         .expect("internal error: expression stack empty")
 }
 
-pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expression {
+pub fn parse_expression(
+    working_set: &mut StateWorkingSet,
+    spans: &[Span],
+    input: Option<Type>,
+) -> Expression {
     trace!("parsing: expression");
 
     let mut pos = 0;
@@ -1506,7 +1510,7 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
                     spans[0],
                 ));
 
-                parse_call(working_set, &spans[pos..], spans[0])
+                parse_call(working_set, &spans[pos..], spans[0], input)
             }
             b"const" | b"mut" => {
                 working_set.error(ParseError::AssignInPipeline(
@@ -1524,19 +1528,19 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
                     .to_string(),
                     spans[0],
                 ));
-                parse_call(working_set, &spans[pos..], spans[0])
+                parse_call(working_set, &spans[pos..], spans[0], input)
             }
             b"overlay" => {
                 if spans.len() > 1 && working_set.get_span_contents(spans[1]) == b"list" {
                     // whitelist 'overlay list'
-                    parse_call(working_set, &spans[pos..], spans[0])
+                    parse_call(working_set, &spans[pos..], spans[0], input)
                 } else {
                     working_set.error(ParseError::BuiltinCommandInPipeline(
                         "overlay".into(),
                         spans[0],
                     ));
 
-                    parse_call(working_set, &spans[pos..], spans[0])
+                    parse_call(working_set, &spans[pos..], spans[0], input)
                 }
             }
             b"where" => parse_where_expr(working_set, &spans[pos..]),
@@ -1551,10 +1555,10 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
                     ));
                 }
 
-                parse_call(working_set, &spans[pos..], spans[0])
+                parse_call(working_set, &spans[pos..], spans[0], input)
             }
 
-            _ => parse_call(working_set, &spans[pos..], spans[0]),
+            _ => parse_call(working_set, &spans[pos..], spans[0], input),
         }
     };
 
@@ -1621,7 +1625,12 @@ pub fn parse_builtin_commands(
             if cmd.is_alias() {
                 // Parse keywords that can be aliased. Note that we check for "unaliasable" keywords
                 // because alias can have any name, therefore, we can't check for "aliasable" keywords.
-                let call_expr = parse_call(working_set, &lite_command.parts, lite_command.parts[0]);
+                let call_expr = parse_call(
+                    working_set,
+                    &lite_command.parts,
+                    lite_command.parts[0],
+                    None,
+                );
 
                 if let Expression {
                     expr: Expr::Call(call),
@@ -1706,7 +1715,7 @@ pub fn parse_builtin_commands(
             parse_keyword(working_set, lite_command)
         }
         _ => {
-            let element = parse_pipeline_element(working_set, lite_command);
+            let element = parse_pipeline_element(working_set, lite_command, Type::Any);
 
             // There is still a chance to make `parse_pipeline_element` parse into
             // some keyword that should apply side effects first, Example:

--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -1438,7 +1438,7 @@ pub fn parse_math_expression(
 pub fn parse_expression(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
-    input: Option<Type>,
+    input_type: Option<Type>,
 ) -> Expression {
     trace!("parsing: expression");
 
@@ -1510,7 +1510,7 @@ pub fn parse_expression(
                     spans[0],
                 ));
 
-                parse_call(working_set, &spans[pos..], spans[0], input)
+                parse_call(working_set, &spans[pos..], spans[0], input_type)
             }
             b"const" | b"mut" => {
                 working_set.error(ParseError::AssignInPipeline(
@@ -1528,19 +1528,19 @@ pub fn parse_expression(
                     .to_string(),
                     spans[0],
                 ));
-                parse_call(working_set, &spans[pos..], spans[0], input)
+                parse_call(working_set, &spans[pos..], spans[0], input_type)
             }
             b"overlay" => {
                 if spans.len() > 1 && working_set.get_span_contents(spans[1]) == b"list" {
                     // whitelist 'overlay list'
-                    parse_call(working_set, &spans[pos..], spans[0], input)
+                    parse_call(working_set, &spans[pos..], spans[0], input_type)
                 } else {
                     working_set.error(ParseError::BuiltinCommandInPipeline(
                         "overlay".into(),
                         spans[0],
                     ));
 
-                    parse_call(working_set, &spans[pos..], spans[0], input)
+                    parse_call(working_set, &spans[pos..], spans[0], input_type)
                 }
             }
             b"where" => parse_where_expr(working_set, &spans[pos..]),
@@ -1555,10 +1555,10 @@ pub fn parse_expression(
                     ));
                 }
 
-                parse_call(working_set, &spans[pos..], spans[0], input)
+                parse_call(working_set, &spans[pos..], spans[0], input_type)
             }
 
-            _ => parse_call(working_set, &spans[pos..], spans[0], input),
+            _ => parse_call(working_set, &spans[pos..], spans[0], input_type),
         }
     };
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -70,7 +70,12 @@ pub fn is_unaliasable_parser_keyword(working_set: &StateWorkingSet, spans: &[Spa
 pub fn parse_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
     let orig_parse_errors_len = working_set.parse_errors.len();
 
-    let call_expr = parse_call(working_set, &lite_command.parts, lite_command.parts[0]);
+    let call_expr = parse_call(
+        working_set,
+        &lite_command.parts,
+        lite_command.parts[0],
+        None,
+    );
 
     // If an error occurred, don't invoke the keyword-specific functionality
     if working_set.parse_errors.len() > orig_parse_errors_len {

--- a/crates/nu-parser/src/parse_module.rs
+++ b/crates/nu-parser/src/parse_module.rs
@@ -115,6 +115,7 @@ pub fn parse_export_in_block(
                     &parts[1..],
                     decl_id,
                     ArgumentParsingLevel::Full,
+                    None,
                 );
 
                 if call_kind != CallKind::Valid {
@@ -396,6 +397,7 @@ pub fn parse_export_env(
                 &[spans[1]],
                 decl_id,
                 ArgumentParsingLevel::Full,
+                None,
             );
 
             if call_kind != CallKind::Valid {
@@ -893,6 +895,7 @@ pub fn parse_module(
                 rest_spans,
                 decl_id,
                 ArgumentParsingLevel::FirstK { k: 1 },
+                None,
             );
 
             let call_span = Span::concat(spans);
@@ -1091,6 +1094,7 @@ pub fn parse_use(
                 rest_spans,
                 decl_id,
                 ArgumentParsingLevel::Full,
+                None,
             );
 
             let call_span = Span::concat(spans);
@@ -1313,6 +1317,7 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
                 &spans[1..],
                 decl_id,
                 ArgumentParsingLevel::Full,
+                None,
             );
 
             if call_kind != CallKind::Valid {

--- a/crates/nu-parser/src/parse_pipelines.rs
+++ b/crates/nu-parser/src/parse_pipelines.rs
@@ -1,5 +1,5 @@
 use log::trace;
-use nu_protocol::{ParseError, Span, SyntaxShape, ast::*, engine::StateWorkingSet};
+use nu_protocol::{ParseError, Span, SyntaxShape, Type, ast::*, engine::StateWorkingSet};
 use std::sync::Arc;
 
 use crate::{
@@ -50,10 +50,11 @@ pub(crate) fn parse_redirection(
 pub(crate) fn parse_pipeline_element(
     working_set: &mut StateWorkingSet,
     command: &LiteCommand,
+    input: Type,
 ) -> PipelineElement {
     trace!("parsing: pipeline element");
 
-    let expr = parse_expression(working_set, &command.parts);
+    let expr = parse_expression(working_set, &command.parts, Some(input));
 
     let redirection = command
         .redirection
@@ -83,7 +84,13 @@ pub(crate) fn redirecting_builtin_error(
     }
 }
 
-pub fn parse_pipeline(working_set: &mut StateWorkingSet, pipeline: &LitePipeline) -> Pipeline {
+pub fn parse_pipeline(
+    working_set: &mut StateWorkingSet,
+    pipeline: &LitePipeline,
+    input: Option<Type>,
+) -> Pipeline {
+    let mut input = input.unwrap_or(Type::Any);
+
     if pipeline.commands.len() > 1 {
         // Parse a normal multi command pipeline
         let elements: Vec<_> = pipeline
@@ -91,7 +98,9 @@ pub fn parse_pipeline(working_set: &mut StateWorkingSet, pipeline: &LitePipeline
             .iter()
             .enumerate()
             .map(|(index, element)| {
-                let element = parse_pipeline_element(working_set, element);
+                let element =
+                    parse_pipeline_element(working_set, element, std::mem::take(&mut input));
+                input = element.expr.ty.clone();
                 // Handle $in for pipeline elements beyond the first one
                 if index > 0 && element.has_in_variable(working_set) {
                     wrap_element_with_collect(working_set, element)
@@ -138,7 +147,7 @@ pub fn parse_block(
     block.span = Some(span);
 
     for lite_pipeline in &lite_block.block {
-        let pipeline = parse_pipeline(working_set, lite_pipeline);
+        let pipeline = parse_pipeline(working_set, lite_pipeline, None);
         block.pipelines.push(pipeline);
     }
 

--- a/crates/nu-parser/src/parse_pipelines.rs
+++ b/crates/nu-parser/src/parse_pipelines.rs
@@ -50,11 +50,11 @@ pub(crate) fn parse_redirection(
 pub(crate) fn parse_pipeline_element(
     working_set: &mut StateWorkingSet,
     command: &LiteCommand,
-    input: Type,
+    input_type: Type,
 ) -> PipelineElement {
     trace!("parsing: pipeline element");
 
-    let expr = parse_expression(working_set, &command.parts, Some(input));
+    let expr = parse_expression(working_set, &command.parts, Some(input_type));
 
     let redirection = command
         .redirection
@@ -87,9 +87,9 @@ pub(crate) fn redirecting_builtin_error(
 pub fn parse_pipeline(
     working_set: &mut StateWorkingSet,
     pipeline: &LitePipeline,
-    input: Option<Type>,
+    input_type: Option<Type>,
 ) -> Pipeline {
-    let mut input = input.unwrap_or(Type::Any);
+    let mut input = input_type.unwrap_or(Type::Any);
 
     if pipeline.commands.len() > 1 {
         // Parse a normal multi command pipeline

--- a/crates/nu-parser/src/parse_signatures.rs
+++ b/crates/nu-parser/src/parse_signatures.rs
@@ -12,8 +12,8 @@ use crate::{
 };
 use log::trace;
 use nu_protocol::{
-    Flag, ParseError, PositionalArg, Signature, Span, SyntaxShape, Type, Value, VarId, ast::*,
-    engine::StateWorkingSet, eval_const::eval_constant,
+    Flag, ParseError, PositionalArg, Signature, Span, SyntaxShape, Type, TypeSet, Value, VarId,
+    ast::*, engine::StateWorkingSet, eval_const::eval_constant,
 };
 use std::{collections::HashSet, sync::Arc};
 
@@ -1201,10 +1201,39 @@ pub fn parse_signature_helper(
                     }
                     sig.required_positional.push(positional)
                 } else {
+                    // optional parameters can be `null`
+                    // their type within the block should reflect that
+                    if positional.default_value.is_none()
+                        && let Some(var_id) = positional.var_id
+                    {
+                        let ty = working_set
+                            .get_variable(var_id)
+                            .ty
+                            .clone()
+                            .union(Type::Nothing);
+                        working_set.set_variable_type(var_id, ty);
+                    };
                     sig.optional_positional.push(positional)
                 }
             }
-            Arg::Flag { flag, .. } => sig.named.push(flag),
+            Arg::Flag {
+                flag,
+                type_annotated,
+                ..
+            } => {
+                if type_annotated
+                    && flag.default_value.is_none()
+                    && let Some(var_id) = flag.var_id
+                {
+                    let ty = working_set
+                        .get_variable(var_id)
+                        .ty
+                        .clone()
+                        .union(Type::Nothing);
+                    working_set.set_variable_type(var_id, ty);
+                }
+                sig.named.push(flag)
+            }
             Arg::RestPositional(positional) => {
                 if positional.name.is_empty() {
                     working_set.error(ParseError::RestNeedsName(span))

--- a/crates/nu-parser/src/parse_source.rs
+++ b/crates/nu-parser/src/parse_source.rs
@@ -61,6 +61,7 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                 &spans[1..],
                 decl_id,
                 ArgumentParsingLevel::Full,
+                None,
             );
 
             if call_kind == CallKind::Help {
@@ -229,6 +230,7 @@ fn parse_run_expr_internal(
                 &spans[1..],
                 decl_id,
                 ArgumentParsingLevel::Full,
+                None,
             );
 
             if call_kind == CallKind::Help {
@@ -467,6 +469,7 @@ pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
                 &spans[1..],
                 decl_id,
                 ArgumentParsingLevel::Full,
+                None,
             );
 
             if call_kind != CallKind::Valid {

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -783,59 +783,60 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
     let mut output_errors = vec![];
 
     for (input_type, output_type) in &block.signature.input_output_types {
-        let current_output_types = match block.pipelines.as_slice() {
-            [] => vec![input_type.clone()],
+        let current_output_type = match block.pipelines.as_slice() {
+            [] => input_type.clone(),
             pipelines => {
                 pipelines
                     .iter()
-                    .fold((input_type.clone(), vec![]), |(ct, _cots), pipeline| {
-                        let (checked_output_types, err) =
+                    .fold((input_type.clone(), Type::Nothing), |(ct, _), pipeline| {
+                        let (checked_output_type, err) =
                             check_pipeline_type(working_set, pipeline, ct);
                         if let Some(err) = err {
                             output_errors.extend(err);
                         }
-                        (Type::Nothing, checked_output_types)
+                        (Type::Nothing, checked_output_type)
                     })
                     .1
             }
         };
 
-        if output_type == &Type::Any || current_output_types.contains(&Type::Any) {
+        if current_output_type.is_assignable_to(output_type) {
             continue;
-        }
+        };
 
-        if !current_output_types
-            .iter()
-            .any(|ty| type_compatible(output_type, ty))
-        {
-            let span = match block.pipelines.as_slice() {
-                [] => match block.span {
-                    Some(span) => span,
-                    None => continue,
-                },
-                [.., last] => {
-                    last.elements
-                        .last()
-                        .expect("internal error: we should have elements")
-                        .expr
-                        .span
-                }
-            };
+        // Error handling
+        let span = match block.pipelines.as_slice() {
+            [] => match block.span {
+                Some(span) => span,
+                None => continue,
+            },
+            [.., last] => {
+                last.elements
+                    .last()
+                    .expect("internal error: we should have elements")
+                    .expr
+                    .span
+            }
+        };
 
-            let Some(current_ty_string) = combined_type_string(&current_output_types, "or") else {
-                output_errors.push(ParseError::InternalError(
-                    "Block has no type at this point".to_string(),
-                    span,
-                ));
-                continue;
-            };
+        let current_ty_string = match &current_output_type {
+            Type::OneOf(types) => combined_type_string(types.iter(), "or"),
+            ty => combined_type_string(std::slice::from_ref(ty).iter(), "or"),
+        };
 
-            output_errors.push(ParseError::OutputMismatch(
-                output_type.clone(),
-                current_ty_string,
+        let Some(current_ty_string) = current_ty_string else {
+            output_errors.push(ParseError::InternalError(
+                "Block has no type at this point".to_string(),
                 span,
-            ))
-        }
+            ));
+            continue;
+        };
+
+        output_errors.push(ParseError::OutputMismatch(
+            output_type.clone(),
+            current_ty_string,
+            span,
+        ))
     }
 
     if block.signature.input_output_types.is_empty() {

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -715,66 +715,52 @@ pub fn check_pipeline_type(
     working_set: &StateWorkingSet,
     pipeline: &Pipeline,
     input_type: Type,
-) -> (Vec<Type>, Option<Vec<ParseError>>) {
-    let mut input_types = Vec::new();
-    let mut output_types = Vec::new();
-
+) -> (Type, Option<Vec<ParseError>>) {
+    let mut input_type = input_type;
     let mut output_errors: Option<Vec<ParseError>> = None;
 
-    output_types.push(input_type);
     for elem in &pipeline.elements {
-        std::mem::swap(&mut input_types, &mut output_types);
-        output_types.clear();
-        input_types.sort();
-        input_types.dedup();
-        // Should be immutable from this point forward
-        let input_types = input_types.as_slice();
-
         if elem.redirection.is_some() {
-            output_types.push(Type::Any);
+            input_type = Type::Any;
             continue;
         }
+        // Only handle pipeline type checking of calls here.
         let Expr::Call(call) = &elem.expr.expr else {
-            output_types.push(elem.expr.ty.clone());
+            // NOTE[1]: Calls with `$in` are wrapped in `Expr::Collect` so are handled in this
+            // branch.
+            // This allows `ls | sort-by { open -r $in.name | lines | length }` to type
+            // check, despite the fact `open` does not support `record` input.
+            // This is thanks to `parse_internal_call` adding `Type::Nothing` to possible input
+            // types.
+            //
+            // see NOTE[2]
+            input_type = elem.expr.ty.clone();
             continue;
         };
         // Dynamic percent dispatch uses a placeholder decl_id that is rewritten later in IR.
         // Defer type constraints for this call at parse/type-check time.
         if call.parser_info.contains_key("percent_forced_builtin") {
-            output_types.push(Type::Any);
+            input_type = Type::Any;
             continue;
         }
 
-        let io_types = working_set
+        let output_type = working_set
             .get_decl(call.decl_id)
             .signature()
-            .input_output_types;
+            // NOTE[2]: unlike `parse_internal_call`, `Type::Nothing` is not added to input types.
+            .get_output_type(Some(input_type.clone()));
 
-        if io_types.is_empty() {
-            output_types.push(Type::Any);
+        if let Some(output_type) = output_type {
+            input_type = output_type;
             continue;
         }
 
-        if input_types.contains(&Type::Any) {
-            // if input type is any, then output type could be any of the valid output types
-            output_types.extend(io_types.into_iter().map(|(_, out_type)| out_type));
-        } else {
-            // any current type which matches an input type is a possible output type
-            output_types.extend(
-                io_types
-                    .into_iter()
-                    .filter(|(in_type, _)| {
-                        input_types.iter().any(|ty| type_compatible(in_type, ty))
-                    })
-                    .map(|(_, out_type)| out_type),
-            );
-        }
+        let types_string = match &input_type {
+            Type::OneOf(types) => combined_type_string(types.iter(), "or"),
+            ty => combined_type_string(std::slice::from_ref(ty).iter(), "or"),
+        };
 
-        if !output_types.is_empty() {
-            continue;
-        }
-
-        let Some(types_string) = combined_type_string(input_types, "or") else {
+        let Some(types_string) = types_string else {
             output_errors
                 .get_or_insert_default()
                 .push(ParseError::InternalError(
@@ -789,7 +775,7 @@ pub fn check_pipeline_type(
             .push(ParseError::InputMismatch(types_string, call.head));
     }
 
-    (output_types, output_errors)
+    (input_type, output_errors)
 }
 
 pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) -> Vec<ParseError> {

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -1,5 +1,5 @@
 use nu_protocol::{
-    CompareTypes, ParseError, Span, Type,
+    CompareTypes, ParseError, Span, Type, TypeSet,
     ast::{Assignment, Block, Comparison, Expr, Expression, Math, Operator, Pipeline, Range},
     combined_type_string,
     engine::StateWorkingSet,
@@ -45,6 +45,307 @@ pub fn type_compatible(dst: &Type, src: &Type) -> bool {
     src.is_assignable_to(dst)
 }
 
+fn type_combinations<'a, F, IL, IR>(op: F, lhs_tys: IL, rhs_ty: IR) -> Option<Type>
+where
+    F: Fn(&Type, &Type) -> Option<Type>,
+    IL: IntoIterator<Item = &'a Type>,
+    IR: IntoIterator<Item = &'a Type> + Clone,
+{
+    lhs_tys
+        .into_iter()
+        .flat_map(|lhs| rhs_ty.clone().into_iter().filter_map(|rhs| op(lhs, rhs)))
+        .reduce(Type::union)
+}
+
+fn operator_check<F>(op: F, on_any: impl Into<Option<Type>>, lhs: &Type, rhs: &Type) -> Option<Type>
+where
+    F: Fn(&Type, &Type) -> Option<Type>,
+{
+    use std::slice::from_ref as as_slice;
+    let on_any = on_any.into();
+
+    match (lhs, rhs) {
+        (Type::Any, _) | (_, Type::Any) if let Some(on_any) = on_any => Some(on_any),
+        (Type::OneOf(lhs_oneof), Type::OneOf(rhs_oneof)) => {
+            type_combinations(op, lhs_oneof.iter(), rhs_oneof.iter())
+        }
+        (Type::OneOf(lhs_oneof), rhs) => type_combinations(op, lhs_oneof.iter(), as_slice(rhs)),
+        (lhs, Type::OneOf(rhs_oneof)) => type_combinations(op, as_slice(lhs), rhs_oneof.iter()),
+        (lhs, rhs) => op(lhs, rhs),
+    }
+}
+
+mod math {
+    use super::*;
+
+    fn commutative<F>(op: F) -> impl Fn(&Type, &Type) -> Option<Type>
+    where
+        F: Fn(&Type, &Type) -> Option<Type>,
+    {
+        move |lhs, rhs| op(lhs, rhs).or_else(|| op(rhs, lhs))
+    }
+
+    pub(super) fn add(lhs: &Type, rhs: &Type) -> Option<Type> {
+        fn reversible_op(lhs: &Type, rhs: &Type) -> Option<Type> {
+            Some(match (lhs, rhs) {
+                (Type::Int, Type::Int) => Type::Int,
+                (Type::Float, Type::Float) => Type::Float,
+                (Type::Number, Type::Number) => Type::Number,
+
+                (Type::Number, Type::Int) => Type::Number,
+                (Type::Number, Type::Float) => Type::Float,
+                (Type::Int, Type::Float) => Type::Float,
+
+                (Type::String, Type::String) => Type::String,
+                // TODO: should this include glob
+                (Type::Date, Type::Duration) => Type::Date,
+
+                (Type::Duration, Type::Duration) => Type::Duration,
+                (Type::Filesize, Type::Filesize) => Type::Filesize,
+
+                (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
+                (Type::Custom(a), _) => Type::Custom(a.clone()),
+
+                _ => return None,
+            })
+        }
+        operator_check(commutative(reversible_op), Type::Any, lhs, rhs)
+    }
+
+    pub(super) fn subtract(lhs: &Type, rhs: &Type) -> Option<Type> {
+        fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
+            Some(match (lhs, rhs) {
+                (Type::Int, Type::Int) => Type::Int,
+
+                (Type::Float | Type::Int, Type::Float | Type::Int) => Type::Float,
+
+                (
+                    Type::Int | Type::Float | Type::Number,
+                    Type::Int | Type::Float | Type::Number,
+                ) => Type::Number,
+
+                (Type::Date, Type::Date) => Type::Duration,
+                (Type::Date, Type::Duration) => Type::Date,
+
+                (Type::Duration, Type::Duration) => Type::Duration,
+                (Type::Filesize, Type::Filesize) => Type::Filesize,
+
+                (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
+                (Type::Custom(a), _) => Type::Custom(a.clone()),
+
+                _ => return None,
+            })
+        }
+        operator_check(op, Type::Any, lhs, rhs)
+    }
+
+    pub(super) fn multiply(lhs: &Type, rhs: &Type) -> Option<Type> {
+        fn reversible_op(lhs: &Type, rhs: &Type) -> Option<Type> {
+            Some(match (lhs, rhs) {
+                (Type::Int, Type::Int) => Type::Int,
+                (Type::Float, Type::Float) => Type::Float,
+                (Type::Number, Type::Number) => Type::Number,
+
+                (Type::Number, Type::Int) => Type::Number,
+                (Type::Number, Type::Float) => Type::Float,
+                (Type::Int, Type::Float) => Type::Float,
+
+                (Type::Filesize, Type::Int | Type::Float | Type::Number) => Type::Filesize,
+                (Type::Duration, Type::Int | Type::Float | Type::Number) => Type::Duration,
+
+                (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
+                (Type::Custom(a), _) => Type::Custom(a.clone()),
+
+                _ => return None,
+            })
+        }
+        operator_check(commutative(reversible_op), Type::Any, lhs, rhs)
+    }
+
+    pub(super) fn divide(lhs: &Type, rhs: &Type) -> Option<Type> {
+        fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
+            Some(match (lhs, rhs) {
+                (
+                    Type::Int | Type::Float | Type::Number,
+                    Type::Int | Type::Float | Type::Number,
+                ) => Type::Float,
+
+                (Type::Filesize, Type::Filesize) => Type::Float,
+                (Type::Duration, Type::Duration) => Type::Float,
+
+                (Type::Filesize, Type::Int | Type::Float | Type::Number) => Type::Filesize,
+                (Type::Duration, Type::Int | Type::Float | Type::Number) => Type::Duration,
+
+                (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
+                (Type::Custom(a), _) => Type::Custom(a.clone()),
+
+                _ => return None,
+            })
+        }
+        operator_check(op, Type::Any, lhs, rhs)
+    }
+
+    pub(super) fn floor_divide(lhs: &Type, rhs: &Type) -> Option<Type> {
+        fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
+            Some(match (lhs, rhs) {
+                (Type::Int, Type::Int) => Type::Int,
+
+                (Type::Int | Type::Float, Type::Int | Type::Float) => Type::Float,
+
+                (
+                    Type::Int | Type::Float | Type::Number,
+                    Type::Int | Type::Float | Type::Number,
+                ) => Type::Number,
+
+                (Type::Filesize, Type::Filesize) => Type::Int,
+                (Type::Duration, Type::Duration) => Type::Int,
+
+                (Type::Filesize, Type::Int | Type::Float | Type::Number) => Type::Filesize,
+                (Type::Duration, Type::Int | Type::Float | Type::Number) => Type::Duration,
+
+                (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
+                (Type::Custom(a), _) => Type::Custom(a.clone()),
+
+                _ => return None,
+            })
+        }
+        operator_check(op, Type::Any, lhs, rhs)
+    }
+
+    pub(super) fn modulo(lhs: &Type, rhs: &Type) -> Option<Type> {
+        fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
+            Some(match (lhs, rhs) {
+                (Type::Int, Type::Int) => Type::Int,
+
+                (Type::Float | Type::Int, Type::Float | Type::Int) => Type::Float,
+
+                (
+                    Type::Int | Type::Float | Type::Number,
+                    Type::Int | Type::Float | Type::Number,
+                ) => Type::Number,
+
+                (Type::Filesize, Type::Filesize) => Type::Filesize,
+                (Type::Duration, Type::Duration) => Type::Duration,
+
+                (Type::Filesize, Type::Int | Type::Float | Type::Number) => Type::Filesize,
+                (Type::Duration, Type::Int | Type::Float | Type::Number) => Type::Duration,
+
+                (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
+                (Type::Custom(a), _) => Type::Custom(a.clone()),
+
+                _ => return None,
+            })
+        }
+        operator_check(op, Type::Any, lhs, rhs)
+    }
+
+    pub(super) fn pow(lhs: &Type, rhs: &Type) -> Option<Type> {
+        fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
+            Some(match (lhs, rhs) {
+                (Type::Int, Type::Int) => Type::Int,
+
+                (Type::Int | Type::Float, Type::Int | Type::Float) => Type::Float,
+
+                (
+                    Type::Int | Type::Float | Type::Number,
+                    Type::Int | Type::Float | Type::Number,
+                ) => Type::Number,
+
+                (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
+                (Type::Custom(a), _) => Type::Custom(a.clone()),
+
+                _ => return None,
+            })
+        }
+        operator_check(op, Type::Any, lhs, rhs)
+    }
+
+    pub(super) fn concatenate(lhs: &Type, rhs: &Type) -> Option<Type> {
+        fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
+            Some(match (lhs, rhs) {
+                (Type::List(a), Type::List(b)) => {
+                    Type::list(a.as_ref().clone().union(b.as_ref().clone()))
+                }
+                (Type::Table(a), Type::Table(b)) => Type::Table(a.clone().union(b.clone())),
+                (Type::Table(table), Type::List(list)) => {
+                    Type::list(Type::Record(table.clone()).union(list.as_ref().clone()))
+                }
+                (Type::String, Type::String) => Type::String,
+                // TODO: should this include glob
+                (Type::Binary, Type::Binary) => Type::Binary,
+
+                (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
+                (Type::Custom(a), _) => Type::Custom(a.clone()),
+
+                _ => return None,
+            })
+        }
+        operator_check(commutative(op), Type::Any, lhs, rhs)
+    }
+}
+
+fn ord_cmp_op(lhs: &Type, rhs: &Type) -> Option<Type> {
+    fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
+        Some(match (lhs, rhs) {
+            (Type::Int | Type::Float | Type::Number, Type::Int | Type::Float | Type::Number) => {
+                Type::Bool
+            }
+
+            (Type::String, Type::String) => Type::Bool,
+            (Type::Duration, Type::Duration) => Type::Bool,
+            (Type::Date, Type::Date) => Type::Bool,
+            (Type::Filesize, Type::Filesize) => Type::Bool,
+            (Type::Bool, Type::Bool) => Type::Bool,
+
+            (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
+            (Type::Custom(a), _) => Type::Custom(a.clone()),
+
+            (Type::Nothing, _) | (_, Type::Nothing) => Type::Nothing, // TODO: is this right
+            // TODO: should this include:
+            // - binary
+            // - glob
+            // - list
+            // - table
+            // - record
+            // - range
+            _ => return None,
+        })
+    }
+    operator_check(op, Type::Bool, lhs, rhs)
+}
+
+fn str_cmp_op(lhs: &Type, rhs: &Type) -> Option<Type> {
+    fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
+        Some(match (lhs, rhs) {
+            (Type::String | Type::Any, Type::String | Type::Any) => Type::Bool,
+            // TODO: should this include glob?
+            (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
+            (Type::Custom(a), _) => Type::Custom(a.clone()),
+            _ => return None,
+        })
+    }
+    operator_check(op, None, lhs, rhs)
+}
+
+fn in_op(lhs: &Type, rhs: &Type) -> Option<Type> {
+    fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
+        Some(match (lhs, rhs) {
+            (t, Type::List(u)) if type_compatible(t, u) => Type::Bool,
+            (Type::Int | Type::Float | Type::Number, Type::Range) => Type::Bool,
+            (Type::String, Type::String) => Type::Bool,
+            (Type::String, Type::Record(_)) => Type::Bool,
+            (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
+            (Type::Custom(a), _) => Type::Custom(a.clone()),
+            _ => return None,
+        })
+    }
+    operator_check(op, Type::Any, lhs, rhs)
+}
+
+fn has_op(lhs: &Type, rhs: &Type) -> Option<Type> {
+    in_op(rhs, lhs)
+}
+
 // TODO: rework type checking for Custom values
 pub fn math_result_type(
     working_set: &mut StateWorkingSet,
@@ -60,27 +361,9 @@ pub fn math_result_type(
         );
     };
     match operator {
-        Operator::Math(Math::Add) => match (&lhs.ty, &rhs.ty) {
-            (Type::Int, Type::Int) => (Type::Int, None),
-            (Type::Float, Type::Int) => (Type::Float, None),
-            (Type::Int, Type::Float) => (Type::Float, None),
-            (Type::Float, Type::Float) => (Type::Float, None),
-            (Type::Number, Type::Number) => (Type::Number, None),
-            (Type::Number, Type::Int) => (Type::Number, None),
-            (Type::Int, Type::Number) => (Type::Number, None),
-            (Type::Number, Type::Float) => (Type::Number, None),
-            (Type::Float, Type::Number) => (Type::Number, None),
-            (Type::String, Type::String) => (Type::String, None),
-            // TODO: should this include glob
-            (Type::Date, Type::Duration) => (Type::Date, None),
-            (Type::Duration, Type::Date) => (Type::Date, None),
-            (Type::Duration, Type::Duration) => (Type::Duration, None),
-            (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Any, _) => (Type::Any, None),
-            (_, Type::Any) => (Type::Any, None),
-            _ => {
+        Operator::Math(Math::Add) => match math::add(&lhs.ty, &rhs.ty) {
+            Some(ty) => (ty, None),
+            None => {
                 *op = Expression::garbage(working_set, op.span);
                 type_error(operator, op.span, lhs, rhs, |ty| {
                     matches!(
@@ -96,25 +379,9 @@ pub fn math_result_type(
                 })
             }
         },
-        Operator::Math(Math::Subtract) => match (&lhs.ty, &rhs.ty) {
-            (Type::Int, Type::Int) => (Type::Int, None),
-            (Type::Float, Type::Int) => (Type::Float, None),
-            (Type::Int, Type::Float) => (Type::Float, None),
-            (Type::Float, Type::Float) => (Type::Float, None),
-            (Type::Number, Type::Number) => (Type::Number, None),
-            (Type::Number, Type::Int) => (Type::Number, None),
-            (Type::Int, Type::Number) => (Type::Number, None),
-            (Type::Number, Type::Float) => (Type::Number, None),
-            (Type::Float, Type::Number) => (Type::Number, None),
-            (Type::Date, Type::Date) => (Type::Duration, None),
-            (Type::Date, Type::Duration) => (Type::Date, None),
-            (Type::Duration, Type::Duration) => (Type::Duration, None),
-            (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Any, _) => (Type::Any, None),
-            (_, Type::Any) => (Type::Any, None),
-            _ => {
+        Operator::Math(Math::Subtract) => match math::subtract(&lhs.ty, &rhs.ty) {
+            Some(ty) => (ty, None),
+            None => {
                 *op = Expression::garbage(working_set, op.span);
                 type_error(operator, op.span, lhs, rhs, |ty| {
                     matches!(
@@ -129,29 +396,9 @@ pub fn math_result_type(
                 })
             }
         },
-        Operator::Math(Math::Multiply) => match (&lhs.ty, &rhs.ty) {
-            (Type::Int, Type::Int) => (Type::Int, None),
-            (Type::Float, Type::Int) => (Type::Float, None),
-            (Type::Int, Type::Float) => (Type::Float, None),
-            (Type::Float, Type::Float) => (Type::Float, None),
-            (Type::Number, Type::Number) => (Type::Number, None),
-            (Type::Number, Type::Int) => (Type::Number, None),
-            (Type::Int, Type::Number) => (Type::Number, None),
-            (Type::Number, Type::Float) => (Type::Number, None),
-            (Type::Float, Type::Number) => (Type::Number, None),
-            (Type::Filesize, Type::Int) => (Type::Filesize, None),
-            (Type::Int, Type::Filesize) => (Type::Filesize, None),
-            (Type::Filesize, Type::Float) => (Type::Filesize, None),
-            (Type::Float, Type::Filesize) => (Type::Filesize, None),
-            (Type::Duration, Type::Int) => (Type::Duration, None),
-            (Type::Int, Type::Duration) => (Type::Duration, None),
-            (Type::Duration, Type::Float) => (Type::Duration, None),
-            (Type::Float, Type::Duration) => (Type::Duration, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Any, _) => (Type::Any, None),
-            (_, Type::Any) => (Type::Any, None),
-            _ => {
+        Operator::Math(Math::Multiply) => match math::multiply(&lhs.ty, &rhs.ty) {
+            Some(ty) => (ty, None),
+            None => {
                 *op = Expression::garbage(working_set, op.span);
                 type_error(operator, op.span, lhs, rhs, |ty| {
                     matches!(
@@ -161,27 +408,9 @@ pub fn math_result_type(
                 })
             }
         },
-        Operator::Math(Math::Divide) => match (&lhs.ty, &rhs.ty) {
-            (Type::Int, Type::Int) => (Type::Float, None),
-            (Type::Float, Type::Int) => (Type::Float, None),
-            (Type::Int, Type::Float) => (Type::Float, None),
-            (Type::Float, Type::Float) => (Type::Float, None),
-            (Type::Number, Type::Number) => (Type::Float, None),
-            (Type::Number, Type::Int) => (Type::Float, None),
-            (Type::Int, Type::Number) => (Type::Float, None),
-            (Type::Number, Type::Float) => (Type::Float, None),
-            (Type::Float, Type::Number) => (Type::Float, None),
-            (Type::Filesize, Type::Filesize) => (Type::Float, None),
-            (Type::Filesize, Type::Int) => (Type::Filesize, None),
-            (Type::Filesize, Type::Float) => (Type::Filesize, None),
-            (Type::Duration, Type::Duration) => (Type::Float, None),
-            (Type::Duration, Type::Int) => (Type::Duration, None),
-            (Type::Duration, Type::Float) => (Type::Duration, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Any, _) => (Type::Any, None),
-            (_, Type::Any) => (Type::Any, None),
-            _ => {
+        Operator::Math(Math::Divide) => match math::divide(&lhs.ty, &rhs.ty) {
+            Some(ty) => (ty, None),
+            None => {
                 *op = Expression::garbage(working_set, op.span);
                 type_error(operator, op.span, lhs, rhs, |ty| {
                     matches!(
@@ -191,27 +420,9 @@ pub fn math_result_type(
                 })
             }
         },
-        Operator::Math(Math::FloorDivide) => match (&lhs.ty, &rhs.ty) {
-            (Type::Int, Type::Int) => (Type::Int, None),
-            (Type::Float, Type::Int) => (Type::Float, None),
-            (Type::Int, Type::Float) => (Type::Float, None),
-            (Type::Float, Type::Float) => (Type::Float, None),
-            (Type::Number, Type::Number) => (Type::Number, None),
-            (Type::Number, Type::Int) => (Type::Number, None),
-            (Type::Int, Type::Number) => (Type::Number, None),
-            (Type::Number, Type::Float) => (Type::Number, None),
-            (Type::Float, Type::Number) => (Type::Number, None),
-            (Type::Filesize, Type::Filesize) => (Type::Int, None),
-            (Type::Filesize, Type::Int) => (Type::Filesize, None),
-            (Type::Filesize, Type::Float) => (Type::Filesize, None),
-            (Type::Duration, Type::Duration) => (Type::Int, None),
-            (Type::Duration, Type::Int) => (Type::Duration, None),
-            (Type::Duration, Type::Float) => (Type::Duration, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Any, _) => (Type::Any, None),
-            (_, Type::Any) => (Type::Any, None),
-            _ => {
+        Operator::Math(Math::FloorDivide) => match math::floor_divide(&lhs.ty, &rhs.ty) {
+            Some(ty) => (ty, None),
+            None => {
                 *op = Expression::garbage(working_set, op.span);
                 type_error(operator, op.span, lhs, rhs, |ty| {
                     matches!(
@@ -221,27 +432,9 @@ pub fn math_result_type(
                 })
             }
         },
-        Operator::Math(Math::Modulo) => match (&lhs.ty, &rhs.ty) {
-            (Type::Int, Type::Int) => (Type::Int, None),
-            (Type::Float, Type::Int) => (Type::Float, None),
-            (Type::Int, Type::Float) => (Type::Float, None),
-            (Type::Float, Type::Float) => (Type::Float, None),
-            (Type::Number, Type::Number) => (Type::Number, None),
-            (Type::Number, Type::Int) => (Type::Number, None),
-            (Type::Int, Type::Number) => (Type::Number, None),
-            (Type::Number, Type::Float) => (Type::Number, None),
-            (Type::Float, Type::Number) => (Type::Number, None),
-            (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
-            (Type::Filesize, Type::Int) => (Type::Filesize, None),
-            (Type::Filesize, Type::Float) => (Type::Filesize, None),
-            (Type::Duration, Type::Duration) => (Type::Duration, None),
-            (Type::Duration, Type::Int) => (Type::Duration, None),
-            (Type::Duration, Type::Float) => (Type::Duration, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Any, _) => (Type::Any, None),
-            (_, Type::Any) => (Type::Any, None),
-            _ => {
+        Operator::Math(Math::Modulo) => match math::modulo(&lhs.ty, &rhs.ty) {
+            Some(ty) => (ty, None),
+            None => {
                 *op = Expression::garbage(working_set, op.span);
                 type_error(operator, op.span, lhs, rhs, |ty| {
                     matches!(
@@ -251,57 +444,18 @@ pub fn math_result_type(
                 })
             }
         },
-        Operator::Math(Math::Pow) => match (&lhs.ty, &rhs.ty) {
-            (Type::Int, Type::Int) => (Type::Int, None),
-            (Type::Float, Type::Int) => (Type::Float, None),
-            (Type::Int, Type::Float) => (Type::Float, None),
-            (Type::Float, Type::Float) => (Type::Float, None),
-            (Type::Number, Type::Number) => (Type::Number, None),
-            (Type::Number, Type::Int) => (Type::Number, None),
-            (Type::Int, Type::Number) => (Type::Number, None),
-            (Type::Number, Type::Float) => (Type::Number, None),
-            (Type::Float, Type::Number) => (Type::Number, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Any, _) => (Type::Any, None),
-            (_, Type::Any) => (Type::Any, None),
-            _ => {
+        Operator::Math(Math::Pow) => match math::pow(&lhs.ty, &rhs.ty) {
+            Some(ty) => (ty, None),
+            None => {
                 *op = Expression::garbage(working_set, op.span);
                 type_error(operator, op.span, lhs, rhs, |ty| {
                     matches!(ty, Type::Int | Type::Float | Type::Number)
                 })
             }
         },
-        Operator::Math(Math::Concatenate) => match (&lhs.ty, &rhs.ty) {
-            (Type::List(a), Type::List(b)) => {
-                if a == b {
-                    (Type::list(a.as_ref().clone()), None)
-                } else {
-                    (Type::list(Type::Any), None)
-                }
-            }
-            (Type::Table(a), Type::Table(_)) => (Type::Table(a.clone()), None),
-            (Type::Table(table), Type::List(list)) => {
-                if matches!(list.as_ref(), Type::Record(..)) {
-                    (Type::Table(table.clone()), None)
-                } else {
-                    (Type::list(Type::Any), None)
-                }
-            }
-            (Type::List(list), Type::Table(_)) => {
-                if matches!(list.as_ref(), Type::Record(..)) {
-                    (Type::list(list.as_ref().clone()), None)
-                } else {
-                    (Type::list(Type::Any), None)
-                }
-            }
-            (Type::String, Type::String) => (Type::String, None),
-            // TODO: should this include glob
-            (Type::Binary, Type::Binary) => (Type::Binary, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Any, _) | (_, Type::Any) => (Type::Any, None),
-            _ => {
+        Operator::Math(Math::Concatenate) => match math::concatenate(&lhs.ty, &rhs.ty) {
+            Some(ty) => (ty, None),
+            None => {
                 *op = Expression::garbage(working_set, op.span);
                 let is_supported = |ty: &Type| {
                     matches!(
@@ -351,184 +505,36 @@ pub fn math_result_type(
                 (Type::Any, Some(err))
             }
         },
-        Operator::Boolean(_) => match (&lhs.ty, &rhs.ty) {
-            (Type::Bool, Type::Bool) => (Type::Bool, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Any, _) => (Type::Any, None),
-            (_, Type::Any) => (Type::Any, None),
-            _ => {
-                *op = Expression::garbage(working_set, op.span);
-                type_error(operator, op.span, lhs, rhs, |ty| matches!(ty, Type::Bool))
+        Operator::Boolean(_) => {
+            let out = operator_check(
+                |lhs, rhs| {
+                    Some(match (lhs, rhs) {
+                        (Type::Bool, Type::Bool) => Type::Bool,
+                        (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
+                        (Type::Custom(a), _) => Type::Custom(a.clone()),
+                        _ => return None,
+                    })
+                },
+                Type::Any,
+                &lhs.ty,
+                &rhs.ty,
+            );
+            match out {
+                Some(ty) => (ty, None),
+                None => {
+                    *op = Expression::garbage(working_set, op.span);
+                    type_error(operator, op.span, lhs, rhs, |ty| matches!(ty, Type::Bool))
+                }
             }
-        },
-        Operator::Comparison(Comparison::LessThan) => match (&lhs.ty, &rhs.ty) {
-            (Type::Int, Type::Int) => (Type::Bool, None),
-            (Type::Float, Type::Int) => (Type::Bool, None),
-            (Type::Int, Type::Float) => (Type::Bool, None),
-            (Type::Float, Type::Float) => (Type::Bool, None),
-            (Type::Number, Type::Number) => (Type::Bool, None),
-            (Type::Number, Type::Int) => (Type::Bool, None),
-            (Type::Int, Type::Number) => (Type::Bool, None),
-            (Type::Number, Type::Float) => (Type::Bool, None),
-            (Type::Float, Type::Number) => (Type::Bool, None),
-            (Type::String, Type::String) => (Type::Bool, None),
-            (Type::Duration, Type::Duration) => (Type::Bool, None),
-            (Type::Date, Type::Date) => (Type::Bool, None),
-            (Type::Filesize, Type::Filesize) => (Type::Bool, None),
-            (Type::Bool, Type::Bool) => (Type::Bool, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Nothing, _) => (Type::Nothing, None), // TODO: is this right
-            (_, Type::Nothing) => (Type::Nothing, None), // TODO: is this right
-            // TODO: should this include:
-            // - binary
-            // - glob
-            // - list
-            // - table
-            // - record
-            // - range
-            (Type::Any, _) => (Type::Bool, None),
-            (_, Type::Any) => (Type::Bool, None),
-            _ => {
-                *op = Expression::garbage(working_set, op.span);
-                type_error(operator, op.span, lhs, rhs, |ty| {
-                    matches!(
-                        ty,
-                        Type::Int
-                            | Type::Float
-                            | Type::Number
-                            | Type::String
-                            | Type::Filesize
-                            | Type::Duration
-                            | Type::Date
-                            | Type::Bool
-                            | Type::Nothing
-                    )
-                })
-            }
-        },
-        Operator::Comparison(Comparison::LessThanOrEqual) => match (&lhs.ty, &rhs.ty) {
-            (Type::Int, Type::Int) => (Type::Bool, None),
-            (Type::Float, Type::Int) => (Type::Bool, None),
-            (Type::Int, Type::Float) => (Type::Bool, None),
-            (Type::Float, Type::Float) => (Type::Bool, None),
-            (Type::Number, Type::Number) => (Type::Bool, None),
-            (Type::Number, Type::Int) => (Type::Bool, None),
-            (Type::Int, Type::Number) => (Type::Bool, None),
-            (Type::Number, Type::Float) => (Type::Bool, None),
-            (Type::Float, Type::Number) => (Type::Bool, None),
-            (Type::String, Type::String) => (Type::Bool, None),
-            (Type::Duration, Type::Duration) => (Type::Bool, None),
-            (Type::Date, Type::Date) => (Type::Bool, None),
-            (Type::Filesize, Type::Filesize) => (Type::Bool, None),
-            (Type::Bool, Type::Bool) => (Type::Bool, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Nothing, _) => (Type::Nothing, None), // TODO: is this right
-            (_, Type::Nothing) => (Type::Nothing, None), // TODO: is this right
-            // TODO: should this include:
-            // - binary
-            // - glob
-            // - list
-            // - table
-            // - record
-            // - range
-            (Type::Any, _) => (Type::Bool, None),
-            (_, Type::Any) => (Type::Bool, None),
-            _ => {
-                *op = Expression::garbage(working_set, op.span);
-                type_error(operator, op.span, lhs, rhs, |ty| {
-                    matches!(
-                        ty,
-                        Type::Int
-                            | Type::Float
-                            | Type::Number
-                            | Type::String
-                            | Type::Filesize
-                            | Type::Duration
-                            | Type::Date
-                            | Type::Bool
-                            | Type::Nothing
-                    )
-                })
-            }
-        },
-        Operator::Comparison(Comparison::GreaterThan) => match (&lhs.ty, &rhs.ty) {
-            (Type::Int, Type::Int) => (Type::Bool, None),
-            (Type::Float, Type::Int) => (Type::Bool, None),
-            (Type::Int, Type::Float) => (Type::Bool, None),
-            (Type::Float, Type::Float) => (Type::Bool, None),
-            (Type::Number, Type::Number) => (Type::Bool, None),
-            (Type::Number, Type::Int) => (Type::Bool, None),
-            (Type::Int, Type::Number) => (Type::Bool, None),
-            (Type::Number, Type::Float) => (Type::Bool, None),
-            (Type::Float, Type::Number) => (Type::Bool, None),
-            (Type::String, Type::String) => (Type::Bool, None),
-            (Type::Duration, Type::Duration) => (Type::Bool, None),
-            (Type::Date, Type::Date) => (Type::Bool, None),
-            (Type::Filesize, Type::Filesize) => (Type::Bool, None),
-            (Type::Bool, Type::Bool) => (Type::Bool, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Nothing, _) => (Type::Nothing, None), // TODO: is this right
-            (_, Type::Nothing) => (Type::Nothing, None), // TODO: is this right
-            // TODO: should this include:
-            // - binary
-            // - glob
-            // - list
-            // - table
-            // - record
-            // - range
-            (Type::Any, _) => (Type::Bool, None),
-            (_, Type::Any) => (Type::Bool, None),
-            _ => {
-                *op = Expression::garbage(working_set, op.span);
-                type_error(operator, op.span, lhs, rhs, |ty| {
-                    matches!(
-                        ty,
-                        Type::Int
-                            | Type::Float
-                            | Type::Number
-                            | Type::String
-                            | Type::Filesize
-                            | Type::Duration
-                            | Type::Date
-                            | Type::Bool
-                            | Type::Nothing
-                    )
-                })
-            }
-        },
-        Operator::Comparison(Comparison::GreaterThanOrEqual) => match (&lhs.ty, &rhs.ty) {
-            (Type::Int, Type::Int) => (Type::Bool, None),
-            (Type::Float, Type::Int) => (Type::Bool, None),
-            (Type::Int, Type::Float) => (Type::Bool, None),
-            (Type::Float, Type::Float) => (Type::Bool, None),
-            (Type::Number, Type::Number) => (Type::Bool, None),
-            (Type::Number, Type::Int) => (Type::Bool, None),
-            (Type::Int, Type::Number) => (Type::Bool, None),
-            (Type::Number, Type::Float) => (Type::Bool, None),
-            (Type::Float, Type::Number) => (Type::Bool, None),
-            (Type::String, Type::String) => (Type::Bool, None),
-            (Type::Duration, Type::Duration) => (Type::Bool, None),
-            (Type::Date, Type::Date) => (Type::Bool, None),
-            (Type::Filesize, Type::Filesize) => (Type::Bool, None),
-            (Type::Bool, Type::Bool) => (Type::Bool, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Nothing, _) => (Type::Nothing, None), // TODO: is this right
-            (_, Type::Nothing) => (Type::Nothing, None), // TODO: is this right
-            // TODO: should this include:
-            // - binary
-            // - glob
-            // - list
-            // - table
-            // - record
-            // - range
-            (Type::Any, _) => (Type::Bool, None),
-            (_, Type::Any) => (Type::Bool, None),
-            _ => {
+        }
+        Operator::Comparison(
+            Comparison::LessThan
+            | Comparison::LessThanOrEqual
+            | Comparison::GreaterThan
+            | Comparison::GreaterThanOrEqual,
+        ) => match ord_cmp_op(&lhs.ty, &rhs.ty) {
+            Some(ty) => (ty, None),
+            None => {
                 *op = Expression::garbage(working_set, op.span);
                 type_error(operator, op.span, lhs, rhs, |ty| {
                     matches!(
@@ -553,45 +559,23 @@ pub fn math_result_type(
                 _ => (Type::Bool, None),
             }
         }
-        Operator::Comparison(Comparison::RegexMatch | Comparison::NotRegexMatch) => {
-            match (&lhs.ty, &rhs.ty) {
-                (Type::String | Type::Any, Type::String | Type::Any) => (Type::Bool, None),
-                // TODO: should this include glob?
-                (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-                (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-                _ => {
-                    *op = Expression::garbage(working_set, op.span);
-                    type_error(operator, op.span, lhs, rhs, |ty| matches!(ty, Type::String))
-                }
-            }
-        }
         Operator::Comparison(
-            Comparison::StartsWith
+            Comparison::RegexMatch
+            | Comparison::NotRegexMatch
+            | Comparison::StartsWith
             | Comparison::NotStartsWith
             | Comparison::EndsWith
             | Comparison::NotEndsWith,
-        ) => {
-            match (&lhs.ty, &rhs.ty) {
-                (Type::String | Type::Any, Type::String | Type::Any) => (Type::Bool, None),
-                // TODO: should this include glob?
-                (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-                (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-                _ => {
-                    *op = Expression::garbage(working_set, op.span);
-                    type_error(operator, op.span, lhs, rhs, |ty| matches!(ty, Type::String))
-                }
+        ) => match str_cmp_op(&lhs.ty, &rhs.ty) {
+            Some(ty) => (ty, None),
+            None => {
+                *op = Expression::garbage(working_set, op.span);
+                type_error(operator, op.span, lhs, rhs, |ty| matches!(ty, Type::String))
             }
-        }
-        Operator::Comparison(Comparison::In | Comparison::NotIn) => match (&lhs.ty, &rhs.ty) {
-            (t, Type::List(u)) if type_compatible(t, u) => (Type::Bool, None),
-            (Type::Int | Type::Float | Type::Number, Type::Range) => (Type::Bool, None),
-            (Type::String, Type::String) => (Type::Bool, None),
-            (Type::String, Type::Record(_)) => (Type::Bool, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Any, _) => (Type::Bool, None),
-            (_, Type::Any) => (Type::Bool, None),
-            _ => {
+        },
+        Operator::Comparison(Comparison::In | Comparison::NotIn) => match in_op(&lhs.ty, &rhs.ty) {
+            Some(ty) => (ty, None),
+            None => {
                 let err = if matches!(
                     &rhs.ty,
                     Type::List(_)
@@ -623,56 +607,62 @@ pub fn math_result_type(
                 (Type::Any, Some(err))
             }
         },
-        Operator::Comparison(Comparison::Has | Comparison::NotHas) => match (&lhs.ty, &rhs.ty) {
-            (Type::List(u), t) if type_compatible(u, t) => (Type::Bool, None),
-            (Type::Range, Type::Int | Type::Float | Type::Number) => (Type::Bool, None),
-            (Type::String, Type::String) => (Type::Bool, None),
-            (Type::Record(_), Type::String) => (Type::Bool, None),
-            (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-            (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
-            (Type::Any, _) => (Type::Bool, None),
-            (_, Type::Any) => (Type::Bool, None),
-            _ => {
-                *op = Expression::garbage(working_set, op.span);
-                let err = if matches!(
-                    &lhs.ty,
-                    Type::List(_)
-                        | Type::Range
-                        | Type::String
-                        | Type::Record(_)
-                        | Type::Custom(_)
-                        | Type::Any
-                ) {
-                    ParseError::OperatorIncompatibleTypes {
-                        op: operator.as_str(),
-                        lhs: lhs.ty.clone(),
-                        rhs: rhs.ty.clone(),
-                        op_span: op.span,
-                        lhs_span: lhs.span,
-                        rhs_span: rhs.span,
-                        help: None,
-                    }
-                } else {
-                    ParseError::OperatorUnsupportedType {
-                        op: operator.as_str(),
-                        unsupported: lhs.ty.clone(),
-                        op_span: op.span,
-                        unsupported_span: lhs.span,
-                        help: None,
-                    }
-                };
-                (Type::Any, Some(err))
+        Operator::Comparison(Comparison::Has | Comparison::NotHas) => {
+            match has_op(&lhs.ty, &rhs.ty) {
+                Some(ty) => (ty, None),
+                None => {
+                    *op = Expression::garbage(working_set, op.span);
+                    let err = if matches!(
+                        &lhs.ty,
+                        Type::List(_)
+                            | Type::Range
+                            | Type::String
+                            | Type::Record(_)
+                            | Type::Custom(_)
+                            | Type::Any
+                    ) {
+                        ParseError::OperatorIncompatibleTypes {
+                            op: operator.as_str(),
+                            lhs: lhs.ty.clone(),
+                            rhs: rhs.ty.clone(),
+                            op_span: op.span,
+                            lhs_span: lhs.span,
+                            rhs_span: rhs.span,
+                            help: None,
+                        }
+                    } else {
+                        ParseError::OperatorUnsupportedType {
+                            op: operator.as_str(),
+                            unsupported: lhs.ty.clone(),
+                            op_span: op.span,
+                            unsupported_span: lhs.span,
+                            help: None,
+                        }
+                    };
+                    (Type::Any, Some(err))
+                }
             }
-        },
-        Operator::Bits(_) => match (&lhs.ty, &rhs.ty) {
-            (Type::Int, Type::Int) => (Type::Int, None),
-            (Type::Any, _) => (Type::Any, None),
-            (_, Type::Any) => (Type::Any, None),
-            _ => {
-                *op = Expression::garbage(working_set, op.span);
-                type_error(operator, op.span, lhs, rhs, |ty| matches!(ty, Type::Int))
+        }
+        Operator::Bits(_) => {
+            let out = operator_check(
+                |lhs, rhs| {
+                    Some(match (lhs, rhs) {
+                        (Type::Int, Type::Int) => Type::Int,
+                        _ => return None,
+                    })
+                },
+                Type::Any,
+                &lhs.ty,
+                &rhs.ty,
+            );
+            match out {
+                Some(ty) => (ty, None),
+                None => {
+                    *op = Expression::garbage(working_set, op.span);
+                    type_error(operator, op.span, lhs, rhs, |ty| matches!(ty, Type::Int))
+                }
             }
-        },
+        }
         Operator::Assignment(Assignment::AddAssign) => {
             compound_assignment_result_type(working_set, lhs, op, rhs, operator, Math::Add)
         }
@@ -709,8 +699,6 @@ pub fn math_result_type(
 }
 
 /// Determine the possible output types of a pipeline.
-///
-/// Output is union of types in the `Vec`.
 pub fn check_pipeline_type(
     working_set: &StateWorkingSet,
     pipeline: &Pipeline,

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -75,6 +75,23 @@ where
     }
 }
 
+// covers number types for operand type checking. this is correct for (at least) these operations:
+// - add
+// - subtract
+// - multiply
+// - floor_divide
+// - modulo
+// - pow
+fn number_types(lhs: &Type, rhs: &Type) -> Option<Type> {
+    Some(match (lhs, rhs) {
+        (Type::Int, Type::Int) => Type::Int,
+        (Type::Int | Type::Number, Type::Int | Type::Number) => Type::Number,
+        (Type::Float, Type::Int | Type::Float | Type::Number)
+        | (Type::Int | Type::Number, Type::Float) => Type::Float,
+        _ => return None,
+    })
+}
+
 mod math {
     use super::*;
 
@@ -88,13 +105,7 @@ mod math {
     pub(super) fn add(lhs: &Type, rhs: &Type) -> Option<Type> {
         fn reversible_op(lhs: &Type, rhs: &Type) -> Option<Type> {
             Some(match (lhs, rhs) {
-                (Type::Int, Type::Int) => Type::Int,
-                (Type::Float, Type::Float) => Type::Float,
-                (Type::Number, Type::Number) => Type::Number,
-
-                (Type::Number, Type::Int) => Type::Number,
-                (Type::Number, Type::Float) => Type::Float,
-                (Type::Int, Type::Float) => Type::Float,
+                (lhs, rhs) if let Some(out) = number_types(lhs, rhs) => out,
 
                 (Type::String, Type::String) => Type::String,
                 // TODO: should this include glob
@@ -115,14 +126,7 @@ mod math {
     pub(super) fn subtract(lhs: &Type, rhs: &Type) -> Option<Type> {
         fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
             Some(match (lhs, rhs) {
-                (Type::Int, Type::Int) => Type::Int,
-
-                (Type::Float | Type::Int, Type::Float | Type::Int) => Type::Float,
-
-                (
-                    Type::Int | Type::Float | Type::Number,
-                    Type::Int | Type::Float | Type::Number,
-                ) => Type::Number,
+                (lhs, rhs) if let Some(out) = number_types(lhs, rhs) => out,
 
                 (Type::Date, Type::Date) => Type::Duration,
                 (Type::Date, Type::Duration) => Type::Date,
@@ -142,13 +146,7 @@ mod math {
     pub(super) fn multiply(lhs: &Type, rhs: &Type) -> Option<Type> {
         fn reversible_op(lhs: &Type, rhs: &Type) -> Option<Type> {
             Some(match (lhs, rhs) {
-                (Type::Int, Type::Int) => Type::Int,
-                (Type::Float, Type::Float) => Type::Float,
-                (Type::Number, Type::Number) => Type::Number,
-
-                (Type::Number, Type::Int) => Type::Number,
-                (Type::Number, Type::Float) => Type::Float,
-                (Type::Int, Type::Float) => Type::Float,
+                (lhs, rhs) if let Some(out) = number_types(lhs, rhs) => out,
 
                 (Type::Filesize, Type::Int | Type::Float | Type::Number) => Type::Filesize,
                 (Type::Duration, Type::Int | Type::Float | Type::Number) => Type::Duration,
@@ -188,14 +186,7 @@ mod math {
     pub(super) fn floor_divide(lhs: &Type, rhs: &Type) -> Option<Type> {
         fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
             Some(match (lhs, rhs) {
-                (Type::Int, Type::Int) => Type::Int,
-
-                (Type::Int | Type::Float, Type::Int | Type::Float) => Type::Float,
-
-                (
-                    Type::Int | Type::Float | Type::Number,
-                    Type::Int | Type::Float | Type::Number,
-                ) => Type::Number,
+                (lhs, rhs) if let Some(out) = number_types(lhs, rhs) => out,
 
                 (Type::Filesize, Type::Filesize) => Type::Int,
                 (Type::Duration, Type::Duration) => Type::Int,
@@ -215,14 +206,7 @@ mod math {
     pub(super) fn modulo(lhs: &Type, rhs: &Type) -> Option<Type> {
         fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
             Some(match (lhs, rhs) {
-                (Type::Int, Type::Int) => Type::Int,
-
-                (Type::Float | Type::Int, Type::Float | Type::Int) => Type::Float,
-
-                (
-                    Type::Int | Type::Float | Type::Number,
-                    Type::Int | Type::Float | Type::Number,
-                ) => Type::Number,
+                (lhs, rhs) if let Some(out) = number_types(lhs, rhs) => out,
 
                 (Type::Filesize, Type::Filesize) => Type::Filesize,
                 (Type::Duration, Type::Duration) => Type::Duration,
@@ -242,14 +226,7 @@ mod math {
     pub(super) fn pow(lhs: &Type, rhs: &Type) -> Option<Type> {
         fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
             Some(match (lhs, rhs) {
-                (Type::Int, Type::Int) => Type::Int,
-
-                (Type::Int | Type::Float, Type::Int | Type::Float) => Type::Float,
-
-                (
-                    Type::Int | Type::Float | Type::Number,
-                    Type::Int | Type::Float | Type::Number,
-                ) => Type::Number,
+                (lhs, rhs) if let Some(out) = number_types(lhs, rhs) => out,
 
                 (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
                 (Type::Custom(a), _) => Type::Custom(a.clone()),

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -3339,6 +3339,23 @@ mod input_types {
     #[case::vardecl(b"let a: table<a: int b: int> = [[a b]; [1 1]]", false)]
     #[case::vardecl(b"let a: list<string asd> = []", true)]
     #[case::vardecl(b"let a: record<a: int b: record<a: int> = {a: 1 b: {a: 1}}", true)]
+    #[case::multiple_output_command_to_variable_oneof(
+        br#"
+            def str-or-int []: [nothing -> int, nothing -> string] { if (random bool) { 42 } else { "hello" } }
+            mut x = str-or-int
+            $x = "string"
+            $x = 42
+        "#,
+        false
+    )]
+    #[case::multiple_output_command_to_variable_not_any(
+        br#"
+            def str-or-int []: [nothing -> int, nothing -> string] { if (random bool) { 42 } else { "hello" } }
+            mut x = str-or-int
+            $x = [1 2 3]
+        "#,
+        true
+    )]
     fn test_type_annotations(#[case] phrase: &[u8], #[case] expect_errors: bool) {
         let mut engine_state = EngineState::new();
         add_declarations(&mut engine_state);

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -3339,6 +3339,16 @@ mod input_types {
     #[case::vardecl(b"let a: table<a: int b: int> = [[a b]; [1 1]]", false)]
     #[case::vardecl(b"let a: list<string asd> = []", true)]
     #[case::vardecl(b"let a: record<a: int b: record<a: int> = {a: 1 b: {a: 1}}", true)]
+    #[case::opt_param_is_nullable(b"def f [p?: int] { mut x = $p; $x = null }", false)]
+    #[case::flag_with_type_is_nullable(b"def f [--flag: int] { mut x = $flag; $x = null }", false)]
+    #[case::opt_param_with_default_is_not_nullable(
+        b"def f [p?: int = 42] { mut x = $p; $x = null }",
+        true
+    )]
+    #[case::flag_with_type_and_default_is_not_nullable(
+        b"def f [--flag: int = 42] { mut x = $flag; $x = null }",
+        true
+    )]
     #[case::multiple_output_command_to_variable_oneof(
         br#"
             def str-or-int []: [nothing -> int, nothing -> string] { if (random bool) { 42 } else { "hello" } }

--- a/crates/nu-protocol/src/one_of.rs
+++ b/crates/nu-protocol/src/one_of.rs
@@ -19,7 +19,7 @@ impl OneOf {
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &Type> {
+    pub fn iter(&self) -> impl Iterator<Item = &Type> + Clone {
         self.into_iter()
     }
 

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BlockId, DeclId, DeprecationEntry, Example, FromValue, IntoValue, PipelineData, ShellError,
-    Span, SyntaxShape, Type, Value, VarId,
+    BlockId, CompareTypes, DeclId, DeprecationEntry, Example, FromValue, IntoValue, PipelineData,
+    ShellError, Span, SyntaxShape, Type, TypeSet, Value, VarId,
     engine::{Call, Command, CommandType, EngineState, Stack},
     shell_error::generic::GenericError,
 };
@@ -391,29 +391,29 @@ impl Signature {
         }
     }
 
-    /// Gets the output type from the signature
+    /// Gets the output type from the signature based on `input`
     ///
-    /// If the output was unspecified or the signature has several different
-    /// input types, [`Type::Any`] is returned.  Otherwise, if the signature has
-    /// one or same output types, this type is returned.
+    /// - If the signature's output was unspecified [`Type::Any`] is returned.
+    /// - If `input` is [`None`], it's treated as [`Type::Any`]. i.e. all IO pairs are considered.
+    /// - IO pairs where the given `input` is [assignable to](crate::CompareTypes::is_assignable_to)
+    ///   the input type are considered valid.
+    /// - [Union](TypeSet::union) of all valid outputs are returned.
+    /// - If there are no valid IO pairs for the given `input`, [`None`] is returned.
     // XXX: remove?
-    pub fn get_output_type(&self) -> Type {
-        match self.input_output_types.len() {
-            0 => Type::Any,
-            1 => self.input_output_types[0].1.clone(),
-            _ => {
-                let first = &self.input_output_types[0].1;
-                if self
-                    .input_output_types
-                    .iter()
-                    .all(|(_, output)| output == first)
-                {
-                    first.clone()
-                } else {
-                    Type::Any
-                }
-            }
+    pub fn get_output_type(&self, input: Option<Type>) -> Option<Type> {
+        if self.input_output_types.is_empty() {
+            return Some(Type::Any);
         }
+        let input = input.unwrap_or(Type::Any);
+        let mut it = self
+            .input_output_types
+            .iter()
+            .filter(|(in_ty, _out_ty)| input.is_assignable_to(in_ty))
+            .map(|(_, out)| out)
+            .peekable();
+
+        it.peek()?;
+        it.cloned().reduce(Type::union)
     }
 
     /// Add a default help option to a signature

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -400,11 +400,11 @@ impl Signature {
     /// - [Union](TypeSet::union) of all valid outputs are returned.
     /// - If there are no valid IO pairs for the given `input`, [`None`] is returned.
     // XXX: remove?
-    pub fn get_output_type(&self, input: Option<Type>) -> Option<Type> {
+    pub fn get_output_type(&self, input_type: Option<Type>) -> Option<Type> {
         if self.input_output_types.is_empty() {
             return Some(Type::Any);
         }
-        let input = input.unwrap_or(Type::Any);
+        let input = input_type.unwrap_or(Type::Any);
         let mut it = self
             .input_output_types
             .iter()

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -344,6 +344,8 @@ impl CompareTypes for Type {
             (Type::OneOf(dst_tys), Type::OneOf(src_tys)) => src_tys.is_assignable_to(dst_tys),
             (Type::OneOf(dst_tys), src_ty) => src_ty.is_assignable_to(dst_tys),
             (dst_ty, Type::OneOf(src_tys)) => src_tys.is_assignable_to(dst_ty),
+            // leave it to the runtime
+            (Type::List(_) | Type::Table(_) | Type::Record(_), Type::Custom(_)) => true,
             (lhs, rhs @ Type::CellPath) => rhs.is_subtype_of(lhs),
             (lhs, rhs) => rhs.compare_types(lhs).is_some(),
         }

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -408,7 +408,10 @@ impl Display for Type {
 /// Get a string nicely combining multiple types
 ///
 /// Helpful for listing types in errors
-pub fn combined_type_string(types: &[Type], join_word: &str) -> Option<String> {
+pub fn combined_type_string<'a, I>(types: I, join_word: &str) -> Option<String>
+where
+    I: IntoIterator<Item = &'a Type>,
+{
     use std::fmt::Write as _;
 
     // Deduplicate types to avoid confusing repeated entries like

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -137,30 +137,24 @@ impl Type {
     pub(crate) fn flat_widen(lhs: Type, rhs: Type) -> Result<Type, (Type, Type)> {
         match (lhs, rhs) {
             // disjoint glob/string pair. We don't want to consume lhs/rhs here because subsequent code still needs them.
-            tys @ (Type::Glob, Type::String) | tys @ (Type::String, Type::Glob) => return Err(tys),
+            tys @ (Type::Glob, Type::String) | tys @ (Type::String, Type::Glob) => Err(tys),
             // primitive number hierarchy is extremely common
-            (Type::Int, Type::Float) | (Type::Float, Type::Int) => return Ok(Type::Number),
+            (Type::Int, Type::Float) | (Type::Float, Type::Int) => Ok(Type::Number),
 
             // widen structural collections without checking for subtyping
-            (Type::Record(lhs), Type::Record(rhs)) => {
-                return Ok(Type::Record(lhs.union(rhs)));
-            }
-            (Type::Table(lhs), Type::Table(rhs)) => {
-                return Ok(Type::Table(lhs.union(rhs)));
-            }
+            (Type::Record(lhs), Type::Record(rhs)) => Ok(Type::Record(lhs.union(rhs))),
+            (Type::Table(lhs), Type::Table(rhs)) => Ok(Type::Table(lhs.union(rhs))),
             // We're choosing to lose some information by preferring
             // - `list<oneof<T, record>>` over
             // - `oneof<list<T>, table>`
             (Type::List(list_elem), Type::Table(table_cols))
             | (Type::Table(table_cols), Type::List(list_elem)) => {
-                return Ok(Type::list(list_elem.union(Type::Record(table_cols))));
+                Ok(Type::list(list_elem.union(Type::Record(table_cols))))
             }
             // We're choosing to lose some information by preferring
             // - `list<oneof<T, U>>` over
             // - `oneof<list<T>, list<U>>`
-            (Type::List(lhs), Type::List(rhs)) => {
-                return Ok(Type::list(lhs.union(*rhs)));
-            }
+            (Type::List(lhs), Type::List(rhs)) => Ok(Type::list(lhs.union(*rhs))),
             // If one type is already a subtype of the other, we can skip all of the heavier logic below.
             (lhs, rhs) => match lhs.compare_types(&rhs) {
                 Some(rel) => Ok(match rel {

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -135,17 +135,13 @@ impl Type {
 
     /// Returns supertype of arguments without creating a `oneof`, or falling back to `any` (unless one or both of the arguments are `any`)
     pub(crate) fn flat_widen(lhs: Type, rhs: Type) -> Result<Type, (Type, Type)> {
-        // handle special cases and hot paths
-        let (lhs, rhs) = match (lhs, rhs) {
+        match (lhs, rhs) {
             // disjoint glob/string pair. We don't want to consume lhs/rhs here because subsequent code still needs them.
             tys @ (Type::Glob, Type::String) | tys @ (Type::String, Type::Glob) => return Err(tys),
             // primitive number hierarchy is extremely common
             (Type::Int, Type::Float) | (Type::Float, Type::Int) => return Ok(Type::Number),
-            tys => tys,
-        };
 
-        // widen structural collections without checking for subtyping
-        let (lhs, rhs) = match (lhs, rhs) {
+            // widen structural collections without checking for subtyping
             (Type::Record(lhs), Type::Record(rhs)) => {
                 return Ok(Type::Record(lhs.union(rhs)));
             }
@@ -165,18 +161,16 @@ impl Type {
             (Type::List(lhs), Type::List(rhs)) => {
                 return Ok(Type::list(lhs.union(*rhs)));
             }
-            tys => tys,
-        };
-
-        // If one type is already a subtype of the other, we can skip all of the heavier logic below.
-        match lhs.compare_types(&rhs) {
-            Some(rel) => Ok(match rel {
-                TypeRelation::Subtype => rhs,
-                TypeRelation::Equal => lhs,
-                TypeRelation::Supertype => lhs,
-            }),
-            // Fallback - the two types are unrelated. Move them out so that callers don't have to clone again.
-            _ => Err((lhs, rhs)),
+            // If one type is already a subtype of the other, we can skip all of the heavier logic below.
+            (lhs, rhs) => match lhs.compare_types(&rhs) {
+                Some(rel) => Ok(match rel {
+                    TypeRelation::Subtype => rhs,
+                    TypeRelation::Equal => lhs,
+                    TypeRelation::Supertype => lhs,
+                }),
+                // Fallback - the two types are unrelated. Move them out so that callers don't have to clone again.
+                _ => Err((lhs, rhs)),
+            },
         }
     }
 

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -151,17 +151,11 @@ impl Type {
             // widen structural collections without checking for subtyping
             (Type::Record(lhs), Type::Record(rhs)) => Ok(Type::Record(lhs.union(rhs))),
             (Type::Table(lhs), Type::Table(rhs)) => Ok(Type::Table(lhs.union(rhs))),
-            // We're choosing to lose some information by preferring
-            // - `list<oneof<T, record>>` over
-            // - `oneof<list<T>, table>`
-            (Type::List(list_elem), Type::Table(table_cols))
-            | (Type::Table(table_cols), Type::List(list_elem)) => {
-                Ok(Type::list(list_elem.union(Type::Record(table_cols))))
-            }
-            // We're choosing to lose some information by preferring
-            // - `list<oneof<T, U>>` over
-            // - `oneof<list<T>, list<U>>`
-            (Type::List(lhs), Type::List(rhs)) => Ok(Type::list(lhs.union(*rhs))),
+
+            // We want to have `oneof<list<T>, table>`, regardless whether one counts as a subtype
+            // of the other.
+            tys @ ((Type::List(_), Type::Table(_)) | (Type::Table(_), Type::List(_))) => Err(tys),
+
             // If one type is already a subtype of the other, we can skip all of the heavier logic below.
             (lhs, rhs) => match lhs.compare_types(&rhs) {
                 Some(rel) => Ok(match rel {
@@ -170,7 +164,7 @@ impl Type {
                     TypeRelation::Supertype => lhs,
                 }),
                 // Fallback - the two types are unrelated. Move them out so that callers don't have to clone again.
-                _ => Err((lhs, rhs)),
+                None => Err((lhs, rhs)),
             },
         }
     }

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -136,8 +136,12 @@ impl Type {
     /// Returns supertype of arguments without creating a `oneof`, or falling back to `any` (unless one or both of the arguments are `any`)
     pub(crate) fn flat_widen(lhs: Type, rhs: Type) -> Result<Type, (Type, Type)> {
         match (lhs, rhs) {
+            // short circuit on `any`
+            (Type::Any, _) | (_, Type::Any) => Ok(Type::Any),
+
             // disjoint glob/string pair. We don't want to consume lhs/rhs here because subsequent code still needs them.
             tys @ (Type::Glob, Type::String) | tys @ (Type::String, Type::Glob) => Err(tys),
+
             // primitive number hierarchy is extremely common
             (Type::Int, Type::Float) | (Type::Float, Type::Int) => Ok(Type::Number),
 

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -566,21 +566,13 @@ mod tests {
 
         #[test]
         fn test_list_table_widen_preserves_list() {
-            // verify that list<record> widened with table does not drop the list wrapper.
-            let list_record = Type::List(Box::new(Type::Record(
-                vec![("a".to_string(), Type::Int)].into(),
-            )));
+            let list_record = Type::list(Type::Record(vec![("a".to_string(), Type::Int)].into()));
             let table = Type::Table(vec![("a".to_string(), Type::Int)].into());
 
             let widened = list_record.clone().union(table.clone());
-            let expected = Type::List(Box::new(Type::Record(
-                vec![("a".to_string(), Type::Int)].into(),
-            )));
-            assert_eq!(widened, expected);
+            let expected = Type::one_of([list_record, table]);
 
-            // and the other way around
-            let widened2 = table.union(list_record.clone());
-            assert_eq!(widened2, expected);
+            assert_eq!(widened, expected);
         }
 
         #[test]

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -139,11 +139,14 @@ impl Type {
             // short circuit on `any`
             (Type::Any, _) | (_, Type::Any) => Ok(Type::Any),
 
-            // disjoint glob/string pair. We don't want to consume lhs/rhs here because subsequent code still needs them.
-            tys @ (Type::Glob, Type::String) | tys @ (Type::String, Type::Glob) => Err(tys),
-
             // primitive number hierarchy is extremely common
             (Type::Int, Type::Float) | (Type::Float, Type::Int) => Ok(Type::Number),
+
+            // despite their subtyping relation, these pairs should not combine into one or the other
+            tys @ ((Type::Glob, Type::String)
+            | (Type::String, Type::Glob)
+            | (Type::String | Type::Int, Type::CellPath)
+            | (Type::CellPath, Type::String | Type::Int)) => Err(tys),
 
             // widen structural collections without checking for subtyping
             (Type::Record(lhs), Type::Record(rhs)) => Ok(Type::Record(lhs.union(rhs))),

--- a/crates/nu-std/std-rfc/tables/mod.nu
+++ b/crates/nu-std/std-rfc/tables/mod.nu
@@ -13,76 +13,60 @@
 export def aggregate [
     --ops: record, # default = {min: {math min}, avg: {math avg}, max: {math max}, sum: {math sum}}  
     ...columns: cell-path, # columns to perform aggregations on
-]: [
-    table -> table<count: int>,
-    record -> error,
-] {
-  def aggregate-default-ops [] {
-      {
-          min: {math min},
-          avg: {math avg},
-          max: {math max},
-          sum: {math sum},
-      }
-  }
+]: [table -> table<count: int>] {
+    def aggregate-default-ops [] {
+        {
+            min: {math min},
+            avg: {math avg},
+            max: {math max},
+            sum: {math sum},
+        }
+    }
 
-  def aggregate-col-name [col: cell-path, op_name: string]: [nothing -> string] {
-      $col | split cell-path | get value | str join "." | $"($in)_($op_name)"
-  }
+    def aggregate-col-name [col: cell-path, op_name: string]: [nothing -> string] {
+        $col | split cell-path | get value | str join "." | $"($in)_($op_name)"
+    }
 
-  def get-item-with-error [
-      col: cell-path,
-      opts: record<span: record<start: int, end: int>, items: bool>
-  ]: [table -> any] {
-      try {
-          get $col
-      } catch {
-          let full_cellpath = if $opts.items {
-              $col
-              | split cell-path
-              | prepend {value: items, optional: false}
-              | into cell-path
-          } else {
-              $col
-          }
-          error make {
-              msg: $"Cannot find column '($full_cellpath)'",
-              label: {
-                  text: "value originates here",
-                  span: $opts.span
-              },
-          }
-      }
-  }
-
-  def "error-make not-a-table" [span: record<start: int, end:int>] {
-      error make {
-          msg: "input must be a table",
-          label: {
-              text: "from here",
-              span: $span
-          },
-          help: "Are you using `group-by`? Make sure to use its `--to-table` flag."
-      }
-  }
+    def get-item-with-error [
+        col: cell-path,
+        opts: record<span: record<start: int, end: int>, items: bool>
+    ]: [table -> any] {
+        try {
+            get $col
+        } catch {
+            let full_cellpath = if $opts.items {
+                $col
+                | split cell-path
+                | prepend {value: items, optional: false}
+                | into cell-path
+            } else {
+                $col
+            }
+            error make {
+                msg: $"Cannot find column '($full_cellpath)'",
+                label: {
+                    text: "value originates here",
+                    span: $opts.span
+                },
+            }
+        }
+    }
 
     let IN = $in
     let md = metadata $in
 
-    let first = try { $IN | first } catch { error-make not-a-table $md.span }
-    if not (($first | describe) starts-with record) {
-        error-make not-a-table $md.span
+    let grouped = "items" in $IN.0
+
+    let IN = match $grouped {
+        true => $IN,
+        # input is treated as if it's a single group
+        false => [[items]; [$IN]]
     }
 
-    let grouped = "items" in $first
-
-    let IN = if $grouped {
-        $IN
-    } else {
-        [{items: $IN}]
+    let agg_ops = match $ops {
+        null => { aggregate-default-ops },
+        _ => $ops,
     }
-
-    let agg_ops = $ops | default (aggregate-default-ops)
 
     let results = $IN
     | update items {|group|
@@ -103,24 +87,10 @@ export def aggregate [
             | reduce {|it| merge $it}
         }
 
-        # Manually propagate errors
-        for r in $column_results {
-            if ($r | describe) == error {
-                return $r
-            }
-        }
-
         $column_results
         | reduce --fold {} {|it| merge $it}
         | insert count ($group.items | length)
         | roll right  # put count as the first column
-    }
-
-    # Manually propagate errors
-    for r in $results {
-        if ($r.items | describe) == error {
-            return $r.items
-        }
     }
 
     $results | flatten items

--- a/crates/nu-std/tests/test_std-rfc_tables.nu
+++ b/crates/nu-std/tests/test_std-rfc_tables.nu
@@ -295,14 +295,12 @@ def aggregate_default_ops [] {
 
 @test
 def throw_error_on_non-table_input [] {
-    # without --to-table
-    let out = try {
-        $movies | group-by Genre | aggregate Worldwide_Gross
-    } catch {|e|
-        $e.msg
-    }
-
-    assert equal $out "input must be a table"
+    assert error {
+        # without --to-table
+        $movies
+        | group-by Genre
+        | aggregate Worldwide_Gross
+    } "Input type not supported."
 }
 
 @test

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -1,4 +1,6 @@
 use crate::repl::tests::{TestResult, fail_test, run_test, run_test_contains};
+use nu_experimental::ENFORCE_RUNTIME_ANNOTATIONS;
+use nu_test_support::prelude::*;
 use rstest::rstest;
 
 #[test]
@@ -310,4 +312,28 @@ fn array_of_wrong_types() -> TestResult {
         "0..128 | each {} | into string | bytes collect",
         "nu::shell::only_supports_this_input_type",
     )
+}
+
+#[test]
+#[exp(ENFORCE_RUNTIME_ANNOTATIONS)]
+fn optional_parameters_and_flags_are_nullable() -> Result {
+    let mut tester = test();
+
+    let code = "
+        def foo [opt_param?: int] {
+            let var = $opt_param
+        }
+        foo
+    ";
+    let () = tester.run(code)?;
+
+    let code = "
+        def foo [--flag: int] {
+            let var = $flag
+        }
+        foo
+    ";
+    let () = tester.run(code)?;
+
+    Ok(())
 }

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -149,15 +149,18 @@ fn record_subtyping_works() -> TestResult {
 // [ list supertype, table ]
 #[case(
     "let foo = [ [ { a: 1 } ], [ [a, b]; [1, 2] ] ];",
-    "list<list<record<a: int>>>"
+    "list<oneof<list<record<a: int>>, table<a: int, b: int>>>"
 )]
 // [ list, table supertype ]
 #[case(
     "let foo = [ [{ a: 1, b: 2 }], [ [a]; [1] ] ];",
-    "list<list<record<a: int>>>"
+    "list<oneof<list<record<a: int, b: int>>, table<a: int>>>"
 )]
 // disjoint element types: empty element supertype
-#[case("let foo = [[ [bar]; [1] ], [ { baz: 1 } ] ];", "list<list<record>>")]
+#[case(
+    "let foo = [[ [bar]; [1] ], [ { baz: 1 } ] ];",
+    "list<oneof<table<bar: int>, list<record<baz: int>>>>"
+)]
 // `bar: int` and `bar: number` are widened to table<bar: number>
 #[case(
     "let n: number = 1; let foo = [ [bar]; [1], [$n] ];",


### PR DESCRIPTION
## Description

- The parse time output type of commands are now based on the provided input's type. Previously if a commands had multiple output types its output was always inferred as `any`
  <img width="928" height="324" alt="image" src="https://github.com/user-attachments/assets/c99e816e-b031-4a67-ad94-ee3e0d4f5aad" />

- The (parse time) types of optional parameters and flags *without a default value* are now a union of their type `T` and `nothing`
  - with no default value the type is `oneof<T, nothing>`
  - with a default value type is `T`

  Demonstrating with lsp inlay hints:
  Before:
    <img width="442" height="100" alt="image" src="https://github.com/user-attachments/assets/ea0ef6f6-4cec-4708-bdc2-9a095d21763c" />
  After:
    <img width="442" height="100" alt="image" src="https://github.com/user-attachments/assets/44ba6cc8-18eb-4569-9498-9ec0eb0285ae" />
    <img width="442" height="100" alt="image" src="https://github.com/user-attachments/assets/167dcd0b-d16a-4ae8-8d2c-0fcaac166ba6" />

- More type information is preserved. e.g.:
  ```nushell
  let list = [["a" "b" "c"] [1 2 3]]
  let elem = $list.0
  ```
  - previously `elem`'s type would be `list<oneof<int, string>>`
  - now `elem`'s type is `oneof<list<int>, list<string>>`

- Operator type checking now works with `oneof` types. Previously, while `int + any` was allowed, `int + oneof<int, nothing>` would be a parse time error.
  Now, as long as the operands *might* work the parse time type checker will accept them and leave any possible errors happen at runtime.
  This might seem like a backwards step at first glance; however due to the other changes, values that would previously have been `any` now have a more specific `oneof` type. As a result, despite this weakening *more* errors are caught at parse time.

This PR supersedes:
- #18215
- #18212

## User-facing changes (Release notes)

### Type System Improvements

This release comes with a handful of improvements to the type system, specifically the parse time type checking. But beware! Type annotations that previously seemed fine might raise errors, as they might have been passing only because typing information was insufficient to check it at parse time.

#### Commands' output types are now inferred based on pipeline input type.

```nushell
let str = "foo" | str uppercase
let str_list = ["foo", "bar" ] | str uppercase

scope variables
| where name starts-with '$str'
| select name type
```

<table><tr><td>

```ansi:no-line-numbers title="Before"
[39m╭───┬───────────┬──────╮[0m
[39m│[0m [1;32m#[0m [39m│[0m   [1;32mname[0m    [39m│[0m [1;32mtype[0m [39m│[0m
[39m├───┼───────────┼──────┤[0m
[39m│[0m [1;32m0[0m [39m│[0m [39m$str[0m      [39m│[0m [39many[0m  [39m│[0m
[39m│[0m [1;32m1[0m [39m│[0m [39m$str_list[0m [39m│[0m [39many[0m  [39m│[0m
[39m╰───┴───────────┴──────╯[0m
```

</td><td>

```ansi:no-line-numbers title="After"
[39m╭───┬───────────┬──────────────╮[0m
[39m│[0m [1;32m#[0m [39m│[0m   [1;32mname[0m    [39m│[0m     [1;32mtype[0m     [39m│[0m
[39m├───┼───────────┼──────────────┤[0m
[39m│[0m [1;32m0[0m [39m│[0m [39m$str[0m      [39m│[0m [39mstring[0m       [39m│[0m
[39m│[0m [1;32m1[0m [39m│[0m [39m$str_list[0m [39m│[0m [39mlist<string>[0m [39m│[0m
[39m╰───┴───────────┴──────────────╯[0m
```

</td></tr></table>

### Optional parameters' type now reflects the fact it might be `null`

The (parse time) types of optional parameters and flags *without a default value* are now a union of their type `T` and `nothing`
- with no default value the type is `oneof<T, nothing>`
- with a default value type is `T`

Demonstrating with LSP inlay hints:
Before:
  <img width="442" height="100" alt="image" src="https://github.com/user-attachments/assets/ea0ef6f6-4cec-4708-bdc2-9a095d21763c" />
After:
  <img width="442" height="100" alt="image" src="https://github.com/user-attachments/assets/44ba6cc8-18eb-4569-9498-9ec0eb0285ae" />
  <img width="442" height="100" alt="image" src="https://github.com/user-attachments/assets/167dcd0b-d16a-4ae8-8d2c-0fcaac166ba6" />

### More precise type widening

More type information is preserved. e.g.:
```nushell
let list = [["a" "b" "c"] [1 2 3]]
let elem = $list.0
```
Previously `$elem`'s type would be `list<oneof<int, string>>`, now `$elem`'s type is `oneof<list<int>, list<string>>`.

### Operator type checking now accounts of `oneof` types

nushell as language tries to strike a careful balance between correctness and convenience.
One should be able to trust nu's type system will help them write correct and robust scripts, but nu shouldn't shouldn't get in the way of a nice REPL experience.

Because of that, some operations that might be invalid but aren't definitely so do not raise parse errors and such checks are delegated to runtime.

For example `int`'s can only be added with `int`'s and `float`'s, yet the following code does not raise parse time error.

```nushell
def foo [anything: any] {
    10 + $anything
}
```

But previously, despite being `oneof<int, nothing>` being specific than `any`, would be rejected by the type checker for addition to `int`s.

```nushell
def foo [maybe_int: oneof<int, nothing>] {
    10 + $maybe_int
}
```
```ansi:no-line-numbers
Error: [31mnu::parser::operator_unsupported_type

[39m  [31m×[39m The '+' operator does not work on values of type 'oneof<int, nothing>'.
   ╭─[[22;1;36;4mrepl_entry #2:2:8[22;39;24m]
 [22;2m1[22m │ def foo [maybe_int: oneof<int, nothing>] {
 [22;2m2[22m │     10 + $maybe_int
   · [22;1;35m       ┬[33m ─────┬────
[22;39m   ·        [22;1;35m│[22;39m      [22;1;33m╰── oneof<int, nothing>
[22;39m   ·        [22;1;35m╰── does not support 'oneof<int, nothing>'
[22;39m [22;2m3[22m │ }
   ╰────[m
```

Now, as long as the two operands have a possibility of being valid for an operation the parse time type checker will accept the expression, leaving errors to runtime type checking.

## Additional Notes

I have further work for:
- properly typing `let` assignments from pipeline input
- correct pipeline input type received in command definitions/blocks
- properly typing `$in` variable

<img width="246" height="227" alt="image" src="https://github.com/user-attachments/assets/730c7af9-dd47-4be7-ad61-344dd7ac0f82" />

However, I'm not happy with the code quality of these changes and unsure of how well edge cases are handled. So I'm leaving them for a later PR to not hinder this one.