### PR TITLE
Fix default configuration links (#18598)

### DIFF
--- a/.github/workflows/friendly-config-reminder.yml
+++ b/.github/workflows/friendly-config-reminder.yml
@@ -21,5 +21,5 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           Hey, just a bot checking in! You edited files related to the configuration.
-          If you changed any of the default values or added a new config option, don't forget to update the [`doc_config.nu`](https://github.com/nushell/nushell/blob/main/crates/nu-utils/src/default_files/doc_config.nu) which documents the options for our users including the defaults provided by the Rust implementation.
+          If you changed any of the default values or added a new config option, don't forget to update the [`doc_config.nu`](https://github.com/nushell/nushell/blob/main/crates/nu-config/default_files/doc_config.nu) which documents the options for our users including the defaults provided by the Rust implementation.
           If you didn't make a change here, you can just ignore me.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For details about which platforms the Nushell team actively supports, see [our p
 
 ## Configuration
 
-The default configurations can be found at [sample_config](crates/nu-utils/src/default_files)
+The default configurations can be found at [sample_config](crates/nu-config/default_files)
 which are the configuration files one gets when they startup Nushell for the first time.
 
 It sets all of the default configuration to run Nushell.  From here one can


### PR DESCRIPTION
## Description

Update the root README and friendly config reminder workflow to use the current
`crates/nu-config/default_files` location. Both links still pointed to the old
`crates/nu-utils/src/default_files` path.

## User-facing changes (Release notes)

n/a

## Additional notes

Fixes #18598.
