### PR TITLE
Assortment of std improvements

### DIFF
--- a/crates/nu-std/std-rfc/conversions/mod.nu
+++ b/crates/nu-std/std-rfc/conversions/mod.nu
@@ -64,6 +64,5 @@ export def table-into-columns []: [table -> list<table>] {
     [1, 2, 3] | name-values a b c
 } --result {a: 1, b: 2, c: 3}
 export def name-values [...names: string]: [list -> record] {
-    let IN = $in
-    0.. | zip $IN | into record | rename ...$names
+    zip 0.. | each { [$in.1 $in.0] } | into record | rename ...$names
 }

--- a/crates/nu-std/std-rfc/conversions/mod.nu
+++ b/crates/nu-std/std-rfc/conversions/mod.nu
@@ -5,15 +5,14 @@
     1..10 | into list
 } --result [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 export def "into list" []: any -> list {
-  let input = $in
-  let type = ($input | describe --detailed | get type)
-  match $type {
-    range => {$input | each {||}}
-    list => $input
-    table => $input
-    record => {$input | transpose -d key value}
-    _ => [ $input ]
-  }
+    peek | metadata access {|md|
+        match $md.peek.type {
+            "range" => { each {|| } }
+            "list" => { }
+            "record" => { transpose key value }
+            _ => { [$in] }
+        }
+    }
 }
 
 # Convert a list of columns into a table

--- a/crates/nu-std/std-rfc/conversions/mod.nu
+++ b/crates/nu-std/std-rfc/conversions/mod.nu
@@ -63,6 +63,9 @@ export def table-into-columns []: [table -> list<table>] {
 @example "Name the items in a list" {
     [1, 2, 3] | name-values a b c
 } --result {a: 1, b: 2, c: 3}
-export def name-values [...names: string]: [list -> record] {
+export def name-values [...names: string]: [
+    list -> record
+    range -> record
+] {
     zip 0.. | each { [$in.1 $in.0] } | into record | rename ...$names
 }

--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -285,12 +285,21 @@ export def only [
     --optional # Return `null` if there are no elements (does not affect behavior of the `cell_path` argument)
     cell_path?: cell-path # The cell path to access within the only element.
 ]: [table -> any, list -> any] {
-    let pipe = {in: $in, meta: (metadata $in)}
-    match $pipe.in {
-        [] if $optional => null
-        [] => (only-error "expected non-empty table/list" $pipe.meta "empty")
-        [$one] => ($one | if $cell_path != null { get $cell_path } else { })
-        _ => (only-error "expected only one element in table/list" $pipe.meta "has more than one element")
+    peek 2 | metadata access {|meta|
+        match $meta.peek.value? {
+            [] => {
+                # discard pipeline input
+                null;
+                # had to move it here from the match guard. while the closure
+                # itself has access to `$optional`, for some reason it was not
+                # available to the match guard at runtime
+                if not $optional {
+                    only-error "expected non-empty table/list" $meta "empty"
+                }
+            }
+            [$one] => ($one | if $cell_path != null { get $cell_path } else { })
+            _ => (only-error "expected only one element in table/list" $meta "has more than one element")
+        }
     }
 }
 

--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -378,6 +378,7 @@ export def prod [
 ]: [
     nothing -> table
     list -> table
+    range -> table
 ] {
     peek | metadata access {|md|
         match $md.peek {

--- a/crates/nu-std/std-rfc/iter/mod.nu
+++ b/crates/nu-std/std-rfc/iter/mod.nu
@@ -270,28 +270,28 @@ def only-error [msg: string, meta: record, label: string]: nothing -> error {
 @search-terms first single
 @category filters
 @example "Get the only item in a list, ensuring it exists and there's no additional items" --result 5 {
-  [5] | only
+    [5] | only
 }
 @example "Get the item (if present) from a list that has no more than one item" --result null {
-  [] | only
+    [] | only
 }
 @example "Get the `name` column of the only row in a table" --result "foo" {
-  [{name: foo, id: 5}] | only name
+    [{name: foo, id: 5}] | only name
 }
 @example "Get the modification time of the file named foo.txt" {
-  ls | where name == "foo.txt" | only modified
+    ls | where name == "foo.txt" | only modified
 }
 export def only [
-  --optional # Return `null` if there are no elements (does not affect behavior of the `cell_path` argument)
-  cell_path?: cell-path # The cell path to access within the only element.
+    --optional # Return `null` if there are no elements (does not affect behavior of the `cell_path` argument)
+    cell_path?: cell-path # The cell path to access within the only element.
 ]: [table -> any, list -> any] {
-  let pipe = {in: $in, meta: (metadata $in)}
-  match $pipe.in {
-    [] if $optional => null
-    [] => (only-error "expected non-empty table/list" $pipe.meta "empty")
-    [$one] => ($one | if $cell_path != null { get $cell_path } else { })
-    _ => (only-error "expected only one element in table/list" $pipe.meta "has more than one element")
-  }
+    let pipe = {in: $in, meta: (metadata $in)}
+    match $pipe.in {
+        [] if $optional => null
+        [] => (only-error "expected non-empty table/list" $pipe.meta "empty")
+        [$one] => ($one | if $cell_path != null { get $cell_path } else { })
+        _ => (only-error "expected only one element in table/list" $pipe.meta "has more than one element")
+    }
 }
 
 def prod-error-helper [] {

--- a/crates/nu-std/std-rfc/tables/mod.nu
+++ b/crates/nu-std/std-rfc/tables/mod.nu
@@ -96,30 +96,16 @@ export def aggregate [
     $results | flatten items
 }
 
-# Used in reject-column-slices and select-column-slices
-def col-indices [ ...slices ] {
-  use std-rfc/conversions *
+# Used in select-row-slices and reject-row-slices
+def row-indices [slices: list<oneof<int, range>>]: nothing -> list<int> {
+    use std-rfc/conversions [ "into list" ]
 
-  let indices = (
-    $slices
-    | reduce -f [] {|slice,indices|
-      $indices ++ ($slice | into list)
-    }
-  )
-
-  $in | columns
-  | select slices $indices 
-  | get item
+    $slices | each --flatten { into list }
 }
 
-# Used in select-row-slices and reject-row-slices
-def row-indices [ ...slices ] {
-  use std-rfc/conversions *
-
-  $slices
-  | reduce -f [] {|slice,indices|
-    $indices ++ ($slice | into list)
-  }
+# Used in reject-column-slices and select-column-slices
+def col-indices [slices: list<oneof<int, range>>]: record -> list<string> {
+    columns | select ...(row-indices $slices)
 }
 
 # Selects one or more rows while keeping the original indices.
@@ -129,21 +115,24 @@ def row-indices [ ...slices ] {
 @example "Select the 4th row (difference to `select 3` is that the index (#) column shows the *original* (pre-select) position in the table)" {
     ls | select slices 3
 }
-export def "select slices" [ ...slices ] {
-  enumerate
-  | flatten
-  | select ...(row-indices ...$slices)
+export def "select slices" [...slices: oneof<int, range>]: [
+    table -> table
+    list -> list
+    range -> list
+] {
+    enumerate | flatten | select ...(row-indices $slices)
 }
 
 # Rejects one or more rows while keeping the original indices.
 @example "Rejects the first, fifth, and sixth rows from the table" {
     ls / | reject slices 0 4..5
 }
-export def "reject slices" [ ...slices ] {
-  enumerate
-  | flatten
-  | collect
-  | reject ...(row-indices ...$slices)
+export def "reject slices" [...slices: oneof<int, range>]: [
+    table -> table
+    list -> list
+    range -> list
+] {
+  enumerate | flatten | reject ...(row-indices $slices)
 }
 
 # Select one or more columns by their indices
@@ -155,20 +144,44 @@ export def "reject slices" [ ...slices ] {
     ["CODE_OF_CONDUCT.md", 2024-07-09T21:58:12+03:00, 2025-02-09T17:58:12+03:00, 2024-07-09T21:58:12+03:00],
     ["CONTRIBUTING.md", 2024-11-09T21:58:12+03:00, 2025-02-09T17:58:12+03:00, 2024-11-09T21:58:12+03:00]
 ]
-export def "select column-slices" [
-    ...slices
+export def "select column-slices" [...slices: oneof<int, range>]: [
+    record -> record
+    table -> table
 ] {
-    let column_selector = ($in | col-indices ...$slices)
-    $in | select ...$column_selector
+    peek 1 | metadata access {|meta|
+        match $meta.peek {
+            {type: "record"} => {
+                let record: record = $in
+                $record | select ...($record | col-indices $slices)
+            }
+            {type: "list", value: [$row] } => {
+                select ...($row | col-indices $slices)
+            }
+            # the list is empty, do nothing
+            {type: "list"} => { }
+        }
+    }
 }
 
 # Reject one or more columns by their indices
 @example "Reject columns [0, 4, 5]" {
     ls | reject column-slices 0 4 5 | first 3
 }
-export def "reject column-slices" [
-    ...slices
+export def "reject column-slices" [...slices: oneof<int, range>]: [
+    record -> record
+    table -> table
 ] {
-    let column_selector = ($in | col-indices ...$slices)
-    $in | reject ...$column_selector
+    peek 1 | metadata access {|meta|
+        match $meta.peek {
+            {type: "record"} => {
+                let record: record = $in
+                $record | reject ...($record | col-indices $slices)
+            }
+            {type: "list", value: [$row] } => {
+                reject ...($row | col-indices $slices)
+            }
+            # the list is empty, do nothing
+            {type: "list"} => { }
+        }
+    }
 }

--- a/crates/nu-std/std/iter/mod.nu
+++ b/crates/nu-std/std/iter/mod.nu
@@ -127,9 +127,7 @@ export def  zip-with [ # -> list<any>
     fn: closure              # the closure to apply to the zips
 ] {
     zip $other 
-    | each {|e|
-        reduce {|e, acc| do $fn $acc $e }
-    }
+    | each {|e| null; do $fn $e.0 $e.1 }
 }
 
 # Zips two lists and returns a record with the first list as headers

--- a/crates/nu-std/std/iter/mod.nu
+++ b/crates/nu-std/std/iter/mod.nu
@@ -46,14 +46,11 @@ export def find-index [
 } --result [1 0 2 0 3 0 4]
 export def intersperse [
     separator: any # the separator to be used
+]: [
+    list -> list
+    range -> list
 ] {
-    reduce --fold [] {|e, acc|
-         $acc ++ [$e, $separator]
-    } 
-    | match $in {
-         [] => [],
-         $xs => ($xs | take (($xs | length) - 1 ))
-    }
+    each --flatten { [$separator $in] } | skip 1
 }
 
 # Returns a list of intermediate steps performed by `reduce` (`fold`).

--- a/crates/nu-std/std/iter/mod.nu
+++ b/crates/nu-std/std/iter/mod.nu
@@ -17,8 +17,11 @@
 @example "Try to find an even element" { ["shell", "abc", "around", "nushell", "std"] | iter find {|e| $e mod 2 == 0} } --result null
 export def find [
     fn: closure # the closure used to perform the search 
+]: [
+    list -> any
+    range -> oneof<number, nothing>
 ] {
-    where {|e| try {do $fn $e} } | try { first }
+    where {|e| try {do $fn $e} } | first
 }
 
 # Returns the index of the first element that matches the predicate or -1 if none

--- a/crates/nu-std/std/iter/mod.nu
+++ b/crates/nu-std/std/iter/mod.nu
@@ -105,12 +105,15 @@ export def filter-map [
 
 # Maps a closure to each nested structure and flattens the result
 @example "Get the sums of list elements" {
-    [[1 2 3] [2 3 4] [5 6 7]] | iter flat-map {|e| $e | math sum}
-} --result [6, 9, 18]
-export def flat-map [ # -> list<any>
+    1..3 | iter flat-map {|e| 0..<$e | each { $e } }
+} --result [1, 2, 2, 3, 3, 3]
+export def flat-map [
     fn: closure              # the closure to map to the nested structures
+]: [
+    list -> list
+    range -> list
 ] {
-    each {|e| do $fn $e } | flatten
+    each --flatten $fn
 }
 
 # Zips two structures and applies a closure to each of the zips

--- a/crates/nu-std/std/iter/mod.nu
+++ b/crates/nu-std/std/iter/mod.nu
@@ -55,6 +55,14 @@ export def intersperse [
     each --flatten { [$separator $in] } | skip 1
 }
 
+def scan-with-init [init: any, closure: closure] {
+    generate {|e, acc|
+        let out = $acc | do $closure $e $acc
+        {next: $out, out: $out}
+    } $init
+    | prepend [$init]
+}
+
 # Returns a list of intermediate steps performed by `reduce` (`fold`).
 #
 # It takes two arguments:
@@ -64,22 +72,39 @@ export def intersperse [
 #   2. the internal state
 #
 # The internal state is also provided as pipeline input.
-@example "Get a running sum of the input list" {
-    [1 2 3] | iter scan 0 {|x, y| $x + $y}
-} --result [0, 1, 3, 6]
-@example "use the `--noinit(-n)` flag to remove the initial value from the final result" {
-    [1 2 3] | iter scan 0 {|x, y| $x + $y} -n
+@example "Get a running sum of the input list." {
+    [1 2 3] | iter scan {|x, y| $x + $y}
 } --result [1, 3, 6]
-export def scan [ # -> list<any>
-    init: any            # initial value to seed the initial state
-    fn: closure          # the closure to perform the scan
-    --noinit(-n)         # remove the initial value from the result
+@example "Append items to a list one at a time and receive all steps." {
+    [1 2 3] | iter scan --fold [] {|e, acc| $acc ++ [$e]}
+} --result [[], [1], [1, 2], [1, 2, 3]]
+export def scan [
+    --fold(-f): any  # Scan with initial value.
+    closure: closure # Scanning closure.
+]: [
+    list -> list
+    range -> list
 ] {
-    generate {|e, acc|
-        let out = $acc | do $fn $e $acc
-        {next: $out, out: $out}
-    } $init
-    | if not $noinit { prepend $init } else { }
+    match (
+        # we really need to a better way to discern why `$flag == null`
+        # - `cmd`
+        # - `cmd --flag null`
+        $fold == null and not (if true {
+            let span = (metadata $fold).span
+            let src = view span $span.start $span.end
+            ($src starts-with "--foo" or $src starts-with "-f")
+        })
+    ) {
+        # --fold
+        false => { scan-with-init $fold $closure }
+        # no --fold
+        true => {
+            peek 1 | metadata access {|md| match $md.peek.value {
+                [] => []
+                [$init] => { skip 1 | scan-with-init $init $closure }
+            }}
+        }
+    }
 }
 
 # Returns a list of values for which the supplied closure does not return `null` or an error.

--- a/crates/nu-std/std/iter/mod.nu
+++ b/crates/nu-std/std/iter/mod.nu
@@ -24,11 +24,7 @@ export def find [
     where {|e| try {do $fn $e} } | first
 }
 
-# Returns the index of the first element that matches the predicate or -1 if none
-#
-# # Invariant
-#
-# The closure must return a bool
+# Returns the index of the first element that matches the predicate, or `null` if none
 @example "Find the index of an element starting with 's'" {
     ["iter", "abc", "shell", "around", "nushell", "std"] | iter find-index {|x| $x starts-with 's'}
 } --result 2
@@ -37,10 +33,13 @@ export def find [
 } --result -1
 export def find-index [
     fn: closure # the closure used to perform the search
+]: [
+    list -> oneof<int, nothing>
+    range -> oneof<int, nothing>
 ] {
     enumerate
     | find {|e| $e.item | do $fn $e.item }
-    | try { get index } catch { -1 }
+    | try { get index }
 }
 
 # Returns a new list with the separator between adjacent items of the original list

--- a/crates/nu-std/tests/test_iter.nu
+++ b/crates/nu-std/tests/test_iter.nu
@@ -44,16 +44,16 @@ def iter_intersperse [] {
 
 @test
 def iter_scan [] {
-    let scanned = ([1 2 3] | iter scan 0 {|x, y| $x + $y} -n)
+    let scanned = ([1 2 3] | iter scan {|x, y| $x + $y})
     assert equal $scanned [1, 3, 6]
 
-    let scanned = ([1 2 3] | iter scan 0 {|x, y| $x + $y})
+    let scanned = ([1 2 3] | iter scan --fold 0 {|x, y| $x + $y})
     assert equal $scanned [0, 1, 3, 6]
 
-    let scanned = ([a b c d] | iter scan "" {|it, acc| [$acc, $it] | str join} -n)
+    let scanned = ([a b c d] | iter scan {|it, acc| [$acc, $it] | str join})
     assert equal $scanned ["a" "ab" "abc" "abcd"]
 
-    let scanned = ([a b c d] | iter scan "" {|it, acc| append $it | str join} -n)
+    let scanned = ([a b c d] | iter scan {|it, acc| append $it | str join})
     assert equal $scanned ["a" "ab" "abc" "abcd"]
 }
 

--- a/crates/nu-std/tests/test_iter.nu
+++ b/crates/nu-std/tests/test_iter.nu
@@ -79,10 +79,7 @@ def iter_find_index [] {
 
     let is_even = {|x| $x mod 2 == 0}
     let res = ([3 5 13 91] | iter find-index $is_even)
-    assert equal $res (-1)
-
-    let res = (42 | iter find-index {|x| $x == 42})
-    assert equal $res 0
+    assert equal $res null
 }
 
 @test


### PR DESCRIPTION
## User-facing changes (Release notes)

### Standard library improvements

- Following general type system improvements, standard library commands now also have more accurate type annotations.

- `std/iter find-index` returns `null` instead of `-1` when failing to find a suitable element

#### `std/iter scan` now has the same signature as `reduce`

> [!WARNING]
> This is a breaking change.

Previously `iter scan` always needed an initial value to start off of (equivalent to `reduce`'s `--fold`), and to compensate for it a `--noinit` flag to remove that initial value from the output.

Now it's signature is identical to `reduce`:

```nushell
# Old
[1 2 3] | iter scan 0 {|x, y| $x + $y}
# New
[1 2 3] | iter scan --fold 0 {|x, y| $x + $y}
# => [0, 1, 3, 6]

# Old
[1 2 3] | iter scan 0 --noinit {|x, y| $x + $y}
# New
[1 2 3] | iter scan {|x, y| $x + $y}
# => [1, 3, 6]
```

#### More streaming

The following commands now stream:
- `std/iter`:
  - `intersperse`
  - `flat-map`
- `std-rfc/conversion`
  - `into list` 
- `std-rfc/tables`
  - `select column-slices`
  - `reject column-slices`

These commands don't really "stream", in that they don't return a stream. Instead they now avoid eagerly collecting input streams:
- `std-rfc/conversions`
  - `name-values`: strictly an internal change with possible performance benefits
- `std-rfc/iter`
  - `only`: will at most consume 2 items from the input

## Additional Notes

> Changed the signature of `std/iter scan` to be the same as `reduce`

I would have liked to make the changes to `iter scan` backwards compatible and raise a deprecation warning for the old signature.
We can do runtime deprecation warnings in rust code but not in nu code. Maybe we should add a `warn deprecated` command (and a `warn` command to leave the possibility of other `warn *` commands open)

If there's interest in that, I can split `iter scan` changes to a separate PR and land only after such a command is added.

> [!TIP]
>  While we have `attr deprecated`/`@deprecated` to mark deprecated commands or flags, we don't have a mechanism for stuff we can detect only at runtime.
