### PR TITLE
Allow PluginCommand::get_dynamic_completion() to use EngineInterface::get_plugin_config()

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1,6 +1,7 @@
 pub mod support;
 
 use std::{
+    collections::HashMap,
     fs::{ReadDir, read_dir},
     path::MAIN_SEPARATOR,
     sync::Arc,
@@ -11,7 +12,7 @@ use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_path::{AbsolutePathBuf, expand_tilde};
 use nu_protocol::{
-    Config, ParseError, PipelineData, debugger::WithoutDebug, engine::StateWorkingSet,
+    Config, ParseError, PipelineData, Value, debugger::WithoutDebug, engine::StateWorkingSet,
 };
 use nu_std::load_standard_library;
 use nu_test_support::fs;
@@ -76,6 +77,21 @@ fn completer() -> NuCompleter {
     // Add record value as example
     let record = "def tst [--mod -s] {}";
     assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    // Config for plugin fake-cmd
+    let plugin_config = Value::test_record(nu_protocol::record! {
+        "completion" => Value::test_string("from fake-cmd plugin config"),
+    });
+
+    let mut plugins = HashMap::default();
+    plugins.insert("fake-cmd".to_string(), plugin_config);
+
+    let config = Config {
+        plugins,
+        ..Default::default()
+    };
+
+    engine.set_config(config);
 
     // Instantiate a new completer
     NuCompleter::new(Arc::new(engine), Arc::new(stack))
@@ -198,6 +214,7 @@ fn fuzzy_alpha_sort_completer() -> NuCompleter {
 #[case::dynamic_short_flag_value("fake-cmd arg0:0 -f ", None, vec!["flag:0", "flag:1", "flag:2"])]
 #[case::dynamic_1st_positional("fake-cmd -f flag:0 ", None, vec!["arg0:0"])]
 #[case::dynamic_2nd_positional("fake-cmd -f flag:0 foo --unknown ", None, vec!["arg1:0", "arg1:1"])]
+#[case::dynamic_plugin_config("fake-cmd --plugin-config ", None, vec!["from fake-cmd plugin config"])]
 fn misc_command_argument_completions(
     mut completer: NuCompleter,
     #[case] input: &str,

--- a/crates/nu-cli/tests/completions/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/completions/support/completions_helpers.rs
@@ -38,12 +38,18 @@ impl Command for FakeCmd {
                 "Example flag which support auto completion.",
                 Some('f'),
             )
+            .named(
+                "plugin-config",
+                SyntaxShape::Int,
+                "Example flag which support auto completion from plugin config.",
+                None,
+            )
     }
 
     #[expect(deprecated, reason = "example usage")]
     fn get_dynamic_completion(
         &self,
-        _engine_state: &EngineState,
+        engine_state: &EngineState,
         _stack: &mut Stack,
         _call: DynamicCompletionCallRef,
         arg_type: &ArgType,
@@ -83,6 +89,18 @@ impl Command for FakeCmd {
                         })
                         .collect(),
                 ),
+                "plugin-config" => engine_state
+                    .get_plugin_config("fake-cmd")
+                    .and_then(|config| {
+                        config.get_data_by_key("completion").map(|completion| {
+                            vec![DynamicSuggestion {
+                                value: completion.into_string().unwrap_or_else(|_| {
+                                    "fake-cmd plugin config incorrect".to_string()
+                                }),
+                                ..Default::default()
+                            }]
+                        })
+                    }),
                 _ => None,
             },
         })

--- a/crates/nu-plugin-engine/src/context.rs
+++ b/crates/nu-plugin-engine/src/context.rs
@@ -106,27 +106,13 @@ impl PluginExecutionContext for PluginExecutionCommandContext<'_> {
     }
 
     fn get_plugin_config(&self) -> Result<Option<Value>, ShellError> {
-        // Fetch the configuration for a plugin
-        //
-        // The `plugin` must match the registered name of a plugin.  For `plugin add
-        // nu_plugin_example` the plugin config lookup uses `"example"`
-        Ok(self
-            .get_config()?
-            .plugins
-            .get(self.identity.name())
-            .cloned()
-            .map(|value| {
-                let span = value.span();
-                match value {
-                    Value::Closure { val, .. } => {
-                        ClosureEvalOnce::new(&self.engine_state, &self.stack, *val)
-                            .run_with_input(PipelineData::empty())
-                            .and_then(|data| data.into_value(span))
-                            .unwrap_or_else(|err| Value::error(err, self.call.head))
-                    }
-                    _ => value.clone(),
-                }
-            }))
+        Ok(plugin_config(
+            self.get_config()?,
+            self.identity.name(),
+            &self.engine_state,
+            &self.stack,
+            self.call.head,
+        ))
     }
 
     fn get_env_var(&self, name: &str) -> Result<Option<&Value>, ShellError> {
@@ -297,6 +283,29 @@ impl PluginExecutionContext for PluginExecutionCommandContext<'_> {
             call: self.call.to_owned(),
         })
     }
+}
+
+// Fetch the configuration for a plugin
+//
+// The `plugin` must match the registered name of a plugin.  For `plugin add nu_plugin_example` the
+// plugin config lookup uses `"example"`
+fn plugin_config(
+    config: Arc<Config>,
+    plugin_name: &str,
+    engine_state: &EngineState,
+    stack: &Stack,
+    head: Span,
+) -> Option<Value> {
+    config.plugins.get(plugin_name).cloned().map(|value| {
+        let span = value.span();
+        match value {
+            Value::Closure { val, .. } => ClosureEvalOnce::new(engine_state, stack, *val)
+                .run_with_input(PipelineData::empty())
+                .and_then(|data| data.into_value(span))
+                .unwrap_or_else(|err| Value::error(err, head)),
+            _ => value.clone(),
+        }
+    })
 }
 
 /// A bogus execution context for testing that doesn't really implement anything properly

--- a/crates/nu-plugin-engine/src/context.rs
+++ b/crates/nu-plugin-engine/src/context.rs
@@ -1,9 +1,9 @@
 use crate::util::MutableCow;
 use nu_engine::{ClosureEvalOnce, get_eval_block_with_early_return, get_full_help};
-use nu_plugin_protocol::EvaluatedCall;
+use nu_plugin_protocol::{DynamicCompletionCall, EvaluatedCall};
 use nu_protocol::{
-    BlockId, Config, DeclId, IntoSpanned, OutDest, PipelineData, PluginIdentity, ShellError,
-    Signals, Span, Spanned, Value,
+    BlockId, Config, DeclId, DynamicCompletionCallRef, IntoSpanned, OutDest, PipelineData,
+    PluginIdentity, ShellError, Signals, Span, Spanned, Value,
     engine::{Call, Closure, EngineState, Redirection, Stack},
     ir::{self, IrBlock},
     shell_error::generic::GenericError,
@@ -306,6 +306,148 @@ fn plugin_config(
             _ => value.clone(),
         }
     })
+}
+
+/// The execution context of plugin completion.
+///
+/// This supports limited interactions suitable for generating completions from nushell
+/// configuration, the environment, current working directory, or existing help.
+pub struct PluginGetDynamicCompletionContext<'a> {
+    identity: Arc<PluginIdentity>,
+    engine_state: Cow<'a, EngineState>,
+    stack: MutableCow<'a, Stack>,
+    call: DynamicCompletionCall,
+}
+
+impl<'a> PluginGetDynamicCompletionContext<'a> {
+    pub fn new(
+        identity: Arc<PluginIdentity>,
+        engine_state: &'a EngineState,
+        stack: &'a mut Stack,
+        call: &DynamicCompletionCallRef<'a>,
+    ) -> Self {
+        Self {
+            identity,
+            engine_state: Cow::Borrowed(engine_state),
+            stack: MutableCow::Borrowed(stack),
+            call: call.into(),
+        }
+    }
+}
+
+impl PluginExecutionContext for PluginGetDynamicCompletionContext<'_> {
+    fn span(&self) -> Span {
+        self.call.call.head
+    }
+
+    fn signals(&self) -> &Signals {
+        &Signals::EMPTY
+    }
+
+    fn pipeline_externals_state(&self) -> Option<&Arc<(AtomicU32, AtomicU32)>> {
+        Some(&self.engine_state.pipeline_externals_state)
+    }
+
+    fn get_config(&self) -> Result<Arc<Config>, ShellError> {
+        Ok(self.stack.get_config(&self.engine_state))
+    }
+
+    fn get_plugin_config(&self) -> Result<Option<Value>, ShellError> {
+        Ok(plugin_config(
+            self.get_config()?,
+            self.identity.name(),
+            &self.engine_state,
+            &self.stack,
+            self.call.call.head,
+        ))
+    }
+
+    fn get_env_var(&self, name: &str) -> Result<Option<&Value>, ShellError> {
+        Ok(self.stack.get_env_var(&self.engine_state, name))
+    }
+
+    fn get_env_vars(&self) -> Result<HashMap<String, Value>, ShellError> {
+        Ok(self.stack.get_env_vars(&self.engine_state))
+    }
+
+    fn get_current_dir(&self) -> Result<Spanned<String>, ShellError> {
+        let cwd = self.engine_state.cwd_as_string(Some(&self.stack))?;
+        // The span is not really used, so just give it call.head
+        Ok(cwd.into_spanned(self.call.call.head))
+    }
+
+    fn add_env_var(&mut self, _name: String, _value: Value) -> Result<(), ShellError> {
+        Err(ShellError::NushellFailed {
+            msg: "add_env_var not implemented for PluginGetDynamicCompletionContext".into(),
+        })
+    }
+
+    fn get_help(&self) -> Result<Spanned<String>, ShellError> {
+        let decl = self.engine_state.get_decl(self.call.call.decl_id);
+
+        Ok(get_full_help(
+            decl,
+            &self.engine_state,
+            &mut self.stack.clone(),
+            self.call.call.head,
+        )
+        .into_spanned(self.call.call.head))
+    }
+
+    fn get_span_contents(&self, span: Span) -> Result<Spanned<Vec<u8>>, ShellError> {
+        Ok(self
+            .engine_state
+            .get_span_contents(span)
+            .to_vec()
+            .into_spanned(self.call.call.head))
+    }
+
+    fn eval_closure(
+        &self,
+        _closure: Spanned<Closure>,
+        _positional: Vec<Value>,
+        _input: PipelineData,
+        _redirect_stdout: bool,
+        _redirect_stderr: bool,
+    ) -> Result<PipelineData, ShellError> {
+        Err(ShellError::NushellFailed {
+            msg: "eval_closure not implemented for PluginGetDynamicCompletionContext".into(),
+        })
+    }
+
+    fn find_decl(&self, _name: &str) -> Result<Option<DeclId>, ShellError> {
+        Err(ShellError::NushellFailed {
+            msg: "find_decl not implemented for PluginGetDynamicCompletionContext".into(),
+        })
+    }
+
+    fn get_block_ir(&self, _block_id: BlockId) -> Result<IrBlock, ShellError> {
+        Err(ShellError::NushellFailed {
+            msg: "get_block_ir not implemented for PluginGetDynamicCompletionContext".into(),
+        })
+    }
+
+    fn call_decl(
+        &mut self,
+        _decl_id: DeclId,
+        _call: EvaluatedCall,
+        _input: PipelineData,
+        _redirect_stdout: bool,
+        _redirect_stderr: bool,
+    ) -> Result<PipelineData, ShellError> {
+        Err(ShellError::NushellFailed {
+            msg: "call_decl not implemented for PluginGetDynamicCompletionContext".into(),
+        })
+    }
+
+    fn boxed(&self) -> Box<dyn PluginExecutionContext + 'static> {
+        Box::new(PluginGetDynamicCompletionContext {
+            identity: self.identity.clone(),
+            engine_state: Cow::Owned(self.engine_state.clone().into_owned()),
+            stack: self.stack.owned(),
+            call: self.call.to_owned(),
+        })
+    }
 }
 
 /// A bogus execution context for testing that doesn't really implement anything properly

--- a/crates/nu-plugin-engine/src/declaration.rs
+++ b/crates/nu-plugin-engine/src/declaration.rs
@@ -159,10 +159,20 @@ impl Command for PluginDeclaration {
             ArgType::Positional(index) => GetCompletionArgType::Positional(*index),
         };
 
-        plugin.get_dynamic_completion(GetCompletionInfo {
-            name: self.name.clone(),
-            arg_type: arg_info,
-            call: (&call).into(),
-        })
+        let mut context = PluginGetDynamicCompletionContext::new(
+            self.source.identity.clone(),
+            engine_state,
+            stack,
+            &call,
+        );
+
+        plugin.get_dynamic_completion(
+            GetCompletionInfo {
+                name: self.name.clone(),
+                arg_type: arg_info,
+                call: (&call).into(),
+            },
+            &mut context,
+        )
     }
 }

--- a/crates/nu-plugin-engine/src/declaration.rs
+++ b/crates/nu-plugin-engine/src/declaration.rs
@@ -1,13 +1,12 @@
 use nu_engine::{command_prelude::*, get_eval_expression};
-use nu_plugin_protocol::{
-    CallInfo, DynamicCompletionCall, EvaluatedCall, GetCompletionArgType, GetCompletionInfo,
-};
+use nu_plugin_protocol::{CallInfo, EvaluatedCall, GetCompletionArgType, GetCompletionInfo};
 use nu_protocol::engine::ArgType;
 use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{DynamicCompletionCallRef, DynamicSuggestion};
 use nu_protocol::{PluginIdentity, PluginSignature, engine::CommandType};
 use std::sync::Arc;
 
+use crate::context::PluginGetDynamicCompletionContext;
 use crate::{GetPlugin, PluginExecutionCommandContext, PluginSource};
 
 /// The command declaration proxy used within the engine for all plugin commands.
@@ -159,14 +158,11 @@ impl Command for PluginDeclaration {
             ArgType::Flag(flag_name) => GetCompletionArgType::Flag(flag_name.to_string()),
             ArgType::Positional(index) => GetCompletionArgType::Positional(*index),
         };
+
         plugin.get_dynamic_completion(GetCompletionInfo {
             name: self.name.clone(),
             arg_type: arg_info,
-            call: DynamicCompletionCall {
-                call: call.call.clone(),
-                strip: call.strip,
-                pos: call.pos,
-            },
+            call: (&call).into(),
         })
     }
 }

--- a/crates/nu-plugin-engine/src/interface/mod.rs
+++ b/crates/nu-plugin-engine/src/interface/mod.rs
@@ -1009,8 +1009,9 @@ impl PluginInterface {
     pub fn get_dynamic_completion(
         &self,
         info: GetCompletionInfo,
+        context: &mut dyn PluginExecutionContext,
     ) -> Result<Option<Vec<DynamicSuggestion>>, ShellError> {
-        match self.plugin_call(PluginCall::GetCompletion(info), None)? {
+        match self.plugin_call(PluginCall::GetCompletion(info), Some(context))? {
             PluginCallResponse::CompletionItems(items) => Ok(items),
             PluginCallResponse::Error(err) => Err(err),
             _ => Err(ShellError::PluginFailedToDecode {

--- a/crates/nu-plugin-engine/src/interface/tests.rs
+++ b/crates/nu-plugin-engine/src/interface/tests.rs
@@ -1135,20 +1135,23 @@ fn interface_get_dynamic_completion() -> Result<(), ShellError> {
             }])),
         )]
     });
-    let result = interface.get_dynamic_completion(GetCompletionInfo {
-        name: "test".to_string(),
-        arg_type: nu_plugin_protocol::GetCompletionArgType::Flag("test_flag".to_string()),
-        call: DynamicCompletionCall {
-            call: nu_protocol::ast::Call {
-                decl_id: Id::new(3),
-                head: Span::test_data(),
-                arguments: vec![],
-                parser_info: HashMap::new(),
+    let result = interface.get_dynamic_completion(
+        GetCompletionInfo {
+            name: "test".to_string(),
+            arg_type: nu_plugin_protocol::GetCompletionArgType::Flag("test_flag".to_string()),
+            call: DynamicCompletionCall {
+                call: nu_protocol::ast::Call {
+                    decl_id: Id::new(3),
+                    head: Span::test_data(),
+                    arguments: vec![],
+                    parser_info: HashMap::new(),
+                },
+                pos: 0,
+                strip: true,
             },
-            pos: 0,
-            strip: true,
         },
-    })?;
+        &mut PluginExecutionBogusContext,
+    )?;
 
     assert_eq!(
         Some(vec![DynamicSuggestion {
@@ -1157,20 +1160,23 @@ fn interface_get_dynamic_completion() -> Result<(), ShellError> {
         }]),
         result
     );
-    let result = interface.get_dynamic_completion(GetCompletionInfo {
-        name: "test".to_string(),
-        arg_type: nu_plugin_protocol::GetCompletionArgType::Positional(1),
-        call: DynamicCompletionCall {
-            call: nu_protocol::ast::Call {
-                decl_id: Id::new(3),
-                head: Span::test_data(),
-                arguments: vec![],
-                parser_info: HashMap::new(),
+    let result = interface.get_dynamic_completion(
+        GetCompletionInfo {
+            name: "test".to_string(),
+            arg_type: nu_plugin_protocol::GetCompletionArgType::Positional(1),
+            call: DynamicCompletionCall {
+                call: nu_protocol::ast::Call {
+                    decl_id: Id::new(3),
+                    head: Span::test_data(),
+                    arguments: vec![],
+                    parser_info: HashMap::new(),
+                },
+                pos: 0,
+                strip: true,
             },
-            pos: 0,
-            strip: true,
         },
-    })?;
+        &mut PluginExecutionBogusContext,
+    )?;
 
     assert_eq!(
         Some(vec![DynamicSuggestion {

--- a/crates/nu-plugin-protocol/src/lib.rs
+++ b/crates/nu-plugin-protocol/src/lib.rs
@@ -22,10 +22,10 @@ mod tests;
 pub mod test_util;
 
 use nu_protocol::{
-    BlockId, ByteStreamType, Config, DeclId, DynamicSuggestion, LabeledError, PipelineData,
-    PipelineMetadata, PluginMetadata, PluginSignature, ShellError, SignalAction, Span, Spanned,
-    Value, ast,
-    ast::Operator,
+    BlockId, ByteStreamType, Config, DeclId, DynamicCompletionCallRef, DynamicSuggestion,
+    LabeledError, PipelineData, PipelineMetadata, PluginMetadata, PluginSignature, ShellError,
+    SignalAction, Span, Spanned, Value,
+    ast::{self, Operator},
     casing::Casing,
     engine::{ArgType, Closure},
     ir::IrBlock,
@@ -88,6 +88,16 @@ pub struct DynamicCompletionCall {
     pub strip: bool,
     /// The position in input buffer, which is useful to find placeholder from arguments.
     pub pos: usize,
+}
+
+impl From<&DynamicCompletionCallRef<'_>> for DynamicCompletionCall {
+    fn from(call: &DynamicCompletionCallRef<'_>) -> Self {
+        DynamicCompletionCall {
+            call: call.call.clone(),
+            strip: call.strip,
+            pos: call.pos,
+        }
+    }
 }
 
 /// Information about `get_dynamic_completion` of a plugin call invocation.


### PR DESCRIPTION
## Description

Allow `get_plugin_completion()` (0.109.0, #16859) to use plugin configuration (0.90.0, #10955) to generate completions.

Previously `get_dynamic_completion()` could only offer completions from
data that was self-contained within the plugin.

During execution (`run()`) plugins can access their plugin configuration
which may be used for plugin arguments.  (Also, current working
directory, environment variables, and nushell configuration).

Now a plugin's get_dynamic_completion() may access:
* nushell config
* plugin config
* current working directory
* environment
* other help (debatable?)

These `PluginExecutionContext` operations are excluded because they seem unnecessary:
* Add environment variables
* Accessing signals
* eval_closure
* find_decl and call_decl
* get_block_ir

## User-facing changes (Release notes)

N/A

## Additional notes

### Concrete use case

My prometheus plugin ([nu_plugin_prometheus](https://github.com/drbrain/nu_plugin_prometheus)) stores prometheus data sources in the plugin config for use like:

```
"up" | prometheus query -s home
```

The source is a shortcut for:

```
"up" | prometheus query --url https://prometheus.example:9090/
```

The plugin config source also allows storing TLS certificates for mTLS authentication.

As of 0.114.1 an implementation of `get_dynamic_completion()` cannot fetch the plugin config so the source names stored there cannot be used to provide completions.  Attempting to call `get_plugin_config()` fails because there is no `impl PluginExecutionContext` available.

### Refactorings

Added `impl From<&DynamicCompletionRef> for DynamicCompletionCall` to avoid duplicate code (used twice).

Added plugin_config() to avoid duplication in `impl PluginExecutionContext` (used twice).