### PR TITLE
fix par-each hang bug

### DIFF
--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -15,9 +15,17 @@ const STREAM_BUFFER_SIZE: usize = 64;
 const CTRL_C_CHECK_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Cache of thread pools keyed by thread count.
+///
 /// Reuses an existing pool instead of spawning OS threads on every top-level `par-each`.
 /// Nested calls intentionally bypass this cache (see [`create_pool`]).
+///
+/// Key `0` means "default size" (`ThreadPoolBuilder::num_threads(0)` → logical CPUs).
 /// Distinct `-t` sizes are rare in practice, so the map is not bounded.
+///
+/// These pools are **dedicated to `par-each`**. We intentionally never use Rayon's
+/// process-wide global pool: other commands (`glob` with dc-glob, `ls`, …) also schedule
+/// work there, and sharing it with the streaming path can deadlock when pool workers
+/// block on channel receives while a producer waits for a free worker.
 static THREAD_POOLS: OnceLock<Mutex<HashMap<usize, Arc<rayon::ThreadPool>>>> = OnceLock::new();
 
 fn lock_pool_cache(
@@ -49,8 +57,8 @@ fn build_pool(num_threads: usize, head: Span) -> Result<Arc<rayon::ThreadPool>, 
 
 /// Get or create a thread pool for this `par-each` invocation.
 ///
-/// - `num_threads == 0` at top level: use Rayon's global pool (`None`).
-/// - `num_threads > 0` at top level: reuse a process-wide cached pool of that size.
+/// - Top-level: reuse a process-wide cached pool. `num_threads == 0` is the default
+///   size pool (still private to `par-each`, not Rayon's global pool).
 /// - **Nested** calls (already running on a Rayon worker): always build a **private,
 ///   uncached** pool. Sharing the outer pool deadlocks because the streaming path
 ///   blocks the caller on a channel while holding a worker of that same pool.
@@ -58,24 +66,17 @@ fn build_pool(num_threads: usize, head: Span) -> Result<Arc<rayon::ThreadPool>, 
 /// Pool construction for the cache path runs outside the cache lock so concurrent
 /// top-level callers are not blocked while OS threads are spawned. A second lookup
 /// after build handles races.
-fn create_pool(
-    num_threads: usize,
-    head: Span,
-) -> Result<Option<Arc<rayon::ThreadPool>>, ShellError> {
-    // Nested: never share a pool with the outer `par-each` (cached or global).
+fn create_pool(num_threads: usize, head: Span) -> Result<Arc<rayon::ThreadPool>, ShellError> {
+    // Nested: never share a pool with the outer `par-each` (or any other Rayon pool).
     if rayon::current_thread_index().is_some() {
         // `num_threads == 0` => Rayon default (logical CPU count), same as a fresh builder.
-        return Ok(Some(build_pool(num_threads, head)?));
-    }
-
-    if num_threads == 0 {
-        return Ok(None);
+        return build_pool(num_threads, head);
     }
 
     {
         let pools = lock_pool_cache(head)?;
         if let Some(pool) = pools.get(&num_threads) {
-            return Ok(Some(pool.clone()));
+            return Ok(pool.clone());
         }
     }
 
@@ -83,18 +84,7 @@ fn create_pool(
 
     let mut pools = lock_pool_cache(head)?;
     // Another caller may have inserted the same key while we were building.
-    Ok(Some(pools.entry(num_threads).or_insert(built).clone()))
-}
-
-/// Run `f` on a custom pool when present, otherwise on Rayon's global pool.
-fn run_on_pool<R>(pool: Option<&Arc<rayon::ThreadPool>>, f: impl FnOnce() -> R + Send) -> R
-where
-    R: Send,
-{
-    match pool {
-        Some(p) => p.install(f),
-        None => f(),
-    }
+    Ok(pools.entry(num_threads).or_insert(built).clone())
 }
 
 #[derive(Clone)]
@@ -110,7 +100,7 @@ impl Command for ParEach {
     }
 
     fn extra_description(&self) -> &str {
-        " Without --threads, uses the process-wide Rayon pool; with --threads, reuses a cached pool of that size. Nested par-each calls use a private pool so they cannot deadlock on the outer pool."
+        " Uses a dedicated thread pool (reused across top-level calls; sized by --threads when set). Nested par-each calls use a private pool so they cannot deadlock on the outer pool."
     }
 
     fn signature(&self) -> nu_protocol::Signature {
@@ -216,7 +206,7 @@ impl Command for ParEach {
         // A helper function sorts the output if needed
         let apply_order = |mut vec: Vec<(usize, Value)>| {
             if keep_order {
-                // Runs under Rayon (custom pool via install, or global pool).
+                // Runs under Rayon (dedicated pool via install).
                 // There are no identical indexes, so unstable sorting can be used.
                 vec.par_sort_unstable_by_key(|(index, _)| *index);
             }
@@ -232,7 +222,7 @@ impl Command for ParEach {
                     Value::List { vals, .. } => {
                         let pool = create_pool(max_threads, head)?;
                         if keep_order {
-                            Ok(run_on_pool(pool.as_ref(), || {
+                            Ok(pool.install(|| {
                                 let par_iter = vals.into_par_iter().enumerate();
                                 let mapped =
                                     parallel_closure_map(engine_state, stack, &closure, par_iter);
@@ -255,7 +245,7 @@ impl Command for ParEach {
                     Value::Range { val, .. } => {
                         let pool = create_pool(max_threads, head)?;
                         if keep_order {
-                            Ok(run_on_pool(pool.as_ref(), || {
+                            Ok(pool.install(|| {
                                 let par_iter = val
                                     .into_range_iter(span, signals.clone())
                                     .enumerate()
@@ -288,7 +278,7 @@ impl Command for ParEach {
             PipelineData::ListStream(stream, ..) => {
                 let pool = create_pool(max_threads, head)?;
                 if keep_order {
-                    Ok(run_on_pool(pool.as_ref(), || {
+                    Ok(pool.install(|| {
                         let par_iter = stream.into_iter().enumerate().par_bridge();
                         let mapped = parallel_closure_map(engine_state, stack, &closure, par_iter);
                         apply_order(mapped.collect()).into_pipeline_data(head, signals.clone())
@@ -310,7 +300,7 @@ impl Command for ParEach {
                 if let Some(chunks) = stream.chunks() {
                     let pool = create_pool(max_threads, head)?;
                     if keep_order {
-                        Ok(run_on_pool(pool.as_ref(), || {
+                        Ok(pool.install(|| {
                             let par_iter = chunks
                                 .enumerate()
                                 .map(move |(idx, val)| {
@@ -349,7 +339,7 @@ fn stream_parallel_values(
     engine_state: &EngineState,
     stack: &Stack,
     closure: Closure,
-    pool: Option<Arc<rayon::ThreadPool>>,
+    pool: Arc<rayon::ThreadPool>,
     span: Span,
     signals: Signals,
     input: impl ParallelIterator<Item = Value> + 'static,
@@ -361,42 +351,41 @@ fn stream_parallel_values(
     let worker_stack = stack.captures_to_stack(closure.captures.clone());
     let worker_signals = signals.clone();
 
-    let spawn_work = move || {
-        rayon::spawn(move || {
-            let map_signals = worker_signals.clone();
-            let send_signals = worker_signals.clone();
+    // Spawn on the dedicated pool (not `rayon::spawn`, which always uses the global
+    // pool). ParallelIterator work then also runs on this pool because the task
+    // executes on one of its workers.
+    pool.spawn(move || {
+        let map_signals = worker_signals.clone();
+        let send_signals = worker_signals.clone();
 
-            let _ = input
-                .map_init(
-                    move || ClosureEval::new(&worker_engine_state, &worker_stack, closure.clone()),
-                    move |closure_eval, value| {
-                        if map_signals.interrupted() {
-                            return Err(());
-                        }
-
-                        let value = run_closure_on_value(closure_eval, value);
-
-                        if map_signals.interrupted() {
-                            Err(())
-                        } else {
-                            Ok(value)
-                        }
-                    },
-                )
-                .try_for_each(move |value| match value {
-                    Ok(value) => {
-                        if send_signals.interrupted() {
-                            Err(())
-                        } else {
-                            tx.send(value).map_err(|_| ())
-                        }
+        let _ = input
+            .map_init(
+                move || ClosureEval::new(&worker_engine_state, &worker_stack, closure.clone()),
+                move |closure_eval, value| {
+                    if map_signals.interrupted() {
+                        return Err(());
                     }
-                    Err(()) => Err(()),
-                });
-        });
-    };
 
-    run_on_pool(pool.as_ref(), spawn_work);
+                    let value = run_closure_on_value(closure_eval, value);
+
+                    if map_signals.interrupted() {
+                        Err(())
+                    } else {
+                        Ok(value)
+                    }
+                },
+            )
+            .try_for_each(move |value| match value {
+                Ok(value) => {
+                    if send_signals.interrupted() {
+                        Err(())
+                    } else {
+                        tx.send(value).map_err(|_| ())
+                    }
+                }
+                Err(()) => Err(()),
+            });
+    });
 
     ReceiverIter::new(rx, signals).into_pipeline_data(span, Signals::empty())
 }

--- a/crates/nu-command/tests/commands/par_each.rs
+++ b/crates/nu-command/tests/commands/par_each.rs
@@ -32,7 +32,7 @@ fn par_each_keep_order_preserves_input_order() -> Result {
     test().run(code).expect_value_eq([3, 1, 2])
 }
 
-/// Default pool path (no `--threads`): global Rayon pool reuse.
+/// Default pool path (no `--threads`): dedicated cached pool of default size.
 #[test]
 fn par_each_default_pool_works() -> Result {
     let code = "[1 2 3 4] | par-each {|x| $x * 2 } | sort";
@@ -67,12 +67,69 @@ fn par_each_threads_flag_repeated() -> Result {
     test().run(code).expect_value_eq(true)
 }
 
-/// Default pool with keep-order (no private pool install).
+/// Default pool with keep-order.
 #[test]
 fn par_each_default_pool_keep_order() -> Result {
     let code = "[5 4 3 2 1] | par-each --keep-order {|x| $x }";
 
     test().run(code).expect_value_eq([5, 4, 3, 2, 1])
+}
+
+/// Streaming `par-each` after a ListStream producer that also uses Rayon (`ls`).
+///
+/// Regression for #18566 comment: sharing Rayon's global pool between a producer
+/// (`ls`/`glob`) and the streaming `par-each` path can hang. `par-each` must use a
+/// dedicated pool so producer and consumer never starve each other.
+#[test]
+fn par_each_after_ls_stream_does_not_deadlock() -> Result {
+    // Compare against a sequential path so the test is independent of cwd contents.
+    let code = "
+        let n = ls | length
+        let m = ls | wrap name | par-each {} | length
+        $n == $m
+    ";
+
+    test().run(code).expect_value_eq(true)
+}
+
+/// Same producer/consumer separation with an identity closure and `--threads`.
+#[test]
+fn par_each_after_ls_stream_with_threads() -> Result {
+    let code = "
+        let n = ls | length
+        let m = ls | wrap name | par-each --threads 2 {} | length
+        $n == $m
+    ";
+
+    test().run(code).expect_value_eq(true)
+}
+
+/// `each` produces a ListStream; streaming `par-each` must still complete.
+#[test]
+fn par_each_after_each_stream_matches_length() -> Result {
+    let code = "
+        let data = 0..199 | each {|x| $x}
+        let n = $data | length
+        let m = $data | each {|x| {name: $x}} | par-each {} | length
+        $n == $m
+    ";
+
+    test().run(code).expect_value_eq(true)
+}
+
+/// dc-glob schedules work on Rayon's global pool; `par-each` must not share it.
+///
+/// Mirrors the reported hang: `glob … | wrap name | par-each {}`.
+#[test]
+#[exp(nu_experimental::DC_GLOB)]
+fn par_each_after_dc_glob_stream_does_not_deadlock() -> Result {
+    let code = "
+        let n = glob '*' | length
+        let m = glob '*' | wrap name | par-each {} | length
+        $n == $m
+    ";
+
+    test().run(code).expect_value_eq(true)
 }
 
 /// Nested `par-each --threads` must not deadlock by sharing one cached pool.
@@ -107,7 +164,7 @@ fn par_each_nested_keep_order_same_threads() -> Result {
     test().run(code).expect_value_eq(100)
 }
 
-/// Nested default pools (global outer would also deadlock if nested reused it).
+/// Nested default pools (shared outer would deadlock if nested reused it).
 #[test]
 fn par_each_nested_default_pool_does_not_deadlock() -> Result {
     let code = "


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
Issue identified by @Tyarel8 where `glob * | par-each {}` would hang. Fixed by changing how threads are used.

<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->