### PR TITLE
fix: `input listen`'s output type

### DIFF
--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -47,8 +47,10 @@ impl Command for InputListen {
             .input_output_types(vec![(
                 Type::Nothing,
                 Type::Record(vec![
-                    ("keycode".to_string(), Type::String),
-                    ("modifiers".to_string(), Type::List(Box::new(Type::String))),
+                    ("type".to_string(), Type::String),
+                    ("key_type".to_string(), Type::String),
+                    ("code".to_string(), Type::String),
+                    ("modifiers".to_string(), Type::list(Type::String)),
                 ].into()),
             )])
     }


### PR DESCRIPTION
## Description

- brought up in: #18528

`input listen` command's signature output type does not match it's actual return value.

The command was added in 2bb0c1c618f961843b49432fb7a21304b41493af, and apparently it's declared signature and actual output never matched.

## User-facing changes (Release notes)

- Fixed `input listen`'s output type signature to match actual returned value.
  With the incorrect signature (and `enforce-runtime-annotations` on) `let x = input listen` would raise an error due to `$x`'s inferred type (based on `input listen`'s signature) not matching the value assigned to it.