### PR TITLE
fix `nu --plugins` handling

### DIFF
--- a/crates/nu-test-support/src/deprecated/macros.rs
+++ b/crates/nu-test-support/src/deprecated/macros.rs
@@ -384,12 +384,10 @@ where
         .arg("--plugin-config")
         .arg(temp_plugin_file);
 
-    // Add each plugin path as a separate argument after --plugins
-    if !plugin_paths.is_empty() {
+    // Pass each plugin path with its own --plugins flag
+    for path in &plugin_paths {
         cmd.arg("--plugins");
-        for path in &plugin_paths {
-            cmd.arg(path);
-        }
+        cmd.arg(path);
     }
 
     let process = match cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {

--- a/src/command.rs
+++ b/src/command.rs
@@ -95,8 +95,6 @@ enum ValueHint {
     Int,
     Path,
     ListString,
-    #[cfg_attr(not(feature = "plugin"), expect(unused))]
-    ListPath,
 }
 
 // Metadata describing a CLI flag in the lexopt parser.
@@ -386,10 +384,10 @@ const CLI_FLAGS: &[CliFlag] = &[
     CliFlag::value(
         "plugins",
         None,
-        ValueHint::ListPath,
-        "list of plugin executable files to load (full paths), separately from the registry file",
+        ValueHint::Path,
+        "list of plugin executable files to load (full paths), separately from the registry file (use multiple `--plugins` flags or a bracketed list: `--plugins '[/path/a /path/b]'`)",
         CliCategory::Plugins,
-        "nu --plugins /path/nu_plugin_one /path/nu_plugin_two",
+        "nu --plugins /path/nu_plugin_one --plugins /path/nu_plugin_two",
     ),
     #[cfg(feature = "mcp")]
     CliFlag::switch(
@@ -677,15 +675,11 @@ pub(crate) fn parse_cli_args(args: Vec<OsString>) -> Result<ParsedCli, CliError>
             }
             #[cfg(feature = "plugin")]
             Long("plugins") => {
-                let values = parse_list_values(&mut parser, "plugins")?;
+                let value = parse_string_value(&mut parser, "plugins")?;
+                let paths = parse_plugin_paths(&value);
                 let mut parsed = Vec::new();
-                for value in values {
-                    let trimmed = value.trim();
-                    // Skip empty strings and bracket-wrapped empty lists like "[]"
-                    if trimmed.is_empty() || trimmed == "[]" {
-                        continue;
-                    }
-                    let path = Path::new(trimmed);
+                for path_str in paths {
+                    let path = Path::new(&path_str);
                     let absolute = if path.is_absolute() {
                         path.to_path_buf()
                     } else {
@@ -710,7 +704,6 @@ pub(crate) fn parse_cli_args(args: Vec<OsString>) -> Result<ParsedCli, CliError>
                         ));
                     }
                 }
-                // Only set plugins if we actually parsed some valid paths
                 if !parsed.is_empty() {
                     cli.plugins.get_or_insert_with(Vec::new).extend(parsed);
                 }
@@ -912,6 +905,91 @@ fn parse_list_values(parser: &mut lexopt::Parser, name: &str) -> Result<Vec<Stri
         parsed.push(value);
     }
     Ok(parsed)
+}
+
+/// Parse a single `--plugins` value into a list of plugin paths.
+///
+/// Supports two formats:
+/// - A single path: `/path/to/nu_plugin_foo`
+/// - A bracketed list (nushell-style): `[/path/foo /path/bar]` or `[/path/foo, /path/bar]`
+///
+/// Paths in the bracketed form may be double-quoted to handle spaces:
+/// `["/path/with spaces/foo" /path/bar]`
+///
+/// Commas are treated as optional separators in the bracketed form.
+/// When present, commas are used as the delimiter instead of whitespace.
+#[cfg(feature = "plugin")]
+fn parse_plugin_paths(value: &str) -> Vec<String> {
+    let trimmed = value.trim();
+
+    // Empty list: `[]`
+    if trimmed == "[]" {
+        return vec![];
+    }
+
+    if let Some(inner) = trimmed.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+        let inner = inner.trim();
+        if inner.is_empty() {
+            return vec![];
+        }
+
+        // Prefer comma-delimited when commas are present
+        if inner.contains(',') {
+            inner
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(strip_quotes)
+                .collect()
+        } else {
+            split_respecting_quotes(inner)
+        }
+    } else {
+        vec![strip_quotes(trimmed)]
+    }
+}
+
+/// Remove surrounding double-quotes from a string.
+#[cfg(feature = "plugin")]
+fn strip_quotes(s: &str) -> String {
+    let s = s.trim();
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        s[1..s.len() - 1].to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+/// Split a string by whitespace, respecting double-quoted sections.
+///
+/// Each segment between whitespace boundaries is returned with quotes stripped.
+#[cfg(feature = "plugin")]
+fn split_respecting_quotes(s: &str) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+
+    for ch in s.chars() {
+        match ch {
+            '"' => {
+                in_quotes = !in_quotes;
+                current.push(ch);
+            }
+            ' ' | '\t' if !in_quotes => {
+                if !current.is_empty() {
+                    result.push(strip_quotes(&current));
+                    current.clear();
+                }
+            }
+            _ => {
+                current.push(ch);
+            }
+        }
+    }
+    if !current.is_empty() {
+        result.push(strip_quotes(&current));
+    }
+    result
 }
 
 // Parse experimental options, allowing bracketed and comma-delimited forms.
@@ -1123,13 +1201,14 @@ fn prevalidate_short_groups_before_lexopt(args: &[OsString]) -> Result<(), CliEr
         }
 
         // Flags that take a single value - skip validation of their values
-        // Note: Multi-value flags (--plugins, --log-include, etc.) are not included here
+        // Note: Multi-value flags (--log-include, --log-exclude) are not included here
         // because they consume multiple arguments and the validator can't know how many.
         if arg == "-e"
             || arg == "--execute"
             || arg == "--config"
             || arg == "--env-config"
             || arg == "--plugin-config"
+            || arg == "--plugins"
             || arg == "--log-level"
             || arg == "--log-target"
             || arg == "-I"
@@ -1349,7 +1428,6 @@ fn value_hint(value: ValueHint) -> &'static str {
         ValueHint::Int => "int",
         ValueHint::Path => "path",
         ValueHint::ListString => "string...",
-        ValueHint::ListPath => "path...",
     }
 }
 
@@ -1546,5 +1624,205 @@ mod tests {
                 "cell-path-types=true".to_string(),
             ]
         );
+    }
+
+    // --- strip_quotes tests ---
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn strip_quotes_removes_double_quotes() {
+        assert_eq!(strip_quotes(r#""hello""#), "hello");
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn strip_quotes_no_op_when_no_quotes() {
+        assert_eq!(strip_quotes("hello"), "hello");
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn strip_quotes_handles_single_quote() {
+        assert_eq!(strip_quotes(r#""hello"#), r#""hello"#);
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn strip_quotes_trims_whitespace() {
+        assert_eq!(strip_quotes(r#"  "/path/foo"  "#), "/path/foo");
+    }
+
+    // --- split_respecting_quotes tests ---
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn split_respecting_quotes_splits_by_whitespace() {
+        assert_eq!(
+            split_respecting_quotes("/path/a /path/b /path/c"),
+            vec!["/path/a", "/path/b", "/path/c"]
+        );
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn split_respecting_quotes_preserves_quoted_spaces() {
+        assert_eq!(
+            split_respecting_quotes(r#""/path/with spaces/a" /path/b"#),
+            vec!["/path/with spaces/a", "/path/b"]
+        );
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn split_respecting_quotes_empty_input() {
+        let empty: Vec<String> = vec![];
+        assert_eq!(split_respecting_quotes(""), empty);
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn split_respecting_quotes_single_value_no_spaces() {
+        assert_eq!(split_respecting_quotes("/path/a"), vec!["/path/a"]);
+    }
+
+    // --- parse_plugin_paths tests ---
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn parse_plugin_paths_single_absolute_path() {
+        assert_eq!(
+            parse_plugin_paths("/path/to/nu_plugin_foo"),
+            vec!["/path/to/nu_plugin_foo"]
+        );
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn parse_plugin_paths_bracketed_list_with_spaces() {
+        assert_eq!(
+            parse_plugin_paths("[/path/foo /path/bar]"),
+            vec!["/path/foo", "/path/bar"]
+        );
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn parse_plugin_paths_bracketed_list_with_commas() {
+        assert_eq!(
+            parse_plugin_paths("[/path/foo, /path/bar]"),
+            vec!["/path/foo", "/path/bar"]
+        );
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn parse_plugin_paths_bracketed_list_with_commas_and_quoted_spaces() {
+        assert_eq!(
+            parse_plugin_paths(r#"["/path/with spaces/a", /path/b]"#),
+            vec!["/path/with spaces/a", "/path/b"]
+        );
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn parse_plugin_paths_quoted_single_path() {
+        assert_eq!(
+            parse_plugin_paths(r#""/path/with spaces/foo""#),
+            vec!["/path/with spaces/foo"]
+        );
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn parse_plugin_paths_empty_brackets() {
+        let empty: Vec<String> = vec![];
+        assert_eq!(parse_plugin_paths("[]"), empty);
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn parse_plugin_paths_brackets_with_whitespace_only() {
+        let empty: Vec<String> = vec![];
+        assert_eq!(parse_plugin_paths("[  ]"), empty);
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn parse_plugin_paths_trims_whitespace() {
+        assert_eq!(
+            parse_plugin_paths("  /path/to/nu_plugin_foo  "),
+            vec!["/path/to/nu_plugin_foo"]
+        );
+    }
+
+    // --- Integration tests for --plugins with script arguments ---
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn plugins_single_path_does_not_consume_script_name() {
+        let args = vec![
+            OsString::from("nu"),
+            OsString::from("--plugins"),
+            OsString::from("/path/to/nu_plugin_foo"),
+            OsString::from("script.nu"),
+        ];
+
+        let parsed = parse_cli_args(args).expect("should parse args");
+        assert_eq!(parsed.script_name, "script.nu");
+
+        let plugins = parsed.nu.plugins.expect("should have plugins");
+        assert_eq!(plugins.len(), 1);
+        assert!(plugins[0].item.contains("nu_plugin_foo"));
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn plugins_bracketed_list_does_not_consume_script_name() {
+        let args = vec![
+            OsString::from("nu"),
+            OsString::from("--plugins"),
+            OsString::from("[/path/nu_plugin_foo /path/nu_plugin_bar]"),
+            OsString::from("script.nu"),
+        ];
+
+        let parsed = parse_cli_args(args).expect("should parse args");
+        assert_eq!(parsed.script_name, "script.nu");
+
+        let plugins = parsed.nu.plugins.expect("should have plugins");
+        assert_eq!(plugins.len(), 2);
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn plugins_multiple_flags_accumulate() {
+        let args = vec![
+            OsString::from("nu"),
+            OsString::from("--plugins"),
+            OsString::from("/path/nu_plugin_foo"),
+            OsString::from("--plugins"),
+            OsString::from("/path/nu_plugin_bar"),
+            OsString::from("script.nu"),
+        ];
+
+        let parsed = parse_cli_args(args).expect("should parse args");
+        assert_eq!(parsed.script_name, "script.nu");
+
+        let plugins = parsed.nu.plugins.expect("should have plugins");
+        assert_eq!(plugins.len(), 2);
+    }
+
+    #[cfg(feature = "plugin")]
+    #[test]
+    fn plugins_empty_list_is_skipped() {
+        let args = vec![
+            OsString::from("nu"),
+            OsString::from("--plugins"),
+            OsString::from("[]"),
+            OsString::from("script.nu"),
+        ];
+
+        let parsed = parse_cli_args(args).expect("should parse args");
+        assert_eq!(parsed.script_name, "script.nu");
+        assert!(parsed.nu.plugins.is_none());
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
A bug was reported on Discord that disallowed the `--plugins` from working. The problem was, when using with a shebang this would happen `nu --plugins '/usr/share/nutext/nu_plugin_nutext' /path/to/rhino-pkg` and then nushell would puke because the cli parsing thinks `/path/to/rhino-pkg` is another plugin but it's named wrong, which is wrong of course.

The fix is to allow only 1 item to be passed as a plugin instead of many. This is what is acceptible now.
```nushell
nu --plugins /path/to/nu_plugin_one --plugins /path/to/nu_plugin_two # mutliple --plugins params
nu --plugins '[/path/to/nu_plugin_one, /path/to/nu_plugin_two]' # comma separation
nu --plugins '[/path/to/nu_plugin_one /path/to/nu_plugin_two]' # no comma separation
nu --plugins '["/path/to plugin/nu_plugin_one", "/path/to plugin/nu_plugin_two"]' # quoted paths, with or without commas
```

## User-facing changes (Release notes)
### Fixed `nu --plugins` handling
The nushell cli parsing now supports the `--plugins` parameter in these variations 
```nushell
nu --plugins /path/to/nu_plugin_one --plugins /path/to/nu_plugin_two # mutliple --plugins params
nu --plugins '[/path/to/nu_plugin_one, /path/to/nu_plugin_two]' # comma separation
nu --plugins '[/path/to/nu_plugin_one /path/to/nu_plugin_two]' # no comma separation
nu --plugins '["/path/to plugin/nu_plugin_one", "/path/to plugin/nu_plugin_two"]' # quoted paths, with or without commas
```
## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->