### PR TITLE
fix: `toolkit run pr` runtime type checking issue

### DIFF
--- a/toolkit/artifact/api.nu
+++ b/toolkit/artifact/api.nu
@@ -32,6 +32,7 @@ export def get-workflow-run [commits: list<string>, span: record]: nothing -> in
       # parse workflow id from url to avoid another request
       | parse "https://github.com/nushell/nushell/actions/runs/{workflow_id}/job/{job_id}"
       | only workflow_id
+      | into int
     )
   }
 


### PR DESCRIPTION
## Description

A command annotated to return `int` was returning `string`.

This wasn't caught until recently, as the return value wasn't used in an operation that wouldn't also accept `string`.
Enabling `enforce-runtime-annotations` (which has been made opt-out recently) caused type checking to occur on the call site (`return` itself is not type checked yet):
```nushell
let workflow_id = get-workflow-run $commits $number.span
# $workflow_id is inferred to be `int` due to `get-workflow-run`'s signature,
# so it's equivalent to:
let workflow_id: int = get-workflow-run $commits $number.span
```

## User-facing changes (Release notes)
N/A