### PR TITLE
require "nu-test-support/os" in dev dependencies

### DIFF
--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -22,7 +22,7 @@ harness = false
 nu-cmd-lang = { workspace = true, features = ["os"] }
 nu-command = { workspace = true, features = ["os"] }
 nu-std.workspace = true
-nu-test-support = { path = "../nu-test-support" }
+nu-test-support = { path = "../nu-test-support", features = ["os"] }
 rstest = { workspace = true, default-features = false }
 tempfile = { workspace = true }
 


### PR DESCRIPTION
require "nu-test-support/os" in dev dependencies
that feature includes "nu-cli" itself

This is a copy of @cptpiepmatz commit from 
https://github.com/nushell/nushell/pull/18510

It fixes this test failure in the crate `nu-cli`

```rust
failures:

---- commands::nu_highlight::nu_highlight_removes_content_type_metadata stdout ----
Error: TestError {
    location: crates/nu-cli/tests/commands/nu_highlight.rs:89:10,
    kind: Shell(
        ExternalCommand {
            label: "Command `nu-highlight` not found",
            help: "`nu-highlight` is neither a Nushell built-in or a known external command",
            span: Span[136383..136395],
        },
    ),
}


failures:
    commands::nu_highlight::nu_highlight_removes_content_type_metadata
```