### PR TITLE
Fix inconsistent missing column validation in sort-by/uniq-by

### DIFF
--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -1,4 +1,5 @@
 use nu_engine::{ClosureEval, command_prelude::*};
+use nu_protocol::ast::CellPath;
 
 use crate::Comparator;
 
@@ -144,7 +145,7 @@ impl Command for SortBy {
             });
         }
 
-        let comparators = comparator_vals
+        let comparators: Vec<Comparator> = comparator_vals
             .into_iter()
             .map(|val| match val {
                 Value::CellPath { val, .. } => Ok(Comparator::CellPath(val)),
@@ -163,6 +164,21 @@ impl Command for SortBy {
                 }),
             })
             .collect::<Result<_, _>>()?;
+
+        let cell_paths: Vec<CellPath> = comparators
+            .iter()
+            .filter_map(|c| {
+                if let Comparator::CellPath(cp) = c {
+                    Some(cp.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if !cell_paths.is_empty() {
+            crate::validate_columns_exist(&vec, &cell_paths, head)?;
+        }
 
         crate::sort_by(&mut vec, comparators, head, insensitive, natural)?;
 

--- a/crates/nu-command/src/filters/uniq_by.rs
+++ b/crates/nu-command/src/filters/uniq_by.rs
@@ -1,6 +1,7 @@
 pub use super::uniq;
 use nu_engine::command_prelude::*;
-use nu_protocol::{ast::PathMember, casing::Casing};
+use nu_protocol::ast::{CellPath, PathMember};
+use nu_protocol::casing::Casing;
 
 #[derive(Clone)]
 pub struct UniqBy;
@@ -75,13 +76,21 @@ impl Command for UniqBy {
 
         let metadata = input.take_metadata();
 
-        let columns = columns
+        let columns: Vec<PathMember> = columns
             .into_iter()
             .map(|col| PathMember::string(col, false, Casing::Sensitive, call.head))
             .collect();
-        let mapper = Box::new(item_mapper_by_col(columns));
 
         let vec: Vec<_> = input.into_iter().collect();
+        let cell_paths: Vec<CellPath> = columns
+            .iter()
+            .map(|pm| CellPath {
+                members: vec![pm.clone()],
+            })
+            .collect();
+        crate::validate_columns_exist(&vec, &cell_paths, call.head)?;
+
+        let mapper = Box::new(item_mapper_by_col(columns));
         uniq(engine_state, stack, call, vec, mapper, metadata)
     }
 
@@ -131,8 +140,6 @@ fn item_mapper_by_col(
     columns: Vec<PathMember>,
 ) -> impl Fn(crate::ItemMapperState) -> Result<crate::ValueCounter, ShellError> {
     move |ms: crate::ItemMapperState| -> Result<crate::ValueCounter, ShellError> {
-        // Resolve each requested column while building the comparison value.
-        // Validation and extraction share the same access semantics.
         let item_column_values = columns
             .iter()
             .map(|column| {

--- a/crates/nu-command/src/sort_utils.rs
+++ b/crates/nu-command/src/sort_utils.rs
@@ -294,6 +294,24 @@ pub fn compare_custom_closure(
         })
 }
 
+/// Check that every value in `vec` has the columns specified by `cell_paths`.
+///
+/// This mirrors the validation that `uniq-by` performs eagerly before processing,
+/// ensuring `sort-by` produces consistent errors for missing columns regardless of
+/// the order of elements in the input.
+pub fn validate_columns_exist(
+    vec: &[Value],
+    cell_paths: &[CellPath],
+    _span: Span,
+) -> Result<(), ShellError> {
+    for v in vec {
+        for cell_path in cell_paths {
+            v.follow_cell_path(&cell_path.members)?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/nu-command/tests/commands/sort_by.rs
+++ b/crates/nu-command/tests/commands/sort_by.rs
@@ -110,3 +110,33 @@ fn fail_on_non_iterator() {
 
     assert!(actual.err.contains("command doesn't support"));
 }
+
+#[test]
+fn missing_column_in_some_rows_errors() {
+    let actual = nu!("[{a: 1} {b: 2}] | sort-by a");
+
+    assert!(actual.err.contains("Cannot find column"));
+    assert!(actual.err.contains("value originates here"));
+}
+
+#[test]
+fn missing_column_in_some_rows_with_multiple_columns_errors() {
+    let actual = nu!("[{a: 1, b: 3} {b: 2}] | sort-by a b");
+
+    assert!(actual.err.contains("Cannot find column"));
+}
+
+#[test]
+fn sort_by_closure_not_affected_by_column_validation() {
+    let actual =
+        nu!("[[name val]; [b 2] [a 1]] | sort-by { |row| $row.name } | get name | str join ','");
+
+    assert_eq!(actual.out, "a,b");
+}
+
+#[test]
+fn sort_by_mixed_cell_path_and_closure_validates_cell_paths() {
+    let actual = nu!("[{a: 1} {b: 2}] | sort-by a { |row| $row | reject a }");
+
+    assert!(actual.err.contains("Cannot find column"));
+}


### PR DESCRIPTION
## Description

Fixes #8667.

`sort-by` validated cell paths lazily while sorting, which could produce inconsistent behavior when some rows were missing the requested column. Depending on the comparison order, the error could occur partway through sorting instead of being reported before sorting began.

This change validates all requested cell paths before sorting and reuses the same validation logic in both `sort-by` and `uniq-by`.

## User-facing changes (Release notes)

`sort-by` now reports missing columns before sorting instead of failing during comparison.

`sort-by` and `uniq-by` now use the same column validation logic, providing consistent behavior when referenced columns are missing.

## Example

Before:

```nu
[{a: 1} {b: 2}] | sort-by a
````

The command could fail during sorting after comparisons had already started.

After:

```nu
[{a: 1} {b: 2}] | sort-by a
```

The command reports the missing column before sorting begins.

## Additional notes

* Added a shared `validate_columns_exist()` helper in `sort_utils`.
* Refactored `uniq-by` to use the shared validation logic.
* Added regression tests covering:

  * missing columns,
  * multiple sort keys,
  * closure comparators,
  * mixed cell path and closure comparators.

Closes #8667.
