### PR TITLE
ci: pin milestone-action to a full commit SHA

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -15,7 +15,7 @@ jobs:
     name: Milestone Update
     steps:
       - name: Set Milestone for PR
-        uses: hustcer/milestone-action@7b69c4cad6b4ad7a5be55e7704146dfcce59a432 # v3
+        uses: hustcer/milestone-action@v3
         if: github.event.pull_request.merged == true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -15,7 +15,7 @@ jobs:
     name: Milestone Update
     steps:
       - name: Set Milestone for PR
-        uses: hustcer/milestone-action@main
+        uses: hustcer/milestone-action@7b69c4cad6b4ad7a5be55e7704146dfcce59a432 # v3
         if: github.event.pull_request.merged == true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
The `set-milestone` workflow used `hustcer/milestone-action@main` in one step while a later step already used `@v3`. `main` is a moving branch, so this pins that step to a fixed reference. Per @hustcer's preference it now uses the `@v3` release tag — stable now that the workflow has run smoothly for a while — keeping the token-holding step on a reviewed release rather than a moving branch.

## User-facing changes (Release notes)
- n/a

## Additional notes
Thanks @hustcer / @cptpiepmatz for the guidance.
