### PR TITLE
feat(config): new duration_max_unit option

### DIFF
--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -1,7 +1,7 @@
 use crate::semver::value::SemverValue;
 use chrono::{DateTime, Datelike, FixedOffset, Timelike};
 use nu_engine::command_prelude::*;
-use nu_protocol::{DurationFormat, format_duration_as_timeperiod};
+use nu_protocol::{DurationMaxUnit, format_duration_as_timeperiod};
 
 #[derive(Clone)]
 pub struct IntoRecord;
@@ -217,7 +217,7 @@ fn parse_date_into_record(date: DateTime<FixedOffset>, span: Span) -> Value {
 }
 
 fn parse_duration_into_record(duration: i64, span: Span) -> Value {
-    let (sign, periods) = format_duration_as_timeperiod(duration, DurationFormat::default());
+    let (sign, periods) = format_duration_as_timeperiod(duration, DurationMaxUnit::default());
 
     let mut record = Record::new();
     for p in periods {

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -1,7 +1,7 @@
 use crate::semver::value::SemverValue;
 use chrono::{DateTime, Datelike, FixedOffset, Timelike};
 use nu_engine::command_prelude::*;
-use nu_protocol::format_duration_as_timeperiod;
+use nu_protocol::{DurationFormat, format_duration_as_timeperiod};
 
 #[derive(Clone)]
 pub struct IntoRecord;
@@ -217,7 +217,7 @@ fn parse_date_into_record(date: DateTime<FixedOffset>, span: Span) -> Value {
 }
 
 fn parse_duration_into_record(duration: i64, span: Span) -> Value {
-    let (sign, periods) = format_duration_as_timeperiod(duration);
+    let (sign, periods) = format_duration_as_timeperiod(duration, DurationFormat::default());
 
     let mut record = Record::new();
     for p in periods {

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -167,7 +167,7 @@ fn local_into_string(
         Value::Int { val, .. } => val.to_string(),
         Value::Float { val, .. } => ObviousFloat(val).to_string(),
         Value::Filesize { val, .. } => val.to_string(),
-        Value::Duration { val, .. } => format_duration(val),
+        Value::Duration { val, .. } => format_duration(val, engine_state.config.duration_format),
         Value::Date { val, .. } => {
             format!(
                 "{} ({})",

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -167,7 +167,7 @@ fn local_into_string(
         Value::Int { val, .. } => val.to_string(),
         Value::Float { val, .. } => ObviousFloat(val).to_string(),
         Value::Filesize { val, .. } => val.to_string(),
-        Value::Duration { val, .. } => format_duration(val, engine_state.config.duration_format),
+        Value::Duration { val, .. } => format_duration(val, engine_state.config.duration_max_unit),
         Value::Date { val, .. } => {
             format!(
                 "{} ({})",

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -514,8 +514,9 @@ $env.config.render_right_prompt_on_last_line = false
 $env.config.float_precision = 2
 
 # duration_format (string): Largest unit when displaying durations.
-# Durations are decomposed from this unit downward. Smaller values produce more
-# granular output (e.g., "day" shows 365day instead of 52wk 1day for one year).
+# Durations are decomposed from this unit downward. A smaller value excludes
+# larger units from the output (e.g., "day" shows 365day instead of
+# 52wk 1day for one year).
 # Options: "wk", "day", "hr", "min", "sec", "ms", "us", "ns".
 # Default: "wk"
 $env.config.duration_format = "wk"

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -513,6 +513,13 @@ $env.config.render_right_prompt_on_last_line = false
 # Default: 2
 $env.config.float_precision = 2
 
+# duration_format (string): Largest unit when displaying durations.
+# Durations are decomposed from this unit downward. Smaller values produce more
+# granular output (e.g., "day" shows 365day instead of 52wk 1day for one year).
+# Options: "wk", "day", "hr", "min", "sec", "ms", "us", "ns".
+# Default: "wk"
+$env.config.duration_format = "wk"
+
 # ls.use_ls_colors (bool): Apply LS_COLORS to filenames in `ls` output.
 # true: Use LS_COLORS environment variable for styling.
 # false: Use color_config string style.

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -513,13 +513,13 @@ $env.config.render_right_prompt_on_last_line = false
 # Default: 2
 $env.config.float_precision = 2
 
-# duration_format (string): Largest unit when displaying durations.
+# duration_max_unit (string): Largest unit when displaying durations.
 # Durations are decomposed from this unit downward. A smaller value excludes
 # larger units from the output (e.g., "day" shows 365day instead of
 # 52wk 1day for one year).
 # Options: "wk", "day", "hr", "min", "sec", "ms", "us", "ns".
 # Default: "wk"
-$env.config.duration_format = "wk"
+$env.config.duration_max_unit = "wk"
 
 # ls.use_ls_colors (bool): Apply LS_COLORS to filenames in `ls` output.
 # true: Use LS_COLORS environment variable for styling.

--- a/crates/nu-protocol/src/config/duration_format.rs
+++ b/crates/nu-protocol/src/config/duration_format.rs
@@ -1,0 +1,54 @@
+use super::{config_update_string_enum, prelude::*};
+
+use crate::{self as nu_protocol};
+
+/// The largest time unit used when formatting durations for display.
+///
+/// When set to a smaller unit, durations that would previously show weeks
+/// will instead show the equivalent number of days, hours, etc.
+#[derive(
+    Clone, Copy, Default, Debug, IntoValue, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+pub enum DurationFormat {
+    #[default]
+    #[nu_value(rename = "wk")]
+    Week,
+    #[nu_value(rename = "day")]
+    Day,
+    #[nu_value(rename = "hr")]
+    Hour,
+    #[nu_value(rename = "min")]
+    Minute,
+    #[nu_value(rename = "sec")]
+    Second,
+    #[nu_value(rename = "ms")]
+    Millisecond,
+    #[nu_value(rename = "us")]
+    Microsecond,
+    #[nu_value(rename = "ns")]
+    Nanosecond,
+}
+
+impl FromStr for DurationFormat {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "wk" => Ok(Self::Week),
+            "day" => Ok(Self::Day),
+            "hr" => Ok(Self::Hour),
+            "min" => Ok(Self::Minute),
+            "sec" => Ok(Self::Second),
+            "ms" => Ok(Self::Millisecond),
+            "us" | "µs" => Ok(Self::Microsecond),
+            "ns" => Ok(Self::Nanosecond),
+            _ => Err("'wk', 'day', 'hr', 'min', 'sec', 'ms', 'us', 'µs', or 'ns'"),
+        }
+    }
+}
+
+impl UpdateFromValue for DurationFormat {
+    fn update(&mut self, value: &Value, path: &mut ConfigPath, errors: &mut ConfigErrors) {
+        config_update_string_enum(self, value, path, errors)
+    }
+}

--- a/crates/nu-protocol/src/config/duration_max_unit.rs
+++ b/crates/nu-protocol/src/config/duration_max_unit.rs
@@ -9,7 +9,7 @@ use crate::{self as nu_protocol};
 #[derive(
     Clone, Copy, Default, Debug, IntoValue, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
 )]
-pub enum DurationFormat {
+pub enum DurationMaxUnit {
     #[default]
     #[nu_value(rename = "wk")]
     Week,
@@ -29,7 +29,7 @@ pub enum DurationFormat {
     Nanosecond,
 }
 
-impl FromStr for DurationFormat {
+impl FromStr for DurationMaxUnit {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -47,7 +47,7 @@ impl FromStr for DurationFormat {
     }
 }
 
-impl UpdateFromValue for DurationFormat {
+impl UpdateFromValue for DurationMaxUnit {
     fn update(&mut self, value: &Value, path: &mut ConfigPath, errors: &mut ConfigErrors) {
         config_update_string_enum(self, value, path, errors)
     }

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -13,6 +13,7 @@ pub use completions::{
 };
 pub use datetime_format::DatetimeFormatConfig;
 pub use display_errors::DisplayErrors;
+pub use duration_format::DurationFormat;
 pub use filesize::FilesizeConfig;
 pub use helper::extract_value;
 pub use hinter::HinterConfig;
@@ -31,6 +32,7 @@ mod clip;
 mod completions;
 mod datetime_format;
 mod display_errors;
+mod duration_format;
 mod error;
 mod filesize;
 mod helper;
@@ -81,6 +83,7 @@ pub struct Config {
     pub use_kitty_protocol: bool,
     pub highlight_resolved_externals: bool,
     pub auto_cd_implicit: bool,
+    pub duration_format: DurationFormat,
     /// Configuration for plugins.
     ///
     /// Users can provide configuration for a plugin through this entry.  The entry name must
@@ -145,6 +148,7 @@ impl Default for Config {
             highlight_resolved_externals: false,
 
             auto_cd_implicit: false,
+            duration_format: DurationFormat::default(),
 
             plugins: HashMap::new(),
             plugin_gc: PluginGcConfigs::default(),
@@ -210,6 +214,7 @@ impl UpdateFromValue for Config {
                     self.highlight_resolved_externals.update(val, path, errors)
                 }
                 "auto_cd_implicit" => self.auto_cd_implicit.update(val, path, errors),
+                "duration_format" => self.duration_format.update(val, path, errors),
                 "plugins" => self.plugins.update(val, path, errors),
                 "plugin_gc" => self.plugin_gc.update(val, path, errors),
                 "menus" => match Vec::from_value(val.clone()) {

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -13,7 +13,7 @@ pub use completions::{
 };
 pub use datetime_format::DatetimeFormatConfig;
 pub use display_errors::DisplayErrors;
-pub use duration_format::DurationFormat;
+pub use duration_max_unit::DurationMaxUnit;
 pub use filesize::FilesizeConfig;
 pub use helper::extract_value;
 pub use hinter::HinterConfig;
@@ -32,7 +32,7 @@ mod clip;
 mod completions;
 mod datetime_format;
 mod display_errors;
-mod duration_format;
+mod duration_max_unit;
 mod error;
 mod filesize;
 mod helper;
@@ -83,7 +83,7 @@ pub struct Config {
     pub use_kitty_protocol: bool,
     pub highlight_resolved_externals: bool,
     pub auto_cd_implicit: bool,
-    pub duration_format: DurationFormat,
+    pub duration_max_unit: DurationMaxUnit,
     /// Configuration for plugins.
     ///
     /// Users can provide configuration for a plugin through this entry.  The entry name must
@@ -148,7 +148,7 @@ impl Default for Config {
             highlight_resolved_externals: false,
 
             auto_cd_implicit: false,
-            duration_format: DurationFormat::default(),
+            duration_max_unit: DurationMaxUnit::default(),
 
             plugins: HashMap::new(),
             plugin_gc: PluginGcConfigs::default(),
@@ -214,7 +214,7 @@ impl UpdateFromValue for Config {
                     self.highlight_resolved_externals.update(val, path, errors)
                 }
                 "auto_cd_implicit" => self.auto_cd_implicit.update(val, path, errors),
-                "duration_format" => self.duration_format.update(val, path, errors),
+                "duration_max_unit" => self.duration_max_unit.update(val, path, errors),
                 "plugins" => self.plugins.update(val, path, errors),
                 "plugin_gc" => self.plugin_gc.update(val, path, errors),
                 "menus" => match Vec::from_value(val.clone()) {

--- a/crates/nu-protocol/src/value/duration.rs
+++ b/crates/nu-protocol/src/value/duration.rs
@@ -4,6 +4,8 @@ use std::{
     fmt::{Display, Formatter},
 };
 
+use crate::DurationFormat;
+
 #[derive(Clone, Copy)]
 pub enum TimePeriod {
     Nanos(i64),
@@ -41,8 +43,8 @@ impl Display for TimePeriod {
     }
 }
 
-pub fn format_duration(duration: i64) -> String {
-    let (sign, periods) = format_duration_as_timeperiod(duration);
+pub fn format_duration(duration: i64, max_unit: DurationFormat) -> String {
+    let (sign, periods) = format_duration_as_timeperiod(duration, max_unit);
 
     let text = periods
         .into_iter()
@@ -56,7 +58,10 @@ pub fn format_duration(duration: i64) -> String {
     )
 }
 
-pub fn format_duration_as_timeperiod(duration: i64) -> (i32, Vec<TimePeriod>) {
+pub fn format_duration_as_timeperiod(
+    duration: i64,
+    max_unit: DurationFormat,
+) -> (i32, Vec<TimePeriod>) {
     // Attribution: most of this is taken from chrono-humanize-rs. Thanks!
     // https://gitlab.com/imp/chrono-humanize-rs/-/blob/master/src/humantime.rs
     // Current duration doesn't know a date it's based on, weeks is the max time unit it can normalize into.
@@ -106,13 +111,13 @@ pub fn format_duration_as_timeperiod(duration: i64) -> (i32, Vec<TimePeriod>) {
         normalize_split(millis, Duration::try_milliseconds(millis), duration)
     }
 
-    /// Split this a duration into number of whole seconds and the remainder
+    /// Split this a duration into number of whole microseconds and the remainder
     fn split_microseconds(duration: Duration) -> (Option<i64>, Duration) {
         let micros = duration.num_microseconds().unwrap_or_default();
         normalize_split(micros, Duration::microseconds(micros), duration)
     }
 
-    /// Split this a duration into number of whole seconds and the remainder
+    /// Split this a duration into number of whole nanoseconds and the remainder
     fn split_nanoseconds(duration: Duration) -> (Option<i64>, Duration) {
         let nanos = duration.num_nanoseconds().unwrap_or_default();
         normalize_split(nanos, Duration::nanoseconds(nanos), duration)
@@ -132,45 +137,69 @@ pub fn format_duration_as_timeperiod(duration: i64) -> (i32, Vec<TimePeriod>) {
     }
 
     let mut periods = vec![];
+    let mut remainder = dur;
 
-    let (weeks, remainder) = split_weeks(dur);
-    if let Some(weeks) = weeks {
-        periods.push(TimePeriod::Weeks(weeks));
+    if max_unit <= DurationFormat::Week {
+        let (weeks, rem) = split_weeks(remainder);
+        remainder = rem;
+        if let Some(weeks) = weeks {
+            periods.push(TimePeriod::Weeks(weeks));
+        }
     }
 
-    let (days, remainder) = split_days(remainder);
-    if let Some(days) = days {
-        periods.push(TimePeriod::Days(days));
+    if max_unit <= DurationFormat::Day {
+        let (days, rem) = split_days(remainder);
+        remainder = rem;
+        if let Some(days) = days {
+            periods.push(TimePeriod::Days(days));
+        }
     }
 
-    let (hours, remainder) = split_hours(remainder);
-    if let Some(hours) = hours {
-        periods.push(TimePeriod::Hours(hours));
+    if max_unit <= DurationFormat::Hour {
+        let (hours, rem) = split_hours(remainder);
+        remainder = rem;
+        if let Some(hours) = hours {
+            periods.push(TimePeriod::Hours(hours));
+        }
     }
 
-    let (minutes, remainder) = split_minutes(remainder);
-    if let Some(minutes) = minutes {
-        periods.push(TimePeriod::Minutes(minutes));
+    if max_unit <= DurationFormat::Minute {
+        let (minutes, rem) = split_minutes(remainder);
+        remainder = rem;
+        if let Some(minutes) = minutes {
+            periods.push(TimePeriod::Minutes(minutes));
+        }
     }
 
-    let (seconds, remainder) = split_seconds(remainder);
-    if let Some(seconds) = seconds {
-        periods.push(TimePeriod::Seconds(seconds));
+    if max_unit <= DurationFormat::Second {
+        let (seconds, rem) = split_seconds(remainder);
+        remainder = rem;
+        if let Some(seconds) = seconds {
+            periods.push(TimePeriod::Seconds(seconds));
+        }
     }
 
-    let (millis, remainder) = split_milliseconds(remainder);
-    if let Some(millis) = millis {
-        periods.push(TimePeriod::Millis(millis));
+    if max_unit <= DurationFormat::Millisecond {
+        let (millis, rem) = split_milliseconds(remainder);
+        remainder = rem;
+        if let Some(millis) = millis {
+            periods.push(TimePeriod::Millis(millis));
+        }
     }
 
-    let (micros, remainder) = split_microseconds(remainder);
-    if let Some(micros) = micros {
-        periods.push(TimePeriod::Micros(micros));
+    if max_unit <= DurationFormat::Microsecond {
+        let (micros, rem) = split_microseconds(remainder);
+        remainder = rem;
+        if let Some(micros) = micros {
+            periods.push(TimePeriod::Micros(micros));
+        }
     }
 
-    let (nanos, _remainder) = split_nanoseconds(remainder);
-    if let Some(nanos) = nanos {
-        periods.push(TimePeriod::Nanos(nanos));
+    if max_unit <= DurationFormat::Nanosecond {
+        let (nanos, _rem) = split_nanoseconds(remainder);
+        if let Some(nanos) = nanos {
+            periods.push(TimePeriod::Nanos(nanos));
+        }
     }
 
     if periods.is_empty() {

--- a/crates/nu-protocol/src/value/duration.rs
+++ b/crates/nu-protocol/src/value/duration.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::{Display, Formatter},
 };
 
-use crate::DurationFormat;
+use crate::DurationMaxUnit;
 
 #[derive(Clone, Copy)]
 pub enum TimePeriod {
@@ -43,7 +43,7 @@ impl Display for TimePeriod {
     }
 }
 
-pub fn format_duration(duration: i64, max_unit: DurationFormat) -> String {
+pub fn format_duration(duration: i64, max_unit: DurationMaxUnit) -> String {
     let (sign, periods) = format_duration_as_timeperiod(duration, max_unit);
 
     let text = periods
@@ -60,7 +60,7 @@ pub fn format_duration(duration: i64, max_unit: DurationFormat) -> String {
 
 pub fn format_duration_as_timeperiod(
     duration: i64,
-    max_unit: DurationFormat,
+    max_unit: DurationMaxUnit,
 ) -> (i32, Vec<TimePeriod>) {
     // Attribution: most of this is taken from chrono-humanize-rs. Thanks!
     // https://gitlab.com/imp/chrono-humanize-rs/-/blob/master/src/humantime.rs
@@ -139,7 +139,7 @@ pub fn format_duration_as_timeperiod(
     let mut periods = vec![];
     let mut remainder = dur;
 
-    if max_unit <= DurationFormat::Week {
+    if max_unit <= DurationMaxUnit::Week {
         let (weeks, rem) = split_weeks(remainder);
         remainder = rem;
         if let Some(weeks) = weeks {
@@ -147,7 +147,7 @@ pub fn format_duration_as_timeperiod(
         }
     }
 
-    if max_unit <= DurationFormat::Day {
+    if max_unit <= DurationMaxUnit::Day {
         let (days, rem) = split_days(remainder);
         remainder = rem;
         if let Some(days) = days {
@@ -155,7 +155,7 @@ pub fn format_duration_as_timeperiod(
         }
     }
 
-    if max_unit <= DurationFormat::Hour {
+    if max_unit <= DurationMaxUnit::Hour {
         let (hours, rem) = split_hours(remainder);
         remainder = rem;
         if let Some(hours) = hours {
@@ -163,7 +163,7 @@ pub fn format_duration_as_timeperiod(
         }
     }
 
-    if max_unit <= DurationFormat::Minute {
+    if max_unit <= DurationMaxUnit::Minute {
         let (minutes, rem) = split_minutes(remainder);
         remainder = rem;
         if let Some(minutes) = minutes {
@@ -171,7 +171,7 @@ pub fn format_duration_as_timeperiod(
         }
     }
 
-    if max_unit <= DurationFormat::Second {
+    if max_unit <= DurationMaxUnit::Second {
         let (seconds, rem) = split_seconds(remainder);
         remainder = rem;
         if let Some(seconds) = seconds {
@@ -179,7 +179,7 @@ pub fn format_duration_as_timeperiod(
         }
     }
 
-    if max_unit <= DurationFormat::Millisecond {
+    if max_unit <= DurationMaxUnit::Millisecond {
         let (millis, rem) = split_milliseconds(remainder);
         remainder = rem;
         if let Some(millis) = millis {
@@ -187,7 +187,7 @@ pub fn format_duration_as_timeperiod(
         }
     }
 
-    if max_unit <= DurationFormat::Microsecond {
+    if max_unit <= DurationMaxUnit::Microsecond {
         let (micros, rem) = split_microseconds(remainder);
         remainder = rem;
         if let Some(micros) = micros {
@@ -195,7 +195,7 @@ pub fn format_duration_as_timeperiod(
         }
     }
 
-    if max_unit <= DurationFormat::Nanosecond {
+    if max_unit <= DurationMaxUnit::Nanosecond {
         let (nanos, _rem) = split_nanoseconds(remainder);
         if let Some(nanos) = nanos {
             periods.push(TimePeriod::Nanos(nanos));

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1105,7 +1105,7 @@ impl Value {
             Value::Int { val, .. } => val.to_string(),
             Value::Float { val, .. } => ObviousFloat(*val).to_string(),
             Value::Filesize { val, .. } => config.filesize.format(*val).to_string(),
-            Value::Duration { val, .. } => format_duration(*val, config.duration_format),
+            Value::Duration { val, .. } => format_duration(*val, config.duration_max_unit),
             Value::Date { val, .. } => match &config.datetime_format.normal {
                 Some(format) => self.format_datetime(val, format),
                 None => {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1105,7 +1105,7 @@ impl Value {
             Value::Int { val, .. } => val.to_string(),
             Value::Float { val, .. } => ObviousFloat(*val).to_string(),
             Value::Filesize { val, .. } => config.filesize.format(*val).to_string(),
-            Value::Duration { val, .. } => format_duration(*val),
+            Value::Duration { val, .. } => format_duration(*val, config.duration_format),
             Value::Date { val, .. } => match &config.datetime_format.normal {
                 Some(format) => self.format_datetime(val, format),
                 None => {

--- a/crates/nu-protocol/tests/into_config.rs
+++ b/crates/nu-protocol/tests/into_config.rs
@@ -138,27 +138,27 @@ fn config_unsupported_value_reverted() -> Result {
 }
 
 #[test]
-fn config_duration_format_valid() -> Result {
+fn config_duration_max_unit_valid() -> Result {
     let mut tester = test();
     for unit in ["wk", "day", "hr", "min", "sec", "ms", "us", "ns"] {
-        let () = tester.run(format!("$env.config.duration_format = '{unit}'"))?;
+        let () = tester.run(format!("$env.config.duration_max_unit = '{unit}'"))?;
         let () = tester
-            .run("$env.config.duration_format")
+            .run("$env.config.duration_max_unit")
             .expect_value_eq(unit)?;
     }
     // µs is accepted by FromStr but normalizes to "us" on output
-    let () = tester.run("$env.config.duration_format = 'µs'")?;
+    let () = tester.run("$env.config.duration_max_unit = 'µs'")?;
     tester
-        .run("$env.config.duration_format")
+        .run("$env.config.duration_max_unit")
         .expect_value_eq("us")?;
     Ok(())
 }
 
 #[test]
-fn config_duration_format_invalid() -> Result {
+fn config_duration_max_unit_invalid() -> Result {
     let mut tester = test();
     let shell_error = tester
-        .run("$env.config.duration_format = 'years'")
+        .run("$env.config.duration_max_unit = 'years'")
         .expect_shell_error()?;
     let [err] = config_error(&shell_error)?;
     match err {
@@ -168,10 +168,10 @@ fn config_duration_format_invalid() -> Result {
 }
 
 #[test]
-fn config_duration_format_wrong_type() -> Result {
+fn config_duration_max_unit_wrong_type() -> Result {
     let mut tester = test();
     let shell_error = tester
-        .run("$env.config.duration_format = 42")
+        .run("$env.config.duration_max_unit = 42")
         .expect_shell_error()?;
     let [err] = config_error(&shell_error)?;
     match err {
@@ -181,13 +181,13 @@ fn config_duration_format_wrong_type() -> Result {
 }
 
 #[test]
-fn config_duration_format_reverted_on_invalid() -> Result {
+fn config_duration_max_unit_reverted_on_invalid() -> Result {
     let mut tester = test();
-    let () = tester.run("$env.config.duration_format = 'day'")?;
+    let () = tester.run("$env.config.duration_max_unit = 'day'")?;
     let _ = tester
-        .run("$env.config.duration_format = 'bogus'")
+        .run("$env.config.duration_max_unit = 'bogus'")
         .expect_shell_error()?;
     tester
-        .run("$env.config.duration_format")
+        .run("$env.config.duration_max_unit")
         .expect_value_eq("day")
 }

--- a/crates/nu-protocol/tests/into_config.rs
+++ b/crates/nu-protocol/tests/into_config.rs
@@ -136,3 +136,58 @@ fn config_unsupported_value_reverted() -> Result {
         .run("$env.config.history.file_format")
         .expect_value_eq("plaintext")
 }
+
+#[test]
+fn config_duration_format_valid() -> Result {
+    let mut tester = test();
+    for unit in ["wk", "day", "hr", "min", "sec", "ms", "us", "ns"] {
+        let () = tester.run(format!("$env.config.duration_format = '{unit}'"))?;
+        let () = tester
+            .run("$env.config.duration_format")
+            .expect_value_eq(unit)?;
+    }
+    // µs is accepted by FromStr but normalizes to "us" on output
+    let () = tester.run("$env.config.duration_format = 'µs'")?;
+    tester
+        .run("$env.config.duration_format")
+        .expect_value_eq("us")?;
+    Ok(())
+}
+
+#[test]
+fn config_duration_format_invalid() -> Result {
+    let mut tester = test();
+    let shell_error = tester
+        .run("$env.config.duration_format = 'years'")
+        .expect_shell_error()?;
+    let [err] = config_error(&shell_error)?;
+    match err {
+        ConfigError::InvalidValue { .. } => Ok(()),
+        _ => Err(shell_error.into()),
+    }
+}
+
+#[test]
+fn config_duration_format_wrong_type() -> Result {
+    let mut tester = test();
+    let shell_error = tester
+        .run("$env.config.duration_format = 42")
+        .expect_shell_error()?;
+    let [err] = config_error(&shell_error)?;
+    match err {
+        ConfigError::TypeMismatch { .. } => Ok(()),
+        _ => Err(shell_error.into()),
+    }
+}
+
+#[test]
+fn config_duration_format_reverted_on_invalid() -> Result {
+    let mut tester = test();
+    let () = tester.run("$env.config.duration_format = 'day'")?;
+    let _ = tester
+        .run("$env.config.duration_format = 'bogus'")
+        .expect_shell_error()?;
+    tester
+        .run("$env.config.duration_format")
+        .expect_value_eq("day")
+}

--- a/crates/nu-protocol/tests/test_value.rs
+++ b/crates/nu-protocol/tests/test_value.rs
@@ -1,5 +1,5 @@
 use nu_protocol::{
-    Config, Span, Value,
+    Config, DurationFormat, Span, Value,
     engine::{EngineState, Stack},
 };
 use rstest::rstest;
@@ -113,6 +113,51 @@ fn test_duration_to_string(#[case] in_ns: i64, #[case] expected: &str) {
         expected,
         dur.to_expanded_string("", &Config::default()),
         "expected != observed"
+    );
+}
+
+// 365 days = 52wk 1day with default (wk) max unit
+const ONE_YEAR_NS: i64 = 365 * 24 * 3600 * 1_000_000_000;
+// 1wk 2day 3hr 4min 5sec 6ms 7µs 8ns
+const MIXED_DURATION_NS: i64 =
+    ((((((7 + 2) * 24 + 3) * 60 + 4) * 60 + 5) * 1000 + 6) * 1000 + 7) * 1000 + 8;
+
+fn config_with_duration_format(format: DurationFormat) -> Config {
+    Config {
+        duration_format: format,
+        ..Default::default()
+    }
+}
+
+#[rstest]
+#[case::day_max(ONE_YEAR_NS, DurationFormat::Day, "365day")]
+#[case::hr_max(ONE_YEAR_NS, DurationFormat::Hour, "8760hr")]
+#[case::min_max(ONE_YEAR_NS, DurationFormat::Minute, "525600min")]
+#[case::sec_max(ONE_YEAR_NS, DurationFormat::Second, "31536000sec")]
+#[case::ms_max(3_000_000_000, DurationFormat::Millisecond, "3000ms")]
+#[case::mixed_day_max(
+    MIXED_DURATION_NS,
+    DurationFormat::Day,
+    "9day 3hr 4min 5sec 6ms 7µs 8ns"
+)]
+#[case::mixed_hr_max(MIXED_DURATION_NS, DurationFormat::Hour, "219hr 4min 5sec 6ms 7µs 8ns")]
+#[case::mixed_min_max(MIXED_DURATION_NS, DurationFormat::Minute, "13144min 5sec 6ms 7µs 8ns")]
+#[case::mixed_sec_max(MIXED_DURATION_NS, DurationFormat::Second, "788645sec 6ms 7µs 8ns")]
+#[case::mixed_ms_max(MIXED_DURATION_NS, DurationFormat::Millisecond, "788645006ms 7µs 8ns")]
+#[case::mixed_us_max(MIXED_DURATION_NS, DurationFormat::Microsecond, "788645006007µs 8ns")]
+#[case::mixed_ns_max(MIXED_DURATION_NS, DurationFormat::Nanosecond, "788645006007008ns")]
+#[case::wk_max_unchanged(ONE_YEAR_NS, DurationFormat::Week, "52wk 1day")]
+fn test_duration_format_config(
+    #[case] in_ns: i64,
+    #[case] max_unit: DurationFormat,
+    #[case] expected: &str,
+) {
+    let dur = Value::test_duration(in_ns);
+    let config = config_with_duration_format(max_unit);
+    assert_eq!(
+        expected,
+        dur.to_expanded_string("", &config),
+        "duration_format={max_unit:?} for {in_ns}ns"
     );
 }
 

--- a/crates/nu-protocol/tests/test_value.rs
+++ b/crates/nu-protocol/tests/test_value.rs
@@ -1,5 +1,5 @@
 use nu_protocol::{
-    Config, DurationFormat, Span, Value,
+    Config, DurationMaxUnit, Span, Value,
     engine::{EngineState, Stack},
 };
 use rstest::rstest;
@@ -122,42 +122,42 @@ const ONE_YEAR_NS: i64 = 365 * 24 * 3600 * 1_000_000_000;
 const MIXED_DURATION_NS: i64 =
     ((((((7 + 2) * 24 + 3) * 60 + 4) * 60 + 5) * 1000 + 6) * 1000 + 7) * 1000 + 8;
 
-fn config_with_duration_format(format: DurationFormat) -> Config {
+fn config_with_duration_max_unit(format: DurationMaxUnit) -> Config {
     Config {
-        duration_format: format,
+        duration_max_unit: format,
         ..Default::default()
     }
 }
 
 #[rstest]
-#[case::day_max(ONE_YEAR_NS, DurationFormat::Day, "365day")]
-#[case::hr_max(ONE_YEAR_NS, DurationFormat::Hour, "8760hr")]
-#[case::min_max(ONE_YEAR_NS, DurationFormat::Minute, "525600min")]
-#[case::sec_max(ONE_YEAR_NS, DurationFormat::Second, "31536000sec")]
-#[case::ms_max(3_000_000_000, DurationFormat::Millisecond, "3000ms")]
+#[case::day_max(ONE_YEAR_NS, DurationMaxUnit::Day, "365day")]
+#[case::hr_max(ONE_YEAR_NS, DurationMaxUnit::Hour, "8760hr")]
+#[case::min_max(ONE_YEAR_NS, DurationMaxUnit::Minute, "525600min")]
+#[case::sec_max(ONE_YEAR_NS, DurationMaxUnit::Second, "31536000sec")]
+#[case::ms_max(3_000_000_000, DurationMaxUnit::Millisecond, "3000ms")]
 #[case::mixed_day_max(
     MIXED_DURATION_NS,
-    DurationFormat::Day,
+    DurationMaxUnit::Day,
     "9day 3hr 4min 5sec 6ms 7µs 8ns"
 )]
-#[case::mixed_hr_max(MIXED_DURATION_NS, DurationFormat::Hour, "219hr 4min 5sec 6ms 7µs 8ns")]
-#[case::mixed_min_max(MIXED_DURATION_NS, DurationFormat::Minute, "13144min 5sec 6ms 7µs 8ns")]
-#[case::mixed_sec_max(MIXED_DURATION_NS, DurationFormat::Second, "788645sec 6ms 7µs 8ns")]
-#[case::mixed_ms_max(MIXED_DURATION_NS, DurationFormat::Millisecond, "788645006ms 7µs 8ns")]
-#[case::mixed_us_max(MIXED_DURATION_NS, DurationFormat::Microsecond, "788645006007µs 8ns")]
-#[case::mixed_ns_max(MIXED_DURATION_NS, DurationFormat::Nanosecond, "788645006007008ns")]
-#[case::wk_max_unchanged(ONE_YEAR_NS, DurationFormat::Week, "52wk 1day")]
-fn test_duration_format_config(
+#[case::mixed_hr_max(MIXED_DURATION_NS, DurationMaxUnit::Hour, "219hr 4min 5sec 6ms 7µs 8ns")]
+#[case::mixed_min_max(MIXED_DURATION_NS, DurationMaxUnit::Minute, "13144min 5sec 6ms 7µs 8ns")]
+#[case::mixed_sec_max(MIXED_DURATION_NS, DurationMaxUnit::Second, "788645sec 6ms 7µs 8ns")]
+#[case::mixed_ms_max(MIXED_DURATION_NS, DurationMaxUnit::Millisecond, "788645006ms 7µs 8ns")]
+#[case::mixed_us_max(MIXED_DURATION_NS, DurationMaxUnit::Microsecond, "788645006007µs 8ns")]
+#[case::mixed_ns_max(MIXED_DURATION_NS, DurationMaxUnit::Nanosecond, "788645006007008ns")]
+#[case::wk_max_unchanged(ONE_YEAR_NS, DurationMaxUnit::Week, "52wk 1day")]
+fn test_duration_max_unit_config(
     #[case] in_ns: i64,
-    #[case] max_unit: DurationFormat,
+    #[case] max_unit: DurationMaxUnit,
     #[case] expected: &str,
 ) {
     let dur = Value::test_duration(in_ns);
-    let config = config_with_duration_format(max_unit);
+    let config = config_with_duration_max_unit(max_unit);
     assert_eq!(
         expected,
         dur.to_expanded_string("", &config),
-        "duration_format={max_unit:?} for {in_ns}ns"
+        "duration_max_unit={max_unit:?} for {in_ns}ns"
     );
 }
 

--- a/crates/nu-protocol/tests/test_value.rs
+++ b/crates/nu-protocol/tests/test_value.rs
@@ -140,8 +140,16 @@ fn config_with_duration_max_unit(format: DurationMaxUnit) -> Config {
     DurationMaxUnit::Day,
     "9day 3hr 4min 5sec 6ms 7µs 8ns"
 )]
-#[case::mixed_hr_max(MIXED_DURATION_NS, DurationMaxUnit::Hour, "219hr 4min 5sec 6ms 7µs 8ns")]
-#[case::mixed_min_max(MIXED_DURATION_NS, DurationMaxUnit::Minute, "13144min 5sec 6ms 7µs 8ns")]
+#[case::mixed_hr_max(
+    MIXED_DURATION_NS,
+    DurationMaxUnit::Hour,
+    "219hr 4min 5sec 6ms 7µs 8ns"
+)]
+#[case::mixed_min_max(
+    MIXED_DURATION_NS,
+    DurationMaxUnit::Minute,
+    "13144min 5sec 6ms 7µs 8ns"
+)]
 #[case::mixed_sec_max(MIXED_DURATION_NS, DurationMaxUnit::Second, "788645sec 6ms 7µs 8ns")]
 #[case::mixed_ms_max(MIXED_DURATION_NS, DurationMaxUnit::Millisecond, "788645006ms 7µs 8ns")]
 #[case::mixed_us_max(MIXED_DURATION_NS, DurationMaxUnit::Microsecond, "788645006007µs 8ns")]


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
Basically, I don't like how when a duration goes over 7 days it starts using weeks as a unit, so I added an option in the config to set the maximum unit it will use for formatting. Default is `wk` so there is no breaking change.

## User-facing changes (Release notes)
Added a new config option that will set the maximum unit used when formatting `duration`s for display.
```nu
# -- doc_config.nu --

# duration_max_unit (string): Largest unit when displaying durations.
# Durations are decomposed from this unit downward. A smaller value excludes
# larger units from the output (e.g., "day" shows 365day instead of
# 52wk 1day for one year).
# Default: "wk"
$env.config.duration_max_unit = "wk"
```

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
I have discovered that `µ` and `μ` are not the same, the former is the micro symbol and the latter is the greek letter mu. Doing some grepping, it seems both are used for microseconds in different places. In this pr I have tried to use the micro symbol since that is probably the most correct.