### PR TITLE
Migrate ulimit tests to the new harness (#8670)

### DIFF
--- a/crates/nu-command/tests/commands/ulimit.rs
+++ b/crates/nu-command/tests/commands/ulimit.rs
@@ -1,129 +1,102 @@
 use nu_test_support::nu;
-use nu_test_support::playground::Playground;
 
 #[test]
 fn limit_set_soft1() {
-    Playground::setup("limit_set_soft1", |dirs, _sandbox| {
-        let actual = nu!(cwd: dirs.test(), "
-            let soft = (ulimit -s | first | get soft);
-            ulimit -s -H $soft;
-            let hard = (ulimit -s | first | get hard);
-            $soft == $hard
-        ");
+    let actual = nu!("
+        let soft = (ulimit -s | first | get soft);
+        ulimit -s -H $soft;
+        let hard = (ulimit -s | first | get hard);
+        $soft == $hard
+    ");
 
-        assert!(actual.out.contains("true"));
-    });
+    assert!(actual.out.contains("true"));
 }
 
 #[test]
 fn limit_set_soft2() {
-    Playground::setup("limit_set_soft2", |dirs, _sandbox| {
-        let actual = nu!(cwd: dirs.test(), "
-            let soft = (ulimit -s | first | get soft);
-            ulimit -s -H soft;
-            let hard = (ulimit -s | first | get hard);
-            $soft == $hard
-        ");
+    let actual = nu!("
+        let soft = (ulimit -s | first | get soft);
+        ulimit -s -H soft;
+        let hard = (ulimit -s | first | get hard);
+        $soft == $hard
+    ");
 
-        assert!(actual.out.contains("true"));
-    });
+    assert!(actual.out.contains("true"));
 }
 
 #[test]
 fn limit_set_hard1() {
-    Playground::setup("limit_set_hard1", |dirs, _sandbox| {
-        let actual = nu!(cwd: dirs.test(), "
-            let hard = (ulimit -s | first | get hard);
-            ulimit -s $hard;
-            let soft = (ulimit -s | first | get soft);
-            $soft == $hard
-                   ");
+    let actual = nu!("
+        let hard = (ulimit -s | first | get hard);
+        ulimit -s $hard;
+        let soft = (ulimit -s | first | get soft);
+        $soft == $hard
+    ");
 
-        assert!(actual.out.contains("true"));
-    });
+    assert!(actual.out.contains("true"));
 }
 
 #[test]
 fn limit_set_hard2() {
-    Playground::setup("limit_set_hard2", |dirs, _sandbox| {
-        let actual = nu!(cwd: dirs.test(), "
-            let hard = (ulimit -s | first | get hard);
-            ulimit -s hard;
-            let soft = (ulimit -s | first | get soft);
-            $soft == $hard
-        ");
+    let actual = nu!("
+        let hard = (ulimit -s | first | get hard);
+        ulimit -s hard;
+        let soft = (ulimit -s | first | get soft);
+        $soft == $hard
+    ");
 
-        assert!(actual.out.contains("true"));
-    });
+    assert!(actual.out.contains("true"));
 }
 
 #[test]
 fn limit_set_invalid1() {
-    Playground::setup("limit_set_invalid1", |dirs, _sandbox| {
-        let actual = nu!(cwd: dirs.test(), "
-            let hard = (ulimit -s | first | get hard);
-            match $hard {
-                \"unlimited\" => { echo \"unlimited\" },
-                $x => {
-                    let new = $x + 1;
-                    ulimit -s $new
-                }
+    let actual = nu!("
+        let hard = (ulimit -s | first | get hard);
+        match $hard {
+            \"unlimited\" => { echo \"unlimited\" },
+            $x => {
+                let new = $x + 1;
+                ulimit -s $new
             }
-        ");
+        }
+    ");
 
-        assert!(
-            actual.out.contains("unlimited")
-                || actual.err.contains("EPERM: Operation not permitted")
-        );
-    });
+    assert!(
+        actual.out.contains("unlimited") || actual.err.contains("EPERM: Operation not permitted")
+    );
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
 #[test]
 fn limit_set_invalid2() {
-    Playground::setup("limit_set_invalid2", |dirs, _sandbox| {
-        let actual = nu!(
-            cwd: dirs.test(),
-            "
-                let val = -100;
-                ulimit -c $val
-            "
-        );
+    let actual = nu!("
+        let val = -100;
+        ulimit -c $val
+    ");
 
-        assert!(actual.err.contains("can't convert i64 to rlim_t"));
-    });
+    assert!(actual.err.contains("can't convert i64 to rlim_t"));
 }
 
 #[test]
 fn limit_set_invalid3() {
-    Playground::setup("limit_set_invalid3", |dirs, _sandbox| {
-        let actual = nu!(
-            cwd: dirs.test(),
-            "
-                ulimit -c abcd
-            "
-        );
+    let actual = nu!("
+        ulimit -c abcd
+    ");
 
-        assert!(
-            actual
-                .err
-                .contains("Only unlimited, soft and hard are supported for strings")
-        );
-    });
+    assert!(
+        actual
+            .err
+            .contains("Only unlimited, soft and hard are supported for strings")
+    );
 }
 
 #[test]
 fn limit_set_invalid4() {
-    Playground::setup("limit_set_invalid4", |dirs, _sandbox| {
-        let actual = nu!(
-            cwd: dirs.test(),
-            "
-                ulimit -c 100.0
-            "
-        );
+    let actual = nu!("
+        ulimit -c 100.0
+    ");
 
-        assert!(actual.err.contains("string, int or filesize required"));
-    });
+    assert!(actual.err.contains("string, int or filesize required"));
 }
 
 #[test]
@@ -132,8 +105,8 @@ fn limit_set_invalid5() {
 
     let max = (rlim_t::MAX / 1024) + 1;
 
-    Playground::setup("limit_set_invalid5", |dirs, _sandbox| {
-        let actual = nu!(cwd: dirs.test(), format!(r#"
+    let actual = nu!(format!(
+        r#"
             let hard = (ulimit -c | first | get hard)
             match $hard {{
                 "unlimited" => {{
@@ -147,54 +120,47 @@ fn limit_set_invalid5() {
                     echo "unlimited"
                 }}
             }}
-        "#));
+        "#
+    ));
 
-        assert!(actual.out.eq("unlimited"));
-    });
+    assert!(actual.out.eq("unlimited"));
 }
 
 #[test]
 fn limit_set_filesize1() {
-    Playground::setup("limit_set_filesize1", |dirs, _sandbox| {
-        let actual = nu!(cwd: dirs.test(), "
-            let hard = (ulimit -c | first | get hard);
-            match $hard {
-                \"unlimited\" => {
-                    ulimit -c 1Mib;
-                    ulimit -c
-                    | first
-                    | get soft
-                },
-                $x if $x >= 1024 * 1024 => {
-                    ulimit -c 1Mib;
-                    ulimit -c
-                    | first
-                    | get soft
-                }
-                _ => {
-                    echo \"hard limit too small\"
-                }
+    let actual = nu!("
+        let hard = (ulimit -c | first | get hard);
+        match $hard {
+            \"unlimited\" => {
+                ulimit -c 1Mib;
+                ulimit -c
+                | first
+                | get soft
+            },
+            $x if $x >= 1024 * 1024 => {
+                ulimit -c 1Mib;
+                ulimit -c
+                | first
+                | get soft
             }
-        ");
+            _ => {
+                echo \"hard limit too small\"
+            }
+        }
+    ");
 
-        assert!(actual.out.eq("1024") || actual.out.eq("hard limit too small"));
-    });
+    assert!(actual.out.eq("1024") || actual.out.eq("hard limit too small"));
 }
 
 #[test]
 fn limit_set_filesize2() {
-    Playground::setup("limit_set_filesize2", |dirs, _sandbox| {
-        let actual = nu!(
-            cwd: dirs.test(),
-            "
-                ulimit -n 10Kib
-            "
-        );
+    let actual = nu!("
+        ulimit -n 10Kib
+    ");
 
-        assert!(
-            actual
-                .err
-                .contains("filesize is not compatible with resource RLIMIT_NOFILE")
-        );
-    });
+    assert!(
+        actual
+            .err
+            .contains("filesize is not compatible with resource RLIMIT_NOFILE")
+    );
 }

--- a/crates/nu-command/tests/commands/ulimit.rs
+++ b/crates/nu-command/tests/commands/ulimit.rs
@@ -1,56 +1,81 @@
-use nu_test_support::nu;
+use nu_test_support::prelude::*;
+
+// Keep resource-limit mutations out of the shared in-process test runner.
+fn run_ulimit(code: &str) -> Result<CompleteResult> {
+    test()
+        .env("NU_TEST_ULIMIT_CODE", code)
+        .run("nu -n -c $env.NU_TEST_ULIMIT_CODE | complete")
+}
 
 #[test]
-fn limit_set_soft1() {
-    let actual = nu!("
+#[deps(NU)]
+fn limit_set_soft1() -> Result {
+    let actual = run_ulimit(
+        "
         let soft = (ulimit -s | first | get soft);
         ulimit -s -H $soft;
         let hard = (ulimit -s | first | get hard);
         $soft == $hard
-    ");
+    ",
+    )?;
 
-    assert!(actual.out.contains("true"));
+    assert!(actual.stdout.contains("true"));
+    Ok(())
 }
 
 #[test]
-fn limit_set_soft2() {
-    let actual = nu!("
+#[deps(NU)]
+fn limit_set_soft2() -> Result {
+    let actual = run_ulimit(
+        "
         let soft = (ulimit -s | first | get soft);
         ulimit -s -H soft;
         let hard = (ulimit -s | first | get hard);
         $soft == $hard
-    ");
+    ",
+    )?;
 
-    assert!(actual.out.contains("true"));
+    assert!(actual.stdout.contains("true"));
+    Ok(())
 }
 
 #[test]
-fn limit_set_hard1() {
-    let actual = nu!("
+#[deps(NU)]
+fn limit_set_hard1() -> Result {
+    let actual = run_ulimit(
+        "
         let hard = (ulimit -s | first | get hard);
         ulimit -s $hard;
         let soft = (ulimit -s | first | get soft);
         $soft == $hard
-    ");
+    ",
+    )?;
 
-    assert!(actual.out.contains("true"));
+    assert!(actual.stdout.contains("true"));
+    Ok(())
 }
 
 #[test]
-fn limit_set_hard2() {
-    let actual = nu!("
+#[deps(NU)]
+fn limit_set_hard2() -> Result {
+    let actual = run_ulimit(
+        "
         let hard = (ulimit -s | first | get hard);
         ulimit -s hard;
         let soft = (ulimit -s | first | get soft);
         $soft == $hard
-    ");
+    ",
+    )?;
 
-    assert!(actual.out.contains("true"));
+    assert!(actual.stdout.contains("true"));
+    Ok(())
 }
 
 #[test]
-fn limit_set_invalid1() {
-    let actual = nu!("
+#[deps(NU)]
+fn limit_set_invalid1() -> Result {
+    let actual = run_ulimit(
+        "
         let hard = (ulimit -s | first | get hard);
         match $hard {
             \"unlimited\" => { echo \"unlimited\" },
@@ -59,53 +84,69 @@ fn limit_set_invalid1() {
                 ulimit -s $new
             }
         }
-    ");
+    ",
+    )?;
 
     assert!(
-        actual.out.contains("unlimited") || actual.err.contains("EPERM: Operation not permitted")
+        actual.stdout.contains("unlimited")
+            || actual.stderr.contains("EPERM: Operation not permitted")
     );
+    Ok(())
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
 #[test]
-fn limit_set_invalid2() {
-    let actual = nu!("
+#[deps(NU)]
+fn limit_set_invalid2() -> Result {
+    let actual = run_ulimit(
+        "
         let val = -100;
         ulimit -c $val
-    ");
+    ",
+    )?;
 
-    assert!(actual.err.contains("can't convert i64 to rlim_t"));
+    assert!(actual.stderr.contains("can't convert i64 to rlim_t"));
+    Ok(())
 }
 
 #[test]
-fn limit_set_invalid3() {
-    let actual = nu!("
+#[deps(NU)]
+fn limit_set_invalid3() -> Result {
+    let actual = run_ulimit(
+        "
         ulimit -c abcd
-    ");
+    ",
+    )?;
 
     assert!(
         actual
-            .err
+            .stderr
             .contains("Only unlimited, soft and hard are supported for strings")
     );
+    Ok(())
 }
 
 #[test]
-fn limit_set_invalid4() {
-    let actual = nu!("
+#[deps(NU)]
+fn limit_set_invalid4() -> Result {
+    let actual = run_ulimit(
+        "
         ulimit -c 100.0
-    ");
+    ",
+    )?;
 
-    assert!(actual.err.contains("string, int or filesize required"));
+    assert!(actual.stderr.contains("string, int or filesize required"));
+    Ok(())
 }
 
 #[test]
-fn limit_set_invalid5() {
+#[deps(NU)]
+fn limit_set_invalid5() -> Result {
     use nix::sys::resource::rlim_t;
 
     let max = (rlim_t::MAX / 1024) + 1;
 
-    let actual = nu!(format!(
+    let actual = run_ulimit(&format!(
         r#"
             let hard = (ulimit -c | first | get hard)
             match $hard {{
@@ -121,14 +162,17 @@ fn limit_set_invalid5() {
                 }}
             }}
         "#
-    ));
+    ))?;
 
-    assert!(actual.out.eq("unlimited"));
+    assert_eq!(actual.stdout.trim(), "unlimited");
+    Ok(())
 }
 
 #[test]
-fn limit_set_filesize1() {
-    let actual = nu!("
+#[deps(NU)]
+fn limit_set_filesize1() -> Result {
+    let actual = run_ulimit(
+        "
         let hard = (ulimit -c | first | get hard);
         match $hard {
             \"unlimited\" => {
@@ -147,20 +191,27 @@ fn limit_set_filesize1() {
                 echo \"hard limit too small\"
             }
         }
-    ");
+    ",
+    )?;
 
-    assert!(actual.out.eq("1024") || actual.out.eq("hard limit too small"));
+    let stdout = actual.stdout.trim();
+    assert!(stdout == "1024" || stdout == "hard limit too small");
+    Ok(())
 }
 
 #[test]
-fn limit_set_filesize2() {
-    let actual = nu!("
+#[deps(NU)]
+fn limit_set_filesize2() -> Result {
+    let actual = run_ulimit(
+        "
         ulimit -n 10Kib
-    ");
+    ",
+    )?;
 
     assert!(
         actual
-            .err
+            .stderr
             .contains("filesize is not compatible with resource RLIMIT_NOFILE")
     );
+    Ok(())
 }


### PR DESCRIPTION
## Description

Migrates all 11 `ulimit` tests from the legacy `nu!` macro and temporary Playground setup to the current `nu-test-support` custom test harness.

Each test now uses `#[deps(NU)]`, `test()`, and a typed `CompleteResult`. Because `ulimit` changes process resource limits, the helper runs the generated `nu` binary as a child process so those mutations cannot leak into the shared in-process test runner.

This keeps the existing assertions and platform coverage while following the harness direction in #8670.

## User-facing changes (Release notes)

n/a — tests only

## Additional notes

Part of #8670.

Validation:
- `cargo test -p nu-command --test tests -- commands::ulimit` — 11 passed
- `toolkit fmt`
- `toolkit clippy` — workspace, tests, and plugins passed
- `toolkit check pr` — all relevant test groups passed, including the 2,634-test `nu-command` group; the run was stopped only at the unrelated macOS `nu-glob::test_lots_of_files` slow-test bottleneck after the other 63 `nu-glob` tests passed
