### PR TITLE
chore(reedline): bump reedline to 4a5ebce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7287,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.48.0"
-source = "git+https://github.com/nushell/reedline?branch=main#4d20caf55282ecff8de32db41cbc499382a31281"
+source = "git+https://github.com/nushell/reedline?branch=main#4a5ebce9f92793b2d4aa570c581f60d48060b304"
 dependencies = [
  "arboard",
  "chrono",

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -124,6 +124,7 @@ impl Prompt for NushellPrompt {
             PromptEditMode::Vi(vi_mode) => match vi_mode {
                 PromptViMode::Normal => self.vi_normal_prompt_indicator.as_deref().unwrap_or("> "),
                 PromptViMode::Insert => self.vi_insert_prompt_indicator.as_deref().unwrap_or(": "),
+                PromptViMode::Visual => self.vi_normal_prompt_indicator.as_deref().unwrap_or("v "),
             },
             PromptEditMode::Custom(str) => &self.default_wrapped_custom_string(str),
         };

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -1814,10 +1814,10 @@ fn parse_motion_target(
                 record,
                 config,
                 span,
-                "'small' or 'big'",
+                "'word' or 'longword'",
                 |name| match name {
-                    "small" => Some(WordKind::Small),
-                    "big" => Some(WordKind::Big),
+                    "word" => Some(WordKind::Word),
+                    "longword" => Some(WordKind::LongWord),
                     _ => None,
                 },
             )?,
@@ -1929,7 +1929,7 @@ mod test {
         let event = Value::test_record(record! {
             "edit" => Value::test_string("Cut"),
             "motion" => Value::test_string("word"),
-            "word_kind" => Value::test_string("big"),
+            "word_kind" => Value::test_string("longword"),
             "edge" => Value::test_string("end"),
             "direction" => Value::test_string("forward"),
             "granularity" => Value::test_string("linewise"),
@@ -1941,7 +1941,7 @@ mod test {
             parsed_event,
             Some(ReedlineEvent::Edit(vec![EditCommand::Cut {
                 target: MotionTarget::Word {
-                    kind: WordKind::Big,
+                    kind: WordKind::LongWord,
                     edge: WordEdge::End,
                     direction: Direction::Forward,
                 },

--- a/crates/nu-command/src/platform/input/reedline_prompt.rs
+++ b/crates/nu-command/src/platform/input/reedline_prompt.rs
@@ -35,6 +35,7 @@ impl Prompt for ReedlinePrompt {
             PromptEditMode::Vi(vi_mode) => match vi_mode {
                 PromptViMode::Normal => DEFAULT_VI_NORMAL_PROMPT_INDICATOR.into(),
                 PromptViMode::Insert => DEFAULT_VI_INSERT_PROMPT_INDICATOR.into(),
+                PromptViMode::Visual => DEFAULT_VI_NORMAL_PROMPT_INDICATOR.into(),
             },
             PromptEditMode::Custom(str) => format!("({str})").into(),
         }


### PR DESCRIPTION
## Description

Bumps reedline to nushell/reedline#1109, which unifies the caret/selection on a single `Cursor`, adds a per-mode rest policy, introduces a real vi **visual mode**, and folds in editing edge-case fixes.
The caret/selection model changed under both vi and emacs, so both editing modes deserve a broad test pass.

### Nushell-side changes

- Adapt to the `WordKind::Small`/`Big` → `Word`/`LongWord` rename (+ new `Unicode` variant), and the matching keybinding `word_kind` values `"word"`/`"longword"`. These names/values only ever existed on reedline `main` this cycle (introduced post-`v0.48.0` in nushell/reedline#1100), so no released version is affected.
- Handle the new `PromptViMode::Visual` in both prompt-indicator impls.

## User-facing changes (Release notes)

- Vi mode gains a real **visual mode**: press `v` to start a selection, then use motions and `d`/`c`/`y`/`r` (including across multiple lines).
- In vi normal mode, the caret now rests *on* the last grapheme, and `h`/`l` move across line boundaries.
- Visual mode uses its own prompt indicator, defaulting to the vi-normal indicator.

## Additional notes

### Test focus

**Vi:**
- new visual mode (`v` + motions + `d`/`c`/`y`/`r`, incl. multi-line)
- normal caret now rests *on* the last grapheme; `h`/`l` cross line boundaries
- word motions/operators on punctuation, contractions, multibyte
- linewise `dd`/`yy` + paste (no stray blank line, incl. last line and single-line buffer)
- abbreviation-on-Enter
- caret position after history nav
- multiline `j`/`k`

**Emacs:**
- word motions (`M-f`/`M-b`/`M-d`/`C-w`), especially mid-word
- shift-selection + cut/copy/paste
- completion while a selection is active

**Cross-cutting:**
- CRLF content, NFD/combining, emoji/ZWJ
- undo/redo
- custom keybindings

### Risk

Editing-model change touching both vi and emacs.
It's a broad surface.
But I believe it's solving more problems than it creates.