### PR TITLE
perf(str): prepare replace matcher once

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -496,6 +496,54 @@ fn bench_table_insert_col(n: usize, m: usize) -> impl IntoBenchmarks {
     bench_command(format!("table_insert_col_{n}_{m}"), insert, stack, engine)
 }
 
+fn setup_str_replace_strings(n: usize) -> (Stack, EngineState) {
+    setup_stack_and_engine_from_command(&format!(
+        r#"let strings = 0..<{n} | each {{ |i| $"abc($i) xyz 123" }}"#
+    ))
+}
+
+fn setup_str_replace_multiline_strings(n: usize) -> (Stack, EngineState) {
+    setup_stack_and_engine_from_command(&format!(
+        r#"let strings = 0..<{n} | each {{ |i| $"($i). first\n($i). second\nplain" }}"#
+    ))
+}
+
+fn setup_str_replace_table(n: usize) -> (Stack, EngineState) {
+    setup_stack_and_engine_from_command(&format!(
+        r#"let table = 0..<{n} | each {{ |i| {{ a: $"abc($i)", b: $"def($i)", c: untouched }} }}"#
+    ))
+}
+
+fn bench_str_replace_regex_list(n: usize) -> impl IntoBenchmarks {
+    let (stack, engine) = setup_str_replace_strings(n);
+    bench_command(
+        format!("str_replace_regex_list_{n}"),
+        r#"$strings | str replace -a -r '\d+' 'N' | ignore"#,
+        stack,
+        engine,
+    )
+}
+
+fn bench_str_replace_regex_table(n: usize) -> impl IntoBenchmarks {
+    let (stack, engine) = setup_str_replace_table(n);
+    bench_command(
+        format!("str_replace_regex_table_{n}_2cols"),
+        r#"$table | str replace -a -r '\d+' 'N' a b | ignore"#,
+        stack,
+        engine,
+    )
+}
+
+fn bench_str_replace_multiline_list(n: usize) -> impl IntoBenchmarks {
+    let (stack, engine) = setup_str_replace_multiline_strings(n);
+    bench_command(
+        format!("str_replace_multiline_list_{n}"),
+        r#"$strings | str replace -a --multiline '^[0-9]+\. ' '' | ignore"#,
+        stack,
+        engine,
+    )
+}
+
 fn bench_eval_interleave(n: usize) -> impl IntoBenchmarks {
     let engine = setup_engine();
     let stack = Stack::new();
@@ -1067,6 +1115,10 @@ tango_benchmarks!(
     bench_table_insert_col(10, 10),
     bench_table_insert_col(100, 10),
     bench_table_insert_col(1000, 10),
+    // Strings
+    bench_str_replace_regex_list(1_000),
+    bench_str_replace_regex_table(500),
+    bench_str_replace_multiline_list(1_000),
     // Eval
     // Interleave
     bench_eval_interleave(100),

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -10,17 +10,39 @@ enum ReplacementValue {
 
 struct Arguments {
     all: bool,
-    find: Spanned<String>,
+    matcher: Matcher,
     replace: ReplacementValue,
     cell_paths: Option<Vec<CellPath>>,
     literal_replace: bool,
-    no_regex: bool,
-    multiline: bool,
 }
 
 impl CmdArgument for Arguments {
     fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
         self.cell_paths.take()
+    }
+}
+
+enum Matcher {
+    Literal(Spanned<String>),
+    Regex(Result<Regex, Spanned<String>>),
+}
+
+impl Matcher {
+    fn new(find: Spanned<String>, regex: bool, multiline: bool) -> Self {
+        if !regex && !multiline {
+            Self::Literal(find)
+        } else {
+            let Spanned { item, span } = find;
+            let pattern = if multiline {
+                format!("(?m){item}")
+            } else {
+                item
+            };
+            Self::Regex(
+                Regex::new(&pattern)
+                    .map_err(|error| format!("Regex error: {error}").into_spanned(span)),
+            )
+        }
     }
 }
 
@@ -122,19 +144,16 @@ groups as its argument. It must return a string that will be used as a replaceme
         }?;
         let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 2)?;
         let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
-        let literal_replace = call.has_flag(engine_state, stack, "no-expand")?;
-        let no_regex = !call.has_flag(engine_state, stack, "regex")?
-            && !call.has_flag(engine_state, stack, "multiline")?;
         let multiline = call.has_flag(engine_state, stack, "multiline")?;
+        let regex = call.has_flag(engine_state, stack, "regex")?;
+        let literal_replace = call.has_flag(engine_state, stack, "no-expand")?;
 
         let args = Arguments {
             all: call.has_flag(engine_state, stack, "all")?,
-            find,
+            matcher: Matcher::new(find, regex, multiline),
             replace,
             cell_paths,
             literal_replace,
-            no_regex,
-            multiline,
         };
         operate(action, args, input, call.head, engine_state.signals())
     }
@@ -149,19 +168,16 @@ groups as its argument. It must return a string that will be used as a replaceme
         let replace: Spanned<String> = call.req_const(working_set, 1)?;
         let cell_paths: Vec<CellPath> = call.rest_const(working_set, 2)?;
         let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
-        let literal_replace = call.has_flag_const(working_set, "no-expand")?;
-        let no_regex = !call.has_flag_const(working_set, "regex")?
-            && !call.has_flag_const(working_set, "multiline")?;
         let multiline = call.has_flag_const(working_set, "multiline")?;
+        let regex = call.has_flag_const(working_set, "regex")?;
+        let literal_replace = call.has_flag_const(working_set, "no-expand")?;
 
         let args = Arguments {
             all: call.has_flag_const(working_set, "all")?,
-            find,
+            matcher: Matcher::new(find, regex, multiline),
             replace: ReplacementValue::String(Arc::new(replace)),
             cell_paths,
             literal_replace,
-            no_regex,
-            multiline,
         };
         operate(
             action,
@@ -258,21 +274,18 @@ groups as its argument. It must return a string that will be used as a replaceme
 fn action(
     input: &Value,
     Arguments {
-        find,
+        matcher,
         replace,
         all,
         literal_replace,
-        no_regex,
-        multiline,
         ..
     }: &Arguments,
     head: Span,
 ) -> Value {
     match input {
-        Value::String { val, .. } => {
-            let find_str: &str = &find.item;
-            if *no_regex {
-                // just use regular string replacement vs regular expressions
+        Value::String { val, .. } => match matcher {
+            Matcher::Literal(find) => {
+                let find_str: &str = &find.item;
                 let replace_str: Result<Arc<Spanned<String>>, (ShellError, Span)> = match replace {
                     ReplacementValue::String(replace_str) => Ok(replace_str.clone()),
                     ReplacementValue::Closure(closure) => {
@@ -306,15 +319,8 @@ fn action(
                     }
                     Err((error, span)) => Value::error(error, span),
                 }
-            } else {
-                // use regular expressions to replace strings
-                let flags = match multiline {
-                    true => "(?m)",
-                    false => "",
-                };
-                let regex_string = flags.to_string() + find_str;
-                let regex = Regex::new(&regex_string);
-
+            }
+            Matcher::Regex(regex) => {
                 match (regex, replace) {
                     (Ok(re), ReplacementValue::String(replace_str)) => {
                         if *all {
@@ -393,17 +399,17 @@ fn action(
                             Some(error) => Value::error(error, span),
                         }
                     }
-                    (Err(e), _) => Value::error(
+                    (Err(error), _) => Value::error(
                         ShellError::IncorrectValue {
-                            msg: format!("Regex error: {e}"),
-                            val_span: find.span,
+                            msg: error.item.clone(),
+                            val_span: error.span,
                             call_span: head,
                         },
-                        find.span,
+                        error.span,
                     ),
                 }
             }
-        }
+        },
         Value::Error { .. } => input.clone(),
         _ => Value::error(
             ShellError::OnlySupportsThisInputType {
@@ -439,13 +445,11 @@ mod tests {
         let word = Value::test_string("Cargo.toml");
 
         let options = Arguments {
-            find: test_spanned_string("Cargo.(.+)"),
+            matcher: Matcher::new(test_spanned_string("Cargo.(.+)"), true, false),
             replace: ReplacementValue::String(Arc::new(test_spanned_string("Carga.$1"))),
             cell_paths: None,
             literal_replace: false,
             all: false,
-            no_regex: false,
-            multiline: false,
         };
 
         let actual = action(&word, &options, Span::test_data());

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -24,13 +24,18 @@ impl CmdArgument for Arguments {
 
 enum Matcher {
     Literal(Spanned<String>),
-    Regex(Result<Regex, Spanned<String>>),
+    Regex(Regex),
 }
 
 impl Matcher {
-    fn new(find: Spanned<String>, regex: bool, multiline: bool) -> Self {
+    fn new(
+        find: Spanned<String>,
+        regex: bool,
+        multiline: bool,
+        head: Span,
+    ) -> Result<Self, ShellError> {
         if !regex && !multiline {
-            Self::Literal(find)
+            Ok(Self::Literal(find))
         } else {
             let Spanned { item, span } = find;
             let pattern = if multiline {
@@ -38,10 +43,13 @@ impl Matcher {
             } else {
                 item
             };
-            Self::Regex(
-                Regex::new(&pattern)
-                    .map_err(|error| format!("Regex error: {error}").into_spanned(span)),
-            )
+            Regex::new(&pattern)
+                .map(Self::Regex)
+                .map_err(|error| ShellError::IncorrectValue {
+                    msg: format!("Regex error: {error}"),
+                    val_span: span,
+                    call_span: head,
+                })
         }
     }
 }
@@ -150,7 +158,7 @@ groups as its argument. It must return a string that will be used as a replaceme
 
         let args = Arguments {
             all: call.has_flag(engine_state, stack, "all")?,
-            matcher: Matcher::new(find, regex, multiline),
+            matcher: Matcher::new(find, regex, multiline, call.head)?,
             replace,
             cell_paths,
             literal_replace,
@@ -174,7 +182,7 @@ groups as its argument. It must return a string that will be used as a replaceme
 
         let args = Arguments {
             all: call.has_flag_const(working_set, "all")?,
-            matcher: Matcher::new(find, regex, multiline),
+            matcher: Matcher::new(find, regex, multiline, call.head)?,
             replace: ReplacementValue::String(Arc::new(replace)),
             cell_paths,
             literal_replace,
@@ -320,95 +328,85 @@ fn action(
                     Err((error, span)) => Value::error(error, span),
                 }
             }
-            Matcher::Regex(regex) => {
-                match (regex, replace) {
-                    (Ok(re), ReplacementValue::String(replace_str)) => {
-                        if *all {
-                            Value::string(
-                                {
-                                    if *literal_replace {
-                                        re.replace_all(val, NoExpand(&replace_str.item)).to_string()
-                                    } else {
-                                        re.replace_all(val, &replace_str.item).to_string()
-                                    }
-                                },
-                                head,
-                            )
-                        } else {
-                            Value::string(
-                                {
-                                    if *literal_replace {
-                                        re.replace(val, NoExpand(&replace_str.item)).to_string()
-                                    } else {
-                                        re.replace(val, &replace_str.item).to_string()
-                                    }
-                                },
-                                head,
-                            )
-                        }
-                    }
-                    (Ok(re), ReplacementValue::Closure(closure)) => {
-                        let span = closure.span;
-                        // TODO: We only need to clone the evaluator here because
-                        //       operate() doesn't allow us to have a mutable reference
-                        //       to Arguments. Would it be worth the effort to change operate()
-                        //       and all commands that use it?
-                        let mut closure_eval = closure.item.clone();
-                        let mut first_error: Option<ShellError> = None;
-                        let replacer = |caps: &Captures| {
-                            for capture in caps.iter().skip(1) {
-                                let arg = match capture {
-                                    Some(m) => Value::string(m.as_str().to_string(), head),
-                                    None => Value::nothing(head),
-                                };
-                                if let Err(error) = closure_eval.add_arg(arg) {
-                                    first_error = Some(error);
-                                    return "".to_string();
+            Matcher::Regex(re) => match replace {
+                ReplacementValue::String(replace_str) => {
+                    if *all {
+                        Value::string(
+                            {
+                                if *literal_replace {
+                                    re.replace_all(val, NoExpand(&replace_str.item)).to_string()
+                                } else {
+                                    re.replace_all(val, &replace_str.item).to_string()
                                 }
-                            }
-                            let value = match caps.get(0) {
+                            },
+                            head,
+                        )
+                    } else {
+                        Value::string(
+                            {
+                                if *literal_replace {
+                                    re.replace(val, NoExpand(&replace_str.item)).to_string()
+                                } else {
+                                    re.replace(val, &replace_str.item).to_string()
+                                }
+                            },
+                            head,
+                        )
+                    }
+                }
+                ReplacementValue::Closure(closure) => {
+                    let span = closure.span;
+                    // TODO: We only need to clone the evaluator here because
+                    //       operate() doesn't allow us to have a mutable reference
+                    //       to Arguments. Would it be worth the effort to change operate()
+                    //       and all commands that use it?
+                    let mut closure_eval = closure.item.clone();
+                    let mut first_error: Option<ShellError> = None;
+                    let replacer = |caps: &Captures| {
+                        for capture in caps.iter().skip(1) {
+                            let arg = match capture {
                                 Some(m) => Value::string(m.as_str().to_string(), head),
                                 None => Value::nothing(head),
                             };
-                            let result: Result<Value, ShellError> = closure_eval
-                                .run_with_input(PipelineData::value(value, None))
-                                .and_then(|result| result.into_value(span));
-                            match result {
-                                Ok(Value::String { val, .. }) => val.to_string(),
-                                Ok(res) => {
-                                    first_error = Some(ShellError::RuntimeTypeMismatch {
-                                        expected: Type::String,
-                                        actual: res.get_type(),
-                                        span: res.span(),
-                                    });
-                                    "".to_string()
-                                }
-                                Err(e) => {
-                                    first_error = Some(e);
-                                    "".to_string()
-                                }
+                            if let Err(error) = closure_eval.add_arg(arg) {
+                                first_error = Some(error);
+                                return "".to_string();
                             }
-                        };
-                        let result = if *all {
-                            Value::string(re.replace_all(val, replacer).to_string(), head)
-                        } else {
-                            Value::string(re.replace(val, replacer).to_string(), head)
-                        };
-                        match first_error {
-                            None => result,
-                            Some(error) => Value::error(error, span),
                         }
+                        let value = match caps.get(0) {
+                            Some(m) => Value::string(m.as_str().to_string(), head),
+                            None => Value::nothing(head),
+                        };
+                        let result: Result<Value, ShellError> = closure_eval
+                            .run_with_input(PipelineData::value(value, None))
+                            .and_then(|result| result.into_value(span));
+                        match result {
+                            Ok(Value::String { val, .. }) => val.to_string(),
+                            Ok(res) => {
+                                first_error = Some(ShellError::RuntimeTypeMismatch {
+                                    expected: Type::String,
+                                    actual: res.get_type(),
+                                    span: res.span(),
+                                });
+                                "".to_string()
+                            }
+                            Err(e) => {
+                                first_error = Some(e);
+                                "".to_string()
+                            }
+                        }
+                    };
+                    let result = if *all {
+                        Value::string(re.replace_all(val, replacer).to_string(), head)
+                    } else {
+                        Value::string(re.replace(val, replacer).to_string(), head)
+                    };
+                    match first_error {
+                        None => result,
+                        Some(error) => Value::error(error, span),
                     }
-                    (Err(error), _) => Value::error(
-                        ShellError::IncorrectValue {
-                            msg: error.item.clone(),
-                            val_span: error.span,
-                            call_span: head,
-                        },
-                        error.span,
-                    ),
                 }
-            }
+            },
         },
         Value::Error { .. } => input.clone(),
         _ => Value::error(
@@ -445,7 +443,13 @@ mod tests {
         let word = Value::test_string("Cargo.toml");
 
         let options = Arguments {
-            matcher: Matcher::new(test_spanned_string("Cargo.(.+)"), true, false),
+            matcher: Matcher::new(
+                test_spanned_string("Cargo.(.+)"),
+                true,
+                false,
+                Span::test_data(),
+            )
+            .unwrap(),
             replace: ReplacementValue::String(Arc::new(test_spanned_string("Carga.$1"))),
             cell_paths: None,
             literal_replace: false,

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -204,6 +204,15 @@ fn regex_error_in_pattern() -> Result {
 }
 
 #[test]
+fn regex_error_in_pattern_without_input() -> Result {
+    let code = r#"[] | str replace -r '[' "destination""#;
+
+    let err = test().run(code).expect_shell_error()?;
+    assert_contains("Incorrect value", err.to_string());
+    Ok(())
+}
+
+#[test]
 fn find_and_replaces_with_closure() -> Result {
     let code = "
          'source string'


### PR DESCRIPTION
## Description

Prepare the literal/regex matcher during `str replace` argument setup so list and table inputs reuse the compiled pattern.

Avoids rebuilding flags and recompiling the same regex for every input value.

Also adds Tango benchmark coverage for regex replacement over list, table cell-path, and multiline inputs.

## User-facing changes (Release notes)

Improved performance of `str replace --regex` and `str replace --multiline` when working with lists, tables, and records with many string values, roughly a 10x speed boost.

## Additional notes

Tango comparison results:

| Benchmark | Reference | Patched | Change |
|---|---:|---:|---:|
| `str_replace_regex_list_1000` | 103.5 ms | 7.4 ms | -92.86%, 14.0x faster |
| `str_replace_regex_table_500_2cols` | 102.1 ms | 8.3 ms | -91.90%, 12.3x faster |
| `str_replace_multiline_list_1000` | 49.8 ms | 6.3 ms | -87.37%, 7.9x faster |