### PR TITLE
fix: `uname` signature, and add detailed column info

### DIFF
--- a/crates/nu-command/src/system/uname.rs
+++ b/crates/nu-command/src/system/uname.rs
@@ -13,7 +13,20 @@ impl Command for UName {
 
     fn signature(&self) -> Signature {
         Signature::build("uname")
-            .input_output_types(vec![(Type::Nothing, Type::table())])
+            .input_output_types(vec![(
+                Type::Nothing,
+                Type::Record(
+                    vec![
+                        ("kernel-name".into(), Type::String),
+                        ("nodename".into(), Type::String),
+                        ("kernel-release".into(), Type::String),
+                        ("kernel-version".into(), Type::String),
+                        ("machine".into(), Type::String),
+                        ("operating-system".into(), Type::String),
+                    ]
+                    .into(),
+                ),
+            )])
             .category(Category::System)
     }
 


### PR DESCRIPTION
## User-facing changes (Release notes)

- Fixed `uname`'s output type signature to match its actual output.
  Previously it was `table`, now it's `record<...>` and also includes its columns.

## Additional notes
- closes #18562