### PR TITLE
fix: assigment errors point to the assigment

### DIFF
--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -138,7 +138,7 @@ fn mut_path_operator_assign_should_error_enforce_runtime() {
         "mut a: record<b: int> = {b:1}; $a.b += 3; $a.b -= 2; $a.b *= 10; $a.b /= 4; $a.b",
     );
 
-    assert!(actual.err.contains("nu::shell::cant_convert"));
+    assert!(actual.err.contains("nu::shell::type_mismatch"));
 }
 
 #[test]

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -4,9 +4,9 @@ use nu_path::{dots::expand_ndots_safe, expand_path, expand_path_with, expand_til
 #[cfg(feature = "os")]
 use nu_protocol::process::check_exit_status_future;
 use nu_protocol::{
-    CompareTypes, DeclId, ENV_VARIABLE_ID, Flag, IntoPipelineData, IntoSpanned, ListStream,
-    OutDest, PipelineData, PipelineExecutionData, PositionalArg, Range, Record, RegId, ShellError,
-    Signals, Signature, Span, Spanned, Type, Value, VarId,
+    CompareTypes, DeclId, ENV_VARIABLE_ID, Flag, IntoPipelineData, IntoSpanned, LabeledError,
+    ListStream, OutDest, PipelineData, PipelineExecutionData, PositionalArg, Range, Record, RegId,
+    ShellError, Signals, Signature, Span, Spanned, Type, Value, VarId,
     ast::{Bits, Block, Boolean, CellPath, Comparison, Math, Operator},
     combined_type_string,
     debugger::DebugContext,
@@ -472,7 +472,7 @@ fn eval_instruction<D: DebugContext>(
             // Perform runtime type checking and conversion for variable assignment
             if nu_experimental::ENFORCE_RUNTIME_ANNOTATIONS.get() {
                 let variable = ctx.engine_state.get_var(*var_id);
-                let converted_value = check_assignment_type(value, &variable.ty)?;
+                let converted_value = check_assignment_type(value, &variable.ty, *span)?;
                 ctx.stack.add_var(*var_id, converted_value);
             } else {
                 ctx.stack.add_var(*var_id, value);
@@ -1533,16 +1533,28 @@ fn check_type(val: &Value, ty: &Type) -> Result<(), ShellError> {
 }
 
 /// Type check and convert value for assignment.
-fn check_assignment_type(val: Value, target_ty: &Type) -> Result<Value, ShellError> {
+fn check_assignment_type(
+    val: Value,
+    target_ty: &Type,
+    assignment_span: Span,
+) -> Result<Value, ShellError> {
     match val {
         Value::Error { error, .. } => Err(*error),
-        _ if val.is_subtype_of(target_ty) => Ok(val), // No conversion needed, but compatible
-        _ => Err(ShellError::CantConvert {
-            to_type: target_ty.to_string(),
-            from_type: val.get_type().to_string(),
-            span: val.span(),
-            help: None,
-        }),
+        _ if val.is_assignable_to(target_ty) => Ok(val), // No conversion needed, but compatible
+        _ => {
+            let expected = target_ty.to_string();
+            let actual = val.get_type().to_string();
+
+            let err = LabeledError::new("Type mismatch.")
+                .with_code("nu::shell::type_mismatch")
+                .with_label(format!("the value is a {actual}"), val.span())
+                .with_label(
+                    format!("expected {expected}, got {actual}"),
+                    assignment_span,
+                );
+
+            Err(ShellError::LabeledError(err.into()))
+        }
     }
 }
 

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1545,13 +1545,20 @@ fn check_assignment_type(
             let expected = target_ty.to_string();
             let actual = val.get_type().to_string();
 
-            let err = LabeledError::new("Type mismatch.")
-                .with_code("nu::shell::type_mismatch")
-                .with_label(format!("the value is a {actual}"), val.span())
-                .with_label(
-                    format!("expected {expected}, got {actual}"),
-                    assignment_span,
-                );
+            let mut err = LabeledError::new("Type mismatch.");
+            err = err.with_code("nu::shell::type_mismatch");
+
+            // Some values, like `$env.CMD_DURATION_MS`, are generated internally and don't have
+            // spans that are relevant to users.
+            // We avoid incorrect error labels by checking for that here.
+            if !(val.span() == Span::unknown() || val.span() == Span::test_data()) {
+                err = err.with_label(format!("the value is a {actual}"), val.span());
+            }
+
+            err = err.with_label(
+                format!("expected {expected}, got {actual}"),
+                assignment_span,
+            );
 
             Err(ShellError::LabeledError(err.into()))
         }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1522,7 +1522,7 @@ fn gather_arguments(
 fn check_type(val: &Value, ty: &Type) -> Result<(), ShellError> {
     match val {
         Value::Error { error, .. } => Err(*error.clone()),
-        _ if val.is_subtype_of(ty) => Ok(()),
+        _ if val.is_assignable_to(ty) => Ok(()),
         _ => Err(ShellError::CantConvert {
             to_type: ty.to_string(),
             from_type: val.get_type().to_string(),

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -1113,7 +1113,7 @@ fn let_variable_record_runtime_mismatch() -> TestResult {
     assert!(
         outcome
             .err
-            .contains("can't convert record<a: int> to record<b: int>")
+            .contains("expected record<b: int>, got record<a: int>")
     );
     Ok(())
 }

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -278,7 +278,7 @@ fn path_is_a_list_in_repl() {
         nu -c "exec nu --no-std-lib -n -e `print $'path:($env.pATh | describe)'; exit`"
     "#);
 
-    assert!(actual.out.ends_with("path:list<string>"));
+    assert_eq!(actual.out, "path:list<string>");
 }
 
 #[test]


### PR DESCRIPTION
## Description

- #16832

Errors raised for assignment errors did not point to the relevant assignment, just pointed to the values origin.

## User-facing changes (Release notes)

### More helpful errors for failed assignments with `enforce-runtime-annotations`

With `enforce-runtime-annotations` enabled, assignments with incorrect types raise errors.

Previously this error was `nu::shell::cant_convert` originally used for unsuccessful type coercions of command arguments. Unfortunately, this error only pointed at the assigned values *origin* and not at the failed assignment.

This error has been switched to `nu::shell::type_mismatch` and now points to the failed assignment in addition to the value's origin.

##### example 1
<table>
<tr>
<td>Code</td>
<td width="1000">

```nushell
mut execution_time = -1
$execution_time = $env.CMD_DURATION_MS
```

</td>
</tr>

<tr>
<td>Before</td>
<td>

```
Error: nu::shell::cant_convert

  × Can't convert to int.
   ╭─[Host Environment Variables:1:1]
 1 │ "LANG"="en_US.UTF-8"
   · ▲
   · ╰── can't convert string to int
 2 │ "LC_TIME"="en_DK.UTF-8"
   ╰────
```

</td>
</tr>

<tr>
<td>After</td>
<td>

```
Error: nu::shell::type_mismatch

  × Type mismatch.
   ╭─[repl_entry #3:2:17]
 1 │ mut execution_time = -1
 2 │ $execution_time = $env.CMD_DURATION_MS
   ·                 ┬
   ·                 ╰── expected int, got string
   ╰────
```

</td>
</tr>
</table>

##### example 2
<table>
<tr>
<td>Code</td>
<td width="1000">

```nushell
# delibarete type erasure
# we need to bypass parse-time
# type checking for this example
let stuff: any = {
	foo: "bar"
}

mut x = 1

$x = $stuff.foo
```

</td>
</tr>

<tr>
<td>Before</td>
<td>

```
Error: nu::shell::cant_convert

  × Can't convert to int.
   ╭─[repl_entry #7:5:7]
 4 │ let stuff: any = {
 5 │     foo: "bar"
   ·          ──┬──
   ·            ╰── can't convert string to int
 6 │ }
   ╰────
```

</td>
</tr>

<tr>
<td>After</td>
<td>

```
Error: nu::shell::type_mismatch

  × Type mismatch.
    ╭─[repl_entry #1:5:7]
  4 │ let stuff: any = {
  5 │     foo: "bar"
    ·          ──┬──
    ·            ╰── the value is a string
  6 │ }
  7 │ 
  8 │ mut x = 1
  9 │ 
 10 │ $x = $stuff.foo
    ·    ┬
    ·    ╰── expected int, got string
    ╰────
```

</td>
</tr>
</table>

## Additional notes

- This should make it much easier to diagnose problems described in #18528