### PR TITLE
Migrate `transpose` tests to the new harness (#8670)

### DIFF
--- a/crates/nu-command/tests/commands/transpose.rs
+++ b/crates/nu-command/tests/commands/transpose.rs
@@ -1,42 +1,58 @@
-use nu_test_support::nu;
+use nu_protocol::test_record;
+use nu_test_support::prelude::*;
 
 #[test]
-fn row() {
-    let actual = nu!("[[key value]; [foo 1] [foo 2]] | transpose -r | debug");
-
-    assert!(actual.out.contains("foo: 1"));
+fn row() -> Result {
+    test()
+        .run("[[key value]; [foo 1] [foo 2]] | transpose -r")
+        .expect_value_eq([test_record! { "foo" => 1 }])
 }
 
 #[test]
-fn row_but_last() {
-    let actual = nu!("[[key value]; [foo 1] [foo 2]] | transpose -r -l | debug");
-
-    assert!(actual.out.contains("foo: 2"));
+fn row_but_last() -> Result {
+    test()
+        .run("[[key value]; [foo 1] [foo 2]] | transpose -r -l")
+        .expect_value_eq([test_record! { "foo" => 2 }])
 }
 
 #[test]
-fn row_but_all() {
-    let actual = nu!("[[key value]; [foo 1] [foo 2]] | transpose -r -a | debug");
-
-    assert!(actual.out.contains("foo: [1, 2]"));
+fn row_but_all() -> Result {
+    test()
+        .run("[[key value]; [foo 1] [foo 2]] | transpose -r -a")
+        .expect_value_eq([test_record! { "foo" => [1, 2] }])
 }
 
 #[test]
-fn throw_inner_error() {
+fn throw_inner_error() -> Result {
     let error_msg = "This message should show up";
     let error = format!("(error make {{ msg: \"{error_msg}\" }})");
-    let actual = nu!(format!(
-        "[[key value]; [foo 1] [foo 2] [{} 3]] | transpose",
-        error
-    ));
+    let err = test()
+        .run(format!(
+            "[[key value]; [foo 1] [foo 2] [{} 3]] | transpose",
+            error
+        ))
+        .expect_shell_error()?;
 
-    assert!(actual.err.contains(error.as_str()));
+    assert_eq!(err.into_labeled()?.msg, error_msg);
+    Ok(())
 }
 
 #[test]
-fn rejects_non_table_stream_input() {
-    let actual = nu!("[1 2 3] | each { |it| ($it * 2) } | transpose | to nuon");
+fn rejects_non_table_stream_input() -> Result {
+    let err = test()
+        .run("[1 2 3] | each { |it| ($it * 2) } | transpose | to nuon")
+        .expect_shell_error()?;
 
-    assert!(actual.out.is_empty());
-    assert!(actual.err.contains("only table"));
+    match err {
+        ShellError::OnlySupportsThisInputType {
+            exp_input_type,
+            wrong_type,
+            ..
+        } => {
+            assert_eq!(exp_input_type, "table or record");
+            assert_eq!(wrong_type, "list<any>");
+            Ok(())
+        }
+        err => Err(err.into()),
+    }
 }


### PR DESCRIPTION
## Description

Migrates all five `transpose` command tests from the external-process `nu!` macro to Nushell's in-process typed test harness.

The successful cases now compare exact structured values. The error cases inspect the forwarded labeled error and the concrete `ShellError::OnlySupportsThisInputType` contract instead of matching rendered stdout or stderr substrings. This removes the tests' dependency on a separately built `nu` binary while preserving their behavior.

This is part of #8670.

## User-facing changes (Release notes)

n/a — tests only

## Additional notes

Validation:

- `cargo test -p nu-command --test tests -- commands::transpose` — 5 passed
- `toolkit fmt`
- `toolkit clippy`
- `toolkit check pr` — formatting, all Clippy phases, complete Rust tests and doctests, optional plugin suites, and stdlib tests passed with Rust 1.95.0
- `git diff --check`

OpenAI Codex assisted with repository research, the test migration, and validation. No human review is claimed.
