### PR TITLE
add navigation shortcuts to `explore config`

### DIFF
--- a/crates/nu-explore/src/explore_config/app.rs
+++ b/crates/nu-explore/src/explore_config/app.rs
@@ -128,9 +128,9 @@ impl App {
         let tree_items = build_tree_items(&json_data, &mut node_map, &nu_type_map, &doc_map);
 
         let status_msg = if config_mode {
-            "↑↓ Navigate | ←→ Collapse/Expand | Tab Switch pane | Ctrl+S Apply | q Quit"
+            "↑↓/jk Navigate | ←→/hl Collapse/Expand | Tab Switch pane | Ctrl+S Apply | q Quit"
         } else {
-            "↑↓ Navigate | ←→ Collapse/Expand | Tab Switch pane | Ctrl+S Save | q Quit"
+            "↑↓/jk Navigate | ←→/hl Collapse/Expand | Tab Switch pane | Ctrl+S Save | q Quit"
         };
 
         App {
@@ -841,7 +841,7 @@ impl App {
                     Span::raw(" Edit  "),
                     Span::styled("Tab", Style::default().fg(Color::Yellow).bold()),
                     Span::raw(" Switch pane  "),
-                    Span::styled("↑↓", Style::default().fg(Color::Yellow).bold()),
+                    Span::styled("↑↓/jk", Style::default().fg(Color::Yellow).bold()),
                     Span::raw(" Scroll"),
                 ])
             }

--- a/crates/nu-explore/src/explore_config/command.rs
+++ b/crates/nu-explore/src/explore_config/command.rs
@@ -69,8 +69,8 @@ You can also pipe JSON data to explore arbitrary data structures, or use
 
 TUI Keybindings:
   Tab           Switch between tree and editor panes
-  ↑↓            Navigate tree / scroll editor
-  ←→            Collapse/Expand tree nodes
+  ↑↓/jk         Navigate tree / scroll editor
+  ←→/hl         Collapse/Expand tree nodes
   Enter/Space   Toggle tree node expansion
   Enter/Space   On leaf nodes, open editor pane and start editing
   Enter/e       Start editing (in editor pane)

--- a/crates/nu-explore/src/explore_config/input.rs
+++ b/crates/nu-explore/src/explore_config/input.rs
@@ -72,19 +72,27 @@ pub fn handle_tree_input(app: &mut App, key: KeyCode, modifiers: KeyModifiers) -
                 return AppResult::Quit;
             }
         }
-        KeyCode::Up => {
+        KeyCode::Up | KeyCode::Char('k') => {
             app.tree_state.key_up();
             app.force_update_editor();
         }
-        KeyCode::Down => {
+        KeyCode::Char('p') if modifiers.contains(KeyModifiers::CONTROL) => {
+            app.tree_state.key_up();
+            app.force_update_editor();
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
             app.tree_state.key_down();
             app.force_update_editor();
         }
-        KeyCode::Left => {
+        KeyCode::Char('n') if modifiers.contains(KeyModifiers::CONTROL) => {
+            app.tree_state.key_down();
+            app.force_update_editor();
+        }
+        KeyCode::Left | KeyCode::Char('h') => {
             app.tree_state.key_left();
             app.force_update_editor();
         }
-        KeyCode::Right => {
+        KeyCode::Right | KeyCode::Char('l') => {
             app.tree_state.key_right();
             app.force_update_editor();
         }
@@ -146,7 +154,7 @@ pub fn get_tree_status_message(app: &App) -> String {
         )
     } else {
         format!(
-            "↑↓ Navigate | / Search | ←→ Collapse/Expand | Tab Switch pane | Ctrl+S {} | q Quit",
+            "↑↓/jk Navigate | / Search | ←→/hl Collapse/Expand | Tab Switch pane | Ctrl+S {} | q Quit",
             save_action
         )
     }
@@ -156,7 +164,7 @@ pub fn get_tree_status_message(app: &App) -> String {
 pub fn handle_editor_normal_input(
     app: &mut App,
     key: KeyCode,
-    _modifiers: KeyModifiers,
+    modifiers: KeyModifiers,
 ) -> AppResult {
     match key {
         KeyCode::Tab => {
@@ -168,10 +176,16 @@ pub fn handle_editor_normal_input(
             app.editor_cursor = 0;
             app.status_message = String::from("Editing - Ctrl+S to apply, Esc to cancel");
         }
-        KeyCode::Up => {
+        KeyCode::Up | KeyCode::Char('k') => {
             app.scroll_editor(-1);
         }
-        KeyCode::Down => {
+        KeyCode::Char('p') if modifiers.contains(KeyModifiers::CONTROL) => {
+            app.scroll_editor(-1);
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            app.scroll_editor(1);
+        }
+        KeyCode::Char('n') if modifiers.contains(KeyModifiers::CONTROL) => {
             app.scroll_editor(1);
         }
         KeyCode::PageUp => {


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
Added vim style navigation to the `explore config` TUI, I think for terminal apps this is pretty much expected and makes using it much more intuitive.

## User-facing changes (Release notes)
Added common navigation shortcuts to `explore config` command: `hl` to collapse/expand, and `jk`/`ctrl+p/n` to go up and down.
