### PR TITLE
fix(help): don't list built-in subcommands under same-named custom commands

### DIFF
--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -458,3 +458,15 @@ fn nothing_type_annotation() -> Result {
         .run("help commands | where name == foo | get input_output.0.output.0")
         .expect_value_eq("nothing")
 }
+
+#[test]
+fn custom_command_does_not_show_builtin_subcommand() -> Result {
+    // Regression test for https://github.com/nushell/nushell/issues/18236:
+    // a user-defined `update` must not advertise the built-in `update cells`
+    // as one of its subcommands.
+    let mut tester = test();
+    let () = tester.run("def update [] {}")?;
+    let outcome: String = tester.run("help update")?;
+    assert!(!outcome.contains("update cells"));
+    Ok(())
+}

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -318,6 +318,11 @@ fn get_command_documentation(
     let signatures = engine_state.get_signatures_and_declids(true);
     // track which declarations we've already added to `subcommands`
     let mut seen = HashSet::new();
+    // A custom (script-defined) command can never own a built-in subcommand, so a
+    // built-in command that merely shares its name prefix (e.g. the built-in
+    // `update cells` vs a user-defined `update`) must not be listed as a subcommand.
+    // See https://github.com/nushell/nushell/issues/18236
+    let parent_is_custom = command.command_type() == CommandType::Custom;
     for (sig, decl_id) in signatures {
         // Prefer the overlay-visible declaration name (if any) for display and matching.
         // Fall back to the signature's name if not present.
@@ -325,6 +330,7 @@ fn get_command_documentation(
             .find_decl_name(decl_id, &[])
             .map(|bytes| String::from_utf8_lossy(bytes).to_string())
             .unwrap_or_else(|| sig.name.clone());
+        let command_type = engine_state.get_decl(decl_id).command_type();
 
         // Don't display removed/deprecated commands in the Subcommands list. We consider a signature a subcommand when either the overlay-visible
         // `display_name` begins with `cmd_name ` *or* the canonical signature name does; the latter covers cases where `display_name` returns the
@@ -332,10 +338,11 @@ fn get_command_documentation(
         if (display_name.starts_with(&format!("{cmd_name} "))
             || sig.name.starts_with(&format!("{cmd_name} ")))
             && !matches!(sig.category, Category::Removed)
+            // A custom command can never own a built-in subcommand, so skip
+            // built-ins that merely share the prefix (issue #18236).
+            && !(parent_is_custom && command_type == CommandType::Builtin)
             && seen.insert(decl_id)
         {
-            let command_type = engine_state.get_decl(decl_id).command_type();
-
             // choose which name to show: prefer the overlay-visible one if it actually matches the prefix, otherwise fall back to the canonical
             // signature name (which is usually the script-qualified form).
             let name_to_print = if display_name.starts_with(&format!("{cmd_name} ")) {


### PR DESCRIPTION
## Description

Commands named `update` incorrectly listed `update cells` as a subcommand in their help. The subcommand list in `nu-engine`'s `get_command_documentation` finds subcommands purely by name prefix — any command whose name starts with `"<cmd> "` is treated as a subcommand. So a user-defined `update` picks up the built-in `update cells`, even though they're unrelated.

A custom (script-defined) command can never actually own a built-in (Rust-defined) subcommand, so this filters those out: when the command being documented is `CommandType::Custom`, built-in candidates that merely share its name prefix are skipped.

This is a targeted fix for the reported case. The broader cross-module subcommand-scoping issues called out in the `// TODO` above this code (#11447, #11625, #11657) are left as-is.

## User-facing changes (Release notes)

Fixed an issue where a user-defined command named `update` (or any command sharing a name with a built-in that has subcommands) would incorrectly show the built-in's subcommands (e.g. `update cells`) in its `--help`.

## Additional notes

Closes #18236
