### PR TITLE
Serialize `CellPath` via string representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4979,6 +4979,7 @@ dependencies = [
  "web-time",
  "windows 0.62.2",
  "windows-sys 0.61.2",
+ "winnow 1.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,15 +280,16 @@ uu_uname = "0.9.0"
 uucore = "0.9.0"
 uuid = "1.23.1"
 v_htmlescape = "0.15.8"
+memchr = "2.8.0"
 wax = "0.7.0"
 web-time = "1.1.0"
+webpki-roots = "1.0.7"
 which = "8.0.2"
 win_uds = "=0.2.2"
 windows = "0.62.2"
 windows-sys = "0.61.2"
+winnow = "1.0"
 winreg = "0.56"
-memchr = "2.8.0"
-webpki-roots = "1.0.7"
 
 [workspace.lints.clippy]
 # Warning: workspace lints affect library code as well as tests, so don't enable lints that would be too noisy in tests like that.

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -43,6 +43,7 @@ heck = { workspace = true }
 humantime = { workspace = true }
 indexmap = { workspace = true }
 lru = { workspace = true }
+memchr = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-backtrace"] }
 num-format = { workspace = true }
 rmp-serde = { workspace = true, optional = true }
@@ -55,7 +56,7 @@ typetag = "0.2"
 os_pipe = { workspace = true, optional = true, features = ["io_safety"] }
 log = { workspace = true }
 web-time = { workspace = true }
-memchr = { workspace = true }
+winnow = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, default-features = false, features = ["signal"] }

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -2,10 +2,11 @@ use super::Expression;
 use crate::{Span, casing::Casing};
 use nu_utils::{escape_quote_string, needs_quoting};
 use serde::{Deserialize, Serialize};
-use std::{cmp::Ordering, fmt::Display};
+use std::{cmp::Ordering, fmt::Display, str::FromStr};
+use winnow::Parser;
 
 /// One level of access of a [`CellPath`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub enum PathMember {
     /// Accessing a member by string (i.e. columns of a table or [`Record`](crate::Record))
     String {
@@ -173,6 +174,70 @@ impl PartialOrd for PathMember {
     }
 }
 
+impl Display for PathMember {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PathMember::Int { val, optional, .. } => {
+                let question_mark = if *optional { "?" } else { "" };
+                write!(f, "{val}{question_mark}")
+            }
+            PathMember::String {
+                val,
+                optional,
+                casing,
+                ..
+            } => {
+                let question_mark = if *optional { "?" } else { "" };
+                let exclamation_mark = if *casing == Casing::Insensitive {
+                    "!"
+                } else {
+                    ""
+                };
+                let val = if needs_quoting(val) {
+                    &escape_quote_string(val)
+                } else {
+                    val
+                };
+                write!(f, "{val}{exclamation_mark}{question_mark}")
+            }
+        }
+    }
+}
+
+// TODO: make this error better
+#[derive(Debug, thiserror::Error)]
+#[error("could not parse path member")]
+pub struct PathMemberParseError;
+
+impl FromStr for PathMember {
+    type Err = PathMemberParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse::path_member
+            .parse(s)
+            .map_err(|_| PathMemberParseError)
+    }
+}
+
+impl Serialize for PathMember {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_string().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for PathMember {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
 /// [`PathMember`] for testing purposes.
 ///
 /// This path member may be converted via [`into_path_member`](Self::into_path_member) into a
@@ -216,7 +281,7 @@ impl TestPathMember<usize> {
 /// col2
 /// 42
 /// ```
-#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct CellPath {
     pub members: Vec<PathMember>,
 }
@@ -265,37 +330,45 @@ impl Display for CellPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "$")?;
         for member in self.members.iter() {
-            match member {
-                PathMember::Int { val, optional, .. } => {
-                    let question_mark = if *optional { "?" } else { "" };
-                    write!(f, ".{val}{question_mark}")?
-                }
-                PathMember::String {
-                    val,
-                    optional,
-                    casing,
-                    ..
-                } => {
-                    let question_mark = if *optional { "?" } else { "" };
-                    let exclamation_mark = if *casing == Casing::Insensitive {
-                        "!"
-                    } else {
-                        ""
-                    };
-                    let val = if needs_quoting(val) {
-                        &escape_quote_string(val)
-                    } else {
-                        val
-                    };
-                    write!(f, ".{val}{exclamation_mark}{question_mark}")?
-                }
-            }
+            write!(f, ".{member}")?;
         }
         // Empty cell-paths are `$.` not `$`
         if self.members.is_empty() {
             write!(f, ".")?;
         }
         Ok(())
+    }
+}
+
+// TODO: make this error better
+#[derive(Debug, thiserror::Error)]
+#[error("could not parse cell path")]
+pub struct CellPathParseError;
+
+impl FromStr for CellPath {
+    type Err = CellPathParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse::cell_path.parse(s).map_err(|_| CellPathParseError)
+    }
+}
+
+impl Serialize for CellPath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_string().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for CellPath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 
@@ -525,7 +598,6 @@ mod parse {
 mod test {
     use super::*;
     use std::cmp::Ordering::Greater;
-    use winnow::prelude::*;
 
     #[test]
     fn path_member_partial_ord() {
@@ -561,12 +633,5 @@ mod test {
                 &PathMember::test_string("e".into(), true, Casing::Sensitive)
             )
         );
-    }
-
-    #[test]
-    fn parse() {
-        let input = r#"$.2!.3?.abc?.'def'!."gh\"lol""#;
-        let cell_path = super::parse::cell_path.parse(input).unwrap();
-        panic!("{cell_path:#?}");
     }
 }

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -204,10 +204,11 @@ impl Display for PathMember {
     }
 }
 
-// TODO: make this error better
 #[derive(Debug, thiserror::Error)]
-#[error("could not parse path member")]
-pub struct PathMemberParseError;
+#[error("could not parse path member {attempted:?}")]
+pub struct PathMemberParseError {
+    attempted: String,
+}
 
 impl FromStr for PathMember {
     type Err = PathMemberParseError;
@@ -215,7 +216,9 @@ impl FromStr for PathMember {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         parse::path_member
             .parse(s)
-            .map_err(|_| PathMemberParseError)
+            .map_err(|_| PathMemberParseError {
+                attempted: s.to_owned(),
+            })
     }
 }
 
@@ -346,16 +349,19 @@ impl Display for CellPath {
     }
 }
 
-// TODO: make this error better
 #[derive(Debug, thiserror::Error)]
-#[error("could not parse cell path")]
-pub struct CellPathParseError;
+#[error("could not parse cell path {attempted:?}")]
+pub struct CellPathParseError {
+    attempted: String,
+}
 
 impl FromStr for CellPath {
     type Err = CellPathParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse::cell_path.parse(s).map_err(|_| CellPathParseError)
+        parse::cell_path.parse(s).map_err(|_| CellPathParseError {
+            attempted: s.to_owned(),
+        })
     }
 }
 

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -308,12 +308,7 @@ pub struct FullCellPath {
 mod parse {
     use super::*;
     use winnow::{
-        Result, Str,
-        combinator::*,
-        error::{ContextError, ParserError, StrContext, StrContextValue},
-        prelude::*,
-        stream::ContainsToken,
-        token::*,
+        Result, Str, combinator::*, error::*, prelude::*, stream::ContainsToken, token::*,
     };
 
     pub fn cell_path(input: &mut &str) -> Result<CellPath> {
@@ -405,7 +400,7 @@ mod parse {
         let string = alt((
             single_quoted_string,
             bare_word_string,
-            // double_quoted_string,
+            double_quoted_string,
             unquoted_string,
         ))
         .parse_next(input)?;
@@ -454,14 +449,38 @@ mod parse {
             .map(|s| s.to_owned())
     }
 
-    fn double_quoted_string(input: &mut &str) -> Result<String> {
-        todo!()
-    }
-
     fn bare_word_string(input: &mut &str) -> Result<String> {
         delimited("`", take_while(0.., |c| c != '`'), "`")
             .parse_next(input)
             .map(|s| s.to_owned())
+    }
+
+    fn double_quoted_string(input: &mut &str) -> Result<String> {
+        fn escaped(input: &mut &str) -> Result<char> {
+            preceded(
+                '\\',
+                alt((
+                    'n'.value('\n'),
+                    'r'.value('\r'),
+                    't'.value('\t'),
+                    '\\'.value('\\'),
+                    '/'.value('/'),
+                    '"'.value('"'),
+                )),
+            )
+            .parse_next(input)
+        }
+
+        fn char(input: &mut &str) -> Result<char> {
+            any.verify(|c| *c != '"').parse_next(input)
+        }
+
+        let content = repeat(0.., alt((escaped, char))).fold(String::new, |mut string, char| {
+            string.push(char);
+            string
+        });
+
+        delimited('"', content, '"').parse_next(input)
     }
 
     #[derive(Default)]
@@ -546,7 +565,7 @@ mod test {
 
     #[test]
     fn parse() {
-        let input = "$.2!.3?.abc?.'def'!";
+        let input = r#"$.2!.3?.abc?.'def'!."gh\"lol""#;
         let cell_path = super::parse::cell_path.parse(input).unwrap();
         panic!("{cell_path:#?}");
     }

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -287,6 +287,12 @@ pub struct CellPath {
 }
 
 impl CellPath {
+    pub fn empty() -> Self {
+        Self {
+            members: Vec::new(),
+        }
+    }
+
     pub fn make_optional(&mut self) {
         for member in &mut self.members {
             member.make_optional();

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -308,24 +308,25 @@ pub struct FullCellPath {
 mod parse {
     use super::*;
     use winnow::{
-        Result, Str, combinator::*, error::{ContextError, ParserError}, prelude::*, stream::ContainsToken,
+        Result, Str,
+        combinator::*,
+        error::{ContextError, ParserError, StrContext, StrContextValue},
+        prelude::*,
+        stream::ContainsToken,
         token::*,
     };
 
     pub fn cell_path(input: &mut &str) -> Result<CellPath> {
-        preceded(
-            opt("$."),
-            repeat(0.., terminated(path_member, opt('.'))),
-        )
-        .parse_next(input)
-        .map(|members| CellPath { members })
+        preceded(opt("$."), repeat(0.., terminated(path_member, opt('.'))))
+            .parse_next(input)
+            .map(|members| CellPath { members })
     }
 
     pub fn path_member(input: &mut &str) -> Result<PathMember> {
         if input.is_empty() {
             return Err(ParserError::from_input(input));
         }
-        
+
         let member = alt((int_path_member, string_path_member)).parse_next(input)?;
 
         // ensure there's no more content after a member
@@ -336,8 +337,12 @@ mod parse {
 
     fn int_path_member(input: &mut &str) -> Result<PathMember> {
         let int = digits.parse_next(input)?;
-        let optional = opt('?').parse_next(input)?.is_some();
-        Ok(PathMember::Int { val: int, span: Span::unknown(), optional })
+        let modifier = modifier.parse_next(input)?;
+        Ok(PathMember::Int {
+            val: int,
+            span: Span::unknown(),
+            optional: modifier.optional,
+        })
     }
 
     fn digits(input: &mut &str) -> Result<usize> {
@@ -397,7 +402,103 @@ mod parse {
     }
 
     fn string_path_member(input: &mut &str) -> Result<PathMember> {
+        let string = alt((
+            single_quoted_string,
+            bare_word_string,
+            // double_quoted_string,
+            unquoted_string,
+        ))
+        .parse_next(input)?;
+
+        let modifier = modifier.parse_next(input)?;
+
+        Ok(PathMember::String {
+            val: string,
+            span: Span::unknown(),
+            optional: modifier.optional,
+            casing: match modifier.case_insensitive {
+                true => Casing::Insensitive,
+                false => Default::default(),
+            },
+        })
+    }
+
+    fn unquoted_string(input: &mut &str) -> Result<String> {
+        struct UnquotedTokens;
+
+        impl ContainsToken<char> for UnquotedTokens {
+            fn contains_token(&self, token: char) -> bool {
+                match token {
+                    // spaces and tabs
+                    ' ' | '\n' | '\t' => false,
+
+                    // syntax characters
+                    '!' | '?' | '.' => false,
+
+                    // brackets
+                    '(' | ')' => false,
+
+                    _ => true,
+                }
+            }
+        }
+
+        take_while(0.., UnquotedTokens)
+            .parse_next(input)
+            .map(|s| s.to_owned())
+    }
+
+    fn single_quoted_string(input: &mut &str) -> Result<String> {
+        delimited("'", take_while(0.., |c| c != '\''), "'")
+            .parse_next(input)
+            .map(|s| s.to_owned())
+    }
+
+    fn double_quoted_string(input: &mut &str) -> Result<String> {
         todo!()
+    }
+
+    fn bare_word_string(input: &mut &str) -> Result<String> {
+        delimited("`", take_while(0.., |c| c != '`'), "`")
+            .parse_next(input)
+            .map(|s| s.to_owned())
+    }
+
+    #[derive(Default)]
+    struct Modifier {
+        optional: bool,
+        case_insensitive: bool,
+    }
+
+    fn modifier(input: &mut &str) -> Result<Modifier> {
+        let mut modifier = Modifier::default();
+
+        loop {
+            let Some(next) = opt(alt(('!', '?'))).parse_next(input)? else {
+                break;
+            };
+
+            let expected = match (next, modifier.optional, modifier.case_insensitive) {
+                ('!', _, false) => {
+                    modifier.case_insensitive = true;
+                    continue;
+                }
+                ('?', false, _) => {
+                    modifier.optional = true;
+                    continue;
+                }
+                ('!', false, true) => "'?' or '.'",
+                ('!', true, true) => "'.'",
+                ('?', true, false) => "'!' or '.'",
+                ('?', true, true) => "'.'",
+                (c, _, _) => unreachable!("parser only returns with '!' or '?', got {c:?}"),
+            };
+
+            fail.context(StrContext::Expected(StrContextValue::Description(expected)))
+                .parse_next(input)?
+        }
+
+        Ok(modifier)
     }
 }
 
@@ -445,7 +546,7 @@ mod test {
 
     #[test]
     fn parse() {
-        let input = "$.2!.3";
+        let input = "$.2!.3?.abc?.'def'!";
         let cell_path = super::parse::cell_path.parse(input).unwrap();
         panic!("{cell_path:#?}");
     }

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -305,10 +305,107 @@ pub struct FullCellPath {
     pub tail: Vec<PathMember>,
 }
 
+mod parse {
+    use super::*;
+    use winnow::{
+        Result, Str, combinator::*, error::{ContextError, ParserError}, prelude::*, stream::ContainsToken,
+        token::*,
+    };
+
+    pub fn cell_path(input: &mut &str) -> Result<CellPath> {
+        preceded(
+            opt("$."),
+            repeat(0.., terminated(path_member, opt('.'))),
+        )
+        .parse_next(input)
+        .map(|members| CellPath { members })
+    }
+
+    pub fn path_member(input: &mut &str) -> Result<PathMember> {
+        if input.is_empty() {
+            return Err(ParserError::from_input(input));
+        }
+        
+        let member = alt((int_path_member, string_path_member)).parse_next(input)?;
+
+        // ensure there's no more content after a member
+        peek(alt((".", eof))).parse_next(input)?;
+
+        Ok(member)
+    }
+
+    fn int_path_member(input: &mut &str) -> Result<PathMember> {
+        let int = digits.parse_next(input)?;
+        let optional = opt('?').parse_next(input)?.is_some();
+        Ok(PathMember::Int { val: int, span: Span::unknown(), optional })
+    }
+
+    fn digits(input: &mut &str) -> Result<usize> {
+        let start = input.checkpoint();
+        if let Ok(prefix) = digit_prefix.parse_next(input) {
+            return match prefix {
+                DigitPrefix::Bin => bin_digits.parse_next(input),
+                DigitPrefix::Oct => oct_digits.parse_next(input),
+                DigitPrefix::Hex => hex_digits.parse_next(input),
+            };
+        }
+
+        input.reset(&start);
+        dec_digits.parse_next(input)
+    }
+
+    enum DigitPrefix {
+        Bin,
+        Oct,
+        Hex,
+    }
+
+    fn digit_prefix(input: &mut &str) -> Result<DigitPrefix> {
+        let prefix = take(2usize).parse_next(input)?;
+        Ok(match prefix {
+            "0b" => DigitPrefix::Bin,
+            "0o" => DigitPrefix::Oct,
+            "Ox" => DigitPrefix::Hex,
+            _ => return fail(input),
+        })
+    }
+
+    fn bin_digits(input: &mut &str) -> Result<usize> {
+        any_radix_digits(2, ('_', '0', '1')).parse_next(input)
+    }
+
+    fn oct_digits(input: &mut &str) -> Result<usize> {
+        any_radix_digits(8, ('_', '0'..='7')).parse_next(input)
+    }
+
+    fn dec_digits(input: &mut &str) -> Result<usize> {
+        any_radix_digits(10, ('_', '0'..='9')).parse_next(input)
+    }
+
+    fn hex_digits(input: &mut &str) -> Result<usize> {
+        any_radix_digits(16, ('_', '0'..='9', 'a'..='f', 'A'..='Z')).parse_next(input)
+    }
+
+    fn any_radix_digits<'i>(
+        radix: u32,
+        tokens: impl ContainsToken<char>,
+    ) -> impl Parser<Str<'i>, usize, ContextError> {
+        take_while(1.., tokens)
+            .map(|d: &str| d.replace('_', ""))
+            .verify(|d: &str| !d.is_empty())
+            .try_map(move |d| usize::from_str_radix(&d, radix))
+    }
+
+    fn string_path_member(input: &mut &str) -> Result<PathMember> {
+        todo!()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use std::cmp::Ordering::Greater;
+    use winnow::prelude::*;
 
     #[test]
     fn path_member_partial_ord() {
@@ -344,5 +441,12 @@ mod test {
                 &PathMember::test_string("e".into(), true, Casing::Sensitive)
             )
         );
+    }
+
+    #[test]
+    fn parse() {
+        let input = "$.2!.3";
+        let cell_path = super::parse::cell_path.parse(input).unwrap();
+        panic!("{cell_path:#?}");
     }
 }

--- a/crates/nu-protocol/tests/cell_path.rs
+++ b/crates/nu-protocol/tests/cell_path.rs
@@ -3,12 +3,48 @@ use nu_test_support::prelude::*;
 use rstest::rstest;
 
 #[rstest]
+#[case("'quoted member'?!.name")]
+#[case("'quoted member'.name")]
+#[case("`two words`!?.name")]
+#[case("`two words`.name")]
+#[case("$.")]
+#[case("$.abc")]
+#[case("0!?")]
+#[case("0!")]
+#[case("0?!")]
+#[case("0?")]
+#[case("0.abc")]
+#[case("0")]
+#[case("abc!?.def")]
+#[case("abc!.def")]
+#[case("abc?!.def")]
+#[case("abc.0?.def?")]
+#[case("abc.0")]
 #[case("abc")]
+#[case("items.0.1")]
+#[case("items.0b1010")]
+#[case("items.0o12")]
+#[case("items.1_000")]
+#[case(r#""double quoted"!?.name"#)]
+#[case(r#""double quoted".name"#)]
 fn engine_eq_from_str(#[case] input: &str) -> Result {
     let mut tester = test();
     let () = tester.run("def cell-path [cp: cell-path] { $cp }")?;
     let via_engine: CellPath = tester.run(format!("cell-path {input}"))?;
-    let via_from_str: CellPath = input.parse().unwrap();
+    let via_from_str: CellPath = input.parse().expect("cell path parses");
     assert_eq!(via_engine, via_from_str);
     Ok(())
+}
+
+#[rstest]
+#[case("abc??")]
+#[case("abc!!")]
+#[case("abc?!?")]
+#[case("abc!?!")]
+#[case("0??")]
+#[case("0!!")]
+#[case("0?!?")]
+#[case("0!?!")]
+fn rejects_invalid_cell_paths(#[case] input: &str) {
+    assert!(input.parse::<CellPath>().is_err());
 }

--- a/crates/nu-protocol/tests/cell_path.rs
+++ b/crates/nu-protocol/tests/cell_path.rs
@@ -46,8 +46,6 @@ fn engine_eq_from_str(#[case] input: &str) -> Result {
 #[case(test_cell_path!("quoted member".name))]
 #[case(test_cell_path!("two words"!?.name))]
 #[case(test_cell_path!("two words".name))]
-#[case(test_cell_path!())]
-#[case(test_cell_path!())]
 #[case(test_cell_path!(0!?))]
 #[case(test_cell_path!(0!))]
 #[case(test_cell_path!(0?!))]
@@ -67,6 +65,7 @@ fn engine_eq_from_str(#[case] input: &str) -> Result {
 #[case(test_cell_path!(items.0b1010))]
 #[case(test_cell_path!(items.0o12))]
 #[case(test_cell_path!(items.1_000))]
+#[case(CellPath::empty())]
 fn roundtrip(#[case] input: CellPath) {
     let serialized = serde_json::to_string(&input).unwrap();
     let deserialized = serde_json::from_str(&serialized).unwrap();

--- a/crates/nu-protocol/tests/cell_path.rs
+++ b/crates/nu-protocol/tests/cell_path.rs
@@ -1,5 +1,5 @@
 use nu_protocol::ast::CellPath;
-use nu_test_support::prelude::*;
+use nu_test_support::{prelude::*, test_cell_path};
 use rstest::rstest;
 
 #[rstest]
@@ -8,6 +8,9 @@ use rstest::rstest;
 #[case("`two words`!?.name")]
 #[case("`two words`.name")]
 #[case("$.")]
+#[case("$.")]
+#[case("$.34")]
+#[case("$.abc")]
 #[case("$.abc")]
 #[case("0!?")]
 #[case("0!")]
@@ -34,6 +37,40 @@ fn engine_eq_from_str(#[case] input: &str) -> Result {
     let via_from_str: CellPath = input.parse().expect("cell path parses");
     assert_eq!(via_engine, via_from_str);
     Ok(())
+}
+
+#[rstest]
+#[case(test_cell_path!("double quoted"!?.name))]
+#[case(test_cell_path!("double quoted".name))]
+#[case(test_cell_path!("quoted member"?!.name))]
+#[case(test_cell_path!("quoted member".name))]
+#[case(test_cell_path!("two words"!?.name))]
+#[case(test_cell_path!("two words".name))]
+#[case(test_cell_path!())]
+#[case(test_cell_path!())]
+#[case(test_cell_path!(0!?))]
+#[case(test_cell_path!(0!))]
+#[case(test_cell_path!(0?!))]
+#[case(test_cell_path!(0?))]
+#[case(test_cell_path!(0.abc))]
+#[case(test_cell_path!(0))]
+#[case(test_cell_path!(34))]
+#[case(test_cell_path!(abc!?.def))]
+#[case(test_cell_path!(abc!.def))]
+#[case(test_cell_path!(abc?!.def))]
+#[case(test_cell_path!(abc.0?.def?))]
+#[case(test_cell_path!(abc.0))]
+#[case(test_cell_path!(abc))]
+#[case(test_cell_path!(abc))]
+#[case(test_cell_path!(abc))]
+#[case(test_cell_path!(items.0 .1))]
+#[case(test_cell_path!(items.0b1010))]
+#[case(test_cell_path!(items.0o12))]
+#[case(test_cell_path!(items.1_000))]
+fn roundtrip(#[case] input: CellPath) {
+    let serialized = serde_json::to_string(&input).unwrap();
+    let deserialized = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(input, deserialized);
 }
 
 #[rstest]

--- a/crates/nu-protocol/tests/cell_path.rs
+++ b/crates/nu-protocol/tests/cell_path.rs
@@ -1,0 +1,14 @@
+use nu_protocol::ast::CellPath;
+use nu_test_support::prelude::*;
+use rstest::rstest;
+
+#[rstest]
+#[case("abc")]
+fn engine_eq_from_str(#[case] input: &str) -> Result {
+    let mut tester = test();
+    let () = tester.run("def cell-path [cp: cell-path] { $cp }")?;
+    let via_engine: CellPath = tester.run(format!("cell-path {input}"))?;
+    let via_from_str: CellPath = input.parse().unwrap();
+    assert_eq!(via_engine, via_from_str);
+    Ok(())
+}

--- a/crates/nu-protocol/tests/main.rs
+++ b/crates/nu-protocol/tests/main.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
+mod cell_path;
 mod into_config;
 mod pipeline;
 mod test_config;


### PR DESCRIPTION
## Description

In this PR I changed how `CellPath` is serialized, from the derived implementation to a single string representation, matching how cell paths are written in Nushell code.

Before this PR, serialization for `CellPath` was derived, which produced record-like output unless it was handled separately. Most commands already used the `Display` impl for serialization anyway, so this should not affect user code.

Since serialization was derived, deserialization was derived as well. Most formats do not have type hints to tell the deserializer to expect a cell path, except for nuon, so this was usually not an issue. However, some formats do allow type hints, and without custom deserialization we cannot easily deserialize cell paths in an elegant way.

This uses `winnow` to implement a very small parser specifically for cell paths. `winnow` is already in our dependency graph anyway, twice actually, so we can just use it here. Extracting this behavior from our parser would be really hard, so to ensure parity, the implementation is tested against the parser.

## User-facing changes (Release notes)

n/a
