### PR TITLE
perf: avoid cloning binary values

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -400,6 +400,36 @@ fn create_example_table_nrows(n: usize) -> String {
     s
 }
 
+fn bench_binary_value_clone(bytes: usize) -> impl IntoBenchmarks {
+    let name = format!("binary_value_clone_{bytes}b");
+    [benchmark_fn(name, move |b| {
+        let value = Value::test_binary(vec![0; bytes]);
+        b.iter(move || {
+            black_box(value.clone());
+        })
+    })]
+}
+
+fn bench_binary_slice_into_int(bytes: usize, reads: usize) -> impl IntoBenchmarks {
+    let (mut stack, engine) = setup_stack_and_engine_from_command(
+        "def bench-u16 [data: binary offset: int] {
+    $data | bytes at $offset..<($offset + 2) | into int --endian big
+}
+let binary = 0x[]",
+    );
+    let binary_id = StateWorkingSet::new(&engine)
+        .find_variable(b"binary")
+        .expect("must exist");
+    stack.add_var(binary_id, Value::test_binary(vec![0; bytes]));
+
+    bench_command(
+        format!("binary_slice_into_int_{bytes}b_{reads}_reads"),
+        format!("0..<{reads} | each {{|offset| bench-u16 $binary $offset }} | math sum | ignore"),
+        stack,
+        engine,
+    )
+}
+
 fn bench_record_create(n: usize) -> impl IntoBenchmarks {
     bench_command(
         format!("record_create_{n}"),
@@ -1013,6 +1043,9 @@ tango_benchmarks!(
     bench_parser_full_parse("medium", parser_input_medium()),
     bench_parser_full_parse("large", parser_input_large()),
     // Data types
+    // Binary
+    bench_binary_value_clone(2 * 1024 * 1024),
+    bench_binary_slice_into_int(2 * 1024 * 1024, 100),
     // Record
     bench_record_create(1),
     bench_record_create(10),

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -430,6 +430,25 @@ let binary = 0x[]",
     )
 }
 
+fn bench_binary_skip_shared_half(bytes: usize, reads: usize) -> impl IntoBenchmarks {
+    let (mut stack, engine) = setup_stack_and_engine_from_command("let binary = 0x[]");
+    let binary_id = StateWorkingSet::new(&engine)
+        .find_variable(b"binary")
+        .expect("must exist");
+    // Keep the original in the stack so each `$binary` lookup exercises shared backing storage.
+    stack.add_var(binary_id, Value::test_binary(vec![0; bytes]));
+
+    bench_command(
+        format!("binary_skip_shared_{bytes}b_half_{reads}_reads"),
+        format!(
+            "0..<{reads} | each {{ $binary | skip {} | ignore }} | ignore",
+            bytes / 2
+        ),
+        stack,
+        engine,
+    )
+}
+
 fn bench_record_create(n: usize) -> impl IntoBenchmarks {
     bench_command(
         format!("record_create_{n}"),
@@ -1046,6 +1065,7 @@ tango_benchmarks!(
     // Binary
     bench_binary_value_clone(2 * 1024 * 1024),
     bench_binary_slice_into_int(2 * 1024 * 1024, 100),
+    bench_binary_skip_shared_half(2 * 1024 * 1024, 100),
     // Record
     bench_record_create(1),
     bench_record_create(10),

--- a/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/bits.rs
@@ -223,7 +223,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
     match input {
         Value::Binary { val, .. } => {
             let mut raw_string = "".to_string();
-            for ch in val {
+            for ch in val.iter() {
                 write!(raw_string, "{ch:08b} ").expect("writing to a String is infallible");
             }
             Value::string(raw_string.trim(), span)

--- a/crates/nu-command/src/bytes/build_.rs
+++ b/crates/nu-command/src/bytes/build_.rs
@@ -52,7 +52,10 @@ impl Command for BytesBuild {
         for val in call.rest::<Value>(engine_state, stack, 0)? {
             let val_span = val.span();
             match val {
-                Value::Binary { mut val, .. } => output.append(&mut val),
+                Value::Binary { val, .. } => {
+                    let mut val = val.into_owned();
+                    output.append(&mut val);
+                }
                 Value::Int { val, .. } => {
                     let byte: u8 = val.try_into().map_err(|_| ShellError::IncorrectValue {
                         msg: format!("{val} is out of range for byte"),

--- a/crates/nu-command/src/bytes/collect.rs
+++ b/crates/nu-command/src/bytes/collect.rs
@@ -60,7 +60,7 @@ impl Command for BytesCollect {
                     }),
                 })
             }),
-            Ok(separator).transpose(),
+            separator.map(|separator| Ok(separator.into())),
         )
         .flatten();
 

--- a/crates/nu-command/src/charting/hashable_value.rs
+++ b/crates/nu-command/src/charting/hashable_value.rs
@@ -98,7 +98,7 @@ impl HashableValue {
                 span: val_span,
             }),
             Value::Binary { val, .. } => Ok(HashableValue::Binary {
-                val,
+                val: val.into_owned(),
                 span: val_span,
             }),
 

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -300,7 +300,6 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         Value::Binary { val, .. } => {
             use byteorder::{BigEndian, ByteOrder, LittleEndian};
 
-            let mut val = val.to_vec();
             let size = val.len();
 
             if size == 0 {
@@ -319,24 +318,12 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
             }
 
             match (endian, signed) {
-                (Endian::Little, true) => Value::int(LittleEndian::read_int(&val, size), head),
-                (Endian::Big, true) => Value::int(BigEndian::read_int(&val, size), head),
+                (Endian::Little, true) => Value::int(LittleEndian::read_int(val, size), head),
+                (Endian::Big, true) => Value::int(BigEndian::read_int(val, size), head),
                 (Endian::Little, false) => {
-                    while val.len() < 8 {
-                        val.push(0);
-                    }
-                    val.resize(8, 0);
-
-                    Value::int(LittleEndian::read_i64(&val), head)
+                    Value::int(LittleEndian::read_uint(val, size) as i64, head)
                 }
-                (Endian::Big, false) => {
-                    while val.len() < 8 {
-                        val.insert(0, 0);
-                    }
-                    val.resize(8, 0);
-
-                    Value::int(BigEndian::read_i64(&val), head)
-                }
+                (Endian::Big, false) => Value::int(BigEndian::read_uint(val, size) as i64, head),
             }
         }
         // Propagate errors by explicitly matching them before the final case.

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -447,7 +447,7 @@ pub fn value_to_sql(
         Value::Duration { val, .. } => Ok(Box::new(val)),
         Value::Date { val, .. } => Ok(Box::new(val)),
         Value::String { val, .. } => Ok(Box::new(val)),
-        Value::Binary { val, .. } => Ok(Box::new(val)),
+        Value::Binary { val, .. } => Ok(Box::new(val.into_owned())),
         Value::Nothing { .. } => Ok(Box::new(rusqlite::types::Null)),
         val => {
             let span = val.span();

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -334,7 +334,7 @@ fn convert_to_extension(
 fn value_to_bytes(value: Value) -> Result<Vec<u8>, ShellError> {
     match value {
         Value::String { val, .. } => Ok(val.into_bytes()),
-        Value::Binary { val, .. } => Ok(val),
+        Value::Binary { val, .. } => Ok(val.into_owned()),
         Value::List { vals, .. } => {
             let val = vals
                 .into_iter()

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -150,7 +150,8 @@ fn first_helper(
                         Ok(Value::list(vals, span).into_pipeline_data_with_metadata(input_meta))
                     }
                 }
-                Value::Binary { mut val, .. } => {
+                Value::Binary { val, .. } => {
+                    let mut val = val.into_owned();
                     // A slice (or single byte as int) is not the whole file/stream; drop MIME.
                     let binary_meta = input_meta.map(|m| m.with_content_type(None));
                     if return_single_element {

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -151,7 +151,6 @@ fn first_helper(
                     }
                 }
                 Value::Binary { val, .. } => {
-                    let mut val = val.into_owned();
                     // A slice (or single byte as int) is not the whole file/stream; drop MIME.
                     let binary_meta = input_meta.map(|m| m.with_content_type(None));
                     if return_single_element {
@@ -166,6 +165,7 @@ fn first_helper(
                             Ok(Value::nothing(head).into_pipeline_data_with_metadata(binary_meta))
                         }
                     } else {
+                        let mut val = val.into_owned();
                         val.truncate(rows);
                         Ok(Value::binary(val, span).into_pipeline_data_with_metadata(binary_meta))
                     }

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -171,10 +171,9 @@ impl Command for Last {
                         }
                     }
                     Value::Binary { val, .. } => {
-                        let mut val = val.into_owned();
                         let binary_meta = metadata.map(|m| m.with_content_type(None));
                         if return_single_element {
-                            if let Some(val) = val.pop() {
+                            if let Some(&val) = val.last() {
                                 Ok(Value::int(val.into(), span)
                                     .into_pipeline_data_with_metadata(binary_meta))
                             } else if strict_mode {
@@ -186,6 +185,7 @@ impl Command for Last {
                                     .into_pipeline_data_with_metadata(binary_meta))
                             }
                         } else {
+                            let mut val = val.into_owned();
                             let i = val.len().saturating_sub(rows);
                             val.drain(..i);
                             Ok(Value::binary(val, span)

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -170,7 +170,8 @@ impl Command for Last {
                             Ok(Value::list(vals, span).into_pipeline_data_with_metadata(metadata))
                         }
                     }
-                    Value::Binary { mut val, .. } => {
+                    Value::Binary { val, .. } => {
+                        let mut val = val.into_owned();
                         let binary_meta = metadata.map(|m| m.with_content_type(None));
                         if return_single_element {
                             if let Some(val) = val.pop() {

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -125,7 +125,10 @@ impl Command for Skip {
                 }
             }
             PipelineData::Value(Value::Binary { val, .. }, metadata) => {
-                let bytes = val.into_owned().into_iter().skip(n).collect::<Vec<_>>();
+                let bytes = match val.try_into_owned() {
+                    Ok(bytes) => bytes.into_iter().skip(n).collect(),
+                    Err(val) => val.as_slice().get(n..).unwrap_or_default().to_vec(),
+                };
                 // if we've skipped over n (greater than 0) amount of binary data and we're
                 // looking at y bytes, the data is really no longer a png image, it's just
                 // some raw bytes. so, in that case there's no need to still have a

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -125,7 +125,7 @@ impl Command for Skip {
                 }
             }
             PipelineData::Value(Value::Binary { val, .. }, metadata) => {
-                let bytes = val.into_iter().skip(n).collect::<Vec<_>>();
+                let bytes = val.into_owned().into_iter().skip(n).collect::<Vec<_>>();
                 // if we've skipped over n (greater than 0) amount of binary data and we're
                 // looking at y bytes, the data is really no longer a png image, it's just
                 // some raw bytes. so, in that case there's no need to still have a

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -60,7 +60,8 @@ impl Command for Take {
                             metadata,
                         )),
                     Value::Binary { val, .. } => {
-                        let slice: Vec<u8> = val.into_iter().take(rows_desired).collect();
+                        let slice: Vec<u8> =
+                            val.into_owned().into_iter().take(rows_desired).collect();
                         Ok(PipelineData::value(
                             Value::binary(slice, span),
                             // first 5 bytes of an image/png stream are not image/png themselves

--- a/crates/nu-command/src/formats/from/sheets.rs
+++ b/crates/nu-command/src/formats/from/sheets.rs
@@ -45,7 +45,7 @@ pub(super) fn collect_binary(
 ) -> Result<Cursor<Vec<u8>>, ShellError> {
     let buf = match input {
         // Deserialize from a byte buffer
-        PipelineData::Value(Value::Binary { val: bytes, .. }, _) => Ok(bytes),
+        PipelineData::Value(Value::Binary { val: bytes, .. }, _) => Ok(bytes.into_owned()),
         // Deserialize from a raw stream directly without having to collect it
         PipelineData::ByteStream(stream, ..) => stream.into_bytes(),
         input => Err(ShellError::PipelineMismatch {

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -691,9 +691,12 @@ fn send_default_request(
     signals: &Signals,
 ) -> Result<Response, ShellErrorOrRequestError> {
     match body {
-        Value::Binary { val, .. } => {
-            send_cancellable_request(request_url, Box::new(move || req.send(&val)), span, signals)
-        }
+        Value::Binary { val, .. } => send_cancellable_request(
+            request_url,
+            Box::new(move || req.send(val.as_slice())),
+            span,
+            signals,
+        ),
         Value::String { val, .. } => {
             send_cancellable_request(request_url, Box::new(move || req.send(&val)), span, signals)
         }

--- a/crates/nu-command/src/strings/base/mod.rs
+++ b/crates/nu-command/src/strings/base/mod.rs
@@ -80,7 +80,7 @@ fn get_binary(input: PipelineData, call_span: Span) -> Result<(Vec<u8>, Span), S
         PipelineData::Value(val, ..) => {
             let span = val.span();
             match val {
-                Value::Binary { val, .. } => Ok((val, span)),
+                Value::Binary { val, .. } => Ok((val.into_owned(), span)),
                 Value::String { val, .. } => Ok((val.into_bytes(), span)),
 
                 value => Err(ShellError::TypeMismatch {

--- a/crates/nu-command/src/strings/encode_decode/decode.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode.rs
@@ -126,7 +126,9 @@ fn run(
             let input_span = v.span();
             match v {
                 Value::Binary { val: bytes, .. } => match encoding {
-                    Some(encoding_name) => detect_and_decode(encoding_name, head, bytes),
+                    Some(encoding_name) => {
+                        detect_and_decode(encoding_name, head, bytes.into_owned())
+                    }
                     None => super::encoding::detect_encoding_name(head, input_span, &bytes)
                         .map(|encoding| encoding.decode(&bytes).0.into_owned())
                         .map(|s| Value::string(s, head)),

--- a/crates/nu-command/tests/commands/conversions/into/int.rs
+++ b/crates/nu-command/tests/commands/conversions/into/int.rs
@@ -8,6 +8,9 @@ fn convert_back_and_forth() -> Result {
 
 #[test]
 fn convert_into_int_little_endian() -> Result {
+    let code = "0x[00 ff] | into int --endian little";
+    test().run(code).expect_value_eq(65280)?;
+
     let code = "0x[01 00 00 00 00 00 00 00] | into int --endian little";
     test().run(code).expect_value_eq(1)?;
 
@@ -17,6 +20,9 @@ fn convert_into_int_little_endian() -> Result {
 
 #[test]
 fn convert_into_int_big_endian() -> Result {
+    let code = "0x[ff 00] | into int --endian big";
+    test().run(code).expect_value_eq(65280)?;
+
     let code = "0x[00 00 00 00 00 00 00 01] | into int --endian big";
     test().run(code).expect_value_eq(1)?;
 
@@ -26,6 +32,9 @@ fn convert_into_int_big_endian() -> Result {
 
 #[test]
 fn convert_into_signed_int_little_endian() -> Result {
+    let code = "0x[00 ff] | into int --endian little --signed";
+    test().run(code).expect_value_eq(-256)?;
+
     let code = "0x[ff 00 00 00 00 00 00 00] | into int --endian little --signed";
     test().run(code).expect_value_eq(255)?;
 
@@ -35,9 +44,12 @@ fn convert_into_signed_int_little_endian() -> Result {
 
 #[test]
 fn convert_into_signed_int_big_endian() -> Result {
-    let code = "0x[00 00 00 00 00 00 00 ff] | into int --endian big";
+    let code = "0x[ff 00] | into int --endian big --signed";
+    test().run(code).expect_value_eq(-256)?;
+
+    let code = "0x[00 00 00 00 00 00 00 ff] | into int --endian big --signed";
     test().run(code).expect_value_eq(255)?;
 
-    let code = "0x[ff 00 00 00 00 00 00 00] | into int --endian big";
+    let code = "0x[ff 00 00 00 00 00 00 00] | into int --endian big --signed";
     test().run(code).expect_value_eq(-72057594037927936_i64)
 }

--- a/crates/nu-explore/src/explore/mod.rs
+++ b/crates/nu-explore/src/explore/mod.rs
@@ -93,7 +93,7 @@ fn help_view() -> Option<Page> {
 
 fn binary_view(input: PipelineData, config: &ExploreConfig) -> Result<Page> {
     let data = match input {
-        PipelineData::Value(Value::Binary { val, .. }, _) => val,
+        PipelineData::Value(Value::Binary { val, .. }, _) => val.into_owned(),
         PipelineData::ByteStream(bs, _) => bs.into_bytes()?,
         _ => unreachable!("checked beforehand"),
     };

--- a/crates/nu-explore/src/explore_config/conversion.rs
+++ b/crates/nu-explore/src/explore_config/conversion.rs
@@ -621,7 +621,7 @@ mod tests {
                 data
             );
             if let nu_protocol::Value::Binary { val, .. } = data {
-                assert_eq!(val, &vec![0u8, 1, 2, 255]);
+                assert_eq!(val.as_slice(), &[0u8, 1, 2, 255]);
             }
         } else {
             panic!("Expected Record");

--- a/crates/nu-plugin-core/src/serializers/tests.rs
+++ b/crates/nu-plugin-core/src/serializers/tests.rs
@@ -328,6 +328,32 @@ macro_rules! generate_tests {
         }
 
         #[test]
+        fn response_round_trip_binary_value() {
+            let value = Value::binary(vec![0, 1, 0x80, 0xff], Span::new(2, 30));
+
+            let response = PluginCallResponse::value(value.clone());
+            let output = PluginOutput::CallResponse(4, response);
+
+            let encoder = $encoder;
+            let mut buffer = Vec::new();
+            encoder
+                .encode(&output, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginOutput::CallResponse(
+                    4,
+                    PluginCallResponse::PipelineData(PipelineDataHeader::Value(returned_value, _)),
+                ) => assert_eq!(value, returned_value),
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
         fn response_round_trip_plugin_custom_value() {
             let name = "test";
 

--- a/crates/nu-plugin/src/plugin/interface/mod.rs
+++ b/crates/nu-plugin/src/plugin/interface/mod.rs
@@ -792,7 +792,7 @@ impl EngineInterface {
     pub fn get_span_contents(&self, span: Span) -> Result<Vec<u8>, ShellError> {
         match self.engine_call(EngineCall::GetSpanContents(span))? {
             EngineCallResponse::PipelineData(PipelineData::Value(Value::Binary { val, .. }, _)) => {
-                Ok(val)
+                Ok(val.into_owned())
             }
             _ => Err(ShellError::PluginFailedToDecode {
                 msg: "Received unexpected response type for EngineCall::GetSpanContents".into(),

--- a/crates/nu-protocol/src/engine/pattern_match.rs
+++ b/crates/nu-protocol/src/engine/pattern_match.rs
@@ -116,7 +116,7 @@ impl Matcher for Pattern {
                     }
                     Expr::Binary(x) => {
                         if let Value::Binary { val, .. } = &value {
-                            x == val
+                            x.as_slice() == val.as_slice()
                         } else {
                             false
                         }

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -328,9 +328,12 @@ impl ByteStream {
         .with_known_size(Some(len as u64))
     }
 
-    /// Create a [`ByteStream`] from a byte vector. The type of the stream is always `Binary`.
-    pub fn read_binary(bytes: Vec<u8>, span: Span, signals: Signals) -> Self {
-        let len = bytes.len();
+    /// Create a [`ByteStream`] from binary data. The type of the stream is always `Binary`.
+    pub fn read_binary<T>(bytes: T, span: Span, signals: Signals) -> Self
+    where
+        T: AsRef<[u8]> + Send + 'static,
+    {
+        let len = bytes.as_ref().len();
         ByteStream::read(Cursor::new(bytes), span, signals, ByteStreamType::Binary)
             .with_known_size(Some(len as u64))
     }
@@ -1245,6 +1248,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nu_utils::SharedCow;
 
     fn test_chunks<T>(data: Vec<T>, type_: ByteStreamType) -> Chunks
     where
@@ -1275,6 +1279,15 @@ mod tests {
             bins_values,
             iter.collect::<Result<Vec<Value>, _>>().expect("error")
         );
+    }
+
+    #[test]
+    fn read_binary_shares_data() {
+        let data = SharedCow::new(vec![0, 1, 2, 3]);
+        let stream = ByteStream::read_binary(data.clone(), Span::test_data(), Signals::empty());
+
+        assert_eq!(SharedCow::ref_count(&data), 2);
+        assert_eq!(stream.into_bytes().expect("error"), data.as_slice());
     }
 
     #[test]

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -351,7 +351,9 @@ impl PipelineData {
                     ),
                     Value::Binary { val, .. } => PipelineIteratorInner::ListStream(
                         ListStream::new(
-                            val.into_iter().map(move |x| Value::int(x as i64, val_span)),
+                            val.into_owned()
+                                .into_iter()
+                                .map(move |x| Value::int(x as i64, val_span)),
                             val_span,
                             Signals::empty(),
                         )
@@ -770,7 +772,7 @@ impl PipelineData {
         if let PipelineData::Value(Value::Binary { val: bytes, .. }, _) = self {
             if to_stderr {
                 write_all_and_flush(
-                    bytes,
+                    bytes.as_slice(),
                     &mut std::io::stderr().lock(),
                     "stderr",
                     span,
@@ -778,7 +780,7 @@ impl PipelineData {
                 )?;
             } else {
                 write_all_and_flush(
-                    bytes,
+                    bytes.as_slice(),
                     &mut std::io::stdout().lock(),
                     "stdout",
                     span,
@@ -1103,7 +1105,7 @@ where
 fn value_to_bytes(value: Value) -> Result<Vec<u8>, ShellError> {
     let bytes = match value {
         Value::String { val, .. } => val.into_bytes(),
-        Value::Binary { val, .. } => val,
+        Value::Binary { val, .. } => val.into_owned(),
         Value::List { vals, .. } => {
             let val = vals
                 .into_iter()

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -557,7 +557,7 @@ impl FromValue for String {
 impl FromValue for Vec<u8> {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         match v {
-            Value::Binary { val, .. } => Ok(val),
+            Value::Binary { val, .. } => Ok(val.into_owned()),
             Value::String { val, .. } => Ok(val.into_bytes()),
             Value::List { vals, .. } => {
                 const U8MIN: i64 = u8::MIN as i64;
@@ -876,7 +876,7 @@ where
 impl FromValue for bytes::Bytes {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         match v {
-            Value::Binary { val, .. } => Ok(val.into()),
+            Value::Binary { val, .. } => Ok(val.into_owned().into()),
             v => Err(ShellError::CantConvert {
                 to_type: Self::expected_type().to_string(),
                 from_type: v.get_type().to_string(),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -5678,6 +5678,20 @@ mod tests {
         }
 
         #[test]
+        fn mutation_is_copy_on_write() {
+            let value = Value::test_binary(vec![1, 2, 3]);
+            let mut clone = value.clone();
+
+            let Value::Binary { val, .. } = &mut clone else {
+                unreachable!();
+            };
+            val.to_mut()[0] = 4;
+
+            assert_eq!(value.as_binary(), Ok([1, 2, 3].as_slice()));
+            assert_eq!(clone.as_binary(), Ok([4, 2, 3].as_slice()));
+        }
+
+        #[test]
         fn into_binary_preserves_shared_value() {
             let value = Value::test_binary(vec![1, 2, 3]);
             let clone = value.clone();

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -188,7 +188,7 @@ pub enum Value {
     },
     #[non_exhaustive]
     Binary {
-        val: Vec<u8>,
+        val: SharedCow<Vec<u8>>,
         /// note: spans are being refactored out of Value
         /// please use .span() instead of matching this span value
         #[serde(rename = "span")]
@@ -370,7 +370,7 @@ impl Debug for Value {
             Value::List { vals, .. } => wrap_tuple("List", vals).fmt(f),
             Value::Closure { val, .. } => wrap_tuple("Closure", val.compact_debug()).fmt(f),
             Value::Error { error, .. } => wrap_tuple("Error", error).fmt(f),
-            Value::Binary { val, .. } => wrap_tuple("Binary", BStr::new(val)).fmt(f),
+            Value::Binary { val, .. } => wrap_tuple("Binary", BStr::new(val.as_slice())).fmt(f),
             Value::CellPath { val, .. } => wrap_tuple("CellPath", display_as_debug(val)).fmt(f),
             Value::Custom { val, .. } => wrap_tuple("Custom", val).fmt(f),
             Value::Nothing { .. } => write!(f, "Nothing"),
@@ -720,7 +720,7 @@ impl Value {
             Value::Float { val, .. } => Ok(val.to_string()),
             Value::String { val, .. } => Ok(val),
             Value::Glob { val, .. } => Ok(val),
-            Value::Binary { val, .. } => match String::from_utf8(val) {
+            Value::Binary { val, .. } => match String::from_utf8(val.into_owned()) {
                 Ok(s) => Ok(s),
                 Err(err) => Value::binary(err.into_bytes(), span).cant_convert_to("string"),
             },
@@ -821,7 +821,7 @@ impl Value {
     /// Unwraps the inner binary `Vec` or returns an error if this `Value` is not a binary value
     pub fn into_binary(self) -> Result<Vec<u8>, ShellError> {
         if let Value::Binary { val, .. } = self {
-            Ok(val)
+            Ok(val.into_owned())
         } else {
             self.cant_convert_to("binary")
         }
@@ -870,7 +870,7 @@ impl Value {
     /// ```
     pub fn coerce_into_binary(self) -> Result<Vec<u8>, ShellError> {
         match self {
-            Value::Binary { val, .. } => Ok(val),
+            Value::Binary { val, .. } => Ok(val.into_owned()),
             Value::String { val, .. } => Ok(val.into_bytes()),
             val => val.cant_convert_to("binary"),
         }
@@ -1974,7 +1974,7 @@ impl Value {
 
     pub fn binary(val: impl Into<Vec<u8>>, span: Span) -> Value {
         Value::Binary {
-            val: val.into(),
+            val: SharedCow::new(val.into()),
             internal_span: span,
         }
     }
@@ -5652,6 +5652,39 @@ mod tests {
         assert!(Value::test_glob("*.rs").coerce_bool().is_err());
         assert!(Value::test_binary(vec![1, 2, 3]).coerce_bool().is_err());
         assert!(Value::test_duration(3600).coerce_bool().is_err());
+    }
+
+    mod binary {
+        use super::*;
+        use nu_utils::SharedCow;
+
+        #[test]
+        fn clone_shares_data() {
+            let value = Value::test_binary(vec![1, 2, 3]);
+            let clone = value.clone();
+
+            let (
+                Value::Binary { val, .. },
+                Value::Binary {
+                    val: cloned_val, ..
+                },
+            ) = (&value, &clone)
+            else {
+                unreachable!();
+            };
+
+            assert_eq!(SharedCow::ref_count(val), 2);
+            assert!(std::ptr::eq(val.as_ptr(), cloned_val.as_ptr()));
+        }
+
+        #[test]
+        fn into_binary_preserves_shared_value() {
+            let value = Value::test_binary(vec![1, 2, 3]);
+            let clone = value.clone();
+
+            assert_eq!(clone.into_binary(), Ok(vec![1, 2, 3]));
+            assert_eq!(value.as_binary(), Ok([1, 2, 3].as_slice()));
+        }
     }
 
     mod memory_size {

--- a/crates/nu-utils/src/shared_cow.rs
+++ b/crates/nu-utils/src/shared_cow.rs
@@ -111,3 +111,9 @@ impl<T: Clone> ops::Deref for SharedCow<T> {
         &self.0
     }
 }
+
+impl<T: Clone> AsRef<[T]> for SharedCow<Vec<T>> {
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}

--- a/crates/nu-utils/src/shared_cow.rs
+++ b/crates/nu-utils/src/shared_cow.rs
@@ -17,12 +17,19 @@ impl<T: Clone> SharedCow<T> {
         SharedCow(Arc::new(value))
     }
 
+    /// Take ownership of the shared value if it has no other references.
+    ///
+    /// If the value is still shared, returns this [`SharedCow`] unchanged without cloning its
+    /// contents.
+    pub fn try_into_owned(self: SharedCow<T>) -> Result<T, SharedCow<T>> {
+        Arc::try_unwrap(self.0).map_err(SharedCow)
+    }
+
     /// Take an exclusive clone of the shared value, or move and take ownership if it wasn't shared.
     pub fn into_owned(self: SharedCow<T>) -> T {
-        // Optimized: if the Arc is not shared, just unwraps the Arc
-        match Arc::try_unwrap(self.0) {
+        match self.try_into_owned() {
             Ok(value) => value,
-            Err(arc) => (*arc).clone(),
+            Err(shared) => (*shared.0).clone(),
         }
     }
 
@@ -115,5 +122,37 @@ impl<T: Clone> ops::Deref for SharedCow<T> {
 impl<T: Clone> AsRef<[T]> for SharedCow<Vec<T>> {
     fn as_ref(&self) -> &[T] {
         self.as_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_into_owned_returns_unique_value() {
+        let value = vec![1, 2, 3];
+        let original_ptr = value.as_ptr();
+        let shared = SharedCow::new(value);
+
+        let Ok(owned) = shared.try_into_owned() else {
+            panic!("value should be uniquely owned");
+        };
+
+        assert_eq!(owned.as_ptr(), original_ptr);
+    }
+
+    #[test]
+    fn try_into_owned_returns_shared_value_without_cloning() {
+        let shared = SharedCow::new(vec![1, 2, 3]);
+        let original_ptr = shared.as_ptr();
+        let clone = shared.clone();
+
+        let Err(still_shared) = clone.try_into_owned() else {
+            panic!("value should still be shared");
+        };
+
+        assert_eq!(still_shared.as_ptr(), original_ptr);
+        assert_eq!(SharedCow::ref_count(&still_shared), 2);
     }
 }

--- a/crates/nu_plugin_formats/src/to/plist.rs
+++ b/crates/nu_plugin_formats/src/to/plist.rs
@@ -67,7 +67,7 @@ fn convert_nu_value(nu_val: &NuValue) -> Result<PlistValue, LabeledError> {
         NuValue::Bool { val, .. } => Ok(PlistValue::Boolean(*val)),
         NuValue::Float { val, .. } => Ok(PlistValue::Real(*val)),
         NuValue::Int { val, .. } => Ok(PlistValue::Integer((*val).into())),
-        NuValue::Binary { val, .. } => Ok(PlistValue::Data(val.to_owned())),
+        NuValue::Binary { val, .. } => Ok(PlistValue::Data(val.to_vec())),
         NuValue::Record { val, .. } => convert_nu_dict(val),
         NuValue::List { vals, .. } => Ok(PlistValue::Array(
             vals.iter()

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -200,7 +200,7 @@ fn value_to_string(
     match v {
         Value::Binary { val, .. } => {
             let mut s = String::with_capacity(2 * val.len());
-            for byte in val {
+            for byte in val.iter() {
                 if write!(s, "{byte:02X}").is_err() {
                     return Err(ShellError::UnsupportedInput {
                         msg: "could not convert binary to string".into(),


### PR DESCRIPTION
## Description

Store binary `Value`s in `SharedCow<Vec<u8>>` so clones share their backing allocation until mutation.

We use that storage when creating byte streams, and read binary input directly in `into int` without cloning or padding it.

Also add tests for copy-on-write behavior, shared byte streams, plugin serialization, endian conversions, and generic Tango benchmarks.

## User-facing changes (Release notes)
### Faster large binary value processing
Large binary values are now substantially cheaper to clone, stream, slice, and convert.

Commands that repeatedly process large binary values now avoid copying the entire value at each step, with repeated slicing and integer conversion roughly 3.4x faster.

## Additional notes

Tango results from 100 paired samples against upstream `main` (https://github.com/nushell/nushell/commit/e8424fe6af516a78cc5fb833f8e91dcda9678148).

| Benchmark | Reference | Patched | Change |
|---|---:|---:|---:|
| `binary_value_clone_2097152b` | 41.3 µs | 11.9 ns | -99.97%, ~3,500x faster (lol) |
| `binary_slice_into_int_2097152b_100_reads` | 14.2 ms | 4.1 ms | -70.73%, 3.4x faster |
| `binary_skip_shared_2097152b_half_100_reads` | 28.2 ms | 20.0 ms | -28.94%, 1.4x faster |

A separate fixed-seed run produced consistent results: 43.1 µs → 12.3 ns and 13.9 ms → 4.3 ms.