### PR TITLE
Fix inconsistent closure argument in `update`, `insert`, and `upsert`

### DIFF
--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -317,17 +317,19 @@ fn insert_single_value_by_closure(
     cell_path: &[PathMember],
     cell_value_as_arg: bool,
 ) -> Result<(), ShellError> {
-    // FIXME: this leads to inconsistent behaviors between
-    // `{a: b} | insert c {|x| print $x}` and
-    // `[{a: b}] | insert 0.c {|x| print $x}`
     let arg = if cell_value_as_arg {
-        value
-            .follow_cell_path(cell_path)
-            .map(Cow::into_owned)
-            .unwrap_or(Value::nothing(span))
+        if matches!(cell_path.first(), Some(PathMember::String { .. })) {
+            value.clone()
+        } else {
+            value
+                .follow_cell_path(cell_path)
+                .map(Cow::into_owned)
+                .unwrap_or(Value::nothing(span))
+        }
     } else {
         value.clone()
     };
+
     let new_value = closure.run_with_value(arg)?.into_value(span)?;
     value.insert_data_at_cell_path(cell_path, new_value, span)
 }

--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -131,6 +131,14 @@ When inserting into a specific index, the closure will instead get the current v
                     )),
                 ])),
             },
+            Example {
+                description: "Use a closure to insert a value at a nested path. The row is passed as the closure argument.",
+                example: "[{a: 1}] | insert 0.b {|row| $row.a + 1 }",
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                    "a" => Value::test_int(1),
+                    "b" => Value::test_int(2),
+                })])),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -432,11 +432,12 @@ fn update_single_value_by_closure(
         return Ok(());
     }
 
-    // FIXME: this leads to inconsistent behaviors between
-    // `{a: b} | update a {|x| print $x}` and
-    // `[{a: b}] | update 0.a {|x| print $x}`
     let arg = if cell_value_as_arg {
-        value_at_path.as_ref()
+        if matches!(cell_path.first(), Some(PathMember::String { .. })) {
+            &*value
+        } else {
+            value_at_path.as_ref()
+        }
     } else {
         &*value
     };

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -98,6 +98,14 @@ When updating a specific index, the closure will instead be run once. The first 
                     Value::test_int(3),
                 ])),
             },
+            Example {
+                description: "Use a closure to update a value at a nested path. The row is passed as the closure argument.",
+                example: "[{a: 1, b: 2}] | update 0.a {|row| $row.b }",
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                    "a" => Value::test_int(2),
+                    "b" => Value::test_int(2),
+                })])),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -353,14 +353,15 @@ fn upsert_single_value_by_closure(
 ) -> Result<(), ShellError> {
     let value_at_path = value.follow_cell_path(cell_path);
 
-    // FIXME: this leads to inconsistent behaviors between
-    // `{a: b} | upsert a {|x| print $x}` and
-    // `[{a: b}] | upsert 0.a {|x| print $x}`
     let arg = if cell_value_as_arg {
-        value_at_path
-            .as_deref()
-            .cloned()
-            .unwrap_or(Value::nothing(span))
+        if matches!(cell_path.first(), Some(PathMember::String { .. })) {
+            value.clone()
+        } else {
+            value_at_path
+                .as_deref()
+                .cloned()
+                .unwrap_or(Value::nothing(span))
+        }
     } else {
         value.clone()
     };

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -161,6 +161,14 @@ If the command is inserting at the end of a list or table, then both of these va
                     )),
                 ])),
             },
+            Example {
+                description: "Use a closure to upsert a value at a nested path. The row is passed as the closure argument.",
+                example: "[{a: 1}] | upsert 0.b {|row| $row.a + 1 }",
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                    "a" => Value::test_int(1),
+                    "b" => Value::test_int(2),
+                })])),
+            },
         ]
     }
 }


### PR DESCRIPTION
## Description
In this PR, I fixed the FIXME comment in [update.rs](https://github.com/nushell/nushell/blob/main/crates/nu-command/src/stor/update.rs#L21), [insert.rs](https://github.com/nushell/nushell/blob/main/crates/nu-command/src/filters/insert.rs#L320) and [upsert.rs](https://github.com/nushell/nushell/blob/main/crates/nu-command/src/filters/upsert.rs#L356).
The comment highlights the following problem:
It is inconsistent what gets passed as the closure argument depending on how you access the data.

2 Cases, different behavior: 

Case 1: `{a: b} | update a {|x| print $x}`
- Input is a single record, which is piped directly 
- The path starts with a string (a)
- cell_value_as_arg is false, so &*value which means the entire record is passed to the closure 
- $in receives the value b
```bash
{a: b} | update a {|x| print $"arg: ($x)"; print $"in: ($in)"; $in}
arg: {a: b}
in: b
```

Case 2: `[{a: b}] | update 0.a {|x| print $x}`
- Input is a list with a record 
- The path starts with an int (0), followed by a string (.a) and cell_value_as_arg true
- arg = value_at_path.as_ref() which means only b is passed to the closure 
- $in receives the value b
```bash
[{a: b}] | update 0.a {|x| print $"arg: ($x)"; print $"in: ($in)";}
arg: b
in: b
```

So the inconsistency was: in case 1, $x = the whole row {a: b}, but in case 2, $x = just the cell value b
insert and upsert contain the same problem. 

**My fix:**
Instead of always passing the cell value as argument, I added a check:
if the remaining path is a column access ( starts with a string), pass the row as argument. 

I used the same approach to fix insert, update and upsert. 

**`update.rs`** after my fix:
```bash
[{a: b}] | update 0.a {|x| print $"arg: ($x)"; print $"in: ($in)";}
arg: {a: b}
in: b
```


## User-facing changes (Release notes)
update, insert, and upsert are now consistent in what they pass as the closure's argument.