### PR TITLE
fix(xlsx,ods): add --prefer-integers flag for whole-number float conversion

### DIFF
--- a/crates/nu-command/src/formats/from/sheets.rs
+++ b/crates/nu-command/src/formats/from/sheets.rs
@@ -29,6 +29,12 @@ pub(super) fn common_sheets_signature(name: &str) -> Signature {
                 By default, reading starts from the firsts non empty row.",
             Some('f'),
         )
+        .switch(
+            "prefer-integers",
+            "Convert whole-number floats (for example, 40.0) to integers, \
+                leaving non-whole floats unchanged.",
+            Some('i'),
+        )
         .category(Category::Formats)
 }
 
@@ -64,6 +70,7 @@ pub(super) fn from_sheets(
         .get_flag::<u32>(engine_state, stack, "first-row")?
         .map(HeaderRow::Row)
         .unwrap_or(HeaderRow::FirstNonEmptyRow);
+    let prefer_integers = call.has_flag(engine_state, stack, "prefer-integers")?;
     let sheet_names = {
         let sel_sheets = call
             .get_flag::<Vec<String>>(engine_state, stack, "sheets")?
@@ -95,9 +102,10 @@ pub(super) fn from_sheets(
                         input_span,
                     })?;
 
-            let rows = sheet
-                .rows()
-                .map(|row| row.iter().map(|cell| cell_to_data(cell, head, tz)));
+            let rows = sheet.rows().map(|row| {
+                row.iter()
+                    .map(|cell| cell_to_data(cell, head, tz, prefer_integers))
+            });
 
             if !noheaders && let Some(headers) = sheet.headers() {
                 let headers = headers
@@ -143,10 +151,17 @@ pub(super) fn from_sheets(
     Ok(output.into_value(head).into_pipeline_data())
 }
 
-fn cell_to_data(cell: &Data, head: Span, tz: chrono::FixedOffset) -> Value {
+fn cell_to_data(cell: &Data, head: Span, tz: chrono::FixedOffset, prefer_integers: bool) -> Value {
     match cell {
         Data::Empty => Value::nothing(head),
         Data::Int(val) => Value::int(*val, head),
+        // Calamine discards number format information, so numeric cells
+        // come through as Data::Float even when the spreadsheet stores
+        // them as integers. When --prefer-integers is set, check whether
+        // a float is a whole number and convert it to int if so.
+        Data::Float(val) if prefer_integers && *val as i64 as f64 == *val => {
+            Value::int(*val as i64, head)
+        }
         Data::Float(val) => Value::float(*val, head),
         Data::String(val) => Value::string(val, head),
         Data::Bool(val) => Value::bool(*val, head),

--- a/crates/nu-command/tests/format_conversions/xlsx.rs
+++ b/crates/nu-command/tests/format_conversions/xlsx.rs
@@ -53,3 +53,33 @@ fn fill_in_missing_headers() -> Result {
         .run(code)
         .expect_value_eq(vec!["header0", "column1", "header2", "column3"])
 }
+
+#[test]
+fn from_excel_prefer_integers_whole_number_float_becomes_int() -> Result {
+    let code = "
+        open sample_data.xlsx --raw
+        | from xlsx --prefer-integers
+        | get SalesOrders.Units
+        | first
+        | describe
+    ";
+    test()
+        .cwd("tests/fixtures/formats")
+        .run(code)
+        .expect_value_eq("int")
+}
+
+#[test]
+fn from_excel_prefer_integers_non_whole_float_stays_float() -> Result {
+    let code = "
+        open sample_data.xlsx --raw
+        | from xlsx --prefer-integers
+        | get SalesOrders.Total
+        | first
+        | describe
+    ";
+    test()
+        .cwd("tests/fixtures/formats")
+        .run(code)
+        .expect_value_eq("float")
+}


### PR DESCRIPTION
## Description

Add a `--prefer-integers` (`-i`) flag to `from xlsx` and `from ods` that optionally converts whole-number floats (e.g. 95.0) to integers, leaving non-whole floats unchanged.

Calamine currently discards number format information, so all numeric cells come through as `Data::Float` regardless of their original format (xlsx cells are IEEE 754 doubles per spec).
A double-cast guard `*f as i64 as f64 == *f` detects whole-number floats reliably across the full f64 range.

## User-facing changes (Release notes)

### `from xlsx`/`from ods` gets a `--prefer-integers` flag

`xlsx` and `ods` files store numbers as floats by default, even if they are not display with decimal points.

`from xlsx` and `from ods` now has a `--prefer-integers` (`-i`) flag that imports whole-number floats as integers.

This has no effect on non-whole floats.

```nushell
open --raw tests/fixtures/formats/sample_data.xlsx
| from xlsx
| get SalesOrders
| first 5
# => ╭───┬─────────────┬─────────┬─────────┬────────┬───────┬───────────┬────────╮
# => │ # │  OrderDate  │ Region  │   Rep   │  Item  │ Units │ Unit Cost │ Total  │
# => ├───┼─────────────┼─────────┼─────────┼────────┼───────┼───────────┼────────┤
# => │ 0 │ 8 years ago │ East    │ Jones   │ Pencil │ 95.00 │      1.99 │ 189.05 │
# => │ 1 │ 8 years ago │ Central │ Kivell  │ Binder │ 50.00 │     19.99 │ 999.50 │
# => │ 2 │ 8 years ago │ Central │ Jardine │ Pencil │ 36.00 │      4.99 │ 179.64 │
# => │ 3 │ 8 years ago │ Central │ Gill    │ Pen    │ 27.00 │     19.99 │ 539.73 │
# => │ 4 │ 8 years ago │ West    │ Sorvino │ Pencil │ 56.00 │      2.99 │ 167.44 │
# => ╰───┴─────────────┴─────────┴─────────┴────────┴───────┴───────────┴────────╯
```

```nushell
open --raw tests/fixtures/formats/sample_data.xlsx
| from xlsx --prefer-integers
| get SalesOrders
| first 5
# => ╭───┬─────────────┬─────────┬─────────┬────────┬───────┬───────────┬────────╮
# => │ # │  OrderDate  │ Region  │   Rep   │  Item  │ Units │ Unit Cost │ Total  │
# => ├───┼─────────────┼─────────┼─────────┼────────┼───────┼───────────┼────────┤
# => │ 0 │ 8 years ago │ East    │ Jones   │ Pencil │    95 │      1.99 │ 189.05 │
# => │ 1 │ 8 years ago │ Central │ Kivell  │ Binder │    50 │     19.99 │ 999.50 │
# => │ 2 │ 8 years ago │ Central │ Jardine │ Pencil │    36 │      4.99 │ 179.64 │
# => │ 3 │ 8 years ago │ Central │ Gill    │ Pen    │    27 │     19.99 │ 539.73 │
# => │ 4 │ 8 years ago │ West    │ Sorvino │ Pencil │    56 │      2.99 │ 167.44 │
# => ╰───┴─────────────┴─────────┴─────────┴────────┴───────┴───────────┴────────╯
```

## Additional notes
- This is an alternative to https://github.com/nushell/nushell/pull/18485 that blindly converted whole-number floats to ints.
- If tafia/calamine#653 (style + number format support) is merged upstream, this flag could eventually be driven by the cell's number format string instead of the float heuristic.
- Assisted-by: OpenCode v1.17.9 (opencode/big-pickle)