### PR TITLE
fix(export-env): don't panic when the block argument is missing or wrong type (#13037)

### DIFF
--- a/crates/nu-command/src/env/export_env.rs
+++ b/crates/nu-command/src/env/export_env.rs
@@ -44,11 +44,17 @@ impl Command for ExportEnv {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let block_id = call
-            .positional_nth(caller_stack, 0)
-            .expect("checked through parser")
-            .as_block()
-            .expect("internal error: missing block");
+        let head = call.head;
+        let arg = call.positional_nth(caller_stack, 0).ok_or_else(|| {
+            ShellError::MissingParameter {
+                param_name: "block".into(),
+                span: head,
+            }
+        })?;
+        let block_id = arg.as_block().ok_or_else(|| ShellError::TypeMismatch {
+            err_message: "expected block".into(),
+            span: arg.span,
+        })?;
 
         let block = engine_state.get_block(block_id);
         let mut callee_stack = caller_stack
@@ -89,5 +95,15 @@ mod test {
     #[test]
     fn test_examples() -> nu_test_support::Result {
         nu_test_support::test().examples(ExportEnv)
+    }
+
+    #[test]
+    fn test_missing_block_does_not_panic() -> nu_test_support::Result {
+        // Regression: previously, `export-env` was given a non-block argument
+        // (e.g. a closure) and panicked with "internal error: missing block".
+        // See https://github.com/nushell/nushell/issues/13037.
+        nu_test_support::test()
+            .run("export-env { |x| $x }")
+            .expect_error()
     }
 }


### PR DESCRIPTION
Closes #13037

## Release notes summary

`notes:fixes` — `export-env` no longer panics with `internal error: missing block` when given a non-block argument; the command now returns a typed `ShellError`.

## Description

Two `expect("...")` calls in `ExportEnv::run` (`crates/nu-command/src/env/export_env.rs`) were panic points. Any path that reached the command without a positional `Block` argument — for example, a closure whose signature the parser did not catch — tore down the main thread with `internal error: missing block`, taking the REPL with it (see issue #13037, which is reproducibly reachable from arbitrary user input).

This change replaces the two `expect("…")` calls with idiomatic `ok_or_else(...)?` returns:

- `call.positional_nth(caller_stack, 0)` returning `None` becomes `ShellError::MissingParameter` with `param_name: "block"` and span `call.head`.
- The value at that position not being a `Block` becomes `ShellError::TypeMismatch` with `err_message: "expected block"` and span `arg.span`.

Both errors are reportable through the normal `ShellError` machinery so the user sees a useful diagnostic instead of a panic, and the REPL stays up. The change is small (16 lines) and mirrors the pattern used by `if`'s parser keyword in `crates/nu-cmd-lang/src/core_commands/if_.rs`.

## Test plan

- [x] Existing example-based test `test_examples` is untouched and still exercises the happy path.
- [x] New test `test_missing_block_does_not_panic` runs `export-env { |x| $x }` (a closure, not a block) and asserts that the result is an `expect_error`. Under the prior code this test would have entered the `expect("internal error: missing block")` branch and aborted the test process.

The new test will be picked up by the project's standard `cargo test -p nu-command` run on CI.

## Risk

This is a pure error-handling change: the success path is unchanged and the only behavioural difference is the error message and the lack of a panic on the failure path. There is no public-API or signature change.

## AI assistance

Used an AI coding assistant to draft the diff; verified against the existing `if` command's block-resolution pattern and against the `ShellError` variants in `crates/nu-protocol/src/errors/shell_error/mod.rs`. No LLM co-author was added.