### PR TITLE
`take while/until` commands can include items after the match

### DIFF
--- a/crates/nu-command/src/filters/take/mod.rs
+++ b/crates/nu-command/src/filters/take/mod.rs
@@ -1,6 +1,7 @@
 mod take_;
 mod take_until;
 mod take_while;
+mod take_while_include;
 
 pub use take_::Take;
 pub use take_until::TakeUntil;

--- a/crates/nu-command/src/filters/take/take_until.rs
+++ b/crates/nu-command/src/filters/take/take_until.rs
@@ -1,5 +1,5 @@
 use nu_engine::{ClosureEval, command_prelude::*};
-use nu_protocol::engine::Closure;
+use nu_protocol::{engine::Closure, test_table, test_value};
 
 #[derive(Clone)]
 pub struct TakeUntil;
@@ -11,10 +11,19 @@ impl Command for TakeUntil {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(
-                Type::List(Box::new(Type::Any)),
-                Type::List(Box::new(Type::Any)),
-            )])
+            .input_output_types(vec![
+                (Type::table(), Type::table()),
+                (
+                    Type::List(Box::new(Type::Any)),
+                    Type::List(Box::new(Type::Any)),
+                ),
+            ])
+            .named(
+                "include",
+                SyntaxShape::Int,
+                "Include extra items after the stream would otherwise have stopped. `0` is a no-op.",
+                Some('i'),
+            )
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
@@ -32,30 +41,27 @@ impl Command for TakeUntil {
             Example {
                 description: "Take until the element is positive.",
                 example: "[-1 -2 9 1] | take until {|x| $x > 0 }",
-                result: Some(Value::test_list(vec![
-                    Value::test_int(-1),
-                    Value::test_int(-2),
-                ])),
+                result: Some(test_value!([-1, -2])),
             },
             Example {
                 description: "Take until the element is positive using stored condition.",
                 example: "let cond = {|x| $x > 0 }; [-1 -2 9 1] | take until $cond",
-                result: Some(Value::test_list(vec![
-                    Value::test_int(-1),
-                    Value::test_int(-2),
-                ])),
+                result: Some(test_value!([-1, -2])),
             },
             Example {
                 description: "Take until the field value is positive.",
                 example: "[{a: -1} {a: -2} {a: 9} {a: 1}] | take until {|x| $x.a > 0 }",
-                result: Some(Value::test_list(vec![
-                    Value::test_record(record! {
-                        "a" => Value::test_int(-1),
-                    }),
-                    Value::test_record(record! {
-                        "a" => Value::test_int(-2),
-                    }),
-                ])),
+                result: Some(test_value!([{a: (-1)}, {a: (-2)}])),
+            },
+            Example {
+                description: "Take until the first item with an uppercase name including that item.",
+                example: "[[name value]; [b, 2], [c, 3], [A, 1], [D, 4]] | take until -i 1 {|x| $x.name like '[A-Z]' }",
+                result: Some(test_table![
+                    ["name", "value"];
+                    ["b", 2],
+                    ["c", 3],
+                    ["A", 1],
+                ]),
             },
         ]
     }
@@ -69,20 +75,30 @@ impl Command for TakeUntil {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         let closure: Closure = call.req(engine_state, stack, 0)?;
-
-        let mut closure = ClosureEval::new(engine_state, stack, closure);
+        let include: usize = call.get_flag(engine_state, stack, "include")?.unwrap_or(0);
 
         let metadata = input.take_metadata();
-        Ok(input
-            .into_iter_strict(head)?
-            .take_while(move |value| {
-                closure
-                    .run_with_value(value.clone())
-                    .and_then(|data| data.into_value(head))
-                    .map(|cond| cond.is_false())
-                    .unwrap_or(false)
-            })
-            .into_pipeline_data_with_metadata(head, engine_state.signals().clone(), metadata))
+
+        let mut closure = ClosureEval::new(engine_state, stack, closure);
+        let predicate = move |value: &Value| {
+            closure
+                .run_with_value(value.clone())
+                .and_then(|data| data.into_value(head))
+                .map(|cond| cond.is_false())
+                .unwrap_or(false)
+        };
+
+        let it = input.into_iter_strict(head)?;
+
+        Ok(match include {
+            0 => it.take_while(predicate).into_pipeline_data_with_metadata(
+                head,
+                engine_state.signals().clone(),
+                metadata,
+            ),
+            n => super::take_while_include::take_while_include_n(it, predicate, n)
+                .into_pipeline_data_with_metadata(head, engine_state.signals().clone(), metadata),
+        })
     }
 }
 

--- a/crates/nu-command/src/filters/take/take_while.rs
+++ b/crates/nu-command/src/filters/take/take_while.rs
@@ -1,5 +1,5 @@
 use nu_engine::{ClosureEval, command_prelude::*};
-use nu_protocol::engine::Closure;
+use nu_protocol::{engine::Closure, test_table, test_value};
 
 #[derive(Clone)]
 pub struct TakeWhile;
@@ -18,6 +18,12 @@ impl Command for TakeWhile {
                     Type::List(Box::new(Type::Any)),
                 ),
             ])
+            .named(
+                "include",
+                SyntaxShape::Int,
+                "Include extra items after the stream would otherwise have stopped. `0` is a no-op.",
+                Some('i'),
+            )
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
@@ -35,30 +41,27 @@ impl Command for TakeWhile {
             Example {
                 description: "Take while the element is negative.",
                 example: "[-1 -2 9 1] | take while {|x| $x < 0 }",
-                result: Some(Value::test_list(vec![
-                    Value::test_int(-1),
-                    Value::test_int(-2),
-                ])),
+                result: Some(test_value!([-1, -2])),
             },
             Example {
                 description: "Take while the element is negative using stored condition.",
                 example: "let cond = {|x| $x < 0 }; [-1 -2 9 1] | take while $cond",
-                result: Some(Value::test_list(vec![
-                    Value::test_int(-1),
-                    Value::test_int(-2),
-                ])),
+                result: Some(test_value!([-1, -2])),
             },
             Example {
                 description: "Take while the field value is negative.",
                 example: "[{a: -1} {a: -2} {a: 9} {a: 1}] | take while {|x| $x.a < 0 }",
-                result: Some(Value::test_list(vec![
-                    Value::test_record(record! {
-                        "a" => Value::test_int(-1),
-                    }),
-                    Value::test_record(record! {
-                        "a" => Value::test_int(-2),
-                    }),
-                ])),
+                result: Some(test_value!([{a: (-1)}, {a: (-2)}])),
+            },
+            Example {
+                description: "Take until the first item without a lowercase name including that item.",
+                example: "[[name value]; [b, 2], [c, 3], [A, 1], [D, 4]] | take while -i 1 {|x| $x.name like '[a-z]' }",
+                result: Some(test_table![
+                    ["name", "value"];
+                    ["b", 2],
+                    ["c", 3],
+                    ["A", 1],
+                ]),
             },
         ]
     }
@@ -72,20 +75,30 @@ impl Command for TakeWhile {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         let closure: Closure = call.req(engine_state, stack, 0)?;
-
-        let mut closure = ClosureEval::new(engine_state, stack, closure);
+        let include: usize = call.get_flag(engine_state, stack, "include")?.unwrap_or(0);
 
         let metadata = input.take_metadata();
-        Ok(input
-            .into_iter_strict(head)?
-            .take_while(move |value| {
-                closure
-                    .run_with_value(value.clone())
-                    .and_then(|data| data.into_value(head))
-                    .map(|cond| cond.is_true())
-                    .unwrap_or(false)
-            })
-            .into_pipeline_data_with_metadata(head, engine_state.signals().clone(), metadata))
+
+        let mut closure = ClosureEval::new(engine_state, stack, closure);
+        let predicate = move |value: &Value| {
+            closure
+                .run_with_value(value.clone())
+                .and_then(|data| data.into_value(head))
+                .map(|cond| cond.is_true())
+                .unwrap_or(false)
+        };
+
+        let it = input.into_iter_strict(head)?;
+
+        Ok(match include {
+            0 => it.take_while(predicate).into_pipeline_data_with_metadata(
+                head,
+                engine_state.signals().clone(),
+                metadata,
+            ),
+            n => super::take_while_include::take_while_include_n(it, predicate, n)
+                .into_pipeline_data_with_metadata(head, engine_state.signals().clone(), metadata),
+        })
     }
 }
 

--- a/crates/nu-command/src/filters/take/take_while_include.rs
+++ b/crates/nu-command/src/filters/take/take_while_include.rs
@@ -1,0 +1,33 @@
+pub(super) fn take_while_include_n<T>(
+    iter: impl IntoIterator<Item = T>,
+    mut predicate: impl FnMut(&T) -> bool,
+    mut n: usize,
+) -> impl Iterator<Item = T> {
+    let mut done = false;
+    let mut peekable = iter.into_iter().peekable();
+
+    std::iter::from_fn(move || {
+        match (done, n) {
+            (true, 0) => None,
+            (true, _) => {
+                n -= 1;
+                peekable.next()
+            }
+            (false, _) => {
+                match peekable.next_if(&mut predicate) {
+                    Some(e) => Some(e),
+                    None => {
+                        done = true;
+                        // very unlikely to be false, just in case
+                        if n > 0 {
+                            n -= 1;
+                            peekable.next()
+                        } else {
+                            None
+                        }
+                    }
+                }
+            }
+        }
+    })
+}

--- a/crates/nu-command/tests/commands/take/until.rs
+++ b/crates/nu-command/tests/commands/take/until.rs
@@ -1,4 +1,5 @@
 use nu_test_support::prelude::*;
+use rstest::rstest;
 
 #[test]
 fn condition_is_met() -> Result {
@@ -40,4 +41,19 @@ fn fail_on_non_iterator() -> Result {
     let err = test().run(code).expect_parse_error()?;
     assert!(matches!(err, ParseError::InputMismatch(..)));
     Ok(())
+}
+
+#[rstest]
+#[case::none(0, ["a", "b", "c"])]
+#[case::one(1, ["a", "b", "c", "d"])]
+#[case::two(2, ["a", "b", "c", "d", "e"])]
+#[case::more_than_input(12, ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"])]
+fn include(#[case] n: i64, #[case] expect: impl IntoValue) -> Result {
+    let code = r#"
+        let n = $in
+
+        [a b c d e f g h i j]
+        | take until -i $n {|e| $e == "d" }
+    "#;
+    test().run_with_data(code, n).expect_value_eq(expect)
 }

--- a/crates/nu-command/tests/commands/take/while_.rs
+++ b/crates/nu-command/tests/commands/take/while_.rs
@@ -1,4 +1,5 @@
 use nu_test_support::prelude::*;
+use rstest::rstest;
 
 #[test]
 fn condition_is_met() -> Result {
@@ -39,4 +40,19 @@ fn fail_on_non_iterator() -> Result {
     let err = test().run(code).expect_parse_error()?;
     assert!(matches!(err, ParseError::InputMismatch(..)));
     Ok(())
+}
+
+#[rstest]
+#[case::none(0, ["a", "b", "c"])]
+#[case::one(1, ["a", "b", "c", "d"])]
+#[case::two(2, ["a", "b", "c", "d", "e"])]
+#[case::more_than_input(12, ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"])]
+fn include(#[case] n: i64, #[case] expect: impl IntoValue) -> Result {
+    let code = r#"
+        let n = $in
+
+        [a b c d e f g h i j]
+        | take while -i $n {|e| $e != "d" }
+    "#;
+    test().run_with_data(code, n).expect_value_eq(expect)
 }


### PR DESCRIPTION
## Description

Makes more sense for `take until` than it does for `take while`. I briefly thought about implementing it for `skip while/until` commands, however skipping extra items is already pretty straightforward: `skip until $predicate | skip 3`.

## User-facing changes (Release notes)

### Added `--include` to `take while` and `take until`

`take until` and `take while` commands get a new `--include (-i)` flag, which allows you to take extra items after the stream would have otherwise stopped:

```nushell
date now
| into record
| transpose key val
| take until { $in.key == day } --include 1
```
```
╭───┬───────┬──────╮
│ # │  key  │ val  │
├───┼───────┼──────┤
│ 0 │ year  │ 2026 │
│ 1 │ month │    7 │
│ 2 │ day   │   16 │
╰───┴───────┴──────╯
```