### PR TITLE
Even more type system improvements

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -873,7 +873,14 @@ fn bench_parser_parse_block(dataset: &str, source: String) -> impl IntoBenchmark
             let span = Span::new(0, input.len());
             let engine_state = parser_engine_state();
             let mut working_set = StateWorkingSet::new(&engine_state);
-            black_box(parse_block(&mut working_set, &tokens, span, true, false));
+            black_box(parse_block(
+                &mut working_set,
+                &tokens,
+                span,
+                true,
+                false,
+                None,
+            ));
         })
     })]
 }

--- a/crates/nu-cmd-lang/src/parse_const_test.rs
+++ b/crates/nu-cmd-lang/src/parse_const_test.rs
@@ -11,8 +11,14 @@ fn quickcheck_parse(data: String) -> bool {
             let mut working_set = StateWorkingSet::new(&context);
             let _ = working_set.add_file("quickcheck", data.as_bytes());
 
-            let _ =
-                nu_parser::parse_block(&mut working_set, &tokens, Span::new(0, 0), false, false);
+            let _ = nu_parser::parse_block(
+                &mut working_set,
+                &tokens,
+                Span::new(0, 0),
+                false,
+                false,
+                None,
+            );
         }
     }
     true

--- a/crates/nu-command/tests/commands/assignment/concat.rs
+++ b/crates/nu-command/tests/commands/assignment/concat.rs
@@ -71,7 +71,7 @@ fn concat_assign_type_mismatch() -> Result {
 fn concat_assign_runtime_type_mismatch() -> Result {
     let code = "
         mut a = [];
-        $a ++= if true { 'str' }
+        $a ++= (echo 'str')
     ";
 
     let err = test().run(code).expect_shell_error()?;

--- a/crates/nu-command/tests/commands/chunks.rs
+++ b/crates/nu-command/tests/commands/chunks.rs
@@ -22,7 +22,7 @@ fn chunk_size_zero() -> Result {
 #[test]
 fn chunk_size_not_int() -> Result {
     let err = test()
-        .run("[0 1 2] | chunks (if true { 1sec })")
+        .run("[0 1 2] | chunks (echo 1sec)")
         .expect_shell_error()?;
     assert!(matches!(err, ShellError::CantConvert { .. }));
     Ok(())

--- a/crates/nu-command/tests/commands/window.rs
+++ b/crates/nu-command/tests/commands/window.rs
@@ -22,7 +22,7 @@ fn window_size_zero() -> Result {
 #[test]
 fn window_size_not_int() -> Result {
     let err = test()
-        .run("[0 1 2] | window (if true { 1sec })")
+        .run("[0 1 2] | window (echo 1sec)")
         .expect_shell_error()?;
     assert!(matches!(err, ShellError::CantConvert { .. }));
     Ok(())
@@ -52,7 +52,7 @@ fn stride_zero() -> Result {
 #[test]
 fn stride_not_int() -> Result {
     let err = test()
-        .run("[0 1 2] | window 1 -s (if true { 1sec })")
+        .run("[0 1 2] | window 1 -s (echo 1sec)")
         .expect_shell_error()?;
     assert!(matches!(err, ShellError::CantConvert { .. }));
     Ok(())

--- a/crates/nu-parser/src/parse_bindings.rs
+++ b/crates/nu-parser/src/parse_bindings.rs
@@ -4,7 +4,7 @@ use crate::{
     parser::{
         ArgumentParsingLevel, ParsedInternalCall, parse_internal_call, parse_var_with_opt_type,
     },
-    type_check::type_compatible,
+    type_check::{check_pipeline_type, type_compatible},
 };
 
 use log::trace;
@@ -47,7 +47,13 @@ pub fn parse_let(
 
                     let output_type = match rvalue_block.pipelines.as_slice() {
                         [pipeline] if let Some(input) = input_type => {
-                            crate::type_check::check_pipeline_type(working_set, pipeline, input).0
+                            match check_pipeline_type(working_set, pipeline, input) {
+                                Ok(output_ty) => output_ty,
+                                Err((output_ty, errors)) => {
+                                    working_set.parse_errors.extend(errors);
+                                    output_ty
+                                }
+                            }
                         }
                         _ => rvalue_block.output_type(),
                     };

--- a/crates/nu-parser/src/parse_bindings.rs
+++ b/crates/nu-parser/src/parse_bindings.rs
@@ -20,7 +20,7 @@ use std::{collections::HashMap, sync::Arc};
 pub fn parse_let(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Pipeline {
     trace!("parsing: let");
 
@@ -42,17 +42,11 @@ pub fn parse_let(
                     }
 
                     let rvalue_span = Span::concat(&spans[(span.0 + 1)..]);
-                    let rvalue_block = parse_block(
-                        working_set,
-                        &tokens,
-                        rvalue_span,
-                        false,
-                        true,
-                        input_type.clone(),
-                    );
+                    let rvalue_block =
+                        parse_block(working_set, &tokens, rvalue_span, false, true, input_type);
 
                     let output_type = match rvalue_block.pipelines.as_slice() {
-                        [pipeline] if let Some(input) = input_type.clone() => {
+                        [pipeline] if let Some(input) = input_type => {
                             crate::type_check::check_pipeline_type(working_set, pipeline, input).0
                         }
                         _ => rvalue_block.output_type(),

--- a/crates/nu-parser/src/parse_bindings.rs
+++ b/crates/nu-parser/src/parse_bindings.rs
@@ -17,7 +17,11 @@ use nu_protocol::{
 use std::{collections::HashMap, sync::Arc};
 
 // TODO: handle pipeline input type based inference
-pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline {
+pub fn parse_let(
+    working_set: &mut StateWorkingSet,
+    spans: &[Span],
+    input_type: Option<Type>,
+) -> Pipeline {
     trace!("parsing: let");
 
     if let Some(decl_id) = working_set.find_decl(b"let") {
@@ -38,7 +42,14 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                     }
 
                     let rvalue_span = Span::concat(&spans[(span.0 + 1)..]);
-                    let rvalue_block = parse_block(working_set, &tokens, rvalue_span, false, true);
+                    let rvalue_block = parse_block(
+                        working_set,
+                        &tokens,
+                        rvalue_span,
+                        false,
+                        true,
+                        input_type.clone(),
+                    );
 
                     let output_type = rvalue_block.output_type();
 
@@ -52,8 +63,13 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                     );
 
                     let mut idx = 0;
-                    let (lvalue, explicit_type) =
-                        parse_var_with_opt_type(working_set, &spans[1..(span.0)], &mut idx, false);
+                    let (lvalue, explicit_type) = parse_var_with_opt_type(
+                        working_set,
+                        &spans[1..(span.0)],
+                        &mut idx,
+                        false,
+                        input_type,
+                    );
                     if idx + 1 < span.0 - 1 {
                         working_set.error(ParseError::ExtraTokens(spans[idx + 2]));
                     }
@@ -99,7 +115,7 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
             &spans[1..],
             decl_id,
             ArgumentParsingLevel::Full,
-            None,
+            input_type,
         );
 
         return Pipeline::from_vec(vec![Expression::new(
@@ -145,7 +161,7 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeli
 
                     trace!("parsing: const right-hand side subexpression");
                     let rvalue_block =
-                        parse_block(working_set, &rvalue_tokens, rvalue_span, false, true);
+                        parse_block(working_set, &rvalue_tokens, rvalue_span, false, true, None);
                     let rvalue_ty = rvalue_block.output_type();
                     let rvalue_block_id = working_set.add_block(Arc::new(rvalue_block));
                     let rvalue = Expression::new(
@@ -157,8 +173,13 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeli
 
                     let mut idx = 0;
 
-                    let (lvalue, explicit_type) =
-                        parse_var_with_opt_type(working_set, &spans[1..(span.0)], &mut idx, false);
+                    let (lvalue, explicit_type) = parse_var_with_opt_type(
+                        working_set,
+                        &spans[1..(span.0)],
+                        &mut idx,
+                        false,
+                        None,
+                    );
                     if idx + 1 < span.0 - 1 {
                         working_set.error(ParseError::ExtraTokens(spans[idx + 2]));
                     }
@@ -290,7 +311,8 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                     }
 
                     let rvalue_span = Span::concat(&spans[(span.0 + 1)..]);
-                    let rvalue_block = parse_block(working_set, &tokens, rvalue_span, false, true);
+                    let rvalue_block =
+                        parse_block(working_set, &tokens, rvalue_span, false, true, None);
 
                     let output_type = rvalue_block.output_type();
 
@@ -305,8 +327,13 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
 
                     let mut idx = 0;
 
-                    let (lvalue, explicit_type) =
-                        parse_var_with_opt_type(working_set, &spans[1..(span.0)], &mut idx, true);
+                    let (lvalue, explicit_type) = parse_var_with_opt_type(
+                        working_set,
+                        &spans[1..(span.0)],
+                        &mut idx,
+                        true,
+                        None,
+                    );
                     if idx + 1 < span.0 - 1 {
                         working_set.error(ParseError::ExtraTokens(spans[idx + 2]));
                     }

--- a/crates/nu-parser/src/parse_bindings.rs
+++ b/crates/nu-parser/src/parse_bindings.rs
@@ -51,7 +51,12 @@ pub fn parse_let(
                         input_type.clone(),
                     );
 
-                    let output_type = rvalue_block.output_type();
+                    let output_type = match rvalue_block.pipelines.as_slice() {
+                        [pipeline] if let Some(input) = input_type.clone() => {
+                            crate::type_check::check_pipeline_type(working_set, pipeline, input).0
+                        }
+                        _ => rvalue_block.output_type(),
+                    };
 
                     let block_id = working_set.add_block(Arc::new(rvalue_block));
 

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -1312,16 +1312,28 @@ pub fn parse_internal_call(
                         Some(SpecialCmd::Match) if &positional.name == "match_block" => {
                             output_override = Some(expr.ty.clone());
                         }
-                        Some(SpecialCmd::If) if positional_idx >= 1 => {
-                            let ty = match &expr.expr {
+                        Some(SpecialCmd::If)
+                            if positional_idx == 1
+                                && let Expr::Block(block_id) = &expr.expr =>
+                        {
+                            let ty = working_set.get_block(*block_id).output_type();
+
+                            output_override = Some(match output_override {
+                                Some(existing_ty) => existing_ty.union(ty),
+                                None => ty,
+                            });
+                        }
+                        Some(SpecialCmd::If)
+                            if positional_idx == 2
+                                && let Expr::Keyword(kw) = &expr.expr =>
+                        {
+                            let ty = match &kw.expr.expr {
                                 Expr::Block(block_id) => {
                                     working_set.get_block(*block_id).output_type()
                                 }
-                                Expr::Keyword(kw) if let Expr::Block(block_id) = &kw.expr.expr => {
-                                    working_set.get_block(*block_id).output_type()
-                                }
-                                _ => expr.ty.clone(),
+                                _ => kw.expr.ty.clone(),
                             };
+
                             output_override = Some(match output_override {
                                 Some(existing_ty) => existing_ty.union(ty),
                                 None => ty,

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -687,7 +687,7 @@ pub(crate) fn parse_oneof(
     spans_idx: &mut usize,
     possible_shapes: &Vec<SyntaxShape>,
     multispan: bool,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     let starting_spans_idx = *spans_idx;
     let mut best_guess = None;
@@ -698,13 +698,8 @@ pub(crate) fn parse_oneof(
         let starting_error_count = working_set.parse_errors.len();
         *spans_idx = starting_spans_idx;
         let value = match multispan {
-            true => parse_multispan_value(working_set, spans, spans_idx, shape, input_type.clone()),
-            false => crate::parser::parse_value(
-                working_set,
-                spans[*spans_idx],
-                shape,
-                input_type.clone(),
-            ),
+            true => parse_multispan_value(working_set, spans, spans_idx, shape, input_type),
+            false => crate::parser::parse_value(working_set, spans[*spans_idx], shape, input_type),
         };
 
         let new_errors = &working_set.parse_errors[starting_error_count..];
@@ -753,7 +748,7 @@ pub fn parse_multispan_value(
     spans: &[Span],
     spans_idx: &mut usize,
     shape: &SyntaxShape,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     trace!("parse multispan value");
     match shape {
@@ -906,7 +901,7 @@ pub fn parse_internal_call(
     spans: &[Span],
     decl_id: DeclId,
     arg_parsing_level: ArgumentParsingLevel,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> ParsedInternalCall {
     trace!("parsing: internal call (decl id: {})", decl_id.get());
 
@@ -950,7 +945,11 @@ pub fn parse_internal_call(
     // Incorrect behavior this may cause will be handled by
     // `check_pipeline_type` in crates/nu-parser/src/type_check.rs
     let output = signature
-        .get_output_type(input_type.clone().map(|ty| ty.union(Type::Nothing)))
+        .get_output_type(
+            input_type
+                .map(|ty| ty.clone().union(Type::Nothing))
+                .as_ref(),
+        )
         .unwrap_or(Type::Error);
 
     // This is necessary for some keywords to have proper expression types.
@@ -1272,14 +1271,14 @@ pub fn parse_internal_call(
                     Expression::garbage(working_set, spans[spans_idx])
                 }
                 _ => {
-                    let input_type = match special_cmd {
+                    let input_type: Option<Type> = match special_cmd {
                         // `let` can assigned from pipeline input, input type is necessary to infer
                         // the variable's type correctly
                         Some(SpecialCmd::Let)
                             if let SyntaxShape::VarWithOptType = &positional.shape =>
                         {
-                            output_override = input_type.clone();
-                            input_type.clone()
+                            output_override = input_type.cloned();
+                            input_type.cloned()
                         }
                         // in a def block, the pipeline input type should be inferred based on the
                         // command input-output signature
@@ -1293,9 +1292,9 @@ pub fn parse_internal_call(
                                 _ => None,
                             }
                         }
-                        Some(SpecialCmd::If) if positional_idx >= 1 => input_type.clone(),
+                        Some(SpecialCmd::If) if positional_idx >= 1 => input_type.cloned(),
                         Some(SpecialCmd::Match) if &positional.name == "match_block" => {
-                            input_type.clone()
+                            input_type.cloned()
                         }
                         _ => None,
                     };
@@ -1305,7 +1304,7 @@ pub fn parse_internal_call(
                         &spans[..end],
                         &mut spans_idx,
                         &positional.shape,
-                        input_type,
+                        input_type.as_ref(),
                     );
 
                     match special_cmd {
@@ -1433,7 +1432,7 @@ pub fn parse_call(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
     head: Span,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     trace!("parsing: call");
     let call_span = Span::concat(spans);

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -921,6 +921,7 @@ pub fn parse_internal_call(
     enum SpecialCmd {
         Let,
         Def,
+        Match,
     }
 
     impl SpecialCmd {
@@ -928,6 +929,7 @@ pub fn parse_internal_call(
             Some(match s {
                 "let" => Self::Let,
                 "def" => Self::Def,
+                "match" => Self::Match,
                 _ => return None,
             })
         }
@@ -1288,15 +1290,28 @@ pub fn parse_internal_call(
                                 _ => None,
                             }
                         }
+                        Some(SpecialCmd::Match) if &positional.name == "match_block" => {
+                            input_type.clone()
+                        }
                         _ => None,
                     };
-                    parse_multispan_value(
+
+                    let expr = parse_multispan_value(
                         working_set,
                         &spans[..end],
                         &mut spans_idx,
                         &positional.shape,
                         input_type,
-                    )
+                    );
+
+                    match special_cmd {
+                        Some(SpecialCmd::Match) if &positional.name == "match_block" => {
+                            output_override = Some(expr.ty.clone());
+                        }
+                        _ => {}
+                    };
+
+                    expr
                 }
             };
 

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -767,7 +767,12 @@ pub fn parse_multispan_value(
         SyntaxShape::MathExpression => {
             trace!("parsing: math expression");
 
-            let arg = crate::parser::parse_math_expression(working_set, &spans[*spans_idx..], None);
+            let arg = crate::parser::parse_math_expression(
+                working_set,
+                &spans[*spans_idx..],
+                None,
+                input_type,
+            );
             *spans_idx = spans.len() - 1;
 
             arg
@@ -846,7 +851,7 @@ pub fn parse_multispan_value(
             let keyword = Keyword {
                 keyword: keyword.as_slice().into(),
                 span: spans[*spans_idx - 1],
-                expr: parse_multispan_value(working_set, spans, spans_idx, arg, None),
+                expr: parse_multispan_value(working_set, spans, spans_idx, arg, input_type),
             };
 
             Expression::new(

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -687,6 +687,7 @@ pub(crate) fn parse_oneof(
     spans_idx: &mut usize,
     possible_shapes: &Vec<SyntaxShape>,
     multispan: bool,
+    input_type: Option<Type>,
 ) -> Expression {
     let starting_spans_idx = *spans_idx;
     let mut best_guess = None;
@@ -697,8 +698,13 @@ pub(crate) fn parse_oneof(
         let starting_error_count = working_set.parse_errors.len();
         *spans_idx = starting_spans_idx;
         let value = match multispan {
-            true => parse_multispan_value(working_set, spans, spans_idx, shape, None),
-            false => crate::parser::parse_value(working_set, spans[*spans_idx], shape, None),
+            true => parse_multispan_value(working_set, spans, spans_idx, shape, input_type.clone()),
+            false => crate::parser::parse_value(
+                working_set,
+                spans[*spans_idx],
+                shape,
+                input_type.clone(),
+            ),
         };
 
         let new_errors = &working_set.parse_errors[starting_error_count..];
@@ -777,16 +783,22 @@ pub fn parse_multispan_value(
 
             arg
         }
-        SyntaxShape::OneOf(possible_shapes) => {
-            parse_oneof(working_set, spans, spans_idx, possible_shapes, true)
-        }
+        SyntaxShape::OneOf(possible_shapes) => parse_oneof(
+            working_set,
+            spans,
+            spans_idx,
+            possible_shapes,
+            true,
+            input_type,
+        ),
 
         SyntaxShape::Expression => {
             trace!("parsing: expression");
 
             // is it subexpression?
             // Not sure, but let's make it not, so the behavior is the same as previous version of nushell.
-            let arg = crate::parser::parse_expression(working_set, &spans[*spans_idx..], None);
+            let arg =
+                crate::parser::parse_expression(working_set, &spans[*spans_idx..], input_type);
             *spans_idx = spans.len().saturating_sub(1);
 
             arg

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -1315,7 +1315,11 @@ pub fn parse_internal_call(
                             if positional_idx == 1
                                 && let Expr::Block(block_id) = &expr.expr =>
                         {
-                            let ty = working_set.get_block(*block_id).output_type();
+                            let block = working_set.get_block(*block_id);
+                            let ty = match block.pipelines.is_empty() {
+                                false => block.output_type(),
+                                true => input_type.unwrap_or(Type::Any),
+                            };
 
                             output_override = Some(match output_override {
                                 Some(existing_ty) => existing_ty.union(ty),
@@ -1328,7 +1332,11 @@ pub fn parse_internal_call(
                         {
                             let ty = match &kw.expr.expr {
                                 Expr::Block(block_id) => {
-                                    working_set.get_block(*block_id).output_type()
+                                    let block = working_set.get_block(*block_id);
+                                    match block.pipelines.is_empty() {
+                                        false => block.output_type(),
+                                        true => input_type.unwrap_or(Type::Any),
+                                    }
                                 }
                                 _ => kw.expr.ty.clone(),
                             };

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -900,6 +900,27 @@ pub fn parse_internal_call(
 
     let decl = working_set.get_decl(decl_id);
     let signature = working_set.get_signature(decl);
+
+    enum SpecialCmd {
+        Let,
+        Def,
+    }
+
+    impl SpecialCmd {
+        fn from_str(s: &str) -> Option<Self> {
+            Some(match s {
+                "let" => Self::Let,
+                "def" => Self::Def,
+                _ => return None,
+            })
+        }
+    }
+
+    let special_cmd = decl
+        .is_keyword()
+        .then(|| decl.name())
+        .and_then(SpecialCmd::from_str);
+
     // TODO: Throw an actual error here, instead of leaning on later type checking code
     //
     // `Type::Nothing` is added to inputs to allow uses like:
@@ -908,8 +929,14 @@ pub fn parse_internal_call(
     // Incorrect behavior this may cause will be handled by
     // `check_pipeline_type` in crates/nu-parser/src/type_check.rs
     let output = signature
-        .get_output_type(input_type.map(|ty| ty.union(Type::Nothing)))
+        .get_output_type(input_type.clone().map(|ty| ty.union(Type::Nothing)))
         .unwrap_or(Type::Error);
+
+    // This is necessary for some keywords to have proper expression types.
+    // `2 | let x | let y`
+    // - `$x` should be `int`
+    // - `$y` should also be `int`, but for that `let x` as an expression must have the type `int`
+    let mut output_override = None;
 
     let deprecation = decl.deprecation_info();
 
@@ -1223,13 +1250,37 @@ pub fn parse_internal_call(
                 ArgumentParsingLevel::FirstK { k } if k <= positional_idx => {
                     Expression::garbage(working_set, spans[spans_idx])
                 }
-                _ => parse_multispan_value(
-                    working_set,
-                    &spans[..end],
-                    &mut spans_idx,
-                    &positional.shape,
-                    None,
-                ),
+                _ => {
+                    let input_type = match special_cmd {
+                        // `let` can assigned from pipeline input, input type is necessary to infer
+                        // the variable's type correctly
+                        Some(SpecialCmd::Let)
+                            if let SyntaxShape::VarWithOptType = &positional.shape =>
+                        {
+                            output_override = input_type.clone();
+                            input_type.clone()
+                        }
+                        // in a def block, the pipeline input type should be inferred based on the
+                        // command input-output signature
+                        Some(SpecialCmd::Def) if &positional.name == "block" => {
+                            match call.arguments.last() {
+                                Some(Argument::Positional(Expression {
+                                    expr: Expr::Signature(sig),
+                                    ..
+                                })) => Some(sig.get_input_type()),
+                                _ => None,
+                            }
+                        }
+                        _ => None,
+                    };
+                    parse_multispan_value(
+                        working_set,
+                        &spans[..end],
+                        &mut spans_idx,
+                        &positional.shape,
+                        input_type,
+                    )
+                }
             };
 
             // HACK: try-catch's signature defines the catch block as a Closure, even though it's
@@ -1297,6 +1348,8 @@ pub fn parse_internal_call(
     if signature.creates_scope {
         working_set.exit_scope();
     }
+
+    let output = output_override.unwrap_or(output);
 
     ParsedInternalCall {
         call: Box::new(call),

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -922,6 +922,7 @@ pub fn parse_internal_call(
         Let,
         Def,
         Match,
+        If,
     }
 
     impl SpecialCmd {
@@ -930,6 +931,7 @@ pub fn parse_internal_call(
                 "let" => Self::Let,
                 "def" => Self::Def,
                 "match" => Self::Match,
+                "if" => Self::If,
                 _ => return None,
             })
         }
@@ -1282,6 +1284,7 @@ pub fn parse_internal_call(
                         // in a def block, the pipeline input type should be inferred based on the
                         // command input-output signature
                         Some(SpecialCmd::Def) if &positional.name == "block" => {
+                            // if we're parsing the `block`, the previous item is the signature
                             match call.arguments.last() {
                                 Some(Argument::Positional(Expression {
                                     expr: Expr::Signature(sig),
@@ -1290,6 +1293,7 @@ pub fn parse_internal_call(
                                 _ => None,
                             }
                         }
+                        Some(SpecialCmd::If) if positional_idx >= 1 => input_type.clone(),
                         Some(SpecialCmd::Match) if &positional.name == "match_block" => {
                             input_type.clone()
                         }
@@ -1307,6 +1311,21 @@ pub fn parse_internal_call(
                     match special_cmd {
                         Some(SpecialCmd::Match) if &positional.name == "match_block" => {
                             output_override = Some(expr.ty.clone());
+                        }
+                        Some(SpecialCmd::If) if positional_idx >= 1 => {
+                            let ty = match &expr.expr {
+                                Expr::Block(block_id) => {
+                                    working_set.get_block(*block_id).output_type()
+                                }
+                                Expr::Keyword(kw) if let Expr::Block(block_id) = &kw.expr.expr => {
+                                    working_set.get_block(*block_id).output_type()
+                                }
+                                _ => expr.ty.clone(),
+                            };
+                            output_override = Some(match output_override {
+                                Some(existing_ty) => existing_ty.union(ty),
+                                None => ty,
+                            });
                         }
                         _ => {}
                     };
@@ -1379,6 +1398,14 @@ pub fn parse_internal_call(
 
     if signature.creates_scope {
         working_set.exit_scope();
+    }
+
+    match special_cmd {
+        // Not having an else branch means the output can be `nothing`
+        Some(SpecialCmd::If) if call.arguments.len() < 3 => {
+            output_override = output_override.map(|ty| ty.union(Type::Nothing))
+        }
+        _ => {}
     }
 
     let output = output_override.unwrap_or(output);

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -93,7 +93,7 @@ fn parse_unknown_arg(
         .map(|arg| arg.shape.clone())
         .unwrap_or(SyntaxShape::Any);
 
-    crate::parser::parse_value(working_set, span, &shape)
+    crate::parser::parse_value(working_set, span, &shape, None)
 }
 
 fn parse_external_string(working_set: &mut StateWorkingSet, span: Span) -> Expression {
@@ -326,6 +326,7 @@ fn parse_external_arg(working_set: &mut StateWorkingSet, span: Span) -> External
             working_set,
             span,
             &SyntaxShape::List(Box::new(SyntaxShape::Any)),
+            None,
         ))
     } else {
         ExternalArgument::Regular(parse_regular_external_arg(working_set, span))
@@ -337,7 +338,7 @@ pub(crate) fn parse_regular_external_arg(
     span: Span,
 ) -> Expression {
     match working_set.get_span_contents(span) {
-        [b'$', ..] => crate::parser::parse_dollar_expr(working_set, span, &SyntaxShape::Any),
+        [b'$', ..] => crate::parser::parse_dollar_expr(working_set, span, &SyntaxShape::Any, None),
         [b'(', ..] => crate::parser::parse_paren_expr(working_set, span, &SyntaxShape::Any),
         [b'[', ..] => crate::parser::parse_list_expression(working_set, span, &SyntaxShape::Any),
         _ => parse_external_string(working_set, span),
@@ -448,7 +449,7 @@ fn parse_long_flag(
                         let mut span = arg_span;
                         span.start += long_name_len + 3; //offset by long flag and '='
 
-                        let arg = crate::parser::parse_value(working_set, span, arg_shape);
+                        let arg = crate::parser::parse_value(working_set, span, arg_shape, None);
                         let (arg_name, val_expression) = ensure_flag_arg_type(
                             working_set,
                             long_name,
@@ -458,7 +459,7 @@ fn parse_long_flag(
                         );
                         LongFlagParseResult::FoundFlag(arg_name, Some(val_expression))
                     } else if let Some(arg) = spans.get(*spans_idx + 1) {
-                        let arg = crate::parser::parse_value(working_set, *arg, arg_shape);
+                        let arg = crate::parser::parse_value(working_set, *arg, arg_shape, None);
 
                         *spans_idx += 1;
                         let (arg_name, val_expression) =
@@ -488,8 +489,12 @@ fn parse_long_flag(
                         let mut span = arg_span;
                         span.start += long_name_len + 3; //offset by long flag and '='
 
-                        let arg =
-                            crate::parser::parse_value(working_set, span, &SyntaxShape::Boolean);
+                        let arg = crate::parser::parse_value(
+                            working_set,
+                            span,
+                            &SyntaxShape::Boolean,
+                            None,
+                        );
 
                         let (arg_name, val_expression) = ensure_flag_arg_type(
                             working_set,
@@ -692,8 +697,8 @@ pub(crate) fn parse_oneof(
         let starting_error_count = working_set.parse_errors.len();
         *spans_idx = starting_spans_idx;
         let value = match multispan {
-            true => parse_multispan_value(working_set, spans, spans_idx, shape),
-            false => crate::parser::parse_value(working_set, spans[*spans_idx], shape),
+            true => parse_multispan_value(working_set, spans, spans_idx, shape, None),
+            false => crate::parser::parse_value(working_set, spans[*spans_idx], shape, None),
         };
 
         let new_errors = &working_set.parse_errors[starting_error_count..];
@@ -742,13 +747,15 @@ pub fn parse_multispan_value(
     spans: &[Span],
     spans_idx: &mut usize,
     shape: &SyntaxShape,
+    input_type: Option<Type>,
 ) -> Expression {
     trace!("parse multispan value");
     match shape {
         SyntaxShape::VarWithOptType => {
             trace!("parsing: var with opt type");
 
-            crate::parser::parse_var_with_opt_type(working_set, spans, spans_idx, false).0
+            crate::parser::parse_var_with_opt_type(working_set, spans, spans_idx, false, input_type)
+                .0
         }
         SyntaxShape::RowCondition => {
             trace!("parsing: row condition");
@@ -839,7 +846,7 @@ pub fn parse_multispan_value(
             let keyword = Keyword {
                 keyword: keyword.as_slice().into(),
                 span: spans[*spans_idx - 1],
-                expr: parse_multispan_value(working_set, spans, spans_idx, arg),
+                expr: parse_multispan_value(working_set, spans, spans_idx, arg, None),
             };
 
             Expression::new(
@@ -853,7 +860,7 @@ pub fn parse_multispan_value(
             // All other cases are single-span values
             let arg_span = spans[*spans_idx];
 
-            crate::parser::parse_value(working_set, arg_span, shape)
+            crate::parser::parse_value(working_set, arg_span, shape, input_type)
         }
     }
 }
@@ -1053,7 +1060,8 @@ pub fn parse_internal_call(
 
                         if let Some(arg_shape) = flag.arg {
                             if let Some(arg) = spans.get(spans_idx + 1) {
-                                let arg = crate::parser::parse_value(working_set, *arg, &arg_shape);
+                                let arg =
+                                    crate::parser::parse_value(working_set, *arg, &arg_shape, None);
                                 let (arg_name, val_expression) = ensure_flag_arg_type(
                                     working_set,
                                     flag.long.clone(),
@@ -1160,6 +1168,7 @@ pub fn parse_internal_call(
                         working_set,
                         spread_arg_span,
                         &SyntaxShape::List(Box::new(rest_shape)),
+                        None,
                     );
 
                     call.add_spread(args);
@@ -1219,6 +1228,7 @@ pub fn parse_internal_call(
                     &spans[..end],
                     &mut spans_idx,
                     &positional.shape,
+                    None,
                 ),
             };
 
@@ -1379,11 +1389,12 @@ pub fn parse_call(
                         working_set,
                         arg_span,
                         &SyntaxShape::List(Box::new(SyntaxShape::Any)),
+                        None,
                     );
                     call.arguments.push(Argument::Spread(spread_expr));
                 } else {
                     let arg_expr =
-                        crate::parser::parse_value(working_set, *arg_span, &SyntaxShape::Any);
+                        crate::parser::parse_value(working_set, *arg_span, &SyntaxShape::Any, None);
                     call.arguments.push(Argument::Positional(arg_expr));
                 }
             }

--- a/crates/nu-parser/src/parse_captures_compile.rs
+++ b/crates/nu-parser/src/parse_captures_compile.rs
@@ -465,7 +465,7 @@ pub(crate) fn wrap_redirection_with_collect(
 pub(crate) fn wrap_element_with_collect(
     working_set: &mut StateWorkingSet,
     element: PipelineElement,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> PipelineElement {
     PipelineElement {
         pipe: element.pipe,
@@ -486,7 +486,7 @@ pub(crate) fn wrap_element_with_collect(
 pub(crate) fn wrap_expr_with_collect(
     working_set: &mut StateWorkingSet,
     mut expr: Expression,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     let span = expr.span;
 
@@ -495,7 +495,7 @@ pub(crate) fn wrap_expr_with_collect(
     let var_id = working_set.add_variable(
         b"$in".into(),
         Span::new(span.start, span.start),
-        input_type.unwrap_or(Type::Any),
+        input_type.cloned().unwrap_or(Type::Any),
         false,
     );
     expr.replace_in_variable(working_set, var_id);

--- a/crates/nu-parser/src/parse_captures_compile.rs
+++ b/crates/nu-parser/src/parse_captures_compile.rs
@@ -454,7 +454,7 @@ pub(crate) fn wrap_redirection_with_collect(
 ) -> RedirectionTarget {
     match target {
         RedirectionTarget::File { expr, append, span } => RedirectionTarget::File {
-            expr: wrap_expr_with_collect(working_set, expr),
+            expr: wrap_expr_with_collect(working_set, expr, None),
             span,
             append,
         },
@@ -465,10 +465,11 @@ pub(crate) fn wrap_redirection_with_collect(
 pub(crate) fn wrap_element_with_collect(
     working_set: &mut StateWorkingSet,
     element: PipelineElement,
+    input_type: Option<Type>,
 ) -> PipelineElement {
     PipelineElement {
         pipe: element.pipe,
-        expr: wrap_expr_with_collect(working_set, element.expr),
+        expr: wrap_expr_with_collect(working_set, element.expr, input_type),
         redirection: element.redirection.map(|r| match r {
             PipelineRedirection::Single { source, target } => PipelineRedirection::Single {
                 source,
@@ -485,6 +486,7 @@ pub(crate) fn wrap_element_with_collect(
 pub(crate) fn wrap_expr_with_collect(
     working_set: &mut StateWorkingSet,
     mut expr: Expression,
+    input_type: Option<Type>,
 ) -> Expression {
     let span = expr.span;
 
@@ -493,7 +495,7 @@ pub(crate) fn wrap_expr_with_collect(
     let var_id = working_set.add_variable(
         b"$in".into(),
         Span::new(span.start, span.start),
-        Type::Any,
+        input_type.unwrap_or(Type::Any),
         false,
     );
     expr.replace_in_variable(working_set, var_id);
@@ -537,7 +539,14 @@ pub fn parse(
                 working_set.error(err)
             }
 
-            Arc::new(parse_block(working_set, &output, new_span, scoped, false))
+            Arc::new(parse_block(
+                working_set,
+                &output,
+                new_span,
+                scoped,
+                false,
+                None,
+            ))
         }
     };
 

--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -459,7 +459,11 @@ pub fn parse_block_expression(
     Expression::new(working_set, Expr::Block(block_id), span, Type::Block)
 }
 
-pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Span) -> Expression {
+pub fn parse_match_block_expression(
+    working_set: &mut StateWorkingSet,
+    span: Span,
+    input_type: Option<Type>,
+) -> Expression {
     let bytes = working_set.get_span_contents(span);
 
     let mut start = span.start;
@@ -491,6 +495,7 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
     let mut position = 0;
 
     let mut output_matches = vec![];
+    let mut output_type = Type::one_of([]);
 
     while position < output.len() {
         // Each match gets its own scope
@@ -642,21 +647,32 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
             &[output[position].span],
             &mut 0,
             &SyntaxShape::OneOf(vec![SyntaxShape::Block, SyntaxShape::Expression]),
-            None,
+            input_type.clone(),
         );
         position += 1;
         if is_closed {
             working_set.exit_scope();
         }
 
+        let branch_output_type = match &result.expr {
+            Expr::Block(block_id) => working_set.get_block(*block_id).output_type().clone(),
+            _ => result.ty.clone(),
+        };
+        output_type = output_type.union(branch_output_type);
+
         output_matches.push((pattern, result));
+    }
+
+    let has_wildcard = output_matches.iter().any(|(pat, _)| pat.is_wildcard());
+    if !has_wildcard {
+        output_type = output_type.union(Type::Nothing);
     }
 
     Expression::new(
         working_set,
         Expr::MatchBlock(output_matches),
         span,
-        Type::Any,
+        output_type,
     )
 }
 

--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -641,7 +641,13 @@ pub fn parse_match_block_expression(
         }
 
         let branch_output_type = match &result.expr {
-            Expr::Block(block_id) => working_set.get_block(*block_id).output_type().clone(),
+            Expr::Block(block_id) => {
+                let block = working_set.get_block(*block_id);
+                match block.pipelines.is_empty() {
+                    false => block.output_type(),
+                    true => input_type.cloned().unwrap_or(Type::Any),
+                }
+            }
             _ => result.ty.clone(),
         };
         output_type = output_type.union(branch_output_type);

--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -825,7 +825,14 @@ pub fn parse_value(
     }
 
     if let SyntaxShape::OneOf(possible_shapes) = shape {
-        return parse_oneof(working_set, &[span], &mut 0, possible_shapes, false);
+        return parse_oneof(
+            working_set,
+            &[span],
+            &mut 0,
+            possible_shapes,
+            false,
+            input_type,
+        );
     }
 
     match bytes[0] {

--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -1234,6 +1234,7 @@ pub fn parse_math_expression(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
     lhs_row_var_id: Option<VarId>,
+    input_type: Option<Type>,
 ) -> Expression {
     trace!("parsing: math expression");
 
@@ -1260,7 +1261,7 @@ pub fn parse_math_expression(
     if first_span == b"if" || first_span == b"match" {
         // If expression
         if spans.len() > 1 {
-            return parse_call(working_set, spans, spans[0], None);
+            return parse_call(working_set, spans, spans[0], input_type);
         } else {
             working_set.error(ParseError::Expected(
                 "expression",
@@ -1291,7 +1292,12 @@ pub fn parse_math_expression(
         }
     }
 
-    let mut lhs = parse_value(working_set, spans[idx], &SyntaxShape::Any, None);
+    let mut lhs = parse_value(
+        working_set,
+        spans[idx],
+        &SyntaxShape::Any,
+        input_type.clone(),
+    );
 
     for not_start_span in not_start_spans.iter().rev() {
         lhs = Expression::new(
@@ -1308,7 +1314,7 @@ pub fn parse_math_expression(
     if idx >= spans.len() {
         // We already found the one part of our expression, so let's expand
         if let Some(row_var_id) = lhs_row_var_id {
-            expand_to_cell_path(working_set, &mut lhs, row_var_id);
+            expand_to_cell_path(working_set, &mut lhs, row_var_id, input_type);
         }
     }
 
@@ -1402,7 +1408,7 @@ pub fn parse_math_expression(
                 .expect("internal error: expression stack empty");
 
             if let Some(row_var_id) = lhs_row_var_id {
-                expand_to_cell_path(working_set, &mut lhs, row_var_id);
+                expand_to_cell_path(working_set, &mut lhs, row_var_id, None);
             }
 
             let (result_ty, err) = math_result_type(working_set, &mut lhs, &mut op, &mut rhs);
@@ -1438,7 +1444,7 @@ pub fn parse_math_expression(
             .expect("internal error: expression stack empty");
 
         if let Some(row_var_id) = lhs_row_var_id {
-            expand_to_cell_path(working_set, &mut lhs, row_var_id);
+            expand_to_cell_path(working_set, &mut lhs, row_var_id, None);
         }
 
         let (result_ty, err) = math_result_type(working_set, &mut lhs, &mut op, &mut rhs);
@@ -1521,7 +1527,7 @@ pub fn parse_expression(
     {
         parse_assignment_expression(working_set, &spans[pos..], input_type)
     } else if is_math_expression_like(working_set, spans[pos]) {
-        parse_math_expression(working_set, &spans[pos..], None)
+        parse_math_expression(working_set, &spans[pos..], None, input_type)
     } else {
         let bytes = working_set.get_span_contents(spans[pos]).to_vec();
 

--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -389,7 +389,7 @@ fn table_type(head: &[Expression], rows: &[Vec<Expression>]) -> (Type, Vec<Parse
 pub fn parse_block_expression(
     working_set: &mut StateWorkingSet,
     span: Span,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     trace!("parsing: block expression");
 
@@ -423,30 +423,16 @@ pub fn parse_block_expression(
 
     working_set.enter_scope();
 
-    // Check to see if we have parameters
-    let (signature, amt_to_skip): (Option<(Box<Signature>, Span)>, usize) = match output.first() {
-        Some(Token {
-            contents: TokenContents::Pipe,
-            span,
-        }) => {
-            working_set.error(ParseError::Expected("block but found closure", *span));
-            (None, 0)
-        }
-        _ => (None, 0),
-    };
-
-    let mut output = parse_block(
-        working_set,
-        &output[amt_to_skip..],
+    // Check to see if we have closure parameters
+    if let Some(Token {
+        contents: TokenContents::Pipe,
         span,
-        false,
-        false,
-        input_type,
-    );
-
-    if let Some(signature) = signature {
-        output.signature = signature.0;
+    }) = output.first()
+    {
+        working_set.error(ParseError::Expected("block but found closure", *span));
     }
+
+    let mut output = parse_block(working_set, &output, span, false, false, input_type);
 
     output.span = Some(span);
 
@@ -462,7 +448,7 @@ pub fn parse_block_expression(
 pub fn parse_match_block_expression(
     working_set: &mut StateWorkingSet,
     span: Span,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     let bytes = working_set.get_span_contents(span);
 
@@ -647,7 +633,7 @@ pub fn parse_match_block_expression(
             &[output[position].span],
             &mut 0,
             &SyntaxShape::OneOf(vec![SyntaxShape::Block, SyntaxShape::Expression]),
-            input_type.clone(),
+            input_type,
         );
         position += 1;
         if is_closed {
@@ -680,7 +666,7 @@ pub fn parse_closure_expression(
     working_set: &mut StateWorkingSet,
     shape: &SyntaxShape,
     span: Span,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     trace!("parsing: closure expression");
 
@@ -829,7 +815,7 @@ pub fn parse_value(
     working_set: &mut StateWorkingSet,
     span: Span,
     shape: &SyntaxShape,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     trace!("parsing: value: {shape}");
 
@@ -1006,7 +992,7 @@ pub fn parse_assignment_operator(working_set: &mut StateWorkingSet, span: Span) 
 pub fn parse_assignment_expression(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     trace!("parsing: assignment expression");
     let expr_span = Span::concat(spans);
@@ -1257,7 +1243,7 @@ pub fn parse_math_expression(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
     lhs_row_var_id: Option<VarId>,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     trace!("parsing: math expression");
 
@@ -1315,12 +1301,7 @@ pub fn parse_math_expression(
         }
     }
 
-    let mut lhs = parse_value(
-        working_set,
-        spans[idx],
-        &SyntaxShape::Any,
-        input_type.clone(),
-    );
+    let mut lhs = parse_value(working_set, spans[idx], &SyntaxShape::Any, input_type);
 
     for not_start_span in not_start_spans.iter().rev() {
         lhs = Expression::new(
@@ -1492,7 +1473,7 @@ pub fn parse_math_expression(
 pub fn parse_expression(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     trace!("parsing: expression");
 
@@ -1667,7 +1648,7 @@ pub fn parse_expression(
 pub fn parse_builtin_commands(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Pipeline {
     trace!("parsing: builtin commands");
     if !is_math_expression_like(working_set, lite_command.parts[0])
@@ -1772,7 +1753,7 @@ pub fn parse_builtin_commands(
         }
         _ => {
             let element =
-                parse_pipeline_element(working_set, lite_command, input_type.unwrap_or(Type::Any));
+                parse_pipeline_element(working_set, lite_command, input_type.unwrap_or(&Type::Any));
 
             // There is still a chance to make `parse_pipeline_element` parse into
             // some keyword that should apply side effects first, Example:

--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -157,6 +157,7 @@ pub fn parse_list_expression(
                         &command.parts,
                         &mut spans_idx,
                         &SyntaxShape::List(Box::new(element_shape.clone())),
+                        None,
                     );
                     let elem_ty = match &spread_arg.ty {
                         Type::List(elem_ty) => *elem_ty.clone(),
@@ -170,6 +171,7 @@ pub fn parse_list_expression(
                         &command.parts,
                         &mut spans_idx,
                         element_shape,
+                        None,
                     );
                     let ty = arg.ty.clone();
                     (ListItem::Item(arg), ty)
@@ -384,7 +386,11 @@ fn table_type(head: &[Expression], rows: &[Vec<Expression>]) -> (Type, Vec<Parse
     (Type::Table(ty), errors)
 }
 
-pub fn parse_block_expression(working_set: &mut StateWorkingSet, span: Span) -> Expression {
+pub fn parse_block_expression(
+    working_set: &mut StateWorkingSet,
+    span: Span,
+    input_type: Option<Type>,
+) -> Expression {
     trace!("parsing: block expression");
 
     let bytes = working_set.get_span_contents(span);
@@ -429,7 +435,14 @@ pub fn parse_block_expression(working_set: &mut StateWorkingSet, span: Span) -> 
         _ => (None, 0),
     };
 
-    let mut output = parse_block(working_set, &output[amt_to_skip..], span, false, false);
+    let mut output = parse_block(
+        working_set,
+        &output[amt_to_skip..],
+        span,
+        false,
+        false,
+        input_type,
+    );
 
     if let Some(signature) = signature {
         output.signature = signature.0;
@@ -594,6 +607,7 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
                 &tokens.iter().map(|tok| tok.span).collect_vec(),
                 &mut start,
                 &SyntaxShape::MathExpression,
+                None,
             );
 
             pattern.guard = Some(Box::new(guard));
@@ -628,6 +642,7 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
             &[output[position].span],
             &mut 0,
             &SyntaxShape::OneOf(vec![SyntaxShape::Block, SyntaxShape::Expression]),
+            None,
         );
         position += 1;
         if is_closed {
@@ -649,6 +664,7 @@ pub fn parse_closure_expression(
     working_set: &mut StateWorkingSet,
     shape: &SyntaxShape,
     span: Span,
+    input_type: Option<Type>,
 ) -> Expression {
     trace!("parsing: closure expression");
 
@@ -757,7 +773,14 @@ pub fn parse_closure_expression(
         }
     }
 
-    let mut output = parse_block(working_set, &output[amt_to_skip..], span, false, false);
+    let mut output = parse_block(
+        working_set,
+        &output[amt_to_skip..],
+        span,
+        false,
+        false,
+        input_type,
+    );
 
     // NOTE: closures need to be compiled eagerly due to these reasons:
     //  - their `Block`s (which contains their `IrBlock`) are stored in the working_set
@@ -790,6 +813,7 @@ pub fn parse_value(
     working_set: &mut StateWorkingSet,
     span: Span,
     shape: &SyntaxShape,
+    input_type: Option<Type>,
 ) -> Expression {
     trace!("parsing: value: {shape}");
 
@@ -805,9 +829,9 @@ pub fn parse_value(
     }
 
     match bytes[0] {
-        b'$' => return parse_dollar_expr(working_set, span, shape),
+        b'$' => return parse_dollar_expr(working_set, span, shape, input_type),
         b'(' => return parse_paren_expr(working_set, span, shape),
-        b'{' => return parse_brace_expr(working_set, span, shape),
+        b'{' => return parse_brace_expr(working_set, span, shape, input_type),
         b'[' => match shape {
             SyntaxShape::Any
             | SyntaxShape::List(_)
@@ -892,7 +916,7 @@ pub fn parse_value(
         SyntaxShape::Any => {
             if bytes.starts_with(b"[") {
                 //parse_value(working_set, span, &SyntaxShape::Table)
-                parse_full_cell_path(working_set, None, span)
+                parse_full_cell_path(working_set, None, span, None)
             } else {
                 let shapes = [
                     SyntaxShape::Binary,
@@ -907,7 +931,7 @@ pub fn parse_value(
                 for shape in shapes.iter() {
                     let starting_error_count = working_set.parse_errors.len();
 
-                    let s = parse_value(working_set, span, shape);
+                    let s = parse_value(working_set, span, shape, None);
 
                     if starting_error_count == working_set.parse_errors.len() {
                         return s;
@@ -959,6 +983,7 @@ pub fn parse_assignment_operator(working_set: &mut StateWorkingSet, span: Span) 
 pub fn parse_assignment_expression(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
+    input_type: Option<Type>,
 ) -> Expression {
     trace!("parsing: assignment expression");
     let expr_span = Span::concat(spans);
@@ -1022,7 +1047,7 @@ pub fn parse_assignment_expression(
     working_set.parse_errors.extend(rhs_error);
 
     trace!("parsing: assignment right-hand side subexpression");
-    let rhs_block = parse_block(working_set, &rhs_tokens, rhs_span, false, true);
+    let rhs_block = parse_block(working_set, &rhs_tokens, rhs_span, false, true, input_type);
     let rhs_ty = rhs_block.output_type();
 
     // TEMP: double-check that if the RHS block starts with an external call, it must start with a
@@ -1266,7 +1291,7 @@ pub fn parse_math_expression(
         }
     }
 
-    let mut lhs = parse_value(working_set, spans[idx], &SyntaxShape::Any);
+    let mut lhs = parse_value(working_set, spans[idx], &SyntaxShape::Any, None);
 
     for not_start_span in not_start_spans.iter().rev() {
         lhs = Expression::new(
@@ -1337,7 +1362,7 @@ pub fn parse_math_expression(
                 return garbage(working_set, spans[idx - 1]);
             }
         }
-        let mut rhs = parse_value(working_set, spans[idx], &SyntaxShape::Any);
+        let mut rhs = parse_value(working_set, spans[idx], &SyntaxShape::Any, None);
 
         for not_start_span in not_start_spans.iter().rev() {
             rhs = Expression::new(
@@ -1460,7 +1485,7 @@ pub fn parse_expression(
         let rhs = if spans[pos].start + point < spans[pos].end {
             let rhs_span = Span::new(spans[pos].start + point, spans[pos].end);
             if split[1].starts_with(b"$") {
-                parse_dollar_expr(working_set, rhs_span, &SyntaxShape::Any)
+                parse_dollar_expr(working_set, rhs_span, &SyntaxShape::Any, None)
             } else {
                 parse_string_strict(working_set, rhs_span)
             }
@@ -1494,7 +1519,7 @@ pub fn parse_expression(
         .iter()
         .any(|span| is_assignment_operator(working_set.get_span_contents(*span)))
     {
-        parse_assignment_expression(working_set, &spans[pos..])
+        parse_assignment_expression(working_set, &spans[pos..], input_type)
     } else if is_math_expression_like(working_set, spans[pos]) {
         parse_math_expression(working_set, &spans[pos..], None)
     } else {
@@ -1613,6 +1638,7 @@ pub fn parse_expression(
 pub fn parse_builtin_commands(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
+    input_type: Option<Type>,
 ) -> Pipeline {
     trace!("parsing: builtin commands");
     if !is_math_expression_like(working_set, lite_command.parts[0])
@@ -1674,6 +1700,7 @@ pub fn parse_builtin_commands(
             &lite_command
                 .parts_including_redirection()
                 .collect::<Vec<Span>>(),
+            input_type,
         ),
         b"const" => parse_const(working_set, &lite_command.parts).0,
         b"mut" => parse_mut(
@@ -1715,7 +1742,8 @@ pub fn parse_builtin_commands(
             parse_keyword(working_set, lite_command)
         }
         _ => {
-            let element = parse_pipeline_element(working_set, lite_command, Type::Any);
+            let element =
+                parse_pipeline_element(working_set, lite_command, input_type.unwrap_or(Type::Any));
 
             // There is still a chance to make `parse_pipeline_element` parse into
             // some keyword that should apply side effects first, Example:
@@ -1890,7 +1918,7 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
         if let Some(Spanned { span, .. }) = extract_spread_record(curr_tok.into_spanned(curr_span))
         {
             // Parse spread operator
-            let inner = parse_value(working_set, span, &SyntaxShape::record());
+            let inner = parse_value(working_set, span, &SyntaxShape::record(), None);
             idx += 1;
 
             match &inner.ty {
@@ -1921,7 +1949,7 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
                 ));
                 garbage(working_set, curr_span)
             } else {
-                let field = parse_value(working_set, curr_span, &SyntaxShape::String);
+                let field = parse_value(working_set, curr_span, &SyntaxShape::String, None);
                 if let Some(error) = check_record_key_or_value(working_set, &field, "key") {
                     working_set.error(error);
                     garbage(working_set, field.span)
@@ -1985,7 +2013,7 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
                     Span::new(value_token.span.start, value_token.span.end),
                 )
             } else {
-                let value = parse_value(working_set, tokens[idx].span, &SyntaxShape::Any);
+                let value = parse_value(working_set, tokens[idx].span, &SyntaxShape::Any, None);
                 if let Some(parse_error) = check_record_key_or_value(working_set, &value, "value") {
                     working_set.error(parse_error);
                     garbage(working_set, value.span)

--- a/crates/nu-parser/src/parse_literals.rs
+++ b/crates/nu-parser/src/parse_literals.rs
@@ -328,6 +328,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Option<Expr
             working_set,
             from_span,
             &SyntaxShape::Number,
+            None,
         ))
     };
 
@@ -339,6 +340,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Option<Expr
             working_set,
             to_span,
             &SyntaxShape::Number,
+            None,
         ))
     };
 
@@ -358,6 +360,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Option<Expr
                 working_set,
                 next_span,
                 &SyntaxShape::Number,
+                None,
             )),
             next_op_span,
         )
@@ -396,6 +399,7 @@ pub(crate) fn parse_dollar_expr(
     working_set: &mut StateWorkingSet,
     span: Span,
     shape: &SyntaxShape,
+    input_type: Option<Type>,
 ) -> Expression {
     trace!("parsing: dollar expression");
     let contents = working_set.get_span_contents(span);
@@ -415,7 +419,7 @@ pub(crate) fn parse_dollar_expr(
             expr
         } else {
             working_set.parse_errors.truncate(starting_error_count);
-            parse_full_cell_path(working_set, None, span)
+            parse_full_cell_path(working_set, None, span, input_type)
         }
     }
 }
@@ -492,7 +496,7 @@ pub fn parse_paren_expr(
         return parse_signature(working_set, span, true);
     }
 
-    let fcp_expr = parse_full_cell_path(working_set, None, span);
+    let fcp_expr = parse_full_cell_path(working_set, None, span, None);
     let fcp_error_count = working_set.parse_errors.len();
     if fcp_error_count > starting_error_count {
         let malformed_subexpr = working_set.parse_errors[starting_error_count..]
@@ -521,6 +525,7 @@ pub fn parse_brace_expr(
     working_set: &mut StateWorkingSet,
     span: Span,
     shape: &SyntaxShape,
+    input_type: Option<Type>,
 ) -> Expression {
     // Try to detect what kind of value we're about to parse
     // FIXME: In the future, we should work over the token stream so we only have to do this once
@@ -543,8 +548,10 @@ pub fn parse_brace_expr(
     match tokens.as_slice() {
         // If we're empty, that means an empty record or closure
         [] => match shape {
-            SyntaxShape::Closure(_) => parse_closure_expression(working_set, shape, span),
-            SyntaxShape::Block => parse_block_expression(working_set, span),
+            SyntaxShape::Closure(_) => {
+                parse_closure_expression(working_set, shape, span, input_type)
+            }
+            SyntaxShape::Block => parse_block_expression(working_set, span, input_type),
             SyntaxShape::MatchBlock => parse_match_block_expression(working_set, span),
             _ => parse_record(working_set, span),
         },
@@ -559,23 +566,25 @@ pub fn parse_brace_expr(
                 working_set.error(ParseError::Mismatch("block".into(), "closure".into(), span));
                 return Expression::garbage(working_set, span);
             }
-            parse_closure_expression(working_set, shape, span)
+            parse_closure_expression(working_set, shape, span, input_type)
         }
         [_, third, ..] if working_set.get_span_contents(third.span) == b":" => {
-            parse_full_cell_path(working_set, None, span)
+            parse_full_cell_path(working_set, None, span, None)
         }
         [second, ..] => {
             let second_bytes = working_set.get_span_contents(second.span);
             match shape {
-                SyntaxShape::Closure(_) => parse_closure_expression(working_set, shape, span),
-                SyntaxShape::Block => parse_block_expression(working_set, span),
+                SyntaxShape::Closure(_) => {
+                    parse_closure_expression(working_set, shape, span, input_type)
+                }
+                SyntaxShape::Block => parse_block_expression(working_set, span, input_type),
                 SyntaxShape::MatchBlock => parse_match_block_expression(working_set, span),
                 // For edge case of `{}.foo?`, #17896
-                _ if second_bytes == b"}" => parse_full_cell_path(working_set, None, span),
+                _ if second_bytes == b"}" => parse_full_cell_path(working_set, None, span, None),
                 _ if extract_spread_record(second_bytes.into_spanned(second.span)).is_some() => {
                     parse_record(working_set, span)
                 }
-                SyntaxShape::Any => parse_closure_expression(working_set, shape, span),
+                SyntaxShape::Any => parse_closure_expression(working_set, shape, span, input_type),
                 _ => {
                     working_set.error(ParseError::ExpectedWithStringMsg(
                         format!("non-block value: {shape}"),
@@ -737,7 +746,7 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
                         if token_start < b {
                             let span = Span::new(token_start, b + 1);
 
-                            let expr = parse_full_cell_path(working_set, None, span);
+                            let expr = parse_full_cell_path(working_set, None, span, None);
                             output.push(expr);
                         }
 
@@ -777,7 +786,7 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
         InterpolationMode::Expression => {
             if token_start < end {
                 let span = Span::new(token_start, end);
-                let expr = parse_full_cell_path(working_set, None, span);
+                let expr = parse_full_cell_path(working_set, None, span, None);
                 output.push(expr);
             }
         }
@@ -791,7 +800,11 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
     )
 }
 
-pub fn parse_variable_expr(working_set: &mut StateWorkingSet, span: Span) -> Expression {
+pub fn parse_variable_expr(
+    working_set: &mut StateWorkingSet,
+    span: Span,
+    input_type: Option<Type>,
+) -> Expression {
     let contents = working_set.get_span_contents(span);
 
     if contents == b"$nu" {
@@ -806,7 +819,7 @@ pub fn parse_variable_expr(working_set: &mut StateWorkingSet, span: Span) -> Exp
             working_set,
             Expr::Var(nu_protocol::IN_VARIABLE_ID),
             span,
-            Type::Any,
+            input_type.unwrap_or(Type::Any),
         );
     } else if contents == b"$env" {
         return Expression::new(
@@ -1031,6 +1044,7 @@ pub fn parse_full_cell_path(
     working_set: &mut StateWorkingSet,
     implicit_head: Option<VarId>,
     span: Span,
+    input_type: Option<Type>,
 ) -> Expression {
     trace!("parsing: full cell path");
     let full_cell_span = span;
@@ -1079,7 +1093,7 @@ pub fn parse_full_cell_path(
 
             // Creating a Type scope to parse the new block. This will keep track of
             // the previous input type found in that block
-            let output = parse_block(working_set, &output, span, is_closed, true);
+            let output = parse_block(working_set, &output, span, is_closed, true, None);
 
             let ty = output.output_type();
 
@@ -1108,7 +1122,7 @@ pub fn parse_full_cell_path(
         } else if bytes.starts_with(b"$") {
             trace!("parsing: $variable head of full cell path");
 
-            let out = parse_variable_expr(working_set, head.span);
+            let out = parse_variable_expr(working_set, head.span, input_type);
 
             tokens.next();
 

--- a/crates/nu-parser/src/parse_literals.rs
+++ b/crates/nu-parser/src/parse_literals.rs
@@ -399,7 +399,7 @@ pub(crate) fn parse_dollar_expr(
     working_set: &mut StateWorkingSet,
     span: Span,
     shape: &SyntaxShape,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     trace!("parsing: dollar expression");
     let contents = working_set.get_span_contents(span);
@@ -525,7 +525,7 @@ pub fn parse_brace_expr(
     working_set: &mut StateWorkingSet,
     span: Span,
     shape: &SyntaxShape,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     // Try to detect what kind of value we're about to parse
     // FIXME: In the future, we should work over the token stream so we only have to do this once
@@ -805,7 +805,7 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
 pub fn parse_variable_expr(
     working_set: &mut StateWorkingSet,
     span: Span,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     let contents = working_set.get_span_contents(span);
 
@@ -821,7 +821,7 @@ pub fn parse_variable_expr(
             working_set,
             Expr::Var(nu_protocol::IN_VARIABLE_ID),
             span,
-            input_type.unwrap_or(Type::Any),
+            input_type.cloned().unwrap_or(Type::Any),
         );
     } else if contents == b"$env" {
         return Expression::new(
@@ -1046,7 +1046,7 @@ pub fn parse_full_cell_path(
     working_set: &mut StateWorkingSet,
     implicit_head: Option<VarId>,
     span: Span,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Expression {
     trace!("parsing: full cell path");
     let full_cell_span = span;

--- a/crates/nu-parser/src/parse_literals.rs
+++ b/crates/nu-parser/src/parse_literals.rs
@@ -552,7 +552,7 @@ pub fn parse_brace_expr(
                 parse_closure_expression(working_set, shape, span, input_type)
             }
             SyntaxShape::Block => parse_block_expression(working_set, span, input_type),
-            SyntaxShape::MatchBlock => parse_match_block_expression(working_set, span),
+            SyntaxShape::MatchBlock => parse_match_block_expression(working_set, span, input_type),
             _ => parse_record(working_set, span),
         },
         [
@@ -578,7 +578,9 @@ pub fn parse_brace_expr(
                     parse_closure_expression(working_set, shape, span, input_type)
                 }
                 SyntaxShape::Block => parse_block_expression(working_set, span, input_type),
-                SyntaxShape::MatchBlock => parse_match_block_expression(working_set, span),
+                SyntaxShape::MatchBlock => {
+                    parse_match_block_expression(working_set, span, input_type)
+                }
                 // For edge case of `{}.foo?`, #17896
                 _ if second_bytes == b"}" => parse_full_cell_path(working_set, None, span, None),
                 _ if extract_spread_record(second_bytes.into_spanned(second.span)).is_some() => {

--- a/crates/nu-parser/src/parse_patterns.rs
+++ b/crates/nu-parser/src/parse_patterns.rs
@@ -38,7 +38,7 @@ pub fn parse_pattern(working_set: &mut StateWorkingSet, span: Span) -> MatchPatt
         }
     } else {
         // Literal value
-        let value = parse_value(working_set, span, &SyntaxShape::Any);
+        let value = parse_value(working_set, span, &SyntaxShape::Any, None);
 
         MatchPattern {
             pattern: Pattern::Expression(Box::new(value)),

--- a/crates/nu-parser/src/parse_pipelines.rs
+++ b/crates/nu-parser/src/parse_pipelines.rs
@@ -140,19 +140,23 @@ pub fn parse_block(
     // Pre-declare any definition so that definitions
     // that share the same block can see each other
     for pipeline in &lite_block.block {
-        if pipeline.commands.len() == 1 {
-            parse_def_predecl(working_set, pipeline.commands[0].command_parts())
+        if let [lite_command] = pipeline.commands.as_slice() {
+            parse_def_predecl(working_set, lite_command.command_parts())
         }
     }
 
     let mut block = Block::new_with_capacity(lite_block.block.len());
     block.span = Some(span);
 
-    let mut first = input_type.clone();
-
-    for lite_pipeline in &lite_block.block {
-        let pipeline = parse_pipeline(working_set, lite_pipeline, first.take());
+    if let [first, rest @ ..] = lite_block.block.as_slice() {
+        // only the first pipeline receives the block's pipeline input
+        let pipeline = parse_pipeline(working_set, first, input_type.clone());
         block.pipelines.push(pipeline);
+
+        for lite_pipeline in rest {
+            let pipeline = parse_pipeline(working_set, lite_pipeline, None);
+            block.pipelines.push(pipeline);
+        }
     }
 
     // If this is not a subexpression and there are any pipelines where the first element has $in,
@@ -188,9 +192,7 @@ pub fn parse_block(
     }
 
     let errors = type_check::check_block_input_output(working_set, &block);
-    if !errors.is_empty() {
-        working_set.parse_errors.extend_from_slice(&errors);
-    }
+    working_set.parse_errors.extend(errors);
 
     block
 }

--- a/crates/nu-parser/src/parse_pipelines.rs
+++ b/crates/nu-parser/src/parse_pipelines.rs
@@ -89,32 +89,44 @@ pub fn parse_pipeline(
     pipeline: &LitePipeline,
     input_type: Option<Type>,
 ) -> Pipeline {
-    if pipeline.commands.len() > 1 {
-        let mut input = input_type.unwrap_or(Type::Any);
+    match pipeline.commands.as_slice() {
+        [] => unreachable!("at this point the pipeline must have at least one element"),
+        [single] => parse_builtin_commands(working_set, single, input_type),
+        [first, rest @ ..] => {
+            let mut current_pipeline_type = input_type.unwrap_or(Type::Any);
 
-        // Parse a normal multi command pipeline
-        let elements: Vec<_> = pipeline
-            .commands
-            .iter()
-            .enumerate()
-            .map(|(index, element)| {
-                let input_clone = input.clone();
-                let element =
-                    parse_pipeline_element(working_set, element, std::mem::take(&mut input));
-                input = element.expr.ty.clone();
+            let mut elements = Vec::new();
+            elements.push({
+                let element = parse_pipeline_element(working_set, first, current_pipeline_type);
+                // the output becomes the input for the next pipeline element
+                current_pipeline_type = element.expr.ty.clone();
+
+                element
+            });
+
+            // Parse a normal multi command pipeline
+            let rest_elements = rest.iter().map(|element| {
+                let input_clone = current_pipeline_type.clone();
+                let element = parse_pipeline_element(
+                    working_set,
+                    element,
+                    std::mem::take(&mut current_pipeline_type),
+                );
+                // the output becomes the input for the next pipeline element
+                current_pipeline_type = element.expr.ty.clone();
+
                 // Handle $in for pipeline elements beyond the first one
-                if index > 0 && element.has_in_variable(working_set) {
+                if element.has_in_variable(working_set) {
                     wrap_element_with_collect(working_set, element, Some(input_clone))
                 } else {
                     element
                 }
-            })
-            .collect();
+            });
 
-        Pipeline { elements }
-    } else {
-        // If there's only one command in the pipeline, this could be a builtin command
-        parse_builtin_commands(working_set, &pipeline.commands[0], input_type)
+            elements.extend(rest_elements);
+
+            Pipeline { elements }
+        }
     }
 }
 

--- a/crates/nu-parser/src/parse_pipelines.rs
+++ b/crates/nu-parser/src/parse_pipelines.rs
@@ -50,7 +50,7 @@ pub(crate) fn parse_redirection(
 pub(crate) fn parse_pipeline_element(
     working_set: &mut StateWorkingSet,
     command: &LiteCommand,
-    input_type: Type,
+    input_type: &Type,
 ) -> PipelineElement {
     trace!("parsing: pipeline element");
 
@@ -87,17 +87,17 @@ pub(crate) fn redirecting_builtin_error(
 pub fn parse_pipeline(
     working_set: &mut StateWorkingSet,
     pipeline: &LitePipeline,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Pipeline {
     match pipeline.commands.as_slice() {
         [] => unreachable!("at this point the pipeline must have at least one element"),
         [single] => parse_builtin_commands(working_set, single, input_type),
         [first, rest @ ..] => {
-            let mut current_pipeline_type = input_type.unwrap_or(Type::Any);
+            let mut current_pipeline_type = input_type.cloned().unwrap_or(Type::Any);
 
             let mut elements = Vec::new();
             elements.push({
-                let element = parse_pipeline_element(working_set, first, current_pipeline_type);
+                let element = parse_pipeline_element(working_set, first, &current_pipeline_type);
                 // the output becomes the input for the next pipeline element
                 current_pipeline_type = element.expr.ty.clone();
 
@@ -107,17 +107,13 @@ pub fn parse_pipeline(
             // Parse a normal multi command pipeline
             let rest_elements = rest.iter().map(|element| {
                 let input_clone = current_pipeline_type.clone();
-                let element = parse_pipeline_element(
-                    working_set,
-                    element,
-                    std::mem::take(&mut current_pipeline_type),
-                );
+                let element = parse_pipeline_element(working_set, element, &current_pipeline_type);
                 // the output becomes the input for the next pipeline element
                 current_pipeline_type = element.expr.ty.clone();
 
                 // Handle $in for pipeline elements beyond the first one
                 if element.has_in_variable(working_set) {
-                    wrap_element_with_collect(working_set, element, Some(input_clone))
+                    wrap_element_with_collect(working_set, element, Some(&input_clone))
                 } else {
                     element
                 }
@@ -136,7 +132,7 @@ pub fn parse_block(
     span: Span,
     scoped: bool,
     is_subexpression: bool,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> Block {
     let (lite_block, err) = lite_parse(tokens, working_set);
     if let Some(err) = err {
@@ -162,7 +158,7 @@ pub fn parse_block(
 
     if let [first, rest @ ..] = lite_block.block.as_slice() {
         // only the first pipeline receives the block's pipeline input
-        let pipeline = parse_pipeline(working_set, first, input_type.clone());
+        let pipeline = parse_pipeline(working_set, first, input_type);
         block.pipelines.push(pipeline);
 
         for lite_pipeline in rest {

--- a/crates/nu-parser/src/parse_pipelines.rs
+++ b/crates/nu-parser/src/parse_pipelines.rs
@@ -23,7 +23,7 @@ fn parse_redirection_target(
             file,
             append,
         } => RedirectionTarget::File {
-            expr: parse_value(working_set, *file, &SyntaxShape::Any),
+            expr: parse_value(working_set, *file, &SyntaxShape::Any, None),
             append: *append,
             span: *connector,
         },
@@ -89,21 +89,22 @@ pub fn parse_pipeline(
     pipeline: &LitePipeline,
     input_type: Option<Type>,
 ) -> Pipeline {
-    let mut input = input_type.unwrap_or(Type::Any);
-
     if pipeline.commands.len() > 1 {
+        let mut input = input_type.unwrap_or(Type::Any);
+
         // Parse a normal multi command pipeline
         let elements: Vec<_> = pipeline
             .commands
             .iter()
             .enumerate()
             .map(|(index, element)| {
+                let input_clone = input.clone();
                 let element =
                     parse_pipeline_element(working_set, element, std::mem::take(&mut input));
                 input = element.expr.ty.clone();
                 // Handle $in for pipeline elements beyond the first one
                 if index > 0 && element.has_in_variable(working_set) {
-                    wrap_element_with_collect(working_set, element)
+                    wrap_element_with_collect(working_set, element, Some(input_clone))
                 } else {
                     element
                 }
@@ -113,7 +114,7 @@ pub fn parse_pipeline(
         Pipeline { elements }
     } else {
         // If there's only one command in the pipeline, this could be a builtin command
-        parse_builtin_commands(working_set, &pipeline.commands[0])
+        parse_builtin_commands(working_set, &pipeline.commands[0], input_type)
     }
 }
 
@@ -123,6 +124,7 @@ pub fn parse_block(
     span: Span,
     scoped: bool,
     is_subexpression: bool,
+    input_type: Option<Type>,
 ) -> Block {
     let (lite_block, err) = lite_parse(tokens, working_set);
     if let Some(err) = err {
@@ -146,8 +148,10 @@ pub fn parse_block(
     let mut block = Block::new_with_capacity(lite_block.block.len());
     block.span = Some(span);
 
+    let mut first = input_type.clone();
+
     for lite_pipeline in &lite_block.block {
-        let pipeline = parse_pipeline(working_set, lite_pipeline, None);
+        let pipeline = parse_pipeline(working_set, lite_pipeline, first.take());
         block.pipelines.push(pipeline);
     }
 
@@ -168,7 +172,7 @@ pub fn parse_block(
 
         // Now wrap it in a Collect expression, and put it in the block as the only pipeline
         let subexpression = Expression::new(working_set, Expr::Subexpression(block_id), span, ty);
-        let collect = wrap_expr_with_collect(working_set, subexpression);
+        let collect = wrap_expr_with_collect(working_set, subexpression, input_type);
 
         block.pipelines.push(Pipeline {
             elements: vec![PipelineElement {

--- a/crates/nu-parser/src/parse_shape_specs.rs
+++ b/crates/nu-parser/src/parse_shape_specs.rs
@@ -86,6 +86,7 @@ pub fn parse_completer(
             SyntaxShape::List(Box::new(SyntaxShape::String)),
             SyntaxShape::String,
         ]),
+        None,
     );
 
     if working_set.parse_errors.len() > error_count {
@@ -278,7 +279,7 @@ fn parse_named_type_params(
         }
 
         let Some(key) =
-            parse_value(working_set, tokens[idx].span, &SyntaxShape::String).as_string()
+            parse_value(working_set, tokens[idx].span, &SyntaxShape::String, None).as_string()
         else {
             working_set.error(key_error(tokens[idx].span));
             return CollectionColumns::default();

--- a/crates/nu-parser/src/parse_signatures.rs
+++ b/crates/nu-parser/src/parse_signatures.rs
@@ -170,6 +170,7 @@ pub fn parse_var_with_opt_type(
     spans: &[Span],
     spans_idx: &mut usize,
     mutable: bool,
+    input_type: Option<Type>,
 ) -> (Expression, Option<Type>) {
     let name_span = spans[*spans_idx];
     let bytes = working_set.get_span_contents(name_span);
@@ -256,7 +257,7 @@ pub fn parse_var_with_opt_type(
         let id = working_set.add_variable(
             var_name,
             Span::concat(&spans[*spans_idx..*spans_idx + 1]),
-            Type::Any,
+            input_type.unwrap_or(Type::Any),
             mutable,
         );
 
@@ -297,7 +298,7 @@ pub fn expand_to_cell_path(
     } = expression
     {
         // Re-parse the string as if it were a cell-path
-        let new_expression = parse_full_cell_path(working_set, Some(var_id), *span);
+        let new_expression = parse_full_cell_path(working_set, Some(var_id), *span, None);
 
         *expression = new_expression;
     }
@@ -456,7 +457,7 @@ pub fn parse_row_condition(working_set: &mut StateWorkingSet, spans: &[Span]) ->
     // Try parsing the expression as a closure first
     {
         let err_count = working_set.parse_errors.len();
-        let expression = parse_closure_expression(working_set, &SyntaxShape::Any, span);
+        let expression = parse_closure_expression(working_set, &SyntaxShape::Any, span, None);
         if working_set.parse_errors.len() == err_count
             && let Expr::Closure(block_id) = expression.expr
         {
@@ -1071,7 +1072,7 @@ pub fn parse_signature_helper(
                                     }
                                 };
 
-                                let expression = parse_value(working_set, span, &shape);
+                                let expression = parse_value(working_set, span, &shape, None);
 
                                 //TODO check if we're replacing a custom parameter already
                                 match last {

--- a/crates/nu-parser/src/parse_signatures.rs
+++ b/crates/nu-parser/src/parse_signatures.rs
@@ -170,7 +170,7 @@ pub fn parse_var_with_opt_type(
     spans: &[Span],
     spans_idx: &mut usize,
     mutable: bool,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) -> (Expression, Option<Type>) {
     let name_span = spans[*spans_idx];
     let bytes = working_set.get_span_contents(name_span);
@@ -257,7 +257,7 @@ pub fn parse_var_with_opt_type(
         let id = working_set.add_variable(
             var_name,
             Span::concat(&spans[*spans_idx..*spans_idx + 1]),
-            input_type.unwrap_or(Type::Any),
+            input_type.cloned().unwrap_or(Type::Any),
             mutable,
         );
 
@@ -289,7 +289,7 @@ pub fn expand_to_cell_path(
     working_set: &mut StateWorkingSet,
     expression: &mut Expression,
     var_id: VarId,
-    input_type: Option<Type>,
+    input_type: Option<&Type>,
 ) {
     trace!("parsing: expanding to cell path");
     if let Expression {
@@ -299,8 +299,7 @@ pub fn expand_to_cell_path(
     } = expression
     {
         // Re-parse the string as if it were a cell-path
-        let new_expression =
-            parse_full_cell_path(working_set, Some(var_id), *span, input_type.clone());
+        let new_expression = parse_full_cell_path(working_set, Some(var_id), *span, input_type);
 
         *expression = new_expression;
     }

--- a/crates/nu-parser/src/parse_signatures.rs
+++ b/crates/nu-parser/src/parse_signatures.rs
@@ -289,6 +289,7 @@ pub fn expand_to_cell_path(
     working_set: &mut StateWorkingSet,
     expression: &mut Expression,
     var_id: VarId,
+    input_type: Option<Type>,
 ) {
     trace!("parsing: expanding to cell path");
     if let Expression {
@@ -298,7 +299,8 @@ pub fn expand_to_cell_path(
     } = expression
     {
         // Re-parse the string as if it were a cell-path
-        let new_expression = parse_full_cell_path(working_set, Some(var_id), *span, None);
+        let new_expression =
+            parse_full_cell_path(working_set, Some(var_id), *span, input_type.clone());
 
         *expression = new_expression;
     }
@@ -308,7 +310,7 @@ pub fn expand_to_cell_path(
         ..
     } = expression
     {
-        expand_to_cell_path(working_set, inner, var_id);
+        expand_to_cell_path(working_set, inner, var_id, input_type);
     }
 }
 
@@ -473,7 +475,7 @@ pub fn parse_row_condition(working_set: &mut StateWorkingSet, spans: &[Span]) ->
     // New scope in case where there's already a variable named `$it`
     working_set.enter_scope();
     let var_id = working_set.add_variable(b"$it".to_vec(), Span::new(pos, pos), Type::Any, false);
-    let expression = parse_math_expression(working_set, spans, Some(var_id));
+    let expression = parse_math_expression(working_set, spans, Some(var_id), None);
 
     let block_id = match expression.expr {
         Expr::Block(block_id) => block_id,

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -680,9 +680,9 @@ pub fn check_pipeline_type(
     working_set: &StateWorkingSet,
     pipeline: &Pipeline,
     input_type: &Type,
-) -> (Type, Option<Vec<ParseError>>) {
+) -> Result<Type, (Type, Vec<ParseError>)> {
     let mut input_type = input_type.clone();
-    let mut output_errors: Option<Vec<ParseError>> = None;
+    let mut output_errors: Vec<ParseError> = Vec::new();
 
     for elem in &pipeline.elements {
         if elem.redirection.is_some() {
@@ -709,9 +709,9 @@ pub fn check_pipeline_type(
             continue;
         }
 
-        let output_type = working_set
-            .get_decl(call.decl_id)
-            .signature()
+        let signature = working_set.get_decl(call.decl_id).signature();
+
+        let output_type = signature
             // NOTE[2]: unlike `parse_internal_call`, `Type::Nothing` is not added to input types.
             .get_output_type(Some(&input_type));
 
@@ -726,21 +726,23 @@ pub fn check_pipeline_type(
         };
 
         let Some(types_string) = types_string else {
-            output_errors
-                .get_or_insert_default()
-                .push(ParseError::InternalError(
-                    "Pipeline has no type at this point".to_string(),
-                    elem.expr.span,
-                ));
+            output_errors.push(ParseError::InternalError(
+                "Pipeline has no type at this point".to_string(),
+                elem.expr.span,
+            ));
             continue;
         };
 
-        output_errors
-            .get_or_insert_default()
-            .push(ParseError::InputMismatch(types_string, call.head));
+        output_errors.push(ParseError::InputMismatch(types_string, call.head));
+
+        input_type = signature.get_output_type(None).unwrap_or(Type::Any);
     }
 
-    (input_type, output_errors)
+    if output_errors.is_empty() {
+        Ok(input_type)
+    } else {
+        Err((input_type, output_errors))
+    }
 }
 
 pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) -> Vec<ParseError> {
@@ -759,12 +761,14 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
                 pipelines
                     .iter()
                     .fold((input_type.clone(), Type::Nothing), |(ct, _), pipeline| {
-                        let (checked_output_type, err) =
-                            check_pipeline_type(working_set, pipeline, &ct);
-                        if let Some(err) = err {
-                            output_errors.extend(err);
-                        }
-                        (Type::Nothing, checked_output_type)
+                        let output_ty = match check_pipeline_type(working_set, pipeline, &ct) {
+                            Ok(output_ty) => output_ty,
+                            Err((output_ty, errors)) => {
+                                output_errors.extend(errors);
+                                output_ty
+                            }
+                        };
+                        (Type::Nothing, output_ty)
                     })
                     .1
             }

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -679,9 +679,9 @@ pub fn math_result_type(
 pub fn check_pipeline_type(
     working_set: &StateWorkingSet,
     pipeline: &Pipeline,
-    input_type: Type,
+    input_type: &Type,
 ) -> (Type, Option<Vec<ParseError>>) {
-    let mut input_type = input_type;
+    let mut input_type = input_type.clone();
     let mut output_errors: Option<Vec<ParseError>> = None;
 
     for elem in &pipeline.elements {
@@ -713,7 +713,7 @@ pub fn check_pipeline_type(
             .get_decl(call.decl_id)
             .signature()
             // NOTE[2]: unlike `parse_internal_call`, `Type::Nothing` is not added to input types.
-            .get_output_type(Some(input_type.clone()));
+            .get_output_type(Some(&input_type));
 
         if let Some(output_type) = output_type {
             input_type = output_type;
@@ -760,7 +760,7 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
                     .iter()
                     .fold((input_type.clone(), Type::Nothing), |(ct, _), pipeline| {
                         let (checked_output_type, err) =
-                            check_pipeline_type(working_set, pipeline, ct);
+                            check_pipeline_type(working_set, pipeline, &ct);
                         if let Some(err) = err {
                             output_errors.extend(err);
                         }

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -747,7 +747,12 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
     // let inputs = block.input_types();
     let mut output_errors = vec![];
 
-    for (input_type, output_type) in &block.signature.input_output_types {
+    let items = match block.signature.input_output_types.as_slice() {
+        [] => &[(Type::Any, Type::Any)],
+        items => items,
+    };
+
+    for (input_type, output_type) in items {
         let current_output_type = match block.pipelines.as_slice() {
             [] => input_type.clone(),
             pipelines => {
@@ -802,19 +807,6 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
             current_ty_string,
             span,
         ))
-    }
-
-    if block.signature.input_output_types.is_empty() {
-        let mut current_type = Type::Any;
-
-        for pipeline in &block.pipelines {
-            let (_, err) = check_pipeline_type(working_set, pipeline, current_type);
-            current_type = Type::Nothing;
-
-            if let Some(err) = err {
-                output_errors.extend_from_slice(&err);
-            }
-        }
     }
 
     output_errors

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -6,7 +6,9 @@ use nu_protocol::{
 };
 use rstest::rstest;
 
-use mock::{Alias, AttrEcho, Const, Def, IfMocked, Let, LsCustom, LsTest, Mut, ToCustom, Where};
+use mock::{
+    Alias, AttrEcho, Const, Def, IfMocked, Let, LsCustom, LsTest, MatchMocked, Mut, ToCustom, Where,
+};
 
 fn test_int(
     test_tag: &str,     // name of sub-test
@@ -2955,6 +2957,10 @@ mod mock {
             todo!()
         }
 
+        fn command_type(&self) -> CommandType {
+            CommandType::Keyword
+        }
+
         fn is_const(&self) -> bool {
             true
         }
@@ -2966,6 +2972,45 @@ mod mock {
             _input: PipelineData,
         ) -> Result<PipelineData, ShellError> {
             panic!("Should not be called!")
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct MatchMocked;
+
+    impl Command for MatchMocked {
+        fn name(&self) -> &str {
+            "match"
+        }
+
+        fn description(&self) -> &str {
+            "Conditionally run a block on a matched value."
+        }
+
+        fn signature(&self) -> nu_protocol::Signature {
+            Signature::build("match")
+                .input_output_types(vec![(Type::Any, Type::Any)])
+                .required("value", SyntaxShape::Any, "Value to check.")
+                .required(
+                    "match_block",
+                    SyntaxShape::MatchBlock,
+                    "Block to run if check succeeds.",
+                )
+                .category(Category::Core)
+        }
+
+        fn command_type(&self) -> CommandType {
+            CommandType::Keyword
+        }
+
+        fn run(
+            &self,
+            _engine_state: &EngineState,
+            _stack: &mut Stack,
+            _call: &Call,
+            _input: PipelineData,
+        ) -> Result<PipelineData, ShellError> {
+            todo!()
         }
     }
 
@@ -3032,6 +3077,7 @@ mod input_types {
             working_set.add_decl(Box::new(Collect));
             working_set.add_decl(Box::new(WithColumn));
             working_set.add_decl(Box::new(IfMocked));
+            working_set.add_decl(Box::new(MatchMocked));
             working_set.add_decl(Box::new(Mut));
 
             working_set.render()
@@ -3590,4 +3636,53 @@ fn empty_closure_as_row_condition() {
         panic!("Expected exactly one positional argument and no other argument")
     };
     assert!(matches!(arg.expr, Expr::RowCondition(_) | Expr::Closure(_)))
+}
+
+#[rstest]
+#[case("if true { 2 }", &[Type::Int, Type::Nothing])]
+#[case("if true { 2 } else { 'foo' }", &[Type::Int, Type::String])]
+#[case("
+    def erase []: any -> any {}
+    def foo []: [int -> string, list<int> -> list<string>] { erase }
+    
+    [1, 2, 3] | if true { foo } else { }
+    ",
+    &[Type::list(Type::String), Type::list(Type::Int)]
+)]
+#[case(r#"
+    match 1 {
+        1 => 1,
+        2 => "foo",
+        3 => [1, 2, 3],
+    }
+    "#,
+    &[Type::Int, Type::String, Type::list(Type::Int), Type::Nothing]
+)]
+fn conditional_branch_types(#[case] code: &str, #[case] expected_tys: &[Type]) {
+    use nu_protocol::TypeSet;
+
+    let mut engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    working_set.add_decl(Box::new(Def));
+    working_set.add_decl(Box::new(IfMocked));
+    working_set.add_decl(Box::new(MatchMocked));
+
+    let _ = engine_state.merge_delta(working_set.render());
+
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let block = parse(&mut working_set, None, code.as_bytes(), true);
+
+    assert_eq!(working_set.parse_errors.as_slice(), &[]);
+
+    let expected_ty = expected_tys
+        .iter()
+        .cloned()
+        .reduce(Type::union)
+        .expect("at least one type should have been expected");
+
+    let out_ty = block.output_type();
+
+    assert_eq!(out_ty, expected_ty);
 }

--- a/crates/nu-protocol/src/ast/block.rs
+++ b/crates/nu-protocol/src/ast/block.rs
@@ -64,18 +64,10 @@ impl Block {
     }
 
     pub fn output_type(&self) -> Type {
-        if let Some(last) = self.pipelines.last() {
-            if let Some(last) = last.elements.last() {
-                if last.redirection.is_some() {
-                    Type::Any
-                } else {
-                    last.expr.ty.clone()
-                }
-            } else {
-                Type::Nothing
-            }
-        } else {
-            Type::Nothing
+        match self.pipelines.last().and_then(|pl| pl.elements.last()) {
+            Some(pe) if pe.redirection.is_none() => pe.expr.ty.clone(),
+            Some(_) => Type::Any,
+            None => Type::Nothing,
         }
     }
 

--- a/crates/nu-protocol/src/ast/match_pattern.rs
+++ b/crates/nu-protocol/src/ast/match_pattern.rs
@@ -14,6 +14,10 @@ impl MatchPattern {
     pub fn variables(&self) -> Vec<VarId> {
         self.pattern.variables()
     }
+
+    pub fn is_wildcard(&self) -> bool {
+        self.guard.is_none() && self.pattern.is_wildcard()
+    }
 }
 
 /// AST Node for pattern matching rules
@@ -72,5 +76,13 @@ impl Pattern {
         }
 
         output
+    }
+
+    pub fn is_wildcard(&self) -> bool {
+        match self {
+            Self::Variable(_) | Self::IgnoreValue => true,
+            Self::Or(match_patterns) => match_patterns.iter().any(|x| x.is_wildcard()),
+            _ => false,
+        }
     }
 }

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -388,11 +388,11 @@ impl Signature {
     /// - [Union](TypeSet::union) of all valid outputs are returned.
     /// - If there are no valid IO pairs for the given `input`, [`None`] is returned.
     // XXX: remove?
-    pub fn get_output_type(&self, input_type: Option<Type>) -> Option<Type> {
+    pub fn get_output_type(&self, input_type: Option<&Type>) -> Option<Type> {
         if self.input_output_types.is_empty() {
             return Some(Type::Any);
         }
-        let input = input_type.unwrap_or(Type::Any);
+        let input = input_type.unwrap_or(&Type::Any);
         let mut it = self
             .input_output_types
             .iter()

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -368,26 +368,14 @@ impl Signature {
 
     /// Gets the input type from the signature
     ///
-    /// If the input was unspecified or the signature has several different
-    /// input types, [`Type::Any`] is returned.  Otherwise, if the signature has
-    /// one or same input types, this type is returned.
-    // XXX: remove?
+    /// - If the input was unspecified  [`Type::Any`] is returned.
+    /// - If the signature has a single input type, it is returned.
+    /// - If there are multiple input types, a [union](Type::union) of them is returned.
     pub fn get_input_type(&self) -> Type {
-        match self.input_output_types.len() {
-            0 => Type::Any,
-            1 => self.input_output_types[0].0.clone(),
-            _ => {
-                let first = &self.input_output_types[0].0;
-                if self
-                    .input_output_types
-                    .iter()
-                    .all(|(input, _)| input == first)
-                {
-                    first.clone()
-                } else {
-                    Type::Any
-                }
-            }
+        match self.input_output_types.as_slice() {
+            [] => Type::Any,
+            [(input, _output)] => input.clone(),
+            multiple => Type::one_of(multiple.iter().map(|(input, _)| input.clone())),
         }
     }
 

--- a/crates/nu-std/testing.nu
+++ b/crates/nu-std/testing.nu
@@ -56,7 +56,10 @@ def get-annotated [
 # Annotations that allow multiple functions are of type list<string>
 # Other annotations are of type string
 # Result gets merged with the template record so that the output shape remains consistent regardless of the table content
-def create-test-record []: nothing -> record<before-each: string, after-each: string, before-all: string, after-all: string, test: list<string>, test-skip: list<string>> {
+def create-test-record []: [
+    table<function_name: string, annotation: string>
+    -> record<before-each: string, after-each: string, before-all: string, after-all: string, test: list<string>, test-skip: list<string>>
+] {
     let input = $in
 
     let template_record = {

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::repl::tests::{TestResult, fail_test, run_test, run_test_contains};
 use nu_experimental::ENFORCE_RUNTIME_ANNOTATIONS;
 use nu_test_support::prelude::*;
@@ -334,6 +336,30 @@ fn optional_parameters_and_flags_are_nullable() -> Result {
         foo
     ";
     let () = tester.run(code)?;
+
+    Ok(())
+}
+
+#[test]
+fn pipeline_let_type() -> Result {
+    let mut tester = test();
+
+    let code = "
+        [1, 2, 3]
+        | let list_int
+        | into string
+        | let list_str
+        | str join
+        | let str
+    ";
+    let _: Value = tester.run(code)?;
+
+    let code = "scope variables | select name type | transpose -dr";
+    let out: HashMap<String, String> = tester.run(code)?;
+
+    assert_eq!(out["$list_int"], "list<int>");
+    assert_eq!(out["$list_str"], "list<string>");
+    assert_eq!(out["$str"], "string");
 
     Ok(())
 }

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -363,3 +363,17 @@ fn pipeline_let_type() -> Result {
 
     Ok(())
 }
+
+#[test]
+fn block_let_rhs_pipeline_input() -> Result {
+    let code = r#"
+        def only-nothing []: nothing -> string { "hello" }
+        def foo []: int -> any { let x = only-nothing; $x + 1 }
+        5 | foo
+    "#;
+
+    let err = test().run(code).expect_parse_error()?;
+    assert!(matches!(err, ParseError::InputMismatch(ty, _) if ty == "int"));
+
+    Ok(())
+}


### PR DESCRIPTION
## User-facing changes (Release notes)

### Type System Improvements

#### Typed `$in`

`$in` variable is now typed based on the pipeline input type of the surrounding expression.

<table>
<tr>
<td>

```ansi:no-line-numbers title="Before"
Error: [31mnu::shell::operator_incompatible_types[0m

  [31m×[0m Types 'int' and 'string' are not compatible for the '+' operator.
   ╭─[[36;1;4msource:1:5[0m]
 [2m1[0m │ 2 | $in + "foo"
   · [35;1m    ─┬─[0m[33;1m ┬[0m[32;1m ──┬──[0m
   ·      [35;1m│[0m  [33;1m│[0m   [32;1m╰── [32;1mstring[0m[0m
   ·      [35;1m│[0m  [33;1m╰── [33;1mdoes not operate between 'int' and 'string'[0m[0m
   ·      [35;1m╰── [35;1mint[0m[0m
   ╰────
```

</td>
<td>

```ansi:no-line-numbers title="After"
Error: [31mnu::parser::operator_incompatible_types[0m

  [31m×[0m Types 'int' and 'string' are not compatible for the '+' operator.
   ╭─[[36;1;4msource:1:5[0m]
 [2m1[0m │ 2 | $in + "foo"
   · [35;1m    ─┬─[0m[33;1m ┬[0m[32;1m ──┬──[0m
   ·      [35;1m│[0m  [33;1m│[0m   [32;1m╰── [32;1mstring[0m[0m
   ·      [35;1m│[0m  [33;1m╰── [33;1mdoes not operate between 'int' and 'string'[0m[0m
   ·      [35;1m╰── [35;1mint[0m[0m
   ╰────
```

</td>
</tr>
</table>


#### Better type inference of `let` bindings

`let` bindings in the middle of a pipeline, or at the end of it, are now properly typed based ont the pipeline input type.

You can observe this using `scope variables`:
```nushell
42 | let x

scope variables
| where name == '$x'
| select name type
```
```ansi:no-line-numbers
[39m╭───┬──────┬──────╮[0m
[39m│[0m [1;32m#[0m [39m│[0m [1;32mname[0m [39m│[0m [1;32mtype[0m [39m│[0m
[39m├───┼──────┼──────┤[0m
[39m│[0m [1;32m0[0m [39m│[0m [39m$x[0m   [39m│[0m [39mint[0m  [39m│[0m
[39m╰───┴──────┴──────╯[0m
```

or with LSP type hints:
```ansi:no-line-numbers
42[3;90m [23;39m|[3;90m [23;35mlet[3;90m [23;31mx[3;90m: int
```

This type information is of course passed through to the rest of the pipeline:
```nushell
def accepts-int []: int -> int {}

"foo" | let x | accepts-int
```
```ansi:no-line-numbers
Error: [31mnu::shell::only_supports_this_input_type[0m

  [31m×[0m Input type not supported.
   ╭─[[36;1;4msource:3:9[0m]
 [2m2[0m │ 
 [2m3[0m │ "foo" | let x | accepts-int
   · [35;1m        ─┬─[0m[33;1m     ─────┬─────[0m
   ·          [35;1m│[0m           [33;1m╰── [33;1monly int input data is supported[0m[0m
   ·          [35;1m╰── [35;1minput type: string[0m[0m
   ╰────
```


#### Command `def`initions

Type checking and inference inside `def` blocks are now affected by the commands input/output signatures.

<table><tr><td>

```nushell
def accepts-int []: int -> int {}

def foo []: string -> any {
    accepts-int
}
```
```ansi:no-line-numbers
Error: [31mnu::parser::input_type_mismatch[0m

  [31m×[0m Command does not support string input.
   ╭─[[36;1;4msource:4:2[0m]
 [2m3[0m │ def foo []: string -> any {
 [2m4[0m │     accepts-int
   · [35;1m    ─────┬─────[0m
   ·          [35;1m╰── [35;1mcommand doesn't support string input[0m[0m
 [2m5[0m │ }
   ╰────
```

</td></tr></table>


#### `if-else`, `match`

Conditionals (`if`, `match`) are now properly typed:

  - output of the expression is a union of all possible output types (based on the branches)
    ```nushell
    if $x == $y {
        42
    } else {
        "foo"
    }
    | let out  # oneof<int, string>

    match $x {
        1 => 1,
        2 => "foo",
        _ => { {a: 1} }
    }
    | let out  # oneof<int, string, record<a: int>>
    ```

  - without a fallback (a final `else` branch for `if` chains, a wildcard pattern for `match` expressions) the output types of conditional expressions include `nothing`
    ```nushell
    if $x == $y {
        42
    }
    | let out  # oneof<int, nothing>

    match $x {
        1 => 1,
        2 => "foo",
    }
    | let out  # oneof<int, string, nothing>
    ```

  - branch blocks get pipeline input type information
    ```nushell
    [1, 2, 3]
    | if true {
        let input  # list<int>
        $input | into string
    } else {
        # pass through
    }
    | let out  # oneof<list<string>, list<int>>
    ```

## Additional Notes

I'm not really happy with the fact that I had to pass down input type through layers of the parser. I would be happy to hear alternative implementation ideas.