### PR TITLE
expand paths for `--config-home` parameter also ensure xdg is absolute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4838,6 +4838,7 @@ dependencies = [
  "derive_setters",
  "dirs 6.0.0",
  "dirs-sys 0.5.0",
+ "nu-path",
  "nu-test-support",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/nu-config/Cargo.toml
+++ b/crates/nu-config/Cargo.toml
@@ -19,6 +19,7 @@ plugin = []
 derive_more = { workspace = true, features = ["display"] }
 derive_setters = { workspace = true }
 dirs = { workspace = true }
+nu-path = { path = "../nu-path" }
 thiserror = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/nu-config/src/errors.rs
+++ b/crates/nu-config/src/errors.rs
@@ -22,8 +22,9 @@ pub enum ConfigError {
 /// Non-fatal warnings produced during config-path resolution.
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]
 pub enum ConfigWarning {
-    /// `$XDG_CONFIG_HOME` was set to a value that was ignored (relative path,
-    /// empty string) and the platform default was used instead.
+    /// `$XDG_CONFIG_HOME` was set to a non-absolute value and was ignored; the
+    /// platform default was used instead. Not emitted when `--config-home`
+    /// simply overrides a valid XDG value.
     #[display(
         "$env.XDG_CONFIG_HOME ({xdg}) is set to a non-absolute path, \
         using default config directory instead: {}", 

--- a/crates/nu-config/src/overrides.rs
+++ b/crates/nu-config/src/overrides.rs
@@ -29,6 +29,10 @@ impl CliOverrides {
     /// path against `cwd`.
     ///
     /// This is the **only** place CLI config path absolute-ization should live.
+    ///
+    /// Resolution is **logical** (not realpath): tilde is expanded via the
+    /// user's home directory, relative segments are joined to `cwd`, and `.` /
+    /// `..` are stripped lexically. Symlinks in the path are **not** followed.
     pub fn from_path_strings(
         config_home: Option<&str>,
         config_file: Option<&str>,
@@ -46,15 +50,20 @@ impl CliOverrides {
     }
 }
 
-/// Resolve a CLI path string against `cwd` when it is relative.
+/// Resolve a CLI path to a logical absolute path against `cwd`.
+///
+/// Uses [`nu_path::expand_path_with`]: expands a leading `~`, joins relative
+/// paths to `cwd`, and lexically normalizes `.` / `..`. Does **not**
+/// canonicalize or follow symlinks — so `~/.config/nushell` becomes
+/// `$HOME/.config/nushell` even when `$HOME` itself is a symlink chain.
 fn absolutize_cli_path(path: &str, cwd: &Path) -> PathBuf {
-    let p = PathBuf::from(path);
-    if p.is_absolute() { p } else { cwd.join(p) }
+    nu_path::expand_path_with(path, cwd, true)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Component;
 
     #[test]
     fn relative_paths_join_cwd() {
@@ -100,5 +109,97 @@ mod tests {
             &cwd,
         );
         assert_eq!(cli.config_file.as_deref(), Some(Path::new(abs)));
+    }
+
+    #[test]
+    fn dot_config_home_is_cwd_without_trailing_curdir() {
+        let cwd = PathBuf::from("/tmp/work");
+        let cli = CliOverrides::from_path_strings(
+            Some("."),
+            None,
+            None,
+            #[cfg(feature = "plugin")]
+            None,
+            &cwd,
+        );
+        assert_eq!(cli.config_home.as_deref(), Some(cwd.as_path()));
+        assert!(
+            !cli
+                .config_home
+                .as_ref()
+                .unwrap()
+                .components()
+                .any(|c| matches!(c, Component::CurDir))
+        );
+    }
+
+    #[test]
+    fn relative_dot_slash_subdir_normalized() {
+        let cwd = PathBuf::from("/tmp/work");
+        let cli = CliOverrides::from_path_strings(
+            Some("./subdir"),
+            Some("./cfg.nu"),
+            None,
+            #[cfg(feature = "plugin")]
+            None,
+            &cwd,
+        );
+        assert_eq!(
+            cli.config_home.as_deref(),
+            Some(Path::new("/tmp/work/subdir"))
+        );
+        assert_eq!(
+            cli.config_file.as_deref(),
+            Some(Path::new("/tmp/work/cfg.nu"))
+        );
+    }
+
+    #[test]
+    fn parent_dir_components_resolved_lexically() {
+        let cwd = PathBuf::from("/tmp/work/nested");
+        assert_eq!(
+            absolutize_cli_path("../sibling", &cwd),
+            PathBuf::from("/tmp/work/sibling")
+        );
+    }
+
+    #[test]
+    fn tilde_config_home_expands_to_user_home_without_cwd_join() {
+        let Some(home) = dirs::home_dir() else {
+            return; // environment without a home dir — skip
+        };
+        let cwd = PathBuf::from("/tmp/unrelated/cwd");
+        let cli = CliOverrides::from_path_strings(
+            Some("~/.config/nushell"),
+            None,
+            None,
+            #[cfg(feature = "plugin")]
+            None,
+            &cwd,
+        );
+        let expected = home.join(".config").join("nushell");
+        assert_eq!(
+            cli.config_home.as_deref(),
+            Some(expected.as_path()),
+            "tilde should expand via $HOME, not join under cwd"
+        );
+        // Must remain the logical home path (no accidental cwd prefix).
+        assert!(
+            !cli
+                .config_home
+                .as_ref()
+                .unwrap()
+                .starts_with(&cwd),
+            "must not resolve under cwd"
+        );
+    }
+
+    #[test]
+    fn bare_tilde_expands_to_home() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let cwd = PathBuf::from("/tmp/unrelated");
+        assert_eq!(absolutize_cli_path("~", &cwd), home);
     }
 }

--- a/crates/nu-config/src/overrides.rs
+++ b/crates/nu-config/src/overrides.rs
@@ -124,8 +124,7 @@ mod tests {
         );
         assert_eq!(cli.config_home.as_deref(), Some(cwd.as_path()));
         assert!(
-            !cli
-                .config_home
+            !cli.config_home
                 .as_ref()
                 .unwrap()
                 .components()
@@ -185,11 +184,7 @@ mod tests {
         );
         // Must remain the logical home path (no accidental cwd prefix).
         assert!(
-            !cli
-                .config_home
-                .as_ref()
-                .unwrap()
-                .starts_with(&cwd),
+            !cli.config_home.as_ref().unwrap().starts_with(&cwd),
             "must not resolve under cwd"
         );
     }

--- a/crates/nu-config/src/resolve.rs
+++ b/crates/nu-config/src/resolve.rs
@@ -31,7 +31,7 @@ pub fn resolve_paths(
     let mut warnings = Vec::new();
 
     // ── config_home ──────────────────────────────────────────────────────
-    let (config_home, xdg_was_absolute) = resolve_config_home_with_source(env, cli)?;
+    let (config_home, config_home_source) = resolve_config_home_with_source(env, cli)?;
 
     // ── config_file / env_file ───────────────────────────────────────────
     let config_file = config_path_from_cli(cli.config_file.as_ref(), config_home.join("config.nu"));
@@ -64,31 +64,35 @@ pub fn resolve_paths(
     );
 
     // ── XDG validation (moved from main.rs) ──────────────────────────────
-    // If the user set XDG_CONFIG_HOME but the platform default was used
-    // (because the value was empty or non-absolute), emit a warning.
-    if let Some(xdg_raw) = env.var("XDG_CONFIG_HOME") {
-        if !xdg_raw.is_empty() && !xdg_was_absolute {
-            warnings.push(ConfigWarning::XdgConfigIgnored {
-                xdg: xdg_raw,
-                resolved: config_home.clone(),
-            });
-        }
+    // Warn only when we fell back to the platform default because XDG was
+    // set but unusable (relative / non-absolute). Do not warn when CLI
+    // `--config-home` simply took priority over a valid XDG value.
+    if matches!(config_home_source, ConfigHomeSource::PlatformDefault)
+        && let Some(xdg_raw) = env.var("XDG_CONFIG_HOME")
+        && !xdg_raw.is_empty()
+    {
+        warnings.push(ConfigWarning::XdgConfigIgnored {
+            xdg: xdg_raw,
+            resolved: config_home.clone(),
+        });
+    }
 
-        // If XDG_CONFIG_HOME was used but the old dir still has files while
-        // the new one is empty, warn about the migration.
-        if xdg_was_absolute && let Some(old_config) = env.config_dir().map(|p| p.join("nushell")) {
-            let new_config_empty = config_home
-                .read_dir()
-                .map_or(true, |mut dir| dir.next().is_none());
-            let old_config_empty = old_config
-                .read_dir()
-                .map_or(true, |mut dir| dir.next().is_none());
-            if !old_config_empty && new_config_empty {
-                warnings.push(ConfigWarning::OldConfigDirHasFiles {
-                    old: old_config,
-                    new: config_home.clone(),
-                });
-            }
+    // If XDG_CONFIG_HOME was used but the old dir still has files while
+    // the new one is empty, warn about the migration.
+    if matches!(config_home_source, ConfigHomeSource::Xdg)
+        && let Some(old_config) = env.config_dir().map(|p| p.join("nushell"))
+    {
+        let new_config_empty = config_home
+            .read_dir()
+            .map_or(true, |mut dir| dir.next().is_none());
+        let old_config_empty = old_config
+            .read_dir()
+            .map_or(true, |mut dir| dir.next().is_none());
+        if !old_config_empty && new_config_empty {
+            warnings.push(ConfigWarning::OldConfigDirHasFiles {
+                old: old_config,
+                new: config_home.clone(),
+            });
         }
     }
 
@@ -121,15 +125,28 @@ fn config_path_from_cli(cli: Option<&PathBuf>, default: PathBuf) -> ConfigPath {
     }
 }
 
-/// Resolve the nushell config directory and track whether an absolute
-/// XDG_CONFIG_HOME was the source.
+/// Where the resolved config home came from.
+///
+/// Used to decide which non-fatal XDG warnings apply. CLI override must not
+/// be treated as “XDG was invalid.”
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigHomeSource {
+    /// `--config-home` CLI flag.
+    Cli,
+    /// Absolute non-empty `$XDG_CONFIG_HOME`.
+    Xdg,
+    /// Platform config dir fallback (dirs crate / no usable XDG).
+    PlatformDefault,
+}
+
+/// Resolve the nushell config directory and record which source won.
 fn resolve_config_home_with_source(
     env: &impl EnvAccess,
     cli: &CliOverrides,
-) -> Result<(PathBuf, bool), ConfigError> {
+) -> Result<(PathBuf, ConfigHomeSource), ConfigError> {
     // 1. CLI override takes highest priority.
     if let Some(ref home) = cli.config_home {
-        return Ok((home.clone(), false));
+        return Ok((home.clone(), ConfigHomeSource::Cli));
     }
 
     // 2. XDG_CONFIG_HOME env var.
@@ -139,12 +156,12 @@ fn resolve_config_home_with_source(
     {
         let mut home = PathBuf::from(xdg);
         home.push("nushell");
-        return Ok((home, true));
+        return Ok((home, ConfigHomeSource::Xdg));
     }
 
     // 3. Platform default.
     let base = env.config_dir().ok_or(ConfigError::ConfigDirNotFound)?;
-    Ok((base.join("nushell"), false))
+    Ok((base.join("nushell"), ConfigHomeSource::PlatformDefault))
 }
 
 /// Resolve an XDG base directory (CONFIG, DATA, CACHE) with fallback.
@@ -313,7 +330,7 @@ mod tests {
             config_home: Some(override_path.clone()),
             ..Default::default()
         };
-        let (dirs, _warnings) = resolve_paths(&env, &cli).expect("resolve should succeed");
+        let (dirs, warnings) = resolve_paths(&env, &cli).expect("resolve should succeed");
         assert_eq!(dirs.config_home, override_path);
         assert_eq!(
             dirs.config_file,
@@ -322,6 +339,62 @@ mod tests {
         assert_eq!(
             dirs.user_autoload_dirs,
             vec![override_path.join("autoload")]
+        );
+        // CLI wins over a valid absolute XDG — must not claim XDG was invalid.
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| matches!(w, ConfigWarning::XdgConfigIgnored { .. })),
+            "unexpected XdgConfigIgnored with --config-home: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn test_cli_config_home_suppresses_xdg_ignored_even_with_relative_xdg() {
+        let override_path = abs_path(&["cli-wins"]);
+        let mut vars = HashMap::new();
+        vars.insert("XDG_CONFIG_HOME".into(), "relative/path".into());
+        let env = test_env_with_platform(vars);
+        let cli = CliOverrides {
+            config_home: Some(override_path.clone()),
+            ..Default::default()
+        };
+        let (dirs, warnings) = resolve_paths(&env, &cli).expect("resolve should succeed");
+        assert_eq!(dirs.config_home, override_path);
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| matches!(w, ConfigWarning::XdgConfigIgnored { .. })),
+            "CLI override should not emit XdgConfigIgnored: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn test_cli_dot_config_home_has_no_curdir_in_derived_paths() {
+        let cwd = abs_path(&["dot-config-home-cwd"]);
+        let cli = CliOverrides::from_path_strings(
+            Some("."),
+            None,
+            None,
+            #[cfg(feature = "plugin")]
+            None,
+            &cwd,
+        );
+        let env = test_env_with_platform(HashMap::new());
+        let (dirs, _) = resolve_paths(&env, &cli).expect("resolve should succeed");
+        assert_eq!(dirs.config_home, cwd);
+        assert_eq!(
+            dirs.env_file.as_path(),
+            cwd.join("env.nu").as_path(),
+            "env path must not contain a /./ segment"
+        );
+        assert_eq!(dirs.user_autoload_dirs, vec![cwd.join("autoload")]);
+        assert!(
+            !dirs
+                .env_file
+                .as_path()
+                .components()
+                .any(|c| { matches!(c, std::path::Component::CurDir) })
         );
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR is a follow up to the nu-config PR and fixes a bug where `--config-home .` wasn't being expanded. We use the normal `nu_path::expand_path_with()` for this so it should behave as expected.

<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
`--config-home .` will now be expanded as well as things like `~/.config/home` without following symlinks so, it's absolute but not the fully resolved symlink target. Also, we enforce that XDG_CONFIG_HOME must be absolute as per the spec just as we did before this PR.
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
closes https://github.com/nushell/nushell/issues/18621

<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->