### PR TITLE
Fix and optimize path completion traversal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4710,6 +4710,7 @@ dependencies = [
  "lru",
  "lscolors",
  "miette 7.6.0",
+ "nix 0.31.3",
  "nu-ansi-term",
  "nu-cmd-base",
  "nu-cmd-lang",
@@ -4736,6 +4737,7 @@ dependencies = [
  "unicode-segmentation",
  "uuid",
  "which 8.0.6",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -58,6 +58,18 @@ unicode-segmentation = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 which = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true, default-features = false, features = ["dir", "fs"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = [
+    "Wdk_Foundation",
+    "Wdk_Storage_FileSystem",
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+] }
+
 [features]
 plugin = ["nu-plugin-engine"]
 system-clipboard = ["reedline/system_clipboard"]

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -78,6 +78,7 @@ fn complete_rec(
     let mut exact_match = None;
     // Only relevant for case insensitive matching
     let mut multiple_exact_matches = false;
+    let mut unreadable_exact_matches = Vec::new();
     for built in built_paths {
         let mut path = built.cwd.clone();
         for part in &built.parts {
@@ -85,6 +86,19 @@ fn complete_rec(
         }
 
         let Ok(result) = path.read_dir() else {
+            if has_more && !prefix.is_empty() {
+                let candidate = path.join(prefix);
+                if candidate.is_dir() {
+                    let mut built_exact = built.clone();
+                    let match_indices = (0..prefix.graphemes(true).count()).collect();
+                    built_exact.parts.push(MatchedPart {
+                        text: prefix.to_string(),
+                        match_indices,
+                    });
+                    built_exact.isdir = true;
+                    unreadable_exact_matches.push(built_exact);
+                }
+            }
             continue;
         };
 
@@ -146,7 +160,7 @@ fn complete_rec(
             });
 
     if has_more {
-        completion_iter
+        let mut completions: Vec<_> = completion_iter
             .flat_map(|completion| {
                 complete_rec(
                     &partial[1..],
@@ -157,7 +171,18 @@ fn complete_rec(
                     false,
                 )
             })
-            .collect()
+            .collect();
+        completions.extend(unreadable_exact_matches.into_iter().flat_map(|completion| {
+            complete_rec(
+                &partial[1..],
+                &[completion],
+                options,
+                want_directory,
+                isdir,
+                true,
+            )
+        }));
+        completions
     } else {
         completion_iter.collect()
     }

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -1,4 +1,4 @@
-use super::{MatchAlgorithm, completion_options::NuMatcher};
+use super::{MatchAlgorithm, completion_options::NuMatcher, directory_handle::Dir};
 use crate::completions::{
     CompletionOptions, Context, Fetched, SemanticSuggestion, to_reedline_span,
 };
@@ -13,13 +13,12 @@ use nu_protocol::{
 use nu_utils::IgnoreCaseExt;
 use nu_utils::get_ls_colors;
 use reedline::Suggestion;
-use std::fmt::Write;
 use std::path::{Component, MAIN_SEPARATOR as SEP, Path, PathBuf, is_separator};
+use std::{ffi::OsStr, fmt::Write, num::NonZeroUsize};
 use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Clone, Default)]
 pub struct PathBuiltFromString {
-    cwd: PathBuf,
     parts: Vec<MatchedPart>,
     isdir: bool,
 }
@@ -30,20 +29,230 @@ pub struct MatchedPart {
     match_indices: Vec<usize>,
 }
 
+/// Arena of output-path components accumulated during one completion request.
+///
+/// Each traversal candidate stores only a one-word `PathTail` identifying its last component.
+/// Extending a path appends one node to this contiguous Vec, so it is O(1) in path depth
+/// without a separate node allocation or atomic reference-count update per component.
+#[derive(Clone, Copy, Default)]
+struct PathTail(Option<NonZeroUsize>);
+
+impl PathTail {
+    fn from_index(index: usize) -> Self {
+        let encoded = index
+            .checked_add(1)
+            .and_then(NonZeroUsize::new)
+            .expect("path arena index overflow");
+        Self(Some(encoded))
+    }
+
+    fn index(self) -> Option<usize> {
+        self.0.map(|encoded| encoded.get() - 1)
+    }
+}
+
+#[derive(Default)]
+struct PathArena {
+    nodes: Vec<PathPartNode>,
+}
+
+struct PathPartNode {
+    parent: PathTail,
+    part: MatchedPart,
+}
+
+impl PathArena {
+    fn push(&mut self, parent: PathTail, part: MatchedPart) -> PathTail {
+        let tail = PathTail::from_index(self.nodes.len());
+        self.nodes.push(PathPartNode { parent, part });
+        tail
+    }
+
+    fn to_vec(&self, tail: PathTail) -> Vec<MatchedPart> {
+        // Count first so materialization needs one Vec allocation rather than collecting
+        // references and then allocating a second Vec for the cloned output parts.
+        let mut len = 0;
+        let mut current = tail;
+        while let Some(index) = current.index() {
+            len += 1;
+            current = self.nodes[index].parent;
+        }
+
+        let mut parts = Vec::with_capacity(len);
+        let mut current = tail;
+        while let Some(index) = current.index() {
+            let node = &self.nodes[index];
+            parts.push(node.part.clone());
+            current = node.parent;
+        }
+        parts.reverse();
+        parts
+    }
+}
+
+/// Index of an open directory ancestry node used only for Windows lexical `..` traversal.
+#[cfg(windows)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct DirTail(usize);
+
+#[cfg(windows)]
+#[derive(Default)]
+struct DirArena {
+    nodes: Vec<DirNode>,
+}
+
+#[cfg(windows)]
+enum DirParent {
+    Known(DirTail),
+    Lexical(PathBuf),
+}
+
+#[cfg(windows)]
+struct DirNode {
+    dir: Dir,
+    parent: DirParent,
+}
+
+#[cfg(windows)]
+impl DirArena {
+    fn get(&self, tail: DirTail) -> &Dir {
+        &self.nodes[tail.0].dir
+    }
+
+    fn push_root(&mut self, dir: Dir, path: &Path) -> DirTail {
+        let tail = DirTail(self.nodes.len());
+        // Cache the filesystem-root self edge immediately. Repeated `..` at a root then needs
+        // neither a pathname scan nor a syscall.
+        let parent = if path.has_root() && path.parent().is_none() {
+            DirParent::Known(tail)
+        } else {
+            DirParent::Lexical(path.to_path_buf())
+        };
+        self.nodes.push(DirNode { dir, parent });
+        tail
+    }
+
+    fn push_relative(&mut self, parent: DirTail, dir: Dir) -> DirTail {
+        debug_assert!(parent.0 < self.nodes.len());
+        let tail = DirTail(self.nodes.len());
+        self.nodes.push(DirNode {
+            dir,
+            parent: DirParent::Known(parent),
+        });
+        tail
+    }
+
+    fn mark(&self) -> usize {
+        self.nodes.len()
+    }
+
+    fn truncate(&mut self, mark: usize) {
+        debug_assert!(mark <= self.nodes.len());
+        self.nodes.truncate(mark);
+    }
+
+    fn lexical_parent(&mut self, tail: DirTail) -> std::io::Result<DirTail> {
+        let parent_path = match &self.nodes[tail.0].parent {
+            DirParent::Known(parent) => return Ok(*parent),
+            DirParent::Lexical(path) => match path.parent() {
+                Some(parent) if parent.as_os_str().is_empty() => PathBuf::from("."),
+                Some(parent) => parent.to_path_buf(),
+                None => path.join(".."),
+            },
+        };
+
+        // This is the only Windows `..` case that needs a pathname open. The caller scopes
+        // nodes created while following this branch, so dead branches release their handles.
+        let dir = Dir::open(&parent_path)?;
+        Ok(self.push_root(dir, &parent_path))
+    }
+}
+
+#[derive(Default)]
+struct TraversalArenas {
+    paths: PathArena,
+    #[cfg(windows)]
+    dirs: DirArena,
+}
+
+/// A live traversal branch. Unix keeps its directory handle directly on the hot path. Windows
+/// stores only a one-word ancestry index, so returning through an already traversed component is
+/// an O(1) arena lookup with no syscall, pathname reconstruction, or refcount update.
+#[derive(Clone)]
+#[cfg_attr(windows, derive(Copy))]
+struct TraversalCandidate {
+    #[cfg(windows)]
+    dir: DirTail,
+    #[cfg(not(windows))]
+    dir: Dir,
+    tail: PathTail,
+}
+
+impl TraversalArenas {
+    fn root_candidate(&mut self, dir: Dir, path: &Path) -> TraversalCandidate {
+        #[cfg(windows)]
+        let dir = self.dirs.push_root(dir, path);
+        #[cfg(not(windows))]
+        let _ = path;
+        TraversalCandidate {
+            dir,
+            tail: PathTail::default(),
+        }
+    }
+
+    fn child_candidate(
+        &mut self,
+        parent: &TraversalCandidate,
+        dir: Dir,
+        tail: PathTail,
+    ) -> TraversalCandidate {
+        #[cfg(windows)]
+        let dir = self.dirs.push_relative(parent.dir, dir);
+        #[cfg(not(windows))]
+        let _ = parent;
+        TraversalCandidate { dir, tail }
+    }
+
+    fn dir<'a>(&'a self, candidate: &'a TraversalCandidate) -> &'a Dir {
+        #[cfg(windows)]
+        {
+            self.dirs.get(candidate.dir)
+        }
+        #[cfg(not(windows))]
+        {
+            &candidate.dir
+        }
+    }
+
+    #[inline]
+    fn scoped_dirs<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        #[cfg(windows)]
+        let mark = self.dirs.mark();
+        let result = f(self);
+        #[cfg(windows)]
+        self.dirs.truncate(mark);
+        result
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TraversalSettings {
+    want_directory: bool,
+}
+
 /// Recursively goes through paths that match a given `partial`.
-/// * `built_paths`: State struct for a valid matching path built so far.
-/// * `want_directory`: Whether we want only directories as completion matches.
-///   Some commands like `cd` can only be run on directories whereas others
-///   like `ls` can be run on regular files as well.
+/// * `built_paths`: Open-directory state for valid matching paths built so far.
+/// * `want_directory`: Whether final completion matches must be directories.
 /// * `isdir`: whether the current partial path has a trailing slash.
 ///   Parsing a path string into a pathbuf loses that bit of information.
 /// * `enable_exact_match`: Whether match algorithm is Prefix and all previous components
 ///   of the path matched a directory exactly.
 fn complete_rec(
     partial: &[&str],
-    built_paths: &[PathBuiltFromString],
+    built_paths: &[TraversalCandidate],
+    arenas: &mut TraversalArenas,
+    settings: &TraversalSettings,
     options: &CompletionOptions,
-    want_directory: bool,
     isdir: bool,
     enable_exact_match: bool,
 ) -> Vec<PathBuiltFromString> {
@@ -53,123 +262,484 @@ fn complete_rec(
         && base.chars().all(|c| c == '.')
         && has_more
     {
-        let built_paths: Vec<_> = built_paths
-            .iter()
-            .map(|built| {
-                let mut built = built.clone();
-                built.parts.push(MatchedPart {
-                    text: base.to_string(),
-                    match_indices: Vec::new(),
-                });
-                built.isdir = true;
-                built
-            })
-            .collect();
-        return complete_rec(
-            rest,
-            &built_paths,
-            options,
-            want_directory,
-            isdir,
-            enable_exact_match,
-        );
+        return arenas.scoped_dirs(|arenas| {
+            let built_paths: Vec<_> = built_paths
+                .iter()
+                .filter_map(|built| {
+                    let tail = arenas.paths.push(
+                        built.tail,
+                        MatchedPart {
+                            text: base.to_string(),
+                            match_indices: Vec::new(),
+                        },
+                    );
+                    if base == "." {
+                        #[cfg(windows)]
+                        let mut candidate = *built;
+                        #[cfg(not(windows))]
+                        let mut candidate = built.clone();
+                        candidate.tail = tail;
+                        Some(candidate)
+                    } else {
+                        #[cfg(windows)]
+                        {
+                            let dir = arenas.dirs.lexical_parent(built.dir).ok()?;
+                            Some(TraversalCandidate { dir, tail })
+                        }
+                        #[cfg(not(windows))]
+                        {
+                            // Unix handle-relative `..` preserves native physical traversal semantics,
+                            // including after following a symlink.
+                            let dir = built.dir.open_dir(OsStr::new(base)).ok()?;
+                            Some(TraversalCandidate { dir, tail })
+                        }
+                    }
+                })
+                .collect();
+            complete_rec(
+                rest,
+                &built_paths,
+                arenas,
+                settings,
+                options,
+                isdir,
+                enable_exact_match,
+            )
+        });
     }
 
+    if has_more {
+        complete_intermediate(
+            partial,
+            built_paths,
+            arenas,
+            settings,
+            options,
+            isdir,
+            enable_exact_match,
+        )
+    } else {
+        complete_final(
+            partial.first().unwrap_or(&""),
+            built_paths,
+            arenas,
+            options,
+            settings.want_directory,
+        )
+    }
+}
+
+fn complete_intermediate(
+    partial: &[&str],
+    built_paths: &[TraversalCandidate],
+    arenas: &mut TraversalArenas,
+    settings: &TraversalSettings,
+    options: &CompletionOptions,
+    isdir: bool,
+    enable_exact_match: bool,
+) -> Vec<PathBuiltFromString> {
     let prefix = partial.first().unwrap_or(&"");
+    let prefix_os = OsStr::new(prefix);
     let mut matcher = NuMatcher::new(prefix, options, true);
+    let mut completions = Vec::new();
 
-    let mut exact_match = None;
-    // Only relevant for case insensitive matching
-    let mut multiple_exact_matches = false;
     for built in built_paths {
-        let mut path = built.cwd.clone();
-        for part in &built.parts {
-            path.push(part.text.as_str());
-        }
-
-        let Ok(result) = path.read_dir() else {
-            continue;
+        let entries = match arenas.dir(built).entries() {
+            Ok(entries) => entries,
+            Err(err) => {
+                // Enumeration needs read/list permission, while handle-relative lookup
+                // of a known child may need only search/traverse permission. If listing
+                // is denied, there are no sibling names to discover: follow only the
+                // literal component the user supplied. Preserve exactness so a branch
+                // that became non-exact earlier never regains exact pruning.
+                if !prefix.is_empty()
+                    && err.kind() == std::io::ErrorKind::PermissionDenied
+                    && let Ok(dir) = arenas.dir(built).open_dir(prefix_os)
+                {
+                    let tail = arenas.paths.push(
+                        built.tail,
+                        MatchedPart {
+                            text: prefix.to_string(),
+                            match_indices: (0..prefix.graphemes(true).count()).collect(),
+                        },
+                    );
+                    let branch = arenas.scoped_dirs(|arenas| {
+                        let literal = arenas.child_candidate(built, dir, tail);
+                        complete_rec(
+                            &partial[1..],
+                            &[literal],
+                            arenas,
+                            settings,
+                            options,
+                            isdir,
+                            enable_exact_match,
+                        )
+                    });
+                    completions.extend(branch);
+                }
+                continue;
+            }
         };
 
-        for entry in result.filter_map(|e| e.ok()) {
-            let entry_name = entry.file_name().to_string_lossy().into_owned();
-            let entry_isdir = entry.path().is_dir();
-            if want_directory && !entry_isdir {
-                continue;
-            }
-            // Match before cloning: the clone copies the whole accumulated path per entry,
-            // but only the few matches survive, and an exact match is also a prefix match.
-            if matcher.check_match(&entry_name).is_none() {
-                continue;
-            }
+        if enable_exact_match {
+            // Look only for exact-name uniqueness first. Do not allocate/build ordinary
+            // matcher candidates unless this shortcut fails. Opening an exact directory
+            // also produces the child handle needed by the next recursion in the same
+            // operation; obvious non-directory entries are rejected from their type hint.
+            let mut exact = None;
+            let mut multiple_exact_matches = false;
 
-            let mut built = built.clone();
-            built.isdir = entry_isdir;
-
-            if enable_exact_match && !multiple_exact_matches && has_more {
-                let matches = if options.case_sensitive {
-                    entry_name.eq(prefix)
+            for entry in &entries {
+                let entry_name = entry.file_name().to_string_lossy();
+                let is_exact = if options.case_sensitive {
+                    entry_name.as_ref() == *prefix
                 } else {
                     entry_name.eq_ignore_case(prefix)
                 };
-                if matches {
-                    if exact_match.is_none() {
-                        let mut built_exact = built.clone();
-                        let match_indices = (0..entry_name.graphemes(true).count()).collect();
-                        built_exact.parts.push(MatchedPart {
-                            text: entry_name.clone(),
-                            match_indices,
-                        });
-                        exact_match = Some(built_exact);
-                    } else {
-                        multiple_exact_matches = true;
-                    }
+                if !is_exact {
+                    continue;
+                }
+
+                let Ok(dir) = arenas.dir(built).open_entry_dir(entry) else {
+                    continue;
+                };
+                if exact.is_none() {
+                    exact = Some((entry_name.into_owned(), dir));
+                } else {
+                    multiple_exact_matches = true;
+                    break;
                 }
             }
 
-            matcher.add(entry_name.clone(), (built, entry_name));
+            if !multiple_exact_matches && let Some((entry_name, dir)) = exact {
+                let tail = arenas.paths.push(
+                    built.tail,
+                    MatchedPart {
+                        match_indices: (0..entry_name.graphemes(true).count()).collect(),
+                        text: entry_name,
+                    },
+                );
+                let branch = arenas.scoped_dirs(|arenas| {
+                    let exact = arenas.child_candidate(built, dir, tail);
+                    complete_rec(
+                        &partial[1..],
+                        &[exact],
+                        arenas,
+                        settings,
+                        options,
+                        isdir,
+                        true,
+                    )
+                });
+                completions.extend(branch);
+                continue;
+            }
+        }
+
+        for entry in entries {
+            let entry_name = entry.file_name().to_string_lossy();
+            let Some(prepared) = matcher.prepare_match(entry_name.as_ref()) else {
+                continue;
+            };
+
+            // Keep names borrowed until they actually match. This avoids allocating a String for
+            // every non-matching directory entry, which matters in wide directories. Committing
+            // the prepared match also avoids running the matcher a second time for survivors.
+            // Borrow the parent handle through sorting instead of cloning its refcount once per
+            // matching sibling. Child handles are still opened one-at-a-time before recursion.
+            matcher.add_prepared_owned(
+                entry_name.into_owned(),
+                prepared,
+                (built.tail, built, entry),
+            );
         }
     }
 
-    // Don't show longer completions if we have a single exact match (#13204, #14794)
-    if !multiple_exact_matches && let Some(built) = exact_match {
-        return complete_rec(
-            &partial[1..],
-            &[built],
-            options,
-            want_directory,
-            isdir,
-            true,
+    for ((tail, parent, entry), match_indices) in matcher.results() {
+        // A directory-type hint rejects obvious files without a syscall. A surviving
+        // entry is opened relative to its parent exactly once to obtain the next handle.
+        let Ok(dir) = arenas.dir(parent).open_entry_dir(&entry) else {
+            continue;
+        };
+        let entry_name = entry.file_name().to_string_lossy().into_owned();
+        let tail = arenas.paths.push(
+            tail,
+            MatchedPart {
+                text: entry_name,
+                match_indices,
+            },
+        );
+        let branch = arenas.scoped_dirs(|arenas| {
+            let candidate = arenas.child_candidate(parent, dir, tail);
+            complete_rec(
+                &partial[1..],
+                &[candidate],
+                arenas,
+                settings,
+                options,
+                isdir,
+                false,
+            )
+        });
+        completions.extend(branch);
+    }
+    completions
+}
+
+fn complete_final(
+    prefix: &str,
+    built_paths: &[TraversalCandidate],
+    arenas: &TraversalArenas,
+    options: &CompletionOptions,
+    want_directory: bool,
+) -> Vec<PathBuiltFromString> {
+    let mut matcher = NuMatcher::new(prefix, options, true);
+
+    for built in built_paths {
+        let dir = arenas.dir(built);
+        let Ok(entries) = dir.entries() else {
+            continue;
+        };
+
+        for entry in entries {
+            let entry_name = entry.file_name().to_string_lossy();
+            let Some(prepared) = matcher.prepare_match(entry_name.as_ref()) else {
+                continue;
+            };
+
+            let entry_isdir = dir.entry_is_dir(&entry);
+            if want_directory && !entry_isdir {
+                continue;
+            }
+            matcher.add_prepared_owned(
+                entry_name.into_owned(),
+                prepared,
+                (built.tail, entry, entry_isdir),
+            );
+        }
+    }
+
+    matcher
+        .results()
+        .into_iter()
+        .map(|((tail, entry, isdir), match_indices)| {
+            let mut parts = arenas.paths.to_vec(tail);
+            parts.push(MatchedPart {
+                text: entry.file_name().to_string_lossy().into_owned(),
+                match_indices,
+            });
+            PathBuiltFromString { parts, isdir }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod path_traversal_tests {
+    use super::*;
+
+    #[test]
+    fn path_tail_is_one_word() {
+        assert_eq!(
+            std::mem::size_of::<PathTail>(),
+            std::mem::size_of::<usize>()
         );
     }
 
-    let completion_iter =
-        matcher
-            .results()
-            .into_iter()
-            .map(|((mut built, last_entry_name), last_match_indices)| {
-                built.parts.push(MatchedPart {
-                    text: last_entry_name,
-                    match_indices: last_match_indices,
-                });
-                built
-            });
+    #[test]
+    fn path_arena_materializes_shared_prefixes() {
+        let mut arena = PathArena::default();
+        let root = arena.push(
+            PathTail::default(),
+            MatchedPart {
+                text: "root".into(),
+                match_indices: vec![0],
+            },
+        );
+        let left = arena.push(
+            root,
+            MatchedPart {
+                text: "left".into(),
+                match_indices: vec![1],
+            },
+        );
+        let right = arena.push(
+            root,
+            MatchedPart {
+                text: "right".into(),
+                match_indices: vec![2],
+            },
+        );
 
-    if has_more {
-        completion_iter
-            .flat_map(|completion| {
-                complete_rec(
-                    &partial[1..],
-                    &[completion],
-                    options,
-                    want_directory,
-                    isdir,
-                    false,
-                )
+        let texts = |tail| {
+            arena
+                .to_vec(tail)
+                .into_iter()
+                .map(|part| part.text)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(texts(left), ["root", "left"]);
+        assert_eq!(texts(right), ["root", "right"]);
+    }
+
+    fn complete_directory_path(roots: &[PathBuf], partial: &[&str]) -> Vec<String> {
+        let mut arenas = TraversalArenas::default();
+        let built_paths: Vec<_> = roots
+            .iter()
+            .map(|root| {
+                let dir = Dir::open(root).expect("open completion root");
+                arenas.root_candidate(dir, root)
             })
-            .collect()
-    } else {
-        completion_iter.collect()
+            .collect();
+        let options = CompletionOptions::default();
+        let settings = TraversalSettings {
+            want_directory: true,
+        };
+        let mut results: Vec<_> = complete_rec(
+            partial,
+            &built_paths,
+            &mut arenas,
+            &settings,
+            &options,
+            true,
+            options.match_algorithm == MatchAlgorithm::Prefix,
+        )
+        .into_iter()
+        .map(|path| {
+            path.parts
+                .iter()
+                .map(|part| part.text.as_str())
+                .collect::<Vec<_>>()
+                .join("/")
+        })
+        .collect();
+        results.sort();
+        results
+    }
+
+    #[test]
+    fn exact_pruning_is_independent_for_each_cwd() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let one = temp.path().join("one");
+        let two = temp.path().join("two");
+        std::fs::create_dir_all(one.join("foo/a")).expect("create first fixture");
+        std::fs::create_dir_all(two.join("foobar/b")).expect("create second fixture");
+
+        assert_eq!(
+            complete_directory_path(&[one, two], &["foo"]),
+            ["foo/a", "foobar/b"]
+        );
+    }
+
+    #[test]
+    fn exact_directory_in_each_cwd_keeps_each_cwd() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let one = temp.path().join("one");
+        let two = temp.path().join("two");
+        std::fs::create_dir_all(one.join("foo/a")).expect("create first fixture");
+        std::fs::create_dir_all(two.join("foo/b")).expect("create second fixture");
+
+        assert_eq!(
+            complete_directory_path(&[one, two], &["foo"]),
+            ["foo/a", "foo/b"]
+        );
+    }
+
+    #[test]
+    fn later_exact_component_does_not_restore_pruning() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let root = temp.path().join("root");
+        std::fs::create_dir_all(root.join("partial/hol/foo")).expect("create exact fixture");
+        std::fs::create_dir_all(root.join("partial-a/hola/foo")).expect("create prefix fixture");
+
+        assert_eq!(
+            complete_directory_path(&[root], &["part", "hol"]),
+            ["partial-a/hola/foo", "partial/hol/foo"]
+        );
+    }
+
+    #[test]
+    fn exact_file_does_not_shadow_prefix_directory() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let root = temp.path().join("root");
+        std::fs::create_dir_all(root.join("foobar/child")).expect("create directory fixture");
+        std::fs::write(root.join("foo"), b"file").expect("create exact file fixture");
+
+        assert_eq!(complete_directory_path(&[root], &["foo"]), ["foobar/child"]);
+    }
+
+    #[test]
+    fn case_sensitive_exact_pruning_uses_directory_entry_spelling() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let root = temp.path().join("root");
+        std::fs::create_dir_all(root.join("Foo/wrong-case"))
+            .expect("create differently-cased fixture");
+        std::fs::create_dir_all(root.join("foobar/right-prefix"))
+            .expect("create matching prefix fixture");
+
+        assert_eq!(
+            complete_directory_path(&[root], &["foo"]),
+            ["foobar/right-prefix"]
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_known_parent_reuses_ancestor_handle() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let root_path = temp.path().join("root");
+        std::fs::create_dir_all(root_path.join("child")).expect("create fixture");
+
+        let mut arenas = TraversalArenas::default();
+        let root =
+            arenas.root_candidate(Dir::open(&root_path).expect("open root handle"), &root_path);
+        let child_dir = arenas
+            .dir(&root)
+            .open_dir(OsStr::new("child"))
+            .expect("open child handle");
+        let child = arenas.child_candidate(&root, child_dir, PathTail::default());
+        let before = arenas.dirs.nodes.len();
+
+        assert_eq!(arenas.dirs.lexical_parent(child.dir).unwrap(), root.dir);
+        assert_eq!(arenas.dirs.nodes.len(), before);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_recursive_branches_release_directory_handles() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let root_path = temp.path().join("root/a/b");
+        std::fs::create_dir_all(root_path.join("child/leaf")).expect("create child fixture");
+
+        let mut arenas = TraversalArenas::default();
+        let root =
+            arenas.root_candidate(Dir::open(&root_path).expect("open root handle"), &root_path);
+        let root_nodes = arenas.dirs.nodes.len();
+        let options = CompletionOptions::default();
+        let settings = TraversalSettings {
+            want_directory: true,
+        };
+
+        let _ = complete_rec(
+            &["child"],
+            &[root],
+            &mut arenas,
+            &settings,
+            &options,
+            true,
+            true,
+        );
+        assert_eq!(arenas.dirs.nodes.len(), root_nodes);
+
+        let _ = complete_rec(
+            &["..", ".."],
+            &[root],
+            &mut arenas,
+            &settings,
+            &options,
+            true,
+            true,
+        );
+        assert_eq!(arenas.dirs.nodes.len(), root_nodes);
     }
 }
 
@@ -324,9 +894,7 @@ pub fn complete_item(
             original_cwd = OriginalCwd::Prefix(String::new());
         }
         Some(Component::Normal(home)) if home.to_string_lossy() == "~" => {
-            cwds = home_dir()
-                .map(|dir| vec![dir.into()])
-                .unwrap_or(cwd_pathbufs);
+            cwds = home_dir().map(|dir| vec![dir.into()]).unwrap_or_default();
             prefix_len = 1;
             original_cwd = OriginalCwd::Home;
         }
@@ -343,18 +911,23 @@ pub fn complete_item(
         .filter(|s| !s.is_empty())
         .collect();
 
+    let mut arenas = TraversalArenas::default();
+    let built_paths: Vec<_> = cwds
+        .iter()
+        .filter_map(|cwd| {
+            Dir::open(cwd)
+                .ok()
+                .map(|dir| arenas.root_candidate(dir, cwd))
+        })
+        .collect();
+
+    let settings = TraversalSettings { want_directory };
     complete_rec(
         partial.as_slice(),
-        &cwds
-            .into_iter()
-            .map(|cwd| PathBuiltFromString {
-                cwd,
-                parts: Vec::new(),
-                isdir: false,
-            })
-            .collect::<Vec<_>>(),
+        &built_paths,
+        &mut arenas,
+        &settings,
         options,
-        want_directory,
         isdir,
         options.match_algorithm == MatchAlgorithm::Prefix,
     )
@@ -489,7 +1062,6 @@ fn collapse_ndots(path: PathBuiltFromString) -> PathBuiltFromString {
     let mut result = PathBuiltFromString {
         parts: Vec::with_capacity(path.parts.len()),
         isdir: path.isdir,
-        cwd: path.cwd,
     };
 
     let mut dot_count = 0;

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -39,7 +39,10 @@ pub struct NuMatcher<'a, T> {
 }
 
 enum State<T> {
-    Unscored(Vec<UnscoredMatch<T>>),
+    Unscored {
+        case_sensitive_needle: Option<Box<str>>,
+        matches: Vec<UnscoredMatch<T>>,
+    },
     Fuzzy {
         matcher: Matcher,
         atom: Atom,
@@ -50,6 +53,7 @@ enum State<T> {
 struct UnscoredMatch<T> {
     item: T,
     haystack: String,
+    folded_haystack: Option<String>,
     match_indices: Vec<usize>,
 }
 
@@ -57,10 +61,98 @@ struct FuzzyMatch<T> {
     item: T,
     haystack: String,
     score: u16,
+    case_sensitive_match: bool,
+    match_indices: Vec<usize>,
+}
+
+/// Match work that has already been computed but not yet committed to the result set.
+/// Completion uses this to avoid running the matcher twice when it needs to perform an
+/// additional filesystem check only for matching entries.
+pub(super) struct PreparedMatch {
+    haystack_start: usize,
+    haystack_end: usize,
+    score: Option<u16>,
+    folded_haystack: Option<String>,
     match_indices: Vec<usize>,
 }
 
 const QUOTES: [char; 3] = ['"', '\'', '`'];
+
+fn match_has_exact_case(needle: &str, haystack: &str, indices: &[usize]) -> bool {
+    if needle.is_ascii() && haystack.is_ascii() {
+        let needle = needle.as_bytes();
+        let haystack = haystack.as_bytes();
+        return needle.len() == indices.len()
+            && needle
+                .iter()
+                .zip(indices)
+                .all(|(needle, index)| haystack.get(*index) == Some(needle));
+    }
+
+    let mut needle = needle
+        .graphemes(true)
+        .filter_map(|grapheme| grapheme.chars().next());
+    let mut haystack = haystack.graphemes(true).enumerate();
+    for index in indices {
+        let Some(needle) = needle.next() else {
+            return false;
+        };
+        let Some((_, haystack)) = haystack.find(|(candidate, _)| candidate == index) else {
+            return false;
+        };
+        if !haystack.starts_with(needle) {
+            return false;
+        }
+    }
+    needle.next().is_none()
+}
+
+#[inline(never)]
+fn finish_substring_case_preferred<T>(
+    matches: Vec<UnscoredMatch<T>>,
+    needle: &str,
+) -> Vec<(T, Vec<usize>)> {
+    let has_exact_case = |mat: &UnscoredMatch<T>| {
+        let exact_at_match = mat.match_indices.first().and_then(|start| {
+            mat.haystack
+                .as_bytes()
+                .get(*start..start.saturating_add(needle.len()))
+        }) == Some(needle.as_bytes());
+        exact_at_match || mat.haystack.contains(needle)
+    };
+
+    let len = matches.len();
+    let mut matches = matches.into_iter();
+    let first = matches.next().expect("matches is not empty");
+    let first_exact = has_exact_case(&first);
+    let mut primary = Vec::with_capacity(len);
+    primary.push((first.item, first.match_indices));
+    let mut secondary = None;
+
+    for mat in matches {
+        let exact_case = has_exact_case(&mat);
+        let result = (mat.item, mat.match_indices);
+        if exact_case == first_exact {
+            primary.push(result);
+        } else {
+            secondary
+                .get_or_insert_with(|| Vec::with_capacity(len))
+                .push(result);
+        }
+    }
+
+    if let Some(mut secondary) = secondary {
+        if first_exact {
+            primary.extend(secondary);
+            primary
+        } else {
+            secondary.extend(primary);
+            secondary
+        }
+    } else {
+        primary
+    }
+}
 
 /// Filters and sorts suggestions
 impl<T> NuMatcher<'_, T> {
@@ -80,14 +172,22 @@ impl<T> NuMatcher<'_, T> {
             MatchAlgorithm::Prefix | MatchAlgorithm::Substring => {
                 let lowercase_needle = if options.case_sensitive {
                     needle.to_owned()
+                } else if needle.is_ascii() {
+                    needle.to_ascii_lowercase()
                 } else {
                     needle.to_folded_case()
                 };
+                let case_sensitive_needle =
+                    (!options.case_sensitive && should_sort && lowercase_needle != needle)
+                        .then(|| needle.to_owned().into_boxed_str());
                 NuMatcher {
                     options,
                     should_sort,
                     needle: lowercase_needle,
-                    state: State::Unscored(Vec::new()),
+                    state: State::Unscored {
+                        case_sensitive_needle,
+                        matches: Vec::new(),
+                    },
                 }
             }
             MatchAlgorithm::Fuzzy => {
@@ -120,16 +220,37 @@ impl<T> NuMatcher<'_, T> {
         }
     }
 
-    /// Returns whether or not the haystack matches the needle. If it does, `item` is added
-    /// to the list of matches (if given).
+    /// Compute a match without committing an item to the result set yet.
     ///
-    /// Helper to avoid code duplication between [NuMatcher::add] and [NuMatcher::matches].
-    fn matches_aux(&mut self, orig_haystack: &str, item: Option<T>) -> Option<Vec<usize>> {
+    /// This lets callers perform work that should happen only for matching candidates and then
+    /// commit the already-computed score/indices without running the matcher a second time.
+    pub(super) fn prepare_match(&mut self, orig_haystack: &str) -> Option<PreparedMatch> {
         let haystack = orig_haystack.trim_start_matches(QUOTES);
-        let offset = orig_haystack.len() - haystack.len();
+        let haystack_start = orig_haystack.len() - haystack.len();
         let haystack = haystack.trim_end_matches(QUOTES);
+        let haystack_end = haystack_start + haystack.len();
+
         match &mut self.state {
-            State::Unscored(matches) => {
+            State::Unscored { .. } => {
+                if !self.options.case_sensitive
+                    && self.options.match_algorithm == MatchAlgorithm::Prefix
+                    && haystack.is_ascii()
+                    && self.needle.is_ascii()
+                {
+                    let needle_len = self.needle.len();
+                    let prefix = haystack.as_bytes().get(..needle_len)?;
+                    if !prefix.eq_ignore_ascii_case(self.needle.as_bytes()) {
+                        return None;
+                    }
+                    return Some(PreparedMatch {
+                        haystack_start,
+                        haystack_end,
+                        score: None,
+                        folded_haystack: self.should_sort.then(|| haystack.to_ascii_lowercase()),
+                        match_indices: (haystack_start..haystack_start + needle_len).collect(),
+                    });
+                }
+
                 let haystack_folded = if self.options.case_sensitive {
                     Cow::Borrowed(haystack)
                 } else {
@@ -146,46 +267,88 @@ impl<T> NuMatcher<'_, T> {
                     MatchAlgorithm::Substring => haystack_folded.find(self.needle.as_str()),
                     _ => unreachable!("Only prefix and substring algorithms don't use score"),
                 };
-                match_start.map(|byte_start| {
-                    let grapheme_start = haystack_folded[0..byte_start].graphemes(true).count();
-                    // TODO this doesn't account for lowercasing changing the length of the haystack
-                    let grapheme_len = self.needle.graphemes(true).count();
-                    let match_indices: Vec<usize> =
-                        (offset + grapheme_start..offset + grapheme_start + grapheme_len).collect();
-                    if let Some(item) = item {
-                        matches.push(UnscoredMatch {
-                            item,
-                            haystack: haystack.to_string(),
-                            match_indices: match_indices.clone(),
-                        });
+                let byte_start = match_start?;
+                let grapheme_start = haystack_folded[0..byte_start].graphemes(true).count();
+                // TODO this doesn't account for lowercasing changing the length of the haystack
+                let grapheme_len = self.needle.graphemes(true).count();
+                let folded_haystack = if self.should_sort {
+                    match haystack_folded {
+                        Cow::Owned(folded) => Some(folded),
+                        Cow::Borrowed(_) => None,
                     }
-                    match_indices
+                } else {
+                    None
+                };
+                Some(PreparedMatch {
+                    haystack_start,
+                    haystack_end,
+                    score: None,
+                    folded_haystack,
+                    match_indices: (haystack_start + grapheme_start
+                        ..haystack_start + grapheme_start + grapheme_len)
+                        .collect(),
                 })
             }
-            State::Fuzzy {
-                matcher,
-                atom,
-                matches,
-            } => {
+            State::Fuzzy { matcher, atom, .. } => {
                 let mut haystack_buf = Vec::new();
                 let haystack_utf32 = Utf32Str::new(haystack, &mut haystack_buf);
                 let mut indices = Vec::new();
                 let score = atom.indices(haystack_utf32, matcher, &mut indices)?;
-                let indices: Vec<usize> = indices
-                    .iter()
-                    .map(|i| {
-                        offset + usize::try_from(*i).expect("should be on at least a 32-bit system")
-                    })
-                    .collect();
-                if let Some(item) = item {
-                    matches.push(FuzzyMatch {
-                        item,
-                        haystack: haystack.to_string(),
-                        score,
-                        match_indices: indices.clone(),
-                    });
-                }
-                Some(indices)
+                Some(PreparedMatch {
+                    haystack_start,
+                    haystack_end,
+                    score: Some(score),
+                    folded_haystack: None,
+                    match_indices: indices
+                        .iter()
+                        .map(|i| {
+                            haystack_start
+                                + usize::try_from(*i)
+                                    .expect("should be on at least a 32-bit system")
+                        })
+                        .collect(),
+                })
+            }
+        }
+    }
+
+    /// Commit an already-computed match, reusing the caller's owned haystack allocation.
+    pub(super) fn add_prepared_owned(
+        &mut self,
+        mut haystack: String,
+        prepared: PreparedMatch,
+        item: T,
+    ) {
+        let fuzzy_case_sensitive_match = !self.options.case_sensitive
+            && self.should_sort
+            && self.options.match_algorithm == MatchAlgorithm::Fuzzy
+            && match_has_exact_case(self.needle.as_str(), &haystack, &prepared.match_indices);
+
+        haystack.truncate(prepared.haystack_end);
+        if prepared.haystack_start != 0 {
+            haystack.replace_range(..prepared.haystack_start, "");
+        }
+
+        match &mut self.state {
+            State::Unscored { matches, .. } => {
+                debug_assert!(prepared.score.is_none());
+                matches.push(UnscoredMatch {
+                    item,
+                    haystack,
+                    folded_haystack: prepared.folded_haystack,
+                    match_indices: prepared.match_indices,
+                });
+            }
+            State::Fuzzy { matches, .. } => {
+                matches.push(FuzzyMatch {
+                    item,
+                    haystack,
+                    score: prepared
+                        .score
+                        .expect("prepared fuzzy match should contain a score"),
+                    case_sensitive_match: fuzzy_case_sensitive_match,
+                    match_indices: prepared.match_indices,
+                });
             }
         }
     }
@@ -194,37 +357,57 @@ impl<T> NuMatcher<'_, T> {
     ///
     /// Returns whether the item was added.
     pub fn add(&mut self, haystack: impl AsRef<str>, item: T) -> bool {
-        self.matches_aux(haystack.as_ref(), Some(item)).is_some()
+        let haystack = haystack.as_ref();
+        let Some(prepared) = self.prepare_match(haystack) else {
+            return false;
+        };
+        self.add_prepared_owned(haystack.to_owned(), prepared, item);
+        true
     }
 
     /// Check if the given haystack matches the needle without adding it as a result.
     ///
     /// Returns match indices if it matched, None if it didn't.
     pub fn check_match(&mut self, haystack: &str) -> Option<Vec<usize>> {
-        self.matches_aux(haystack, None)
+        self.prepare_match(haystack)
+            .map(|prepared| prepared.match_indices)
     }
 
     fn sort(&mut self) {
         match &mut self.state {
-            State::Unscored(matches) => {
+            State::Unscored { matches, .. } => {
                 matches.sort_by(|a, b| {
                     let cmp_sensitive = a.haystack.cmp(&b.haystack);
                     if self.options.case_sensitive {
                         cmp_sensitive
                     } else {
-                        a.haystack
-                            .to_folded_case()
-                            .cmp(&b.haystack.to_folded_case())
+                        a.folded_haystack
+                            .as_deref()
+                            .expect("case-insensitive match should retain folded haystack")
+                            .cmp(
+                                b.folded_haystack
+                                    .as_deref()
+                                    .expect("case-insensitive match should retain folded haystack"),
+                            )
                             .then(cmp_sensitive)
                     }
                 });
             }
             State::Fuzzy { matches, .. } => match self.options.sort {
                 CompletionSort::Alphabetical => {
-                    matches.sort_by(|a, b| a.haystack.cmp(&b.haystack));
+                    matches.sort_by(|a, b| {
+                        b.case_sensitive_match
+                            .cmp(&a.case_sensitive_match)
+                            .then_with(|| a.haystack.cmp(&b.haystack))
+                    });
                 }
                 CompletionSort::Smart => {
-                    matches.sort_by(|a, b| b.score.cmp(&a.score).then(a.haystack.cmp(&b.haystack)));
+                    matches.sort_by(|a, b| {
+                        b.case_sensitive_match
+                            .cmp(&a.case_sensitive_match)
+                            .then_with(|| b.score.cmp(&a.score))
+                            .then_with(|| a.haystack.cmp(&b.haystack))
+                    });
                 }
             },
         }
@@ -236,14 +419,64 @@ impl<T> NuMatcher<'_, T> {
             self.sort();
         }
         match self.state {
-            State::Unscored(matches) => matches
-                .into_iter()
-                .map(|mat| (mat.item, mat.match_indices))
-                .collect::<Vec<_>>(),
+            State::Unscored {
+                case_sensitive_needle,
+                matches,
+            } => {
+                if !self.options.case_sensitive && self.should_sort && !matches.is_empty() {
+                    let needle = case_sensitive_needle
+                        .as_deref()
+                        .unwrap_or(self.needle.as_str());
+                    match self.options.match_algorithm {
+                        MatchAlgorithm::Prefix => {
+                            let len = matches.len();
+                            let mut matches = matches.into_iter();
+                            let first = matches.next().expect("matches is not empty");
+                            let first_exact = first.haystack.starts_with(needle);
+                            let mut primary = Vec::with_capacity(len);
+                            primary.push((first.item, first.match_indices));
+                            let mut secondary = None;
+
+                            for mat in matches {
+                                let exact_case = mat.haystack.starts_with(needle);
+                                let result = (mat.item, mat.match_indices);
+                                if exact_case == first_exact {
+                                    primary.push(result);
+                                } else {
+                                    secondary
+                                        .get_or_insert_with(|| Vec::with_capacity(len))
+                                        .push(result);
+                                }
+                            }
+
+                            if let Some(mut secondary) = secondary {
+                                if first_exact {
+                                    primary.extend(secondary);
+                                    primary
+                                } else {
+                                    secondary.extend(primary);
+                                    secondary
+                                }
+                            } else {
+                                primary
+                            }
+                        }
+                        MatchAlgorithm::Substring => {
+                            finish_substring_case_preferred(matches, needle)
+                        }
+                        MatchAlgorithm::Fuzzy => unreachable!("fuzzy matches use scored state"),
+                    }
+                } else {
+                    matches
+                        .into_iter()
+                        .map(|mat| (mat.item, mat.match_indices))
+                        .collect()
+                }
+            }
             State::Fuzzy { matches, .. } => matches
                 .into_iter()
                 .map(|mat| (mat.item, mat.match_indices))
-                .collect::<Vec<_>>(),
+                .collect(),
         }
     }
 }
@@ -327,7 +560,7 @@ impl Default for CompletionOptions {
 mod test {
     use rstest::rstest;
 
-    use super::{CompletionOptions, MatchAlgorithm, NuMatcher};
+    use super::{CompletionOptions, CompletionSort, MatchAlgorithm, NuMatcher};
 
     #[rstest]
     #[case(MatchAlgorithm::Prefix, "example text", "", true)]
@@ -359,6 +592,103 @@ mod test {
         } else {
             assert_ne!(vec![haystack], results);
         }
+    }
+
+    #[rstest]
+    #[case(MatchAlgorithm::Prefix, CompletionSort::Smart)]
+    #[case(MatchAlgorithm::Substring, CompletionSort::Smart)]
+    #[case(MatchAlgorithm::Fuzzy, CompletionSort::Smart)]
+    #[case(MatchAlgorithm::Fuzzy, CompletionSort::Alphabetical)]
+    fn case_insensitive_sort_prefers_case_sensitive_match(
+        #[case] match_algorithm: MatchAlgorithm,
+        #[case] sort: CompletionSort,
+    ) {
+        let options = CompletionOptions {
+            case_sensitive: false,
+            match_algorithm,
+            sort,
+            ..Default::default()
+        };
+        let mut matcher = NuMatcher::new("test-t", &options, true);
+        for item in ["test-Test", "test-test"] {
+            matcher.add(item, item);
+        }
+
+        let results: Vec<_> = matcher
+            .results()
+            .into_iter()
+            .map(|result| result.0)
+            .collect();
+        assert_eq!(vec!["test-test", "test-Test"], results);
+    }
+
+    #[rstest]
+    #[case(MatchAlgorithm::Prefix)]
+    #[case(MatchAlgorithm::Substring)]
+    #[case(MatchAlgorithm::Fuzzy)]
+    fn case_sensitive_match_precedes_better_alphabetical_insensitive_match(
+        #[case] match_algorithm: MatchAlgorithm,
+    ) {
+        let options = CompletionOptions {
+            case_sensitive: false,
+            match_algorithm,
+            sort: CompletionSort::Smart,
+            ..Default::default()
+        };
+        let mut matcher = NuMatcher::new("test-t", &options, true);
+        for item in ["test-Ta", "test-tz"] {
+            matcher.add(item, item);
+        }
+
+        let results: Vec<_> = matcher
+            .results()
+            .into_iter()
+            .map(|result| result.0)
+            .collect();
+        assert_eq!(vec!["test-tz", "test-Ta"], results);
+    }
+
+    #[test]
+    fn case_preference_does_not_reorder_unsorted_matches() {
+        let options = CompletionOptions {
+            case_sensitive: false,
+            ..Default::default()
+        };
+        let mut matcher = NuMatcher::new("test-t", &options, false);
+        for item in ["test-Test", "test-test"] {
+            matcher.add(item, item);
+        }
+
+        let results: Vec<_> = matcher
+            .results()
+            .into_iter()
+            .map(|result| result.0)
+            .collect();
+        assert_eq!(vec!["test-Test", "test-test"], results);
+    }
+
+    #[rstest]
+    #[case(MatchAlgorithm::Prefix)]
+    #[case(MatchAlgorithm::Substring)]
+    #[case(MatchAlgorithm::Fuzzy)]
+    fn prepared_match_is_equivalent_to_add(#[case] match_algorithm: MatchAlgorithm) {
+        let options = CompletionOptions {
+            case_sensitive: false,
+            match_algorithm,
+            ..Default::default()
+        };
+        let haystacks = ["foo", "'Foo bar'", "food", "bar", "`fob`", "afoo"];
+        let mut normal = NuMatcher::new("foo", &options, true);
+        let mut prepared = NuMatcher::new("foo", &options, true);
+
+        for (index, haystack) in haystacks.into_iter().enumerate() {
+            normal.add(haystack, index);
+            if let Some(matched) = prepared.prepare_match(haystack) {
+                prepared.add_prepared_owned(haystack.to_owned(), matched, index);
+            }
+        }
+
+        assert_eq!(normal.results(), prepared.results());
     }
 
     #[test]

--- a/crates/nu-cli/src/completions/directory_handle.rs
+++ b/crates/nu-cli/src/completions/directory_handle.rs
@@ -1,0 +1,598 @@
+//! Small stable-Rust adapter for handle-relative directory traversal.
+//!
+//! This intentionally mirrors the direction of the unstable `std::fs::Dir` API tracked by
+//! rust-lang/rust#120426. Once `std::fs::Dir` supports stable handle-relative enumeration, this
+//! module should become a thin adapter or disappear. Completion keeps its own layer for now because
+//! stable `std` cannot yet enumerate an already-open directory handle on all supported platforms.
+
+use std::{
+    ffi::{OsStr, OsString},
+    io,
+    path::Path,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EntryKind {
+    Directory,
+    NonDirectory,
+    NeedsLookup,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct DirEntry {
+    name: OsString,
+    kind: EntryKind,
+}
+
+impl DirEntry {
+    pub(super) fn file_name(&self) -> &OsStr {
+        &self.name
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct Dir(platform::Dir);
+
+impl Dir {
+    pub(super) fn open(path: &Path) -> io::Result<Self> {
+        platform::Dir::open(path).map(Self)
+    }
+
+    pub(super) fn entries(&self) -> io::Result<Vec<DirEntry>> {
+        self.0.entries()
+    }
+
+    /// Opens `name` as a directory relative to this open directory. Extension cost therefore
+    /// depends on the child component, not on the depth of the accumulated path.
+    pub(super) fn open_dir(&self, name: &OsStr) -> io::Result<Self> {
+        self.0.open_dir(name).map(Self)
+    }
+
+    /// Opens an enumerated entry as a child directory. Obvious non-directories are rejected
+    /// without another syscall; symlinks/reparse points are resolved by the relative open.
+    pub(super) fn open_entry_dir(&self, entry: &DirEntry) -> io::Result<Self> {
+        if entry.kind == EntryKind::NonDirectory {
+            return Err(io::Error::new(
+                io::ErrorKind::NotADirectory,
+                "directory entry is not a directory",
+            ));
+        }
+        self.open_dir(entry.file_name())
+    }
+
+    pub(super) fn entry_is_dir(&self, entry: &DirEntry) -> bool {
+        match entry.kind {
+            EntryKind::Directory => true,
+            EntryKind::NonDirectory => false,
+            EntryKind::NeedsLookup => self.open_entry_dir(entry).is_ok(),
+        }
+    }
+}
+
+#[cfg(unix)]
+mod platform {
+    use super::{DirEntry, EntryKind};
+    use nix::{
+        dir::{Dir as NixDir, Type},
+        errno::Errno,
+        fcntl::{OFlag, open, openat},
+        sys::stat::Mode,
+    };
+    use std::{
+        ffi::{OsStr, OsString},
+        io,
+        os::{fd::OwnedFd, unix::ffi::OsStringExt},
+        path::Path,
+        sync::{Arc, Mutex},
+    };
+
+    #[derive(Clone)]
+    pub(super) struct Dir(Arc<DirInner>);
+
+    enum DirInner {
+        // A normal readable directory keeps only its fd. Enumeration duplicates this fd into a
+        // temporary DIR stream, avoiding both the old openat(fd, ".") pathname lookup and a
+        // long-lived libc directory buffer for every ancestor in a deep completion.
+        Readable {
+            file: std::fs::File,
+            enumeration_lock: Mutex<()>,
+        },
+        // Search-only directories cannot be opened for reading. Keep the O_PATH/O_SEARCH
+        // descriptor so exact known-name traversal still works through them.
+        TraverseOnly(OwnedFd),
+    }
+
+    fn io_error(error: Errno) -> io::Error {
+        io::Error::from_raw_os_error(error as i32)
+    }
+
+    fn readable_flags() -> OFlag {
+        OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn traversal_flags() -> OFlag {
+        OFlag::O_PATH | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC
+    }
+
+    #[cfg(all(
+        unix,
+        not(any(target_os = "linux", target_os = "android")),
+        any(
+            target_vendor = "apple",
+            target_os = "solaris",
+            target_os = "illumos",
+            target_os = "netbsd",
+            target_os = "freebsd",
+            target_os = "fuchsia",
+            target_os = "emscripten",
+            target_os = "aix",
+            target_os = "wasi"
+        )
+    ))]
+    fn traversal_flags() -> OFlag {
+        OFlag::O_SEARCH | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC
+    }
+
+    #[cfg(all(
+        unix,
+        not(any(target_os = "linux", target_os = "android")),
+        not(any(
+            target_vendor = "apple",
+            target_os = "solaris",
+            target_os = "illumos",
+            target_os = "netbsd",
+            target_os = "freebsd",
+            target_os = "fuchsia",
+            target_os = "emscripten",
+            target_os = "aix",
+            target_os = "wasi"
+        ))
+    ))]
+    fn traversal_flags() -> OFlag {
+        // Some Unix targets expose neither O_PATH nor O_SEARCH. O_RDONLY still
+        // provides handle-relative traversal, though it cannot represent a directory
+        // that grants search permission without read permission.
+        readable_flags()
+    }
+
+    impl Dir {
+        fn readable(fd: OwnedFd) -> Self {
+            Self(Arc::new(DirInner::Readable {
+                file: std::fs::File::from(fd),
+                enumeration_lock: Mutex::new(()),
+            }))
+        }
+
+        fn traverse_only(fd: OwnedFd) -> Self {
+            Self(Arc::new(DirInner::TraverseOnly(fd)))
+        }
+
+        fn should_try_traverse_only(error: Errno) -> bool {
+            traversal_flags() != readable_flags() && matches!(error, Errno::EACCES | Errno::EPERM)
+        }
+
+        fn open_traverse_only(path: &Path, readable_error: Errno) -> io::Result<Self> {
+            if !Self::should_try_traverse_only(readable_error) {
+                return Err(io_error(readable_error));
+            }
+            open(path, traversal_flags(), Mode::empty())
+                .map(Self::traverse_only)
+                .map_err(io_error)
+        }
+
+        pub(super) fn open(path: &Path) -> io::Result<Self> {
+            match open(path, readable_flags(), Mode::empty()) {
+                Ok(fd) => Ok(Self::readable(fd)),
+                Err(error) => Self::open_traverse_only(path, error),
+            }
+        }
+
+        fn open_dir_from<Fd: std::os::fd::AsFd>(parent: Fd, name: &OsStr) -> io::Result<Self> {
+            match openat(&parent, name, readable_flags(), Mode::empty()) {
+                Ok(fd) => Ok(Self::readable(fd)),
+                Err(error) if Self::should_try_traverse_only(error) => {
+                    openat(&parent, name, traversal_flags(), Mode::empty())
+                        .map(Self::traverse_only)
+                        .map_err(io_error)
+                }
+                Err(error) => Err(io_error(error)),
+            }
+        }
+
+        pub(super) fn open_dir(&self, name: &OsStr) -> io::Result<Self> {
+            match &*self.0 {
+                DirInner::Readable { file, .. } => Self::open_dir_from(file, name),
+                DirInner::TraverseOnly(fd) => Self::open_dir_from(fd, name),
+            }
+        }
+
+        pub(super) fn entries(&self) -> io::Result<Vec<DirEntry>> {
+            match &*self.0 {
+                DirInner::Readable {
+                    file,
+                    enumeration_lock,
+                } => {
+                    // A duplicated descriptor shares the directory offset with `file`, so serialize
+                    // enumeration across clones. NixDir::iter rewinds on drop, restoring that shared
+                    // offset before the lock is released. This avoids a pathname lookup while keeping
+                    // the libc DIR buffer temporary.
+                    let _guard = enumeration_lock
+                        .lock()
+                        .map_err(|_| io::Error::other("directory enumeration lock poisoned"))?;
+                    let duplicate: OwnedFd = file.try_clone()?.into();
+                    let mut dir = NixDir::from_fd(duplicate).map_err(io_error)?;
+                    collect_entries(&mut dir)
+                }
+                DirInner::TraverseOnly(fd) => {
+                    // Permissions may have changed since this handle was opened, so retain the old
+                    // behavior of attempting a readable view when enumeration is actually needed.
+                    let mut dir = NixDir::openat(fd, ".", readable_flags(), Mode::empty())
+                        .map_err(io_error)?;
+                    collect_entries(&mut dir)
+                }
+            }
+        }
+    }
+
+    fn collect_entries(dir: &mut NixDir) -> io::Result<Vec<DirEntry>> {
+        let mut entries = Vec::new();
+        for entry in dir.iter() {
+            let entry = entry.map_err(io_error)?;
+            let name_bytes = entry.file_name().to_bytes();
+            if name_bytes == b"." || name_bytes == b".." {
+                continue;
+            }
+
+            let kind = match entry.file_type() {
+                Some(Type::Directory) => EntryKind::Directory,
+                Some(Type::Symlink) | None => EntryKind::NeedsLookup,
+                Some(_) => EntryKind::NonDirectory,
+            };
+            entries.push(DirEntry {
+                name: OsString::from_vec(name_bytes.to_vec()),
+                kind,
+            });
+        }
+        Ok(entries)
+    }
+}
+
+#[cfg(windows)]
+mod platform {
+    use super::{DirEntry, EntryKind};
+    use std::{
+        ffi::{OsStr, OsString},
+        io,
+        mem::{offset_of, size_of},
+        os::windows::{
+            ffi::{OsStrExt, OsStringExt},
+            fs::OpenOptionsExt,
+            io::{AsRawHandle, FromRawHandle},
+        },
+        path::Path,
+        ptr, slice,
+        sync::{Arc, Mutex},
+    };
+    use windows_sys::Wdk::{
+        Foundation::OBJECT_ATTRIBUTES,
+        Storage::FileSystem::{
+            FILE_DIRECTORY_FILE, FILE_OPEN, FILE_SYNCHRONOUS_IO_NONALERT, NtCreateFile,
+        },
+    };
+    use windows_sys::Win32::{
+        Foundation::{
+            ERROR_NO_MORE_FILES, GetLastError, HANDLE, RtlNtStatusToDosError, UNICODE_STRING,
+        },
+        Storage::FileSystem::{
+            FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_BACKUP_SEMANTICS,
+            FILE_FULL_DIR_INFO, FILE_LIST_DIRECTORY, FILE_SHARE_DELETE, FILE_SHARE_READ,
+            FILE_SHARE_WRITE, FILE_TRAVERSE, FileFullDirectoryInfo, FileFullDirectoryRestartInfo,
+            GetFileInformationByHandleEx, SYNCHRONIZE,
+        },
+        System::IO::IO_STATUS_BLOCK,
+    };
+
+    const SHARE_ALL: u32 = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
+    const LIST_ACCESS: u32 = FILE_LIST_DIRECTORY | FILE_TRAVERSE | SYNCHRONIZE;
+    const TRAVERSE_ACCESS: u32 = FILE_TRAVERSE | SYNCHRONIZE;
+
+    #[derive(Clone)]
+    pub(super) struct Dir {
+        file: Arc<std::fs::File>,
+        can_list: bool,
+        enumeration_lock: Arc<Mutex<()>>,
+    }
+
+    impl Dir {
+        fn from_file(file: std::fs::File, can_list: bool) -> Self {
+            Self {
+                file: Arc::new(file),
+                can_list,
+                enumeration_lock: Arc::new(Mutex::new(())),
+            }
+        }
+    }
+
+    fn ntstatus_error(status: i32) -> io::Error {
+        // SAFETY: RtlNtStatusToDosError is a pure conversion routine for an NTSTATUS.
+        let error = unsafe { RtlNtStatusToDosError(status) };
+        io::Error::from_raw_os_error(error as i32)
+    }
+
+    fn unicode_string(name: &OsStr) -> io::Result<(Vec<u16>, UNICODE_STRING)> {
+        let mut wide: Vec<u16> = name.encode_wide().collect();
+        let byte_len = wide
+            .len()
+            .checked_mul(size_of::<u16>())
+            .filter(|len| *len <= u16::MAX as usize)
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "path component too long")
+            })?;
+        let string = UNICODE_STRING {
+            Length: byte_len as u16,
+            MaximumLength: byte_len as u16,
+            Buffer: wide.as_mut_ptr(),
+        };
+        Ok((wide, string))
+    }
+
+    fn open_root_with_access(path: &Path, access: u32) -> io::Result<std::fs::File> {
+        let mut options = std::fs::OpenOptions::new();
+        options
+            .access_mode(access)
+            .share_mode(SHARE_ALL)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
+        options.open(path)
+    }
+
+    impl Dir {
+        pub(super) fn open(path: &Path) -> io::Result<Self> {
+            match open_root_with_access(path, LIST_ACCESS) {
+                Ok(file) => Ok(Self::from_file(file, true)),
+                Err(error) if error.kind() == io::ErrorKind::PermissionDenied => {
+                    open_root_with_access(path, TRAVERSE_ACCESS)
+                        .map(|file| Self::from_file(file, false))
+                }
+                Err(error) => Err(error),
+            }
+        }
+
+        fn raw_handle(&self) -> HANDLE {
+            self.file.as_raw_handle().cast()
+        }
+
+        fn open_child_with_access(&self, name: &OsStr, access: u32) -> io::Result<std::fs::File> {
+            let (_wide, mut object_name) = unicode_string(name)?;
+            let attributes = OBJECT_ATTRIBUTES {
+                Length: size_of::<OBJECT_ATTRIBUTES>() as u32,
+                RootDirectory: self.raw_handle(),
+                ObjectName: &mut object_name,
+                // Do not force OBJ_CASE_INSENSITIVE. Completion opens names obtained from
+                // enumeration, so preserving native per-directory case sensitivity matters.
+                Attributes: 0,
+                SecurityDescriptor: ptr::null(),
+                SecurityQualityOfService: ptr::null(),
+            };
+            let mut handle: HANDLE = ptr::null_mut();
+            let mut io_status = IO_STATUS_BLOCK::default();
+
+            // SAFETY: all pointers refer to live stack/Vec storage for this synchronous call.
+            // On success `handle` is newly owned and immediately transferred to File.
+            let status = unsafe {
+                NtCreateFile(
+                    &mut handle,
+                    access,
+                    &attributes,
+                    &mut io_status,
+                    ptr::null(),
+                    0,
+                    SHARE_ALL,
+                    FILE_OPEN,
+                    FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT,
+                    ptr::null(),
+                    0,
+                )
+            };
+            if status < 0 {
+                return Err(ntstatus_error(status));
+            }
+
+            // SAFETY: NtCreateFile succeeded and transferred ownership of a valid HANDLE.
+            Ok(unsafe { std::fs::File::from_raw_handle(handle.cast()) })
+        }
+
+        pub(super) fn open_dir(&self, name: &OsStr) -> io::Result<Self> {
+            match self.open_child_with_access(name, LIST_ACCESS) {
+                Ok(file) => Ok(Self::from_file(file, true)),
+                Err(error) if error.kind() == io::ErrorKind::PermissionDenied => self
+                    .open_child_with_access(name, TRAVERSE_ACCESS)
+                    .map(|file| Self::from_file(file, false)),
+                Err(error) => Err(error),
+            }
+        }
+
+        pub(super) fn entries(&self) -> io::Result<Vec<DirEntry>> {
+            // GetFileInformationByHandleEx does not itself require FILE_LIST_DIRECTORY.
+            // Preserve filesystem access semantics by remembering whether this handle was
+            // successfully opened with list rights instead of letting the query API bypass them.
+            if !self.can_list {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "directory was opened without list permission",
+                ));
+            }
+
+            // Directory enumeration has cursor state on the Windows file object. Every call
+            // restarts explicitly, and clones of this Dir serialize enumeration so two callers
+            // cannot reset each other's cursor mid-scan. Relative child opens do not use this
+            // cursor and therefore do not need the lock.
+            let _enumeration_guard = self
+                .enumeration_lock
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let readable_handle = self.raw_handle();
+            const BUFFER_BYTES: usize = 64 * 1024;
+            const WORDS: usize = BUFFER_BYTES / size_of::<u64>();
+            const NAME_OFFSET: usize = offset_of!(FILE_FULL_DIR_INFO, FileName);
+
+            // FILE_FULL_DIR_INFO requires 8-byte alignment. A u64 allocation provides that.
+            let mut storage = vec![0_u64; WORDS];
+            let mut entries = Vec::new();
+            let mut restart = true;
+
+            loop {
+                storage.fill(0);
+                let class = if restart {
+                    FileFullDirectoryRestartInfo
+                } else {
+                    FileFullDirectoryInfo
+                };
+                restart = false;
+
+                // SAFETY: `storage` is writable, 8-byte aligned, and lives for the call.
+                // GetFileInformationByHandleEx advances enumeration state on this handle.
+                let ok = unsafe {
+                    GetFileInformationByHandleEx(
+                        readable_handle,
+                        class,
+                        storage.as_mut_ptr().cast(),
+                        BUFFER_BYTES as u32,
+                    )
+                };
+                if ok == 0 {
+                    // SAFETY: GetLastError immediately follows the failed Win32 call.
+                    let error = unsafe { GetLastError() };
+                    if error == ERROR_NO_MORE_FILES {
+                        break;
+                    }
+                    return Err(io::Error::from_raw_os_error(error as i32));
+                }
+
+                let base = storage.as_ptr().cast::<u8>();
+                let mut offset = 0usize;
+                loop {
+                    if offset > BUFFER_BYTES.saturating_sub(NAME_OFFSET) {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "invalid directory entry returned by GetFileInformationByHandleEx",
+                        ));
+                    }
+
+                    // SAFETY: base is 8-byte aligned and every documented NextEntryOffset is
+                    // 8-byte aligned; bounds are checked before reading variable data.
+                    let info = unsafe { &*base.add(offset).cast::<FILE_FULL_DIR_INFO>() };
+                    let name_len = info.FileNameLength as usize;
+                    let record_end = offset
+                        .checked_add(NAME_OFFSET)
+                        .and_then(|end| end.checked_add(name_len));
+                    if !name_len.is_multiple_of(size_of::<u16>())
+                        || record_end.is_none_or(|end| end > BUFFER_BYTES)
+                    {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "invalid filename returned by GetFileInformationByHandleEx",
+                        ));
+                    }
+
+                    // SAFETY: validation above proves the UTF-16 filename lies in the buffer.
+                    let name = unsafe {
+                        let ptr = base.add(offset + NAME_OFFSET).cast::<u16>();
+                        OsString::from_wide(slice::from_raw_parts(ptr, name_len / size_of::<u16>()))
+                    };
+                    if name != "." && name != ".." {
+                        let attributes = info.FileAttributes;
+                        let kind = if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                            EntryKind::NeedsLookup
+                        } else if attributes & FILE_ATTRIBUTE_DIRECTORY != 0 {
+                            EntryKind::Directory
+                        } else {
+                            EntryKind::NonDirectory
+                        };
+                        entries.push(DirEntry { name, kind });
+                    }
+
+                    let next = info.NextEntryOffset as usize;
+                    if next == 0 {
+                        break;
+                    }
+                    if !next.is_multiple_of(8)
+                        || next < NAME_OFFSET
+                        || offset
+                            .checked_add(next)
+                            .is_none_or(|next_offset| next_offset >= BUFFER_BYTES)
+                    {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "invalid directory entry offset returned by GetFileInformationByHandleEx",
+                        ));
+                    }
+                    offset += next;
+                }
+            }
+
+            Ok(entries)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Dir;
+
+    #[test]
+    fn entries_restart_from_the_beginning() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let root = temp.path().join("root");
+        std::fs::create_dir_all(&root).expect("create root");
+        for name in ["a", "b", "c"] {
+            std::fs::write(root.join(name), b"fixture").expect("create fixture");
+        }
+
+        let dir = Dir::open(&root).expect("open root handle");
+        let collect = || {
+            let mut names: Vec<_> = dir
+                .entries()
+                .expect("enumerate directory")
+                .into_iter()
+                .map(|entry| entry.file_name().to_owned())
+                .collect();
+            names.sort();
+            names
+        };
+
+        assert_eq!(collect(), ["a", "b", "c"]);
+        assert_eq!(collect(), ["a", "b", "c"]);
+    }
+
+    #[test]
+    fn handle_relative_traversal_survives_root_rename() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let root = temp.path().join("root");
+        let moved = temp.path().join("moved");
+        std::fs::create_dir_all(root.join("child/grandchild")).expect("create fixture");
+
+        let handle = Dir::open(&root).expect("open root handle");
+        std::fs::rename(&root, &moved).expect("rename open root");
+        assert!(!root.exists());
+
+        let names: Vec<_> = handle
+            .entries()
+            .expect("enumerate renamed directory by handle")
+            .into_iter()
+            .map(|entry| entry.file_name().to_owned())
+            .collect();
+        assert!(names.iter().any(|name| name == "child"));
+
+        let child = handle
+            .open_dir("child".as_ref())
+            .expect("open child relative to renamed root handle");
+        assert!(
+            child
+                .entries()
+                .expect("enumerate child")
+                .iter()
+                .any(|entry| entry.file_name() == "grandchild")
+        );
+    }
+}

--- a/crates/nu-cli/src/completions/directory_handle.rs
+++ b/crates/nu-cli/src/completions/directory_handle.rs
@@ -97,9 +97,17 @@ mod platform {
             file: std::fs::File,
             enumeration_lock: Mutex<()>,
         },
-        // Search-only directories cannot be opened for reading. Keep the O_PATH/O_SEARCH
-        // descriptor so exact known-name traversal still works through them.
+        // Search-only directories cannot be opened for reading. Most Unix targets keep an
+        // O_PATH/O_SEARCH descriptor so exact known-name traversal still works through them.
+        #[cfg(not(target_os = "openbsd"))]
         TraverseOnly(OwnedFd),
+        // OpenBSD exposes neither O_PATH nor O_SEARCH. Retain the last readable anchor and the
+        // exact suffix below it; each known child retries openat() with the growing suffix.
+        #[cfg(target_os = "openbsd")]
+        TraverseOnly {
+            anchor: Arc<std::fs::File>,
+            suffix: std::path::PathBuf,
+        },
     }
 
     fn io_error(error: Errno) -> io::Error {
@@ -136,7 +144,7 @@ mod platform {
 
     #[cfg(all(
         unix,
-        not(any(target_os = "linux", target_os = "android")),
+        not(any(target_os = "linux", target_os = "android", target_os = "openbsd")),
         not(any(
             target_vendor = "apple",
             target_os = "solaris",
@@ -164,14 +172,27 @@ mod platform {
             }))
         }
 
+        #[cfg(not(target_os = "openbsd"))]
         fn traverse_only(fd: OwnedFd) -> Self {
             Self(Arc::new(DirInner::TraverseOnly(fd)))
         }
 
+        #[cfg(target_os = "openbsd")]
+        fn traverse_only(anchor: Arc<std::fs::File>, suffix: std::path::PathBuf) -> Self {
+            Self(Arc::new(DirInner::TraverseOnly { anchor, suffix }))
+        }
+
+        #[cfg(not(target_os = "openbsd"))]
         fn should_try_traverse_only(error: Errno) -> bool {
             traversal_flags() != readable_flags() && matches!(error, Errno::EACCES | Errno::EPERM)
         }
 
+        #[cfg(target_os = "openbsd")]
+        fn should_try_traverse_only(error: Errno) -> bool {
+            matches!(error, Errno::EACCES | Errno::EPERM)
+        }
+
+        #[cfg(not(target_os = "openbsd"))]
         fn open_traverse_only(path: &Path, readable_error: Errno) -> io::Result<Self> {
             if !Self::should_try_traverse_only(readable_error) {
                 return Err(io_error(readable_error));
@@ -181,6 +202,31 @@ mod platform {
                 .map_err(io_error)
         }
 
+        #[cfg(target_os = "openbsd")]
+        fn open_traverse_only(path: &Path, readable_error: Errno) -> io::Result<Self> {
+            if !Self::should_try_traverse_only(readable_error) {
+                return Err(io_error(readable_error));
+            }
+
+            // An unreadable root path has no usable directory descriptor on OpenBSD. Anchor it at
+            // `/` and retain the exact absolute suffix instead. Descendants retry that suffix with
+            // openat(), which is O(depth²) across an execute-only run but needs no helper process.
+            let absolute = if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                std::env::current_dir()?.join(path)
+            };
+            let suffix = absolute
+                .strip_prefix(Path::new("/"))
+                .unwrap_or(&absolute)
+                .to_path_buf();
+            let anchor = open(Path::new("/"), readable_flags(), Mode::empty()).map_err(io_error)?;
+            Ok(Self::traverse_only(
+                Arc::new(std::fs::File::from(anchor)),
+                suffix,
+            ))
+        }
+
         pub(super) fn open(path: &Path) -> io::Result<Self> {
             match open(path, readable_flags(), Mode::empty()) {
                 Ok(fd) => Ok(Self::readable(fd)),
@@ -188,6 +234,7 @@ mod platform {
             }
         }
 
+        #[cfg(not(target_os = "openbsd"))]
         fn open_dir_from<Fd: std::os::fd::AsFd>(parent: Fd, name: &OsStr) -> io::Result<Self> {
             match openat(&parent, name, readable_flags(), Mode::empty()) {
                 Ok(fd) => Ok(Self::readable(fd)),
@@ -200,10 +247,49 @@ mod platform {
             }
         }
 
+        #[cfg(target_os = "openbsd")]
+        fn open_dir_from_readable(parent: &std::fs::File, name: &OsStr) -> io::Result<Self> {
+            match openat(parent, name, readable_flags(), Mode::empty()) {
+                Ok(fd) => Ok(Self::readable(fd)),
+                Err(error) if Self::should_try_traverse_only(error) => Ok(Self::traverse_only(
+                    Arc::new(parent.try_clone()?),
+                    std::path::PathBuf::from(name),
+                )),
+                Err(error) => Err(io_error(error)),
+            }
+        }
+
+        #[cfg(target_os = "openbsd")]
+        fn open_dir_from_suffix(
+            anchor: &Arc<std::fs::File>,
+            suffix: &Path,
+            name: &OsStr,
+        ) -> io::Result<Self> {
+            let next = suffix.join(name);
+            match openat(anchor.as_ref(), &next, readable_flags(), Mode::empty()) {
+                Ok(fd) => Ok(Self::readable(fd)),
+                Err(error) if Self::should_try_traverse_only(error) => {
+                    Ok(Self::traverse_only(Arc::clone(anchor), next))
+                }
+                Err(error) => Err(io_error(error)),
+            }
+        }
+
+        #[cfg(not(target_os = "openbsd"))]
         pub(super) fn open_dir(&self, name: &OsStr) -> io::Result<Self> {
             match &*self.0 {
                 DirInner::Readable { file, .. } => Self::open_dir_from(file, name),
                 DirInner::TraverseOnly(fd) => Self::open_dir_from(fd, name),
+            }
+        }
+
+        #[cfg(target_os = "openbsd")]
+        pub(super) fn open_dir(&self, name: &OsStr) -> io::Result<Self> {
+            match &*self.0 {
+                DirInner::Readable { file, .. } => Self::open_dir_from_readable(file, name),
+                DirInner::TraverseOnly { anchor, suffix } => {
+                    Self::open_dir_from_suffix(anchor, suffix, name)
+                }
             }
         }
 
@@ -224,11 +310,21 @@ mod platform {
                     let mut dir = NixDir::from_fd(duplicate).map_err(io_error)?;
                     collect_entries(&mut dir)
                 }
+                #[cfg(not(target_os = "openbsd"))]
                 DirInner::TraverseOnly(fd) => {
                     // Permissions may have changed since this handle was opened, so retain the old
                     // behavior of attempting a readable view when enumeration is actually needed.
                     let mut dir = NixDir::openat(fd, ".", readable_flags(), Mode::empty())
                         .map_err(io_error)?;
+                    collect_entries(&mut dir)
+                }
+                #[cfg(target_os = "openbsd")]
+                DirInner::TraverseOnly { anchor, suffix } => {
+                    // Retrying the accumulated suffix also observes permission changes: once the
+                    // final directory becomes readable, enumeration resumes through a normal fd.
+                    let mut dir =
+                        NixDir::openat(anchor.as_ref(), suffix, readable_flags(), Mode::empty())
+                            .map_err(io_error)?;
                     collect_entries(&mut dir)
                 }
             }
@@ -563,6 +659,43 @@ mod tests {
 
         assert_eq!(collect(), ["a", "b", "c"]);
         assert_eq!(collect(), ["a", "b", "c"]);
+    }
+
+    #[cfg(target_os = "openbsd")]
+    #[test]
+    fn openbsd_growing_suffix_traverses_execute_only_chain() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let root = temp.path().join("root");
+        let first = root.join("first");
+        let second = first.join("second");
+        let readable = second.join("readable");
+        std::fs::create_dir_all(readable.join("target")).expect("create fixture");
+        std::fs::set_permissions(&first, std::fs::Permissions::from_mode(0o111))
+            .expect("make first execute-only");
+        std::fs::set_permissions(&second, std::fs::Permissions::from_mode(0o111))
+            .expect("make second execute-only");
+
+        let result = (|| -> std::io::Result<()> {
+            let handle = Dir::open(&root)?;
+            let first = handle.open_dir("first".as_ref())?;
+            let second = first.open_dir("second".as_ref())?;
+            let readable = second.open_dir("readable".as_ref())?;
+            assert!(
+                readable
+                    .entries()?
+                    .iter()
+                    .any(|entry| entry.file_name() == "target")
+            );
+            Ok(())
+        })();
+
+        std::fs::set_permissions(&second, std::fs::Permissions::from_mode(0o700))
+            .expect("restore second permissions");
+        std::fs::set_permissions(&first, std::fs::Permissions::from_mode(0o700))
+            .expect("restore first permissions");
+        result.expect("traverse execute-only chain with growing suffix");
     }
 
     #[test]

--- a/crates/nu-cli/src/completions/mod.rs
+++ b/crates/nu-cli/src/completions/mod.rs
@@ -8,6 +8,7 @@ mod completion_common;
 mod completion_options;
 mod custom_completions;
 mod directory_completions;
+mod directory_handle;
 mod dotnu_completions;
 mod env_var_completions;
 mod exportable_completions;

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -17,6 +17,8 @@ use nu_std::load_standard_library;
 use nu_test_support::fs;
 use reedline::{Completer, Span, Suggestion};
 use rstest::{fixture, rstest};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use support::{
     completions_helpers::{
         new_dotnu_engine, new_engine_helper, new_external_engine, new_partial_engine,
@@ -1566,6 +1568,47 @@ fn file_completions() {
 
     // Match the results
     match_suggestions(&expected_paths, &suggestions)
+}
+
+#[cfg(unix)]
+#[test]
+fn file_completions_traverse_unreadable_exact_parent_components() {
+    struct RestorePermissions(std::path::PathBuf);
+
+    impl Drop for RestorePermissions {
+        fn drop(&mut self) {
+            if self.0.exists() {
+                let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o700));
+            }
+        }
+    }
+
+    let (_, _, engine, stack) = new_engine();
+    let test_dir = tempfile::tempdir().expect("create tempdir");
+    let unreadable_parent = test_dir.path().join("unreadable");
+    let traversable_child = unreadable_parent.join("child");
+    let target = traversable_child.join("target");
+    std::fs::create_dir_all(&target).expect("create completion fixture");
+
+    let _restore_permissions = RestorePermissions(unreadable_parent.clone());
+    std::fs::set_permissions(&unreadable_parent, std::fs::Permissions::from_mode(0o111))
+        .expect("make parent execute-only");
+
+    if unreadable_parent.read_dir().is_ok() {
+        // The test is only meaningful when the platform enforces execute-only directories.
+        return;
+    }
+
+    // Exact traversal through the unreadable parent still works, just like `ls` on the
+    // complete path does on Android's /data/data/... hierarchy.
+    assert!(traversable_child.read_dir().is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let target_dir = format!("cp {}", folder(&traversable_child));
+    let suggestions = completer.complete(&target_dir, target_dir.len());
+    let expected_paths = [folder(&target)];
+
+    match_suggestions_by_string(&expected_paths, &suggestions);
 }
 
 #[test]

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -19,6 +19,8 @@ use nu_std::load_standard_library;
 use nu_test_support::prelude::*;
 use reedline::{Completer, CompletionResult, Span, Suggestion, Suggestions};
 use rstest::{fixture, rstest};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use support::{
     completions_helpers::{
         new_dotnu_engine, new_engine_helper, new_external_engine, new_partial_engine,
@@ -260,6 +262,21 @@ fn misc_custom_completions(
 ) {
     let suggestions = completer_strings.complete_blocking(input, pos.unwrap_or(input.len()));
     match_suggestions(&expected, &suggestions);
+}
+
+#[test]
+fn command_completion_prefers_case_sensitive_match() {
+    let (_, _, mut engine, mut stack) = new_engine();
+    let setup = r#"
+        def "test-test" [] {}
+        def "test-Test" [] {}
+        $env.config.completions.case_sensitive = false
+    "#;
+    assert!(support::merge_input(setup.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let suggestions = completer.complete_blocking("test-t", 6);
+    match_suggestions(&vec!["test-test", "test-Test"], &suggestions);
 }
 
 /// $env.config should be overridden by the custom completer's options
@@ -2028,6 +2045,50 @@ fn file_completions() {
 
     // Match the results
     match_suggestions(&expected_paths, &suggestions)
+}
+
+#[cfg(unix)]
+#[test]
+fn file_completions_traverse_unreadable_exact_parent_components() {
+    Playground::setup(
+        "file_completions_traverse_unreadable_exact_parent_components",
+        |dirs, playground| {
+            playground.mkdir("unreadable/child/target");
+
+            let unreadable_parent = dirs.test().join("unreadable");
+            let traversable_child = unreadable_parent.join("child");
+            let target = traversable_child.join("target");
+            std::fs::set_permissions(&unreadable_parent, std::fs::Permissions::from_mode(0o111))
+                .expect("make parent execute-only");
+
+            if unreadable_parent.read_dir().is_ok() {
+                std::fs::set_permissions(
+                    &unreadable_parent,
+                    std::fs::Permissions::from_mode(0o700),
+                )
+                .expect("restore parent permissions");
+                panic!("execute-only directory remained readable; permission test is invalid");
+            }
+
+            assert!(
+                traversable_child.read_dir().is_ok(),
+                "known child should remain traversable through execute-only parent"
+            );
+
+            let tester = test().cwd(dirs.test());
+            let mut completer =
+                NuCompleter::new(Arc::new(tester.engine_state), Arc::new(tester.stack));
+            let input = format!("cp {}", folder(&traversable_child));
+            let suggestions = completer.complete_blocking(&input, input.len());
+            let expected_paths = [folder(&target)];
+
+            // Restore before assertions so Playground can always clean up the tree.
+            std::fs::set_permissions(&unreadable_parent, std::fs::Permissions::from_mode(0o700))
+                .expect("restore parent permissions");
+
+            match_suggestions_by_string(&expected_paths, &suggestions);
+        },
+    );
 }
 
 #[test]
@@ -3946,11 +4007,13 @@ fn exact_match_case_insensitive() {
         let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
         let target = format!("open {}", folder(dir.join("aa")));
+        // Case-insensitive matching still includes all three paths, but the two
+        // candidates that also match `aa` with exact case are ranked first.
         match_suggestions(
             &vec![
-                folder(dir.join("AA").join("foo")).as_str(),
                 folder(dir.join("aa").join("foo")).as_str(),
                 folder(dir.join("aaa").join("foo")).as_str(),
+                folder(dir.join("AA").join("foo")).as_str(),
             ],
             &completer.complete_blocking(&target, target.len()),
         );


### PR DESCRIPTION
## Description

Fix path completion so exact paths can traverse directories that are searchable but cannot be listed, such as `/data/data/...` on Android/Termux.

Path traversal is now handle-relative on Unix and Windows instead of repeatedly rebuilding descendant paths. The completer also uses arena-backed path state and avoids several unnecessary matcher allocations and repeated match computations.

This preserves exact entry spelling and platform case-sensitivity semantics while improving deep and wide path completion.

## User-facing changes

- Path completion works through searchable but unlistable parent directories.
- Deep and wide path completion is more efficient.
- Case-insensitive completions rank exact-case matches first (#16608).

