### PR TITLE
`CompleteResult` type for working with `complete` in tests

### DIFF
--- a/crates/nu-test-support/src/lib.rs
+++ b/crates/nu-test-support/src/lib.rs
@@ -429,7 +429,7 @@
 //! # }
 //! #
 //! # fn main() -> Result {
-//!     let code = r#"nu -n -c 'print -e "cococo"; exit 1' | complete"#
+//!     let code = r#"nu -n -c 'print -e "cococo"; exit 1' | complete"#;
 //!     let result: CompleteResult = test().run(code)?;
 //!
 //!     assert_eq!(result.exit_code, 1);

--- a/crates/nu-test-support/src/lib.rs
+++ b/crates/nu-test-support/src/lib.rs
@@ -420,6 +420,7 @@
 //! ```no_run
 //! # #[macro_use] extern crate nu_test_support;
 //! use nu_test_support::prelude::*;
+//! use nu_test_support::value_types::CompleteResult;
 //!
 //! #[test]
 //! #[deps(NU)]
@@ -428,9 +429,12 @@
 //! # }
 //! #
 //! # fn main() -> Result {
-//!     test()
-//!         .run("nu --testbin cococo")
-//!         .expect_value_eq("cococo")
+//!     let code = r#"nu -n -c 'print -e "cococo"; exit 1' | complete"#
+//!     let result: CompleteResult = test().run(code)?;
+//!
+//!     assert_eq!(result.exit_code, 1);
+//!     assert_eq!(result.stderr, "cococo");
+//!     Ok(())
 //! }
 //! ```
 //!
@@ -594,6 +598,7 @@ pub mod fs;
 pub mod harness;
 pub mod net;
 pub mod playground;
+pub mod value_types;
 
 pub mod deprecated;
 #[doc(no_inline)]
@@ -612,6 +617,7 @@ pub mod prelude {
         nu,
         playground::Playground,
         tester::{Result, ShellErrorExt, TestError as Error, TestResultExt, test},
+        value_types::*,
     };
 
     #[doc(no_inline)]

--- a/crates/nu-test-support/src/value_types.rs
+++ b/crates/nu-test-support/src/value_types.rs
@@ -25,7 +25,7 @@ use nu_protocol::FromValue;
 ///     let exit_code = result["exit_code"].as_int()?;
 ///
 ///     assert_ne!(exit_code, 0);
-///     assert!(stderr.contains("nu::shell::io::file_not_found"));
+///     assert_contains("nu::shell::io::file_not_found", stderr);
 ///
 ///     Ok(())
 /// }
@@ -46,7 +46,7 @@ use nu_protocol::FromValue;
 ///     let result: CompleteResult = test().run("nu non-existent-script.nu | complete")?;
 ///
 ///     assert_ne!(result.exit_code, 0);
-///     assert!(result.stderr.contains("nu::shell::io::file_not_found"));
+///     assert_contains("nu::shell::io::file_not_found", result.stderr);
 ///
 ///     Ok(())
 /// }

--- a/crates/nu-test-support/src/value_types.rs
+++ b/crates/nu-test-support/src/value_types.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::test_attr_in_doctest)]
-
 use nu_protocol::FromValue;
 
 /// Output of the `complete` command as a struct.
@@ -7,14 +5,14 @@ use nu_protocol::FromValue;
 /// Working with external processes in tests often require inspecting all of `stdin`, `stdout` and
 /// the exit code separately.
 /// This is easy to achieve using `complete`:
-/// ```
+/// ```no_run
 /// # #[macro_use] extern crate nu_test_support;
 /// use nu_protocol::Record;
 /// use nu_test_support::prelude::*;
 ///
 /// #[test]
 /// #[deps(NU)]
-/// fn run_non-existent_script() -> Result {
+/// fn run_non_existent_script() -> Result {
 /// #     unimplemented!()
 /// # }
 /// #
@@ -32,13 +30,13 @@ use nu_protocol::FromValue;
 /// ```
 ///
 /// This type exists to avoid repetition and to make it more convenient to work with `complete`:
-/// ```
+/// ```no_run
 /// # #[macro_use] extern crate nu_test_support;
 /// use nu_test_support::prelude::*;
 ///
 /// #[test]
 /// #[deps(NU)]
-/// fn run_non-existent_script() -> Result {
+/// fn run_non_existent_script() -> Result {
 /// #     unimplemented!()
 /// # }
 /// #

--- a/crates/nu-test-support/src/value_types.rs
+++ b/crates/nu-test-support/src/value_types.rs
@@ -1,0 +1,59 @@
+#![expect(clippy::test_attr_in_doctest)]
+
+use nu_protocol::FromValue;
+
+/// Output of the `complete` command as a struct.
+///
+/// Working with external processes in tests often require inspecting all of `stdin`, `stdout` and
+/// the exit code separately.
+/// This is easy to achieve using `complete`:
+/// ```
+/// # #[macro_use] extern crate nu_test_support;
+/// use nu_protocol::Record;
+/// use nu_test_support::prelude::*;
+///
+/// #[test]
+/// #[deps(NU)]
+/// fn run_non-existent_script() -> Result {
+/// #     unimplemented!()
+/// # }
+/// #
+/// # fn main() -> Result {
+///     let result: Record = test().run("nu non-existent-script.nu | complete")?;
+///     let stdout = result["stdout"].as_str()?;
+///     let stderr = result["stdrr"].as_str()?;
+///     let exit_code = result["exit_code"].as_int()?;
+///
+///     assert_ne!(exit_code, 0);
+///     assert!(stderr.contains("nu::shell::io::file_not_found"));
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// This type exists to avoid repetition and to make it more convenient to work with `complete`:
+/// ```
+/// # #[macro_use] extern crate nu_test_support;
+/// use nu_test_support::prelude::*;
+///
+/// #[test]
+/// #[deps(NU)]
+/// fn run_non-existent_script() -> Result {
+/// #     unimplemented!()
+/// # }
+/// #
+/// # fn main() -> Result {
+///     let result: CompleteResult = test().run("nu non-existent-script.nu | complete")?;
+///
+///     assert_ne!(result.exit_code, 0);
+///     assert!(result.stderr.contains("nu::shell::io::file_not_found"));
+///
+///     Ok(())
+/// }
+/// ```
+#[derive(FromValue)]
+pub struct CompleteResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i64,
+}

--- a/tests/plugins/stress_internals.rs
+++ b/tests/plugins/stress_internals.rs
@@ -3,13 +3,6 @@
 
 use nu_test_support::prelude::*;
 
-#[derive(FromValue)]
-struct CompleteResult {
-    pub stdout: String,
-    pub stderr: String,
-    pub exit_code: i64,
-}
-
 const CODE_STRESS_INTERNALS_COMPLETE: &str = r#"
     let plugin_path = (which nu_plugin_stress_internals).path.0
     nu --no-config-file --plugins $plugin_path --commands "stress_internals" | complete


### PR DESCRIPTION
## Description

Added a new `value_types` module under `nu_test_support` for helper types (implementing `FromValue`) to work with output values in tests.

Currently contains a single type, `CompleteResult` for the output of the `complete` command. Makes it easier to work with external processes in tests.

## User-facing changes (Release notes)
N/A