### PR TITLE
fix(compile): clone `$in` register for binary-op RHS to avoid clobbering LHS (#18323)

### DIFF
--- a/crates/nu-engine/src/compile/operator.rs
+++ b/crates/nu-engine/src/compile/operator.rs
@@ -106,9 +106,17 @@ pub(crate) fn compile_binary_op(
                 // the RHS expression
                 let rhs_reg = builder.next_register()?;
 
-                // Pass in_reg to rhs if it uses $in
+                // Pass in_reg to rhs if it uses $in. But if in_reg aliases lhs_reg (which can
+                // happen because lhs_reg == out_reg), the rhs compilation might `drop` it while
+                // following a `drop_input` path, which would clobber the live lhs value. Clone it
+                // in that case so the rhs gets its own droppable input register.
                 let rhs_in_reg = if rhs.has_in_variable(working_set) {
-                    in_reg
+                    match in_reg {
+                        Some(in_reg) if in_reg == lhs_reg => {
+                            Some(builder.clone_reg(in_reg, rhs.span)?)
+                        }
+                        other => other,
+                    }
                 } else {
                     None
                 };
@@ -140,9 +148,15 @@ pub(crate) fn compile_binary_op(
             _ => {
                 let rhs_reg = builder.next_register()?;
 
-                // Pass in_reg to rhs if it uses $in
+                // Pass in_reg to rhs if it uses $in. See the and/or branch above for why we may
+                // need to clone in_reg when it aliases lhs_reg.
                 let rhs_in_reg = if rhs.has_in_variable(working_set) {
-                    in_reg
+                    match in_reg {
+                        Some(in_reg) if in_reg == lhs_reg => {
+                            Some(builder.clone_reg(in_reg, rhs.span)?)
+                        }
+                        other => other,
+                    }
                 } else {
                     None
                 };

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -188,6 +188,9 @@ fn binary_op_rhs_collects_in_variable() {
     // Regression test for #18323: a binary op whose RHS collects `$in` (e.g. through `not`,
     // a list literal, or a subexpression) used to clobber the LHS register and emit a
     // `register_uninitialized` compiler error.
+    //
+    // `$in` (not `$it`) is deliberate: it is the form that triggers the bug. The `$it`
+    // equivalent compiles fine on `main`, so it would not guard this regression.
     test_eval(
         "[[v]; [1] [2] [6]] | where $in.v > 0 and not ($in.v > 5) | get v | to nuon",
         Eq("[1, 2]"),

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -184,6 +184,21 @@ fn binary_op_example() {
 }
 
 #[test]
+fn binary_op_rhs_collects_in_variable() {
+    // Regression test for #18323: a binary op whose RHS collects `$in` (e.g. through `not`,
+    // a list literal, or a subexpression) used to clobber the LHS register and emit a
+    // `register_uninitialized` compiler error.
+    test_eval(
+        "[[v]; [1] [2] [6]] | where $in.v > 0 and not ($in.v > 5) | get v | to nuon",
+        Eq("[1, 2]"),
+    );
+    test_eval(
+        "[[v]; [1] [2] [6]] | where ($in.v == 1) or (0..($in.v) | is-empty) | get v | to nuon",
+        Eq("[1]"),
+    );
+}
+
+#[test]
 fn range_from_expressions() {
     test_eval("(1 + 1)..(2 + 2)", Matches("2.*3.*4"))
 }


### PR DESCRIPTION
## Description

A binary op (`and`/`or`/comparison) whose right-hand side collects `$in` — via `not (…$in…)`, a `[$in…]` list literal, or a subexpression — inside a `where`/closure row condition raised a compiler error:

```nu
[1 2] | where true and not $in
# Error: nu::compile::register_uninitialized
```

In `compile_binary_op` (`crates/nu-engine/src/compile/operator.rs`), `lhs_reg = out_reg`, so for a `$in`-using binary op the input register aliases the LHS (`in_reg == lhs_reg`). The RHS is compiled with `rhs_in_reg = in_reg`, and several RHS paths in `compile_expression` then call `drop_input`, which emits `Drop` on that register and frees the still-live LHS — so the following `BinaryOp` reads a freed register → `register_uninitialized`.

Fix: when the RHS uses `$in` and `in_reg` aliases `lhs_reg`, clone it so the RHS gets its own droppable input register. Applied to both the `and`/`or` and the comparison branches; it fires only on the exact aliasing condition that currently crashes, so all other binary ops are unchanged.

This fixes the compiler crash only. Two pre-existing, unrelated runtime issues are out of scope: misusing `$in` (vs `$it`) in a `where` row condition still yields a runtime `variable_not_found`, and `where … in [$in.field]` list-literal `$in` resolution is a separate runtime gap.

## User-facing changes (Release notes)

- Fixed a compiler error (`register_uninitialized`) when the right-hand side of an `and`/`or`/comparison collects `$in`, for example `... | where $in.x > 0 and not ($in.x > 5)`.

## Additional notes

Fixes #18323. Added a regression test in `tests/eval/`. `cargo fmt --check`, `cargo clippy -p nu-engine`, and the `eval` suite (69 tests) pass.
