### PR TITLE
fix: apply dotall flag to regex in find command

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -263,17 +263,20 @@ impl Command for Find {
 
         let multiline = call.has_flag(engine_state, stack, "multiline")?;
 
+        let dotall = call.has_flag(engine_state, stack, "dotall")?;
+
         let columns_to_search: Vec<_> = call
             .get_flag(engine_state, stack, "columns")?
             .unwrap_or_default();
 
-        let input = if multiline {
+        let input = if multiline || dotall {
             if let PipelineData::ByteStream(..) = input {
                 // ByteStream inputs are processed by iterating over the lines, which necessarily
                 // breaks the multi-line text being streamed into a list of lines.
+                let flag = if dotall { "dotall" } else { "multiline" };
                 return Err(ShellError::IncompatibleParametersSingle {
-                    msg: "Flag `--multiline` currently doesn't work for byte stream inputs. Consider using `collect`".into(),
-                    span: call.get_flag_span(stack, "multiline").expect("has flag"),
+                    msg: format!("Flag `--{flag}` currently doesn't work for byte stream inputs. Consider using `collect`"),
+                    span: call.get_flag_span(stack, flag).expect("has flag"),
                 });
             };
             input

--- a/crates/nu-command/tests/commands/find.rs
+++ b/crates/nu-command/tests/commands/find.rs
@@ -303,6 +303,22 @@ fn find_in_nested_list_dont_match_bracket() {
 }
 
 #[test]
+fn find_with_dotall_regex_matches_across_lines() {
+    let actual = nu!(
+        r#""One\nTwo" | find --no-highlight --dotall --regex "One.*Two" | length"#
+    );
+    assert_eq!(actual.out, "1");
+}
+
+#[test]
+fn find_with_regex_no_match_across_lines_without_dotall() {
+    let actual = nu!(
+        r#""One\nTwo" | find --no-highlight --regex "One.*Two" | length"#
+    );
+    assert_eq!(actual.out, "0");
+}
+
+#[test]
 fn find_and_highlight_in_nested_list() {
     let actual = nu!(r#"[ [foo bar] [foo baz] ] | find "foo" | to json -r"#);
 


### PR DESCRIPTION
## Description\nThe ind command with --dotall --regex was not matching across lines because the multi-line input string was split before the regex was applied. This made the (?s) dotall flag ineffective since the newlines were already removed from each individual line.\n\n## Fix\nWhen --dotall is used, the input is no longer split into individual lines, allowing the dotall regex flag to match . across newline boundaries as intended.\n\n## Tests\n- Added test verifying ind --dotall --regex matches across lines\n- Added test confirming regex without dotall does not match across lines (preserving existing behavior)\n\nFixes #16267