### PR TITLE
fix(xlsx,ods): convert whole-number floats to int

### DIFF
--- a/crates/nu-command/src/formats/from/sheets.rs
+++ b/crates/nu-command/src/formats/from/sheets.rs
@@ -147,7 +147,13 @@ fn cell_to_data(cell: &Data, head: Span, tz: chrono::FixedOffset) -> Value {
     match cell {
         Data::Empty => Value::nothing(head),
         Data::Int(val) => Value::int(*val, head),
-        Data::Float(val) => Value::float(*val, head),
+        Data::Float(val) => {
+            if *val as i64 as f64 == *val {
+                Value::int(*val as i64, head)
+            } else {
+                Value::float(*val, head)
+            }
+        }
         Data::String(val) => Value::string(val, head),
         Data::Bool(val) => Value::bool(*val, head),
         Data::DateTime(d) => excel_datetime_to_value(d, tz, head),

--- a/crates/nu-command/tests/format_conversions/xlsx.rs
+++ b/crates/nu-command/tests/format_conversions/xlsx.rs
@@ -53,3 +53,31 @@ fn fill_in_missing_headers() -> Result {
         .run(code)
         .expect_value_eq(vec!["header0", "column1", "header2", "column3"])
 }
+
+#[test]
+fn from_excel_int_column_is_int() -> Result {
+    let code = "
+        open sample_data.xlsx
+        | get SalesOrders.Units
+        | first
+        | describe
+    ";
+    test()
+        .cwd("tests/fixtures/formats")
+        .run(code)
+        .expect_value_eq("int")
+}
+
+#[test]
+fn from_excel_float_column_is_float() -> Result {
+    let code = "
+        open sample_data.xlsx
+        | get SalesOrders.Total
+        | first
+        | describe
+    ";
+    test()
+        .cwd("tests/fixtures/formats")
+        .run(code)
+        .expect_value_eq("float")
+}


### PR DESCRIPTION
## Description
When reading `.xlsx` and `.ods` files, float values that are whole numbers (e.g. 95.0) are now converted to int type.
This fixes integer columns displaying with decimal points.

Before:
```
❯ nu -c "open tests/fixtures/formats/sample_data.xlsx | get SalesOrders | first"
╭───────────┬─────────────╮
│ OrderDate │ 8 years ago │
│ Region    │ East        │
│ Rep       │ Jones       │
│ Item      │ Pencil      │
│ Units     │ 95.00       │
│ Unit Cost │ 1.99        │
│ Total     │ 189.05      │
╰───────────┴─────────────╯
```

After:
```
❯ ./target/debug/nu -c "open tests/fixtures/formats/sample_data.xlsx | get SalesOrders | first"
╭───────────┬─────────────╮
│ OrderDate │ 8 years ago │
│ Region    │ East        │
│ Rep       │ Jones       │
│ Item      │ Pencil      │
│ Units     │ 95          │
│ Unit Cost │ 1.99        │
│ Total     │ 189.05      │
╰───────────┴─────────────╯
```

Calamine returns all xlsx/ods numeric cells as Data::Float (xlsx cells are IEEE 754 doubles per spec).
A double-cast guard `*f as i64 as f64 == *f` detects whole-number floats reliably across the full f64 range.

## User-facing changes (Release notes)
- Fixed an issue where integer columns in xlsx and ods files were displayed as floats (e.g. 95.0 instead of 95)

## Additional notes
- Closes https://github.com/tafia/calamine/pull/669
- Assisted-by: OpenCode v1.17.9 (opencode/big-pickle)