### PR TITLE
Fix `--content-type` flag being ignored for JSON body variants (#17640)

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -72,7 +72,12 @@ pub enum BodyType {
 impl From<Option<ContentType>> for BodyType {
     fn from(content_type: Option<ContentType>) -> Self {
         match content_type {
-            Some(it) if it.contains("application/json") => BodyType::Json,
+            Some(it)
+                if mime::Mime::from_str(&it)
+                    .is_ok_and(|m| m.type_() == mime::APPLICATION && m.subtype() == "json") =>
+            {
+                BodyType::Json
+            }
             Some(it) if it.contains("application/x-www-form-urlencoded") => BodyType::Form,
             Some(it) if it.contains("multipart/form-data") => BodyType::Multipart,
             Some(it) => BodyType::Unknown(Some(it)),
@@ -1355,6 +1360,24 @@ mod test {
 
         let multipart = Some("multipart/form-data".to_string());
         assert_eq!(BodyType::Multipart, BodyType::from(multipart));
+
+        let json_patch = Some("application/json-patch+json".to_string());
+        assert_eq!(
+            BodyType::Unknown(json_patch.clone()),
+            BodyType::from(json_patch)
+        );
+
+        let json_api = Some("application/vnd.api+json".to_string());
+        assert_eq!(
+            BodyType::Unknown(json_api.clone()),
+            BodyType::from(json_api)
+        );
+
+        let merge_patch = Some("application/merge-patch+json".to_string());
+        assert_eq!(
+            BodyType::Unknown(merge_patch.clone()),
+            BodyType::from(merge_patch)
+        );
 
         let unknown = Some("application/octet-stream".to_string());
         assert_eq!(BodyType::Unknown(unknown.clone()), BodyType::from(unknown));


### PR DESCRIPTION
Fixes #17640

`--content-type` is ignored for JSON-variant types like `application/json-patch+json` and `application/vnd.api+json` — nushell sends `application/json` instead.

The detection in `BodyType::from` used `it.contains("application/json")` which is too broad. `"application/json-patch+json".contains("application/json")` is `true`, so these variant types get classified as `BodyType::Json` and the user's explicit content type is discarded.

Switched to the `mime` crate (already a dep) for proper MIME type parsing. Only exact `application/json` (with or without charset) matches as JSON. Variants correctly fall through to `BodyType::Unknown` and the user's content type is preserved.

## Release notes summary
`http post`/`put`/`patch`/`delete` now respects `--content-type` for JSON-variant MIME types like `application/json-patch+json`.