### PR TITLE
Row-conditions should parse `{}` as closure, not record

### DIFF
--- a/crates/nu-parser/src/parse_signatures.rs
+++ b/crates/nu-parser/src/parse_signatures.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::byte_char_slices)]
 
 use crate::parse_captures_compile::compile_block;
-use crate::parse_expressions::{parse_math_expression, parse_value};
+use crate::parse_expressions::{parse_closure_expression, parse_math_expression, parse_value};
 use crate::parse_literals::parse_full_cell_path;
 use crate::{
     Token, TokenContents,
@@ -451,11 +451,28 @@ pub fn parse_full_signature(
 
 pub fn parse_row_condition(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expression {
     let pos = spans.first().map(|s| s.start).unwrap_or(0);
+    let span = Span::concat(spans);
+
+    // Try parsing the expression as a closure first
+    {
+        let err_count = working_set.parse_errors.len();
+        let expression = parse_closure_expression(working_set, &SyntaxShape::Any, span);
+        if working_set.parse_errors.len() == err_count
+            && let Expr::Closure(block_id) = expression.expr
+        {
+            // Successfully parsed a closure
+            return Expression::new(working_set, Expr::RowCondition(block_id), span, Type::Bool);
+        }
+        // Couldn't parse a closure, roll back the errors and try parsing it as a row condition
+        working_set.parse_errors.truncate(err_count);
+    }
+    // The following code can still parse closures (and it did so before the preceding shortcut).
+    // It is very unlikely to happen, but should be kept in mind.
+
     // New scope in case where there's already a variable named `$it`
     working_set.enter_scope();
     let var_id = working_set.add_variable(b"$it".to_vec(), Span::new(pos, pos), Type::Any, false);
     let expression = parse_math_expression(working_set, spans, Some(var_id));
-    let span = Span::concat(spans);
 
     let block_id = match expression.expr {
         Expr::Block(block_id) => block_id,

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -6,7 +6,7 @@ use nu_protocol::{
 };
 use rstest::rstest;
 
-use mock::{Alias, AttrEcho, Const, Def, IfMocked, Let, LsCustom, LsTest, Mut, ToCustom};
+use mock::{Alias, AttrEcho, Const, Def, IfMocked, Let, LsCustom, LsTest, Mut, ToCustom, Where};
 
 fn test_int(
     test_tag: &str,     // name of sub-test
@@ -2968,6 +2968,48 @@ mod mock {
             panic!("Should not be called!")
         }
     }
+
+    #[derive(Clone)]
+    pub struct Where;
+
+    impl Command for Where {
+        fn name(&self) -> &str {
+            "where"
+        }
+
+        fn description(&self) -> &str {
+            "Mock `where` command."
+        }
+
+        fn signature(&self) -> nu_protocol::Signature {
+            Signature::build("where")
+                .input_output_types(vec![
+                    (
+                        Type::List(Box::new(Type::Any)),
+                        Type::List(Box::new(Type::Any)),
+                    ),
+                    (Type::table(), Type::table()),
+                    (Type::Range, Type::Any),
+                ])
+                .required(
+                    "condition",
+                    SyntaxShape::RowCondition,
+                    "Filter row condition or closure.",
+                )
+                .allow_variants_without_examples(true)
+                .category(Category::Filters)
+        }
+
+        fn run(
+            &self,
+            _engine_state: &EngineState,
+            _stack: &mut Stack,
+            _call: &Call,
+            _input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
+            todo!()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -3493,4 +3535,32 @@ fn parse_let_in_pipeline() {
         pipeline.elements[1].expr.expr,
         Expr::ExternalCall(_, _)
     ));
+}
+
+#[test]
+fn empty_closure_as_row_condition() {
+    let mut engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    working_set.add_decl(Box::new(Where));
+    let _ = engine_state.merge_delta(working_set.render());
+
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let block = parse(&mut working_set, None, b"[0 1 2] | where {}", true);
+
+    assert_eq!(working_set.parse_errors.as_slice(), &[]);
+    let [pipeline] = block.pipelines.as_slice() else {
+        panic!("Expected exactly one pipeline")
+    };
+    let [_, where_call] = pipeline.elements.as_slice() else {
+        panic!("Expected exactly two pipeline elements")
+    };
+    let Expr::Call(where_call) = &where_call.expr.expr else {
+        panic!("Expected a call expression")
+    };
+    let [Argument::Positional(arg)] = where_call.arguments.as_slice() else {
+        panic!("Expected exactly one positional argument and no other argument")
+    };
+    assert!(matches!(arg.expr, Expr::RowCondition(_) | Expr::Closure(_)))
 }


### PR DESCRIPTION
## Description

While parsing row conditions, prioritize parsing possible closures before anything else.

## User-facing changes (Release notes)

Empty braces (`{}`) as row conditions are now parsed as empty closures rather than empty records.

```nushell
1..3 | where {}
```
- before:
  ```
  Error: nu::parser::type_mismatch

    × Type mismatch.
     ╭─[repl_entry #1:1:14]
   1 │ 1..3 | where {}
     ·              ─┬
     ·               ╰── expected bool, found record
     ╰────
  ```
- after:
  ```
  ╭────────────╮
  │ empty list │
  ╰────────────╯
  ```

## Additional notes

- This should help keep #18353 backwards compatible.