### PR TITLE
Allow `is-terminal` to detect redirection

### DIFF
--- a/crates/nu-command/src/platform/is_terminal.rs
+++ b/crates/nu-command/src/platform/is_terminal.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::OutDest;
 use std::io::IsTerminal as _;
 
 #[derive(Clone)]
@@ -23,11 +24,28 @@ impl Command for IsTerminal {
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![Example {
-            description: r#"Return "terminal attached" if standard input is attached to a terminal, and "no terminal" if not."#,
-            example: r#"if (is-terminal --stdin) { "terminal attached" } else { "no terminal" }"#,
-            result: Some(Value::test_string("terminal attached")),
-        }]
+        vec![
+            Example {
+                description: "Check if stdout is a terminal (default when no flag is specified).",
+                example: "is-terminal",
+                result: None,
+            },
+            Example {
+                description: "Return false when output is piped to another command.",
+                example: "is-terminal | to text",
+                result: Some(Value::test_string("false")),
+            },
+            Example {
+                description: "Return false when output is collected into a variable.",
+                example: "let x = (is-terminal); $x",
+                result: Some(Value::test_bool(false)),
+            },
+            Example {
+                description: r#"Return "terminal attached" if standard input is attached to a terminal, and "no terminal" if not."#,
+                example: r#"if (is-terminal --stdin) { "terminal attached" } else { "no terminal" }"#,
+                result: Some(Value::test_string("terminal attached")),
+            },
+        ]
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -47,14 +65,9 @@ impl Command for IsTerminal {
 
         let is_terminal = match (stdin, stdout, stderr) {
             (true, false, false) => std::io::stdin().is_terminal(),
-            (false, true, false) => std::io::stdout().is_terminal(),
-            (false, false, true) => std::io::stderr().is_terminal(),
-            (false, false, false) => {
-                return Err(ShellError::MissingParameter {
-                    param_name: "one of --stdin, --stdout, --stderr".into(),
-                    span: call.head,
-                });
-            }
+            (false, true, false) => stream_is_terminal(stack, Stream::Stdout),
+            (false, false, true) => stream_is_terminal(stack, Stream::Stderr),
+            (false, false, false) => stream_is_terminal(stack, Stream::Stdout),
             _ => {
                 return Err(ShellError::IncompatibleParametersSingle {
                     msg: "Only one stream may be checked".into(),
@@ -67,5 +80,32 @@ impl Command for IsTerminal {
             Value::bool(is_terminal, call.head),
             None,
         ))
+    }
+}
+
+enum Stream {
+    Stdout,
+    Stderr,
+}
+
+fn stream_is_terminal(stack: &Stack, stream: Stream) -> bool {
+    let pipe_dest = match stream {
+        Stream::Stdout => stack.pipe_stdout(),
+        Stream::Stderr => stack.pipe_stderr(),
+    };
+
+    match pipe_dest {
+        Some(
+            OutDest::Pipe
+            | OutDest::PipeSeparate
+            | OutDest::Value
+            | OutDest::Null
+            | OutDest::File(_)
+            | OutDest::Inherit,
+        ) => false,
+        Some(OutDest::Print) | None => match stream {
+            Stream::Stdout => std::io::stdout().is_terminal(),
+            Stream::Stderr => std::io::stderr().is_terminal(),
+        },
     }
 }

--- a/crates/nu-command/tests/commands/terminal.rs
+++ b/crates/nu-command/tests/commands/terminal.rs
@@ -1,20 +1,35 @@
-use nu_test_support::nu;
+use nu_test_support::prelude::*;
 
-// Inside nu! stdout is piped so it won't be a terminal
 #[test]
-fn is_terminal_stdout_piped() {
-    let actual = nu!("
-        is-terminal --stdout
-    ");
-
-    assert_eq!(actual.out, "false");
+fn is_terminal_returns_false_when_piped() -> Result {
+    test().run("is-terminal | to text").expect_value_eq("false")
 }
 
 #[test]
-fn is_terminal_two_streams() {
-    let actual = nu!("
-        is-terminal --stdin --stderr
-    ");
+fn is_terminal_returns_false_when_collected() -> Result {
+    test()
+        .run("let x = (is-terminal); $x")
+        .expect_value_eq(false)
+}
 
-    assert!(actual.err.contains("Only one stream may be checked"));
+#[test]
+fn is_terminal_rejects_multiple_streams() -> Result {
+    test()
+        .run("is-terminal --stdin --stderr")
+        .expect_shell_error()?;
+    Ok(())
+}
+
+#[test]
+fn is_terminal_accepts_stdin_flag() -> Result {
+    let value = test().run("is-terminal --stdin")?;
+    assert!(matches!(value, Value::Bool { .. }));
+    Ok(())
+}
+
+#[test]
+fn is_terminal_defaults_to_stdout() -> Result {
+    let value = test().run("is-terminal")?;
+    assert!(matches!(value, Value::Bool { .. }));
+    Ok(())
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR enables the `is-terminal` command to detect redirection. The command without any flags defaults to `--stdout`.

Scenario | Before PR | After PR
-- | -- | --
is-terminal --stdout (in terminal) | true | true
is-terminal --stdout \| cmd | true  | false 
is-terminal --stdout o> file | true | false 
let x = (is-terminal --stdout) | true | false 
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
The `is-terminal` command can detect redirection now. It now defaults to `--stdout`.

Scenario | Current
-- | -- 
is-terminal (in terminal)| true
is-terminal \| cmd  | false 
is-terminal  o> file  | false 
let x = (is-terminal) | false 

<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
closes https://github.com/nushell/nushell/issues/15368
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->