### PR TITLE
parser: add external shape annotation

### DIFF
--- a/crates/nu-parser/src/parse_shape_specs.rs
+++ b/crates/nu-parser/src/parse_shape_specs.rs
@@ -41,6 +41,7 @@ pub fn parse_shape_name(
         b"directory" => SyntaxShape::Directory,
         b"duration" => SyntaxShape::Duration,
         b"error" => SyntaxShape::Error,
+        b"external_arg" => SyntaxShape::ExternalArgument,
         b"float" => SyntaxShape::Float,
         b"filesize" => SyntaxShape::Filesize,
         b"glob" => SyntaxShape::GlobPattern,

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -1,6 +1,10 @@
 use crate::repl::tests::{TestResult, fail_test, run_test, run_test_contains, run_test_with_env};
 use nu_protocol::ParseError;
-use nu_test_support::{fs::Stub, nu_repl_code, prelude::*};
+use nu_test_support::{
+    fs::Stub::{self, FileWithContent},
+    nu_repl_code,
+    prelude::*,
+};
 use rstest::rstest;
 use std::collections::HashMap;
 
@@ -1489,4 +1493,48 @@ fn allow_it_as_variable_name() -> TestResult {
 fn keep_variable_it_after_where() -> TestResult {
     // Test for https://github.com/nushell/nushell/issues/17380
     run_test("let it = 3; [1 2 3 4] | where $it > 2; $it", "3")
+}
+
+#[test]
+fn external_arg_correctness() -> TestResult {
+    Playground::setup("external_arg_correctness", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContent(
+            "script.nu",
+            "
+            def main [
+                --flag: external_arg
+                --flag2: external_arg
+                --flag3: external_arg
+                arg: external_arg
+                arg2: external_arg
+                arg3: external_arg
+                ...rest: external_arg
+            ] {
+                [
+                    [label value type];
+                    [flag $flag ($flag | describe)]
+                    [flag2 $flag2 ($flag2 | describe)]
+                    [flag3 $flag3 ($flag3 | describe)]
+                    [arg $arg ($arg | describe)]
+                    [arg2 $arg2 ($arg2 | describe)]
+                    [arg3 $arg3 ($arg3 | describe)]
+                    [rest $rest ($rest | describe)]
+                ]
+                | to nuon
+            }
+            ",
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            "nu script.nu --flag=false --flag2=0001 --flag3={fake: null} false 0001 {fake: null} false 0001 {fake: null}"
+        );
+
+        assert_eq!(
+            actual.out,
+            r#"[[label, value, type]; [flag, "false", glob], ["flag2", "0001", glob], ["flag3", "{fake: null}", string], [arg, "false", glob], ["arg2", "0001", glob], ["arg3", "{fake: null}", string], [rest, ["false", "0001", "{fake: null}"], "list<oneof<glob, string>>"]]"#
+        );
+
+        Ok(())
+    })
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
In a nushell script being called outside of a nushell environment has some limitations regarding argument parsing. Said limitation is nushell will do type conversion on all arguments where it might change or lose the original meaning or unable to pass certain values. For example we currently have `def --wrapped` for rest arguments which is a workaround for allowing stuff like true, false and other types through and without changing its value due to some kind of formatting.

The problem is that there isn't anything for non rest arguments like `--flag=true` or `--flag true` or `def main [ i: string ]` so if calling the script and passing `script.nu --flag=true` where flag expects a string it will not work as true will be converted to boolean and since the type is not correct it will error out, the same applies for `def main [i: string]`.

Now with `external` annotation it will make allow said patterns. And essentially where just exposing `SyntaxShape::ExternalArgument`.
## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
### Added `external_arg` annotations for script parameters

You can now do the following:
script.nu
```nushell
def main [
   a: external_arg
   b: external_arg
   -c: external_arg
   ...rest: external_arg
] {
   [
      [label value type];
      [a $a ($a | describe)]
      [b $b ($b | describe)]
      [c $c ($c | describe)]
      [rest $rest ($rest | describe)]
   ]
}
```
Then:
```
./script2.nu 0001 true -c true -- 001 true
┌───┬───────┬──────────────┬────────────┐
│ # │ label │    value     │    type    │
├───┼───────┼──────────────┼────────────┤
│ 0 │ a     │ 0001         │ glob       │
├───┼───────┼──────────────┼────────────┤
│ 1 │ b     │ true         │ glob       │
├───┼───────┼──────────────┼────────────┤
│ 2 │ c     │ true         │ glob       │
├───┼───────┼──────────────┼────────────┤
│ 3 │ rest  │ ┌───┬──────┐ │ list<glob> │
│   │       │ │ 0 │ 001  │ │            │
│   │       │ ├───┼──────┤ │            │
│   │       │ │ 1 │ true │ │            │
│   │       │ └───┴──────┘ │            │
└───┴───────┴──────────────┴────────────┘
```
## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
