### PR TITLE
fix(math): propagate errors from table columns instead of silencing them

### DIFF
--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -46,17 +46,7 @@ fn helper_for_tables(
     // The mathematical function operates over the columns of the table
     let mut column_totals = IndexMap::new();
     for (col_name, col_vals) in column_values {
-        if let Ok(out) = mf(&col_vals, val_span, name) {
-            column_totals.insert(col_name, out);
-        }
-    }
-    if column_totals.keys().len() == 0 {
-        return Err(ShellError::UnsupportedInput {
-            msg: "Unable to give a result with this input".to_string(),
-            input: "value originates from here".into(),
-            msg_span: name,
-            input_span: val_span,
-        });
+        column_totals.insert(col_name, mf(&col_vals, val_span, name)?);
     }
 
     Ok(Value::record(column_totals.into_iter().collect(), name))

--- a/crates/nu-command/tests/commands/math/avg.rs
+++ b/crates/nu-command/tests/commands/math/avg.rs
@@ -39,3 +39,23 @@ fn const_avg() -> Result {
         .run("const AVG = [1 3 5] | math avg; $AVG")
         .expect_value_eq(3.0)
 }
+
+#[test]
+fn overflow_error_is_consistent_between_list_and_table() -> Result {
+    // Large durations that sum beyond i64::MAX nanoseconds
+    let durations = "[618019200000000000ns, 650422800000000000ns, 652579200000000000ns, 657849600000000000ns, 660873600000000000ns, 662342400000000000ns, 664416000000000000ns, 667782000000000000ns, 669855600000000000ns, 673311600000000000ns, 675903600000000000ns, 677462400000000000ns, 681609600000000000ns, 683766000000000000ns]";
+
+    let list_err = test()
+        .run(format!("{durations} | math avg"))
+        .expect_shell_error()?;
+
+    let table_err = test()
+        .run(format!("{durations} | wrap d | math avg"))
+        .expect_shell_error()?;
+
+    assert!(
+        std::mem::discriminant(&list_err) == std::mem::discriminant(&table_err),
+        "list and table paths produced different error variants:\n  list:  {list_err:?}\n  table: {table_err:?}"
+    );
+    Ok(())
+}

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -95,3 +95,23 @@ fn cannot_sum_infinite_range() -> Result {
     assert!(matches!(outcome, ShellError::IncorrectValue { .. }));
     Ok(())
 }
+
+#[test]
+fn overflow_error_is_consistent_between_list_and_table() -> Result {
+    // Large durations that sum beyond i64::MAX nanoseconds
+    let durations = "[618019200000000000ns, 650422800000000000ns, 652579200000000000ns, 657849600000000000ns, 660873600000000000ns, 662342400000000000ns, 664416000000000000ns, 667782000000000000ns, 669855600000000000ns, 673311600000000000ns, 675903600000000000ns, 677462400000000000ns, 681609600000000000ns, 683766000000000000ns]";
+
+    let list_err = test()
+        .run(format!("{durations} | math sum"))
+        .expect_shell_error()?;
+
+    let table_err = test()
+        .run(format!("{durations} | wrap d | math sum"))
+        .expect_shell_error()?;
+
+    assert!(
+        std::mem::discriminant(&list_err) == std::mem::discriminant(&table_err),
+        "list and table paths produced different error variants:\n  list:  {list_err:?}\n  table: {table_err:?}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Description

`math avg`, `math sum`, and other math commands that operate on tables iterate column by column in `helper_for_tables`. When the computation for a column failed, the error was silently discarded via `if let Ok(out) = mf(...)`. If all columns failed, the function fell through to a generic fallback error: "Unable to give a result with this input".

The same operation on a list gave the real error (e.g. `operator_overflow` when summing `duration` values that exceed `i64::MAX`). This made the table and list paths inconsistent and the table error useless for debugging.

Fix: propagate errors with `?` and remove the now-unreachable fallback.

Before:
```nushell
$durations | wrap distance | math avg
# Error: Unable to give a result with this input  ← not helpful
```

After:
```nushell
$durations | wrap distance | math avg
# Error: Operator overflow.  ← same as the list path
```

## User-facing changes (Release notes)

Fixed an issue where `math avg`, `math sum`, and other math commands on tables produced a generic "Unable to give a result with this input" error instead of the real underlying error. List and table inputs now produce consistent error messages.

## Additional notes

Fixes #16563