### PR TITLE
fix multiple search items help message

### DIFF
--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -28,7 +28,7 @@ impl Command for MathSqrt {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["square", "sqrt", "root"]
+        vec!["square", "root"]
     }
 
     fn is_const(&self) -> bool {

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -28,7 +28,7 @@ impl Command for MathSqrt {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["square", "root"]
+        vec!["square", "sqrt", "root"]
     }
 
     fn is_const(&self) -> bool {

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -608,14 +608,28 @@ pub fn command_not_found(
 
     // Try to match the name with the search terms of existing commands.
     let signatures = engine_state.get_signatures_and_declids(false);
-    if let Some((sig, _)) = signatures.iter().find(|(sig, _)| {
-        sig.search_terms
-            .iter()
-            .any(|term| term.to_folded_case() == name.to_folded_case())
-    }) {
+    if let Some((last, others)) = signatures
+        .iter()
+        .map(|(sig, _)| sig)
+        .filter(|sig| {
+            sig.search_terms
+                .iter()
+                .any(|term| term.to_folded_case() == name.to_folded_case())
+        })
+        .map(|sig| format!("`{}`", sig.name))
+        .collect::<Vec<_>>()
+        .split_last()
+    {
+        let commands = if others.is_empty() {
+            last
+        } else {
+            // other or last
+            // other, other or last
+            &format!("{} or {last}", others.join(", "))
+        };
         return ShellError::ExternalCommand {
             label: format!("Command `{name}` not found"),
-            help: format!("Did you mean `{}`?", sig.name),
+            help: format!("Did you mean {commands}?"),
             span,
         };
     }

--- a/src/command_context.rs
+++ b/src/command_context.rs
@@ -163,32 +163,6 @@ mod tests {
     }
 
     #[test]
-    fn no_search_term_duplicates() {
-        let ctx = add_command_context(EngineState::new());
-        let decls = ctx.get_decls_sorted(true);
-        let mut failures = Vec::new();
-
-        for (name_bytes, decl_id) in decls {
-            let cmd = ctx.get_decl(decl_id);
-            let cmd_name = String::from_utf8_lossy(&name_bytes);
-            let search_terms = cmd.search_terms();
-            let category = cmd.signature().category;
-
-            for search_term in search_terms {
-                if cmd_name.contains(search_term) {
-                    failures.push(format!("{cmd_name} ({category:?}): Search term \"{search_term}\" is substring of command name \"{cmd_name}\""));
-                }
-            }
-        }
-
-        assert!(
-            failures.is_empty(),
-            "Duplication in search terms:\n{}",
-            failures.join("\n")
-        );
-    }
-
-    #[test]
     fn description_end_period() {
         let ctx = add_command_context(EngineState::new());
         let decls = ctx.get_decls_sorted(true);

--- a/src/command_context.rs
+++ b/src/command_context.rs
@@ -163,6 +163,32 @@ mod tests {
     }
 
     #[test]
+    fn no_command_name_contains_search_terms() {
+        let ctx = add_command_context(EngineState::new());
+        let decls = ctx.get_decls_sorted(true);
+        let mut failures = Vec::new();
+
+        for (name_bytes, decl_id) in decls {
+            let cmd = ctx.get_decl(decl_id);
+            let cmd_name = String::from_utf8_lossy(&name_bytes);
+            let search_terms = cmd.search_terms();
+            let category = cmd.signature().category;
+
+            for search_term in search_terms {
+                if cmd_name.contains(search_term) {
+                    failures.push(format!("{cmd_name} ({category:?}): Search term \"{search_term}\" is substring of command name \"{cmd_name}\""));
+                }
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "Command names contain their search terms:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    #[test]
     fn description_end_period() {
         let ctx = add_command_context(EngineState::new());
         let decls = ctx.get_decls_sorted(true);


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

Adresses two issues.
First, there was a bad test `no_search_term_duplicates` which despite its name merely checked whether search terms for all commands are not contained in the name of their own commands. ~~Which meant that for whatever reason redirecting people who want to use `sqrt` to `math sqrt` would violate tests.
The test would make sense (before the second change in the PR) if it actually did what it's supposed to, but it didn't do even that, so I've opted to just remove it.
Oh, also yes, I've added `sqrt` as `math sqrt` search term.~~
To avoid further confusion, I've renamed the test to `no_command_name_contains_search_terms`

Second, help messages for search terms would only show the first command that satisfies. For example, try typing `root` into the shell. You will see this:
```sh
❯ root
Error: nu::shell::external_command

  × External command failed
   ╭─[repl_entry #1:1:1]
 1 │ root
   · ──┬─
   ·   ╰── Command `root` not found
   ╰────
  help: Did you mean `is-admin`?
```
And this is despite "math sqrt" also having "root" as its search terms. I've made it so all commands show up:
```sh
Error: nu::shell::external_command

  × External command failed
   ╭─[source:1:1]
 1 │ root
   · ──┬─
   ·   ╰── Command `root` not found
   ╰────
  help: Did you mean `is-admin` or `math sqrt`?
```
## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
n/a really
## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->