### PR TITLE
fix!: make `from ods` and `from xlsx` consistent

### DIFF
--- a/crates/nu-command/src/formats/from/mod.rs
+++ b/crates/nu-command/src/formats/from/mod.rs
@@ -8,6 +8,7 @@ mod msgpack;
 mod msgpackz;
 mod nuon;
 mod ods;
+mod sheets;
 mod ssv;
 mod toml;
 mod tsv;

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -1,8 +1,6 @@
-use std::io::Cursor;
-
 use calamine::{Ods, Reader, Sheets};
 
-use super::sheets::{collect_binary, from_sheets};
+use super::sheets::{collect_binary, common_sheets_signature, from_sheets};
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
@@ -14,16 +12,7 @@ impl Command for FromOds {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("from ods")
-            .input_output_types(vec![(Type::String, Type::record())])
-            .allow_variants_without_examples(true)
-            .named(
-                "sheets",
-                SyntaxShape::List(Box::new(SyntaxShape::String)),
-                "Only convert specified sheets.",
-                Some('s'),
-            )
-            .category(Category::Formats)
+        common_sheets_signature("from ods")
     }
 
     fn description(&self) -> &str {
@@ -38,22 +27,20 @@ impl Command for FromOds {
         mut input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let sel_sheets = call
-            .get_flag::<Vec<String>>(engine_state, stack, "sheets")?
-            .unwrap_or_default();
         let metadata = input.take_metadata().map(|md| md.with_content_type(None));
 
         let input_span = input.span().unwrap_or(head);
-        let bytes = collect_binary(input, head)?;
-        let buf: Cursor<Vec<u8>> = Cursor::new(bytes);
-        let sheets = Sheets::Ods(Ods::new(buf).map_err(|_| ShellError::UnsupportedInput {
+        let reader = collect_binary(input, head)?;
+        let ods = Ods::new(reader).map_err(|_| ShellError::UnsupportedInput {
             msg: "Could not load ODS file".to_string(),
             input: "value originates from here".into(),
             msg_span: head,
             input_span,
-        })?);
+        })?;
+        let sheets = Sheets::Ods(ods);
 
-        from_sheets(sheets, sel_sheets, input_span, head).map(|pd| pd.set_metadata(metadata))
+        from_sheets(sheets, input_span, engine_state, stack, call)
+            .map(|pd| pd.set_metadata(metadata))
     }
 
     fn examples(&self) -> Vec<Example<'_>> {

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -55,6 +55,11 @@ impl Command for FromOds {
                 example: "open --raw test.ods | from ods --sheets [Spreadsheet1]",
                 result: None,
             },
+            Example {
+                description: "Convert binary .ods data to a table, specifying the tables and specifying no header row.",
+                example: "open --raw test.ods | from ods --sheets [Spreadsheet1] --noheaders",
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -1,8 +1,9 @@
-use calamine::*;
-use indexmap::IndexMap;
-use nu_engine::command_prelude::*;
-
 use std::io::Cursor;
+
+use calamine::{Ods, Reader, Sheets};
+
+use super::sheets::{collect_binary, from_sheets};
+use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
 pub struct FromOds;
@@ -14,7 +15,7 @@ impl Command for FromOds {
 
     fn signature(&self) -> Signature {
         Signature::build("from ods")
-            .input_output_types(vec![(Type::String, Type::table())])
+            .input_output_types(vec![(Type::String, Type::record())])
             .allow_variants_without_examples(true)
             .named(
                 "sheets",
@@ -37,17 +38,22 @@ impl Command for FromOds {
         mut input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-
-        let sel_sheets = if let Some(Value::List { vals: columns, .. }) =
-            call.get_flag(engine_state, stack, "sheets")?
-        {
-            convert_columns(columns.as_slice())?
-        } else {
-            vec![]
-        };
-
+        let sel_sheets = call
+            .get_flag::<Vec<String>>(engine_state, stack, "sheets")?
+            .unwrap_or_default();
         let metadata = input.take_metadata().map(|md| md.with_content_type(None));
-        from_ods(input, head, sel_sheets).map(|pd| pd.set_metadata(metadata))
+
+        let input_span = input.span().unwrap_or(head);
+        let bytes = collect_binary(input, head)?;
+        let buf: Cursor<Vec<u8>> = Cursor::new(bytes);
+        let sheets = Sheets::Ods(Ods::new(buf).map_err(|_| ShellError::UnsupportedInput {
+            msg: "Could not load ODS file".to_string(),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span,
+        })?);
+
+        from_sheets(sheets, sel_sheets, input_span, head).map(|pd| pd.set_metadata(metadata))
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -64,114 +70,6 @@ impl Command for FromOds {
             },
         ]
     }
-}
-
-fn convert_columns(columns: &[Value]) -> Result<Vec<String>, ShellError> {
-    let res = columns
-        .iter()
-        .map(|value| match &value {
-            Value::String { val: s, .. } => Ok(s.clone()),
-            _ => Err(ShellError::IncompatibleParametersSingle {
-                msg: "Incorrect column format, Only string as column name".to_string(),
-                span: value.span(),
-            }),
-        })
-        .collect::<Result<Vec<String>, _>>()?;
-
-    Ok(res)
-}
-
-fn collect_binary(input: PipelineData, span: Span) -> Result<Vec<u8>, ShellError> {
-    if let PipelineData::ByteStream(stream, ..) = input {
-        stream.into_bytes()
-    } else {
-        let mut bytes = vec![];
-        let mut values = input.into_iter();
-
-        loop {
-            match values.next() {
-                Some(Value::Binary { val: b, .. }) => {
-                    bytes.extend_from_slice(&b);
-                }
-                Some(Value::Error { error, .. }) => return Err(*error),
-                Some(x) => {
-                    return Err(ShellError::UnsupportedInput {
-                        msg: "Expected binary from pipeline".to_string(),
-                        input: "value originates from here".into(),
-                        msg_span: span,
-                        input_span: x.span(),
-                    });
-                }
-                None => break,
-            }
-        }
-
-        Ok(bytes)
-    }
-}
-
-fn from_ods(
-    input: PipelineData,
-    head: Span,
-    sel_sheets: Vec<String>,
-) -> Result<PipelineData, ShellError> {
-    let span = input.span();
-    let bytes = collect_binary(input, head)?;
-    let buf: Cursor<Vec<u8>> = Cursor::new(bytes);
-    let mut ods = Ods::<_>::new(buf).map_err(|_| ShellError::UnsupportedInput {
-        msg: "Could not load ODS file".to_string(),
-        input: "value originates from here".into(),
-        msg_span: head,
-        input_span: span.unwrap_or(head),
-    })?;
-
-    let mut dict = IndexMap::new();
-
-    let mut sheet_names = ods.sheet_names();
-    if !sel_sheets.is_empty() {
-        sheet_names.retain(|e| sel_sheets.contains(e));
-    }
-
-    for sheet_name in sheet_names {
-        let mut sheet_output = vec![];
-
-        if let Ok(current_sheet) = ods.worksheet_range(&sheet_name) {
-            for row in current_sheet.rows() {
-                let record = row
-                    .iter()
-                    .enumerate()
-                    .map(|(i, cell)| {
-                        let value = match cell {
-                            Data::Empty => Value::nothing(head),
-                            Data::String(s) => Value::string(s, head),
-                            Data::Float(f) => Value::float(*f, head),
-                            Data::Int(i) => Value::int(*i, head),
-                            Data::Bool(b) => Value::bool(*b, head),
-                            _ => Value::nothing(head),
-                        };
-
-                        (format!("column{i}"), value)
-                    })
-                    .collect();
-
-                sheet_output.push(Value::record(record, head));
-            }
-
-            dict.insert(sheet_name, Value::list(sheet_output, head));
-        } else {
-            return Err(ShellError::UnsupportedInput {
-                msg: "Could not load sheet".to_string(),
-                input: "value originates from here".into(),
-                msg_span: head,
-                input_span: span.unwrap_or(head),
-            });
-        }
-    }
-
-    Ok(PipelineData::value(
-        Value::record(dict.into_iter().collect(), head),
-        None,
-    ))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/formats/from/sheets.rs
+++ b/crates/nu-command/src/formats/from/sheets.rs
@@ -17,6 +17,18 @@ pub(super) fn common_sheets_signature(name: &str) -> Signature {
             "Only convert specified sheets.",
             Some('s'),
         )
+        .switch(
+            "noheaders",
+            "Don't treat the first row as column names.",
+            Some('n'),
+        )
+        .named(
+            "first-row",
+            SyntaxShape::Int,
+            "The row to start reading the sheets from. \
+                By default, reading starts from the firsts non empty row.",
+            Some('f'),
+        )
         .category(Category::Formats)
 }
 
@@ -47,6 +59,11 @@ pub(super) fn from_sheets(
 ) -> std::result::Result<PipelineData, ShellError> {
     let head = call.head;
 
+    let noheaders = call.has_flag(engine_state, stack, "noheaders")?;
+    let first_row = call
+        .get_flag::<u32>(engine_state, stack, "first-row")?
+        .map(HeaderRow::Row)
+        .unwrap_or(HeaderRow::FirstNonEmptyRow);
     let sheet_names = {
         let sel_sheets = call
             .get_flag::<Vec<String>>(engine_state, stack, "sheets")?
@@ -63,6 +80,8 @@ pub(super) fn from_sheets(
         _ => Utc.fix(),
     };
 
+    sheets.with_header_row(first_row);
+
     let output = sheet_names
         .into_iter()
         .map(|name| {
@@ -78,16 +97,46 @@ pub(super) fn from_sheets(
 
             let rows = sheet
                 .rows()
-                .map(|row| {
-                    row.iter()
-                        .enumerate()
-                        .map(|(idx, cell)| (format!("column{idx}"), cell_to_data(cell, head, tz)))
-                        .collect::<Record>()
-                        .into_value(head)
-                })
-                .collect::<Vec<_>>();
+                .map(|row| row.iter().map(|cell| cell_to_data(cell, head, tz)));
 
-            Ok((name, rows.into_value(head)))
+            if !noheaders && let Some(headers) = sheet.headers() {
+                let headers = headers
+                    .into_iter()
+                    .chain(std::iter::repeat(String::new()))
+                    .enumerate()
+                    .map(|(idx, s)| {
+                        if s.is_empty() {
+                            format!("column{idx}")
+                        } else {
+                            s
+                        }
+                    });
+
+                // the original iterator must remain immutable. can only be used by cloning
+                let headers = &headers;
+
+                let rows = rows
+                    .skip(1)
+                    .map(|row| {
+                        headers
+                            .clone()
+                            .zip(row)
+                            .collect::<Record>()
+                            .into_value(head)
+                    })
+                    .collect::<Vec<_>>();
+                Ok((name, rows.into_value(head)))
+            } else {
+                let rows = rows
+                    .map(|row| {
+                        row.enumerate()
+                            .map(|(idx, value)| (format!("column{idx}"), value))
+                            .collect::<Record>()
+                            .into_value(head)
+                    })
+                    .collect::<Vec<_>>();
+                Ok((name, rows.into_value(head)))
+            }
         })
         .collect::<Result<Record, ShellError>>()?;
 

--- a/crates/nu-command/src/formats/from/sheets.rs
+++ b/crates/nu-command/src/formats/from/sheets.rs
@@ -7,8 +7,24 @@ use chrono::{
 
 use nu_engine::command_prelude::*;
 
-pub(super) fn collect_binary(input: PipelineData, head: Span) -> Result<Vec<u8>, ShellError> {
-    match input {
+pub(super) fn common_sheets_signature(name: &str) -> Signature {
+    Signature::build(name)
+        .input_output_types(vec![(Type::Binary, Type::record())])
+        .allow_variants_without_examples(true)
+        .named(
+            "sheets",
+            SyntaxShape::List(Box::new(SyntaxShape::String)),
+            "Only convert specified sheets.",
+            Some('s'),
+        )
+        .category(Category::Formats)
+}
+
+pub(super) fn collect_binary(
+    input: PipelineData,
+    head: Span,
+) -> Result<Cursor<Vec<u8>>, ShellError> {
+    let buf = match input {
         // Deserialize from a byte buffer
         PipelineData::Value(Value::Binary { val: bytes, .. }, _) => Ok(bytes),
         // Deserialize from a raw stream directly without having to collect it
@@ -18,16 +34,23 @@ pub(super) fn collect_binary(input: PipelineData, head: Span) -> Result<Vec<u8>,
             dst_span: head,
             src_span: input.span().unwrap_or(head),
         }),
-    }
+    };
+    Ok(Cursor::new(buf?))
 }
 
 pub(super) fn from_sheets(
     mut sheets: Sheets<Cursor<Vec<u8>>>,
-    sel_sheets: Vec<String>,
     input_span: Span,
-    head: Span,
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
 ) -> std::result::Result<PipelineData, ShellError> {
+    let head = call.head;
+
     let sheet_names = {
+        let sel_sheets = call
+            .get_flag::<Vec<String>>(engine_state, stack, "sheets")?
+            .unwrap_or_default();
         let mut sheets = sheets.sheet_names();
         if !sel_sheets.is_empty() {
             sheets.retain(|e| sel_sheets.contains(e));

--- a/crates/nu-command/src/formats/from/sheets.rs
+++ b/crates/nu-command/src/formats/from/sheets.rs
@@ -1,0 +1,127 @@
+use std::io::Cursor;
+
+use calamine::*;
+use chrono::{
+    Local, NaiveDateTime, Offset as _, TimeDelta, TimeZone as _, Utc, offset::LocalResult,
+};
+
+use nu_engine::command_prelude::*;
+
+pub(super) fn collect_binary(input: PipelineData, head: Span) -> Result<Vec<u8>, ShellError> {
+    match input {
+        // Deserialize from a byte buffer
+        PipelineData::Value(Value::Binary { val: bytes, .. }, _) => Ok(bytes),
+        // Deserialize from a raw stream directly without having to collect it
+        PipelineData::ByteStream(stream, ..) => stream.into_bytes(),
+        input => Err(ShellError::PipelineMismatch {
+            exp_input_type: "binary or byte stream".into(),
+            dst_span: head,
+            src_span: input.span().unwrap_or(head),
+        }),
+    }
+}
+
+pub(super) fn from_sheets(
+    mut sheets: Sheets<Cursor<Vec<u8>>>,
+    sel_sheets: Vec<String>,
+    input_span: Span,
+    head: Span,
+) -> std::result::Result<PipelineData, ShellError> {
+    let sheet_names = {
+        let mut sheets = sheets.sheet_names();
+        if !sel_sheets.is_empty() {
+            sheets.retain(|e| sel_sheets.contains(e));
+        }
+        sheets
+    };
+
+    let tz = match Local.timestamp_opt(0, 0) {
+        LocalResult::Single(tz) => *tz.offset(),
+        _ => Utc.fix(),
+    };
+
+    let output = sheet_names
+        .into_iter()
+        .map(|name| {
+            let sheet =
+                sheets
+                    .worksheet_range(&name)
+                    .map_err(|_| ShellError::UnsupportedInput {
+                        msg: "Could not load sheet".to_string(),
+                        input: "value originates from here".into(),
+                        msg_span: head,
+                        input_span,
+                    })?;
+
+            let rows = sheet
+                .rows()
+                .map(|row| {
+                    row.iter()
+                        .enumerate()
+                        .map(|(idx, cell)| (format!("column{idx}"), cell_to_data(cell, head, tz)))
+                        .collect::<Record>()
+                        .into_value(head)
+                })
+                .collect::<Vec<_>>();
+
+            Ok((name, rows.into_value(head)))
+        })
+        .collect::<Result<Record, ShellError>>()?;
+
+    Ok(output.into_value(head).into_pipeline_data())
+}
+
+fn cell_to_data(cell: &Data, head: Span, tz: chrono::FixedOffset) -> Value {
+    match cell {
+        Data::Empty => Value::nothing(head),
+        Data::Int(val) => Value::int(*val, head),
+        Data::Float(val) => Value::float(*val, head),
+        Data::String(val) => Value::string(val, head),
+        Data::Bool(val) => Value::bool(*val, head),
+        Data::DateTime(d) => excel_datetime_to_value(d, tz, head),
+        d @ Data::DateTimeIso(_) => d
+            .as_datetime()
+            .map(|naive_datetime| datetime_naive_to_fixed(naive_datetime, tz, head))
+            .unwrap_or(Value::nothing(head)),
+        d @ Data::DurationIso(_) => d
+            .as_duration()
+            .map(|time_delta| timedelta_to_value(time_delta, head))
+            .unwrap_or(Value::nothing(head)),
+
+        // Not great.
+        Data::Error(_) => Value::nothing(head),
+    }
+}
+
+fn datetime_naive_to_fixed(
+    naive_datetime: NaiveDateTime,
+    tz: chrono::FixedOffset,
+    span: Span,
+) -> Value {
+    match tz.from_local_datetime(&naive_datetime) {
+        LocalResult::Single(d) => d.into_value(span),
+        LocalResult::Ambiguous(_, d) => d.into_value(span),
+        _ => Value::nothing(span),
+    }
+}
+
+fn timedelta_to_value(time_delta: TimeDelta, span: Span) -> Value {
+    time_delta
+        .num_nanoseconds()
+        .map(|val| Value::duration(val, span))
+        .unwrap_or(Value::nothing(span))
+}
+
+fn excel_datetime_to_value(
+    excel_datetime: &ExcelDateTime,
+    tz: chrono::FixedOffset,
+    span: Span,
+) -> Value {
+    match excel_datetime {
+        d if let Some(naive_datetime) = d.as_datetime() => {
+            datetime_naive_to_fixed(naive_datetime, tz, span)
+        }
+        d if let Some(time_delta) = d.as_duration() => timedelta_to_value(time_delta, span),
+        _ => Value::nothing(span),
+    }
+}

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -57,7 +57,7 @@ impl Command for FromXlsx {
             },
             Example {
                 description: "Convert binary .xlsx data to a table, specifying the tables and specifying no header row.",
-                example: "open --raw test.xlsx | from xlsx --sheets [Spreadsheet1] --header-row null",
+                example: "open --raw test.xlsx | from xlsx --sheets [Spreadsheet1] --noheaders",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -1,8 +1,6 @@
-use std::io::Cursor;
+use calamine::{Reader, Sheets, Xlsx};
 
-use calamine::*;
-
-use super::sheets::{collect_binary, from_sheets};
+use super::sheets::{collect_binary, common_sheets_signature, from_sheets};
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
@@ -14,16 +12,7 @@ impl Command for FromXlsx {
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("from xlsx")
-            .input_output_types(vec![(Type::Binary, Type::record())])
-            .allow_variants_without_examples(true)
-            .named(
-                "sheets",
-                SyntaxShape::List(Box::new(SyntaxShape::String)),
-                "Only convert specified sheets.",
-                Some('s'),
-            )
-            .category(Category::Formats)
+        common_sheets_signature("from xlsx")
     }
 
     fn description(&self) -> &str {
@@ -38,22 +27,20 @@ impl Command for FromXlsx {
         mut input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let sel_sheets = call
-            .get_flag::<Vec<String>>(engine_state, stack, "sheets")?
-            .unwrap_or_default();
         let metadata = input.take_metadata().map(|md| md.with_content_type(None));
 
         let input_span = input.span().unwrap_or(head);
-        let bytes = collect_binary(input, head)?;
-        let buf: Cursor<Vec<u8>> = Cursor::new(bytes);
-        let sheets = Sheets::Xlsx(Xlsx::new(buf).map_err(|_| ShellError::UnsupportedInput {
+        let reader = collect_binary(input, head)?;
+        let xlsx = Xlsx::new(reader).map_err(|_| ShellError::UnsupportedInput {
             msg: "Could not load XLSX file".to_string(),
             input: "value originates from here".into(),
             msg_span: head,
             input_span,
-        })?);
+        })?;
+        let sheets = Sheets::Xlsx(xlsx);
 
-        from_sheets(sheets, sel_sheets, input_span, head).map(|pd| pd.set_metadata(metadata))
+        from_sheets(sheets, input_span, engine_state, stack, call)
+            .map(|pd| pd.set_metadata(metadata))
     }
 
     fn examples(&self) -> Vec<Example<'_>> {

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -1,9 +1,9 @@
-use calamine::*;
-use chrono::{Local, LocalResult, Offset, TimeZone, Utc};
-use indexmap::IndexMap;
-use nu_engine::command_prelude::*;
-
 use std::io::Cursor;
+
+use calamine::*;
+
+use super::sheets::{collect_binary, from_sheets};
+use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
 pub struct FromXlsx;
@@ -15,19 +15,13 @@ impl Command for FromXlsx {
 
     fn signature(&self) -> Signature {
         Signature::build("from xlsx")
-            .input_output_types(vec![(Type::Binary, Type::table())])
+            .input_output_types(vec![(Type::Binary, Type::record())])
             .allow_variants_without_examples(true)
             .named(
                 "sheets",
                 SyntaxShape::List(Box::new(SyntaxShape::String)),
                 "Only convert specified sheets.",
                 Some('s'),
-            )
-            .named(
-                "header-row",
-                SyntaxShape::OneOf(vec![SyntaxShape::Int, SyntaxShape::Nothing]),
-                "Specify row (0-indexed) to designate the header (default first non-empty row) or null for no header",
-                Some('r'),
             )
             .category(Category::Formats)
     }
@@ -44,26 +38,22 @@ impl Command for FromXlsx {
         mut input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-
-        let sel_sheets = if let Some(Value::List { vals: columns, .. }) =
-            call.get_flag(engine_state, stack, "sheets")?
-        {
-            convert_columns(columns.as_slice())?
-        } else {
-            vec![]
-        };
-
-        let header_row = match call.get_flag(engine_state, stack, "header-row")? {
-            Some(Value::Int { val, .. }) => Some(HeaderRow::Row(
-                val.try_into()
-                    .expect("Header row index should not exceed u32"),
-            )),
-            Some(Value::Nothing { .. }) => None,
-            _ => Some(HeaderRow::FirstNonEmptyRow),
-        };
-
+        let sel_sheets = call
+            .get_flag::<Vec<String>>(engine_state, stack, "sheets")?
+            .unwrap_or_default();
         let metadata = input.take_metadata().map(|md| md.with_content_type(None));
-        from_xlsx(input, head, sel_sheets, header_row).map(|pd| pd.set_metadata(metadata))
+
+        let input_span = input.span().unwrap_or(head);
+        let bytes = collect_binary(input, head)?;
+        let buf: Cursor<Vec<u8>> = Cursor::new(bytes);
+        let sheets = Sheets::Xlsx(Xlsx::new(buf).map_err(|_| ShellError::UnsupportedInput {
+            msg: "Could not load XLSX file".to_string(),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span,
+        })?);
+
+        from_sheets(sheets, sel_sheets, input_span, head).map(|pd| pd.set_metadata(metadata))
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -85,153 +75,6 @@ impl Command for FromXlsx {
             },
         ]
     }
-}
-
-fn convert_columns(columns: &[Value]) -> Result<Vec<String>, ShellError> {
-    let res = columns
-        .iter()
-        .map(|value| match &value {
-            Value::String { val: s, .. } => Ok(s.clone()),
-            _ => Err(ShellError::IncompatibleParametersSingle {
-                msg: "Incorrect column format, Only string as column name".to_string(),
-                span: value.span(),
-            }),
-        })
-        .collect::<Result<Vec<String>, _>>()?;
-
-    Ok(res)
-}
-
-fn collect_binary(input: PipelineData, span: Span) -> Result<Vec<u8>, ShellError> {
-    if let PipelineData::ByteStream(stream, ..) = input {
-        stream.into_bytes()
-    } else {
-        let mut bytes = vec![];
-        let mut values = input.into_iter();
-
-        loop {
-            match values.next() {
-                Some(Value::Binary { val: b, .. }) => {
-                    bytes.extend_from_slice(&b);
-                }
-                Some(x) => {
-                    return Err(ShellError::UnsupportedInput {
-                        msg: "Expected binary from pipeline".to_string(),
-                        input: "value originates from here".into(),
-                        msg_span: span,
-                        input_span: x.span(),
-                    });
-                }
-                None => break,
-            }
-        }
-
-        Ok(bytes)
-    }
-}
-
-fn from_xlsx(
-    input: PipelineData,
-    head: Span,
-    sel_sheets: Vec<String>,
-    header_row: Option<HeaderRow>,
-) -> Result<PipelineData, ShellError> {
-    let span = input.span();
-    let bytes = collect_binary(input, head)?;
-    let buf: Cursor<Vec<u8>> = Cursor::new(bytes);
-    let mut xlsx = Xlsx::<_>::new(buf).map_err(|_| ShellError::UnsupportedInput {
-        msg: "Could not load XLSX file".to_string(),
-        input: "value originates from here".into(),
-        msg_span: head,
-        input_span: span.unwrap_or(head),
-    })?;
-
-    let mut dict = IndexMap::new();
-
-    let mut sheet_names = xlsx.sheet_names();
-    if !sel_sheets.is_empty() {
-        sheet_names.retain(|e| sel_sheets.contains(e));
-    }
-
-    let tz = match Local.timestamp_opt(0, 0) {
-        LocalResult::Single(tz) => *tz.offset(),
-        _ => Utc.fix(),
-    };
-
-    for sheet_name in sheet_names {
-        let mut sheet_output = vec![];
-
-        if let Some(hr) = header_row {
-            xlsx.with_header_row(hr);
-        }
-
-        if let Ok(current_sheet) = xlsx.worksheet_range(&sheet_name) {
-            let sheet_width = current_sheet.width();
-            let default_headers = (0..sheet_width)
-                .map(|i| {
-                    format!(
-                        "column{:0width$}",
-                        i,
-                        width = (sheet_width.ilog10() + 1) as usize
-                    )
-                })
-                .collect::<Vec<String>>();
-
-            let headers = current_sheet
-                .headers()
-                .unwrap_or_else(|| vec!["".to_string(); sheet_width])
-                .into_iter()
-                .zip(default_headers)
-                .map(
-                    |(name, default)| {
-                        if name.is_empty() { default } else { name }
-                    },
-                );
-
-            for row in current_sheet.rows().skip(header_row.is_some() as usize) {
-                let record = headers
-                    .clone()
-                    .zip(row.iter())
-                    .map(|(header_name, cell)| {
-                        let value = match cell {
-                            Data::Empty => Value::nothing(head),
-                            Data::String(s) => Value::string(s, head),
-                            Data::Float(f) => Value::float(*f, head),
-                            Data::Int(i) => Value::int(*i, head),
-                            Data::Bool(b) => Value::bool(*b, head),
-                            Data::DateTime(d) => d
-                                .as_datetime()
-                                .and_then(|d| match tz.from_local_datetime(&d) {
-                                    LocalResult::Single(d) => Some(d),
-                                    _ => None,
-                                })
-                                .map(|d| Value::date(d, head))
-                                .unwrap_or(Value::nothing(head)),
-                            _ => Value::nothing(head),
-                        };
-
-                        (header_name, value)
-                    })
-                    .collect();
-
-                sheet_output.push(Value::record(record, head));
-            }
-
-            dict.insert(sheet_name, Value::list(sheet_output, head));
-        } else {
-            return Err(ShellError::UnsupportedInput {
-                msg: "Could not load sheet".to_string(),
-                input: "value originates from here".into(),
-                msg_span: head,
-                input_span: span.unwrap_or(head),
-            });
-        }
-    }
-
-    Ok(PipelineData::value(
-        Value::record(dict.into_iter().collect(), head),
-        None,
-    ))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/tests/commands/headers.rs
+++ b/crates/nu-command/tests/commands/headers.rs
@@ -4,7 +4,7 @@ use nu_test_support::nu;
 fn headers_uses_first_row_as_header() {
     let actual = nu!(cwd: "tests/fixtures/formats", "
         open sample_headers.xlsx --raw
-        | from xlsx --header-row null
+        | from xlsx --noheaders
         | get Sheet1
         | headers
         | get header0
@@ -17,7 +17,7 @@ fn headers_uses_first_row_as_header() {
 fn headers_adds_missing_column_name() {
     let actual = nu!(cwd: "tests/fixtures/formats", "
         open sample_headers.xlsx --raw
-        | from xlsx --header-row null
+        | from xlsx --noheaders
         | get Sheet1
         | headers
         | get column1

--- a/crates/nu-command/tests/format_conversions/ods.rs
+++ b/crates/nu-command/tests/format_conversions/ods.rs
@@ -3,7 +3,8 @@ use nu_test_support::prelude::*;
 #[test]
 fn from_ods_file_to_table() -> Result {
     let code = "
-        open sample_data.ods
+        open sample_data.ods --raw
+        | from ods --noheaders
         | get SalesOrders
         | get 4
         | get column2
@@ -32,7 +33,7 @@ fn from_ods_file_to_table_select_sheet() -> Result {
 fn from_ods_file_to_table_select_sheet_with_annotations() -> Result {
     let code = r#"
         open sample_data_with_annotation.ods --raw
-        | from ods --sheets ["SalesOrders"]
+        | from ods --sheets ["SalesOrders"] --noheaders
         | get SalesOrders
         | get column4
         | get 0
@@ -43,4 +44,21 @@ fn from_ods_file_to_table_select_sheet_with_annotations() -> Result {
         .cwd("tests/fixtures/formats")
         .run(code)
         .expect_value_eq("Units")
+}
+
+#[test]
+fn from_ods_file_to_table_select_sheet_with_header() -> Result {
+    let code = r#"
+        open sample_data_with_annotation.ods --raw
+        | from ods --sheets ["SalesOrders"]
+        | get SalesOrders
+        | get Units
+        | get 0
+    "#;
+
+    // The Units column in the sheet SalesOrders has an annotation and should be ignored.
+    test()
+        .cwd("tests/fixtures/formats")
+        .run(code)
+        .expect_value_eq(95.00)
 }


### PR DESCRIPTION
## Description

The existing `--header-row` flag conflates 2 separate concepts, likely due to poor naming on calamine's part:

- the first row to be read:

  this has nothing to do with column names of the resulting table. by default, calamine skips the empty rows at the top of a sheet.

  the `with_header_row` method allows explicitly choosing the first row.  it can be used to
  - skip non-empty rows
  - preserve empty rows at the top

  comparable to `detect columns --skip $n`

- naming of the output table's columns. comparable to:
  - using `from csv --noheaders` to treat all rows as data
  - using `headers` to treat the first row as headers

### The current behavior

- ```nushell
  open tests/fixtures/formats/sample_headers.xlsx
  # or
  open tests/fixtures/formats/sample_headers.xlsx --raw
  | from xlsx
  ```
  ```
  ╭────────┬───────────────────────────────────────────────╮
  │        │ ╭───┬─────────┬─────────┬─────────┬─────────╮ │
  │ Sheet1 │ │ # │ header0 │ column1 │ header2 │ column3 │ │
  │        │ ├───┼─────────┼─────────┼─────────┼─────────┤ │
  │        │ │ 0 │ r1c0    │ r1c1    │ r1c2    │ r1c3    │ │
  │        │ │ 1 │ r2c0    │ r2c1    │ r2c2    │ r2c3    │ │
  │        │ ╰───┴─────────┴─────────┴─────────┴─────────╯ │
  ╰────────┴───────────────────────────────────────────────╯
  ```
<!-- -->
- ```nushell
  open tests/fixtures/formats/sample_headers.xlsx --raw
  | from xlsx --header-row null
  ```
  ```
  ╭────────┬───────────────────────────────────────────────╮
  │        │ ╭───┬─────────┬─────────┬─────────┬─────────╮ │
  │ Sheet1 │ │ # │ header0 │ column1 │ header2 │ column3 │ │
  │        │ ├───┼─────────┼─────────┼─────────┼─────────┤ │
  │        │ │ 0 │ header0 │         │ header2 │         │ │
  │        │ │ 1 │ r1c0    │ r1c1    │ r1c2    │ r1c3    │ │
  │        │ │ 2 │ r2c0    │ r2c1    │ r2c2    │ r2c3    │ │
  │        │ ╰───┴─────────┴─────────┴─────────┴─────────╯ │
  ╰────────┴───────────────────────────────────────────────╯
  ```

`--header-row null` keeps the first row in table as data, but *still* uses it for the headers.

### Changes so far

- Remove some code that became redundant due to improvements to `FromValue`
- Fix command signatures. These commands do not return tables, they return *records* that have *tables* as values.
- De-duplicate code between `from xlsx` and `from ods`.
- Properly handle more data types. Particularly date-time and duration.
- Switch to a more functional, pipeline style of code.
- remove `--header-row` flag in favor of `--noheaders` and `--first-row`

### The new behavior

- ```nushell
  open tests/fixtures/formats/sample_headers.xlsx
  # or
  open tests/fixtures/formats/sample_headers.xlsx --raw
  | from xlsx
  ```
  Unchanged
  ```
  ╭────────┬───────────────────────────────────────────────╮
  │        │ ╭───┬─────────┬─────────┬─────────┬─────────╮ │
  │ Sheet1 │ │ # │ header0 │ column1 │ header2 │ column3 │ │
  │        │ ├───┼─────────┼─────────┼─────────┼─────────┤ │
  │        │ │ 0 │ r1c0    │ r1c1    │ r1c2    │ r1c3    │ │
  │        │ │ 1 │ r2c0    │ r2c1    │ r2c2    │ r2c3    │ │
  │        │ ╰───┴─────────┴─────────┴─────────┴─────────╯ │
  ╰────────┴───────────────────────────────────────────────╯
  ```
<!-- -->
- ```nushell
  open tests/fixtures/formats/sample_headers.xlsx --raw
  | from xlsx --noheaders
  ```
  ```
  ╭────────┬───────────────────────────────────────────────╮
  │        │ ╭───┬─────────┬─────────┬─────────┬─────────╮ │
  │ Sheet1 │ │ # │ column0 │ column1 │ column2 │ column3 │ │
  │        │ ├───┼─────────┼─────────┼─────────┼─────────┤ │
  │        │ │ 0 │ header0 │         │ header2 │         │ │
  │        │ │ 1 │ r1c0    │ r1c1    │ r1c2    │ r1c3    │ │
  │        │ │ 2 │ r2c0    │ r2c1    │ r2c2    │ r2c3    │ │
  │        │ ╰───┴─────────┴─────────┴─────────┴─────────╯ │
  ╰────────┴───────────────────────────────────────────────╯
  ```
<!-- -->
- ```nushell
  open tests/fixtures/formats/sample_headers.xlsx --raw
  | from xlsx --first-row 1 --noheaders
  ```
  ```
  ╭────────┬───────────────────────────────────────────────╮
  │        │ ╭───┬─────────┬─────────┬─────────┬─────────╮ │
  │ Sheet1 │ │ # │ column0 │ column1 │ column2 │ column3 │ │
  │        │ ├───┼─────────┼─────────┼─────────┼─────────┤ │
  │        │ │ 0 │ r1c0    │ r1c1    │ r1c2    │ r1c3    │ │
  │        │ │ 1 │ r2c0    │ r2c1    │ r2c2    │ r2c3    │ │
  │        │ ╰───┴─────────┴─────────┴─────────┴─────────╯ │
  ╰────────┴───────────────────────────────────────────────╯
  ```
<!-- -->
- ```nushell
  open tests/fixtures/formats/sample_headers.xlsx --raw
  | from xlsx --first-row 1
  ```
  ```
  ╭────────┬───────────────────────────────────────────────╮
  │        │ ╭───┬─────────┬─────────┬─────────┬─────────╮ │
  │ Sheet1 │ │ # │ r1c0    │ r1c1    │ r1c2    │ r1c3    │ │
  │        │ ├───┼─────────┼─────────┼─────────┼─────────┤ │
  │        │ │ 0 │ r2c0    │ r2c1    │ r2c2    │ r2c3    │ │
  │        │ ╰───┴─────────┴─────────┴─────────┴─────────╯ │
  ╰────────┴───────────────────────────────────────────────╯
  ```

## User-facing changes (Release notes)

### Changes to spreadsheet commands: `from xlsx` & `from ods`

This release comes with various improvements to `from xlsx` and `from ods` commands, and makes them behave as similarly as the file formats themselves allow.

#### More accurate command signatures

These commands' signatures previously incorrectly indicated that they return tables.
They return *records* that contain *tables*, with a table for each sheet in the file.

Also, signature of the `from ods` command previously had `string` as its input type rather than `binary`. This has been fixed.

#### Support for more data types

Previously importing `datetime` values were supported only for `xlsx` files.

This release not only adds that for `ods` files as well, but also broadens the `datetime` formats that can be imported.

Aside from that, values that couldn't be properly coerced to nushell types were simply imported as `null`. Now those values are imported as `string` or `float` depending on the source data.

#### Finer control over spreadsheet headers

Last release changed `from xlsx` to use the first row of a sheet as the imported table's headers, and added a new flag, `--header-row`, to control which row should be used as the header or if any row should become the headers at all.

This release removes it.

Don't worry! Instead of the `--header-row` flag, `from xlsx` *and* `from ods` get two new flags that will provide finer control over how spreadsheets are imported:

- `--noheaders`: What it says on the tin, identical to same flag on `from csv`, `from tsv` and `from ssv` commands.
- `--first-row`: This is where it gets a little interesting. `from xlsx` and `from ods` skip reading all leading empty rows. This is how it has worked for a long time.
  `--first-row=0` allows you to turn that off and keep those empty lines. It can also be used to start reading from an arbitrary row: `--first-row $n`

Let's see how this works with an example:
- The contents of the file, with all the conveniences like skipping empty rows or auto headers:
  ```nushell
  open example.xlsx --raw
  | from xlsx --noheaders --first-row 0
  ```
  ```ansi
  ╭────────┬───────────────────────────────────────────────╮
  │        │ ╭───┬─────────┬─────────┬─────────┬─────────╮ │
  │ [22;1;32mSheet1[22;39m │ │ [22;1;32m#[22;39m │ [22;1;32mcolumn0[22;39m │ [22;1;32mcolumn1[22;39m │ [22;1;32mcolumn2[22;39m │ [22;1;32mcolumn3[22;39m │ │
  │        │ ├───┼─────────┼─────────┼─────────┼─────────┤ │
  │        │ │ [22;1;32m0[22;39m │         │         │         │         │ │
  │        │ │ [22;1;32m1[22;39m │         │         │         │         │ │
  │        │ │ [22;1;32m2[22;39m │         │         │         │         │ │
  │        │ │ [22;1;32m3[22;39m │ a       │ b       │ c       │ d       │ │
  │        │ │ [22;1;32m4[22;39m │    0.00 │    1.00 │    2.00 │    3.00 │ │
  │        │ │ [22;1;32m5[22;39m │   10.00 │   11.00 │   12.00 │   13.00 │ │
  │        │ │ [22;1;32m6[22;39m │   20.00 │   21.00 │   22.00 │   23.00 │ │
  │        │ │ [22;1;32m7[22;39m │   30.00 │   31.00 │   32.00 │   33.00 │ │
  │        │ ╰───┴─────────┴─────────┴─────────┴─────────╯ │
  ╰────────┴───────────────────────────────────────────────╯
  ```
- How it is imported by default:
  ```nushell
  open example.xlsx
  # or `open example.xlsx --raw | from xlsx`
  ```
  ```ansi
  ╭────────┬───────────────────────────────────────╮
  │        │ ╭───┬───────┬───────┬───────┬───────╮ │
  │ [22;1;32mSheet1[22;39m │ │ [22;1;32m#[22;39m │   [22;1;32ma[22;39m   │   [22;1;32mb[22;39m   │   [22;1;32mc[22;39m   │   [22;1;32md[22;39m   │ │
  │        │ ├───┼───────┼───────┼───────┼───────┤ │
  │        │ │ [22;1;32m0[22;39m │  0.00 │  1.00 │  2.00 │  3.00 │ │
  │        │ │ [22;1;32m1[22;39m │ 10.00 │ 11.00 │ 12.00 │ 13.00 │ │
  │        │ │ [22;1;32m2[22;39m │ 20.00 │ 21.00 │ 22.00 │ 23.00 │ │
  │        │ │ [22;1;32m3[22;39m │ 30.00 │ 31.00 │ 32.00 │ 33.00 │ │
  │        │ ╰───┴───────┴───────┴───────┴───────╯ │
  ╰────────┴───────────────────────────────────────╯
  ```
  Most of the time, this is what you want.
- Or if your file doesn't have any headers and all the rows are data:
  ```nushell
  open example.xlsx --raw | from xlsx --noheaders
  ```
  ```ansi
  ╭────────┬───────────────────────────────────────────────╮
  │        │ ╭───┬─────────┬─────────┬─────────┬─────────╮ │
  │ [22;1;32mSheet1[22;39m │ │ [22;1;32m#[22;39m │ [22;1;32mcolumn0[22;39m │ [22;1;32mcolumn1[22;39m │ [22;1;32mcolumn2[22;39m │ [22;1;32mcolumn3[22;39m │ │
  │        │ ├───┼─────────┼─────────┼─────────┼─────────┤ │
  │        │ │ [22;1;32m0[22;39m │ a       │ b       │ c       │ d       │ │
  │        │ │ [22;1;32m1[22;39m │    0.00 │    1.00 │    2.00 │    3.00 │ │
  │        │ │ [22;1;32m2[22;39m │   10.00 │   11.00 │   12.00 │   13.00 │ │
  │        │ │ [22;1;32m3[22;39m │   20.00 │   21.00 │   22.00 │   23.00 │ │
  │        │ │ [22;1;32m4[22;39m │   30.00 │   31.00 │   32.00 │   33.00 │ │
  │        │ ╰───┴─────────┴─────────┴─────────┴─────────╯ │
  ╰────────┴───────────────────────────────────────────────╯
  ```
