### PR TITLE
feat(date): add new commands `date floor` and `date ceil`

### DIFF
--- a/crates/nu-command/src/date/ceil.rs
+++ b/crates/nu-command/src/date/ceil.rs
@@ -1,0 +1,143 @@
+use chrono::{DateTime, Utc};
+use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::generic::GenericError;
+
+#[derive(Clone)]
+pub struct DateCeil;
+
+impl Command for DateCeil {
+    fn name(&self) -> &str {
+        "date ceil"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("date ceil")
+            .input_output_types(vec![
+                (Type::Date, Type::Date),
+                (
+                    Type::List(Box::new(Type::Date)),
+                    Type::List(Box::new(Type::Date)),
+                ),
+            ])
+            .required(
+                "period",
+                SyntaxShape::Duration,
+                "Duration value representing the period boundary to which to round up to.",
+            )
+            .category(Category::Date)
+    }
+
+    fn description(&self) -> &str {
+        "Round to the nearest specified datetime boundary after the input date."
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let duration_ns = match call.req::<Value>(engine_state, stack, 0)? {
+            Value::Duration { val, .. } => Ok(val),
+            x => Err(ShellError::IncompatibleParametersSingle {
+                msg: format!("Expected duration type but got {}", x.get_type()),
+                span: call.head,
+            }),
+        }?;
+
+        if let PipelineData::Empty = input {
+            return Err(ShellError::PipelineEmpty {
+                dst_span: call.head,
+            });
+        }
+
+        input.map(
+            move |value| match value {
+                Value::Date {
+                    val, internal_span, ..
+                } => val
+                    .timestamp_nanos_opt()
+                    .map(|nanos| {
+                        // use local-utc offset to properly adjust the day boundaries from UTC to input timezone
+                        let offset_ns = val.timezone().local_minus_utc() as i64 * 1_000_000_000;
+                        Value::date(
+                            DateTime::<Utc>::from_timestamp_nanos(
+                                nanos - ((nanos + offset_ns) % duration_ns) + duration_ns - 1,
+                            )
+                            .with_timezone(&val.timezone()),
+                            internal_span,
+                        )
+                    })
+                    .unwrap_or(Value::error(
+                        ShellError::Generic(GenericError::new(
+                            "date out of range",
+                            "converting date to nanoseconds caused overflow",
+                            internal_span,
+                        )),
+                        internal_span,
+                    )),
+                _ => Value::error(
+                    ShellError::TypeMismatch {
+                        err_message: "Input must be of type date".into(),
+                        span: value.span(),
+                    },
+                    value.span(),
+                ),
+            },
+            engine_state.signals(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                description: "Round date up to nearest hour",
+                example: "2026-07-15T12:11:10-04:00 | date ceil 1hr",
+                result: Some(Value::date(
+                    DateTime::parse_from_str(
+                        "2026-07-15 12:59:59.999999999 -0400",
+                        "%Y-%m-%d %H:%M:%S.%f %z",
+                    )
+                    .expect("date calculation should not fail in test"),
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Round list of dates up to nearest 2day boundary",
+                example: "[2026-07-10T00:00:00-04:00 2026-07-15T00:00:00-04:00] | date ceil 2day",
+                result: Some(Value::list(
+                    vec![
+                        Value::date(
+                            DateTime::parse_from_str(
+                                "2026-07-11 23:59:59.999999999 -0400",
+                                "%Y-%m-%d %H:%M:%S.%f %z",
+                            )
+                            .expect("date calculation should not fail in test"),
+                            Span::test_data(),
+                        ),
+                        Value::date(
+                            DateTime::parse_from_str(
+                                "2026-07-15 23:59:59.999999999 -0400",
+                                "%Y-%m-%d %H:%M:%S.%f %z",
+                            )
+                            .expect("date calculation should not fail in test"),
+                            Span::test_data(),
+                        ),
+                    ],
+                    Span::test_data(),
+                )),
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() -> nu_test_support::Result {
+        nu_test_support::test().examples(DateCeil)
+    }
+}

--- a/crates/nu-command/src/date/floor.rs
+++ b/crates/nu-command/src/date/floor.rs
@@ -1,0 +1,140 @@
+use chrono::{DateTime, Utc};
+use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::generic::GenericError;
+
+#[derive(Clone)]
+pub struct DateFloor;
+
+impl Command for DateFloor {
+    fn name(&self) -> &str {
+        "date floor"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("date floor")
+            .input_output_types(vec![
+                (Type::Date, Type::Date),
+                (
+                    Type::List(Box::new(Type::Date)),
+                    Type::List(Box::new(Type::Date)),
+                ),
+            ])
+            .required(
+                "period",
+                SyntaxShape::Duration,
+                "Duration value representing the period boundary to which to round down to.",
+            )
+            .category(Category::Date)
+    }
+
+    fn description(&self) -> &str {
+        "Round to the nearest specified datetime boundary before the input date."
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let duration_ns = match call.req::<Value>(engine_state, stack, 0)? {
+            Value::Duration { val, .. } => Ok(val),
+            x => Err(ShellError::IncompatibleParametersSingle {
+                msg: format!("Expected duration type but got {}", x.get_type()),
+                span: call.head,
+            }),
+        }?;
+
+        if let PipelineData::Empty = input {
+            return Err(ShellError::PipelineEmpty {
+                dst_span: call.head,
+            });
+        }
+
+        input.map(
+            move |value| match value {
+                Value::Date {
+                    val, internal_span, ..
+                } => val
+                    .timestamp_nanos_opt()
+                    .map(|nanos| {
+                        // use local-utc offset to properly adjust the day boundaries from UTC to input timezone
+                        let offset_ns = val.timezone().local_minus_utc() as i64 * 1_000_000_000;
+                        Value::date(
+                            DateTime::<Utc>::from_timestamp_nanos(
+                                nanos - ((nanos + offset_ns) % duration_ns),
+                            )
+                            .with_timezone(&val.timezone()),
+                            internal_span,
+                        )
+                    })
+                    .unwrap_or(Value::error(
+                        ShellError::Generic(GenericError::new(
+                            "date out of range",
+                            "converting date to nanoseconds caused overflow",
+                            internal_span,
+                        )),
+                        internal_span,
+                    )),
+                _ => Value::error(
+                    ShellError::TypeMismatch {
+                        err_message: "Input must be of type date".into(),
+                        span: value.span(),
+                    },
+                    value.span(),
+                ),
+            },
+            engine_state.signals(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                description: "Round down to the nearest hour",
+                example: "2026-07-15T12:11:10-04:00 | date floor 1hr",
+                result: Some(Value::date(
+                    DateTime::parse_from_str("2026-07-15 12:00:00 -0400", "%Y-%m-%d %H:%M:%S %z")
+                        .expect("date calculation should not fail in test"),
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Round list of dates down to the nearest 2day boundary",
+                example: "[2026-07-10T00:00:00-04:00 2026-07-15T00:00:00-04:00] | date floor 2day",
+                result: Some(Value::list(
+                    vec![
+                        Value::date(
+                            DateTime::parse_from_str(
+                                "2026-07-10 00:00:00 -0400",
+                                "%Y-%m-%d %H:%M:%S %z",
+                            )
+                            .expect("date calculation should not fail in test"),
+                            Span::test_data(),
+                        ),
+                        Value::date(
+                            DateTime::parse_from_str(
+                                "2026-07-14 00:00:00 -0400",
+                                "%Y-%m-%d %H:%M:%S %z",
+                            )
+                            .expect("date calculation should not fail in test"),
+                            Span::test_data(),
+                        ),
+                    ],
+                    Span::test_data(),
+                )),
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() -> nu_test_support::Result {
+        nu_test_support::test().examples(DateFloor)
+    }
+}

--- a/crates/nu-command/src/date/mod.rs
+++ b/crates/nu-command/src/date/mod.rs
@@ -1,4 +1,6 @@
+mod ceil;
 mod date_;
+mod floor;
 mod from_human;
 mod humanize;
 mod list_timezone;
@@ -7,7 +9,9 @@ mod parser;
 mod to_timezone;
 mod utils;
 
+pub use ceil::DateCeil;
 pub use date_::Date;
+pub use floor::DateFloor;
 pub use from_human::DateFromHuman;
 pub use humanize::DateHumanize;
 pub use list_timezone::DateListTimezones;

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -314,6 +314,8 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
         // Date
         bind_command! {
             Date,
+            DateCeil,
+            DateFloor,
             DateFromHuman,
             DateHumanize,
             DateListTimezones,


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
This PR adds two new commands `date floor` and `date ceil` that rounds a date value down and up, respectively, to a specified duration boundary. See examples

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
### Added `date floor` and `date ceil` commands

Users will have access to two new commands `date floor` and `date ceil` that rounds a date value down and up, respectively, to a specified duration boundary.
```nushell
#  Round down to the nearest hour
  > 2026-07-15T12:11:10-04:00 | date floor 1hr
  Wed, 15 Jul 2026 12:00:00 -0400

# Round list of dates down to the nearest 2day boundary
  > [2026-07-10T00:00:00-04:00 2026-07-15T00:00:00-04:00] | date floor 2day
  ╭───┬───────────────────────╮
  │ 0 │ 07/10/2026 12:00:00AM │
  │ 1 │ 07/14/2026 12:00:00AM │
  ╰───┴───────────────────────╯

#  Round date up to nearest hour
  > 2026-07-15T12:11:10-04:00 | date ceil 1hr
  Wed, 15 Jul 2026 12:59:59 -0400

#  Round list of dates up to nearest 2day boundary
  > [2026-07-10T00:00:00-04:00 2026-07-15T00:00:00-04:00] | date ceil 2day
  ╭───┬───────────────────────╮
  │ 0 │ 07/11/2026 11:59:59PM │
  │ 1 │ 07/15/2026 11:59:59PM │
  ╰───┴───────────────────────╯
```

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
