### PR TITLE
Migrate `rename` tests to the new harness (#8670)

### DIFF
--- a/crates/nu-command/tests/commands/rename.rs
+++ b/crates/nu-command/tests/commands/rename.rs
@@ -1,81 +1,77 @@
-use nu_test_support::nu;
+use nu_test_support::prelude::*;
 
-#[test]
-fn changes_the_column_name() {
-    let sample = r#"[
+fn sample() -> serde_json::Value {
+    json!([
         ["Andrés N. Robalino"],
         ["JT Turner"],
         ["Yehuda Katz"],
         ["Jason Gedge"]
-    ]"#;
-
-    let actual = nu!(format!(
-        "
-            {sample}
-            | wrap name
-            | rename mosqueteros
-            | get mosqueteros
-            | length
-        "
-    ));
-
-    assert_eq!(actual.out, "4");
+    ])
 }
 
 #[test]
-fn keeps_remaining_original_names_given_less_new_names_than_total_original_names() {
-    let sample = r#"[
-        ["Andrés N. Robalino"],
-        ["JT Turner"],
-        ["Yehuda Katz"],
-        ["Jason Gedge"]
-    ]"#;
+fn changes_the_column_name() -> Result {
+    let code = "
+        $in
+        | wrap name
+        | rename mosqueteros
+        | get mosqueteros
+        | length
+    ";
 
-    let actual = nu!(format!(
-        r#"
-            {sample}
-            | wrap name
-            | default "arepa!" hit
-            | rename mosqueteros
-            | get hit
-            | length
-        "#
-    ));
-
-    assert_eq!(actual.out, "4");
+    test().run_with_data(code, sample()).expect_value_eq(4)
 }
 
 #[test]
-fn errors_if_no_columns_present() {
-    let sample = r#"[
-        ["Andrés N. Robalino"],
-        ["JT Turner"],
-        ["Yehuda Katz"],
-        ["Jason Gedge"]
-    ]"#;
+fn keeps_remaining_original_names_given_less_new_names_than_total_original_names() -> Result {
+    let code = r#"
+        $in
+        | wrap name
+        | default "arepa!" hit
+        | rename mosqueteros
+        | get hit
+        | length
+    "#;
 
-    let actual = nu!(format!("{sample} | rename mosqueteros"));
-
-    assert!(actual.err.contains("command doesn't support"));
+    test().run_with_data(code, sample()).expect_value_eq(4)
 }
 
 #[test]
-fn errors_if_columns_param_is_empty() {
-    let sample = r#"[
-        ["Andrés N. Robalino"],
-        ["JT Turner"],
-        ["Yehuda Katz"],
-        ["Jason Gedge"]
-    ]"#;
+fn errors_if_no_columns_present() -> Result {
+    let err = test()
+        .run_with_data("$in | rename mosqueteros", sample())
+        .expect_shell_error()?;
 
-    let actual = nu!(format!(
-        r#"
-            {sample}
-            | wrap name
-            | default "arepa!" hit
-            | rename --column {{}}
-        "#
-    ));
+    match err {
+        ShellError::OnlySupportsThisInputType {
+            exp_input_type,
+            wrong_type,
+            ..
+        } => {
+            assert_eq!(exp_input_type, "record and table");
+            assert_eq!(wrong_type, "list<list<string>>");
+            Ok(())
+        }
+        err => Err(err.into()),
+    }
+}
 
-    assert!(actual.err.contains("The column info cannot be empty"));
+#[test]
+fn errors_if_columns_param_is_empty() -> Result {
+    let code = r#"
+        $in
+        | wrap name
+        | default "arepa!" hit
+        | rename --column {}
+    "#;
+
+    let err = test().run_with_data(code, sample()).expect_shell_error()?;
+
+    match err {
+        ShellError::TypeMismatch { err_message, .. } => {
+            assert_eq!(err_message, "The column info cannot be empty");
+            Ok(())
+        }
+        err => Err(err.into()),
+    }
 }


### PR DESCRIPTION
## Description

Migrates all four `rename` command tests from the legacy subprocess-based `nu!` macro to the current in-process `nu-test-support` harness.

The tests now pass the shared sample as typed input with `run_with_data`, compare successful results as values, and match the two error cases against their structured `ShellError` variants. This removes the tests' dependency on a separately built `nu` binary while preserving and strengthening their assertions.

This follows the test-harness direction in #8670.

## User-facing changes (Release notes)

n/a — tests only

## Additional notes

Part of #8670.

Validation:
- `cargo test -p nu-command --test tests -- commands::rename` — 4 passed
- `toolkit fmt`
- `toolkit clippy` — workspace, tests, and plugins passed
- `toolkit check pr` — formatting, all clippy phases, the 1,959-test `nu` group, and the 2,637-test `nu-command` group passed; the run was stopped after the unrelated macOS `nu-glob::test_lots_of_files` root-filesystem glob remained active for more than 10 minutes after the other 63 `nu-glob` tests passed
