### PR TITLE
Fix indented NUON tables without commas

### DIFF
--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -78,6 +78,20 @@ fn to_nuon_table() -> Result {
 }
 
 #[test]
+fn to_nuon_table_indented_without_commas_keeps_columns_separated() -> Result {
+    let code = r#"
+        [[name, type, size, modified];
+            ["CHANGELOG.md", file, 279384b, 2026-04-07T18:46:29.753556336-07:00],
+            ["Cargo.lock", file, 82973b, 2026-06-17T17:19:53.350382583-07:00]]
+        | to nuon --indent 2 --no-commas
+    "#;
+
+    test().run(code).expect_value_eq(
+        "[\n  [name           type size    modified];\n  [\"CHANGELOG.md\" file 279384b 2026-04-07T18:46:29.753556336-07:00]\n  [\"Cargo.lock\"   file 82973b  2026-06-17T17:19:53.350382583-07:00]\n]",
+    )
+}
+
+#[test]
 fn to_nuon_table_as_list_of_records() -> Result {
     let code = "
         [[a, b]; [1, 2], [3, 4]]

--- a/crates/nuon/src/lib.rs
+++ b/crates/nuon/src/lib.rs
@@ -670,10 +670,8 @@ version = "1.0.0"
         );
     }
 
-    #[test]
-    fn table_column_alignment_with_indent() {
-        let engine_state = EngineState::new();
-        let val = Value::test_list(vec![
+    fn aligned_table_value() -> Value {
+        Value::test_list(vec![
             Value::test_record(record!(
                 "name" => Value::test_string("alice"),
                 "age" => Value::test_int(22),
@@ -689,7 +687,13 @@ version = "1.0.0"
                 "age" => Value::test_int(20),
                 "active" => Value::test_bool(false)
             )),
-        ]);
+        ])
+    }
+
+    #[test]
+    fn table_column_alignment_with_indent() {
+        let engine_state = EngineState::new();
+        let val = aligned_table_value();
         let result = to_nuon(
             &engine_state,
             &val,
@@ -700,6 +704,27 @@ version = "1.0.0"
             result,
             "[\n  [name,    age, active];\n  [alice,   22,  true],\n  [bob,     20,  false],\n  [charlie, 20,  false]\n]"
         );
+        // roundtrip: aligned output parses back to the same value
+        assert_eq!(val, from_nuon(&result, None).unwrap());
+    }
+
+    #[test]
+    fn table_column_alignment_with_indent_and_no_commas() {
+        let engine_state = EngineState::new();
+        let val = aligned_table_value();
+        let result = to_nuon(
+            &engine_state,
+            &val,
+            ToNuonConfig::default()
+                .style(ToStyle::Spaces(2))
+                .use_commas(false),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            "[\n  [name    age active];\n  [alice   22  true]\n  [bob     20  false]\n  [charlie 20  false]\n]"
+        );
+        assert!(!result.contains("[nameageactive]"));
         // roundtrip: aligned output parses back to the same value
         assert_eq!(val, from_nuon(&result, None).unwrap());
     }

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -338,9 +338,10 @@ fn value_to_string(
                         }
                     }
 
-                    // Per-cell trailing separator: comma (if enabled) plus padding to column
-                    // width + 2 keeps columns aligned in both `--pretty` and
-                    // `--pretty --no-commas` modes.
+                    // Per-cell trailing separator: comma (if enabled) plus enough padding to
+                    // keep the next column separated and aligned. When commas are disabled, the
+                    // padding is the only separator, so keep at least one space between cells.
+                    let cell_separator_width = if options.use_commas { 2 } else { 1 };
                     let pad_row = |items: &[String]| -> String {
                         let mut out = String::new();
                         for (i, item) in items.iter().enumerate() {
@@ -349,7 +350,7 @@ fn value_to_string(
                                     out,
                                     "{:<width$}",
                                     format!("{item}{c}"),
-                                    width = widths[i] + 2
+                                    width = widths[i] + cell_separator_width
                                 );
                             } else {
                                 out.push_str(item);


### PR DESCRIPTION
## Description

Fixes #18429.

This updates indented NUON table formatting so `--no-commas` still leaves whitespace between aligned table cells after the comma separator is removed. It prevents outputs like `[nametypesizemodified]` while keeping indented table rows parseable.

## User-facing changes (Release notes)

Fixed `to nuon --indent ... --no-commas` table output so columns remain separated by whitespace instead of being concatenated.

## Additional notes

Focused verification run locally:

- `cargo fmt --all -- --check`
- `cargo test -p nuon --lib --quiet`
- `cargo test -p nu-command --test tests format_conversions::nuon --quiet`
- `cargo clippy -p nuon --lib --tests -- -D warnings -D clippy::unwrap_used`
