### PR TITLE
feat(`chunks`, `first`, `last`, `take`, `drop` and `skip`): arg can now also be a filesize for binary

### DIFF
--- a/crates/nu-command/src/filters/chunks.rs
+++ b/crates/nu-command/src/filters/chunks.rs
@@ -149,15 +149,13 @@ pub fn chunks(
     match input {
         PipelineData::Value(Value::List { .. }, _) if is_filesize => {
             Err(ShellError::IncompatibleParametersSingle {
-                msg: "Filesize as chunk size is only supported for binary/byte stream input"
-                    .into(),
+                msg: "Filesize as chunk size is only supported for binary/byte stream input".into(),
                 span,
             })
         }
         PipelineData::ListStream(_, _) if is_filesize => {
             Err(ShellError::IncompatibleParametersSingle {
-                msg: "Filesize as chunk size is only supported for binary/byte stream input"
-                    .into(),
+                msg: "Filesize as chunk size is only supported for binary/byte stream input".into(),
                 span,
             })
         }

--- a/crates/nu-command/src/filters/chunks.rs
+++ b/crates/nu-command/src/filters/chunks.rs
@@ -132,7 +132,9 @@ impl Command for Chunks {
             call_span: head,
         })?;
 
-        chunks(engine_state, input, size, head)
+        let is_filesize = matches!(chunk_size, Value::Filesize { .. });
+
+        chunks(engine_state, input, size, head, is_filesize)
     }
 }
 
@@ -141,9 +143,24 @@ pub fn chunks(
     input: PipelineData,
     chunk_size: NonZeroUsize,
     span: Span,
+    is_filesize: bool,
 ) -> Result<PipelineData, ShellError> {
     let from_io_error = IoError::factory(span, None);
     match input {
+        PipelineData::Value(Value::List { .. }, _) if is_filesize => {
+            Err(ShellError::IncompatibleParametersSingle {
+                msg: "Filesize as chunk size is only supported for binary/byte stream input"
+                    .into(),
+                span,
+            })
+        }
+        PipelineData::ListStream(_, _) if is_filesize => {
+            Err(ShellError::IncompatibleParametersSingle {
+                msg: "Filesize as chunk size is only supported for binary/byte stream input"
+                    .into(),
+                span,
+            })
+        }
         PipelineData::Value(Value::List { vals, .. }, metadata) => {
             let chunks = ChunksIter::new(vals, chunk_size, span);
             let stream = ListStream::new(chunks, span, engine_state.signals().clone());

--- a/crates/nu-command/src/filters/chunks.rs
+++ b/crates/nu-command/src/filters/chunks.rs
@@ -90,7 +90,7 @@ impl Command for Chunks {
                 ])),
             },
             Example {
-                example: "open foo.bin | chunks 8kib",
+                example: "open --raw foo.bin | chunks 8kib",
                 description: "Open a binary file and make 8 kibibyte chunks",
                 result: None,
             },

--- a/crates/nu-command/src/filters/chunks.rs
+++ b/crates/nu-command/src/filters/chunks.rs
@@ -20,12 +20,16 @@ impl Command for Chunks {
                 (Type::list(Type::Any), Type::list(Type::list(Type::Any))),
                 (Type::Binary, Type::list(Type::Binary)),
             ])
-            .required("chunk_size", SyntaxShape::Int, "The size of each chunk.")
+            .required(
+                "chunk_size",
+                SyntaxShape::OneOf(vec![SyntaxShape::Int, SyntaxShape::Filesize]),
+                "The size of each chunk.",
+            )
             .category(Category::Filters)
     }
 
     fn description(&self) -> &str {
-        "Divide a list, table or binary input into chunks of `chunk_size`."
+        "Divide a list, table or binary input into chunks of `chunk_size`. For binary input, `chunk_size` can also be specified as a filesize."
     }
 
     fn extra_description(&self) -> &str {
@@ -85,6 +89,11 @@ impl Command for Chunks {
                     Value::test_binary(vec![0x77, 0x88]),
                 ])),
             },
+            Example {
+                example: "open foo.bin | chunks 8kib",
+                description: "Open a binary file and make 8 kibibyte chunks",
+                result: None,
+            },
         ]
     }
 
@@ -99,10 +108,23 @@ impl Command for Chunks {
         let head = call.head;
         let chunk_size: Value = call.req(engine_state, stack, 0)?;
 
-        let size =
-            usize::try_from(chunk_size.as_int()?).map_err(|_| ShellError::NeedsPositiveValue {
-                span: chunk_size.span(),
-            })?;
+        let size = match chunk_size {
+            Value::Int { val, .. } => {
+                usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue {
+                    span: chunk_size.span(),
+                })
+            }
+            Value::Filesize { val, .. } => {
+                usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue {
+                    span: chunk_size.span(),
+                })
+            }
+            ref val => Err(ShellError::RuntimeTypeMismatch {
+                expected: Type::custom("int or filesize"),
+                actual: val.get_type(),
+                span: val.span(),
+            }),
+        }?;
 
         let size = NonZeroUsize::try_from(size).map_err(|_| ShellError::IncorrectValue {
             msg: "`chunk_size` cannot be zero".into(),

--- a/crates/nu-command/src/filters/drop/drop_.rs
+++ b/crates/nu-command/src/filters/drop/drop_.rs
@@ -94,27 +94,26 @@ impl Command for Drop {
             .as_ref()
             .is_some_and(|v| matches!(v, Value::Filesize { .. }));
 
-        let rows: usize = match rows_val {
-            Some(v) => {
-                let span = v.span();
-                match v {
-                    Value::Int { val, .. } => {
-                        usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue { span })?
-                    }
-                    Value::Filesize { val, .. } => {
-                        usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue { span })?
-                    }
-                    ref val => {
-                        return Err(ShellError::RuntimeTypeMismatch {
-                            expected: Type::custom("int or filesize"),
-                            actual: val.get_type(),
-                            span: val.span(),
-                        });
+        let rows: usize =
+            match rows_val {
+                Some(v) => {
+                    let span = v.span();
+                    match v {
+                        Value::Int { val, .. } => usize::try_from(val)
+                            .map_err(|_| ShellError::NeedsPositiveValue { span })?,
+                        Value::Filesize { val, .. } => usize::try_from(val)
+                            .map_err(|_| ShellError::NeedsPositiveValue { span })?,
+                        ref val => {
+                            return Err(ShellError::RuntimeTypeMismatch {
+                                expected: Type::custom("int or filesize"),
+                                actual: val.get_type(),
+                                span: val.span(),
+                            });
+                        }
                     }
                 }
-            }
-            None => 1,
-        };
+                None => 1,
+            };
 
         if is_filesize {
             let is_binary = matches!(
@@ -133,15 +132,13 @@ impl Command for Drop {
             PipelineData::Value(Value::Binary { val, .. }, ..) => {
                 let len = val.len();
                 let take = len.saturating_sub(rows);
-                Ok(Value::binary(&val[..take], head)
-                    .into_pipeline_data_with_metadata(metadata))
+                Ok(Value::binary(&val[..take], head).into_pipeline_data_with_metadata(metadata))
             }
             PipelineData::ByteStream(stream, ..) => {
                 let bytes = stream.into_bytes()?;
                 let len = bytes.len();
                 let take = len.saturating_sub(rows);
-                Ok(Value::binary(&bytes[..take], head)
-                    .into_pipeline_data_with_metadata(metadata))
+                Ok(Value::binary(&bytes[..take], head).into_pipeline_data_with_metadata(metadata))
             }
             _ => {
                 let mut values = input.into_iter_strict(head)?.collect::<Vec<_>>();

--- a/crates/nu-command/src/filters/drop/drop_.rs
+++ b/crates/nu-command/src/filters/drop/drop_.rs
@@ -16,13 +16,18 @@ impl Command for Drop {
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),
                 ),
+                (Type::Binary, Type::Binary),
             ])
-            .optional("rows", SyntaxShape::Int, "The number of items to remove.")
+            .optional(
+                "rows",
+                SyntaxShape::OneOf(vec![SyntaxShape::Int, SyntaxShape::Filesize]),
+                "The number of items to remove.",
+            )
             .category(Category::Filters)
     }
 
     fn description(&self) -> &str {
-        "Remove items/rows from the end of the input list/table. Counterpart of `skip`. Opposite of `last`."
+        "Remove items/rows from the end of the input list/table, or remove bytes from the end of binary data. Counterpart of `skip`. Opposite of `last`. For binary input, `rows` can also be specified as a filesize."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -66,6 +71,11 @@ impl Command for Drop {
                     "b" => Value::test_int(2),
                 })])),
             },
+            Example {
+                example: "0x[01 23 45] | drop 2b",
+                description: "Remove the last 2 bytes of a binary value, using a filesize argument",
+                result: Some(Value::test_binary(vec![0x01])),
+            },
         ]
     }
 
@@ -78,11 +88,67 @@ impl Command for Drop {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         let metadata = input.take_metadata();
-        let rows = call.opt::<usize>(engine_state, stack, 0)?.unwrap_or(1);
-        let mut values = input.into_iter_strict(head)?.collect::<Vec<_>>();
 
-        values.truncate(values.len().saturating_sub(rows));
-        Ok(Value::list(values, head).into_pipeline_data_with_metadata(metadata))
+        let rows_val: Option<Value> = call.opt(engine_state, stack, 0)?;
+        let is_filesize = rows_val
+            .as_ref()
+            .is_some_and(|v| matches!(v, Value::Filesize { .. }));
+
+        let rows: usize = match rows_val {
+            Some(v) => {
+                let span = v.span();
+                match v {
+                    Value::Int { val, .. } => {
+                        usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue { span })?
+                    }
+                    Value::Filesize { val, .. } => {
+                        usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue { span })?
+                    }
+                    ref val => {
+                        return Err(ShellError::RuntimeTypeMismatch {
+                            expected: Type::custom("int or filesize"),
+                            actual: val.get_type(),
+                            span: val.span(),
+                        });
+                    }
+                }
+            }
+            None => 1,
+        };
+
+        if is_filesize {
+            let is_binary = matches!(
+                &input,
+                PipelineData::Value(Value::Binary { .. }, _) | PipelineData::ByteStream(..)
+            );
+            if !is_binary {
+                return Err(ShellError::IncompatibleParametersSingle {
+                    msg: "Filesize is only supported for binary/byte stream input".into(),
+                    span: head,
+                });
+            }
+        }
+
+        match input {
+            PipelineData::Value(Value::Binary { val, .. }, ..) => {
+                let len = val.len();
+                let take = len.saturating_sub(rows);
+                Ok(Value::binary(&val[..take], head)
+                    .into_pipeline_data_with_metadata(metadata))
+            }
+            PipelineData::ByteStream(stream, ..) => {
+                let bytes = stream.into_bytes()?;
+                let len = bytes.len();
+                let take = len.saturating_sub(rows);
+                Ok(Value::binary(&bytes[..take], head)
+                    .into_pipeline_data_with_metadata(metadata))
+            }
+            _ => {
+                let mut values = input.into_iter_strict(head)?.collect::<Vec<_>>();
+                values.truncate(values.len().saturating_sub(rows));
+                Ok(Value::list(values, head).into_pipeline_data_with_metadata(metadata))
+            }
+        }
     }
 }
 

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -26,7 +26,7 @@ impl Command for First {
             ])
             .optional(
                 "rows",
-                SyntaxShape::Int,
+                SyntaxShape::OneOf(vec![SyntaxShape::Int, SyntaxShape::Filesize]),
                 "Starting from the front, the number of rows to return.",
             )
             .switch("strict", "Throw an error if input is empty.", Some('s'))
@@ -39,7 +39,7 @@ impl Command for First {
     }
 
     fn description(&self) -> &str {
-        "Return only the first several rows of the input. Counterpart of `last`. Opposite of `skip`."
+        "Return only the first several rows of the input. Counterpart of `last`. Opposite of `skip`. For binary input, rows can also be specified as a filesize."
     }
 
     fn run(
@@ -77,6 +77,11 @@ impl Command for First {
                 example: "1..3 | first",
                 result: Some(Value::test_int(1)),
             },
+            Example {
+                description: "Return the first 2 bytes of a binary value, using a filesize argument.",
+                example: "0x[01 23 45] | first 2b",
+                result: Some(Value::test_binary(vec![0x01, 0x23])),
+            },
         ]
     }
 }
@@ -88,8 +93,33 @@ fn first_helper(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let head = call.head;
-    let rows: Option<usize> = call.opt(engine_state, stack, 0)?;
+    let rows_val: Option<Value> = call.opt(engine_state, stack, 0)?;
+    let is_filesize = rows_val
+        .as_ref()
+        .is_some_and(|v| matches!(v, Value::Filesize { .. }));
     let strict_mode = call.has_flag(engine_state, stack, "strict")?;
+
+    let rows: Option<usize> = match rows_val {
+        Some(v) => {
+            let span = v.span();
+            match v {
+                Value::Int { val, .. } => Some(
+                    usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue { span })?,
+                ),
+                Value::Filesize { val, .. } => Some(
+                    usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue { span })?,
+                ),
+                ref val => {
+                    return Err(ShellError::RuntimeTypeMismatch {
+                        expected: Type::custom("int or filesize"),
+                        actual: val.get_type(),
+                        span: val.span(),
+                    });
+                }
+            }
+        }
+        None => None,
+    };
 
     // FIXME: for backwards compatibility reasons, if `rows` is not specified we
     // return a single element and otherwise we return a single list. We should probably
@@ -100,6 +130,19 @@ fn first_helper(
 
     let mut input = input;
     let input_meta = input.take_metadata();
+
+    if is_filesize {
+        let is_binary = matches!(
+            &input,
+            PipelineData::Value(Value::Binary { .. }, _) | PipelineData::ByteStream(..)
+        );
+        if !is_binary {
+            return Err(ShellError::IncompatibleParametersSingle {
+                msg: "Filesize is only supported for binary/byte stream input".into(),
+                span: head,
+            });
+        }
+    }
 
     // Count is 0: return empty data immediately.
     //

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -94,10 +94,12 @@ impl Command for Last {
                 let span = v.span();
                 match v {
                     Value::Int { val, .. } => Some(
-                        usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue { span })?,
+                        usize::try_from(val)
+                            .map_err(|_| ShellError::NeedsPositiveValue { span })?,
                     ),
                     Value::Filesize { val, .. } => Some(
-                        usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue { span })?,
+                        usize::try_from(val)
+                            .map_err(|_| ShellError::NeedsPositiveValue { span })?,
                     ),
                     ref val => {
                         return Err(ShellError::RuntimeTypeMismatch {

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -26,7 +26,7 @@ impl Command for Last {
             ])
             .optional(
                 "rows",
-                SyntaxShape::Int,
+                SyntaxShape::OneOf(vec![SyntaxShape::Int, SyntaxShape::Filesize]),
                 "Starting from the back, the number of rows to return.",
             )
             .allow_variants_without_examples(true)
@@ -39,7 +39,7 @@ impl Command for Last {
     }
 
     fn description(&self) -> &str {
-        "Return only the last several rows of the input. Counterpart of `first`. Opposite of `drop`."
+        "Return only the last several rows of the input. Counterpart of `first`. Opposite of `drop`. For binary input, rows can also be specified as a filesize."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -67,6 +67,11 @@ impl Command for Last {
                 description: "Return the last item of a range.",
                 result: Some(Value::test_int(3)),
             },
+            Example {
+                example: "0x[01 23 45] | last 2b",
+                description: "Return the last 2 bytes of a binary value, using a filesize argument.",
+                result: Some(Value::test_binary(vec![0x23, 0x45])),
+            },
         ]
     }
 
@@ -78,8 +83,33 @@ impl Command for Last {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let rows = call.opt::<usize>(engine_state, stack, 0)?;
+        let rows_val: Option<Value> = call.opt(engine_state, stack, 0)?;
+        let is_filesize = rows_val
+            .as_ref()
+            .is_some_and(|v| matches!(v, Value::Filesize { .. }));
         let strict_mode = call.has_flag(engine_state, stack, "strict")?;
+
+        let rows: Option<usize> = match rows_val {
+            Some(v) => {
+                let span = v.span();
+                match v {
+                    Value::Int { val, .. } => Some(
+                        usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue { span })?,
+                    ),
+                    Value::Filesize { val, .. } => Some(
+                        usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue { span })?,
+                    ),
+                    ref val => {
+                        return Err(ShellError::RuntimeTypeMismatch {
+                            expected: Type::custom("int or filesize"),
+                            actual: val.get_type(),
+                            span: val.span(),
+                        });
+                    }
+                }
+            }
+            None => None,
+        };
 
         // FIXME: Please read the FIXME message in `first.rs`'s `first_helper` implementation.
         // It has the same issue.
@@ -88,6 +118,19 @@ impl Command for Last {
 
         let mut input = input;
         let metadata = input.take_metadata();
+
+        if is_filesize {
+            let is_binary = matches!(
+                &input,
+                PipelineData::Value(Value::Binary { .. }, _) | PipelineData::ByteStream(..)
+            );
+            if !is_binary {
+                return Err(ShellError::IncompatibleParametersSingle {
+                    msg: "Filesize is only supported for binary/byte stream input".into(),
+                    span: head,
+                });
+            }
+        }
 
         // Count is 0: return empty data immediately.
         //

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -20,12 +20,16 @@ impl Command for Skip {
                     Type::List(Box::new(Type::Any)),
                 ),
             ])
-            .optional("n", SyntaxShape::Int, "The number of elements to skip.")
+            .optional(
+                "n",
+                SyntaxShape::OneOf(vec![SyntaxShape::Int, SyntaxShape::Filesize]),
+                "The number of elements to skip.",
+            )
             .category(Category::Filters)
     }
 
     fn description(&self) -> &str {
-        "Skip the first several rows of the input. Counterpart of `drop`. Opposite of `first`."
+        "Skip the first several rows of the input. Counterpart of `drop`. Opposite of `first`. For binary input, n can also be specified as a filesize."
     }
 
     fn extra_description(&self) -> &str {
@@ -59,6 +63,11 @@ impl Command for Skip {
                 example: "0x[01 23 45 67] | skip 2",
                 result: Some(Value::test_binary(vec![0x45, 0x67])),
             },
+            Example {
+                description: "Skip 2 bytes of a binary value, using a filesize argument.",
+                example: "0x[01 23 45 67] | skip 2b",
+                result: Some(Value::test_binary(vec![0x45, 0x67])),
+            },
         ]
     }
     fn run(
@@ -68,28 +77,47 @@ impl Command for Skip {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let n: Option<Value> = call.opt(engine_state, stack, 0)?;
+        let n_val: Option<Value> = call.opt(engine_state, stack, 0)?;
+        let is_filesize = n_val.as_ref().is_some_and(|v| matches!(v, Value::Filesize { .. }));
 
-        let n: usize = match n {
+        let n: usize = match n_val {
             Some(v) => {
                 let span = v.span();
                 match v {
                     Value::Int { val, .. } => {
-                        val.try_into().map_err(|err| ShellError::TypeMismatch {
-                            err_message: format!("Could not convert {val} to unsigned int: {err}"),
+                        usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue {
                             span,
                         })?
                     }
-                    _ => {
-                        return Err(ShellError::TypeMismatch {
-                            err_message: "expected int".into(),
+                    Value::Filesize { val, .. } => {
+                        usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue {
                             span,
+                        })?
+                    }
+                    ref val => {
+                        return Err(ShellError::RuntimeTypeMismatch {
+                            expected: Type::custom("int or filesize"),
+                            actual: val.get_type(),
+                            span: val.span(),
                         });
                     }
                 }
             }
             None => 1,
         };
+
+        if is_filesize {
+            let is_binary = matches!(
+                &input,
+                PipelineData::Value(Value::Binary { .. }, _) | PipelineData::ByteStream(..)
+            );
+            if !is_binary {
+                return Err(ShellError::IncompatibleParametersSingle {
+                    msg: "Filesize is only supported for binary/byte stream input".into(),
+                    span: input.span().unwrap_or(call.head),
+                });
+            }
+        }
 
         let input_span = input.span().unwrap_or(call.head);
 

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -78,33 +78,30 @@ impl Command for Skip {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let n_val: Option<Value> = call.opt(engine_state, stack, 0)?;
-        let is_filesize = n_val.as_ref().is_some_and(|v| matches!(v, Value::Filesize { .. }));
+        let is_filesize = n_val
+            .as_ref()
+            .is_some_and(|v| matches!(v, Value::Filesize { .. }));
 
-        let n: usize = match n_val {
-            Some(v) => {
-                let span = v.span();
-                match v {
-                    Value::Int { val, .. } => {
-                        usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue {
-                            span,
-                        })?
-                    }
-                    Value::Filesize { val, .. } => {
-                        usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue {
-                            span,
-                        })?
-                    }
-                    ref val => {
-                        return Err(ShellError::RuntimeTypeMismatch {
-                            expected: Type::custom("int or filesize"),
-                            actual: val.get_type(),
-                            span: val.span(),
-                        });
+        let n: usize =
+            match n_val {
+                Some(v) => {
+                    let span = v.span();
+                    match v {
+                        Value::Int { val, .. } => usize::try_from(val)
+                            .map_err(|_| ShellError::NeedsPositiveValue { span })?,
+                        Value::Filesize { val, .. } => usize::try_from(val)
+                            .map_err(|_| ShellError::NeedsPositiveValue { span })?,
+                        ref val => {
+                            return Err(ShellError::RuntimeTypeMismatch {
+                                expected: Type::custom("int or filesize"),
+                                actual: val.get_type(),
+                                span: val.span(),
+                            });
+                        }
                     }
                 }
-            }
-            None => 1,
-        };
+                None => 1,
+            };
 
         if is_filesize {
             let is_binary = matches!(

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -22,14 +22,14 @@ impl Command for Take {
             ])
             .required(
                 "n",
-                SyntaxShape::Int,
+                SyntaxShape::OneOf(vec![SyntaxShape::Int, SyntaxShape::Filesize]),
                 "Starting from the front, the number of elements to return.",
             )
             .category(Category::Filters)
     }
 
     fn description(&self) -> &str {
-        "Take only the first n elements of a list, or the first n bytes of a binary value."
+        "Take only the first n elements of a list, or the first n bytes of a binary value. For binary input, n can also be specified as a filesize."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -44,8 +44,39 @@ impl Command for Take {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let rows_desired: usize = call.req(engine_state, stack, 0)?;
+        let n_val: Value = call.req(engine_state, stack, 0)?;
+        let is_filesize = matches!(n_val, Value::Filesize { .. });
+        let rows_desired: usize = match n_val {
+            Value::Int { val, .. } => {
+                usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue {
+                    span: n_val.span(),
+                })?
+            }
+            Value::Filesize { val, .. } => {
+                usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue {
+                    span: n_val.span(),
+                })?
+            }
+            ref val => Err(ShellError::RuntimeTypeMismatch {
+                expected: Type::custom("int or filesize"),
+                actual: val.get_type(),
+                span: val.span(),
+            })?,
+        };
         let input = input.into_stream_or_original(engine_state);
+
+        if is_filesize {
+            let is_binary = matches!(
+                &input,
+                PipelineData::Value(Value::Binary { .. }, _) | PipelineData::ByteStream(..)
+            );
+            if !is_binary {
+                return Err(ShellError::IncompatibleParametersSingle {
+                    msg: "Filesize is only supported for binary/byte stream input".into(),
+                    span: n_val.span(),
+                });
+            }
+        }
 
         match input {
             PipelineData::Value(val, metadata) => {
@@ -155,6 +186,12 @@ impl Command for Take {
                     Value::test_int(2),
                     Value::test_int(3),
                 ])),
+            },
+            Example {
+                description:
+                    "Return the first 3 bytes of a binary value, using a filesize argument.",
+                example: "0x[01 23 45] | take 3b",
+                result: Some(Value::test_binary(vec![0x01, 0x23, 0x45])),
             },
         ]
     }

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -47,16 +47,10 @@ impl Command for Take {
         let n_val: Value = call.req(engine_state, stack, 0)?;
         let is_filesize = matches!(n_val, Value::Filesize { .. });
         let rows_desired: usize = match n_val {
-            Value::Int { val, .. } => {
-                usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue {
-                    span: n_val.span(),
-                })?
-            }
-            Value::Filesize { val, .. } => {
-                usize::try_from(val).map_err(|_| ShellError::NeedsPositiveValue {
-                    span: n_val.span(),
-                })?
-            }
+            Value::Int { val, .. } => usize::try_from(val)
+                .map_err(|_| ShellError::NeedsPositiveValue { span: n_val.span() })?,
+            Value::Filesize { val, .. } => usize::try_from(val)
+                .map_err(|_| ShellError::NeedsPositiveValue { span: n_val.span() })?,
             ref val => Err(ShellError::RuntimeTypeMismatch {
                 expected: Type::custom("int or filesize"),
                 actual: val.get_type(),
@@ -188,8 +182,7 @@ impl Command for Take {
                 ])),
             },
             Example {
-                description:
-                    "Return the first 3 bytes of a binary value, using a filesize argument.",
+                description: "Return the first 3 bytes of a binary value, using a filesize argument.",
                 example: "0x[01 23 45] | take 3b",
                 result: Some(Value::test_binary(vec![0x01, 0x23, 0x45])),
             },

--- a/crates/nu-command/src/filters/window.rs
+++ b/crates/nu-command/src/filters/window.rs
@@ -101,7 +101,7 @@ impl Command for Window {
         let remainder = call.has_flag(engine_state, stack, "remainder")?;
 
         if remainder && size == stride {
-            super::chunks::chunks(engine_state, input, size, head)
+            super::chunks::chunks(engine_state, input, size, head, false)
         } else if stride >= size {
             match input {
                 PipelineData::Value(Value::List { vals, .. }, metadata) => {

--- a/crates/nu-command/tests/commands/chunks.rs
+++ b/crates/nu-command/tests/commands/chunks.rs
@@ -55,3 +55,31 @@ fn no_empty_chunks() -> Result {
         .run("([0 1 2 3 4 5] | chunks 3 | length) == 2")
         .expect_value_eq(true)
 }
+
+#[test]
+fn chunk_binary_with_filesize() -> Result {
+    test()
+        .run("(0x[11 22 33 44 55 66 77 88] | chunks 3b | length) == 3")
+        .expect_value_eq(true)
+}
+
+#[test]
+fn chunk_binary_with_int() -> Result {
+    test()
+        .run(
+            "0x[11 22 33 44 55 66 77 88] | chunks 3 | each { |chunk| $chunk | length } | to json -r",
+        )
+        .expect_value_eq("[3,3,2]")
+}
+
+#[test]
+fn chunk_size_filesize_list_error() -> Result {
+    let err = test()
+        .run("[1 2 3] | chunks 1kb")
+        .expect_shell_error()?;
+    assert!(
+        matches!(err, ShellError::IncompatibleParametersSingle { .. }),
+        "expected IncompatibleParametersSingle, got {err:?}"
+    );
+    Ok(())
+}

--- a/crates/nu-command/tests/commands/chunks.rs
+++ b/crates/nu-command/tests/commands/chunks.rs
@@ -20,11 +20,11 @@ fn chunk_size_zero() -> Result {
 }
 
 #[test]
-fn chunk_size_not_int() -> Result {
+fn chunk_size_not_int_or_filesize() -> Result {
     let err = test()
         .run("[0 1 2] | chunks (echo 1sec)")
         .expect_shell_error()?;
-    assert!(matches!(err, ShellError::CantConvert { .. }));
+    assert!(matches!(err, ShellError::RuntimeTypeMismatch { .. }));
     Ok(())
 }
 

--- a/crates/nu-command/tests/commands/chunks.rs
+++ b/crates/nu-command/tests/commands/chunks.rs
@@ -74,9 +74,7 @@ fn chunk_binary_with_int() -> Result {
 
 #[test]
 fn chunk_size_filesize_list_error() -> Result {
-    let err = test()
-        .run("[1 2 3] | chunks 1kb")
-        .expect_shell_error()?;
+    let err = test().run("[1 2 3] | chunks 1kb").expect_shell_error()?;
     assert!(
         matches!(err, ShellError::IncompatibleParametersSingle { .. }),
         "expected IncompatibleParametersSingle, got {err:?}"

--- a/crates/nu-command/tests/commands/drop.rs
+++ b/crates/nu-command/tests/commands/drop.rs
@@ -1,3 +1,4 @@
+use nu_protocol::{ParseError, ShellError};
 use nu_test_support::prelude::*;
 
 #[test]
@@ -91,6 +92,24 @@ fn nth_missing_first_argument() -> Result {
 fn fail_on_non_iterator() -> Result {
     let err = test().run("1 | drop 50").expect_parse_error()?;
     assert!(matches!(err, ParseError::InputMismatch { .. }));
+    Ok(())
+}
+
+#[test]
+fn drop_bytes_with_filesize() -> Result {
+    let code = "(0x[aa bb cc] | drop 2b) == 0x[aa]";
+    test().run(code).expect_value_eq(true)
+}
+
+#[test]
+fn drop_filesize_list_error() -> Result {
+    let err = test()
+        .run("[1 2 3] | drop 1kb")
+        .expect_shell_error()?;
+    assert!(
+        matches!(err, ShellError::IncompatibleParametersSingle { .. }),
+        "expected IncompatibleParametersSingle, got {err:?}"
+    );
     Ok(())
 }
 

--- a/crates/nu-command/tests/commands/drop.rs
+++ b/crates/nu-command/tests/commands/drop.rs
@@ -103,9 +103,7 @@ fn drop_bytes_with_filesize() -> Result {
 
 #[test]
 fn drop_filesize_list_error() -> Result {
-    let err = test()
-        .run("[1 2 3] | drop 1kb")
-        .expect_shell_error()?;
+    let err = test().run("[1 2 3] | drop 1kb").expect_shell_error()?;
     assert!(
         matches!(err, ShellError::IncompatibleParametersSingle { .. }),
         "expected IncompatibleParametersSingle, got {err:?}"

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -175,6 +175,24 @@ fn wrapping_first_with_optional_explicit_rows() -> Result {
     test().run(code).expect_value_eq(2)
 }
 
+#[test]
+fn first_bytes_with_filesize() -> Result {
+    let code = "(0x[aa bb cc] | first 2b) == 0x[aa bb]";
+    test().run(code).expect_value_eq(true)
+}
+
+#[test]
+fn first_filesize_list_error() -> Result {
+    let err = test()
+        .run("[1 2 3] | first 1kb")
+        .expect_shell_error()?;
+    assert!(
+        matches!(err, ShellError::IncompatibleParametersSingle { .. }),
+        "expected IncompatibleParametersSingle, got {err:?}"
+    );
+    Ok(())
+}
+
 #[rstest]
 #[case::list_first(InputKind::List, "first")]
 #[case::list_first_n(InputKind::List, "first 2")]

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -183,9 +183,7 @@ fn first_bytes_with_filesize() -> Result {
 
 #[test]
 fn first_filesize_list_error() -> Result {
-    let err = test()
-        .run("[1 2 3] | first 1kb")
-        .expect_shell_error()?;
+    let err = test().run("[1 2 3] | first 1kb").expect_shell_error()?;
     assert!(
         matches!(err, ShellError::IncompatibleParametersSingle { .. }),
         "expected IncompatibleParametersSingle, got {err:?}"

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -146,9 +146,7 @@ fn last_bytes_with_filesize() -> Result {
 
 #[test]
 fn last_filesize_list_error() -> Result {
-    let err = test()
-        .run("[1 2 3] | last 1kb")
-        .expect_shell_error()?;
+    let err = test().run("[1 2 3] | last 1kb").expect_shell_error()?;
     assert!(
         matches!(err, ShellError::IncompatibleParametersSingle { .. }),
         "expected IncompatibleParametersSingle, got {err:?}"

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -138,6 +138,24 @@ fn wrapping_last_with_optional_explicit_rows() -> Result {
     test().run(code).expect_value_eq(2)
 }
 
+#[test]
+fn last_bytes_with_filesize() -> Result {
+    let code = "(0x[aa bb cc] | last 2b) == 0x[bb cc]";
+    test().run(code).expect_value_eq(true)
+}
+
+#[test]
+fn last_filesize_list_error() -> Result {
+    let err = test()
+        .run("[1 2 3] | last 1kb")
+        .expect_shell_error()?;
+    assert!(
+        matches!(err, ShellError::IncompatibleParametersSingle { .. }),
+        "expected IncompatibleParametersSingle, got {err:?}"
+    );
+    Ok(())
+}
+
 #[derive(Clone, Copy)]
 enum InputKind {
     List,

--- a/crates/nu-command/tests/commands/skip/skip_.rs
+++ b/crates/nu-command/tests/commands/skip/skip_.rs
@@ -44,9 +44,7 @@ fn skips_bytes_with_filesize() -> Result {
 
 #[test]
 fn skip_filesize_list_error() -> Result {
-    let err = test()
-        .run("[1 2 3] | skip 1kb")
-        .expect_shell_error()?;
+    let err = test().run("[1 2 3] | skip 1kb").expect_shell_error()?;
     assert!(
         matches!(err, ShellError::IncompatibleParametersSingle { .. }),
         "expected IncompatibleParametersSingle, got {err:?}"

--- a/crates/nu-command/tests/commands/skip/skip_.rs
+++ b/crates/nu-command/tests/commands/skip/skip_.rs
@@ -36,6 +36,24 @@ fn skips_bytes_and_drops_content_type() -> Result {
     Ok(())
 }
 
+#[test]
+fn skips_bytes_with_filesize() -> Result {
+    let code = "(0x[aa bb cc] | skip 2b) == 0x[cc]";
+    test().run(code).expect_value_eq(true)
+}
+
+#[test]
+fn skip_filesize_list_error() -> Result {
+    let err = test()
+        .run("[1 2 3] | skip 1kb")
+        .expect_shell_error()?;
+    assert!(
+        matches!(err, ShellError::IncompatibleParametersSingle { .. }),
+        "expected IncompatibleParametersSingle, got {err:?}"
+    );
+    Ok(())
+}
+
 enum InputType {
     Binary,
     List,

--- a/crates/nu-command/tests/commands/take/rows.rs
+++ b/crates/nu-command/tests/commands/take/rows.rs
@@ -71,3 +71,21 @@ fn takes_bytes_and_drops_content_type() -> Result {
     assert!(content_type.is_none());
     Ok(())
 }
+
+#[test]
+fn takes_bytes_with_filesize() -> Result {
+    let code = "(0x[aa bb cc] | take 2b) == 0x[aa bb]";
+    test().run(code).expect_value_eq(true)
+}
+
+#[test]
+fn take_filesize_list_error() -> Result {
+    let err = test()
+        .run("[1 2 3] | take 1kb")
+        .expect_shell_error()?;
+    assert!(
+        matches!(err, ShellError::IncompatibleParametersSingle { .. }),
+        "expected IncompatibleParametersSingle, got {err:?}"
+    );
+    Ok(())
+}

--- a/crates/nu-command/tests/commands/take/rows.rs
+++ b/crates/nu-command/tests/commands/take/rows.rs
@@ -80,9 +80,7 @@ fn takes_bytes_with_filesize() -> Result {
 
 #[test]
 fn take_filesize_list_error() -> Result {
-    let err = test()
-        .run("[1 2 3] | take 1kb")
-        .expect_shell_error()?;
+    let err = test().run("[1 2 3] | take 1kb").expect_shell_error()?;
     assert!(
         matches!(err, ShellError::IncompatibleParametersSingle { .. }),
         "expected IncompatibleParametersSingle, got {err:?}"

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -547,6 +547,15 @@ fn parse_long_flag(
     }
 }
 
+/// Check if a syntax shape can accept a negative number (for distinguishing short flags from
+/// negative numeric arguments like `-1`).
+fn shape_allows_negative_number(shape: &SyntaxShape) -> bool {
+    matches!(
+        shape,
+        SyntaxShape::Int | SyntaxShape::Number | SyntaxShape::Float
+    ) || matches!(shape, SyntaxShape::OneOf(shapes) if shapes.iter().any(shape_allows_negative_number))
+}
+
 fn parse_short_flags(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
@@ -584,13 +593,9 @@ fn parse_short_flags(
 
             if found_short_flags.is_empty()
                 // check to see if we have a negative number
-                && matches!(
-                    sig.get_positional(positional_idx),
-                    Some(PositionalArg {
-                        shape: SyntaxShape::Int | SyntaxShape::Number | SyntaxShape::Float,
-                        ..
-                    })
-                )
+                && sig
+                    .get_positional(positional_idx)
+                    .is_some_and(|p| shape_allows_negative_number(&p.shape))
                 && String::from_utf8_lossy(working_set.get_span_contents(arg_span))
                     .parse::<f64>()
                     .is_ok()

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -547,15 +547,6 @@ fn parse_long_flag(
     }
 }
 
-/// Check if a syntax shape can accept a negative number (for distinguishing short flags from
-/// negative numeric arguments like `-1`).
-fn shape_allows_negative_number(shape: &SyntaxShape) -> bool {
-    matches!(
-        shape,
-        SyntaxShape::Int | SyntaxShape::Number | SyntaxShape::Float
-    ) || matches!(shape, SyntaxShape::OneOf(shapes) if shapes.iter().any(shape_allows_negative_number))
-}
-
 fn parse_short_flags(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
@@ -593,9 +584,13 @@ fn parse_short_flags(
 
             if found_short_flags.is_empty()
                 // check to see if we have a negative number
-                && sig
-                    .get_positional(positional_idx)
-                    .is_some_and(|p| shape_allows_negative_number(&p.shape))
+                && matches!(
+                    sig.get_positional(positional_idx),
+                    Some(PositionalArg {
+                        shape: SyntaxShape::Int | SyntaxShape::Number | SyntaxShape::Float,
+                        ..
+                    })
+                )
                 && String::from_utf8_lossy(working_set.get_span_contents(arg_span))
                     .parse::<f64>()
                     .is_ok()


### PR DESCRIPTION
## Description
`chunks`, `first`, `last`, `take`, `drop` and `skip` now takes `oneof<int, filesize>`, making using them with binary easier, previously you could just do `chunks (10MiB | into int)` but I think this change makes sense for binary data.

## User-facing changes (Release notes)

### `drop` now supports `binary` inputs as well

### `chunks`, `first`, `last`, `take`, `skip` and `drop` can now be used with a `filesize` arguments

These commands can work on `binary` data, it only makes sense for them to work with not just `int` but `filesize` arguments as well:
```nushell
# split compressed file into 10MiB chunks
open --raw file.7z
    | chunks 10MiB
    | enumerate 
    | each {|chunk| 
        let suffix = $chunk.index + 1 | fill -a right -c '0' -w 3
        $chunk.item
        | save $"file.7z.($suffix)"
    }
```

## Additional notes

- Depends on #18514.

Needs to be merged from or rebased onto `main` after #18514 is merged.