### PR TITLE
fix(parser): infer for loop items from iterable unions

### DIFF
--- a/crates/nu-parser/src/parse_def.rs
+++ b/crates/nu-parser/src/parse_def.rs
@@ -232,11 +232,24 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
         *block.signature = sig;
     };
 
+    // `oneof` is usually flat, but yielded-type inference is recursive by
+    // definition: every union alternative may itself be an iterable.
+    fn yielded_type(ty: Type) -> Type {
+        match ty {
+            Type::List(item) => *item,
+            Type::Table(columns) => Type::Record(columns),
+            Type::Range => Type::Number,
+            Type::OneOf(types) => Type::one_of(types.into_iter().map(yielded_type)),
+            ty => ty,
+        }
+    }
+
+    // Infer the loop variable from yielded values, not from the iterable itself.
+    // Filter commands can return unions like `oneof<table, binary, list<any>>`,
+    // which yield records, binary chunks, or list items respectively.
     let var_type = match iteration_expr.ty.clone() {
-        Type::List(x) => *x,
-        Type::Table(x) => Type::Record(x),
-        Type::Range => Type::Number,
-        x => x,
+        Type::OneOf(types) => Type::one_of(types.into_iter().map(yielded_type)),
+        ty => yielded_type(ty),
     };
 
     if let (Some(var_id), Some(block_id)) = (var_decl.as_var(), block_expr.as_block()) {

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::repl::tests::{TestResult, fail_test, run_test, run_test_contains};
+use miette::Diagnostic;
 use nu_experimental::ENFORCE_RUNTIME_ANNOTATIONS;
 use nu_test_support::prelude::*;
 use rstest::rstest;
@@ -249,6 +250,36 @@ fn pipeline_oneof() -> TestResult {
 fn for_loop_item_type_from_iterable_union(#[case] input: &str) -> Result {
     // should return nothing
     let () = test().run(input)?;
+    Ok(())
+}
+
+#[test]
+#[exp(ENFORCE_RUNTIME_ANNOTATIONS)]
+fn for_loop_incorrect_type_raises_error() -> Result {
+    let code = "
+        def incorrectly_typed_stream []: nothing -> list<int> {
+            # using `each`:
+            # - erases the type: bypassing parse time type checking
+            # - returns a stream rather than a value: bypassing runtime type checking
+            [a b c] | each {}
+        }
+
+        for item in (incorrectly_typed_stream) {}
+    ";
+    let err = test().run(code).expect_shell_error()?;
+
+    assert_eq!(err.code().unwrap().to_string(), "nu::shell::type_mismatch");
+
+    let labels = err
+        .labels()
+        .into_iter()
+        .flatten()
+        .filter_map(|label| label.label().map(String::from))
+        .collect::<Vec<_>>();
+
+    assert_contains("the value is a string".to_string(), &labels);
+    assert_contains("expected int, got string".to_string(), &labels);
+
     Ok(())
 }
 

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -215,17 +215,41 @@ fn pipeline_oneof() -> TestResult {
 #[case::filter_output_union(
     "
     let pending = ([a] | each {} | collect | skip 0)
-    for item in $pending { print $item }
+    for item in $pending {}
     "
 )]
 #[case::union_of_iterables(
     "
-    def choose []: nothing -> oneof<list<list<string>>, list<int>> { [[a]] }
-    for item in (choose) { print ($item | str join '') }
+    def choose []: nothing -> oneof<list<list<string>>, list<int>> {
+        [[a]]
+    }
+    for item in (choose) {}
     "
 )]
-fn for_loop_item_type_from_iterable_union(#[case] input: &str) -> TestResult {
-    run_test(input, "a")
+#[case::static_list_source(
+    "
+    let pending: oneof<table, binary, list<int>> = [1 2 3]
+    for item in $pending {}
+    "
+)]
+#[case::static_table_source(
+    "
+    let pending: oneof<table, binary, list<int>> = [[a b]; [1 2], [3 4]]
+    for item in $pending {}
+    "
+)]
+#[case::static_binary_source(
+    "
+    let pending: oneof<table, binary, list<int>> = 0x[deadbeef]
+    for item in $pending {}
+    "
+)]
+#[test]
+#[exp(ENFORCE_RUNTIME_ANNOTATIONS)]
+fn for_loop_item_type_from_iterable_union(#[case] input: &str) -> Result {
+    // should return nothing
+    let () = test().run(input)?;
+    Ok(())
 }
 
 #[test]

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -211,6 +211,23 @@ fn pipeline_oneof() -> TestResult {
     )
 }
 
+#[rstest]
+#[case::filter_output_union(
+    "
+    let pending = ([a] | each {} | collect | skip 0)
+    for item in $pending { print $item }
+    "
+)]
+#[case::union_of_iterables(
+    "
+    def choose []: nothing -> oneof<list<list<string>>, list<int>> { [[a]] }
+    for item in (choose) { print ($item | str join '') }
+    "
+)]
+fn for_loop_item_type_from_iterable_union(#[case] input: &str) -> TestResult {
+    run_test(input, "a")
+}
+
 #[test]
 fn transpose_into_load_env() -> TestResult {
     run_test(


### PR DESCRIPTION
## Description

`parse_for` inferred the loop variable from the type of the iterable expression. That works for direct list, table, and range types, but fails for iterable unions returned by commands like `skip`.

For `oneof<table, binary, list<any>>`, the loop variable was typed as the whole iterable union instead of the yielded row or item type. With `enforce-runtime-annotations` enabled, assigning the yielded value to that loop variable raised a runtime type mismatch.

The parser now maps iterable types to their yielded types when inferring the loop variable type, including alternatives inside `oneof`.

### example: filter output union

<table>
<tr>
<td>Code</td>
<td width="1000">

```nushell
let pending = ([a] | each {} | collect | skip 0)
for item in $pending { print $item }
```

</td>
</tr>

<tr>
<td>Before</td>
<td>

```ansi
Error: nu::shell::type_mismatch

  × Type mismatch.
   ╭─[source:1:17]
 1 │ let pending = ([a] | each {} | collect | skip 0); for item in $pending { print $item }
   ·                 ┬                                     ──┬─
   ·                 │                                       ╰── expected oneof<table, binary, list<any>>, got string
   ·                 ╰── the value is a string
   ╰────
```

</td>
</tr>

<tr>
<td>After</td>
<td>

```ansi
a
```

</td>
</tr>
</table>

## User-facing changes (Release notes)

- Fixed an issue in `for` loops where type of the looping variable was inferred incorrectly when iterating over a value/stream with a union type (`oneof<list, table, binary>`). This could manifest as a runtime type checking error with `enforce-runtime-annotations` enabled.