### PR TITLE
Bump pin of transient dependency causing unsound transmute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"


### PR DESCRIPTION
## Description

A transient dependency of the Nushell polars plugin (ethnum) had an unsound transmute between types of different sizes. This was fixed in a patch release, but the 0.114.1 release of Nushell had the old version of the transitive dependency pinned in the lock file. This introduces the potential bug into Nushell.

This bumps the pinned version of just the one affected transient dependency without messing with the entire dependency tree.

Note this was *discovered* by attempting to build with the current Rust stable toolchain (1.97.0) but that's only because the new toolchain includes a check for this problem. The problem existed before but earlier toolchains didn't catch the bug and just silently compile the bad code.

## User-facing changes (Release notes)

No user facing changes.

## Additional notes

Closes #18578

See also https://github.com/pola-rs/polars/issues/27863.
