### PR TITLE
perf: avoid cloning list values

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -434,7 +434,11 @@ fn bench_stack_list_get_var(items: usize) -> impl IntoBenchmarks {
             Value::test_list((0..items).map(|i| Value::test_int(i as i64)).collect()),
         );
         b.iter(move || {
-            black_box(stack.get_var(var_id, Span::test_data()).expect("var present"));
+            black_box(
+                stack
+                    .get_var(var_id, Span::test_data())
+                    .expect("var present"),
+            );
         })
     })]
 }

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -412,6 +412,33 @@ fn bench_binary_value_clone(bytes: usize) -> impl IntoBenchmarks {
     })]
 }
 
+fn bench_list_value_clone(items: usize) -> impl IntoBenchmarks {
+    let name = format!("list_value_clone_{items}");
+    [benchmark_fn(name, move |b| {
+        let value = Value::test_list((0..items).map(|i| Value::test_int(i as i64)).collect());
+        b.iter(move || {
+            black_box(value.clone());
+        })
+    })]
+}
+
+fn bench_stack_list_get_var(items: usize) -> impl IntoBenchmarks {
+    use nu_protocol::VarId;
+
+    let name = format!("stack_list_get_var_{items}");
+    [benchmark_fn(name, move |b| {
+        let mut stack = Stack::new();
+        let var_id = VarId::new(0);
+        stack.add_var(
+            var_id,
+            Value::test_list((0..items).map(|i| Value::test_int(i as i64)).collect()),
+        );
+        b.iter(move || {
+            black_box(stack.get_var(var_id, Span::test_data()).expect("var present"));
+        })
+    })]
+}
+
 fn bench_binary_slice_into_int(bytes: usize, reads: usize) -> impl IntoBenchmarks {
     let (mut stack, engine) = setup_stack_and_engine_from_command(
         "def bench-u16 [data: binary offset: int] {
@@ -1438,6 +1465,9 @@ tango_benchmarks!(
     bench_binary_value_clone(2 * 1024 * 1024),
     bench_binary_slice_into_int(2 * 1024 * 1024, 100),
     bench_binary_skip_shared_half(2 * 1024 * 1024, 100),
+    // List
+    bench_list_value_clone(100_000),
+    bench_stack_list_get_var(100_000),
     // Record
     bench_record_create(1),
     bench_record_create(10),

--- a/crates/nu-cmd-extra/src/extra/filters/roll/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/mod.rs
@@ -26,7 +26,7 @@ fn vertical_rotate_value(
     match value {
         Value::List { mut vals, .. } => {
             let rotations = by.map(|n| n % vals.len()).unwrap_or(1);
-            let values = vals.as_mut_slice();
+            let values = vals.to_mut().as_mut_slice();
 
             match direction {
                 VerticalDirection::Up => values.rotate_left(rotations),

--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -401,7 +401,7 @@ fn describe_value_inner(
             })
         }
         Value::List { ref mut vals, .. } => {
-            for val in &mut *vals {
+            for val in vals.to_mut() {
                 *val =
                     describe_value_inner(std::mem::take(val), head, engine_state).into_value(head);
             }

--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -401,7 +401,8 @@ fn describe_value_inner(
             })
         }
         Value::List { ref mut vals, .. } => {
-            for val in vals.to_mut() {
+            let vals = vals.to_mut();
+            for val in &mut *vals {
                 *val =
                     describe_value_inner(std::mem::take(val), head, engine_state).into_value(head);
             }

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -151,10 +151,11 @@ fn into_record(call: &Call, input: PipelineData) -> Result<PipelineData, ShellEr
                         }
                         expected_type = Some(ExpectedType::Record);
                     }
-                    Value::List { mut vals, .. }
+                    Value::List { vals, .. }
                         if matches!(expected_type, None | Some(ExpectedType::Pair)) =>
                     {
                         if vals.len() == 2 {
+                            let mut vals = vals.into_owned();
                             let (val, key) = vals.pop().zip(vals.pop()).expect("length is < 2");
                             record.insert(key.coerce_into_string()?, val);
                         } else {

--- a/crates/nu-command/src/debug/inspect_table.rs
+++ b/crates/nu-command/src/debug/inspect_table.rs
@@ -230,7 +230,8 @@ mod util {
             }
             Value::List { vals, .. } => {
                 let mut columns = get_columns(&vals);
-                let data = convert_records_to_dataset(engine_state, &columns, vals);
+                let data =
+                    convert_records_to_dataset(engine_state, &columns, vals.into_owned());
 
                 if columns.is_empty() {
                     columns = vec![String::from("")];

--- a/crates/nu-command/src/debug/inspect_table.rs
+++ b/crates/nu-command/src/debug/inspect_table.rs
@@ -230,8 +230,7 @@ mod util {
             }
             Value::List { vals, .. } => {
                 let mut columns = get_columns(&vals);
-                let data =
-                    convert_records_to_dataset(engine_state, &columns, vals.into_owned());
+                let data = convert_records_to_dataset(engine_state, &columns, vals.into_owned());
 
                 if columns.is_empty() {
                     columns = vec![String::from("")];

--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -123,13 +123,14 @@ fn drop_cols(
             let span = v.span();
             match v {
                 Value::List { mut vals, .. } => {
-                    if let Some((first, rest)) = vals.split_first_mut() {
+                    if let Some((first, rest)) = vals.to_mut().split_first_mut() {
                         let drop_cols = drop_cols_set(first, head, columns, from_left)?;
                         for val in rest {
                             drop_record_cols(val, head, &drop_cols)?
                         }
                     }
-                    Ok(Value::list(vals, span).into_pipeline_data_with_metadata(metadata))
+                    Ok(Value::list(vals.into_owned(), span)
+                        .into_pipeline_data_with_metadata(metadata))
                 }
                 Value::Record {
                     val: ref mut record,

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -180,9 +180,7 @@ fn first_helper(
                 Value::List { vals, .. } => {
                     if return_single_element {
                         if let Some(val) = vals.first() {
-                            Ok(val
-                                .clone()
-                                .into_pipeline_data_with_metadata(input_meta))
+                            Ok(val.clone().into_pipeline_data_with_metadata(input_meta))
                         } else if strict_mode {
                             Err(ShellError::AccessEmptyContent { span: head })
                         } else {

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -177,10 +177,12 @@ fn first_helper(
         PipelineData::Value(val, _) => {
             let span = val.span();
             match val {
-                Value::List { mut vals, .. } => {
+                Value::List { vals, .. } => {
                     if return_single_element {
-                        if let Some(val) = vals.first_mut() {
-                            Ok(std::mem::take(val).into_pipeline_data_with_metadata(input_meta))
+                        if let Some(val) = vals.first() {
+                            Ok(val
+                                .clone()
+                                .into_pipeline_data_with_metadata(input_meta))
                         } else if strict_mode {
                             Err(ShellError::AccessEmptyContent { span: head })
                         } else {
@@ -189,8 +191,12 @@ fn first_helper(
                             Ok(Value::nothing(head).into_pipeline_data_with_metadata(input_meta))
                         }
                     } else {
-                        vals.truncate(rows);
-                        Ok(Value::list(vals, span).into_pipeline_data_with_metadata(input_meta))
+                        let value = if rows >= vals.len() {
+                            Value::list_shared(vals, span)
+                        } else {
+                            Value::list(vals.iter().take(rows).cloned().collect(), span)
+                        };
+                        Ok(value.into_pipeline_data_with_metadata(input_meta))
                     }
                 }
                 Value::Binary { val, .. } => {

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -240,10 +240,7 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                                     Value::list_shared(vals, span),
                                 );
                             } else {
-                                out.insert(
-                                    column,
-                                    Value::list_shared(vals, span),
-                                );
+                                out.insert(column, Value::list_shared(vals, span));
                             }
                         } else if !columns.is_empty() {
                             let cell_path =
@@ -253,17 +250,13 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                                 });
 
                             if let Some(r) = cell_path {
-                                inner_table =
-                                    Some(TableInside::Entries(
-                                        r.clone(),
-                                        vals.into_owned(),
-                                        column_index,
-                                    ));
+                                inner_table = Some(TableInside::Entries(
+                                    r.clone(),
+                                    vals.into_owned(),
+                                    column_index,
+                                ));
                             } else {
-                                out.insert(
-                                    column,
-                                    Value::list_shared(vals, span),
-                                );
+                                out.insert(column, Value::list_shared(vals, span));
                             }
                         } else {
                             inner_table = Some(TableInside::Entries(

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -235,9 +235,15 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                                     parent_column_index: column_index,
                                 });
                             } else if out.contains_key(&column) {
-                                out.insert(format!("{column}_{column}"), Value::list(vals, span));
+                                out.insert(
+                                    format!("{column}_{column}"),
+                                    Value::list_shared(vals, span),
+                                );
                             } else {
-                                out.insert(column, Value::list(vals, span));
+                                out.insert(
+                                    column,
+                                    Value::list_shared(vals, span),
+                                );
                             }
                         } else if !columns.is_empty() {
                             let cell_path =
@@ -248,12 +254,23 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
 
                             if let Some(r) = cell_path {
                                 inner_table =
-                                    Some(TableInside::Entries(r.clone(), vals, column_index));
+                                    Some(TableInside::Entries(
+                                        r.clone(),
+                                        vals.into_owned(),
+                                        column_index,
+                                    ));
                             } else {
-                                out.insert(column, Value::list(vals, span));
+                                out.insert(
+                                    column,
+                                    Value::list_shared(vals, span),
+                                );
                             }
                         } else {
-                            inner_table = Some(TableInside::Entries(column, vals, column_index));
+                            inner_table = Some(TableInside::Entries(
+                                column,
+                                vals.into_owned(),
+                                column_index,
+                            ));
                         }
                     }
                     _ => {
@@ -338,7 +355,7 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
             }
             expanded
         }
-        Value::List { vals, .. } => vals,
+        Value::List { vals, .. } => vals.into_owned(),
         item => vec![item],
     }
 }

--- a/crates/nu-command/src/filters/headers.rs
+++ b/crates/nu-command/src/filters/headers.rs
@@ -69,7 +69,7 @@ impl Command for Headers {
         };
 
         let (old_headers, new_headers) = extract_headers(&table, span, config)?;
-        let value = replace_headers(table, span, &old_headers, &new_headers)?;
+        let value = replace_headers(table.into_owned(), span, &old_headers, &new_headers)?;
 
         Ok(value.into_pipeline_data_with_metadata(metadata))
     }

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -198,10 +198,10 @@ impl Command for Last {
             PipelineData::Value(val, _) => {
                 let span = val.span();
                 match val {
-                    Value::List { mut vals, .. } => {
+                    Value::List { vals, .. } => {
                         if return_single_element {
-                            if let Some(v) = vals.pop() {
-                                Ok(v.into_pipeline_data_with_metadata(metadata))
+                            if let Some(v) = vals.last() {
+                                Ok(v.clone().into_pipeline_data_with_metadata(metadata))
                             } else if strict_mode {
                                 Err(ShellError::AccessEmptyContent { span: head })
                             } else {
@@ -211,8 +211,12 @@ impl Command for Last {
                             }
                         } else {
                             let i = vals.len().saturating_sub(rows);
-                            vals.drain(..i);
-                            Ok(Value::list(vals, span).into_pipeline_data_with_metadata(metadata))
+                            let value = if i == 0 {
+                                Value::list_shared(vals, span)
+                            } else {
+                                Value::list(vals.iter().skip(i).cloned().collect(), span)
+                            };
+                            Ok(value.into_pipeline_data_with_metadata(metadata))
                         }
                     }
                     Value::Binary { val, .. } => {
@@ -279,8 +283,8 @@ impl Command for Last {
 
                                 if let Value::List { mut vals, .. } = value {
                                     // Reverse the results to restore original order
-                                    vals.reverse();
-                                    Ok(Value::list(vals, head)
+                                    vals.to_mut().reverse();
+                                    Ok(Value::list(vals.into_owned(), head)
                                         .into_pipeline_data_with_metadata(metadata))
                                 } else {
                                     Ok(value.into_pipeline_data_with_metadata(metadata))

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -223,14 +223,14 @@ impl Command for ParEach {
                         let pool = create_pool(max_threads, head)?;
                         if keep_order {
                             Ok(pool.install(|| {
-                                let par_iter = vals.into_par_iter().enumerate();
+                                let par_iter = vals.into_owned().into_par_iter().enumerate();
                                 let mapped =
                                     parallel_closure_map(engine_state, stack, &closure, par_iter);
                                 apply_order(mapped.collect())
                                     .into_pipeline_data(span, signals.clone())
                             }))
                         } else {
-                            let par_iter = vals.into_par_iter();
+                            let par_iter = vals.into_owned().into_par_iter();
                             Ok(stream_parallel_values(
                                 engine_state,
                                 stack,

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -269,7 +269,7 @@ pub fn transpose(
                             let current_span = val.span();
                             match val {
                                 Value::List { vals, .. } => {
-                                    vals.push(x);
+                                    vals.to_mut().push(x);
                                 }
                                 v => {
                                     *v = Value::list(vec![std::mem::take(v), x], current_span);

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -324,7 +324,7 @@ fn update_value_by_closure_recursive(
             let path_span = Span::new(path_span.start, path_span.end);
             match value {
                 Value::List { vals, .. } => {
-                    for val in vals.iter_mut() {
+                    for val in vals.to_mut() {
                         // Each nested record becomes the new row context so that `|row|`
                         // refers to the immediately-enclosing record, not the outer row.
                         let row_context = val.clone();
@@ -396,7 +396,8 @@ fn update_value_by_closure_recursive(
             let path_span = Span::new(path_span.start, path_span.end);
             match value {
                 Value::List { vals, .. } => {
-                    if let Some(cell) = vals.get_mut(*row_num) {
+                    if *row_num < vals.len() {
+                        let cell = &mut vals.to_mut()[*row_num];
                         update_value_by_closure_recursive(
                             cell, row_value, closure, path_span, path,
                         )?;

--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -477,7 +477,7 @@ fn table(
     let vec_of_values = input
         .into_iter()
         .flat_map(|val| match val {
-            Value::List { vals, .. } => vals,
+            Value::List { vals, .. } => vals.into_owned(),
             other => vec![other],
         })
         .collect::<Vec<Value>>();

--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -337,7 +337,7 @@ impl Job {
             };
 
             let content = match content {
-                Value::List { vals, .. } => vals,
+                Value::List { vals, .. } => vals.into_owned(),
                 Value::Nothing { .. } => Vec::new(),
                 _ => {
                     return Err(ShellError::CantConvert {

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -824,7 +824,7 @@ impl InputList {
     ) -> Result<(Vec<Value>, Option<StreamReader>), ShellError> {
         match input {
             PipelineData::ListStream(stream, ..) => Ok(Self::read_initial_stream_values(stream)),
-            PipelineData::Value(Value::List { vals, .. }, ..) => Ok((vals, None)),
+            PipelineData::Value(Value::List { vals, .. }, ..) => Ok((vals.into_owned(), None)),
             input @ PipelineData::Value(Value::Range { .. }, ..) => {
                 let stream = ListStream::new(input.into_iter(), head, signals);
                 Ok(Self::read_initial_stream_values(stream))

--- a/crates/nu-command/src/stor/insert.rs
+++ b/crates/nu-command/src/stor/insert.rs
@@ -127,7 +127,7 @@ fn handle(
             });
         }
         PipelineData::ListStream(stream, ..) => stream.into_iter().collect::<Vec<_>>(),
-        PipelineData::Value(Value::List { vals, .. }, ..) => vals,
+        PipelineData::Value(Value::List { vals, .. }, ..) => vals.into_owned(),
         PipelineData::Value(val, ..) => vec![val],
         _ => {
             return Err(ShellError::OnlySupportsThisInputType {

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -770,7 +770,7 @@ fn eval_instruction<D: DebugContext>(
             let list_span = list_value.span();
             let items_span = items.span();
             let items = match items {
-                Value::List { vals, .. } => vals,
+                Value::List { vals, .. } => vals.into_owned(),
                 Value::Nothing { .. } => Vec::new(),
                 _ => return Err(ShellError::CannotSpreadAsList { span: items_span }),
             };

--- a/crates/nu-explore/src/explore/nu_common/table.rs
+++ b/crates/nu-explore/src/explore/nu_common/table.rs
@@ -25,7 +25,7 @@ pub fn try_build_table(
         vec![],
     );
     match value {
-        Value::List { vals, .. } => try_build_list(vals, opts),
+        Value::List { vals, .. } => try_build_list(vals.into_owned(), opts),
         Value::Record { val, .. } => try_build_map(&val, opts),
         val @ Value::String { .. } => {
             nu_value_to_string_clean(&val, config, &opts.style_computer).0

--- a/crates/nu-explore/src/explore/nu_common/value.rs
+++ b/crates/nu-explore/src/explore/nu_common/value.rs
@@ -104,7 +104,7 @@ pub fn collect_input(value: Value) -> Result<(Vec<String>, Vec<Vec<Value>>)> {
         }
         Value::List { vals, .. } => {
             let mut columns = get_columns(&vals);
-            let data = convert_records_to_dataset(&columns, vals);
+            let data = convert_records_to_dataset(&columns, vals.into_owned());
 
             if columns.is_empty() && !data.is_empty() {
                 columns = vec![String::from("")];

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -321,7 +321,7 @@ impl Call {
             let result = eval(expr)?;
             if spread {
                 match result {
-                    Value::List { mut vals, .. } => output.append(&mut vals),
+                    Value::List { vals, .. } => output.extend(vals),
                     Value::Nothing { .. } => (),
                     _ => return Err(ShellError::CannotSpreadAsList { span: expr.span }),
                 }

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -442,7 +442,7 @@ macro_rules! tuple_from_value {
                 let span = v.span();
                 match v {
                     Value::List { vals, .. } => {
-                        let mut deque = VecDeque::from(vals);
+                        let mut deque = VecDeque::from(vals.into_owned());
 
                         Ok(($(
                             {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -164,7 +164,7 @@ pub enum Value {
     },
     #[non_exhaustive]
     List {
-        vals: Vec<Value>,
+        vals: SharedCow<Vec<Value>>,
         #[serde(skip)]
         signals: Option<Signals>,
         /// note: spans are being refactored out of Value
@@ -787,7 +787,7 @@ impl Value {
     /// Unwraps the inner list `Vec` or returns an error if this `Value` is not a list
     pub fn into_list(self) -> Result<Vec<Value>, ShellError> {
         if let Value::List { vals, .. } = self {
-            Ok(vals)
+            Ok(vals.into_owned())
         } else {
             self.cant_convert_to("list")
         }
@@ -1439,7 +1439,7 @@ impl Value {
                 casing,
             } => match self {
                 Value::List { vals, .. } => {
-                    for val in vals.iter_mut() {
+                    for val in vals.to_mut() {
                         let v_span = val.span();
                         match val {
                             Value::Record { val: record, .. } => {
@@ -1491,8 +1491,8 @@ impl Value {
                 optional,
             } => match self {
                 Value::List { vals, .. } => {
-                    if vals.get_mut(*row_num).is_some() {
-                        vals.remove(*row_num);
+                    if *row_num < vals.len() {
+                        vals.to_mut().remove(*row_num);
                         Ok(())
                     } else if *optional {
                         Ok(())
@@ -1592,7 +1592,7 @@ impl Value {
                     {
                         self.mutate_data_at_cell_path(&new_cell_path, new_val.clone(), action)?;
                     } else {
-                        for val in vals.iter_mut() {
+                        for val in vals.to_mut() {
                             let v_span = val.span();
                             match val {
                                 Value::Record { val: record, .. } => {
@@ -1688,7 +1688,9 @@ impl Value {
                 optional,
             } => match self {
                 Value::List { vals, .. } => {
-                    if let Some(v) = vals.get_mut(*row_num) {
+                    if *row_num < vals.len() {
+                        let vals = vals.to_mut();
+                        let v = &mut vals[*row_num];
                         if path.is_empty() && matches!(action, CellPathMutation::Insert { .. }) {
                             vals.insert(*row_num, new_val);
                         } else {
@@ -1703,7 +1705,8 @@ impl Value {
                                         span: *span,
                                     });
                                 }
-                                vals.push(Value::with_data_at_cell_path(path, new_val)?);
+                                vals.to_mut()
+                                    .push(Value::with_data_at_cell_path(path, new_val)?);
                             }
                             CellPathMutation::Update | CellPathMutation::Remove { .. } => {
                                 if !*optional {
@@ -1789,6 +1792,7 @@ impl Value {
                 .iter_mut()
                 .try_for_each(|(_, rec_value)| rec_value.recurse_mut(f)),
             Value::List { vals, .. } => vals
+                .to_mut()
                 .iter_mut()
                 .try_for_each(|list_value| list_value.recurse_mut(f)),
             // Closure captures are visited. Maybe these don't have to be if they are changed to
@@ -1962,6 +1966,11 @@ impl Value {
     }
 
     pub fn list(vals: Vec<Value>, span: Span) -> Value {
+        Value::list_shared(SharedCow::new(vals), span)
+    }
+
+    /// Creates a list that retains existing shared storage.
+    pub fn list_shared(vals: SharedCow<Vec<Value>>, span: Span) -> Value {
         Value::List {
             vals,
             signals: None,
@@ -3555,9 +3564,9 @@ impl Value {
         match (self, rhs) {
             (Value::List { vals: lhs, .. }, Value::List { vals: rhs, .. }) => {
                 if lhs.is_empty() {
-                    Ok(Value::list(rhs.clone(), span))
+                    Ok(Value::list_shared(rhs.clone(), span))
                 } else if rhs.is_empty() {
-                    Ok(Value::list(lhs.clone(), span))
+                    Ok(Value::list_shared(lhs.clone(), span))
                 } else {
                     let mut new_vals = Vec::with_capacity(lhs.len() + rhs.len());
                     new_vals.extend_from_slice(lhs);
@@ -5639,6 +5648,57 @@ mod tests {
         assert!(Value::test_glob("*.rs").coerce_bool().is_err());
         assert!(Value::test_binary(vec![1, 2, 3]).coerce_bool().is_err());
         assert!(Value::test_duration(3600).coerce_bool().is_err());
+    }
+
+    mod list {
+        use super::*;
+        use crate::ast::PathMember;
+        use nu_utils::SharedCow;
+
+        #[test]
+        fn clone_shares_data() {
+            let value = Value::test_list(vec![Value::test_int(1), Value::test_int(2)]);
+            let clone = value.clone();
+
+            let (
+                Value::List { vals, .. },
+                Value::List {
+                    vals: cloned_vals,
+                    ..
+                },
+            ) = (&value, &clone)
+            else {
+                unreachable!();
+            };
+
+            assert_eq!(SharedCow::ref_count(vals), 2);
+            assert!(std::ptr::eq(vals.as_ptr(), cloned_vals.as_ptr()));
+        }
+
+        #[test]
+        fn mutation_is_copy_on_write() {
+            let value = Value::test_list(vec![Value::test_int(1), Value::test_int(2)]);
+            let mut clone = value.clone();
+
+            clone
+                .upsert_data_at_cell_path(
+                    &[PathMember::test_int(0, false)],
+                    Value::test_int(3),
+                )
+                .unwrap();
+
+            assert_eq!(value.as_list(), Ok([Value::test_int(1), Value::test_int(2)].as_slice()));
+            assert_eq!(clone.as_list(), Ok([Value::test_int(3), Value::test_int(2)].as_slice()));
+        }
+
+        #[test]
+        fn into_list_preserves_shared_value() {
+            let value = Value::test_list(vec![Value::test_int(1), Value::test_int(2)]);
+            let clone = value.clone();
+
+            assert_eq!(clone.into_list(), Ok(vec![Value::test_int(1), Value::test_int(2)]));
+            assert_eq!(value.as_list(), Ok([Value::test_int(1), Value::test_int(2)].as_slice()));
+        }
     }
 
     mod binary {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -5663,8 +5663,7 @@ mod tests {
             let (
                 Value::List { vals, .. },
                 Value::List {
-                    vals: cloned_vals,
-                    ..
+                    vals: cloned_vals, ..
                 },
             ) = (&value, &clone)
             else {
@@ -5681,14 +5680,17 @@ mod tests {
             let mut clone = value.clone();
 
             clone
-                .upsert_data_at_cell_path(
-                    &[PathMember::test_int(0, false)],
-                    Value::test_int(3),
-                )
+                .upsert_data_at_cell_path(&[PathMember::test_int(0, false)], Value::test_int(3))
                 .unwrap();
 
-            assert_eq!(value.as_list(), Ok([Value::test_int(1), Value::test_int(2)].as_slice()));
-            assert_eq!(clone.as_list(), Ok([Value::test_int(3), Value::test_int(2)].as_slice()));
+            assert_eq!(
+                value.as_list(),
+                Ok([Value::test_int(1), Value::test_int(2)].as_slice())
+            );
+            assert_eq!(
+                clone.as_list(),
+                Ok([Value::test_int(3), Value::test_int(2)].as_slice())
+            );
         }
 
         #[test]
@@ -5696,8 +5698,14 @@ mod tests {
             let value = Value::test_list(vec![Value::test_int(1), Value::test_int(2)]);
             let clone = value.clone();
 
-            assert_eq!(clone.into_list(), Ok(vec![Value::test_int(1), Value::test_int(2)]));
-            assert_eq!(value.as_list(), Ok([Value::test_int(1), Value::test_int(2)].as_slice()));
+            assert_eq!(
+                clone.into_list(),
+                Ok(vec![Value::test_int(1), Value::test_int(2)])
+            );
+            assert_eq!(
+                value.as_list(),
+                Ok([Value::test_int(1), Value::test_int(2)].as_slice())
+            );
         }
     }
 

--- a/crates/nu-table/src/types/collapse.rs
+++ b/crates/nu-table/src/types/collapse.rs
@@ -55,7 +55,7 @@ fn colorize_value(value: &mut Value, config: &Config, style_computer: &StyleComp
             );
         }
         Value::List { vals, .. } => {
-            for val in vals {
+            for val in vals.to_mut() {
                 colorize_value(val, config, style_computer);
             }
         }

--- a/crates/nu-table/src/unstructured_table.rs
+++ b/crates/nu-table/src/unstructured_table.rs
@@ -75,9 +75,9 @@ fn convert_nu_value_to_table_value(value: Value, config: &Config) -> TableValue 
         Value::List { vals, .. } => {
             let rebuild_array_as_map = is_valid_record(&vals) && count_columns_in_record(&vals) > 0;
             if rebuild_array_as_map {
-                build_map_from_record(vals, config)
+                build_map_from_record(vals.into_owned(), config)
             } else {
-                build_vertical_array(vals, config)
+                build_vertical_array(vals.into_owned(), config)
             }
         }
         value => build_string_value(value, config),

--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -320,7 +320,7 @@ impl NuTester {
     fn path(&self) -> Vec<Value> {
         match self.engine_state.get_env_var("PATH") {
             None => Vec::new(),
-            Some(Value::List { vals, .. }) => vals.clone(),
+            Some(Value::List { vals, .. }) => vals.to_vec(),
             Some(Value::String { val, .. }) => val
                 .split(ENV_PATH_SEPARATOR_CHAR)
                 .map(Value::test_string)

--- a/crates/nu-utils/src/shared_cow.rs
+++ b/crates/nu-utils/src/shared_cow.rs
@@ -125,6 +125,24 @@ impl<T: Clone> AsRef<[T]> for SharedCow<Vec<T>> {
     }
 }
 
+impl<T: Clone> IntoIterator for SharedCow<Vec<T>> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.into_owned().into_iter()
+    }
+}
+
+impl<'a, T: Clone> IntoIterator for &'a SharedCow<Vec<T>> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/nu_plugin_polars/src/dataframe/command/data/replace.rs
+++ b/crates/nu_plugin_polars/src/dataframe/command/data/replace.rs
@@ -175,7 +175,7 @@ impl PluginCommand for Replace {
                 .into_iter()
                 .unzip(),
             (Value::List { vals: old_vals, .. }, Some(Value::List { vals: new_vals, .. })) => {
-                (old_vals, new_vals)
+                (old_vals.into_owned(), new_vals.into_owned())
             }
             (_, _) => {
                 return Err(LabeledError::from(ShellError::Generic(

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/mod.rs
@@ -231,7 +231,11 @@ impl NuDataFrame {
         add_missing_columns(df, &maybe_schema, span)
     }
 
-    pub fn fill_list_nan(list: Vec<Value>, list_span: Span, fill: Value) -> Value {
+    pub fn fill_list_nan(
+        list: impl IntoIterator<Item = Value>,
+        list_span: Span,
+        fill: Value,
+    ) -> Value {
         let newlist = list
             .into_iter()
             .map(|value| {


### PR DESCRIPTION
## Description

Store list `Value`s in `SharedCow<Vec<Value>>` so clones share their backing allocation until mutation.

Use copy-on-write storage at list mutation sites and only materialize an owned `Vec<Value>` when an operation genuinely consumes the list. Preserve shared storage through `first`, `last`, empty-list concatenation, and no-op flattening paths.

Add tests for shared cloning and copy-on-write behavior, plus Tango benchmarks for cloning list values and loading them from the stack.

## User-facing changes (Release notes)

### Faster large list and table access

Large lists and tables are now much faster to read from, load from variables, and capture in closures.

Accessing a small part of a large list, such as `$list.0`, no longer copies the entire list each time the variable is loaded. In a 100,000-element test, 200 repeated reads improved from roughly 131 ms to 138 µs (~950x faster).

## Additional notes

Tango results from 100 paired samples against current unpatched main:

| Benchmark | Reference | Patched | Change |
|---|---:|---:|---:|
| `list_value_clone_100000` | 668.3 µs | 35.4 ns | -99.995%, ~18,900x faster |
| `stack_list_get_var_100000` | 649.1 µs | 75.7 ns | -99.988%, ~8,600x faster |

Local end-to-end results for 200 repeated `$list.0` reads:

| List size | Reference | Patched | Change |
|---:|---:|---:|---:|
| 1,000 | 1.41 ms | 149 µs | -89.4%, 9.4x faster |
| 10,000 | 12.13 ms | 140 µs | -98.8%, 86.8x faster |
| 100,000 | 131.19 ms | 138 µs | -99.89%, ~950x faster |

Perf is approximately constant as the list grows, removing the previous O(list length) cost from each variable load.