### PR TITLE
fix(try): only pop error handler if it was pushed by current `try` block

### DIFF
--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -435,3 +435,18 @@ fn try_wont_run_twice_when_no_catch_and_finally_block() {
     );
     assert_eq!(actual.out, "aa")
 }
+
+#[test]
+fn try_with_just_finally_wont_pop_enclosing_error_handler() {
+    let actual = nu!(
+        experimental: vec!["pipefail".to_string()],
+        r#"
+        try {
+            try { print "inner" } finally { print "finally" }
+            error make { msg: "error" }
+        }
+        print "outer"
+        "#
+    );
+    assert!(actual.out.contains("outer"));
+}

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -550,6 +550,7 @@ pub(crate) fn compile_try(
     // Put the error handler instruction. If we have a catch expression then we should capture the
     // error.
     let mut has_try_comment = false;
+    let mut pushed_error_handler = false;
     if catch_type.is_some() {
         builder.push(
             Instruction::OnErrorInto {
@@ -560,12 +561,14 @@ pub(crate) fn compile_try(
         )?;
         builder.add_comment("try");
         has_try_comment = true;
+        pushed_error_handler = true;
     } else if finally_expr.is_none() {
         // Simply try, without `catch` and `finally` block, need to set up OnErrorHandler.
         // so `try { 1 / 0 }` works
         builder.push(Instruction::OnError { index: err_label.0 }.into_spanned(call.head))?;
         builder.add_comment("try");
         has_try_comment = true;
+        pushed_error_handler = true;
     };
 
     builder.begin_try();
@@ -616,7 +619,10 @@ pub(crate) fn compile_try(
     } else {
         builder.push(Instruction::DrainIfEnd { src: io_reg }.into_spanned(call.head))?;
     }
-    builder.push(Instruction::PopErrorHandler.into_spanned(call.head))?;
+
+    if pushed_error_handler {
+        builder.push(Instruction::PopErrorHandler.into_spanned(call.head))?;
+    }
 
     builder.end_try()?;
 


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

This PR makes it so that `try` blocks only pop an error handler if they actually installed one.

A recent PR (#18173) made `try` blocks insert a `PopErrorHandler` instruction unconditionally. However, a `try/finally` with no `catch` _doesn't_ install an error handler, but after that change it still pops one. Thus, a `try/finally` nested inside another `try` or `try/catch` will pop the enclosing `try` block's error handler, leading to confusing (and pretty obviously incorrect) behavior.

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

### Fixed nested `try/finally` blocks interfering with outer error handling

When nesting a `try/finally` block within a `try` or `try/catch` block, it no longer prevents the outer block from catching errors.

This is showcased by the following code:

```nushell
# /path/to/file.nu
try {
    try { print "inner" } finally { print "finally" }
    error make { msg: "error" }
}
print "outer"
```

Output before this change:

```nushell
> nu /path/to/file.nu
inner
finally
Error: nu::shell::error

  × error
   ╭─[/path/to/file.nu:3:16]
 2 │     try { print "inner" } finally { print "finally" }
 3 │     error make { msg: "error" }
   ·                ────────────────
 4 │ }
   ╰────
```

Note that the error was surfaced despite being thrown inside a `try` block!

Output after this change:

```nushell
> nu /path/to/file.nu
inner
finally
outer
```

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->

I introduced a new variable `pushed_error_handler` to track whether a pop should be inserted.
There's an existing `has_try_comment` variable that is `true` in exactly the same code paths, so we could reuse that one instead (but they might diverge in the future, which might silently break things).