### PR TITLE
Error record passed to the `catch` block has more details

### DIFF
--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -1,4 +1,5 @@
-use nu_test_support::nu;
+use nu_protocol::test_record;
+use nu_test_support::prelude::*;
 
 #[test]
 fn try_succeed() {
@@ -207,23 +208,36 @@ fn prints_only_if_last_pipeline() {
 }
 
 #[test]
-fn get_error_columns() {
-    let actual = nu!(" try { non_existent_command } catch {|err| $err} | columns | to json -r");
-    assert_eq!(
-        actual.out,
-        "[\"msg\",\"debug\",\"raw\",\"rendered\",\"json\"]"
-    );
+fn get_error_columns() -> Result {
+    test()
+        .run(" try { non_existent_command } catch { columns }")
+        .expect_value_eq(["msg", "debug", "raw", "rendered", "details"])
 }
 
 #[test]
-fn get_json_error() {
-    let actual = nu!(
-        "try { non_existent_command } catch {|err| $err} | get json | from json | update labels.span {{start: 0 end: 0}} | to json -r"
-    );
-    assert_eq!(
-        actual.out,
-        "{\"msg\":\"External command failed\",\"labels\":[{\"text\":\"Command `non_existent_command` not found\",\"span\":{\"start\":0,\"end\":0}}],\"code\":\"nu::shell::external_command\",\"url\":null,\"help\":\"`non_existent_command` is neither a Nushell built-in or a known external command\",\"inner\":[]}"
-    );
+fn get_json_error() -> Result {
+    let empty_list = [(); 0];
+    test()
+        .run("try { non_existent_command } catch { get details | reject labels.span }")
+        .expect_value_eq(test_record! {
+            "msg" => "External command failed",
+            "labels" => [
+                test_record! {
+                    "text" => "Command `non_existent_command` not found",
+                    "resolved_span" => test_record! {
+                        "file" => "source",
+                        "span" => test_record! { 
+                            "start" => 6,
+                            "end" => 26,
+                         },
+                    },
+                }
+            ],
+            "code" => "nu::shell::external_command",
+            "url" => (),
+            "help" => "`non_existent_command` is neither a Nushell built-in or a known external command",
+            "inner" => empty_list,
+        })
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -224,12 +224,10 @@ fn get_json_error() -> Result {
             "labels" => [
                 test_record! {
                     "text" => "Command `non_existent_command` not found",
-                    "resolved_span" => test_record! {
+                    "location" => test_record! {
                         "file" => "source",
-                        "span" => test_record! { 
-                            "start" => 6,
-                            "end" => 26,
-                         },
+                        "start" => 6,
+                        "end" => 26,
                     },
                 }
             ],

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1,7 +1,7 @@
 use crate::{
     BlockId, Category, CompileError, Config, DeclId, FileId, GetSpan, Module, ModuleId, OverlayId,
-    ParseError, ParseWarning, ResolvedImportPattern, Signature, Span, SpanId, Type, Value, VarId,
-    VirtualPathId,
+    ParseError, ParseWarning, ResolvedImportPattern, ResolvedSpan, Signature, Span, SpanId, Type,
+    Value, VarId, VirtualPathId,
     ast::Block,
     engine::{
         CachedFile, Command, CommandType, EngineState, OverlayFrame, StateDelta, Variable,
@@ -314,7 +314,7 @@ impl<'a> StateWorkingSet<'a> {
         }
     }
 
-    pub fn files(&self) -> impl Iterator<Item = &CachedFile> {
+    pub fn files(&self) -> impl DoubleEndedIterator<Item = &CachedFile> {
         self.permanent_state.files().chain(self.delta.files.iter())
     }
 
@@ -1042,6 +1042,14 @@ impl<'a> StateWorkingSet<'a> {
         None
     }
 
+    /// Find the file which contains the given [`Span`]
+    pub fn find_file_by_span(&self, span: Span) -> Option<&CachedFile> {
+        self.files()
+            // the span we're looking for is much more likely to be in a recently added file
+            .rev()
+            .find(|file| file.covered_span.contains_span(span))
+    }
+
     pub fn find_virtual_path(&self, name: &str) -> Option<&VirtualPath> {
         // Platform appropriate virtual path (slashes or backslashes)
         let virtual_path_name = Path::new(name);
@@ -1077,6 +1085,13 @@ impl<'a> StateWorkingSet<'a> {
         let num_permanent_spans = self.permanent_state.spans.len();
         self.delta.spans.push(span);
         SpanId::new(num_permanent_spans + self.delta.spans.len() - 1)
+    }
+
+    pub fn resolve_span<'s>(&'s self, span: Span) -> Option<ResolvedSpan<'s>> {
+        let cached_file = self.find_file_by_span(span)?;
+        let file = cached_file.name.as_ref().into();
+        let span = span.offset(cached_file.covered_span.start);
+        Some(ResolvedSpan { file, span })
     }
 }
 

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -1,5 +1,5 @@
 use super::{ShellError, shell_error::io::IoError};
-use crate::{FromValue, IntoValue, Span, Type, Value, record};
+use crate::{FromValue, IntoValue, Span, Type, Value, engine::StateWorkingSet, record};
 use miette::{Diagnostic, LabeledSpan, NamedSource, SourceSpan};
 use serde::{Deserialize, Serialize};
 use std::{fmt, fs};
@@ -245,9 +245,29 @@ impl FromValue for ErrorLabel {
 
 impl IntoValue for ErrorLabel {
     fn into_value(self, span: Span) -> Value {
+        let ErrorLabel {
+            text,
+            span: label_span,
+        } = self;
         record! {
-            "text" => Value::string(self.text, span),
-            "span" => span.into_value(span),
+            "text" => Value::string(text, span),
+            "span" => label_span.into_value(span),
+        }
+        .into_value(span)
+    }
+}
+
+impl ErrorLabel {
+    fn into_value_with_resolved_span(self, span: Span, working_set: &StateWorkingSet) -> Value {
+        let ErrorLabel {
+            text,
+            span: label_span,
+        } = self;
+        let resolved_span = working_set.resolve_span(label_span);
+        record! {
+            "text" => Value::string(text, span),
+            "span" => label_span.into_value(span),
+            "resolved_span" => resolved_span.into_value(span),
         }
         .into_value(span)
     }
@@ -424,6 +444,38 @@ impl From<ShellError> for LabeledError {
 impl From<IoError> for LabeledError {
     fn from(err: IoError) -> Self {
         Self::from_diagnostic(&err)
+    }
+}
+
+impl LabeledError {
+    pub fn into_value(self, span: Span, working_set: &StateWorkingSet) -> Value {
+        let LabeledError {
+            msg,
+            labels,
+            code,
+            url,
+            help,
+            inner,
+        } = self;
+        let inner = inner
+            .into_iter()
+            .map(|err| Self::from(err).into_value(span, working_set))
+            .collect::<Vec<_>>()
+            .into_value(span);
+        let labels = labels
+            .into_iter()
+            .map(|e| e.into_value_with_resolved_span(span, working_set))
+            .collect::<Vec<_>>()
+            .into_value(span);
+        let record = record! {
+            "msg" => msg.into_value(span),
+            "labels" => labels,
+            "code" => code.into_value(span),
+            "url" => url.into_value(span),
+            "help" => help.into_value(span),
+            "inner" => inner,
+        };
+        Value::record(record, span)
     }
 }
 

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -267,7 +267,7 @@ impl ErrorLabel {
         record! {
             "text" => Value::string(text, span),
             "span" => label_span.into_value(span),
-            "resolved_span" => resolved_span.into_value(span),
+            "location" => resolved_span.into_value(span),
         }
         .into_value(span)
     }

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1509,7 +1509,7 @@ impl ShellError {
             "debug" => Value::string(format!("{self:?}"), span),
             "raw" => Value::error(self.clone(), span),
             "rendered" => Value::string(format_cli_error(Some(stack), working_set, &self, Some("nu::shell::error")), span),
-            "json" => Value::string(serde_json::to_string(&self).expect("Could not serialize error"), span),
+            "details" => LabeledError::from(self).into_value(span, working_set),
         };
 
         if let Some(code) = exit_code {

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -154,7 +154,8 @@ impl<'a> IntoValue for ResolvedSpan<'a> {
     fn into_value(self, span: Span) -> Value {
         let record = record! {
             "file" => self.file.into_value(span),
-            "span" => self.span.into_value(span),
+            "start" => Value::int(self.span.start as i64, span),
+            "end" => Value::int(self.span.end as i64, span),
         };
         record.into_value(span)
     }

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -3,6 +3,7 @@ use crate::shell_error::generic::GenericError;
 use crate::{FromValue, IntoValue, ShellError, Signals, SpanId, Value, record};
 use miette::SourceSpan;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::{fmt, ops::Deref};
 
 pub trait GetSpan {
@@ -141,6 +142,22 @@ impl<T> IntoSpanned for T {
 pub struct Span {
     pub start: usize,
     pub end: usize,
+}
+
+#[derive(Clone)]
+pub struct ResolvedSpan<'a> {
+    pub file: Cow<'a, str>,
+    pub span: Span,
+}
+
+impl<'a> IntoValue for ResolvedSpan<'a> {
+    fn into_value(self, span: Span) -> Value {
+        let record = record! {
+            "file" => self.file.into_value(span),
+            "span" => self.span.into_value(span),
+        };
+        record.into_value(span)
+    }
 }
 
 impl fmt::Debug for Span {

--- a/crates/nu-std/tests/test_std-rfc_tables.nu
+++ b/crates/nu-std/tests/test_std-rfc_tables.nu
@@ -308,8 +308,8 @@ def throw_error_on_non-existing_column [] {
     let grouped = $movies | group-by Genre --to-table
     let error = try {
         $grouped | aggregate --ops {avg: {math avg}} NotInTheDataSet
-    } catch {|e|
-        $e.json | from json
+    } catch {
+        get details
     }
 
     assert equal $error.inner.0.msg "Cannot find column '$.items.NotInTheDataSet'"


### PR DESCRIPTION
## Description

## User-facing changes (Release notes)

### Errors with more `details` and file relative spans

The error record you receive in `try {..} catch {..}` blocks no longer has a `json` field. A new field named `details` takes its place instead. It holds the same information as the `json` field but requires no deserialization stop like `from json`.

There is one small but significant difference: the error labels now have additional field `location` in addition to `span`.
`location` contains the name of the file the label points to, with `start` and `end` offsets that are relative to the file itself.

<table>
<tr>
<td>

`/tmp/example.nu`

</td>
<td>rendered</td>
</tr>

<tr>
<td>

```nushell
use std/assert

export def wrong [] {
  assert equal (2 + 2) 5
}
``` 

</td>
<td>

```nushell
use /tmp/example.nu *; wrong
```
![](https://gist.githubusercontent.com/Bahex/c56672ea1ca0791039495fa1d07df2b4/raw/2de7941390150eb75383a04a309699813c792a81/rendered-error.svg)

</td>
</tr>
<tr><td colspan=2>

```nushell
use /tmp/example.nu *
try { wrong } catch { get details }
```
```
╭────────┬─────────────────────────────────────────────────────────────────────╮
│ msg    │ These are not equal.                                                │
│        │ ╭───┬──────────┬────────────────────┬─────────────────────────────╮ │
│ labels │ │ # │   text   │        span        │          location           │ │
│        │ ├───┼──────────┼────────────────────┼─────────────────────────────┤ │
│        │ │ 0 │ left: 4  │ ╭───────┬────────╮ │ ╭───────┬─────────────────╮ │ │
│        │ │   │          │ │ start │ 239936 │ │ │ file  │ /tmp/example.nu │ │ │
│        │ │   │          │ │ end   │ 239943 │ │ │ start │ 52              │ │ │
│        │ │   │          │ ╰───────┴────────╯ │ │ end   │ 59              │ │ │
│        │ │   │          │                    │ ╰───────┴─────────────────╯ │ │
│        │ │ 1 │ right: 5 │ ╭───────┬────────╮ │ ╭───────┬─────────────────╮ │ │
│        │ │   │          │ │ start │ 239944 │ │ │ file  │ /tmp/example.nu │ │ │
│        │ │   │          │ │ end   │ 239945 │ │ │ start │ 60              │ │ │
│        │ │   │          │ ╰───────┴────────╯ │ │ end   │ 61              │ │ │
│        │ │   │          │                    │ ╰───────┴─────────────────╯ │ │
│        │ ╰───┴──────────┴────────────────────┴─────────────────────────────╯ │
│ code   │                                                                     │
│ url    │                                                                     │
│ help   │                                                                     │
│ inner  │ [list 0 items]                                                      │
╰────────┴─────────────────────────────────────────────────────────────────────╯
```

</td></tr>
</table>

With these file relative spans, making external tools for reporting nushell errors should be much easier.