### PR TITLE
tests(for): regression test for non-block `for` body (#13746)

### DIFF
--- a/crates/nu-command/tests/commands/for_.rs
+++ b/crates/nu-command/tests/commands/for_.rs
@@ -51,3 +51,16 @@ fn for_loops_dont_collect_source() {
     ");
     assert_eq!(actual.out, "1122334455");
 }
+
+// Regression test for https://github.com/nushell/nushell/issues/13746
+// Passing a non-block (e.g. the loop variable) as the `for` block used to panic
+// on the `.expect("internal error: missing block")` in `for`'s `run`. It must
+// surface a clean error instead and never panic.
+#[test]
+fn for_with_non_block_body_errors_without_panic() {
+    for src in ["for i in [1 2 3] $i", "for i in [] $i"] {
+        let actual = nu!(src);
+        assert!(actual.err.contains("invalid_keyword_call"));
+        assert!(!actual.err.to_lowercase().contains("panic"));
+    }
+}

--- a/crates/nu-command/tests/commands/if_.rs
+++ b/crates/nu-command/tests/commands/if_.rs
@@ -1,0 +1,15 @@
+use nu_test_support::nu;
+
+// Companion to the `for` non-block-body regression test
+// (https://github.com/nushell/nushell/issues/13746): passing a non-block
+// (e.g. a bare variable) as the `if` body must surface a clean
+// `nu::compile::invalid_keyword_call` error from the IR compiler and never
+// panic, per the AGENTS.md "No panicking on user input" guideline.
+#[test]
+fn if_with_non_block_body_errors_without_panic() {
+    for src in ["if true $nu", "if true $nu else { 1 }"] {
+        let actual = nu!(src);
+        assert!(actual.err.contains("invalid_keyword_call"));
+        assert!(!actual.err.to_lowercase().contains("panic"));
+    }
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -52,6 +52,7 @@ mod headers;
 mod help;
 mod histogram;
 mod idx;
+mod if_;
 mod ignore;
 mod insert;
 mod inspect;


### PR DESCRIPTION
## Description

Using the loop variable (or any non-block) as the `for` body — e.g. `for i in [1 2 3] $i` — used to panic. On current `main` it's already handled: `for` is lowered by the IR compiler, which returns `nu::compile::invalid_keyword_call` instead of panicking. There was no regression test covering this case, so this adds one (per the AGENTS.md "No panicking on user input" guideline): it asserts the error surfaces and the output never contains `panic`. No production code changes.

## User-facing changes (Release notes)

- n/a (test-only; no behavior change)

## Additional notes

Closes #13746.
