### PR TITLE
fix type comparisons between `table` and `list<oneof>`

### DIFF
--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -371,6 +371,10 @@ fn table_with_record_error() -> Result {
 }
 
 #[test]
+#[ignore = "\
+    After relaxing type checking of table and `list<oneof<record, ...>>` \
+    this is a runtime error, which is checked by the following test.\
+"]
 fn list_not_table_parse_time_error() -> Result {
     let code = "
         [{a: 1 b: 2} {a: 3 b: 4} 1]

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -885,7 +885,13 @@ impl PipelineData {
 
 impl CompareTypes<Type> for PipelineData {
     fn compare_types(&self, other: &Type) -> Option<TypeRelation> {
-        self.get_type().compare_types(other)
+        let self_ty = match self {
+            PipelineData::Empty => Type::Nothing,
+            PipelineData::ListStream(_, _) => Type::list(Type::Any),
+            PipelineData::ByteStream(stream, _) => stream.type_().into(),
+            PipelineData::Value(value, _) => return value.compare_types(other),
+        };
+        self_ty.compare_types(other)
     }
 
     /// Determine if the `PipelineData` can be assigned to `other`.
@@ -903,7 +909,13 @@ impl CompareTypes<Type> for PipelineData {
     /// A `ByteStream` is a subtype of [`string`](Type::String) if it is coercible into a string.
     /// Likewise, a `ByteStream` is a subtype of [`binary`](Type::Binary) if it is coercible into a binary value.
     fn is_assignable_to(&self, dst: &Type) -> bool {
-        self.get_type().is_assignable_to(dst)
+        let self_ty = match self {
+            PipelineData::Empty => Type::Nothing,
+            PipelineData::ListStream(_, _) => Type::list(Type::Any),
+            PipelineData::ByteStream(stream, _) => stream.type_().into(),
+            PipelineData::Value(value, _) => return value.is_assignable_to(dst),
+        };
+        self_ty.is_assignable_to(dst)
     }
 }
 

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -287,12 +287,12 @@ impl CompareTypes for Type {
             (Type::Table(table_cols), Type::List(list_elem)) => match list_elem.as_ref() {
                 Type::Any => Some(TypeRelation::Subtype),
                 Type::Record(record_cols) => table_cols.compare_types(record_cols),
-                _ => None,
+                ty => Type::Record(table_cols.clone()).compare_types(ty),
             },
             (Type::List(list_elem), Type::Table(table_cols)) => match list_elem.as_ref() {
                 Type::Any => Some(TypeRelation::Supertype),
                 Type::Record(record_cols) => record_cols.compare_types(table_cols),
-                _ => None,
+                ty => ty.compare_types(&Type::Record(table_cols.clone())),
             },
 
             (Type::OneOf(lhs_oneof), Type::OneOf(rhs_oneof)) => lhs_oneof.compare_types(rhs_oneof),
@@ -325,16 +325,16 @@ impl CompareTypes for Type {
     fn is_assignable_to(&self, dst: &Self) -> bool {
         let src = self;
         match (dst, src) {
-            (Type::Table(dst_cols), Type::List(src_ty))
-                if let Type::Record(src_cols) = src_ty.as_ref() =>
-            {
-                src_cols.is_assignable_to(dst_cols)
-            }
-            (Type::List(dst_ty), Type::Table(src_cols))
-                if let Type::Record(dst_cols) = dst_ty.as_ref() =>
-            {
-                src_cols.is_assignable_to(dst_cols)
-            }
+            (Type::Table(dst_cols), Type::List(src_ty)) => match src_ty.as_ref() {
+                Type::Any => true,
+                Type::Record(src_cols) => src_cols.is_assignable_to(dst_cols),
+                src_ty => src_ty.is_assignable_to(&Type::Record(dst_cols.clone())),
+            },
+            (Type::List(dst_ty), Type::Table(src_cols)) => match dst_ty.as_ref() {
+                Type::Any => true,
+                Type::Record(dst_cols) => src_cols.is_assignable_to(dst_cols),
+                dst_ty => Type::Record(src_cols.clone()).is_assignable_to(dst_ty),
+            },
             (Type::List(dst_ty), Type::List(src_ty)) => src_ty.is_assignable_to(dst_ty.as_ref()),
             (Type::Record(dst_cols), Type::Record(src_cols))
             | (Type::Table(dst_cols), Type::Table(src_cols)) => src_cols.is_assignable_to(dst_cols),

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -469,6 +469,22 @@ mod tests {
                 }
             }
         }
+
+        #[test]
+        fn table_list_oneof_covariance() {
+            let columns = CollectionColumns::<Type>::default();
+
+            let single_ty = Type::Record(columns.clone());
+            let union_ty = Type::one_of([Type::Number, Type::Record(columns.clone())]);
+
+            let direct_cmp = union_ty.compare_types(&single_ty);
+            let list_cmp = Type::list(union_ty.clone()).compare_types(&Type::list(single_ty));
+
+            let table_cmp = Type::list(union_ty).compare_types(&Type::Table(columns));
+
+            assert_eq!(list_cmp, direct_cmp);
+            assert_eq!(table_cmp, list_cmp);
+        }
     }
 
     mod oneof {


### PR DESCRIPTION
## User-facing changes (Release notes)

- Type checking treats `table` and `list<record>` as compatible (provided the columns aren't disjoint), but that did not extend to `list<oneof<record, ...>>`. This has been fixed.
- Runtime type checking of *non-stream* pipeline data is now more accurate.

## Additional notes

- closes #18557