### PR TITLE
fix: relax assignability of list types

### DIFF
--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -335,6 +335,7 @@ impl CompareTypes for Type {
             {
                 src_cols.is_assignable_to(dst_cols)
             }
+            (Type::List(dst_ty), Type::List(src_ty)) => src_ty.is_assignable_to(dst_ty.as_ref()),
             (Type::Record(dst_cols), Type::Record(src_cols))
             | (Type::Table(dst_cols), Type::Table(src_cols)) => src_cols.is_assignable_to(dst_cols),
             // strings can be coerced globs


### PR DESCRIPTION
## Description

see https://github.com/nushell/nushell/issues/18528#issuecomment-4915003067

## User-facing changes (Release notes)

- Type checking of lists are relaxed.