### PR TITLE
Preserve drive-relative prefixes in `path split` (#18607)

### DIFF
--- a/crates/nu-command/src/path/split.rs
+++ b/crates/nu-command/src/path/split.rs
@@ -155,29 +155,46 @@ impl Command for PathSplit {
     }
 }
 
+#[cfg(windows)]
+fn split_components(path: &Path) -> Vec<String> {
+    let mut components = path.components().peekable();
+    let mut parts = Vec::new();
+
+    while let Some(component) = components.next() {
+        match component {
+            Component::Prefix(_) => {
+                let mut prefix = component.as_os_str().to_string_lossy().to_string();
+                if matches!(components.peek(), Some(Component::RootDir)) {
+                    prefix.push('\\');
+                    components.next();
+                }
+                parts.push(prefix);
+            }
+            Component::RootDir => {}
+            component => parts.push(component.as_os_str().to_string_lossy().to_string()),
+        }
+    }
+
+    parts
+}
+
 fn split(path: &Path, span: Span, _: &Arguments) -> Value {
+    #[cfg(windows)]
+    let parts = split_components(path);
+
+    #[cfg(not(windows))]
+    let parts = path
+        .components()
+        .filter_map(process_component)
+        .collect::<Vec<_>>();
+
     Value::list(
-        path.components()
-            .filter_map(|comp| {
-                let comp = process_component(comp);
-                comp.map(|s| Value::string(s, span))
-            })
+        parts
+            .into_iter()
+            .map(|part| Value::string(part, span))
             .collect(),
         span,
     )
-}
-
-#[cfg(windows)]
-fn process_component(comp: Component) -> Option<String> {
-    match comp {
-        Component::RootDir => None,
-        Component::Prefix(_) => {
-            let mut s = comp.as_os_str().to_string_lossy().to_string();
-            s.push('\\');
-            Some(s)
-        }
-        comp => Some(comp.as_os_str().to_string_lossy().to_string()),
-    }
 }
 
 #[cfg(not(windows))]
@@ -192,5 +209,17 @@ mod tests {
     #[test]
     fn test_examples() -> nu_test_support::Result {
         nu_test_support::test().examples(PathSplit)
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn keeps_drive_relative_prefix_without_root_separator() {
+        assert_eq!(split_components(Path::new("C:Desktop")), ["C:", "Desktop"]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn keeps_root_separator_for_absolute_drive_path() {
+        assert_eq!(split_components(Path::new(r"C:\\Users")), [r"C:\", "Users"]);
     }
 }

--- a/crates/nu-command/src/path/split.rs
+++ b/crates/nu-command/src/path/split.rs
@@ -222,4 +222,13 @@ mod tests {
     fn keeps_root_separator_for_absolute_drive_path() {
         assert_eq!(split_components(Path::new(r"C:\\Users")), [r"C:\", "Users"]);
     }
+
+    #[cfg(windows)]
+    #[test]
+    fn keeps_unc_share_as_rooted_prefix() {
+        assert_eq!(
+            split_components(Path::new(r"\\server\share\some\path")),
+            [r"\\server\share\", "some", "path"]
+        );
+    }
 }


### PR DESCRIPTION
## Description

Fix `path split` on Windows so a drive-relative path such as `C:Desktop` retains `C:` as its first component. The implementation only folds a following root separator into a drive prefix when the input actually contains one, preserving the existing output for absolute drive paths such as `C:\\Users`.

## User-facing changes (Release notes)

Fixed `path split` changing Windows drive-relative paths such as `C:Desktop` into rooted paths. These paths now preserve their original `C:` prefix.

## Additional notes

Fixes #18607

Validation:

- `cargo fmt --all -- --check`
- `cargo test --package nu-command --lib path::split::tests`
- `cargo clippy --package nu-command --lib --tests -- -D warnings -D clippy::unwrap_used`
