### PR TITLE
fix(help): document list input support for hash md5/sha256

### DIFF
--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -50,8 +50,14 @@ where
             .input_output_types(vec![
                 (Type::String, Type::one_of([Type::String, Type::Binary])),
                 (Type::Binary, Type::one_of([Type::String, Type::Binary])),
-                (Type::list(Type::String), Type::list(Type::one_of([Type::String, Type::Binary]))),
-                (Type::list(Type::Binary), Type::list(Type::one_of([Type::String, Type::Binary]))),
+                (
+                    Type::list(Type::String),
+                    Type::list(Type::one_of([Type::String, Type::Binary])),
+                ),
+                (
+                    Type::list(Type::Binary),
+                    Type::list(Type::one_of([Type::String, Type::Binary])),
+                ),
                 (Type::table(), Type::table()),
                 (Type::record(), Type::record()),
             ])

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -50,6 +50,8 @@ where
             .input_output_types(vec![
                 (Type::String, Type::one_of([Type::String, Type::Binary])),
                 (Type::Binary, Type::one_of([Type::String, Type::Binary])),
+                (Type::list(Type::String), Type::list(Type::one_of([Type::String, Type::Binary]))),
+                (Type::list(Type::Binary), Type::list(Type::one_of([Type::String, Type::Binary]))),
                 (Type::table(), Type::table()),
                 (Type::record(), Type::record()),
             ])

--- a/crates/nu-command/src/hash/md5.rs
+++ b/crates/nu-command/src/hash/md5.rs
@@ -40,6 +40,11 @@ impl HashDigest for Md5 {
                 example: "open ./nu_0_24_1_windows.zip | hash md5",
                 result: None,
             },
+            Example {
+                description: "Return the md5 hash of a list of strings",
+                example: "[abc def ghi] | hash md5",
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/hash/md5.rs
+++ b/crates/nu-command/src/hash/md5.rs
@@ -43,7 +43,23 @@ impl HashDigest for Md5 {
             Example {
                 description: "Return the md5 hash of a list of strings",
                 example: "[abc def ghi] | hash md5",
-                result: None,
+                result: Some(Value::list(
+                    vec![
+                        Value::string(
+                            "900150983cd24fb0d6963f7d28e17f72".to_owned(),
+                            Span::test_data(),
+                        ),
+                        Value::string(
+                            "4ed9407630eb1000c0f6b63842defa7d".to_owned(),
+                            Span::test_data(),
+                        ),
+                        Value::string(
+                            "826bbc5d0522f5f20a1da4b60fa8c871".to_owned(),
+                            Span::test_data(),
+                        ),
+                    ],
+                    Span::test_data(),
+                )),
             },
         ]
     }

--- a/crates/nu-command/src/hash/sha256.rs
+++ b/crates/nu-command/src/hash/sha256.rs
@@ -41,6 +41,11 @@ impl HashDigest for Sha256 {
                 example: "open ./nu_0_24_1_windows.zip | hash sha256",
                 result: None,
             },
+            Example {
+                description: "Return the sha256 hash of a list of strings",
+                example: "[abc def ghi] | hash sha256",
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/hash/sha256.rs
+++ b/crates/nu-command/src/hash/sha256.rs
@@ -44,7 +44,26 @@ impl HashDigest for Sha256 {
             Example {
                 description: "Return the sha256 hash of a list of strings",
                 example: "[abc def ghi] | hash sha256",
-                result: None,
+                result: Some(Value::list(
+                    vec![
+                        Value::string(
+                            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+                                .to_owned(),
+                            Span::test_data(),
+                        ),
+                        Value::string(
+                            "cb8379ac2098aa165029e3938a51da0bcecfc008fd6795f401178647f96c5b34"
+                                .to_owned(),
+                            Span::test_data(),
+                        ),
+                        Value::string(
+                            "50ae61e841fac4e8f9e40baf2ad36ec868922ea48368c18f9535e47db56dd7fb"
+                                .to_owned(),
+                            Span::test_data(),
+                        ),
+                    ],
+                    Span::test_data(),
+                )),
             },
         ]
     }


### PR DESCRIPTION
## Description

Fixes #9573.

`hash md5` and `hash sha256` already supported `list<string>` and `list<binary>` inputs through Nushell's auto-mapping, but their signatures and examples only showed single `string` and `binary` inputs. This made the commands look more limited than they are.

This PR updates the help metadata by:
- Adding `list<string>` and `list<binary>` to `input_output_types` for both commands.
- Adding examples showing list input for both `hash md5` and `hash sha256`.

## User-facing changes (Release notes)

Improved `hash md5` and `hash sha256` help to show that both commands support `list<string>` and `list<binary>` inputs.

## Additional notes

Testing reported by the author:
- `cargo test -p nu-command --lib hash::md5::tests`
- `cargo test -p nu-command --lib hash::sha256::tests`