### PR TITLE
Fix `run` binding forwarded flags to the wrong parameter

### DIFF
--- a/crates/nu-command/src/misc/run.rs
+++ b/crates/nu-command/src/misc/run.rs
@@ -317,7 +317,19 @@ fn parse_flag_token(engine_state: &EngineState, value: &Value) -> Option<(String
 /// Matches on the long name (`--char` → `"char"`) or by comparing the single short character
 /// extracted from a `-c` token against the flag's declared short character.
 fn matches_named_flag(named: &Flag, long: &str, short: Option<&str>) -> bool {
-    named.long == long || short.and_then(|name| name.chars().next()) == named.short
+    if named.long == long {
+        return true;
+    }
+
+    // Only fall back to short-character matching when the token actually was a
+    // short flag (`-c`). A long flag (`--name`) carries `short == None`, and
+    // comparing that directly against `named.short` would treat "no short given"
+    // as equal to "flag declares no short", spuriously matching the first
+    // short-less flag and binding the value to the wrong parameter.
+    match short.and_then(|name| name.chars().next()) {
+        Some(short_char) => named.short == Some(short_char),
+        None => false,
+    }
 }
 
 /// Resolve a parsed flag token to the matching signature flag, if any.

--- a/crates/nu-command/tests/commands/run.rs
+++ b/crates/nu-command/tests/commands/run.rs
@@ -606,7 +606,7 @@ fn run_script_exporting_run_does_not_override_builtin_run_in_repl_session() -> R
 }
 
 #[test]
-fn run_script_binds_long_flag_by_name_not_declaration_order() {
+fn run_script_binds_long_flag_by_name_not_declaration_order() -> Result {
     Playground::setup(
         "run_script_binds_long_flag_by_name_not_declaration_order",
         |dirs, sandbox| {
@@ -622,15 +622,16 @@ fn run_script_binds_long_flag_by_name_not_declaration_order() {
             // `--gamma` must bind to `--gamma` by name. Previously a long flag
             // matched the first declared flag that had no short character
             // (`--alpha`), so the value silently landed in the wrong slot.
-            let actual = nu!(cwd: dirs.test(), "run flags.nu --gamma 3");
-            assert_eq!(actual.out, "0/0/3");
-            assert!(actual.err.is_empty());
+            let mut tester = test().cwd(dirs.test());
+            tester
+                .run("run flags.nu --gamma 3")
+                .expect_value_eq("0/0/3")
         },
-    );
+    )
 }
 
 #[test]
-fn run_script_binds_switch_by_name_without_shifting_positional() {
+fn run_script_binds_switch_by_name_without_shifting_positional() -> Result {
     Playground::setup(
         "run_script_binds_switch_by_name_without_shifting_positional",
         |dirs, sandbox| {
@@ -646,9 +647,10 @@ fn run_script_binds_switch_by_name_without_shifting_positional() {
             // `--verbose` is a switch declared after the value-taking `--num`.
             // It must bind by name; otherwise it matched `--num`, which then
             // swallowed `hello` as its (int) value and left `word` unbound.
-            let actual = nu!(cwd: dirs.test(), "run switch.nu hello --verbose");
-            assert_eq!(actual.out, "word=hello num=0 verbose=true");
-            assert!(actual.err.is_empty());
+            let mut tester = test().cwd(dirs.test());
+            tester
+                .run("run switch.nu hello --verbose")
+                .expect_value_eq("word=hello num=0 verbose=true")
         },
-    );
+    )
 }

--- a/crates/nu-command/tests/commands/run.rs
+++ b/crates/nu-command/tests/commands/run.rs
@@ -604,3 +604,51 @@ fn run_script_exporting_run_does_not_override_builtin_run_in_repl_session() -> R
         },
     )
 }
+
+#[test]
+fn run_script_binds_long_flag_by_name_not_declaration_order() {
+    Playground::setup(
+        "run_script_binds_long_flag_by_name_not_declaration_order",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "flags.nu",
+                "
+                def main [--alpha: int, --beta: int, --gamma: int] {
+                    $\"($alpha | default 0)/($beta | default 0)/($gamma | default 0)\"
+                }
+            ",
+            )]);
+
+            // `--gamma` must bind to `--gamma` by name. Previously a long flag
+            // matched the first declared flag that had no short character
+            // (`--alpha`), so the value silently landed in the wrong slot.
+            let actual = nu!(cwd: dirs.test(), "run flags.nu --gamma 3");
+            assert_eq!(actual.out, "0/0/3");
+            assert!(actual.err.is_empty());
+        },
+    );
+}
+
+#[test]
+fn run_script_binds_switch_by_name_without_shifting_positional() {
+    Playground::setup(
+        "run_script_binds_switch_by_name_without_shifting_positional",
+        |dirs, sandbox| {
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
+                "switch.nu",
+                "
+                def main [word: string, --num: int, --verbose] {
+                    $\"word=($word) num=($num | default 0) verbose=($verbose)\"
+                }
+            ",
+            )]);
+
+            // `--verbose` is a switch declared after the value-taking `--num`.
+            // It must bind by name; otherwise it matched `--num`, which then
+            // swallowed `hello` as its (int) value and left `word` unbound.
+            let actual = nu!(cwd: dirs.test(), "run switch.nu hello --verbose");
+            assert_eq!(actual.out, "word=hello num=0 verbose=true");
+            assert!(actual.err.is_empty());
+        },
+    );
+}


### PR DESCRIPTION
## Description

Fixes #18532.

When `run file.nu ...args` forwards a flag to a script's `def main`, the flag is resolved by `matches_named_flag` in `crates/nu-command/src/misc/run.rs`:

```rust
fn matches_named_flag(named: &Flag, long: &str, short: Option<&str>) -> bool {
    named.long == long || short.and_then(|name| name.chars().next()) == named.short
}
```

For a long flag token (`--name`) the parsed short part is `None`, so `short.and_then(...)` is `None`, and the fallback comparison becomes `None == named.short`. That is true for every flag that declares no short character, so `resolve_named_flag`'s `.find()` returned the first short-less flag regardless of its long name.

With a `main` that declares more than one flag, this bound a passed flag to the first declared slot. When that first flag took a value it swallowed the following argument (shifting positionals), and the value bypassed type checking, for example a bare switch landing in an `int`-typed flag.

The fix only falls back to short-character matching when the token actually was a short flag (`-c`); long flags now match by exact long name. Short-flag matching is unchanged.

I added two regression tests in `crates/nu-command/tests/commands/run.rs`. Both fail on the current code and pass with the fix:

- three `int` flags, `run flags.nu --gamma 3`: was `3/0/0` (bound to the first flag `--alpha`), now `0/0/3`.
- `run switch.nu hello --verbose`: the `--verbose` switch was binding to the value-taking `--num` and gave `num=true verbose=false` (a bool in an `int` flag), now `num=0 verbose=true`.

Verified locally on Windows: the full `commands::run::` suite passes (28 tests, including the existing single long-flag and short-flag cases), and `cargo clippy -p nu-command --tests -- -D warnings` plus `cargo fmt --check` are clean.

## User-facing changes (Release notes)

Fixed an issue where `run script.nu --some-flag` could bind the value to the wrong flag of the script's `main` when `main` declared multiple flags, causing shifted positional arguments or a value being accepted into a flag of the wrong type. Flags passed to `run` are now matched to `main` parameters by name.

## Tests + Formatting

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy` on the changed crate with `-D warnings`
- [x] Added regression tests (`cargo test -p nu-command --test tests commands::run`)

## After Submitting

N/A
