### PR TITLE
Preserve pipeline input in boolean expressions (#18624)

### DIFF
--- a/crates/nu-engine/src/compile/operator.rs
+++ b/crates/nu-engine/src/compile/operator.rs
@@ -63,9 +63,14 @@ pub(crate) fn compile_binary_op(
         // Not an assignment: just do the binary op
         let lhs_reg = out_reg;
 
-        // Pass in_reg to lhs if it uses $in
-        let lhs_in_reg = if lhs.has_in_variable(working_set) {
-            in_reg
+        // Both sides of a binary operation can consume pipeline input. Preserve it for the
+        // right-hand side before compiling the left-hand side, which may overwrite its input
+        // register.
+        let rhs_in_reg = if rhs.has_in_variable(working_set) {
+            match in_reg {
+                Some(in_reg) => Some(builder.clone_reg(in_reg, rhs.span)?),
+                None => None,
+            }
         } else {
             None
         };
@@ -75,7 +80,7 @@ pub(crate) fn compile_binary_op(
             builder,
             lhs,
             RedirectModes::value(lhs.span),
-            lhs_in_reg,
+            in_reg,
             lhs_reg,
         )?;
 
@@ -106,21 +111,6 @@ pub(crate) fn compile_binary_op(
                 // the RHS expression
                 let rhs_reg = builder.next_register()?;
 
-                // Pass in_reg to rhs if it uses $in. But if in_reg aliases lhs_reg (which can
-                // happen because lhs_reg == out_reg), the rhs compilation might `drop` it while
-                // following a `drop_input` path, which would clobber the live lhs value. Clone it
-                // in that case so the rhs gets its own droppable input register.
-                let rhs_in_reg = if rhs.has_in_variable(working_set) {
-                    match in_reg {
-                        Some(in_reg) if in_reg == lhs_reg => {
-                            Some(builder.clone_reg(in_reg, rhs.span)?)
-                        }
-                        other => other,
-                    }
-                } else {
-                    None
-                };
-
                 compile_expression(
                     working_set,
                     builder,
@@ -147,19 +137,6 @@ pub(crate) fn compile_binary_op(
             }
             _ => {
                 let rhs_reg = builder.next_register()?;
-
-                // Pass in_reg to rhs if it uses $in. See the and/or branch above for why we may
-                // need to clone in_reg when it aliases lhs_reg.
-                let rhs_in_reg = if rhs.has_in_variable(working_set) {
-                    match in_reg {
-                        Some(in_reg) if in_reg == lhs_reg => {
-                            Some(builder.clone_reg(in_reg, rhs.span)?)
-                        }
-                        other => other,
-                    }
-                } else {
-                    None
-                };
 
                 compile_expression(
                     working_set,

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -202,6 +202,14 @@ fn binary_op_rhs_collects_in_variable() {
 }
 
 #[test]
+fn binary_op_subexpression_receives_pipeline_input() {
+    test_eval(
+        "'wow' | (is-not-empty) and ($in not-starts-with '#')",
+        Eq("true"),
+    );
+}
+
+#[test]
 fn range_from_expressions() {
     test_eval("(1 + 1)..(2 + 2)", Matches("2.*3.*4"))
 }


### PR DESCRIPTION
## Description

Preserves the original pipeline input for both operands of binary expressions. A command nested in the left operand can now consume the input while `$in` in the right operand still receives the same value.

## User-facing changes (Release notes)

Fixed boolean expressions in pipeline stages where a left-hand command and a right-hand `$in` condition were evaluated against different input. For example, `'wow' | (is-not-empty) and ($in not-starts-with '#')` now returns `true`.

## Additional notes

Fixes #18624

## Validation

- `cargo test --test tests eval:: -- --nocapture`
- `cargo test -p nu-engine`
- `cargo clippy -p nu-engine -- -D warnings -D clippy::unwrap_used`
- `nu -c "use toolkit.nu; toolkit fmt"`
- `cargo fmt --all -- --check`
- `git diff --check`

`nu -c "use toolkit.nu; toolkit check pr"` did not complete locally within ten minutes and produced no diagnostic before the time limit.
