### PR TITLE
fix(engine): preserve metadata and streams through early return

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -173,14 +173,12 @@ pub fn evaluate_file(
     let exit_code = if file_has_main && engine_state.find_decl(&script_name_bytes, &[]).is_some() {
         // Evaluate the file, but don't run main yet.
         let pipeline =
-            match eval_block::<WithoutDebug>(engine_state, stack, &block, PipelineData::empty())
-                .map(|p| p.body)
-            {
-                Ok(data) => data,
-                Err(ShellError::Return { .. }) => {
+            match eval_block::<WithoutDebug>(engine_state, stack, &block, PipelineData::empty()) {
+                Ok(data) if data.early_return => {
                     // Allow early return before main is run.
                     return Ok(());
                 }
+                Ok(data) => data.body,
                 Err(err) => return Err(err),
             };
 

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -1090,8 +1090,9 @@ pub(crate) fn compile_return(
         builder.load_empty(io_reg)?;
     }
 
-    // TODO: It would be nice if this could be `return` instead, but there is a little bit of
-    // behaviour remaining that still depends on `ShellError::Return`
+    // This is distinct from the terminal `return` instruction: it runs pending `finally`
+    // handlers, and marks the result as an early return so boundaries can observe it (e.g. a
+    // top-level `return` in a script prevents `main` from running).
     builder.push(Instruction::ReturnEarly { src: io_reg }.into_spanned(call.head))?;
 
     // io_reg is supposed to remain allocated

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -1091,8 +1091,9 @@ pub(crate) fn compile_return(
     }
 
     // This is distinct from the terminal `return` instruction: it runs pending `finally`
-    // handlers, and marks the result as an early return so boundaries can observe it (e.g. a
-    // top-level `return` in a script prevents `main` from running).
+    // handlers, and flags the result as an early return. Custom command and closure calls clear
+    // that flag; top-level file evaluation reads it (e.g. so a top-level `return` in a script
+    // prevents `main` from running).
     builder.push(Instruction::ReturnEarly { src: io_reg }.into_spanned(call.head))?;
 
     // io_reg is supposed to remain allocated

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -527,8 +527,9 @@ pub fn eval_block<D: DebugContext>(
 /// an ordinary result.
 ///
 /// This is used for blocks that `return` should not escape from, such as custom command bodies
-/// and closures. In contrast, [`eval_block`] leaves the flag intact so that direct callers (such
-/// as file evaluation) can observe that the block returned early.
+/// and closures: clearing the flag keeps an early `return` from leaking into the calling block.
+/// In contrast, [`eval_block`] leaves the flag intact, so its one consumer (top-level file
+/// evaluation) can see a top-level `return` and skip running `main`.
 pub fn eval_block_with_early_return<D: DebugContext>(
     engine_state: &EngineState,
     stack: &mut Stack,

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -513,18 +513,22 @@ pub fn eval_block<D: DebugContext>(
     result
 }
 
+/// Evaluate a block as an early return boundary: an early `return` inside the block produces the
+/// block's result here, exactly like a value in tail position.
+///
+/// This is used for blocks that `return` should not escape from, such as custom command bodies
+/// and closures. In contrast, [`eval_block`] leaves the
+/// [`early_return`](PipelineExecutionData::early_return) flag intact so that direct callers (such
+/// as file evaluation) can observe that the block returned early.
 pub fn eval_block_with_early_return<D: DebugContext>(
     engine_state: &EngineState,
     stack: &mut Stack,
     block: &Block,
     input: PipelineData,
 ) -> Result<PipelineExecutionData, ShellError> {
-    match eval_block::<D>(engine_state, stack, block, input) {
-        Err(ShellError::Return { span: _, value }) => Ok(PipelineExecutionData::from(
-            PipelineData::value(*value, None),
-        )),
-        x => x,
-    }
+    let mut result = eval_block::<D>(engine_state, stack, block, input)?;
+    result.early_return = false;
+    Ok(result)
 }
 
 pub fn eval_collect<D: DebugContext>(

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -513,12 +513,21 @@ pub fn eval_block<D: DebugContext>(
     result
 }
 
-/// Evaluate a block as an early return boundary: an early `return` inside the block produces the
-/// block's result here, exactly like a value in tail position.
+/// Evaluate a block as an early return boundary.
+///
+/// A `return` is meant to end the command or closure it appears in and go no further. The
+/// "boundary" is the point where such a `return` stops propagating outward and becomes the
+/// block's normal result, instead of escaping to whatever called the command. This function is
+/// that point: an early `return` inside the block produces the block's result here, exactly like
+/// a value in tail position.
+///
+/// Concretely, [`eval_block`] runs the block and sets
+/// [`early_return`](PipelineExecutionData::early_return) to mark a result that came from a
+/// `return`; this function clears that flag, which is what "absorbs" the `return` so callers see
+/// an ordinary result.
 ///
 /// This is used for blocks that `return` should not escape from, such as custom command bodies
-/// and closures. In contrast, [`eval_block`] leaves the
-/// [`early_return`](PipelineExecutionData::early_return) flag intact so that direct callers (such
+/// and closures. In contrast, [`eval_block`] leaves the flag intact so that direct callers (such
 /// as file evaluation) can observe that the block returned early.
 pub fn eval_block_with_early_return<D: DebugContext>(
     engine_state: &EngineState,

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -299,8 +299,9 @@ fn eval_ir_block_impl<D: DebugContext>(
                     pc = always_run_handler.handler_index;
                 } else {
                     // No `finally` pending: this is the same as a tail return, keeping streams
-                    // and metadata intact, except the data is marked as an early return so that
-                    // boundaries can observe it.
+                    // and metadata intact, except the data is flagged as an early return. The
+                    // nearest custom command or closure call clears that flag; top-level file
+                    // evaluation reads it to skip `main`.
                     return Ok(ctx.take_reg(reg_id).with_early_return());
                 }
             }
@@ -412,8 +413,10 @@ enum InstructionResult {
     /// Return from the block before reaching the end, carrying the full register contents.
     ///
     /// Unlike `Return`, this runs any pending `finally` handlers before the value leaves the
-    /// block, and marks the resulting data as an early return so that boundaries (custom command
-    /// calls, closures, file evaluation) can observe it.
+    /// block, and flags the resulting data as an early return. The flag exists for one consumer:
+    /// top-level file evaluation, which reads it to skip `main`. Custom command calls and closure
+    /// invocations clear the flag instead, so a `return` in a nested call can't leak out and be
+    /// mistaken for a `return` at the current level.
     ReturnEarly(RegId),
 }
 

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -242,7 +242,10 @@ fn eval_ir_block_impl<D: DebugContext>(
     // Program counter, starts at zero.
     let mut pc = 0;
     let need_backtrace = ctx.engine_state.get_env_var("NU_BACKTRACE").is_some();
-    let mut ret_val = None;
+    // The result of an early exit (`return` or an error) that must still run pending `finally`
+    // handlers before it can leave the block. It takes precedence over the register contents at
+    // the terminal `Return` instruction.
+    let mut ret_val: Option<Result<PipelineExecutionData, ShellError>> = None;
 
     while pc < ir_block.instructions.len() {
         let instruction = &ir_block.instructions[pc];
@@ -269,25 +272,50 @@ fn eval_ir_block_impl<D: DebugContext>(
                 pc = next_pc;
             }
             Ok(InstructionResult::Return(reg_id)) => {
-                // need to check if the return value is set by
-                // `Shell::Return` first. If so, we need to respect that value.
+                // need to check if the return value was stashed by an early `return` or an error
+                // that ran a `finally` handler first. If so, we need to respect that value.
                 match ret_val {
-                    Some(err) => return Err(err),
+                    Some(res) => return res,
                     None => return Ok(ctx.take_reg(reg_id)),
+                }
+            }
+            Ok(InstructionResult::ReturnEarly(reg_id)) => {
+                if let Some(always_run_handler) =
+                    ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
+                {
+                    // A `finally` block is pending: collect the value first (mirroring the
+                    // `try-collect` the compiler emits on the fall-through path, which also
+                    // preserves metadata), stash it, and run the `finally` block. The stashed
+                    // value is returned at the terminal `Return` instruction.
+                    let data = ctx.take_reg(reg_id);
+                    #[cfg(feature = "os")]
+                    let collected = collect(data, *span, false);
+                    #[cfg(not(feature = "os"))]
+                    let collected = collect(data, *span);
+                    ret_val = Some(
+                        collected.map(|body| PipelineExecutionData::from(body).with_early_return()),
+                    );
+                    prepare_error_handler(ctx, always_run_handler, None);
+                    pc = always_run_handler.handler_index;
+                } else {
+                    // No `finally` pending: this is the same as a tail return, keeping streams
+                    // and metadata intact, except the data is marked as an early return so that
+                    // boundaries can observe it.
+                    return Ok(ctx.take_reg(reg_id).with_early_return());
                 }
             }
             Err(err @ (ShellError::Continue { .. } | ShellError::Break { .. })) => {
                 return Err(err);
             }
-            Err(err @ (ShellError::Return { .. } | ShellError::Exit { abort: false, .. })) => {
+            Err(err @ ShellError::Exit { abort: false, .. }) => {
                 if let Some(always_run_handler) =
                     ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
                 {
-                    // need to run finally block before return.
-                    // and record the return value firstly.
+                    // need to run finally block before exiting.
+                    // and record the exit error firstly.
                     prepare_error_handler(ctx, always_run_handler, None);
                     pc = always_run_handler.handler_index;
-                    ret_val = Some(err);
+                    ret_val = Some(Err(err));
                 } else {
                     // These block control related errors should be passed through
                     return Err(err);
@@ -323,7 +351,7 @@ fn eval_ir_block_impl<D: DebugContext>(
                         Some(err.clone().into_spanned(*span)),
                     );
                     pc = always_run_handler.handler_index;
-                    ret_val = Some(err);
+                    ret_val = Some(Err(err));
                 } else if need_backtrace {
                     let err = ShellError::into_chained(err, *span);
                     return Err(err);
@@ -381,6 +409,12 @@ enum InstructionResult {
     Continue,
     Branch(usize),
     Return(RegId),
+    /// Return from the block before reaching the end, carrying the full register contents.
+    ///
+    /// Unlike `Return`, this runs any pending `finally` handlers before the value leaves the
+    /// block, and marks the resulting data as an early return so that boundaries (custom command
+    /// calls, closures, file evaluation) can observe it.
+    ReturnEarly(RegId),
 }
 
 /// Perform an instruction
@@ -708,11 +742,18 @@ fn eval_instruction<D: DebugContext>(
                     PipelineExecutionData {
                         body: result,
                         exit: original_exit,
+                        early_return: false,
                     },
                 );
             }
             #[cfg(not(feature = "os"))]
-            ctx.put_reg(*src_dst, PipelineExecutionData { body: result });
+            ctx.put_reg(
+                *src_dst,
+                PipelineExecutionData {
+                    body: result,
+                    early_return: false,
+                },
+            );
             Ok(Continue)
         }
         Instruction::StringAppend { src_dst, val } => {
@@ -1045,13 +1086,7 @@ fn eval_instruction<D: DebugContext>(
             ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base);
             Ok(Continue)
         }
-        Instruction::ReturnEarly { src } => {
-            let val = ctx.collect_reg(*src, *span)?;
-            Err(ShellError::Return {
-                span: *span,
-                value: Box::new(val),
-            })
-        }
+        Instruction::ReturnEarly { src } => Ok(InstructionResult::ReturnEarly(*src)),
         Instruction::Return { src } => Ok(Return(*src)),
     }
 }

--- a/crates/nu-protocol/src/errors/shell_error/mod.rs
+++ b/crates/nu-protocol/src/errors/shell_error/mod.rs
@@ -1171,6 +1171,15 @@ pub enum ShellError {
     },
 
     /// Return event, which may become an error if used outside of a custom command or closure
+    ///
+    /// This is no longer raised by the engine: an early `return` now leaves the block through the
+    /// same path as a value in tail position, preserving pipeline metadata and streams (see
+    /// `PipelineExecutionData::early_return`). The variant is kept temporarily for compatibility
+    /// and will be removed in a future release.
+    #[deprecated(
+        since = "0.114.2",
+        note = "the engine no longer raises this; an early `return` now flows out through `PipelineExecutionData::early_return`"
+    )]
     #[error("Return used outside of custom command or closure")]
     Return {
         #[label("used outside of custom command or closure")]
@@ -1490,6 +1499,8 @@ impl ShellError {
     }
 
     pub fn exit_code(&self) -> Option<i32> {
+        // `Return` is deprecated but still a valid variant to match on here.
+        #[allow(deprecated)]
         match self {
             Self::Return { .. } | Self::Break { .. } | Self::Continue { .. } => None,
             _ => self.external_exit_code().map(|e| e.item).or(Some(1)),

--- a/crates/nu-protocol/src/ir/mod.rs
+++ b/crates/nu-protocol/src/ir/mod.rs
@@ -277,8 +277,9 @@ pub enum Instruction {
     /// Return early from the block with the value in the register.
     ///
     /// Unlike `return`, this runs pending `finally` handlers first (collecting the value in that
-    /// case, like the `try-collect` on the fall-through path), and marks the result as an early
-    /// return so that boundaries can observe it.
+    /// case, like the `try-collect` on the fall-through path), and flags the result as an early
+    /// return. Custom command and closure calls clear that flag; only top-level file evaluation
+    /// reads it, to skip `main`.
     ReturnEarly { src: RegId },
     /// Return from the block with the value in the register
     Return { src: RegId },

--- a/crates/nu-protocol/src/ir/mod.rs
+++ b/crates/nu-protocol/src/ir/mod.rs
@@ -274,9 +274,11 @@ pub enum Instruction {
     PopErrorHandler,
     /// Pop an finally handler.
     PopFinallyRun,
-    /// Return early from the block, raising a `ShellError::Return` instead.
+    /// Return early from the block with the value in the register.
     ///
-    /// Collecting the value is unavoidable.
+    /// Unlike `return`, this runs pending `finally` handlers first (collecting the value in that
+    /// case, like the `try-collect` on the fall-through path), and marks the result as an early
+    /// return so that boundaries can observe it.
     ReturnEarly { src: RegId },
     /// Return from the block with the value in the register
     Return { src: RegId },

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -1131,6 +1131,14 @@ pub struct PipelineExecutionData {
     pub body: PipelineData,
     #[cfg(feature = "os")]
     pub exit: Vec<Option<ExitStatusGuard>>,
+    /// Whether this data was produced by an early `return` from the block, rather than by
+    /// evaluating to the end of the block.
+    ///
+    /// Early return boundaries (custom command calls, closure invocations) consume this flag via
+    /// [`eval_block_with_early_return`](https://docs.rs/nu-engine/latest/nu_engine/fn.eval_block_with_early_return.html),
+    /// so it only propagates out of direct block evaluations. This is used to detect a top-level
+    /// `return` in a script, which should prevent `main` from running.
+    pub early_return: bool,
 }
 
 impl Deref for PipelineExecutionData {
@@ -1153,7 +1161,14 @@ impl PipelineExecutionData {
             body: PipelineData::empty(),
             #[cfg(feature = "os")]
             exit: vec![],
+            early_return: false,
         }
+    }
+
+    /// Mark this data as having been produced by an early `return`.
+    pub fn with_early_return(mut self) -> Self {
+        self.early_return = true;
+        self
     }
 }
 
@@ -1167,11 +1182,15 @@ impl From<PipelineData> for PipelineExecutionData {
         Self {
             body: value,
             exit: vec![exit_status_future],
+            early_return: false,
         }
     }
 
     #[cfg(not(feature = "os"))]
     fn from(value: PipelineData) -> Self {
-        Self { body: value }
+        Self {
+            body: value,
+            early_return: false,
+        }
     }
 }

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -1134,10 +1134,11 @@ pub struct PipelineExecutionData {
     /// Whether this data was produced by an early `return` from the block, rather than by
     /// evaluating to the end of the block.
     ///
-    /// Early return boundaries (custom command calls, closure invocations) consume this flag via
+    /// The flag exists for a single consumer: top-level file evaluation reads it to detect a
+    /// top-level `return` in a script and skip running `main`. Custom command calls and closure
+    /// invocations instead clear it via
     /// [`eval_block_with_early_return`](https://docs.rs/nu-engine/latest/nu_engine/fn.eval_block_with_early_return.html),
-    /// so it only propagates out of direct block evaluations. This is used to detect a top-level
-    /// `return` in a script, which should prevent `main` from running.
+    /// so it never leaks past a nested call and only ever reflects a `return` at the current level.
     pub early_return: bool,
 }
 

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -418,6 +418,108 @@ fn early_return_from_for() {
 }
 
 #[test]
+fn early_return_keeps_metadata() {
+    // An early `return` used to drop pipeline metadata that a value in tail position kept.
+    // https://github.com/nushell/nushell/issues/18552
+    test_eval(
+        r#"def foo [] { if true { return ("body" | metadata set { merge {my: 302} }) } };
+        foo | metadata | get my"#,
+        Eq("302"),
+    )
+}
+
+#[test]
+fn early_return_keeps_stream() {
+    // An early `return` used to collect its value; it should stay a stream like a value in
+    // tail position does.
+    test_eval(
+        "def foo [] { return (1..3 | each { |x| $x }) }; foo | describe",
+        Eq("list<int> (stream)"),
+    )
+}
+
+#[test]
+fn early_return_with_finally_runs_cleanup_and_keeps_value() {
+    test_eval(
+        "def foo [] { try { return 1 } finally { print cleanup } }; foo | print",
+        Eq("cleanup1"),
+    )
+}
+
+#[test]
+fn early_return_with_finally_keeps_metadata() {
+    test_eval(
+        r#"def foo [] { try { return ("body" | metadata set { merge {my: 302} }) } finally { } };
+        foo | metadata | get my"#,
+        Eq("302"),
+    )
+}
+
+#[test]
+fn early_return_not_intercepted_by_catch() {
+    test_eval(
+        "def foo [] { try { return early } catch { 'caught' } }; foo",
+        Eq("early"),
+    )
+}
+
+#[test]
+fn early_return_in_export_env_stays_in_env_block() {
+    // `return` inside `export-env` ends the environment block; it used to unwind further and
+    // abort the enclosing command.
+    test_eval(
+        "def foo [] { export-env { return }; 'after' }; foo",
+        Eq("after"),
+    )
+}
+
+#[test]
+fn early_return_in_export_env_guard_skips_rest_of_env_block() {
+    test_eval(
+        "def foo [] { export-env { if true { return }; $env.FOO = 'set' }; $env.FOO? | default 'unset' };
+        foo",
+        Eq("unset"),
+    )
+}
+
+#[test]
+fn early_return_inside_command_does_not_skip_main() {
+    // A `return` inside a command called at the top level of a script is consumed at the call
+    // boundary; only a top-level `return` should prevent `main` from running.
+    Playground::setup(
+        "return_in_command_does_not_skip_main",
+        |dirs, playground| {
+            playground.with_files(&[nu_test_support::fs::Stub::FileWithContent(
+                "script.nu",
+                "def helper [] { return 1 }\nhelper\ndef main [] { print 'main ran' }",
+            )]);
+            let actual = nu!(
+                cwd: dirs.test(),
+                "nu -n script.nu"
+            );
+            assert!(actual.out.contains("main ran"), "out: {}", actual.out);
+            assert!(actual.status.success());
+        },
+    );
+}
+
+#[test]
+fn early_return_in_module_export_env_does_not_abort_caller() {
+    Playground::setup("return_in_module_export_env", |dirs, playground| {
+        playground.with_files(&[nu_test_support::fs::Stub::FileWithContent(
+            "mod.nu",
+            "export-env { return }\nexport def hi [] { 'hi' }",
+        )]);
+        let actual = nu!(
+            cwd: dirs.test(),
+            "def foo [] { use mod.nu *; hi }; foo"
+        );
+        assert_eq!(actual.out, "hi");
+        assert!(actual.status.success());
+    });
+}
+
+#[test]
 fn try_no_catch() {
     test_eval("try { error make { msg: foo } }; 'pass'", Eq("pass"))
 }

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -502,14 +502,6 @@ fn early_return_in_export_env_guard_skips_rest_of_env_block() -> Result {
         .expect_value_eq(())
 }
 
-/// Subset of the record `complete` returns, captured in a single `nu` run rather than re-running
-/// the binary once per field.
-#[derive(FromValue)]
-struct CompleteResult {
-    exit_code: i64,
-    stdout: String,
-}
-
 #[test]
 #[deps(NU)]
 fn early_return_inside_command_does_not_skip_main() -> Result {

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -1,5 +1,5 @@
 use fancy_regex::Regex;
-use nu_protocol::PipelineData;
+use nu_protocol::{PipelineData, test_value};
 use nu_test_support::{fs::Stub::FileWithContent, prelude::*, tester::TestError};
 
 #[test]
@@ -448,15 +448,22 @@ fn early_return_keeps_stream() -> Result {
 #[test]
 fn early_return_with_finally_runs_cleanup_and_keeps_value() -> Result {
     // In-process `print` output isn't captured, so the `finally` block reports through the root
-    // job's mailbox (`job send 0`) instead. Interpolating the recovered message with the returned
-    // value yields "cleanup1", proving the cleanup ran and the early-return value survived it.
+    // job's mailbox (`job send 0`) instead. The recovered message and the returned value confirm
+    // the cleanup ran and the early-return value survived it. The pipeline is single-threaded, so
+    // by the time `job recv` runs the message is already queued and no timeout is needed.
     test()
         .run(
             r#"def foo [] { try { return 1 } finally { "cleanup" | job send 0 } };
             let val = foo;
-            $"(job recv --timeout 10sec)($val)""#,
+            {
+                finally: (job recv --timeout 0sec),
+                returned: $val,
+            }"#,
         )
-        .expect_value_eq("cleanup1")
+        .expect_value_eq(test_value!({
+            finally: "cleanup",
+            returned: 1,
+        }))
 }
 
 #[test]
@@ -489,10 +496,10 @@ fn early_return_in_export_env_stays_in_env_block() -> Result {
 fn early_return_in_export_env_guard_skips_rest_of_env_block() -> Result {
     test()
         .run(
-            "def foo [] { export-env { if true { return }; $env.FOO = 'set' }; $env.FOO? | default 'unset' };
+            "def foo [] { export-env { if true { return }; $env.FOO = 'set' }; $env.FOO? };
             foo",
         )
-        .expect_value_eq("unset")
+        .expect_value_eq(())
 }
 
 /// Subset of the record `complete` returns, captured in a single `nu` run rather than re-running

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -1,5 +1,6 @@
 use fancy_regex::Regex;
-use nu_test_support::{nu, playground::Playground};
+use nu_protocol::PipelineData;
+use nu_test_support::{fs::Stub::FileWithContent, prelude::*, tester::TestError};
 
 #[test]
 fn record_with_redefined_key() {
@@ -418,105 +419,129 @@ fn early_return_from_for() {
 }
 
 #[test]
-fn early_return_keeps_metadata() {
+fn early_return_keeps_metadata() -> Result {
     // An early `return` used to drop pipeline metadata that a value in tail position kept.
     // https://github.com/nushell/nushell/issues/18552
-    test_eval(
-        r#"def foo [] { if true { return ("body" | metadata set { merge {my: 302} }) } };
-        foo | metadata | get my"#,
-        Eq("302"),
-    )
+    test()
+        .run(
+            r#"def foo [] { if true { return ("body" | metadata set { merge {my: 302} }) } };
+            foo | metadata | get my"#,
+        )
+        .expect_value_eq(302)
 }
 
 #[test]
-fn early_return_keeps_stream() {
+fn early_return_keeps_stream() -> Result {
     // An early `return` used to collect its value; it should stay a stream like a value in
-    // tail position does.
-    test_eval(
-        "def foo [] { return (1..3 | each { |x| $x }) }; foo | describe",
-        Eq("list<int> (stream)"),
-    )
+    // tail position does. Assert on the pipeline structure rather than `describe` output, so a
+    // regression that collects the stream into a list is caught directly.
+    let output = test().run_raw("def foo [] { return (1..3 | each { |x| $x }) }; foo")?;
+    let PipelineData::ListStream(stream, _) = output.body else {
+        panic!("early return should stay a stream")
+    };
+    stream
+        .into_value()
+        .map_err(TestError::from)
+        .expect_value_eq(vec![1i64, 2, 3])
 }
 
 #[test]
-fn early_return_with_finally_runs_cleanup_and_keeps_value() {
-    test_eval(
-        "def foo [] { try { return 1 } finally { print cleanup } }; foo | print",
-        Eq("cleanup1"),
-    )
+fn early_return_with_finally_runs_cleanup_and_keeps_value() -> Result {
+    // In-process `print` output isn't captured, so the `finally` block reports through the root
+    // job's mailbox (`job send 0`) instead. Interpolating the recovered message with the returned
+    // value yields "cleanup1", proving the cleanup ran and the early-return value survived it.
+    test()
+        .run(
+            r#"def foo [] { try { return 1 } finally { "cleanup" | job send 0 } };
+            let val = foo;
+            $"(job recv --timeout 10sec)($val)""#,
+        )
+        .expect_value_eq("cleanup1")
 }
 
 #[test]
-fn early_return_with_finally_keeps_metadata() {
-    test_eval(
-        r#"def foo [] { try { return ("body" | metadata set { merge {my: 302} }) } finally { } };
-        foo | metadata | get my"#,
-        Eq("302"),
-    )
+fn early_return_with_finally_keeps_metadata() -> Result {
+    test()
+        .run(
+            r#"def foo [] { try { return ("body" | metadata set { merge {my: 302} }) } finally { } };
+            foo | metadata | get my"#,
+        )
+        .expect_value_eq(302)
 }
 
 #[test]
-fn early_return_not_intercepted_by_catch() {
-    test_eval(
-        "def foo [] { try { return early } catch { 'caught' } }; foo",
-        Eq("early"),
-    )
+fn early_return_not_intercepted_by_catch() -> Result {
+    test()
+        .run("def foo [] { try { return early } catch { 'caught' } }; foo")
+        .expect_value_eq("early")
 }
 
 #[test]
-fn early_return_in_export_env_stays_in_env_block() {
+fn early_return_in_export_env_stays_in_env_block() -> Result {
     // `return` inside `export-env` ends the environment block; it used to unwind further and
     // abort the enclosing command.
-    test_eval(
-        "def foo [] { export-env { return }; 'after' }; foo",
-        Eq("after"),
-    )
+    test()
+        .run("def foo [] { export-env { return }; 'after' }; foo")
+        .expect_value_eq("after")
 }
 
 #[test]
-fn early_return_in_export_env_guard_skips_rest_of_env_block() {
-    test_eval(
-        "def foo [] { export-env { if true { return }; $env.FOO = 'set' }; $env.FOO? | default 'unset' };
-        foo",
-        Eq("unset"),
-    )
+fn early_return_in_export_env_guard_skips_rest_of_env_block() -> Result {
+    test()
+        .run(
+            "def foo [] { export-env { if true { return }; $env.FOO = 'set' }; $env.FOO? | default 'unset' };
+            foo",
+        )
+        .expect_value_eq("unset")
+}
+
+/// Subset of the record `complete` returns, captured in a single `nu` run rather than re-running
+/// the binary once per field.
+#[derive(FromValue)]
+struct CompleteResult {
+    exit_code: i64,
+    stdout: String,
 }
 
 #[test]
-fn early_return_inside_command_does_not_skip_main() {
-    // A `return` inside a command called at the top level of a script is consumed at the call
-    // boundary; only a top-level `return` should prevent `main` from running.
+#[deps(NU)]
+fn early_return_inside_command_does_not_skip_main() -> Result {
+    // A `return` inside a command called at the top level of a script is consumed where the
+    // command is called; only a top-level `return` should prevent `main` from running. This runs
+    // the `nu` binary because that "skip main" decision lives in file evaluation, not in the
+    // in-process engine.
     Playground::setup(
-        "return_in_command_does_not_skip_main",
-        |dirs, playground| {
-            playground.with_files(&[nu_test_support::fs::Stub::FileWithContent(
+        "early_return_inside_command_does_not_skip_main",
+        |dirs, sandbox| -> Result {
+            sandbox.with_files(&[FileWithContent(
                 "script.nu",
                 "def helper [] { return 1 }\nhelper\ndef main [] { print 'main ran' }",
             )]);
-            let actual = nu!(
-                cwd: dirs.test(),
-                "nu -n script.nu"
-            );
-            assert!(actual.out.contains("main ran"), "out: {}", actual.out);
-            assert!(actual.status.success());
+
+            let result: CompleteResult =
+                test().cwd(dirs.test()).run("nu -n script.nu | complete")?;
+            assert_eq!(result.exit_code, 0);
+            assert_contains("main ran", result.stdout);
+            Ok(())
         },
-    );
+    )
 }
 
 #[test]
-fn early_return_in_module_export_env_does_not_abort_caller() {
-    Playground::setup("return_in_module_export_env", |dirs, playground| {
-        playground.with_files(&[nu_test_support::fs::Stub::FileWithContent(
-            "mod.nu",
-            "export-env { return }\nexport def hi [] { 'hi' }",
-        )]);
-        let actual = nu!(
-            cwd: dirs.test(),
-            "def foo [] { use mod.nu *; hi }; foo"
-        );
-        assert_eq!(actual.out, "hi");
-        assert!(actual.status.success());
-    });
+fn early_return_in_module_export_env_does_not_abort_caller() -> Result {
+    Playground::setup(
+        "early_return_in_module_export_env_does_not_abort_caller",
+        |dirs, sandbox| -> Result {
+            sandbox.with_files(&[FileWithContent(
+                "mod.nu",
+                "export-env { return }\nexport def hi [] { 'hi' }",
+            )]);
+            test()
+                .cwd(dirs.test())
+                .run("def foo [] { use mod.nu *; hi }; foo")
+                .expect_value_eq("hi")
+        },
+    )
 }
 
 #[test]


### PR DESCRIPTION
## Description

Returning a value early with `return` didn't behave like putting the same value on a command's last line. The metadata got dropped, and a lazy stream was read into memory (#18552).

```nushell
def to-csv [] { if true { return ("a,b" | metadata set --content-type text/csv) } }

to-csv | metadata | get content_type?
# before:  nothing (the content type was dropped)
# after:   text/csv
```

### The cause

`return` passed its value back by raising an internal error, `ShellError::Return`, that carried the value out of the command. Raising the error forced any stream to collect into a list. Catching it again where the command was called turned it back into a value with its metadata set to none.

### The change

An early `return` now leaves the block through the same path as a value in tail position, so streams and metadata survive. Concretely:

- The `ReturnEarly` IR instruction no longer raises `ShellError::Return`; it hands back the register value directly.
- The result carries a new flag, `PipelineExecutionData::early_return`, marking "this came from a `return`".
- Custom command and closure calls (via `eval_block_with_early_return`) clear that flag, so it can't leak out of a nested call. The single consumer that reads it is top-level file evaluation, which uses it to skip running `main`.

`ShellError::Return` isn't raised anymore; the variant is kept but `#[deprecated]`.

### Behavior preserved (with tests)

- `finally` still runs on the way out; `catch` still doesn't catch a `return`.
- A top-level `return` in a script still stops `main` from running.
- A `return` inside a command/closure called at the top level does **not** skip `main`; it's absorbed where the command was called.
- `return` inside `export-env` stays scoped to the env block instead of aborting the caller.

### Caveat: `finally` collects

When a `finally` is present, the returned value is still collected (a stream becomes a list). That's existing behavior, not a regression here; a value on the last line of a `try`/`finally` has always collected the same way. Metadata still comes through.

### Out of scope: control flow *after* `try`/`finally`

This PR does not change what runs after a `try`/`finally` that early-returns. On both `main` and this branch, `try { return 5 } finally { ... }; <code>` still runs `<code>` (while returning `5`), and `break`/`continue` skip a pending `finally`. Straightening that out is a separate rework on top of this branch, tracked in https://github.com/cablehead/nushell/pull/4 (WIP on my fork, still coming together; feedback welcome).

## User-facing changes (Release notes)

Fixed an issue where returning a value early with `return` from a custom command or closure dropped the value's metadata and read its streaming output into memory. `return` now matches a value on the command's last line: metadata is kept and streams stay lazy.

```nushell
def foo [] { return (1..3 | each { $in }) }

foo | describe
# before:  list<int>
# after:   list<int> (stream)
```

## Additional notes

Fixes #18552. Suggested label: `notes:fixes`.

- Adds one public field, `PipelineExecutionData::early_return`, relevant to embedders and plugin authors.
- `ShellError::Return` is now `#[deprecated]` and no longer raised by the engine; the variant is retained for one release for compatibility.
- Follow-up: https://github.com/cablehead/nushell/pull/5 (WIP on my fork) reworks `finally` control flow (`return`/`break`/`continue`) on top of this branch.
