### PR TITLE
fix: closure's input type shouldn't be inherited from scope

### DIFF
--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -1299,13 +1299,50 @@ pub fn parse_internal_call(
                         _ => None,
                     };
 
-                    let expr = parse_multispan_value(
-                        working_set,
-                        &spans[..end],
-                        &mut spans_idx,
-                        &positional.shape,
-                        input_type.as_ref(),
-                    );
+                    // HACK: `def` block parameter is of type `closure`, which is wrong.
+                    // However, that's used to make sure `def` blocks don't capture mutable
+                    // variables. (Which is also a HACK)
+                    //
+                    // Closure bodies do not get pipeline input type, but `def` bodies should.
+                    // Thus, we work around the mentioned hack with another one here.
+                    //
+                    // This is of course unideal, but it's the way to go to fix the issue without a
+                    // big refactor, which could neither be done in time for the 0.114.1 patch
+                    // release, nor would it be appropriate to include in a patch release.
+                    let expr = match special_cmd {
+                        Some(SpecialCmd::Def) if &positional.name == "block" => {
+                            let starting_error_count = working_set.parse_errors.len();
+
+                            let out = crate::parse_expressions::parse_closure_expression(
+                                working_set,
+                                &positional.shape,
+                                spans[spans_idx],
+                                input_type.as_ref(),
+                            );
+
+                            if let Expr::Closure(_) = out.expr {
+                                out
+                            } else {
+                                // on failure, we fallback to the normal code path to keep errors
+                                // the same as before this hack
+                                working_set.parse_errors.truncate(starting_error_count);
+                                parse_multispan_value(
+                                    working_set,
+                                    &spans[..end],
+                                    &mut spans_idx,
+                                    &positional.shape,
+                                    input_type.as_ref(),
+                                )
+                            }
+                        }
+                        _ => parse_multispan_value(
+                            working_set,
+                            &spans[..end],
+                            &mut spans_idx,
+                            &positional.shape,
+                            input_type.as_ref(),
+                        ),
+                    };
 
                     match special_cmd {
                         Some(SpecialCmd::Match) if &positional.name == "match_block" => {

--- a/crates/nu-parser/src/parse_literals.rs
+++ b/crates/nu-parser/src/parse_literals.rs
@@ -548,9 +548,7 @@ pub fn parse_brace_expr(
     match tokens.as_slice() {
         // If we're empty, that means an empty record or closure
         [] => match shape {
-            SyntaxShape::Closure(_) => {
-                parse_closure_expression(working_set, shape, span, input_type)
-            }
+            SyntaxShape::Closure(_) => parse_closure_expression(working_set, shape, span, None),
             SyntaxShape::Block => parse_block_expression(working_set, span, input_type),
             SyntaxShape::MatchBlock => parse_match_block_expression(working_set, span, input_type),
             _ => parse_record(working_set, span),
@@ -566,7 +564,7 @@ pub fn parse_brace_expr(
                 working_set.error(ParseError::Mismatch("block".into(), "closure".into(), span));
                 return Expression::garbage(working_set, span);
             }
-            parse_closure_expression(working_set, shape, span, input_type)
+            parse_closure_expression(working_set, shape, span, None)
         }
         [_, third, ..] if working_set.get_span_contents(third.span) == b":" => {
             parse_full_cell_path(working_set, None, span, None)
@@ -574,9 +572,7 @@ pub fn parse_brace_expr(
         [second, ..] => {
             let second_bytes = working_set.get_span_contents(second.span);
             match shape {
-                SyntaxShape::Closure(_) => {
-                    parse_closure_expression(working_set, shape, span, input_type)
-                }
+                SyntaxShape::Closure(_) => parse_closure_expression(working_set, shape, span, None),
                 SyntaxShape::Block => parse_block_expression(working_set, span, input_type),
                 SyntaxShape::MatchBlock => {
                     parse_match_block_expression(working_set, span, input_type)
@@ -586,7 +582,7 @@ pub fn parse_brace_expr(
                 _ if extract_spread_record(second_bytes.into_spanned(second.span)).is_some() => {
                     parse_record(working_set, span)
                 }
-                SyntaxShape::Any => parse_closure_expression(working_set, shape, span, input_type),
+                SyntaxShape::Any => parse_closure_expression(working_set, shape, span, None),
                 _ => {
                     working_set.error(ParseError::ExpectedWithStringMsg(
                         format!("non-block value: {shape}"),

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -377,3 +377,26 @@ fn block_let_rhs_pipeline_input() -> Result {
 
     Ok(())
 }
+
+#[test]
+fn closure_body_input_type_not_inherited_from_pipeline_input() -> Result {
+    let mut tester = test();
+
+    let () = tester.run("let fn = 42 | {|| $in ++ 'kB'}")?;
+    tester.run("'10' | do $fn").expect_value_eq("10kB")
+}
+
+#[test]
+fn closure_body_input_type_not_inherited_from_surrounding_command() -> Result {
+    let mut tester = test();
+
+    let code = r#"
+        def cmd [p: string]: nothing -> string {
+            let fn = {|| $in ++ "bar"}
+            $p | do $fn
+        }
+    "#;
+
+    let () = tester.run(code)?;
+    tester.run("cmd foo").expect_value_eq("foobar")
+}


### PR DESCRIPTION
## User-facing changes (Release notes)

### Closure's input type is not inherited from the surrounding scope

With last release, pipeline input type and how it affects various expressions are being tracked in a lot more cases.

In fact, at least one too many:
```nushell
def mk-add-suffix [suffix: string]: nothing -> closure {
	{|| $in ++ $suffix }
}
```
```
Error: nu::parser::operator_unsupported_type

  × The '++' operator does not work on values of type 'nothing'.
   ╭─[repl_entry #1:2:6]
 1 │ def mk-add-suffix [suffix: string]: nothing -> closure {
 2 │     {|| $in ++ $suffix }
   ·         ─┬─ ─┬
   ·          │   ╰── does not support 'nothing'
   ·          ╰── nothing
 3 │ }
   ╰────
```

This is now fixed, and closures' input type will be inferred as `any`, the way it was before `0.114.0`.