### PR TITLE
add `idx watch` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "fff-grep"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac5720676a3e1cb901683073c0bcc0a8f04e1bfe6bea391e1f14b9f95dbdef2"
+checksum = "03bcb2a8d550991064489567e7947d930d544c2cdfea1ca017ffc380e6ba3616"
 dependencies = [
  "bstr",
  "memchr",
@@ -2308,15 +2308,15 @@ dependencies = [
 
 [[package]]
 name = "fff-query-parser"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e83290e48a8e4dc6ff7cfdfcf382b2a07b6ef1f07e7d477427e3ebb60192307"
+checksum = "3f801a4d6af6b790b4fb3e5d4bbd7392310d138c899072a13c2d750b54001b7b"
 
 [[package]]
 name = "fff-search"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdc9cb0a546fa219b073df04bd58884c1b1b43c21d33008a69b785f24819eb2"
+checksum = "f7fe9ee9cecc5f2f84eef17c91c4008ef2e3c2988009fc9da56e8127fb0d2d52"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -2774,9 +2774,9 @@ checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -3341,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "d4ffa3a0547a138e59ddd6fa3b7c672ed47e6ad6a3cd177984ff1116aa5ba742"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -4360,13 +4360,9 @@ dependencies = [
 
 [[package]]
 name = "neo_frizbee"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd76fab81213d184cc28a7757791775bdcfd7f2a15e3558d7a4f7e4ee7de864"
-dependencies = [
- "itertools 0.14.0",
- "raw-cpuid",
-]
+checksum = "7a2f6120a8da26bea3587731072111062c5d8c51ca3a3a75a716bd8b735d5882"
 
 [[package]]
 name = "new_debug_unreachable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ encoding_rs = "0.8"
 fancy-regex = "0.18"
 filesize = "0.2"
 filetime = "0.2.27"
-fff-search = { version = "=0.9.6", default-features = false }
+fff-search = { version = "=0.10.0", default-features = false, features = ["ripgrep"] }
 fluent = "0.17.0"
 gatekeeper = "3.0.0"
 heck = "0.5.0"

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -268,6 +268,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             IdxStatus,
             IdxFind,
             IdxSearch,
+            IdxWatch,
             IdxDrop,
             IdxDirs,
             IdxFiles,

--- a/crates/nu-command/src/filesystem/idx/idx_.rs
+++ b/crates/nu-command/src/filesystem/idx/idx_.rs
@@ -19,7 +19,9 @@ impl Command for Idx {
     }
 
     fn extra_description(&self) -> &str {
-        "Use one of the subcommands: init, status, find, search, export, import, drop, dirs, files. Watch mode keeps the index warm as files change; disable it when you only need a snapshot of the current tree."
+        "Use one of the subcommands: init, status, find, search, watch, export, import, drop, dirs, files. \
+By default `idx init` enables filesystem watching so the index stays warm as files change; pass `--no-watch` for a static snapshot. \
+Use `idx watch` to stream change events from that live index into a pipeline (distinct from the plain `watch` command)."
     }
 
     fn run(

--- a/crates/nu-command/src/filesystem/idx/import.rs
+++ b/crates/nu-command/src/filesystem/idx/import.rs
@@ -18,7 +18,7 @@ impl Command for IdxImport {
             )
             .switch(
                 "no-watch",
-                "Disable filesystem watching after import (watching is enabled by default).",
+                "Disable filesystem watching after import (watching is enabled by default; required for `idx watch`).",
                 None,
             )
             .input_output_types(vec![(Type::Nothing, Type::record())])
@@ -30,7 +30,8 @@ impl Command for IdxImport {
     }
 
     fn extra_description(&self) -> &str {
-        "Reads a SQLite snapshot created by `idx export` and auto-initializes idx runtime for immediate queries."
+        "Reads a SQLite snapshot created by `idx export` and auto-initializes idx runtime for immediate queries. \
+Filesystem watching is enabled by default (needed for `idx watch`); pass `--no-watch` to keep a static restored snapshot."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {

--- a/crates/nu-command/src/filesystem/idx/init.rs
+++ b/crates/nu-command/src/filesystem/idx/init.rs
@@ -41,7 +41,8 @@ impl Command for IdxInit {
     }
 
     fn extra_description(&self) -> &str {
-        "By default idx init returns immediately and indexing continues in the background. Use `idx status` to check when scanning completes. Pass `--wait` to block until the initial scan finishes. Filesystem watching is enabled by default; pass `--no-watch` to disable it."
+        "By default idx init returns immediately and indexing continues in the background. Use `idx status` to check when scanning completes. Pass `--wait` to block until the initial scan finishes. \
+Filesystem watching is enabled by default so the index stays warm and `idx watch` can stream events; pass `--no-watch` to disable both."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {

--- a/crates/nu-command/src/filesystem/idx/mod.rs
+++ b/crates/nu-command/src/filesystem/idx/mod.rs
@@ -11,6 +11,7 @@ mod init;
 mod search;
 mod state;
 mod status;
+mod watch;
 
 pub use dirs::IdxDirs;
 pub use drop::IdxDrop;
@@ -24,3 +25,4 @@ pub use import::IdxImport;
 pub use init::IdxInit;
 pub use search::IdxSearch;
 pub use status::IdxStatus;
+pub use watch::IdxWatch;

--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Local, LocalResult, TimeZone, Utc};
 use fff_search::{
     FFFMode, FilePicker, FilePickerOptions, FuzzySearchOptions, GrepConfig, GrepMode,
     GrepSearchOptions, MixedItemRef, PaginationArgs, QueryParser, SharedFilePicker, SharedFrecency,
+    watch::{WatchEvent, WatchId, WatchOptions},
 };
 use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
@@ -23,6 +24,7 @@ use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
@@ -1843,9 +1845,10 @@ pub fn restore_snapshot(path: &Path, no_watch: bool, span: Span) -> Result<Value
     // Wait for the picker scan to complete so grep can search indexed content.
     let _ = shared_picker.wait_for_scan(Duration::from_secs(300));
 
+    let watch = !no_watch;
     let previous = guard.replace(IdxRuntime {
         base_path: PathBuf::from(&base_path_str),
-        watch: false,
+        watch,
         shared_picker: shared_picker.clone(),
         scan_start_time: Instant::now(),
         scan_completed: Arc::new(AtomicBool::new(true)),
@@ -1874,7 +1877,7 @@ pub fn restore_snapshot(path: &Path, no_watch: bool, span: Span) -> Result<Value
                 "base_path".to_string(),
                 Value::string(base_path_str.clone(), span),
             ),
-            ("watch".to_string(), Value::bool(false, span)),
+            ("watch".to_string(), Value::bool(watch, span)),
             (
                 "rehydration_mode".to_string(),
                 Value::string("snapshot_runtime_restored", span),
@@ -2055,6 +2058,194 @@ pub fn stream_grep(context: GrepSearchContext<'_>) -> Result<PipelineData, Shell
         ListStream::new(stream, context.span, context.signals.clone()),
         Some(PipelineMetadata::default()),
     ))
+}
+
+/// How often the watch stream polls for Ctrl-C / timeout while waiting on events.
+const WATCH_POLL_INTERVAL: Duration = Duration::from_millis(100);
+/// How long `idx watch` waits for the background OS watcher after a non-blocking init.
+const WATCHER_READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Options for [`stream_watch`].
+pub struct WatchStreamOptions {
+    /// Base-relative glob, exact path, directory, or empty for the whole tree.
+    pub pattern: String,
+    /// Additional glob or path-prefix exclusions (fff `WatchOptions.ignore`).
+    pub ignore: Vec<String>,
+    /// Optional duration after which the stream ends cleanly.
+    pub timeout: Option<Duration>,
+    /// Optional cap on the number of events emitted before the stream ends.
+    pub max_events: Option<usize>,
+    pub span: Span,
+    pub signals: Signals,
+}
+
+/// Subscribe to filesystem changes on the live idx runtime and stream events as records.
+///
+/// Requires an initialized runtime with watching enabled (`idx init` / `idx import` without
+/// `--no-watch`). Each event is a record `{ kind, path }` with lowercase kind strings and a
+/// path-typed absolute path. Batches from fff-search are flattened to one pipeline item each.
+pub fn stream_watch(options: WatchStreamOptions) -> Result<PipelineData, ShellError> {
+    let snapshot = require_runtime(options.span)?;
+
+    if !snapshot.watch {
+        return Err(ShellError::Generic(GenericError::new(
+            "idx watching is disabled",
+            "re-run `idx init` or `idx import` without `--no-watch` to enable filesystem watching",
+            options.span,
+        )));
+    }
+
+    if !snapshot
+        .shared_picker
+        .wait_for_watcher(WATCHER_READY_TIMEOUT)
+    {
+        return Err(ShellError::Generic(GenericError::new(
+            "idx watcher not ready",
+            "timed out waiting for the background filesystem watcher to become ready (30 s). Try `idx init <path> --wait` first.",
+            options.span,
+        )));
+    }
+
+    let (tx, rx): (Sender<Vec<WatchEvent>>, Receiver<Vec<WatchEvent>>) = channel();
+    let shared_picker = snapshot.shared_picker.clone();
+
+    let watch_id = shared_picker
+        .watch(
+            &options.pattern,
+            WatchOptions {
+                ignore: options.ignore,
+            },
+            move |_id, events| {
+                // Best-effort: if the receiver is gone the stream already ended.
+                let _ = tx.send(events.to_vec());
+            },
+        )
+        .map_err(|err| fff_error(err, options.span))?;
+
+    let stream = WatchEventStream {
+        rx: Some(rx),
+        pending: Vec::new(),
+        pending_idx: 0,
+        events_emitted: 0,
+        max_events: options.max_events,
+        deadline: options.timeout.map(|d| Instant::now() + d),
+        signals: options.signals.clone(),
+        span: options.span,
+        cleanup: Some(WatchSubscription {
+            shared_picker,
+            watch_id,
+        }),
+    };
+
+    Ok(PipelineData::ListStream(
+        ListStream::new(stream, options.span, options.signals),
+        Some(PipelineMetadata::default()),
+    ))
+}
+
+/// RAII guard that unsubscribes a fff-search watch when the stream ends.
+struct WatchSubscription {
+    shared_picker: SharedFilePicker,
+    watch_id: WatchId,
+}
+
+impl Drop for WatchSubscription {
+    fn drop(&mut self) {
+        let _ = self.shared_picker.unwatch(self.watch_id);
+    }
+}
+
+/// Blocking iterator that flattens debounced watch batches into Nushell records.
+struct WatchEventStream {
+    rx: Option<Receiver<Vec<WatchEvent>>>,
+    pending: Vec<WatchEvent>,
+    pending_idx: usize,
+    events_emitted: usize,
+    max_events: Option<usize>,
+    deadline: Option<Instant>,
+    signals: Signals,
+    span: Span,
+    cleanup: Option<WatchSubscription>,
+}
+
+impl WatchEventStream {
+    fn finished(&mut self) -> Option<Value> {
+        // Drop the receiver first so the callback channel closes, then unwatch.
+        self.rx = None;
+        self.cleanup.take();
+        None
+    }
+
+    fn next_pending(&mut self) -> Option<Value> {
+        if self.pending_idx < self.pending.len() {
+            let event = self.pending[self.pending_idx].clone();
+            self.pending_idx += 1;
+            self.events_emitted += 1;
+            return Some(watch_event_to_value(&event, self.span));
+        }
+        None
+    }
+
+    fn reached_max_events(&self) -> bool {
+        self.max_events
+            .is_some_and(|max| self.events_emitted >= max)
+    }
+
+    fn timed_out(&self) -> bool {
+        self.deadline.is_some_and(|d| Instant::now() >= d)
+    }
+}
+
+impl Iterator for WatchEventStream {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.reached_max_events() || self.timed_out() {
+                return self.finished();
+            }
+
+            if let Err(err) = self.signals.check(&self.span) {
+                self.rx = None;
+                self.cleanup.take();
+                return Some(Value::error(err, self.span));
+            }
+
+            // Emit the last allowed event when max-events is reached; the next
+            // call hits reached_max_events() and tears the subscription down.
+            if let Some(value) = self.next_pending() {
+                return Some(value);
+            }
+
+            let rx = self.rx.as_ref()?;
+            match rx.recv_timeout(WATCH_POLL_INTERVAL) {
+                Ok(batch) => {
+                    self.pending = batch;
+                    self.pending_idx = 0;
+                }
+                Err(RecvTimeoutError::Timeout) => continue,
+                Err(RecvTimeoutError::Disconnected) => {
+                    return self.finished();
+                }
+            }
+        }
+    }
+}
+
+fn watch_event_to_value(event: &WatchEvent, span: Span) -> Value {
+    // Paths are absolute (fff WatchEvent); Nu represents filesystem paths as strings.
+    Value::record(
+        [
+            ("kind".to_string(), Value::string(event.kind.as_str(), span)),
+            (
+                "path".to_string(),
+                Value::string(event.path.to_string_lossy(), span),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+        span,
+    )
 }
 
 fn path_for_cwd(path: &Path, cwd: Option<&Path>, fallback: &str) -> String {

--- a/crates/nu-command/src/filesystem/idx/watch.rs
+++ b/crates/nu-command/src/filesystem/idx/watch.rs
@@ -1,0 +1,129 @@
+use super::state::{WatchStreamOptions, stream_watch};
+use nu_engine::command_prelude::*;
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct IdxWatch;
+
+impl Command for IdxWatch {
+    fn name(&self) -> &str {
+        "idx watch"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .optional(
+                "pattern",
+                SyntaxShape::String,
+                "Base-relative glob, path, or directory to watch. Omit or pass empty to watch the whole indexed tree.",
+            )
+            .named(
+                "ignore",
+                SyntaxShape::List(Box::new(SyntaxShape::String)),
+                "List of globs or path-prefixes to exclude.",
+                Some('i'),
+            )
+            .named(
+                "timeout",
+                SyntaxShape::Duration,
+                "Stop streaming after this duration.",
+                Some('t'),
+            )
+            .named(
+                "max-events",
+                SyntaxShape::Int,
+                "Stop after emitting this many events.",
+                Some('n'),
+            )
+            .input_output_types(vec![(
+                Type::Nothing,
+                Type::Table(
+                    vec![
+                        ("kind".into(), Type::String),
+                        ("path".into(), Type::String),
+                    ]
+                    .into(),
+                ),
+            )])
+            .category(Category::FileSystem)
+    }
+
+    fn description(&self) -> &str {
+        "Stream filesystem change events from the live idx index."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Requires a live runtime with watching enabled (`idx init` or `idx import` without `--no-watch`). \
+Events are debounced by fff-search and emitted as records with `kind` (`created`, `modified`, `removed`, `rescan`) \
+and absolute `path`. Gitignored and other index-ignored files do not produce events. \
+Patterns must be inside the indexed base path. Use plain `watch` for ad-hoc path watching without an index."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["watcher", "filesystem", "notify", "events"]
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                description: "Watch the whole indexed tree after initializing idx.",
+                example: "idx init .; idx watch",
+                result: None,
+            },
+            Example {
+                description: "Watch only Rust files, ignoring a vendor-style path prefix.",
+                example: r#"idx watch "**/*.rs" --ignore [target]"#,
+                result: None,
+            },
+            Example {
+                description: "Take action on modified files in a pipeline.",
+                example: r#"idx watch | where kind == "modified" | each { |e| print $"changed: ($e.path)" }"#,
+                result: None,
+            },
+            Example {
+                description: "Stop after a single event (useful in scripts).",
+                example: "idx watch --max-events 1",
+                result: None,
+            },
+            Example {
+                description: "Stop after a duration if no more events are needed.",
+                example: "idx watch --timeout 5sec",
+                result: None,
+            },
+        ]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let pattern: Option<String> = call.opt(engine_state, stack, 0)?;
+        let ignore = call
+            .get_flag::<Vec<String>>(engine_state, stack, "ignore")?
+            .unwrap_or_default();
+        let timeout: Option<Duration> = call.get_flag(engine_state, stack, "timeout")?;
+        let max_events: Option<i64> = call.get_flag(engine_state, stack, "max-events")?;
+
+        let max_events = max_events
+            .map(|n| {
+                if n < 0 {
+                    Err(ShellError::NeedsPositiveValue { span: call.head })
+                } else {
+                    Ok(n as usize)
+                }
+            })
+            .transpose()?;
+
+        stream_watch(WatchStreamOptions {
+            pattern: pattern.unwrap_or_default(),
+            ignore,
+            timeout,
+            max_events,
+            span: call.head,
+            signals: engine_state.signals().clone(),
+        })
+    }
+}

--- a/crates/nu-command/src/filesystem/mod.rs
+++ b/crates/nu-command/src/filesystem/mod.rs
@@ -19,7 +19,7 @@ pub use self::open::Open;
 pub use cd::Cd;
 pub use du::Du;
 pub use glob::Glob;
-pub use idx::{Idx, IdxDirs, IdxDrop, IdxFiles, IdxFind, IdxInit, IdxSearch, IdxStatus};
+pub use idx::{Idx, IdxDirs, IdxDrop, IdxFiles, IdxFind, IdxInit, IdxSearch, IdxStatus, IdxWatch};
 #[cfg(feature = "sqlite")]
 pub use idx::{IdxExport, IdxImport};
 pub use ls::Ls;


### PR DESCRIPTION
## Description
The `idx` command family already keeps an in-memory file index via [fff-search](https://crates.io/crates/fff-search). After `idx init`, the library can maintain that index with an optional background OS watcher (`--no-watch` disables it). Users could not, however, **subscribe to those filesystem changes as a Nushell pipeline** — they had to use the separate, index-unaware `watch` command.

fff-search **0.10.0** adds a public watch-subscription API on `SharedFilePicker` and I wanted to add `idx watch` so it can react to index-relative changes with normal pipeline tooling (`where`, `each`, `for`, etc.). So, I added a new command to the `idx` family.

```nushell
idx watch [pattern]
  --ignore <list>      # globs / path-prefixes to exclude
  --timeout <duration> # clean stream end after duration
  --max-events <int>   # clean stream end after N events
```

## User-facing changes (Release notes)
### Added `idx watch` for streaming indexed filesystem changes

Added `idx watch` to stream filesystem change events from a live `idx` index as tabular records (`kind`, `path`). Requires `idx init` with watching enabled. Optional pattern, `--ignore`, `--timeout`, and `--max-events` are supported for filtering and clean stream termination. Events respect gitignore/index ignores and can be piped into normal Nushell pipelines.

Also updated the `fff-search` dependency to 0.10.0 (enables the watch subscription API).

Examples:

```nushell
idx init . --wait
idx watch
idx watch "**/*.rs" --ignore [target]
idx watch | where kind == "modified" | each {|e| print $"changed: ($e.path)"}
idx watch --max-events 1 --timeout 5sec
```
## Additional notes
- Related fff-search API docs:
  - https://docs.rs/fff-search/0.10.0/fff_search/watch/index.html
  - https://docs.rs/fff-search/0.10.0/fff_search/shared/struct.SharedFilePicker.html#method.watch
- Distinct from the existing `watch` command: that watches arbitrary paths without an index; `idx watch` is scoped to the indexed tree and uses fff’s subscription + ignore rules.
