### PR TITLE
respect table mode passed on cli for scripts and repl

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -13,6 +13,7 @@ use nu_protocol::{
 };
 use nu_utils::perf;
 use nu_utils::time::Instant;
+use std::sync::Arc;
 
 pub(crate) fn run_commands(
     engine_state: &mut EngineState,
@@ -167,6 +168,14 @@ pub(crate) fn run_file(
     // Regenerate the $nu constant to contain the startup time and any other potential updates
     engine_state.generate_nu_constant();
 
+    // Apply --table-mode / -m CLI flag override before evaluating the file
+    if let Some(ref t_mode) = parsed_nu_cli_args.table_mode
+        && let Ok(s) = t_mode.coerce_str()
+        && let Ok(mode) = s.parse()
+    {
+        Arc::make_mut(&mut engine_state.config).table.mode = mode;
+    }
+
     let start_time = Instant::now();
     let result = evaluate_file(
         script_name,
@@ -213,6 +222,14 @@ pub(crate) fn run_repl(
         .use_ansi_coloring
         .get(engine_state);
     perf!("setup_config", start_time, use_color);
+
+    // Apply --table-mode / -m CLI flag override before starting the REPL
+    if let Some(ref t_mode) = parsed_nu_cli_args.table_mode
+        && let Ok(s) = t_mode.coerce_str()
+        && let Ok(mode) = s.parse()
+    {
+        Arc::make_mut(&mut engine_state.config).table.mode = mode;
+    }
 
     let start_time = Instant::now();
     let ret_val = evaluate_repl(


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes. 
-->

## Description
Respect the table mode passed in on the cli when running scripts. Before it would ignore table mode passed like this `nu -m "none" script.nu`.
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
### Fixed table mode handling from CLI arguments
Respect the table mode when passed in on the cli when running script so you can do things like this.
```nushell
❯ '1..3 | each { { number: $in, comment: "hello" } }' | save script.nu
❯ nu -m "none" script.nu
 #   number   comment
 0        1   hello
 1        2   hello
 2        3   hello
```
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
closes https://github.com/nushell/nushell/issues/18445
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->