### PR TITLE
suggest command categories in help messages

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use nu_cmd_base::hook::eval_hook;
 use nu_engine::{command_prelude::*, env_to_strings};
 use nu_path::{AbsolutePath, dots::expand_ndots_safe, expand_tilde};
@@ -520,7 +521,7 @@ fn write_pipeline_data(
     Ok(())
 }
 
-/// Returns a helpful error message given an invalid command name,
+/// Returns a helpful error message given an invalid command name.
 pub fn command_not_found(
     name: &str,
     span: Span,
@@ -584,89 +585,81 @@ pub fn command_not_found(
         };
     }
 
-    // The command might be from another module. Try to find it.
-    if let Some(module) = engine_state.which_module_has_decl(name.as_bytes(), &[]) {
-        let module = String::from_utf8_lossy(module);
-        // Is the command already imported?
-        let full_name = format!("{module} {name}");
-        if engine_state.find_decl(full_name.as_bytes(), &[]).is_some() {
-            return ShellError::ExternalCommand {
-                label: format!("Command `{name}` not found"),
-                help: format!("Did you mean `{full_name}`?"),
-                span,
-            };
-        } else {
-            return ShellError::ExternalCommand {
-                label: format!("Command `{name}` not found"),
-                help: format!(
-                    "A command with that name exists in module `{module}`. Try importing it with `use`"
-                ),
-                span,
-            };
+    // Making this a closure allows using return inside instead of nesting if-else's
+    let help = (|| {
+        // The command might be from another module. Try to find it.
+        // Note that built-in command categories are not modules,
+        // hence this won't find `math sqrt` if the user types `sqrt`.
+        if let Some(module) = engine_state.which_module_has_decl(name.as_bytes(), &[]) {
+            let module = String::from_utf8_lossy(module);
+
+            // Is the command already imported?
+            let full_name = format!("{module} {name}");
+            if engine_state.find_decl(full_name.as_bytes(), &[]).is_some() {
+                return format!("Did you mean `{full_name}`?");
+            }
+
+            return format!(
+                "A command with that name exists in module `{module}`. Try importing it with `use`"
+            );
         }
-    }
 
-    // Try to match the name with the search terms of existing commands.
-    let signatures = engine_state.get_signatures_and_declids(false);
-    if let Some((last, others)) = signatures
-        .iter()
-        .map(|(sig, _)| sig)
-        .filter(|sig| {
-            sig.search_terms
-                .iter()
-                .any(|term| term.to_folded_case() == name.to_folded_case())
-        })
-        .map(|sig| format!("`{}`", sig.name))
-        .collect::<Vec<_>>()
-        .split_last()
-    {
-        let commands = if others.is_empty() {
-            last
-        } else {
-            // other or last
-            // other, other or last
-            &format!("{} or {last}", others.join(", "))
-        };
-        return ShellError::ExternalCommand {
-            label: format!("Command `{name}` not found"),
-            help: format!("Did you mean {commands}?"),
-            span,
-        };
-    }
-
-    // Try a fuzzy search on the names of all existing commands.
-    if let Some(cmd) = did_you_mean(signatures.iter().map(|(sig, _)| &sig.name), name) {
-        // The user is invoking an external command with the same name as a
-        // built-in command. Remind them of this.
-        if cmd == name {
-            return ShellError::ExternalCommand {
-                label: format!("Command `{name}` not found"),
-                help: "There is a built-in command with the same name".into(),
-                span,
+        // Try to match the name with the search terms of existing commands.
+        let signatures = engine_state.get_signatures_and_declids(false);
+        if let Some((last, others)) = signatures
+            .iter()
+            .map(|(sig, _)| sig)
+            .filter(|sig| {
+                let name = name.to_folded_case(); // do not allocate new strings in any()
+                sig.name
+                    .to_folded_case()
+                    .split_ascii_whitespace() // basically split into words
+                    .contains(name.as_str()) // find this one `math sqrt` from the example above
+                    || sig
+                        .search_terms
+                        .iter()
+                        .any(|term| term.to_folded_case() == name)
+            })
+            .map(|sig| format!("`{}`", sig.name))
+            .collect::<Vec<_>>()
+            .split_last()
+        {
+            let commands = if others.is_empty() {
+                last
+            } else {
+                // other or last
+                // other, other or last
+                &format!("{} or {last}", others.join(", "))
             };
-        }
-        return ShellError::ExternalCommand {
-            label: format!("Command `{name}` not found"),
-            help: format!("Did you mean `{cmd}`?"),
-            span,
-        };
-    }
 
-    // If we find a file, it's likely that the user forgot to set permissions
-    if cwd.join(name).is_file() {
-        return ShellError::ExternalCommand {
-            label: format!("Command `{name}` not found"),
-            help: format!(
+            return format!("Did you mean {commands}?");
+        }
+
+        // Try a fuzzy search on the names of all existing commands.
+        if let Some(cmd) = did_you_mean(signatures.iter().map(|(sig, _)| &sig.name), name) {
+            // The user is invoking an external command with the same name as a
+            // built-in command. Remind them of this.
+            if cmd == name {
+                return "There is a built-in command with the same name".to_string();
+            }
+
+            return format!("Did you mean `{cmd}`?");
+        }
+
+        // If we find a file, it's likely that the user forgot to set permissions
+        if cwd.join(name).is_file() {
+            return format!(
                 "`{name}` refers to a file that is not executable. Did you forget to set execute permissions?"
-            ),
-            span,
-        };
-    }
+            );
+        }
 
-    // We found nothing useful. Give up and return a generic error message.
+        // We found nothing useful. Give up and return a generic error message.
+        format!("`{name}` is neither a Nushell built-in or a known external command")
+    })();
+
     ShellError::ExternalCommand {
         label: format!("Command `{name}` not found"),
-        help: format!("`{name}` is neither a Nushell built-in or a known external command"),
+        help,
         span,
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
command not found error message now makes a bit more sense if the command exists as a category subcommand
0.113:
```sh
Error: nu::shell::external_command

  × External command failed
   ╭─[repl_entry #1:1:1]
 1 │ sqrt
   · ──┬─
   ·   ╰── Command `sqrt` not found
   ╰────
  help: Did you mean `sort`?
```
this pr:
```sh
Error: nu::shell::external_command

  × External command failed
   ╭─[source:1:1]
 1 │ sqrt
   · ──┬─
   ·   ╰── Command `sqrt` not found
   ╰────
  help: Did you mean `math sqrt`?
```
also ended up refactoring `fn command_not_found` a bit to avoid duplication: instead of early returning whole `ShellError::ExternalCommand`, compute help message, then return generic
```rs
    ShellError::ExternalCommand {
        label: format!("Command `{name}` not found"),
        help,
        span,
    }
``` 
## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
"Command not found" error messages will now suggest full command from a category if you type just its ending, for example `sqrt` will suggest `math sqrt`. 

<!--
## Additional notes
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->