### PR TITLE
tests(for): regression test for non-block `for` body (#13746)

### DIFF
--- a/crates/nu-command/tests/commands/for_.rs
+++ b/crates/nu-command/tests/commands/for_.rs
@@ -51,3 +51,16 @@ fn for_loops_dont_collect_source() {
     ");
     assert_eq!(actual.out, "1122334455");
 }
+
+// Regression test for https://github.com/nushell/nushell/issues/13746
+// Passing a non-block (e.g. the loop variable) as the `for` block used to panic
+// on the `.expect("internal error: missing block")` in `for`'s `run`. It must
+// surface a clean error instead and never panic.
+#[test]
+fn for_with_non_block_body_errors_without_panic() {
+    for src in ["for i in [1 2 3] $i", "for i in [] $i"] {
+        let actual = nu!(src);
+        assert!(actual.err.contains("invalid_keyword_call"));
+        assert!(!actual.err.to_lowercase().contains("panic"));
+    }
+}


### PR DESCRIPTION
Closes #13746.

Using the loop variable (or any non-block) as the `for` body — e.g. `for i in [1 2 3] $i` — used to panic on the `.expect("internal error: missing block")` in `for`'s `run`. On current `main` this is already handled: `for`/`if` are lowered by the IR compiler, which resolves the block via `block_arg.as_block().ok_or_else(invalid)?` (`crates/nu-engine/src/compile/keyword.rs`) and returns `nu::compile::invalid_keyword_call` instead of panicking. `for`'s `run` is now `unreachable!()`.

The fix was incidental to the IR-compiler rewrite and there is no regression test for this case, so this adds one (per the AGENTS.md "No panicking on user input" guideline) to keep it from regressing: it asserts the error surfaces `invalid_keyword_call` and that the output never contains `panic`.

No production code changes.

_Disclosure: prepared with AI assistance; reproduced and verified against `main`._
