### PR TITLE
Fix date floor/ceil rounding for dates before the Unix epoch

### DIFF
--- a/crates/nu-command/src/date/ceil.rs
+++ b/crates/nu-command/src/date/ceil.rs
@@ -63,7 +63,8 @@ impl Command for DateCeil {
                         let offset_ns = val.timezone().local_minus_utc() as i64 * 1_000_000_000;
                         Value::date(
                             DateTime::<Utc>::from_timestamp_nanos(
-                                nanos - ((nanos + offset_ns) % duration_ns) + duration_ns - 1,
+                                nanos - ((nanos + offset_ns).rem_euclid(duration_ns)) + duration_ns
+                                    - 1,
                             )
                             .with_timezone(&val.timezone()),
                             internal_span,
@@ -125,6 +126,18 @@ impl Command for DateCeil {
                             Span::test_data(),
                         ),
                     ],
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Round a date before the Unix epoch up to the nearest hour",
+                example: "1969-12-31T23:30:00+00:00 | date ceil 1hr",
+                result: Some(Value::date(
+                    DateTime::parse_from_str(
+                        "1969-12-31 23:59:59.999999999 +0000",
+                        "%Y-%m-%d %H:%M:%S.%f %z",
+                    )
+                    .expect("date calculation should not fail in test"),
                     Span::test_data(),
                 )),
             },

--- a/crates/nu-command/src/date/floor.rs
+++ b/crates/nu-command/src/date/floor.rs
@@ -63,7 +63,7 @@ impl Command for DateFloor {
                         let offset_ns = val.timezone().local_minus_utc() as i64 * 1_000_000_000;
                         Value::date(
                             DateTime::<Utc>::from_timestamp_nanos(
-                                nanos - ((nanos + offset_ns) % duration_ns),
+                                nanos - ((nanos + offset_ns).rem_euclid(duration_ns)),
                             )
                             .with_timezone(&val.timezone()),
                             internal_span,
@@ -122,6 +122,15 @@ impl Command for DateFloor {
                             Span::test_data(),
                         ),
                     ],
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Round a date before the Unix epoch down to the nearest hour",
+                example: "1969-12-31T23:30:00+00:00 | date floor 1hr",
+                result: Some(Value::date(
+                    DateTime::parse_from_str("1969-12-31 23:00:00 +0000", "%Y-%m-%d %H:%M:%S %z")
+                        .expect("date calculation should not fail in test"),
                     Span::test_data(),
                 )),
             },


### PR DESCRIPTION
### Problem

`date floor` and `date ceil` mis-round datetimes **before the Unix epoch**. They compute the boundary with `(nanos + offset_ns) % duration_ns`, and Rust's `%` truncates toward zero, so for a pre-epoch datetime the remainder is negative and subtracting it pushes the result *forward* in time:

```
> 1969-12-31T23:30:00+00:00 | date floor 1hr
Wed, 31 Dec 1969 24:00:00  # 1970-01-01T00:00:00 -- a boundary AFTER the input; should be 1969-12-31T23:00:00
> 1969-12-31T23:30:00+00:00 | date ceil 1hr
1970-01-01T00:59:59.999999999  # off by one hour; should be 1969-12-31T23:59:59.999999999
```

The `date floor` output landing *after* the input directly contradicts the command's own description ("...boundary before the input date"). Post-epoch inputs are correct.

### Fix

Use `rem_euclid`, whose remainder is always non-negative, so the boundary is always at or before the local time. The same one-line change applies to both `floor.rs` and `ceil.rs` (the only two occurrences of this pattern).

### Tests

Added a pre-epoch example to each command (nushell runs command examples as tests via `test_examples`); they fail on the old code and pass now. Verified end-to-end by building `nu` and running floor/ceil on pre-epoch dates (now correct) and post-epoch dates (unchanged).
