### PR TITLE
fix(idx): correct search context help example

### DIFF
--- a/crates/nu-command/src/filesystem/idx/search.rs
+++ b/crates/nu-command/src/filesystem/idx/search.rs
@@ -64,7 +64,7 @@ impl Command for IdxSearch {
             },
             Example {
                 description: "Include 2 lines of context before and 5 lines after each match.",
-                example: "idx search error -2..5",
+                example: "idx search --context -2..5 error",
                 result: None,
             },
             Example {


### PR DESCRIPTION
## Description
Fixes the `idx search` context example so the range is passed with `--context`.

## User-facing changes (Release notes)
Fixed an incorrect `idx search --help` example.