### PR TITLE
Fix  showing target command name instead of alias name (#18351)

### DIFF
--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -86,7 +86,6 @@ fn help_alias_description_3() -> Result {
 }
 
 #[test]
-#[ignore = "`help aliases` produces different results for aliases, see #18351"]
 fn help_alias_name() -> Result {
     Playground::setup("help_alias_name", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
@@ -131,7 +130,6 @@ fn help_alias_name_f() -> Result {
 }
 
 #[test]
-#[ignore = "`help aliases` produces different results for aliases, see #18351"]
 fn help_export_alias_name_single_word() -> Result {
     Playground::setup("help_export_alias_name_single_word", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
@@ -155,7 +153,6 @@ fn help_export_alias_name_single_word() -> Result {
 }
 
 #[test]
-#[ignore = "`help aliases` produces different results for aliases, see #18351"]
 fn help_export_alias_name_multi_word() -> Result {
     Playground::setup("help_export_alias_name_multi_word", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -87,6 +87,8 @@ fn help_alias_description_3() -> Result {
 
 #[test]
 fn help_alias_name() -> Result {
+    // Regression test for #18351 — ensure the alias name "SPAM" appears in
+    // `help aliases SPAM` output, not the target command name "print"
     Playground::setup("help_alias_name", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -131,6 +133,7 @@ fn help_alias_name_f() -> Result {
 
 #[test]
 fn help_export_alias_name_single_word() -> Result {
+    // #18351: same as help_alias_name but for export alias
     Playground::setup("help_export_alias_name_single_word", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",
@@ -154,6 +157,7 @@ fn help_export_alias_name_single_word() -> Result {
 
 #[test]
 fn help_export_alias_name_multi_word() -> Result {
+    // #18351: same as help_alias_name but for multi-word export alias
     Playground::setup("help_export_alias_name_multi_word", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "spam.nu",

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -180,6 +180,52 @@ fn help_export_alias_name_multi_word() -> Result {
 }
 
 #[test]
+fn help_alias_name_external() -> Result {
+    Playground::setup("help_alias_name_external", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContent(
+            "spam.nu",
+            "
+                # line1
+                alias SPAM = ^echo 'spam' # line2
+            ",
+        )]);
+
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("source spam.nu")?;
+        let outcome: String = tester.run("help aliases SPAM")?;
+
+        assert_contains("line1", &outcome);
+        assert_contains("line2", &outcome);
+        assert_contains("SPAM", &outcome);
+        assert_contains("^echo 'spam'", &outcome);
+        Ok(())
+    })
+}
+
+#[test]
+fn help_export_alias_name_external() -> Result {
+    Playground::setup("help_export_alias_name_external", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContent(
+            "spam.nu",
+            "
+                # line1
+                export alias SPAM = ^echo 'spam' # line2
+            ",
+        )]);
+
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("use spam.nu SPAM")?;
+        let outcome: String = tester.run("help aliases SPAM")?;
+
+        assert_contains("line1", &outcome);
+        assert_contains("line2", &outcome);
+        assert_contains("SPAM", &outcome);
+        assert_contains("^echo 'spam'", &outcome);
+        Ok(())
+    })
+}
+
+#[test]
 fn help_module_description_1() -> Result {
     Playground::setup("help_module_description", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -66,7 +66,6 @@ pub fn get_full_help(
         CommandType::Alias => get_alias_documentation(
             &mut long_desc,
             command,
-            &sig,
             &help_style,
             engine_state,
             stack,
@@ -239,7 +238,6 @@ fn highlight_code<'a>(
 fn get_alias_documentation(
     long_desc: &mut String,
     command: &dyn Command,
-    sig: &Signature,
     help_style: &HelpStyle,
     engine_state: &EngineState,
     stack: &mut Stack,
@@ -248,7 +246,7 @@ fn get_alias_documentation(
     let help_section_name = &help_style.section_name;
     let help_subcolor_one = &help_style.subcolor_one;
 
-    let alias_name = &sig.name;
+    let alias_name = command.name();
 
     write!(
         long_desc,


### PR DESCRIPTION
Fixes #18351

`get_alias_documentation()` used `sig.name` to display the alias name, but for internal command aliases, `Alias::signature()` delegates to the wrapped command's signature, returning the target command name instead of the alias name.

Changed to `command.name()` which always returns the actual alias name via `Alias::name()`.

## Release notes summary
`help aliases` now correctly shows the alias name (not the target command name) for aliases to internal commands.