### PR TITLE
Migrate `length` tests to the new harness (#8670)

### DIFF
--- a/crates/nu-command/tests/commands/length.rs
+++ b/crates/nu-command/tests/commands/length.rs
@@ -1,26 +1,37 @@
 use nu_test_support::fs::Stub::FileWithContent;
-use nu_test_support::nu;
-use nu_test_support::playground::Playground;
+use nu_test_support::prelude::*;
 
 #[test]
-fn length_columns_in_cal_table() {
-    let actual = nu!("cal --as-table | columns | length");
-
-    assert_eq!(actual.out, "7");
+fn length_columns_in_cal_table() -> Result {
+    test()
+        .run("cal --as-table | columns | length")
+        .expect_value_eq(7)
 }
 
 #[test]
-fn length_columns_no_rows() {
-    let actual = nu!("echo [] | length");
-
-    assert_eq!(actual.out, "0");
+fn length_columns_no_rows() -> Result {
+    test().run("echo [] | length").expect_value_eq(0)
 }
 
 #[test]
-fn length_fails_on_echo_record() {
-    let actual = nu!("echo {a:1 b:2} | length");
+fn length_fails_on_echo_record() -> Result {
+    let err = test().run("echo {a:1 b:2} | length").expect_shell_error()?;
 
-    assert!(actual.err.contains("only_supports_this_input_type"));
+    match err {
+        ShellError::OnlySupportsThisInputType {
+            exp_input_type,
+            wrong_type,
+            ..
+        } => {
+            assert_eq!(
+                exp_input_type,
+                "list<any>, binary, nothing, and SQLiteQueryBuilder"
+            );
+            assert_eq!(wrong_type, "record<a: int, b: int>");
+            Ok(())
+        }
+        err => Err(err.into()),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Description

Migrates the three pure `length` command tests from the external-process `nu!` macro to Nushell's in-process typed test harness.

The successful cases now compare exact integer values, and the error case checks the concrete `ShellError::OnlySupportsThisInputType` contract. The filesystem-backed byte-stream test deliberately remains on `nu!` and `Playground`, because it exercises behavior that requires a real file and external process.

This is part of #8670.

## User-facing changes (Release notes)

n/a — tests only

## Additional notes

Validation:

- `cargo test -p nu-command --test tests -- commands::length` — 4 passed
- `toolkit fmt`
- `toolkit clippy`
- `toolkit check pr` — formatting, all Clippy phases, complete Rust tests and doctests, optional plugin suites, and stdlib tests passed with Rust 1.95.0
- `git diff --check`

OpenAI Codex assisted with repository research, the test migration, and validation. No human review is claimed.
