### PR TITLE
fix: `into binary` not accepting Duration type as input

### DIFF
--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -31,6 +31,7 @@ impl Command for IntoBinary {
                 (Type::String, Type::Binary),
                 (Type::Bool, Type::Binary),
                 (Type::Filesize, Type::Binary),
+                (Type::Duration, Type::Binary),
                 (Type::Date, Type::Binary),
                 (Type::table(), Type::table()),
                 (Type::record(), Type::record()),
@@ -135,6 +136,14 @@ impl Command for IntoBinary {
                 description: "convert an int to a nushell binary primitive with compact enabled.",
                 example: "10 | into binary --compact",
                 result: Some(Value::binary(vec![10], Span::test_data())),
+            },
+            Example {
+                description: "convert a duration to a nushell binary primitive.",
+                example: "1sec | into binary",
+                result: Some(Value::binary(
+                    1_000_000_000i64.to_ne_bytes().to_vec(),
+                    Span::test_data(),
+                )),
             },
         ]
     }


### PR DESCRIPTION
## Description
I’ve noticed that the [action function](https://github.com/nushell/nushell/blob/main/crates/nu-command/src/conversions/into/binary.rs#L212) accepts and handles the Duration type. 
But Duration is missing from the signature of the command:
```
42hr | into binary
Error: nu::parser::input_type_mismatch

  × Command does not support duration input.
   ╭─[repl_entry #17:1:8]
 1 │ 42hr | into binary
   ·        ─────┬─────
   ·             ╰── command doesn't support duration input
   ╰────
```
This PR adds the Duration type to the signature and adds an example.

## User-facing changes (Release notes)
`into binary` now accepts duration input (e.g. `1sec`, `1hr`, …).

