### PR TITLE
fix(mcp): initialize `start_time` for MCP only in MCP mode to avoid cargo warning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -590,10 +590,9 @@ fn main() -> Result<()> {
         perf!("load plugins specified in --plugins", start_time, use_color)
     }
 
-    start_time = nu_utils::time::Instant::now();
-
     #[cfg(feature = "mcp")]
     if parsed_nu_cli_args.mcp {
+        start_time = nu_utils::time::Instant::now();
         perf!("mcp starting", start_time, use_color);
         // Mark MCP mode before config evaluation so startup scripts can adapt behavior.
         engine_state.is_mcp = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -593,7 +593,6 @@ fn main() -> Result<()> {
     #[cfg(feature = "mcp")]
     if parsed_nu_cli_args.mcp {
         start_time = nu_utils::time::Instant::now();
-        perf!("mcp starting", start_time, use_color);
         // Mark MCP mode before config evaluation so startup scripts can adapt behavior.
         engine_state.is_mcp = true;
         let mcp_transport_kind = parsed_nu_cli_args
@@ -629,6 +628,7 @@ fn main() -> Result<()> {
             _ => nu_mcp::McpTransport::Stdio,
         };
         nu_mcp::initialize_mcp_server(engine_state, transport)?;
+        perf!("mcp started", start_time, use_color);
         return Ok(());
     }
 


### PR DESCRIPTION
## Description
Building nushell without `mcp` feature (`--no-default-features`) produces this warning about unused variable

## User-facing changes (Release notes)
N/A