### PR TITLE
fix: unsigned binary overflow in into int

### DIFF
--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -317,13 +317,30 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                 );
             }
 
-            match (endian, signed) {
-                (Endian::Little, true) => Value::int(LittleEndian::read_int(val, size), head),
-                (Endian::Big, true) => Value::int(BigEndian::read_int(val, size), head),
-                (Endian::Little, false) => {
-                    Value::int(LittleEndian::read_uint(val, size) as i64, head)
-                }
-                (Endian::Big, false) => Value::int(BigEndian::read_uint(val, size) as i64, head),
+            if signed {
+                let val = match endian {
+                    Endian::Little => LittleEndian::read_int(val, size),
+                    Endian::Big => BigEndian::read_int(val, size),
+                };
+
+                return Value::int(val, head);
+            }
+
+            let val = match endian {
+                Endian::Little => LittleEndian::read_uint(val, size),
+                Endian::Big => BigEndian::read_uint(val, size),
+            };
+
+            match i64::try_from(val) {
+                Ok(val) => Value::int(val, head),
+                Err(_) => Value::error(
+                    ShellError::IncorrectValue {
+                        msg: "unsigned binary input is too large to convert to int".into(),
+                        val_span,
+                        call_span: head,
+                    },
+                    head,
+                ),
             }
         }
         // Propagate errors by explicitly matching them before the final case.

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -317,21 +317,14 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                 );
             }
 
-            if signed {
-                let val = match endian {
-                    Endian::Little => LittleEndian::read_int(val, size),
-                    Endian::Big => BigEndian::read_int(val, size),
-                };
-
-                return Value::int(val, head);
-            }
-
-            let val = match endian {
-                Endian::Little => LittleEndian::read_uint(val, size),
-                Endian::Big => BigEndian::read_uint(val, size),
+            let val = match (endian, signed) {
+                (Endian::Little, true) => Ok(LittleEndian::read_int(val, size)),
+                (Endian::Big, true) => Ok(BigEndian::read_int(val, size)),
+                (Endian::Little, false) => i64::try_from(LittleEndian::read_uint(val, size)),
+                (Endian::Big, false) => i64::try_from(BigEndian::read_uint(val, size)),
             };
 
-            match i64::try_from(val) {
+            match val {
                 Ok(val) => Value::int(val, head),
                 Err(_) => Value::error(
                     ShellError::IncorrectValue {

--- a/crates/nu-command/tests/commands/conversions/into/int.rs
+++ b/crates/nu-command/tests/commands/conversions/into/int.rs
@@ -31,6 +31,33 @@ fn convert_into_int_big_endian() -> Result {
 }
 
 #[test]
+fn convert_into_int_at_unsigned_limit() -> Result {
+    let code = "0x[ff ff ff ff ff ff ff 7f] | into int --endian little";
+    test().run(code).expect_value_eq(i64::MAX)?;
+
+    let code = "0x[7f ff ff ff ff ff ff ff] | into int --endian big";
+    test().run(code).expect_value_eq(i64::MAX)
+}
+
+#[test]
+fn convert_into_int_above_unsigned_limit() -> Result {
+    for code in [
+        "0x[00 00 00 00 00 00 00 80] | into int --endian little",
+        "0x[80 00 00 00 00 00 00 00] | into int --endian big",
+    ] {
+        let err = test().run(code).expect_shell_error()?;
+        match err {
+            ShellError::IncorrectValue { msg, .. } => {
+                assert_eq!(msg, "unsigned binary input is too large to convert to int");
+            }
+            err => return Err(err.into()),
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
 fn convert_into_signed_int_little_endian() -> Result {
     let code = "0x[00 ff] | into int --endian little --signed";
     test().run(code).expect_value_eq(-256)?;

--- a/crates/nu-command/tests/commands/math/abs.rs
+++ b/crates/nu-command/tests/commands/math/abs.rs
@@ -27,7 +27,7 @@ fn abs_int_min_overflows_without_panic() -> Result {
     // i64::MIN has no representable absolute value; `math abs` must report an
     // overflow error rather than panic. i64::MIN is produced via `into int` to
     // avoid relying on negated-literal parsing.
-    let code = "0x[00 00 00 00 00 00 00 80] | into int --endian little | math abs";
+    let code = "0x[00 00 00 00 00 00 00 80] | into int --endian little --signed | math abs";
     let outcome = test().run(code).expect_shell_error()?;
 
     assert!(matches!(outcome, ShellError::OperatorOverflow { .. }));
@@ -36,7 +36,7 @@ fn abs_int_min_overflows_without_panic() -> Result {
 
 #[test]
 fn abs_duration_min_overflows_without_panic() -> Result {
-    let code = "0x[00 00 00 00 00 00 00 80] | into int --endian little | into duration | math abs";
+    let code = "0x[00 00 00 00 00 00 00 80] | into int --endian little --signed | into duration | math abs";
     let outcome = test().run(code).expect_shell_error()?;
 
     assert!(matches!(outcome, ShellError::OperatorOverflow { .. }));


### PR DESCRIPTION
## Description

This PR fixes unsigned binary-to-integer conversions for values that do not fit in an `i64`.

`into int` previously converted the `u64` returned by `read_uint` using `as i64`. Eight-byte values greater than `i64::MAX` therefore wrapped into negative integers, despite `--signed` not being specified.

The conversion now uses `i64::try_from` and returns `ShellError::IncorrectValue` when the unsigned value is too large. Signed conversions are unchanged.

Regression tests cover `i64::MAX` and the first overflowing value in both little-endian and big-endian representations.

## User-facing changes (Release notes)

Error early instead of letting `into int` silently wrap unsigned 8-byte binary values greater than `i64::MAX` into negative values.

## Additional notes

Follow-up to the correctness issue deferred from #18572:
https://github.com/nushell/nushell/pull/18572#discussion_r3579227830