### PR TITLE
feat: add `--right` to `split row` and `split column`

### DIFF
--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -250,6 +250,7 @@ fn split_column_helper(
 ) -> Vec<Value> {
     if let Ok(s) = v.as_str() {
         let split_result: Vec<_> = match (max_split, split_from_right) {
+            (Some(0), _) => vec![],
             (Some(max_split), true) => {
                 let sep_bounds: Vec<_> = separator
                     .find_iter(s)

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -31,7 +31,7 @@ impl Command for SplitColumn {
             .named(
                 "number",
                 SyntaxShape::Int,
-                "Split into maximum number of items.",
+                "Split into maximum number of columns.",
                 Some('n'),
             )
             .switch(

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -2,7 +2,7 @@ use fancy_regex::{Regex, escape};
 use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
 
-use super::rsplitn;
+use super::split;
 
 #[derive(Clone)]
 pub struct SplitColumn;
@@ -257,7 +257,7 @@ fn split_column_helper(
                     .map(|x| (x.start(), x.end()))
                     .collect();
                 // get the last `max_split` separators and split `s` with them
-                rsplitn(s, sep_bounds.into_iter().rev().take(max_split).rev()).collect()
+                split(s, sep_bounds.into_iter().rev().take(max_split - 1).rev()).collect()
             }
             (Some(max_split), false) => separator
                 .splitn(s, max_split)

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -2,6 +2,8 @@ use fancy_regex::{Regex, escape};
 use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
 
+use super::rsplitn;
+
 #[derive(Clone)]
 pub struct SplitColumn;
 
@@ -31,6 +33,11 @@ impl Command for SplitColumn {
                 SyntaxShape::Int,
                 "Split into maximum number of items.",
                 Some('n'),
+            )
+            .switch(
+                "right",
+                "When `--number` is used, collect the remainder in the leftmost column.",
+                None,
             )
             .switch("regex", "Separator is a regular expression.", Some('r'))
             .rest(
@@ -111,6 +118,24 @@ impl Command for SplitColumn {
                     }),
                 ])),
             },
+            Example {
+                description: "Split into columns, first column may contain the delimiter.",
+                example: "['some-package-1.2.3' 'pkg2-1.0' 'do-smart-things-0.9.1'] | split column --number 2 --right '-' name version",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "name" => Value::test_string("some-package"),
+                        "version" => Value::test_string("1.2.3"),
+                    }),
+                    Value::test_record(record! {
+                        "name" => Value::test_string("pkg2"),
+                        "version" => Value::test_string("1.0"),
+                    }),
+                    Value::test_record(record! {
+                        "name" => Value::test_string("do-smart-things"),
+                        "version" => Value::test_string("0.9.1"),
+                    }),
+                ])),
+            },
         ]
     }
 
@@ -129,6 +154,7 @@ impl Command for SplitColumn {
         let rest: Vec<Spanned<String>> = call.rest(engine_state, stack, 1)?;
         let collapse_empty = call.has_flag(engine_state, stack, "collapse-empty")?;
         let max_split: Option<usize> = call.get_flag(engine_state, stack, "number")?;
+        let split_from_right = call.has_flag(engine_state, stack, "right")?;
         let has_regex = call.has_flag(engine_state, stack, "regex")?;
 
         let args = Arguments {
@@ -136,6 +162,7 @@ impl Command for SplitColumn {
             rest,
             collapse_empty,
             max_split,
+            split_from_right,
             has_regex,
         };
         split_column(engine_state, call, input, args)
@@ -151,6 +178,7 @@ impl Command for SplitColumn {
         let rest: Vec<Spanned<String>> = call.rest_const(working_set, 1)?;
         let collapse_empty = call.has_flag_const(working_set, "collapse-empty")?;
         let max_split: Option<usize> = call.get_flag_const(working_set, "number")?;
+        let split_from_right = call.has_flag_const(working_set, "right")?;
         let has_regex = call.has_flag_const(working_set, "regex")?;
 
         let args = Arguments {
@@ -158,6 +186,7 @@ impl Command for SplitColumn {
             rest,
             collapse_empty,
             max_split,
+            split_from_right,
             has_regex,
         };
         split_column(working_set.permanent(), call, input, args)
@@ -169,6 +198,7 @@ struct Arguments {
     rest: Vec<Spanned<String>>,
     collapse_empty: bool,
     max_split: Option<usize>,
+    split_from_right: bool,
     has_regex: bool,
 }
 
@@ -201,6 +231,7 @@ fn split_column(
                 &args.rest,
                 args.collapse_empty,
                 args.max_split,
+                args.split_from_right,
                 name_span,
             )
         },
@@ -214,16 +245,26 @@ fn split_column_helper(
     rest: &[Spanned<String>],
     collapse_empty: bool,
     max_split: Option<usize>,
+    split_from_right: bool,
     head: Span,
 ) -> Vec<Value> {
     if let Ok(s) = v.as_str() {
-        let split_result: Vec<_> = match max_split {
-            Some(max_split) => separator
+        let split_result: Vec<_> = match (max_split, split_from_right) {
+            (Some(max_split), true) => {
+                let sep_bounds: Vec<_> = separator
+                    .find_iter(s)
+                    .filter_map(|x| x.ok())
+                    .map(|x| (x.start(), x.end()))
+                    .collect();
+                // get the last `max_split` separators and split `s` with them
+                rsplitn(s, sep_bounds.into_iter().rev().take(max_split).rev()).collect()
+            }
+            (Some(max_split), false) => separator
                 .splitn(s, max_split)
                 .filter_map(|x| x.ok())
                 .filter(|x| !(collapse_empty && x.is_empty()))
                 .collect(),
-            None => separator
+            (None, _) => separator
                 .split(s)
                 .filter_map(|x| x.ok())
                 .filter(|x| !(collapse_empty && x.is_empty()))

--- a/crates/nu-command/src/strings/split/mod.rs
+++ b/crates/nu-command/src/strings/split/mod.rs
@@ -13,7 +13,7 @@ pub use row::SplitRow;
 pub use words::SplitWords;
 
 /// Split `s` given the bounds of the separators in `sep_bounds`.
-fn rsplitn<I>(s: &str, sep_bounds: I) -> impl Iterator<Item = &str>
+fn split<I>(s: &str, sep_bounds: I) -> impl Iterator<Item = &str>
 where
     I: IntoIterator<Item = (usize, usize)>,
 {

--- a/crates/nu-command/src/strings/split/mod.rs
+++ b/crates/nu-command/src/strings/split/mod.rs
@@ -11,3 +11,15 @@ pub use command::Split;
 pub use list::SubCommand as SplitList;
 pub use row::SplitRow;
 pub use words::SplitWords;
+
+/// Split `s` given the bounds of the separators in `sep_bounds`.
+fn rsplitn<I>(s: &str, sep_bounds: I) -> impl Iterator<Item = &str>
+where
+    I: IntoIterator<Item = (usize, usize)>,
+{
+    use itertools::Itertools;
+
+    itertools::chain!([(0, 0)], sep_bounds, [(s.len(), 0)])
+        .tuple_windows()
+        .map(|(a, b)| &s[(a.1)..(b.0)])
+}

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -2,6 +2,8 @@ use fancy_regex::{Regex, escape};
 use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
 
+use super::rsplitn;
+
 #[derive(Clone)]
 pub struct SplitRow;
 
@@ -30,6 +32,11 @@ impl Command for SplitRow {
                 SyntaxShape::Int,
                 "Split into maximum number of items.",
                 Some('n'),
+            )
+            .switch(
+                "right",
+                "When `--number` is used, collect the remainder in the leftmost column.",
+                None,
             )
             .switch("regex", "Use regex syntax for separator.", Some('r'))
             .category(Category::Strings)
@@ -97,6 +104,22 @@ impl Command for SplitRow {
                     Span::test_data(),
                 )),
             },
+            Example {
+                description: "Split a string a limited number of times.",
+                example: "'a-b-c' | split row --number 2 '-'",
+                result: Some(Value::list(
+                    vec![Value::test_string("a"), Value::test_string("b-c")],
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Split a string a limited number of times, starting from the right.",
+                example: "'a-b-c' | split row --number 2 --right '-'",
+                result: Some(Value::list(
+                    vec![Value::test_string("a-b"), Value::test_string("c")],
+                    Span::test_data(),
+                )),
+            },
         ]
     }
 
@@ -113,11 +136,13 @@ impl Command for SplitRow {
     ) -> Result<PipelineData, ShellError> {
         let separator: Spanned<String> = call.req(engine_state, stack, 0)?;
         let max_split: Option<usize> = call.get_flag(engine_state, stack, "number")?;
+        let split_from_right = call.has_flag(engine_state, stack, "right")?;
         let has_regex = call.has_flag(engine_state, stack, "regex")?;
 
         let args = Arguments {
             separator,
             max_split,
+            split_from_right,
             has_regex,
         };
         split_row(engine_state, call, input, args)
@@ -131,11 +156,13 @@ impl Command for SplitRow {
     ) -> Result<PipelineData, ShellError> {
         let separator: Spanned<String> = call.req_const(working_set, 0)?;
         let max_split: Option<usize> = call.get_flag_const(working_set, "number")?;
+        let split_from_right = call.has_flag_const(working_set, "right")?;
         let has_regex = call.has_flag_const(working_set, "regex")?;
 
         let args = Arguments {
             separator,
             max_split,
+            split_from_right,
             has_regex,
         };
         split_row(working_set.permanent(), call, input, args)
@@ -146,6 +173,7 @@ struct Arguments {
     has_regex: bool,
     separator: Spanned<String>,
     max_split: Option<usize>,
+    split_from_right: bool,
 }
 
 fn split_row(
@@ -169,64 +197,63 @@ fn split_row(
         ))
     })?;
     input.flat_map(
-        move |x| split_row_helper(&x, &regex, args.max_split, name_span),
+        move |x| split_row_helper(&x, &regex, args.max_split, args.split_from_right, name_span),
         engine_state.signals(),
     )
 }
 
-fn split_row_helper(v: &Value, regex: &Regex, max_split: Option<usize>, name: Span) -> Vec<Value> {
+fn split_row_helper(
+    v: &Value,
+    regex: &Regex,
+    max_split: Option<usize>,
+    split_from_right: bool,
+    name: Span,
+) -> Vec<Value> {
     let span = v.span();
-    match v {
-        Value::Error { error, .. } => {
-            vec![Value::error(*error.clone(), span)]
-        }
-        v => {
-            let v_span = v.span();
-
-            if let Ok(s) = v.coerce_str() {
-                match max_split {
-                    Some(max_split) => regex
-                        .splitn(&s, max_split)
-                        .map(|x| match x {
-                            Ok(val) => Value::string(val, v_span),
-                            Err(err) => Value::error(
-                                ShellError::Generic(GenericError::new(
-                                    "Error with regular expression",
-                                    err.to_string(),
-                                    v_span,
-                                )),
-                                v_span,
-                            ),
-                        })
-                        .collect(),
-                    None => regex
-                        .split(&s)
-                        .map(|x| match x {
-                            Ok(val) => Value::string(val, v_span),
-                            Err(err) => Value::error(
-                                ShellError::Generic(GenericError::new(
-                                    "Error with regular expression",
-                                    err.to_string(),
-                                    v_span,
-                                )),
-                                v_span,
-                            ),
-                        })
-                        .collect(),
-                }
-            } else {
-                vec![Value::error(
-                    ShellError::OnlySupportsThisInputType {
-                        exp_input_type: "string".into(),
-                        wrong_type: v.get_type().to_string(),
-                        dst_span: name,
-                        src_span: v_span,
-                    },
-                    name,
-                )]
-            }
-        }
+    if let Value::Error { error, .. } = v {
+        return vec![Value::error(*error.clone(), span)];
     }
+    let Ok(s) = v.coerce_str() else {
+        return vec![Value::error(
+            ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: v.get_type().to_string(),
+                dst_span: name,
+                src_span: span,
+            },
+            name,
+        )];
+    };
+
+    match (max_split, split_from_right) {
+        (Some(max_split), true) => regex
+            .find_iter(&s)
+            .map(|x| x.map(|x| (x.start(), x.end())))
+            .collect::<Result<Vec<_>, _>>()
+            .map(|sep_bounds| {
+                rsplitn(&s, sep_bounds.into_iter().rev().take(max_split).rev())
+                    .map(|val| Value::string(val, span))
+                    .collect()
+            }),
+        (Some(max_split), false) => regex
+            .splitn(&s, max_split)
+            .map(|x| x.map(|val| Value::string(val, span)))
+            .collect(),
+        (None, _) => regex
+            .split(&s)
+            .map(|x| x.map(|val| Value::string(val, span)))
+            .collect(),
+    }
+    .unwrap_or_else(|err| {
+        vec![Value::error(
+            ShellError::Generic(GenericError::new(
+                "Error executing regular expression",
+                err.to_string(),
+                span,
+            )),
+            span,
+        )]
+    })
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -2,7 +2,7 @@ use fancy_regex::{Regex, escape};
 use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
 
-use super::rsplitn;
+use super::split;
 
 #[derive(Clone)]
 pub struct SplitRow;
@@ -231,7 +231,7 @@ fn split_row_helper(
             .map(|x| x.map(|x| (x.start(), x.end())))
             .collect::<Result<Vec<_>, _>>()
             .map(|sep_bounds| {
-                rsplitn(&s, sep_bounds.into_iter().rev().take(max_split).rev())
+                split(&s, sep_bounds.into_iter().rev().take(max_split - 1).rev())
                     .map(|val| Value::string(val, span))
                     .collect()
             }),

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -35,7 +35,7 @@ impl Command for SplitRow {
             )
             .switch(
                 "right",
-                "When `--number` is used, collect the remainder in the leftmost column.",
+                "When `--number` is used, collect the remainder in the leftmost item.",
                 None,
             )
             .switch("regex", "Use regex syntax for separator.", Some('r'))

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -226,6 +226,7 @@ fn split_row_helper(
     };
 
     match (max_split, split_from_right) {
+        (Some(0), _) => Ok(vec![]),
         (Some(max_split), true) => regex
             .find_iter(&s)
             .map(|x| x.map(|x| (x.start(), x.end())))

--- a/crates/nu-command/tests/commands/split_column.rs
+++ b/crates/nu-command/tests/commands/split_column.rs
@@ -87,3 +87,22 @@ fn split_column_no_sep_found() -> Result {
         .expect_value_eq(expected.clone())?;
     Ok(())
 }
+
+#[test]
+fn split_column_number_zero() -> Result {
+    let code = r#""x" | split column -n 0 ",""#;
+    let expected = vec![Value::test_record(record! {})];
+    test().run(code).expect_value_eq(expected.clone())?;
+    let code = r#""x" | split column -n 0 --right ",""#;
+    test().run(code).expect_value_eq(expected.clone())?;
+    Ok(())
+}
+
+#[test]
+fn split_column_number_error() -> Result {
+    let code = r#""x" | split column -n -1 ",""#;
+    test().run(code).expect_shell_error()?;
+    let code = r#""x" | split column -n -1 --right ",""#;
+    test().run(code).expect_shell_error()?;
+    Ok(())
+}

--- a/crates/nu-command/tests/commands/split_column.rs
+++ b/crates/nu-command/tests/commands/split_column.rs
@@ -1,9 +1,11 @@
+use nu_protocol::record;
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
+use nu_test_support::prelude::*;
 
 #[test]
-fn to_column() {
+fn split_column() {
     Playground::setup("split_column_test_1", |dirs, sandbox| {
         sandbox.with_files(&[
             FileWithContentToBeTrimmed(
@@ -40,6 +42,16 @@ fn to_column() {
 
         assert!(actual.out.contains("tariff_item,name,origin"));
 
+        let actual = nu!(cwd: dirs.test(), r#"
+            open sample.txt
+            | lines
+            | str trim
+            | split column -n 3 --right ","
+            | get column0
+        "#);
+
+        assert!(actual.out.contains("importer,shipper,tariff_item"));
+
         let actual = nu!(cwd: dirs.test(), r"
             open sample2.txt
             | lines
@@ -50,4 +62,28 @@ fn to_column() {
 
         assert!(actual.out.contains("shipper"));
     })
+}
+
+#[test]
+fn split_column_no_sep_found() -> Result {
+    let sample = "stuff";
+    let expected = vec![Value::test_record(
+        record! { "column0" => Value::test_string(sample) },
+    )];
+
+    let code = r#"$in | split column "|""#;
+    test()
+        .run_with_data(code, sample)
+        .expect_value_eq(expected.clone())?;
+
+    let code = r#"$in | split column -n 3 "|""#;
+    test()
+        .run_with_data(code, sample)
+        .expect_value_eq(expected.clone())?;
+
+    let code = r#"$in | split column -n 3 --right "|""#;
+    test()
+        .run_with_data(code, sample)
+        .expect_value_eq(expected.clone())?;
+    Ok(())
 }

--- a/crates/nu-command/tests/commands/split_row.rs
+++ b/crates/nu-command/tests/commands/split_row.rs
@@ -1,15 +1,78 @@
 use nu_test_support::prelude::*;
 
 #[test]
-fn to_row() -> Result {
+fn split_row() -> Result {
     let sample = "importer,shipper,tariff_item,name,origin";
     let code = r#"$in | split row "," | length"#;
-    test().run_with_data(code, sample).expect_value_eq(5)?;
+    test().run_with_data(code, sample).expect_value_eq(5)
+}
 
+#[test]
+fn split_row_number() -> Result {
+    let sample = "importer,shipper,tariff_item,name,origin";
+
+    let code = r#"$in | split row -n 3 ",""#;
+    test().run_with_data(code, sample).expect_value_eq(vec![
+        "importer",
+        "shipper",
+        "tariff_item,name,origin",
+    ])?;
+
+    let code = r#"$in | split row -n 3 --right ",""#;
+    test().run_with_data(code, sample).expect_value_eq(vec![
+        "importer,shipper,tariff_item",
+        "name",
+        "origin",
+    ])
+}
+
+#[test]
+fn split_row_number_zero() -> Result {
+    let code = r#""x" | split row -n 0 ",""#;
+    test().run(code).expect_value_eq::<Vec<Value>>(vec![])?;
+    let code = r#""x" | split row -n 0 --right ",""#;
+    test().run(code).expect_value_eq::<Vec<Value>>(vec![])?;
+    Ok(())
+}
+
+#[test]
+fn split_row_number_error() -> Result {
+    let code = r#""x" | split row -n -1 ",""#;
+    test().run(code).expect_shell_error()?;
+    let code = r#""x" | split row -n -1 --right ",""#;
+    test().run(code).expect_shell_error()?;
+    Ok(())
+}
+
+#[test]
+fn to_row_no_sep_found() -> Result {
+    let sample = "stuff";
+
+    let code = r#"$in | split row "|""#;
+    test()
+        .run_with_data(code, sample)
+        .expect_value_eq(vec![sample])?;
+
+    let code = r#"$in | split row -n 3 "|""#;
+    test()
+        .run_with_data(code, sample)
+        .expect_value_eq(vec![sample])?;
+
+    let code = r#"$in | split row -n 3 --right "|""#;
+    test()
+        .run_with_data(code, sample)
+        .expect_value_eq(vec![sample])
+}
+
+#[test]
+fn split_row_regex() -> Result {
     let sample = "importer      ,   shipper      ,  tariff_item,name      ,    origin";
     let code = r#"$in | split row -r '\s*,\s*' | length"#;
-    test().run_with_data(code, sample).expect_value_eq(5)?;
+    test().run_with_data(code, sample).expect_value_eq(5)
+}
 
+#[test]
+fn split_row_type() -> Result {
     let code = r#"
         def foo [a: list<string>] {
             $a | describe


### PR DESCRIPTION
## Description
- Adds `--right` to both `split column` and `split row`
- Adds examples for its use to both commands
- Adds an example for `--number …` to `split row` since none existed
- Refactors `split row` to be less nested, less redundant, and fail earlier if regex execution failed

## User-facing changes (Release notes)
### Added `--right` to `split row` and `split column`
Both `split row` and `split column` now support `--right`, which modifies where splits are skipped, e.g.:

```nushell
> 'some-package-1.0' | split row --number 2
['some' 'package-1.0']
> 'some-package-1.0' | split row --number 2 --right
['some-package' '1.0']
```

## Additional notes
closes #16507

I also observed that `split row` and `split column` work differently: if regex execution failed (which only happens when running into a stack overflow or so), `split row` converts that into a nushell error whereas `split column` silently drops vector items with errors. I think that should be fixed, but I don’t know if driveby-fixing it in this PR is the correct way to do it.