### PR TITLE
Add `to ini` to the formats plugin

### DIFF
--- a/crates/nu_plugin_formats/src/lib.rs
+++ b/crates/nu_plugin_formats/src/lib.rs
@@ -8,6 +8,7 @@ use from::ics::FromIcs;
 use from::ini::FromIni;
 use from::plist::FromPlist;
 use from::vcf::FromVcf;
+use to::ini::IntoIni;
 use to::plist::IntoPlist;
 
 pub struct FormatCmdsPlugin;
@@ -24,6 +25,7 @@ impl Plugin for FormatCmdsPlugin {
             Box::new(FromIni),
             Box::new(FromVcf),
             Box::new(FromPlist),
+            Box::new(IntoIni),
             Box::new(IntoPlist),
         ]
     }

--- a/crates/nu_plugin_formats/src/lib.rs
+++ b/crates/nu_plugin_formats/src/lib.rs
@@ -8,7 +8,7 @@ use from::ics::FromIcs;
 use from::ini::FromIni;
 use from::plist::FromPlist;
 use from::vcf::FromVcf;
-use to::ini::IntoIni;
+use to::ini::ToIni;
 use to::plist::IntoPlist;
 
 pub struct FormatCmdsPlugin;
@@ -25,7 +25,7 @@ impl Plugin for FormatCmdsPlugin {
             Box::new(FromIni),
             Box::new(FromVcf),
             Box::new(FromPlist),
-            Box::new(IntoIni),
+            Box::new(ToIni),
             Box::new(IntoPlist),
         ]
     }

--- a/crates/nu_plugin_formats/src/to/ini.rs
+++ b/crates/nu_plugin_formats/src/to/ini.rs
@@ -1,0 +1,116 @@
+use crate::FormatCmdsPlugin;
+
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand, SimplePluginCommand};
+use nu_protocol::{Category, Example, LabeledError, Signature, Type, Value};
+
+pub(crate) struct IntoIni;
+
+impl SimplePluginCommand for IntoIni {
+    type Plugin = FormatCmdsPlugin;
+
+    fn name(&self) -> &str {
+        "to ini"
+    }
+
+    fn description(&self) -> &str {
+        "Convert a record into .ini text."
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(PluginCommand::name(self))
+            .input_output_types(vec![(Type::record(), Type::String)])
+            .category(Category::Formats)
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                example: "{ foo: { a: '1', b: '2' } } | to ini",
+                description: "Convert a record of sections into ini text",
+                result: Some(Value::test_string("[foo]\na=1\nb=2\n")),
+            },
+            Example {
+                example: "{ port: 8080, debug: true, server: { host: localhost } } | to ini",
+                description: "Top-level values that are not records become global properties, written above the first section",
+                result: Some(Value::test_string(
+                    "port=8080\ndebug=true\n\n[server]\nhost=localhost\n",
+                )),
+            },
+            Example {
+                example: "'[foo]
+a=1' | from ini | to ini",
+                description: "Ini text survives a round trip through from ini",
+                result: Some(Value::test_string("[foo]\na=1\n")),
+            },
+        ]
+    }
+
+    fn run(
+        &self,
+        _plugin: &FormatCmdsPlugin,
+        _engine: &EngineInterface,
+        _call: &EvaluatedCall,
+        input: &Value,
+    ) -> Result<Value, LabeledError> {
+        let Value::Record { val: record, .. } = input else {
+            return Err(LabeledError::new("Cannot convert to ini")
+                .with_label("expected a record", input.span()));
+        };
+
+        let mut config = ini::Ini::new();
+
+        // Ini::new pre-seeds the general section at slot 0, so global keys always
+        // land above the first [section] no matter when we insert them.
+        for (key, value) in record.iter() {
+            match value {
+                Value::Record { val: section, .. } => {
+                    let section_name = (!key.is_empty()).then(|| key.to_owned());
+                    let props = config.entry(section_name).or_insert_with(Default::default);
+                    for (prop_key, prop_value) in section.iter() {
+                        props.insert(prop_key, property_text(prop_key, prop_value)?);
+                    }
+                }
+                _ => {
+                    config
+                        .general_section_mut()
+                        .insert(key, property_text(key, value)?);
+                }
+            }
+        }
+
+        let write_option = ini::WriteOption {
+            line_separator: ini::LineSeparator::CR,
+            ..Default::default()
+        };
+        let mut out = Vec::new();
+        config
+            .write_to_opt(&mut out, write_option)
+            .and_then(|_| String::from_utf8(out).map_err(std::io::Error::other))
+            .map(|text| Value::string(text, input.span()))
+            .map_err(|err| {
+                LabeledError::new("Cannot convert to ini").with_label(err.to_string(), input.span())
+            })
+    }
+}
+
+fn property_text(key: &str, value: &Value) -> Result<String, LabeledError> {
+    match value {
+        Value::Nothing { .. } => Ok(String::new()),
+        Value::Record { .. } => Err(LabeledError::new("Cannot convert to ini").with_label(
+            format!("`{key}` is a nested record, and ini sections cannot nest"),
+            value.span(),
+        )),
+        Value::List { .. } => Err(LabeledError::new("Cannot convert to ini").with_label(
+            format!("`{key}` is a list, and ini has no list values"),
+            value.span(),
+        )),
+        other => other.coerce_string().map_err(Into::into),
+    }
+}
+
+#[test]
+fn test_examples() -> Result<(), nu_protocol::ShellError> {
+    use nu_plugin_test_support::PluginTest;
+
+    PluginTest::new("formats", crate::FormatCmdsPlugin.into())?.test_command_examples(&IntoIni)
+}

--- a/crates/nu_plugin_formats/src/to/ini.rs
+++ b/crates/nu_plugin_formats/src/to/ini.rs
@@ -3,9 +3,9 @@ use crate::FormatCmdsPlugin;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand, SimplePluginCommand};
 use nu_protocol::{Category, Example, LabeledError, Signature, Type, Value};
 
-pub(crate) struct IntoIni;
+pub(crate) struct ToIni;
 
-impl SimplePluginCommand for IntoIni {
+impl SimplePluginCommand for ToIni {
     type Plugin = FormatCmdsPlugin;
 
     fn name(&self) -> &str {
@@ -26,7 +26,7 @@ impl SimplePluginCommand for IntoIni {
         vec![
             Example {
                 example: "{ foo: { a: '1', b: '2' } } | to ini",
-                description: "Convert a record of sections into ini text",
+                description: "Convert a record of sections to ini text",
                 result: Some(Value::test_string("[foo]\na=1\nb=2\n")),
             },
             Example {
@@ -112,5 +112,5 @@ fn property_text(key: &str, value: &Value) -> Result<String, LabeledError> {
 fn test_examples() -> Result<(), nu_protocol::ShellError> {
     use nu_plugin_test_support::PluginTest;
 
-    PluginTest::new("formats", crate::FormatCmdsPlugin.into())?.test_command_examples(&IntoIni)
+    PluginTest::new("formats", crate::FormatCmdsPlugin.into())?.test_command_examples(&ToIni)
 }

--- a/crates/nu_plugin_formats/src/to/mod.rs
+++ b/crates/nu_plugin_formats/src/to/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod ini;
 pub(crate) mod plist;

--- a/tests/plugins/formats/ini.rs
+++ b/tests/plugins/formats/ini.rs
@@ -132,6 +132,32 @@ fn read_ini_with_indented_multiline_value() {
 }
 
 #[test]
+fn to_ini_roundtrips_through_from_ini() {
+    let actual = nu_with_plugins!(
+        cwd: TEST_CWD,
+        plugin: ("nu_plugin_formats"),
+        "open sample.ini | to ini | from ini | to nuon"
+    );
+
+    assert_eq!(
+        actual.out,
+        r#"{SectionOne: {key: value, integer: "1234", real: "3.14", "string1": "Case 1", "string2": "Case 2"}, SectionTwo: {key: "new value", integer: "5678", real: "3.14", "string1": "Case 1", "string2": "Case 2", "string3": "Case 3"}}"#
+    )
+}
+
+#[test]
+fn to_ini_writes_global_keys_before_sections() {
+    let actual = nu_with_plugins!(
+        cwd: TEST_CWD,
+        plugin: ("nu_plugin_formats"),
+        "{ port: 8080, server: { host: localhost } } | to ini"
+    );
+
+    // the test harness strips newlines; the raw output is "port=8080\n\n[server]\nhost=localhost\n"
+    assert_eq!(actual.out, "port=8080[server]host=localhost");
+}
+
+#[test]
 fn read_ini_with_preserve_key_leading_whitespace() {
     Playground::setup("from ini with key whitespace", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(


### PR DESCRIPTION
## Description

Adds `to ini` to `nu_plugin_formats`, next to the existing `from ini`, so ini config files round-trip through the pipeline like the other formats (`toml`, `yaml`, `json`, …).

- Top-level scalar fields become global keys, flushed before the first `[section]` (ini binds every key after a header to that section).
- Record fields become `[sections]`.
- ini cannot nest deeper than one level, so lists / records-inside-sections are rejected with a clear error rather than mangled.
- Serializes through the same `rust-ini` crate that `from ini` already uses, so round trips are exact.

```nu
> { name: nushell, server: { port: 8080 } } | to ini
name=nushell

[server]
port=8080

> '[foo]
a=1' | from ini | to ini
[foo]
a=1
```

## User-facing changes (Release notes)

New command: `to ini` (record → ini string) in the formats plugin.

## Additional notes

Example tests execute the pipelines; `cargo fmt` and `cargo clippy` are clean.