### PR TITLE
fix(ps): skip exited processes instead of erroring in ps -l

### DIFF
--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -115,13 +115,9 @@ fn run_ps(
             record.push("command", Value::string(proc.command(), span));
             #[cfg(target_os = "linux")]
             {
-                let proc_stat = proc.curr_proc.stat().map_err(|e| {
-                    ShellError::Generic(nu_protocol::shell_error::generic::GenericError::new(
-                        "Error getting process stat",
-                        e.to_string(),
-                        span,
-                    ))
-                })?;
+                let Ok(proc_stat) = proc.curr_proc.stat() else {
+                    continue;
+                };
                 record.push(
                     "start_time",
                     match proc_stat.starttime().get() {


### PR DESCRIPTION
## Description

Fixes #12938.

When `ps -l` is collecting process information on Linux, a process can exit before
its `stat` information is read.

Previously, this caused `ps -l` to return an error and stop.

This change skips the exited process and continues showing the remaining
processes.

## User-facing changes (Release notes)

### Fixed `ps -l` failing when processes exit during collection

Fixed a Linux race condition where `ps -l` could fail if a process exited
while process information was being collected.

The exited process is now skipped instead of causing the command to fail.

### Example

Before:

```text
Error getting process stat
File not found: /proc/<pid>/stat
````

After:

`ps -l` continues running and omits the exited process.

## Additional notes

Closes #12938.