### PR TITLE
Fix return dropping metadata

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -520,8 +520,8 @@ pub fn eval_block_with_early_return<D: DebugContext>(
     input: PipelineData,
 ) -> Result<PipelineExecutionData, ShellError> {
     match eval_block::<D>(engine_state, stack, block, input) {
-        Err(ShellError::Return { span: _, value }) => Ok(PipelineExecutionData::from(
-            PipelineData::value(*value, None),
+        Err(ShellError::Return { span: _, value, metadata }) => Ok(PipelineExecutionData::from(
+            PipelineData::value(*value, metadata),
         )),
         x => x,
     }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1015,10 +1015,12 @@ fn eval_instruction<D: DebugContext>(
             Ok(Continue)
         }
         Instruction::ReturnEarly { src } => {
+            let metadata = ctx.borrow_reg(*src).metadata_ref().cloned();
             let val = ctx.collect_reg(*src, *span)?;
             Err(ShellError::Return {
                 span: *span,
                 value: Box::new(val),
+                metadata,
             })
         }
         Instruction::Return { src } => Ok(Return(*src)),

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -294,7 +294,7 @@ pub enum ShellError {
         span: Span,
     },
 
-    /// The first value in a pect a single interface to using the`..` range must be compatible with the second one.
+    /// The first value in a `..` range must be compatible with the second one.
     ///
     /// ## Resolution
     ///

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1,10 +1,7 @@
 #![allow(unused_assignments)]
 use super::chained_error::ChainedError;
 use crate::{
-    ConfigError, FromValue, LabeledError, ParseError, Span, Spanned, Type, Value,
-    ast::Operator,
-    engine::{Stack, StateWorkingSet},
-    format_cli_error, record,
+    ConfigError, FromValue, LabeledError, ParseError, PipelineMetadata, Span, Spanned, Type, Value, ast::Operator, engine::{Stack, StateWorkingSet}, format_cli_error, record
 };
 use generic::GenericError;
 use job::JobError;
@@ -297,7 +294,7 @@ pub enum ShellError {
         span: Span,
     },
 
-    /// The first value in a `..` range must be compatible with the second one.
+    /// The first value in a pect a single interface to using the`..` range must be compatible with the second one.
     ///
     /// ## Resolution
     ///
@@ -1176,6 +1173,7 @@ pub enum ShellError {
         #[label("used outside of custom command or closure")]
         span: Span,
         value: Box<Value>,
+        metadata: Option<PipelineMetadata>
     },
 
     /// Exit event, it can still be caught by `try {..} finally {..}` block.


### PR DESCRIPTION
## Description
Fixes #18552 

This PR makes `return` no longer drop metadata, by including it in ShellError::Return


## User-facing changes (Release notes)
`return` no longer drops metadata

