### PR TITLE
Fix usize underflow on insert/upsert into a nested path of an empty list

### DIFF
--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -213,6 +213,8 @@ fn insert_recursive(
                         value.insert_data_at_cell_path(path, replacement, head_span)?;
                     }
                     pre_elems.push(value)
+                } else if pre_elems.is_empty() {
+                    return Err(ShellError::AccessEmptyContent { span: path_span });
                 } else {
                     return Err(ShellError::AccessBeyondEnd {
                         max_idx: pre_elems.len() - 1,

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -234,6 +234,8 @@ fn upsert_recursive(
                         value.upsert_data_at_cell_path(path, replacement)?;
                     }
                     value
+                } else if pre_elems.is_empty() {
+                    return Err(ShellError::AccessEmptyContent { span: path_span });
                 } else {
                     return Err(ShellError::AccessBeyondEnd {
                         max_idx: pre_elems.len() - 1,

--- a/crates/nu-command/tests/commands/insert.rs
+++ b/crates/nu-command/tests/commands/insert.rs
@@ -190,3 +190,14 @@ fn insert_new_to_table_cell_mixed_rows() {
 
     assert_eq!(actual.out, "z")
 }
+
+#[test]
+fn insert_nested_path_into_empty_list_errors_without_underflow() {
+    // Regression test for #18426: inserting into a nested path of an empty list
+    // used to underflow `pre_elems.len() - 1` to usize::MAX and print a garbage
+    // error containing 18446744073709551615.
+    let actual = nu!("[] | insert 0.0 1");
+
+    assert!(!actual.err.contains("18446744073709551615"));
+    assert!(actual.err.contains("empty content"));
+}

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -321,3 +321,14 @@ fn list_stream_replacement_closure() -> Result {
         .run("[[a]; [text]] | every 1 | upsert b { default TEXT } | to nuon")
         .expect_value_eq("[[a, b]; [text, TEXT]]")
 }
+
+#[test]
+fn upsert_nested_path_into_empty_list_errors_without_underflow() {
+    // Regression test for #18426: upserting into a nested path of an empty list
+    // used to underflow `pre_elems.len() - 1` to usize::MAX and print a garbage
+    // error containing 18446744073709551615.
+    let actual = nu!("[] | upsert 0.0 1");
+
+    assert!(!actual.err.contains("18446744073709551615"));
+    assert!(actual.err.contains("empty content"));
+}


### PR DESCRIPTION
## Description

`[] | insert 0.0 1` and `[] | upsert 0.0 1` printed a confusing error containing `18446744073709551615` (`usize::MAX`).

In the `ListStream` arm of both `insert` and `upsert`, when the cell path has a nested member and the list is empty, the code fell into the `AccessBeyondEnd` branch and computed `pre_elems.len() - 1`. With an empty `pre_elems` that subtraction underflows to `usize::MAX`, which then showed up verbatim in the error label.

This PR adds an explicit empty check that returns `ShellError::AccessEmptyContent` when `pre_elems` is empty, and keeps `AccessBeyondEnd` for the genuine out of range case. That mirrors the convention already used for cell path mutation in `nu-protocol` (`Value::mutate`), where an empty list maps to `AccessEmptyContent` and a non empty one to `AccessBeyondEnd`.

The change is intentionally small and self contained. It only fixes the underflowed error message. The separate behavioral question of whether `[] | insert 0.0 1` should auto create the nested structure is left to the issue author, who is handling that part.

## User-facing changes (Release notes)

Fixed an issue where inserting or upserting into a nested cell path of an empty list, such as `[] | insert 0.0 1`, produced a confusing error mentioning `18446744073709551615`. It now reports a clear "Row number too large (empty content)" error.

## Additional notes

Addresses the integer underflow and error message part of #18426. The author of that issue is taking the related refactor (#18433) and the behavioral consistency change separately, so this PR deliberately does not close the issue.

Tests: added regression tests in `tests/commands/insert.rs` and `tests/commands/upsert.rs`. `cargo test -p nu-command`, `cargo fmt --check`, and `cargo clippy -p nu-command --tests` are green locally.