### PR TITLE
fix parse_calls negative number detection

### DIFF
--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -547,6 +547,15 @@ fn parse_long_flag(
     }
 }
 
+/// Check if a syntax shape can accept a negative number (for distinguishing short flags from
+/// negative numeric arguments like `-1`).
+fn shape_allows_negative_number(shape: &SyntaxShape) -> bool {
+    matches!(
+        shape,
+        SyntaxShape::Int | SyntaxShape::Number | SyntaxShape::Float
+    ) || matches!(shape, SyntaxShape::OneOf(shapes) if shapes.iter().any(shape_allows_negative_number))
+}
+
 fn parse_short_flags(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
@@ -584,13 +593,9 @@ fn parse_short_flags(
 
             if found_short_flags.is_empty()
                 // check to see if we have a negative number
-                && matches!(
-                    sig.get_positional(positional_idx),
-                    Some(PositionalArg {
-                        shape: SyntaxShape::Int | SyntaxShape::Number | SyntaxShape::Float,
-                        ..
-                    })
-                )
+                && sig
+                    .get_positional(positional_idx)
+                    .is_some_and(|p| shape_allows_negative_number(&p.shape))
                 && String::from_utf8_lossy(working_set.get_span_contents(arg_span))
                     .parse::<f64>()
                     .is_ok()


### PR DESCRIPTION
## Description
Makes the negative number or short flag detection work with `OneOff` when the options can be negative numbers, necessary for the tests on #18511 to pass.

## User-facing changes (Release notes)

### Fixed negative arguments for `oneof` parameters

Parameters with `int`, `float` and `number` types can be supplied negative arguments:
```nushell
def foo [p: int] {
    $p
}

foo -2
# => -2
```

However this didn't work with parameters with types like `oneof<int, ...>`:
```nushell
def foo [p: <int, string>] {
    $p
}

foo -2
# => Error: nu::parser::unknown_flag
# => 
# =>   × The `foo` command doesn't have flag `-2`.
# =>    ╭─[repl_entry #1:3:6]
# =>  2 │ 
# =>  3 │ foo -2
# =>    ·      ┬
# =>    ·      ╰── unknown flag
# =>    ╰────
# =>   help: Use `--help` to see available flags
```

This is now fixed:
```nushell
def foo [p: <int, string>] {
    $p
}

foo -2
# => -2
```

## Additional notes
N/A