### PR TITLE
Update some tests to use the new test infra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ parking_lot = "0.12.5"
 pastey = "0.2.3"
 pathdiff = "0.2"
 percent-encoding = "2"
-pretty_assertions = "1.4"
+pretty_assertions = { version = "1.4", features = ["unstable"] }
 print-positions = "0.6"
 proc-macro-error2 = "2.0"
 proc-macro2 = "1.0"

--- a/crates/nu-cli/tests/commands/keybindings_list.rs
+++ b/crates/nu-cli/tests/commands/keybindings_list.rs
@@ -1,7 +1,8 @@
-use nu_test_support::nu;
+use nu_test_support::prelude::*;
 
 #[test]
-fn not_empty() {
-    let result = nu!("keybindings list | is-not-empty");
-    assert_eq!(result.out, "true");
+fn not_empty() -> Result {
+    test()
+        .run("keybindings list | is-not-empty")
+        .expect_value_eq(true)
 }

--- a/crates/nu-cli/tests/commands/nu_highlight.rs
+++ b/crates/nu-cli/tests/commands/nu_highlight.rs
@@ -1,6 +1,7 @@
+use rstest::rstest;
+
 use nu_protocol::{IntoPipelineData, PipelineMetadata, Span};
 use nu_test_support::prelude::*;
-use rstest::rstest;
 
 /// checks that garbage is highlighted as error
 #[rstest]
@@ -21,7 +22,7 @@ use rstest::rstest;
 )]
 // https://github.com/nushell/nushell/issues/18369
 #[case::leading_pipe("| ls", "garbage")]
-fn nu_highlight_color_detection(#[case] cmd: &str, #[case] shape: &str) {
+fn nu_highlight_color_detection(#[case] cmd: &str, #[case] shape: &str) -> Result {
     use std::fmt::Write;
 
     let color = "#112233";
@@ -37,41 +38,44 @@ fn nu_highlight_color_detection(#[case] cmd: &str, #[case] shape: &str) {
     writeln!(&mut buf, "let highlight = '{cmd}' | nu-highlight").unwrap();
     write!(&mut buf, "$highlight has (ansi $color)").unwrap();
 
-    let outcome = nu!(buf);
-
-    assert_eq!(outcome.out, "true");
+    test().run(buf).expect_value_eq(true)
 }
 
 #[test]
-fn nu_highlight_not_expr() {
-    let actual = nu!("'not false' | nu-highlight | ansi strip");
-    assert_eq!(actual.out, "not false");
+fn nu_highlight_not_expr() -> Result {
+    test()
+        .run("'not false' | nu-highlight | ansi strip")
+        .expect_value_eq("not false")
 }
 
 #[test]
-fn nu_highlight_where_row_condition() {
-    let actual = nu!("'ls | where a b 12345(' | nu-highlight | ansi strip");
-    assert_eq!(actual.out, "ls | where a b 12345(");
+fn nu_highlight_where_row_condition() -> Result {
+    test()
+        .run("'ls | where a b 12345(' | nu-highlight | ansi strip")
+        .expect_value_eq("ls | where a b 12345(")
 }
 
 #[test]
-fn nu_highlight_aliased_external_resolved() {
-    let actual = nu!("$env.config.highlight_resolved_externals = true
+#[deps(NU)]
+fn nu_highlight_aliased_external_resolved() -> Result {
+    let code = "
+        $env.config.highlight_resolved_externals = true
         $env.config.color_config.shape_external_resolved = '#ffffff'
-        alias fff = ^rustc
-        ('fff' | nu-highlight) has (ansi $env.config.color_config.shape_external_resolved)");
-
-    assert_eq!(actual.out, "true");
+        alias fff = ^nu
+        ('fff' | nu-highlight) has (ansi $env.config.color_config.shape_external_resolved)
+    ";
+    test().run(code).expect_value_eq(true)
 }
 
 #[test]
-fn nu_highlight_aliased_external_unresolved() {
-    let actual = nu!("$env.config.highlight_resolved_externals = true
+fn nu_highlight_aliased_external_unresolved() -> Result {
+    let code = "
+        $env.config.highlight_resolved_externals = true
         $env.config.color_config.shape_external = '#ffffff'
         alias fff = ^nonexist
-        ('fff' | nu-highlight) has (ansi $env.config.color_config.shape_external)");
-
-    assert_eq!(actual.out, "true");
+        ('fff' | nu-highlight) has (ansi $env.config.color_config.shape_external)
+    ";
+    test().run(code).expect_value_eq(true)
 }
 
 #[test]

--- a/crates/nu-cli/tests/commands/nu_highlight.rs
+++ b/crates/nu-cli/tests/commands/nu_highlight.rs
@@ -23,22 +23,12 @@ use nu_test_support::prelude::*;
 // https://github.com/nushell/nushell/issues/18369
 #[case::leading_pipe("| ls", "garbage")]
 fn nu_highlight_color_detection(#[case] cmd: &str, #[case] shape: &str) -> Result {
-    use std::fmt::Write;
-
-    let color = "#112233";
-
-    let mut buf = String::new();
-    writeln!(&mut buf, "let color = '{color}'").unwrap();
-    writeln!(
-        &mut buf,
-        "$env.config.color_config.shape_{} = $color",
-        shape
-    )
-    .unwrap();
-    writeln!(&mut buf, "let highlight = '{cmd}' | nu-highlight").unwrap();
-    write!(&mut buf, "$highlight has (ansi $color)").unwrap();
-
-    test().run(buf).expect_value_eq(true)
+    let mut tester = test();
+    let () = tester.run_with_data("let color = $in", "#112233")?;
+    let () = tester.run(format!("$env.config.color_config.shape_{} = $color", shape))?;
+    tester
+        .run_with_data("nu-highlight | $in has (ansi $color)", cmd)
+        .expect_value_eq(true)
 }
 
 #[test]

--- a/crates/nu-cmd-lang/tests/commands/describe.rs
+++ b/crates/nu-cmd-lang/tests/commands/describe.rs
@@ -1,4 +1,3 @@
-use nu_test_support::nu;
 use nu_test_support::prelude::*;
 
 #[test]

--- a/crates/nu-cmd-lang/tests/commands/describe.rs
+++ b/crates/nu-cmd-lang/tests/commands/describe.rs
@@ -1,41 +1,33 @@
 use nu_test_support::nu;
+use nu_test_support::prelude::*;
 
 #[test]
-fn test_oneof_flattening_in_describe() {
+fn test_oneof_flattening_in_describe() -> Result {
     // Reverse order (already flat)
-    let result =
-        nu!("[ ...(0..4 | each { {content:[{content:[any]}]} }), {content:[any]} ] | describe");
-    assert_eq!(
-        result.out,
-        "table<content: oneof<table<content: list<string>>, list<string>>>"
-    );
+
+    test()
+        .run("[ ...(0..4 | each { {content:[{content:[any]}]} }), {content:[any]} ] | describe")
+        .expect_value_eq("table<content: oneof<table<content: list<string>>, list<string>>>")
 }
 
 #[test]
-fn test_oneof_flattening_in_describe_reverse_order() {
-    // Original problematic order (should now be flat, even if not fully deduped)
-    let result =
-        nu!("[ {content:[any]} ...(0..4 | each { {content:[{content:[any]}]} }) ] | describe");
-    assert!(
-        result
-            .out
-            .contains("table<content: oneof<list<string>, table<content: list<string>>>>",)
-    );
-    assert!(!result.out.contains("oneof<oneof<"));
+fn test_oneof_flattening_in_describe_reverse_order() -> Result {
+    // Original problematic order `oneof<oneof<` (should now be flat, even if not fully deduped)
+    test()
+        .run("[ {content:[any]} ...(0..4 | each { {content:[{content:[any]}]} }) ] | describe")
+        .expect_value_eq("table<content: oneof<list<string>, table<content: list<string>>>>")
 }
 
 #[test]
-fn test_oneof_flattening_in_describe_glob_string() {
-    let result =
-        nu!("do { let g: glob = \"*.rs\"; [ {content: $g} {content: \"README.rs\"} ] | describe }");
-    assert!(result.out.contains("table<content: oneof<glob, string>>"));
-    assert!(!result.out.contains("oneof<oneof<"));
+fn test_oneof_flattening_in_describe_glob_string() -> Result {
+    test()
+        .run("do { let g: glob = \"*.rs\"; [ {content: $g} {content: \"README.rs\"} ] | describe }")
+        .expect_value_eq("table<content: oneof<glob, string>>")
 }
 
 #[test]
-fn test_oneof_flattening_in_describe_glob_string_reverse_order() {
-    let result =
-        nu!("do { let g: glob = \"*.rs\"; [ {content: \"README.rs\"} {content: $g} ] | describe }");
-    assert_eq!("table<content: oneof<string, glob>>", result.out);
-    assert!(!result.out.contains("oneof<oneof<"));
+fn test_oneof_flattening_in_describe_glob_string_reverse_order() -> Result {
+    test()
+        .run("do { let g: glob = \"*.rs\"; [ {content: \"README.rs\"} {content: $g} ] | describe }")
+        .expect_value_eq("table<content: oneof<string, glob>>")
 }

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -12,6 +12,11 @@ version.workspace = true
 bench = false
 harness = false
 
+[[test]]
+name = "tests"
+path = "tests/main.rs"
+harness = false
+
 [lints]
 workspace = true
 
@@ -24,4 +29,4 @@ nu-ansi-term.workspace = true
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support" }
+nu-test-support = { path = "../nu-test-support", features = ["os"] }

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -176,74 +176,34 @@ impl<'a> StyleComputer<'a> {
     }
 }
 
-#[test]
-fn test_computable_style_static() {
-    use nu_protocol::Span;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let style1 = Style::default().italic();
-    let style2 = Style::default().underline();
-    // Create a "dummy" style_computer for this test.
-    let dummy_engine_state = EngineState::new();
-    let dummy_stack = Stack::new();
-    let style_computer = StyleComputer::new(
-        &dummy_engine_state,
-        &dummy_stack,
-        [
-            ("string".into(), ComputableStyle::Static(style1)),
-            ("row_index".into(), ComputableStyle::Static(style2)),
-        ]
-        .into_iter()
-        .collect(),
-    );
-    assert_eq!(
-        style_computer.compute("string", &Value::nothing(Span::unknown())),
-        style1
-    );
-    assert_eq!(
-        style_computer.compute("row_index", &Value::nothing(Span::unknown())),
-        style2
-    );
-}
-
-// Because each closure currently runs in a separate environment, checks that the closures have run
-// must use the filesystem.
-#[test]
-fn test_computable_style_closure_basic() {
-    use nu_test_support::{nu, nu_repl_code, playground::Playground};
-    Playground::setup("computable_style_closure_basic", |dirs, _| {
-        let inp = [
-            "$env.config = {
-                color_config: {
-                    string: {|e| touch ($e + '.obj'); 'red' }
-                }
-            };",
-            "[bell book candle] | table | ignore",
-            "ls | get name | to nuon",
-        ];
-        let actual_repl = nu!(cwd: dirs.test(), nu_repl_code(&inp));
-        assert_eq!(actual_repl.err, "");
-        assert_eq!(actual_repl.out, r#"["bell.obj", "book.obj", "candle.obj"]"#);
-    });
-}
-
-#[test]
-fn test_computable_style_closure_errors() {
-    use nu_test_support::{nu, nu_repl_code};
-    let inp = [
-        "$env.config = {
-            color_config: {
-                string: {|e| $e + 2 }
-            }
-        };",
-        "[bell] | table",
-    ];
-    let actual_repl = nu!(nu_repl_code(&inp));
-    // Check that the error was printed
-    assert!(
-        actual_repl
-            .err
-            .contains("nu::shell::operator_incompatible_types")
-    );
-    // Check that the value was printed
-    assert!(actual_repl.out.contains("bell"));
+    #[test]
+    fn test_computable_style_static() {
+        let style1 = Style::default().italic();
+        let style2 = Style::default().underline();
+        // Create a "dummy" style_computer for this test.
+        let dummy_engine_state = EngineState::new();
+        let dummy_stack = Stack::new();
+        let style_computer = StyleComputer::new(
+            &dummy_engine_state,
+            &dummy_stack,
+            [
+                ("string".into(), ComputableStyle::Static(style1)),
+                ("row_index".into(), ComputableStyle::Static(style2)),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        assert_eq!(
+            style_computer.compute("string", &Value::nothing(Span::unknown())),
+            style1
+        );
+        assert_eq!(
+            style_computer.compute("row_index", &Value::nothing(Span::unknown())),
+            style2
+        );
+    }
 }

--- a/crates/nu-color-config/tests/main.rs
+++ b/crates/nu-color-config/tests/main.rs
@@ -17,7 +17,7 @@ fn test_computable_style_closure_basic() -> Result {
 
         $env.config = {
             color_config: {
-                string: {|e| $e | job send $id; 'red' }
+                string: {|e| $e | job send $id; "red" }
             }
         }
     "#;

--- a/crates/nu-color-config/tests/main.rs
+++ b/crates/nu-color-config/tests/main.rs
@@ -1,0 +1,60 @@
+#![allow(clippy::unwrap_used)]
+
+#[macro_use]
+extern crate nu_test_support;
+use nu_test_support::harness::main;
+
+use nu_test_support::prelude::*;
+
+// Because the color config closures can't modify the global environment, passing information out
+// requires using the in memory sqlite database (`stor`) or job messaging as a queue.
+#[test]
+fn test_computable_style_closure_basic() -> Result {
+    let mut tester = test();
+
+    let code = r#"
+        let id = job id
+
+        $env.config = {
+            color_config: {
+                string: {|e| $e | job send $id; 'red' }
+            }
+        }
+    "#;
+    let () = tester.run(code)?;
+
+    let () = tester.run("[bell book candle] | table | ignore")?;
+
+    for e in ["bell", "book", "candle"] {
+        tester.run("job recv --timeout 0sec").expect_value_eq(e)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+#[deps(NU)]
+fn test_computable_style_closure_errors() -> Result {
+    let child_code = "
+        $env.config = {
+            color_config: {
+                string: {|e| $e + 2 }
+            }
+        }
+
+        [bell] | table
+    ";
+
+    let code = "
+        let child_code
+
+        nu --no-config-file --commands $child_code | complete
+    ";
+
+    let result: CompleteResult = test().run_with_data(code, child_code)?;
+
+    assert_contains("nu::shell::operator_incompatible_types", result.stderr);
+    assert_contains("bell", result.stdout);
+
+    Ok(())
+}

--- a/crates/nu-command/tests/commands/exec.rs
+++ b/crates/nu-command/tests/commands/exec.rs
@@ -1,46 +1,39 @@
-use nu_test_support::nu;
-use nu_test_support::playground::Playground;
+use nu_test_support::prelude::*;
 
 #[test]
-fn basic_exec() {
-    Playground::setup("test_exec_1", |dirs, _| {
-        let actual = nu!(cwd: dirs.test(), "
-            nu -n -c 'exec nu --testbin cococo a b c'
-        ");
-
-        assert_eq!(actual.out, "a b c");
-    })
+#[deps(NU)]
+fn basic_exec() -> Result {
+    test()
+        .run("nu -n -c 'exec nu --testbin cococo a b c'")
+        .expect_value_eq("a b c")
 }
 
 #[test]
-fn exec_complex_args() {
-    Playground::setup("test_exec_2", |dirs, _| {
-        let actual = nu!(cwd: dirs.test(), "
-            nu -n -c 'exec nu --testbin cococo b --bar=2 -sab --arwr - -DTEEE=aasd-290 -90 --'
-        ");
-
-        assert_eq!(actual.out, "b --bar=2 -sab --arwr - -DTEEE=aasd-290 -90 --");
-    })
+#[deps(NU)]
+fn exec_complex_args() -> Result {
+    test()
+        .run("nu -n -c 'exec nu --testbin cococo b --bar=2 -sab --arwr - -DTEEE=aasd-290 -90 --'")
+        .expect_value_eq("b --bar=2 -sab --arwr - -DTEEE=aasd-290 -90 --")
 }
 
 #[test]
-fn exec_fail_batched_short_args() {
-    Playground::setup("test_exec_3", |dirs, _| {
-        let actual = nu!(cwd: dirs.test(), "
-            nu -n -c 'exec nu --testbin cococo -ab 10'
-        ");
+#[deps(NU)]
+fn exec_fail_batched_short_args() -> Result {
+    let code = "
+        nu -n -c 'exec nu --testbin cococo -ab 10'
+        | complete
+    ";
+    let result: CompleteResult = test().run(code)?;
 
-        assert_eq!(actual.out, "");
-    })
+    assert_eq!(result.exit_code, 1);
+    assert_contains("Unknown flag", result.stderr);
+    Ok(())
 }
 
 #[test]
-fn exec_misc_values() {
-    Playground::setup("test_exec_4", |dirs, _| {
-        let actual = nu!(cwd: dirs.test(), r#"
-            nu -n -c 'let x = "abc"; exec nu --testbin cococo $x ...[ a b c ]'
-        "#);
-
-        assert_eq!(actual.out, "abc a b c");
-    })
+#[deps(NU)]
+fn exec_misc_values() -> Result {
+    test()
+        .run(r#"nu -n -c 'let x = "abc"; exec nu --testbin cococo $x ...[ a b c ]'"#)
+        .expect_value_eq("abc a b c")
 }

--- a/crates/nu-command/tests/commands/if_.rs
+++ b/crates/nu-command/tests/commands/if_.rs
@@ -1,15 +1,18 @@
-use nu_test_support::nu;
+use pretty_assertions::assert_matches;
+use rstest::rstest;
+
+use nu_test_support::prelude::*;
 
 // Companion to the `for` non-block-body regression test
 // (https://github.com/nushell/nushell/issues/13746): passing a non-block
 // (e.g. a bare variable) as the `if` body must surface a clean
 // `nu::compile::invalid_keyword_call` error from the IR compiler and never
 // panic, per the AGENTS.md "No panicking on user input" guideline.
-#[test]
-fn if_with_non_block_body_errors_without_panic() {
-    for src in ["if true $nu", "if true $nu else { 1 }"] {
-        let actual = nu!(src);
-        assert!(actual.err.contains("invalid_keyword_call"));
-        assert!(!actual.err.to_lowercase().contains("panic"));
-    }
+#[rstest]
+#[case("if true $nu")]
+#[case("if true $nu else { 1 }")]
+fn if_with_non_block_body_errors_without_panic(#[case] src: &str) -> Result {
+    let err = test().run(src).expect_compile_error()?;
+    assert_matches!(err, CompileError::InvalidKeywordCall { .. });
+    Ok(())
 }

--- a/crates/nu-command/tests/commands/insert.rs
+++ b/crates/nu-command/tests/commands/insert.rs
@@ -1,203 +1,177 @@
-use nu_test_support::nu;
+use pretty_assertions::assert_matches;
+use rstest::rstest;
+
+use nu_experimental::REORDER_CELL_PATHS;
+use nu_protocol::{test_table, test_value};
+use nu_test_support::prelude::*;
 
 #[test]
-fn insert_the_column() {
-    let actual = nu!(cwd: "tests/fixtures/formats", r#"
+fn insert_the_column() -> Result {
+    let code = r#"
         open cargo_sample.toml
         | insert dev-dependencies.new_assertions "0.7.0"
         | get dev-dependencies.new_assertions
-    "#);
-
-    assert_eq!(actual.out, "0.7.0");
+    "#;
+    test()
+        .cwd("tests/fixtures/formats")
+        .run(code)
+        .expect_value_eq("0.7.0")
 }
 
 #[test]
-fn doesnt_convert_record_to_table() {
-    let actual = nu!("{a:1} | insert b 2 | to nuon");
-
-    assert_eq!(actual.out, "{a: 1, b: 2}");
+fn doesnt_convert_record_to_table() -> Result {
+    test()
+        .run("{a:1} | insert b 2")
+        .expect_value_eq(test_value!({a: 1, b: 2}))
 }
 
 #[test]
-fn insert_the_column_conflict() {
-    let actual = nu!(cwd: "tests/fixtures/formats", r#"
+fn insert_the_column_conflict() -> Result {
+    let code = r#"
         open cargo_sample.toml
         | insert dev-dependencies.pretty_assertions "0.7.0"
-    "#);
-
-    assert!(
-        actual
-            .err
-            .contains("column 'pretty_assertions' already exists")
-    );
+    "#;
+    let err = test()
+        .cwd("tests/fixtures/formats")
+        .run(code)
+        .expect_shell_error()?;
+    assert_matches!(err, ShellError::ColumnAlreadyExists { col_name, .. } if col_name == "pretty_assertions");
+    Ok(())
 }
 
 #[test]
-fn insert_into_list() {
-    let actual = nu!("[1, 2, 3] | insert 1 abc | to json -r");
-
-    assert_eq!(actual.out, r#"[1,"abc",2,3]"#);
+fn insert_into_list() -> Result {
+    test()
+        .run("[1, 2, 3] | insert 1 abc")
+        .expect_value_eq(test_value!([1, "abc", 2, 3]))
 }
 
 #[test]
-fn insert_at_start_of_list() {
-    let actual = nu!("[1, 2, 3] | insert 0 abc | to json -r");
-
-    assert_eq!(actual.out, r#"["abc",1,2,3]"#);
+fn insert_at_start_of_list() -> Result {
+    test()
+        .run("[1, 2, 3] | insert 0 abc")
+        .expect_value_eq(test_value!(["abc", 1, 2, 3]))
 }
 
 #[test]
-fn insert_at_end_of_list() {
-    let actual = nu!("[1, 2, 3] | insert 3 abc | to json -r");
-
-    assert_eq!(actual.out, r#"[1,2,3,"abc"]"#);
+fn insert_at_end_of_list() -> Result {
+    test()
+        .run("[1, 2, 3] | insert 3 abc")
+        .expect_value_eq(test_value!([1, 2, 3, "abc"]))
 }
 
 #[test]
-fn insert_past_end_of_list() {
-    let actual = nu!("[1, 2, 3] | insert 5 abc");
-
-    assert!(
-        actual
-            .err
-            .contains("can't insert at index (the next available index is 3)")
-    );
+fn insert_past_end_of_list() -> Result {
+    test()
+        .run("[1, 2, 3] | insert 5 abc")
+        .expect_error_code_eq("nu::shell::access_beyond_end")
 }
 
 #[test]
-fn insert_into_list_stream() {
-    let actual = nu!("[1, 2, 3] | every 1 | insert 1 abc | to json -r");
-
-    assert_eq!(actual.out, r#"[1,"abc",2,3]"#);
+fn insert_into_list_stream() -> Result {
+    test()
+        .run("[1, 2, 3] | every 1 | insert 1 abc")
+        .expect_value_eq(test_value!([1, "abc", 2, 3]))
 }
 
 #[test]
-fn insert_at_end_of_list_stream() {
-    let actual = nu!("[1, 2, 3] | every 1 | insert 3 abc | to json -r");
-
-    assert_eq!(actual.out, r#"[1,2,3,"abc"]"#);
+fn insert_at_end_of_list_stream() -> Result {
+    test()
+        .run("[1, 2, 3] | every 1 | insert 3 abc")
+        .expect_value_eq(test_value!([1, 2, 3, "abc"]))
 }
 
 #[test]
-fn insert_past_end_of_list_stream() {
-    let actual = nu!("[1, 2, 3] | every 1 | insert 5 abc");
-
-    assert!(
-        actual
-            .err
-            .contains("can't insert at index (the next available index is 3)")
-    );
+fn insert_past_end_of_list_stream() -> Result {
+    test()
+        .run("[1, 2, 3] | every 1 | insert 5 abc")
+        .expect_error_code_eq("nu::shell::access_beyond_end")
 }
 
 #[test]
-fn insert_uses_enumerate_index() {
-    let actual = nu!(
-        "[[a]; [7] [6]] | enumerate | insert b {|el| $el.index + 1 + $el.item.a } | flatten | to nuon"
-    );
-
-    assert_eq!(actual.out, "[[index, a, b]; [0, 7, 8], [1, 6, 8]]");
+fn insert_uses_enumerate_index() -> Result {
+    let code = "
+        [[a]; [7] [6]]
+        | enumerate
+        | insert b {|el| $el.index + 1 + $el.item.a }
+        | flatten
+    ";
+    test().run(code).expect_value_eq(test_table![
+        ["index", "a", "b"];
+        [0, 7, 8],
+        [1, 6, 8],
+    ])
 }
 
 #[test]
-fn deep_cell_path_creates_all_nested_records() {
-    let actual = nu!("{a: {}} | insert a.b.c 0 | get a.b.c");
-    assert_eq!(actual.out, "0");
+fn deep_cell_path_creates_all_nested_records() -> Result {
+    test()
+        .run("{a: {}} | insert a.b.c 0 | get a.b.c")
+        .expect_value_eq(0)
 }
 
 #[test]
-fn inserts_all_rows_in_table_in_record() {
-    let actual = nu!(
-        "{table: [[col]; [{a: 1}], [{a: 1}]]} | insert table.col.b 2 | get table.col.b | to nuon"
-    );
-    assert_eq!(actual.out, "[2, 2]");
+fn inserts_all_rows_in_table_in_record() -> Result {
+    test()
+        .run("{table: [[col]; [{a: 1}], [{a: 1}]]} | insert table.col.b 2 | get table.col.b")
+        .expect_value_eq(test_value!([2, 2]))
+}
+
+#[rstest]
+#[case("[1, 2] | insert 1 {|i| $i + 1 }", [1, 3, 2])]
+#[case("[1, 2] | insert 1 { $in + 1 }", [1, 3, 2])]
+#[case("[1, 2] | insert 2 {|i| if $i == null { 0 } else { $in + 1 } }", [1, 2, 0])]
+#[case("[1, 2] | insert 2 { if $in == null { 0 } else { $in + 1 } }", [1, 2, 0])]
+fn list_replacement_closure(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    test().run(code).expect_value_eq(expect)
+}
+
+#[rstest]
+#[case("{ a: text } | insert b {|r| $r.a | str upcase }", test_value!({a: "text", b: "TEXT"}))]
+#[case("{ a: text } | insert b { $in.a | str upcase }", test_value!({a: "text", b: "TEXT"}))]
+#[case("{ a: { b: 1 } } | insert a.c {|r| $r.a.b }", test_value!({a: {b: 1, c: 1}}))]
+#[case("{ a: { b: 1 } } | insert a.c { $in.a.b }", test_value!({a: {b: 1, c: 1}}))]
+fn record_replacement_closure(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    test().run(code).expect_value_eq(expect)
+}
+
+#[rstest]
+#[case("[[a]; [text]] | insert b {|r| $r.a | str upcase }", test_value!([{"a":"text","b":"TEXT"}]))]
+#[case("[[a]; [text]] | insert b { $in.a | str upcase }", test_value!([{"a":"text","b":"TEXT"}]))]
+#[case("[[b]; [1]] | wrap a | insert a.c {|r| $r.a.b }", test_value!([{"a":{"b":1,"c":1}}]))]
+#[case("[[b]; [1]] | wrap a | insert a.c { $in.a.b }", test_value!([{"a":{"b":1,"c":1}}]))]
+fn table_replacement_closure(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    test().run(code).expect_value_eq(expect)
+}
+
+#[rstest]
+#[case("[1, 2] | every 1 | insert 1 {|i| $i + 1 }", test_value!([1, 3, 2]))]
+#[case("[1, 2] | every 1 | insert 1 { $in + 1 }", test_value!([1, 3, 2]))]
+#[case("[1, 2] | every 1 | insert 2 {|i| if $i == null { 0 } else { $in + 1 } }", test_value!([1, 2, 0]))]
+#[case("[1, 2] | every 1 | insert 2 { if $in == null { 0 } else { $in + 1 } }", test_value!([1, 2, 0]))]
+#[case("[[a]; [text]] | every 1 | insert b {|r| $r.a | str upcase }", test_table![["a", "b"]; ["text", "TEXT"]])]
+#[case("[[a]; [text]] | every 1 | insert b { $in.a | str upcase }", test_table![["a", "b"]; ["text", "TEXT"]])]
+fn list_stream_replacement_closure(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    test().run(code).expect_value_eq(expect)
 }
 
 #[test]
-fn list_replacement_closure() {
-    let actual = nu!("[1, 2] | insert 1 {|i| $i + 1 } | to nuon");
-    assert_eq!(actual.out, "[1, 3, 2]");
-
-    let actual = nu!("[1, 2] | insert 1 { $in + 1 } | to nuon");
-    assert_eq!(actual.out, "[1, 3, 2]");
-
-    let actual = nu!("[1, 2] | insert 2 {|i| if $i == null { 0 } else { $in + 1 } } | to nuon");
-    assert_eq!(actual.out, "[1, 2, 0]");
-
-    let actual = nu!("[1, 2] | insert 2 { if $in == null { 0 } else { $in + 1 } } | to nuon");
-    assert_eq!(actual.out, "[1, 2, 0]");
-}
-
-#[test]
-fn record_replacement_closure() {
-    let actual = nu!("{ a: text } | insert b {|r| $r.a | str upcase } | to nuon");
-    assert_eq!(actual.out, "{a: text, b: TEXT}");
-
-    let actual = nu!("{ a: text } | insert b { $in.a | str upcase } | to nuon");
-    assert_eq!(actual.out, "{a: text, b: TEXT}");
-
-    let actual = nu!("{ a: { b: 1 } } | insert a.c {|r| $r.a.b } | to nuon");
-    assert_eq!(actual.out, "{a: {b: 1, c: 1}}");
-
-    let actual = nu!("{ a: { b: 1 } } | insert a.c { $in.a.b } | to nuon");
-    assert_eq!(actual.out, "{a: {b: 1, c: 1}}");
-}
-
-#[test]
-fn table_replacement_closure() {
-    let actual = nu!("[[a]; [text]] | insert b {|r| $r.a | str upcase } | to nuon");
-    assert_eq!(actual.out, "[[a, b]; [text, TEXT]]");
-
-    let actual = nu!("[[a]; [text]] | insert b { $in.a | str upcase } | to nuon");
-    assert_eq!(actual.out, "[[a, b]; [text, TEXT]]");
-
-    let actual = nu!("[[b]; [1]] | wrap a | insert a.c {|r| $r.a.b } | to nuon");
-    assert_eq!(actual.out, "[[a]; [{b: 1, c: 1}]]");
-
-    let actual = nu!("[[b]; [1]] | wrap a | insert a.c { $in.a.b } | to nuon");
-    assert_eq!(actual.out, "[[a]; [{b: 1, c: 1}]]");
-}
-
-#[test]
-fn list_stream_replacement_closure() {
-    let actual = nu!("[1, 2] | every 1 | insert 1 {|i| $i + 1 } | to nuon");
-    assert_eq!(actual.out, "[1, 3, 2]");
-
-    let actual = nu!("[1, 2] | every 1 | insert 1 { $in + 1 } | to nuon");
-    assert_eq!(actual.out, "[1, 3, 2]");
-
-    let actual =
-        nu!("[1, 2] | every 1 | insert 2 {|i| if $i == null { 0 } else { $in + 1 } } | to nuon");
-    assert_eq!(actual.out, "[1, 2, 0]");
-
-    let actual =
-        nu!("[1, 2] | every 1 | insert 2 { if $in == null { 0 } else { $in + 1 } } | to nuon");
-    assert_eq!(actual.out, "[1, 2, 0]");
-
-    let actual = nu!("[[a]; [text]] | every 1 | insert b {|r| $r.a | str upcase } | to nuon");
-    assert_eq!(actual.out, "[[a, b]; [text, TEXT]]");
-
-    let actual = nu!("[[a]; [text]] | every 1 | insert b { $in.a | str upcase } | to nuon");
-    assert_eq!(actual.out, "[[a, b]; [text, TEXT]]");
-}
-
-#[test]
-fn insert_new_to_table_cell_mixed_rows() {
-    let actual = nu!(experimental: vec!["reorder-cell-paths".to_string()], "
+#[exp(REORDER_CELL_PATHS)]
+fn insert_new_to_table_cell_mixed_rows() -> Result {
+    let code = "
         let table = [ [foo]; ['a'] ['b'] ];
         let t = ($table | insert bar.0 'z');
         $t.0.bar
-    ");
-
-    assert_eq!(actual.out, "z")
+    ";
+    test().run(code).expect_value_eq("z")
 }
 
 #[test]
-fn insert_nested_path_into_empty_list_errors_without_underflow() {
+fn insert_nested_path_into_empty_list_errors_without_underflow() -> Result {
     // Regression test for #18426: inserting into a nested path of an empty list
     // used to underflow `pre_elems.len() - 1` to usize::MAX and print a garbage
     // error containing 18446744073709551615.
-    let actual = nu!("[] | insert 0.0 1");
-
-    assert!(!actual.err.contains("18446744073709551615"));
-    assert!(actual.err.contains("empty content"));
+    let err = test().run("[] | insert 0.0 1").expect_shell_error()?;
+    assert_matches!(err, ShellError::AccessEmptyContent { .. });
+    Ok(())
 }

--- a/crates/nu-command/tests/commands/interleave.rs
+++ b/crates/nu-command/tests/commands/interleave.rs
@@ -9,12 +9,12 @@ fn interleave_external_commands() -> Result {
             {
                 nu -n -c 'print hello; print world'
                 | lines
-                | each { 'greeter: ' ++ $in }
+                | each { "greeter: " ++ $in }
             }
             {
                 nu -n -c 'print nushell; print rocks'
                 | lines
-                | each { 'evangelist: ' ++ $in }
+                | each { "evangelist: " ++ $in }
             }
         )
     "#;

--- a/crates/nu-command/tests/commands/interleave.rs
+++ b/crates/nu-command/tests/commands/interleave.rs
@@ -1,13 +1,30 @@
-use nu_test_support::nu;
+use nu_test_support::prelude::*;
 
 #[test]
-fn interleave_external_commands() {
-    let result = nu!("interleave \
-        { nu -n -c 'print hello; print world' | lines | each { 'greeter: ' ++ $in } } \
-        { nu -n -c 'print nushell; print rocks' | lines | each { 'evangelist: ' ++ $in } } | \
-        each { print }; null");
-    assert!(result.out.contains("greeter: hello"), "{}", result.out);
-    assert!(result.out.contains("greeter: world"), "{}", result.out);
-    assert!(result.out.contains("evangelist: nushell"), "{}", result.out);
-    assert!(result.out.contains("evangelist: rocks"), "{}", result.out);
+#[deps(NU)]
+fn interleave_external_commands() -> Result {
+    let code = r#"
+        (
+            interleave
+            {
+                nu -n -c 'print hello; print world'
+                | lines
+                | each { 'greeter: ' ++ $in }
+            }
+            {
+                nu -n -c 'print nushell; print rocks'
+                | lines
+                | each { 'evangelist: ' ++ $in }
+            }
+        )
+    "#;
+    let out: Vec<String> = test().run(code)?;
+    let out = out.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+    let out = &out;
+    assert_contains("greeter: hello", out);
+    assert_contains("greeter: world", out);
+    assert_contains("evangelist: nushell", out);
+    assert_contains("evangelist: rocks", out);
+
+    Ok(())
 }

--- a/crates/nu-command/tests/commands/length.rs
+++ b/crates/nu-command/tests/commands/length.rs
@@ -1,35 +1,35 @@
 use nu_test_support::fs::Stub::FileWithContent;
-use nu_test_support::nu;
 use nu_test_support::playground::Playground;
+use nu_test_support::prelude::*;
 
 #[test]
-fn length_columns_in_cal_table() {
-    let actual = nu!("cal --as-table | columns | length");
-
-    assert_eq!(actual.out, "7");
+fn length_columns_in_cal_table() -> Result {
+    test()
+        .run("cal --as-table | columns | length")
+        .expect_value_eq(7)
 }
 
 #[test]
-fn length_columns_no_rows() {
-    let actual = nu!("echo [] | length");
-
-    assert_eq!(actual.out, "0");
+fn length_columns_no_rows() -> Result {
+    test().run("echo [] | length").expect_value_eq(0)
 }
 
 #[test]
-fn length_fails_on_echo_record() {
-    let actual = nu!("echo {a:1 b:2} | length");
-
-    assert!(actual.err.contains("only_supports_this_input_type"));
+fn length_fails_on_echo_record() -> Result {
+    test()
+        .run("echo {a:1 b:2} | length")
+        .expect_error_code_eq("nu::shell::only_supports_this_input_type")
 }
 
 #[test]
-fn length_byte_stream() {
+fn length_byte_stream() -> Result {
     Playground::setup("length_bytes", |dirs, sandbox| {
         sandbox.mkdir("length_bytes");
         sandbox.with_files(&[FileWithContent("data.txt", "😀")]);
 
-        let actual = nu!(cwd: dirs.test(), "open data.txt | length");
-        assert_eq!(actual.out, "4");
-    });
+        test()
+            .cwd(dirs.test())
+            .run("open data.txt | length")
+            .expect_value_eq(4)
+    })
 }

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -1,6 +1,5 @@
 use nu_protocol::ParseError;
 use nu_test_support::fs::Stub::EmptyFile;
-use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 use nu_test_support::prelude::*;
 use pretty_assertions::assert_matches;
@@ -544,8 +543,8 @@ fn can_list_system_folder() -> Result {
     "#;
     let out: nu_protocol::Record = test().cwd("C:\\Windows\\System32").run(code)?;
 
-    assert_eq!(out["name"].into_string()?, "Configuration");
-    assert_eq!(out["type"].into_string()?, "dir");
+    assert_eq!(out["name"].as_str().unwrap(), "Configuration");
+    assert_eq!(out["type"].as_str().unwrap(), "dir");
 
     let _ = out["size"].as_filesize()?;
     let _ = out["modified"].as_date()?;

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -692,7 +692,10 @@ fn list_with_tilde() -> Result {
         test()
             .cwd(dirs.test())
             .run("(ls '~tilde').name")
-            .expect_value_eq(["~tilde/f1.txt", "~tilde/f2.txt"])?;
+            .expect_value_eq(cfg_select! {
+                unix => ["~tilde/f1.txt", "~tilde/f2.txt"],
+                windows => ["~tilde\\f1.txt", "~tilde\\f2.txt"],
+            })?;
 
         test()
             .cwd(dirs.test())
@@ -703,7 +706,10 @@ fn list_with_tilde() -> Result {
         test()
             .cwd(dirs.test())
             .run("let f = '~tilde'; (ls $f).name")
-            .expect_value_eq(["~tilde/f1.txt", "~tilde/f2.txt"])?;
+            .expect_value_eq(cfg_select! {
+                unix => ["~tilde/f1.txt", "~tilde/f2.txt"],
+                windows => ["~tilde\\f1.txt", "~tilde\\f2.txt"],
+            })?;
 
         Ok(())
     })

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -1,48 +1,47 @@
+use nu_protocol::ParseError;
 use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 use nu_test_support::prelude::*;
+use pretty_assertions::assert_matches;
 
 #[test]
-fn lists_regular_files() {
+fn lists_regular_files() -> Result {
     Playground::setup("ls_test_1", |dirs, sandbox| {
         sandbox.with_files(&[
-            EmptyFile("yehuda.txt"),
-            EmptyFile("jttxt"),
             EmptyFile("andres.txt"),
+            EmptyFile("jt.txt"),
+            EmptyFile("yehuda.txt"),
         ]);
 
-        let actual = nu!(cwd: dirs.test(), "
-            ls
-            | length
-        ");
-
-        assert_eq!(actual.out, "3");
+        test().cwd(dirs.test()).run("(ls).name").expect_value_eq([
+            "andres.txt",
+            "jt.txt",
+            "yehuda.txt",
+        ])
     })
 }
 
 #[test]
-fn lists_regular_files_using_asterisk_wildcard() {
+fn lists_regular_files_using_asterisk_wildcard() -> Result {
     Playground::setup("ls_test_2", |dirs, sandbox| {
         sandbox.with_files(&[
-            EmptyFile("los.txt"),
-            EmptyFile("tres.txt"),
             EmptyFile("amigos.txt"),
             EmptyFile("arepas.clu"),
+            EmptyFile("los.txt"),
+            EmptyFile("tres.txt"),
         ]);
 
-        let actual = nu!(cwd: dirs.test(), "
-            ls *.txt
-            | length
-        ");
-
-        assert_eq!(actual.out, "3");
+        test()
+            .cwd(dirs.test())
+            .run("(ls *.txt).name")
+            .expect_value_eq(["amigos.txt", "los.txt", "tres.txt"])
     })
 }
 
 #[cfg(not(target_os = "windows"))]
 #[test]
-fn lists_regular_files_in_special_folder() {
+fn lists_regular_files_in_special_folder() -> Result {
     Playground::setup("ls_test_3", |dirs, sandbox| {
         sandbox
             .mkdir("[abcd]")
@@ -51,42 +50,65 @@ fn lists_regular_files_in_special_folder() {
             .mkdir("abcd")
             .mkdir("abcd/*")
             .mkdir("abcd/?")
-            .with_files(&[EmptyFile("[abcd]/test.txt")])
-            .with_files(&[EmptyFile("abcd]/test.txt")])
-            .with_files(&[EmptyFile("abcd/*/test.txt")])
-            .with_files(&[EmptyFile("abcd/?/test.txt")])
-            .with_files(&[EmptyFile("abcd/?/test2.txt")]);
+            .with_files(&[
+                EmptyFile("[abcd]/test.txt"),
+                EmptyFile("abcd]/test.txt"),
+                EmptyFile("abcd/*/test.txt"),
+                EmptyFile("abcd/?/test.txt"),
+                EmptyFile("abcd/?/test2.txt"),
+            ]);
 
-        let actual = nu!(
-            cwd: dirs.test().join("abcd]"), format!("ls | length"));
-        assert_eq!(actual.out, "1");
-        let actual = nu!(
-            cwd: dirs.test(), format!("ls abcd] | length"));
-        assert_eq!(actual.out, "1");
-        let actual = nu!(
-            cwd: dirs.test().join("[abcd]"), format!("ls | length"));
-        assert_eq!(actual.out, "1");
-        let actual = nu!(
-            cwd: dirs.test().join("[bbcd]"), format!("ls | length"));
-        assert_eq!(actual.out, "0");
-        let actual = nu!(
-            cwd: dirs.test().join("abcd/*"), format!("ls | length"));
-        assert_eq!(actual.out, "1");
-        let actual = nu!(
-            cwd: dirs.test().join("abcd/?"), format!("ls | length"));
-        assert_eq!(actual.out, "2");
-        let actual = nu!(
-            cwd: dirs.test().join("abcd/*"), format!("ls -D ../* | length"));
-        assert_eq!(actual.out, "2");
-        let actual = nu!(
-            cwd: dirs.test().join("abcd/*"), format!("ls ../* | length"));
-        assert_eq!(actual.out, "2");
-        let actual = nu!(
-            cwd: dirs.test().join("abcd/?"), format!("ls -D ../* | length"));
-        assert_eq!(actual.out, "2");
-        let actual = nu!(
-            cwd: dirs.test().join("abcd/?"), format!("ls ../* | length"));
-        assert_eq!(actual.out, "2");
+        test()
+            .cwd(dirs.test().join("abcd]"))
+            .run("(ls).name")
+            .expect_value_eq(["test.txt"])?;
+
+        test()
+            .cwd(dirs.test())
+            .run("(ls abcd]).name")
+            .expect_value_eq(["abcd]/test.txt"])?;
+
+        test()
+            .cwd(dirs.test().join("[abcd]"))
+            .run("(ls).name")
+            .expect_value_eq(["test.txt"])?;
+
+        test()
+            .cwd(dirs.test().join("[bbcd]"))
+            .run("ls")
+            .expect_value_eq([(); 0])?;
+
+        test()
+            .cwd(dirs.test().join("abcd/*"))
+            .run("(ls).name")
+            .expect_value_eq(["test.txt"])?;
+
+        test()
+            .cwd(dirs.test().join("abcd/?"))
+            .run("(ls).name")
+            .expect_value_eq(["test.txt", "test2.txt"])?;
+
+        test()
+            .cwd(dirs.test().join("abcd/*"))
+            .run("ls -D ../* | length")
+            .expect_value_eq(2)?;
+
+        test()
+            .cwd(dirs.test().join("abcd/*"))
+            .run("ls ../* | length")
+            .expect_value_eq(2)?;
+
+        test()
+            .cwd(dirs.test().join("abcd/?"))
+            .run("ls -D ../* | length")
+            .expect_value_eq(2)?;
+
+        test()
+            .cwd(dirs.test().join("abcd/?"))
+            .run("ls ../* | length")
+            .expect_value_eq(2)?;
+
+        Ok(())
     })
 }
 
@@ -112,7 +134,7 @@ fn lists_regular_files_in_special_folder() {
 #[case("[[][abcd]bcd[]].txt", 2)]
 #[case("'[abcd].txt'", 1)]
 #[case("'[bbcd].txt'", 1)]
-fn lists_regular_files_using_question_mark(#[case] command: &str, #[case] expected: usize) {
+fn lists_regular_files_using_question_mark(#[case] ls_arg: &str, #[case] expected: i64) -> Result {
     Playground::setup("ls_test_3", |dirs, sandbox| {
         sandbox.mkdir("abcd").mkdir("bbcd").with_files(&[
             EmptyFile("abcd/xy.txt"),
@@ -127,14 +149,15 @@ fn lists_regular_files_using_question_mark(#[case] command: &str, #[case] expect
             EmptyFile("chicken_not_to_be_picked_up.100.txt"),
         ]);
 
-        let actual = nu!(
-            cwd: dirs.test(), format!("ls {command} | length"));
-        assert_eq!(actual.out, expected.to_string());
+        test()
+            .cwd(dirs.test())
+            .run(format!("ls {ls_arg} | length"))
+            .expect_value_eq(expected)
     })
 }
 
 #[test]
-fn lists_regular_files_using_question_mark_wildcard() {
+fn lists_regular_files_using_question_mark_wildcard() -> Result {
     Playground::setup("ls_test_3", |dirs, sandbox| {
         sandbox.with_files(&[
             EmptyFile("yehuda.10.txt"),
@@ -143,17 +166,15 @@ fn lists_regular_files_using_question_mark_wildcard() {
             EmptyFile("chicken_not_to_be_picked_up.100.txt"),
         ]);
 
-        let actual = nu!(cwd: dirs.test(), "
-            ls *.??.txt
-            | length
-        ");
-
-        assert_eq!(actual.out, "3");
+        test()
+            .cwd(dirs.test())
+            .run("ls *.??.txt | length")
+            .expect_value_eq(3)
     })
 }
 
 #[test]
-fn lists_all_files_in_directories_from_stream() {
+fn lists_all_files_in_directories_from_stream() -> Result {
     Playground::setup("ls_test_4", |dirs, sandbox| {
         sandbox
             .with_files(&[EmptyFile("root1.txt"), EmptyFile("root2.txt")])
@@ -165,46 +186,46 @@ fn lists_all_files_in_directories_from_stream() {
                 EmptyFile("chicken_not_to_be_picked_up.100.txt"),
             ]);
 
-        let actual = nu!(cwd: dirs.test(), "
+        let code = "
             echo dir_a dir_b
             | each { |it| ls $it }
-            | flatten | length
-        ");
-
-        assert_eq!(actual.out, "4");
+            | flatten
+            | length
+        ";
+        test().cwd(dirs.test()).run(code).expect_value_eq(4)
     })
 }
 
 #[test]
-fn does_not_fail_if_glob_matches_empty_directory() {
+fn does_not_fail_if_glob_matches_empty_directory() -> Result {
     Playground::setup("ls_test_5", |dirs, sandbox| {
         sandbox.within("dir_a");
 
-        let actual = nu!(cwd: dirs.test(), "
-            ls dir_a
-            | length
-        ");
-
-        assert_eq!(actual.out, "0");
+        test()
+            .cwd(dirs.test())
+            .run("ls dir_a | length")
+            .expect_value_eq(0)
     })
 }
 
 #[test]
-fn fails_when_glob_doesnt_match() {
+fn fails_when_glob_doesnt_match() -> Result {
     Playground::setup("ls_test_5", |dirs, sandbox| {
         sandbox.with_files(&[EmptyFile("root1.txt"), EmptyFile("root2.txt")]);
 
-        let actual = nu!(
-            cwd: dirs.test(),
-            "ls root3*"
-        );
+        let err = test()
+            .cwd(dirs.test())
+            .run("ls root3*")
+            .expect_shell_error()?;
+        let err_msg = err.generic_msg()?;
+        assert_contains("file or folder not found", err_msg);
 
-        assert!(actual.err.contains("no matches found"));
+        Ok(())
     })
 }
 
 #[test]
-fn list_files_from_two_parents_up_using_multiple_dots() {
+fn list_files_from_two_parents_up_using_multiple_dots() -> Result {
     Playground::setup("ls_test_6", |dirs, sandbox| {
         sandbox.with_files(&[
             EmptyFile("yahuda.yaml"),
@@ -215,47 +236,44 @@ fn list_files_from_two_parents_up_using_multiple_dots() {
 
         sandbox.within("foo").mkdir("bar");
 
-        let actual = nu!(
-            cwd: dirs.test().join("foo/bar"),
-            "
-                ls ... | length
-            "
-        );
+        test()
+            .cwd(dirs.test().join("foo/bar"))
+            .run("ls ... | length")
+            .expect_value_eq(5)?;
 
-        assert_eq!(actual.out, "5");
-
-        let actual = nu!(
-            cwd: dirs.test().join("foo/bar"),
-            r#"ls ... | sort-by name | get name.0 | str replace -a '\' '/'"#
-        );
-        assert_eq!(actual.out, "../../andres.xml");
+        test()
+            .cwd(dirs.test().join("foo/bar"))
+            .run(r#"ls ... | sort-by name | get name.0 | str replace -a '\' '/'"#)
+            .expect_value_eq("../../andres.xml")
     })
 }
 
 #[test]
-fn let_typed_glob_expands_in_ls() {
+fn let_typed_glob_expands_in_ls() -> Result {
     Playground::setup("ls_let_glob_expand", |dirs, sandbox| {
         sandbox.with_files(&[EmptyFile("a.toml"), EmptyFile("b.toml"), EmptyFile("c.txt")]);
 
-        let actual = nu!(cwd: dirs.test(), r#"let g: glob = "*.toml"; ls $g | length"#);
-
-        assert_eq!(actual.out, "2");
+        test()
+            .cwd(dirs.test())
+            .run(r#"let g: glob = "*.toml"; ls $g | length"#)
+            .expect_value_eq(2)
     })
 }
 
 #[test]
-fn let_into_glob_still_works_in_ls() {
+fn let_into_glob_still_works_in_ls() -> Result {
     Playground::setup("ls_into_glob_regression", |dirs, sandbox| {
         sandbox.with_files(&[EmptyFile("a.toml"), EmptyFile("b.toml"), EmptyFile("c.txt")]);
 
-        let actual = nu!(cwd: dirs.test(), r#"let g = "*.toml" | into glob; ls $g | length"#);
-
-        assert_eq!(actual.out, "2");
+        test()
+            .cwd(dirs.test())
+            .run(r#"let g = "*.toml" | into glob; ls $g | length"#)
+            .expect_value_eq(2)
     })
 }
 
 #[test]
-fn lists_hidden_file_when_explicitly_specified() {
+fn lists_hidden_file_when_explicitly_specified() -> Result {
     Playground::setup("ls_test_7", |dirs, sandbox| {
         sandbox.with_files(&[
             EmptyFile("los.txt"),
@@ -265,17 +283,15 @@ fn lists_hidden_file_when_explicitly_specified() {
             EmptyFile(".testdotfile"),
         ]);
 
-        let actual = nu!(cwd: dirs.test(), "
-            ls .testdotfile
-            | length
-        ");
-
-        assert_eq!(actual.out, "1");
+        test()
+            .cwd(dirs.test())
+            .run("ls .testdotfile | length")
+            .expect_value_eq(1)
     })
 }
 
 #[test]
-fn lists_all_hidden_files_when_glob_contains_dot() {
+fn lists_all_hidden_files_when_glob_contains_dot() -> Result {
     Playground::setup("ls_test_8", |dirs, sandbox| {
         sandbox
             .with_files(&[
@@ -296,12 +312,10 @@ fn lists_all_hidden_files_when_glob_contains_dot() {
                 EmptyFile(".dotfile3"),
             ]);
 
-        let actual = nu!(cwd: dirs.test(), "
-            ls **/.*
-            | length
-        ");
-
-        assert_eq!(actual.out, "3");
+        test()
+            .cwd(dirs.test())
+            .run("ls **/.* | length")
+            .expect_value_eq(3)
     })
 }
 
@@ -309,7 +323,7 @@ fn lists_all_hidden_files_when_glob_contains_dot() {
 // TODO Remove this cfg value when we have an OS-agnostic way
 // of creating hidden files using the playground.
 #[cfg(unix)]
-fn lists_all_hidden_files_when_glob_does_not_contain_dot() {
+fn lists_all_hidden_files_when_glob_does_not_contain_dot() -> Result {
     Playground::setup("ls_test_8", |dirs, sandbox| {
         sandbox
             .with_files(&[
@@ -330,12 +344,10 @@ fn lists_all_hidden_files_when_glob_does_not_contain_dot() {
                 EmptyFile(".dotfile3"),
             ]);
 
-        let actual = nu!(cwd: dirs.test(), "
-            ls **/*
-            | length
-        ");
-
-        assert_eq!(actual.out, "5");
+        test()
+            .cwd(dirs.test())
+            .run("ls **/* | length")
+            .expect_value_eq(5)
     })
 }
 
@@ -343,7 +355,7 @@ fn lists_all_hidden_files_when_glob_does_not_contain_dot() {
 // TODO Remove this cfg value when we have an OS-agnostic way
 // of creating hidden files using the playground.
 #[cfg(unix)]
-fn glob_with_hidden_directory() {
+fn glob_with_hidden_directory() -> Result {
     Playground::setup("ls_test_8", |dirs, sandbox| {
         sandbox.within(".dir_b").with_files(&[
             EmptyFile("andres.10.txt"),
@@ -351,21 +363,18 @@ fn glob_with_hidden_directory() {
             EmptyFile(".dotfile3"),
         ]);
 
-        let actual = nu!(cwd: dirs.test(), "
-            ls **/*
-            | length
-        ");
-
-        assert_eq!(actual.out, "");
-        assert!(actual.err.contains("No matches found"));
+        let err = test()
+            .cwd(dirs.test())
+            .run("ls **/* | length")
+            .expect_shell_error()?;
+        let err_msg = err.generic_msg()?;
+        assert_contains("file or folder not found", err_msg);
 
         // will list files if provide `-a` flag.
-        let actual = nu!(cwd: dirs.test(), "
-            ls -a **/*
-            | length
-        ");
-
-        assert_eq!(actual.out, "4");
+        test()
+            .cwd(dirs.test())
+            .run("ls -a **/* | length")
+            .expect_value_eq(4)
     })
 }
 
@@ -397,7 +406,7 @@ fn fails_with_permission_denied() {
 }
 
 #[test]
-fn lists_files_including_starting_with_dot() {
+fn lists_files_including_starting_with_dot() -> Result {
     Playground::setup("ls_test_9", |dirs, sandbox| {
         sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
@@ -407,17 +416,15 @@ fn lists_files_including_starting_with_dot() {
             EmptyFile(".hidden2.txt"),
         ]);
 
-        let actual = nu!(cwd: dirs.test(), "
-            ls -a
-            | length
-        ");
-
-        assert_eq!(actual.out, "5");
+        test()
+            .cwd(dirs.test())
+            .run("ls -a | length")
+            .expect_value_eq(5)
     })
 }
 
 #[test]
-fn list_all_columns() {
+fn list_all_columns() -> Result {
     Playground::setup("ls_test_all_columns", |dirs, sandbox| {
         sandbox.with_files(&[
             EmptyFile("Leonardo.yaml"),
@@ -425,21 +432,15 @@ fn list_all_columns() {
             EmptyFile("Donatello.xml"),
             EmptyFile("Michelangelo.txt"),
         ]);
+
         // Normal Operation
-        let actual = nu!(
-            cwd: dirs.test(),
-            "ls | columns | to md --list none"
-        );
-        let expected = ["name", "type", "size", "modified"].join("");
-        assert_eq!(actual.out, expected, "column names are incorrect for ls");
+        test()
+            .cwd(dirs.test())
+            .run("ls | columns")
+            .expect_value_eq(["name", "type", "size", "modified"])?;
         // Long
-        let actual = nu!(
-            cwd: dirs.test(),
-            "ls -l | columns | to md --list none"
-        );
-        let expected = {
-            #[cfg(unix)]
-            {
+        let expected = cfg_select! {
+            unix => {
                 [
                     "name",
                     "type",
@@ -455,81 +456,74 @@ fn list_all_columns() {
                     "accessed",
                     "modified",
                 ]
-                .join("")
             }
-
-            #[cfg(windows)]
-            {
+            windows => {
                 [
-                    "name", "type", "target", "readonly", "size", "created", "accessed", "modified",
+                    "name",
+                    "type",
+                    "target",
+                    "readonly",
+                    "size",
+                    "created",
+                    "accessed",
+                    "modified",
                 ]
-                .join("")
             }
         };
-        assert_eq!(
-            actual.out, expected,
-            "column names are incorrect for ls long"
-        );
-    });
+        test()
+            .cwd(dirs.test())
+            .run("ls -l | columns")
+            .expect_value_eq(expected)
+    })
 }
 
 #[test]
-fn lists_with_directory_flag() {
+fn lists_with_directory_flag() -> Result {
     Playground::setup("ls_test_flag_directory_1", |dirs, sandbox| {
         sandbox
             .within("dir_files")
             .with_files(&[EmptyFile("nushell.json")])
             .within("dir_empty");
-        let actual = nu!(cwd: dirs.test(), "
-            cd dir_empty;
+
+        let code = "
             ['.' '././.' '..' '../dir_files' '../dir_files/*']
             | each { |it| ls --directory ($it | into glob) }
             | flatten
             | get name
-            | to text
-        ");
-        let expected = [".", ".", "..", "../dir_files", "../dir_files/nushell.json"].join("");
+        ";
+        let expected = [".", ".", "..", "../dir_files", "../dir_files/nushell.json"];
         #[cfg(windows)]
-        let expected = expected.replace('/', "\\");
-        assert_eq!(
-            actual.out, expected,
-            "column names are incorrect for ls --directory (-D)"
-        );
-    });
+        let expected = expected.map(|e| e.replace('/', "\\"));
+
+        test()
+            .cwd(dirs.test().join("dir_empty"))
+            .run(code)
+            .expect_value_eq(expected)
+    })
 }
 
 #[test]
-fn lists_with_directory_flag_without_argument() {
+fn lists_with_directory_flag_without_argument() -> Result {
     Playground::setup("ls_test_flag_directory_2", |dirs, sandbox| {
         sandbox
             .within("dir_files")
             .with_files(&[EmptyFile("nushell.json")])
             .within("dir_empty");
+
         // Test if there are some files in the current directory
-        let actual = nu!(cwd: dirs.test(), "
-            cd dir_files;
-            ls --directory
-            | get name
-            | to text
-        ");
-        let expected = ".";
-        assert_eq!(
-            actual.out, expected,
-            "column names are incorrect for ls --directory (-D)"
-        );
+        test()
+            .cwd(dirs.test().join("dir_files"))
+            .run("ls --directory | get name")
+            .expect_value_eq(["."])?;
+
         // Test if there is no file in the current directory
-        let actual = nu!(cwd: dirs.test(), "
-            cd dir_empty;
-            ls -D
-            | get name
-            | to text
-        ");
-        let expected = ".";
-        assert_eq!(
-            actual.out, expected,
-            "column names are incorrect for ls --directory (-D)"
-        );
-    });
+        test()
+            .cwd(dirs.test().join("dir_empty"))
+            .run("ls -D | get name")
+            .expect_value_eq(["."])?;
+
+        Ok(())
+    })
 }
 
 /// Rust's fs::metadata function is unable to read info for certain system files on Windows,
@@ -537,40 +531,48 @@ fn lists_with_directory_flag_without_argument() {
 /// This test confirms that Nu can work around this successfully.
 #[test]
 #[cfg(windows)]
-fn can_list_system_folder() {
+fn can_list_system_folder() -> Result {
     // the awkward `ls Configuration* | where name == "Configuration"` thing is for speed;
     // listing the entire System32 folder is slow and `ls Configuration*` alone
     // might return more than 1 file someday
-    let file_type = nu!(cwd: "C:\\Windows\\System32", r#"ls Configuration* | where name == "Configuration" | get type.0"#);
-    assert_eq!(file_type.out, "dir");
 
-    let file_size = nu!(cwd: "C:\\Windows\\System32", r#"ls Configuration* | where name == "Configuration" | get size.0"#);
-    assert_ne!(file_size.out.trim(), "");
+    let code = r#"
+        ls -l Configuration*
+        | where name == "Configuration"
+        | first -s 
+        | select name type size modified accessed created
+    "#;
+    let out: nu_protocol::Record = test().cwd("C:\\Windows\\System32").run(code)?;
 
-    let file_modified = nu!(cwd: "C:\\Windows\\System32", r#"ls Configuration* | where name == "Configuration" | get modified.0"#);
-    assert_ne!(file_modified.out.trim(), "");
+    assert_eq!(out["name"].into_string()?, "Configuration");
+    assert_eq!(out["type"].into_string()?, "dir");
 
-    let file_accessed = nu!(cwd: "C:\\Windows\\System32", r#"ls -l Configuration* | where name == "Configuration" | get accessed.0"#);
-    assert_ne!(file_accessed.out.trim(), "");
+    let _ = out["size"].as_filesize()?;
+    let _ = out["modified"].as_date()?;
+    let _ = out["accessed"].as_date()?;
+    let _ = out["created"].as_date()?;
 
-    let file_created = nu!(cwd: "C:\\Windows\\System32", r#"ls -l Configuration* | where name == "Configuration" | get created.0"#);
-    assert_ne!(file_created.out.trim(), "");
+    let _: Value = test()
+        .cwd("C:\\Windows\\System32")
+        .run("ls | where size > 10mb")?;
 
-    let ls_with_filter = nu!(cwd: "C:\\Windows\\System32", "ls | where size > 10mb");
-    assert_eq!(ls_with_filter.err, "");
+    Ok(())
 }
 
 #[test]
-fn list_a_directory_not_exists() {
+fn list_a_directory_not_exists() -> Result {
     Playground::setup("ls_test_directory_not_exists", |dirs, _sandbox| {
-        let actual = nu!(cwd: dirs.test(), "ls a_directory_not_exists");
-        assert!(actual.err.contains("nu::shell::io::not_found"));
+        test()
+            .cwd(dirs.test())
+            .run("ls a_directory_not_exists")
+            .expect_error_code_eq("nu::shell::io::not_found")
     })
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 #[test]
-fn list_directory_contains_invalid_utf8() {
+#[deps(NU)]
+fn list_directory_contains_invalid_utf8() -> Result {
     use std::ffi::OsStr;
     use std::os::unix::ffi::OsStrExt;
 
@@ -585,16 +587,19 @@ fn list_directory_contains_invalid_utf8() {
 
             std::fs::create_dir_all(path).expect("failed to create directory");
 
-            let actual = nu!(cwd: cwd, "ls");
+            // unfortunately `ls` prints warning on stdout for this
+            let result: CompleteResult = test().cwd(cwd).run("nu -n -c 'ls' | complete")?;
 
-            assert!(actual.out.contains("warning: get non-utf8 filename"));
-            assert!(actual.err.contains("No matches found for"));
+            assert_contains("warning: get non-utf8 filename", result.stdout);
+            assert_contains("No matches found for", result.stderr);
+
+            Ok(())
         },
     )
 }
 
 #[test]
-fn list_ignores_ansi() {
+fn list_ignores_ansi() -> Result {
     Playground::setup("ls_test_ansi", |dirs, sandbox| {
         sandbox.with_files(&[
             EmptyFile("los.txt"),
@@ -603,30 +608,37 @@ fn list_ignores_ansi() {
             EmptyFile("arepas.clu"),
         ]);
 
-        let actual = nu!(cwd: dirs.test(), "
-            ls | find .txt | each {|| ls $in.name }
-        ");
+        // asserting no errors are raised
+        let _: Value = test()
+            .cwd(dirs.test())
+            .run("ls | find .txt | each {|| ls $in.name }")?;
 
-        assert!(actual.err.is_empty());
+        Ok(())
     })
 }
 
 #[test]
-fn list_unknown_long_flag() {
-    let actual = nu!("ls --full-path");
-
-    assert!(actual.err.contains("Did you mean: `--full-paths`?"));
+fn list_unknown_long_flag() -> Result {
+    let err = test().run("ls --full-path").expect_parse_error()?;
+    assert_matches!(
+        err,
+        ParseError::UnknownFlag(_, _, _, help) if help == "Did you mean: `--full-paths`?"
+    );
+    Ok(())
 }
 
 #[test]
-fn list_unknown_short_flag() {
-    let actual = nu!("ls -r");
-
-    assert!(actual.err.contains("Use `--help` to see available flags"));
+fn list_unknown_short_flag() -> Result {
+    let err = test().run("ls -r").expect_parse_error()?;
+    assert_matches!(
+        err,
+        ParseError::UnknownFlag(_, _, _, help) if help == "Use `--help` to see available flags"
+    );
+    Ok(())
 }
 
 #[test]
-fn list_flag_false() {
+fn list_flag_false() -> Result {
     // Check that ls flags respect explicit values
     Playground::setup("ls_test_false_flag", |dirs, sandbox| {
         sandbox.with_files(&[
@@ -639,61 +651,67 @@ fn list_flag_false() {
         // of creating hidden files using the playground.
         #[cfg(unix)]
         {
-            let actual = nu!(cwd: dirs.test(), "
-            ls --all=false | length
-                        ");
-
-            assert_eq!(actual.out, "2");
+            test()
+                .cwd(dirs.test())
+                .run("ls --all=false | length")
+                .expect_value_eq(2)?;
         }
 
-        let actual = nu!(cwd: dirs.test(), "
-            ls --long=false | columns | length
-        ");
+        test()
+            .cwd(dirs.test())
+            .run("ls --long=false | columns | length")
+            .expect_value_eq(4)?;
 
-        assert_eq!(actual.out, "4");
+        test()
+            .cwd(dirs.test())
+            .run("ls --full-paths=false | get name | any { $in =~ / }")
+            .expect_value_eq(false)?;
 
-        let actual = nu!(cwd: dirs.test(), "
-            ls --full-paths=false | get name | any { $in =~ / }
-        ");
-
-        assert_eq!(actual.out, "false");
+        Ok(())
     })
 }
 
 #[test]
-fn list_empty_string() {
+fn list_empty_string() -> Result {
     Playground::setup("ls_empty_string", |dirs, sandbox| {
         sandbox.with_files(&[EmptyFile("yehuda.txt")]);
 
-        let actual = nu!(cwd: dirs.test(), "ls ''");
-        assert!(actual.err.contains("does not exist"));
+        test()
+            .cwd(dirs.test())
+            .run("ls ''")
+            .expect_error_code_eq("nu::shell::io::not_found")
     })
 }
 
 #[test]
-fn list_with_tilde() {
+fn list_with_tilde() -> Result {
     Playground::setup("ls_tilde", |dirs, sandbox| {
         sandbox
             .within("~tilde")
             .with_files(&[EmptyFile("f1.txt"), EmptyFile("f2.txt")]);
 
-        let actual = nu!(cwd: dirs.test(), "ls '~tilde'");
-        assert!(actual.out.contains("f1.txt"));
-        assert!(actual.out.contains("f2.txt"));
-        assert!(actual.out.contains("~tilde"));
-        let actual = nu!(cwd: dirs.test(), "ls ~tilde");
-        assert!(actual.err.contains("nu::shell::io::not_found"));
+        test()
+            .cwd(dirs.test())
+            .run("(ls '~tilde').name")
+            .expect_value_eq(["~tilde/f1.txt", "~tilde/f2.txt"])?;
+
+        test()
+            .cwd(dirs.test())
+            .run("ls ~tilde")
+            .expect_error_code_eq("nu::shell::io::not_found")?;
 
         // pass variable
-        let actual = nu!(cwd: dirs.test(), "let f = '~tilde'; ls $f");
-        assert!(actual.out.contains("f1.txt"));
-        assert!(actual.out.contains("f2.txt"));
-        assert!(actual.out.contains("~tilde"));
+        test()
+            .cwd(dirs.test())
+            .run("let f = '~tilde'; (ls $f).name")
+            .expect_value_eq(["~tilde/f1.txt", "~tilde/f2.txt"])?;
+
+        Ok(())
     })
 }
 
 #[test]
-fn list_with_multiple_path() {
+fn list_with_multiple_path() -> Result {
     Playground::setup("ls_multiple_path", |dirs, sandbox| {
         sandbox.with_files(&[
             EmptyFile("f1.txt"),
@@ -701,41 +719,44 @@ fn list_with_multiple_path() {
             EmptyFile("f3.txt"),
         ]);
 
-        let actual = nu!(cwd: dirs.test(), "ls f1.txt f2.txt");
-        assert!(actual.out.contains("f1.txt"));
-        assert!(actual.out.contains("f2.txt"));
-        assert!(!actual.out.contains("f3.txt"));
-        assert!(actual.status.success());
+        test()
+            .cwd(dirs.test())
+            .run("(ls f1.txt f2.txt).name")
+            .expect_value_eq(["f1.txt", "f2.txt"])?;
 
         // report errors if one path not exists
-        let actual = nu!(cwd: dirs.test(), "ls asdf f1.txt");
-        assert!(actual.err.contains("nu::shell::io::not_found"));
-        assert!(!actual.status.success());
+        test()
+            .cwd(dirs.test())
+            .run("ls asdf f1.txt")
+            .expect_error_code_eq("nu::shell::io::not_found")?;
 
         // ls with spreading empty list should returns nothing.
-        let actual = nu!(cwd: dirs.test(), "ls ...[] | length");
-        assert_eq!(actual.out, "0");
+        test()
+            .cwd(dirs.test())
+            .run("ls ...[]")
+            .expect_value_eq([(); 0])?;
+
+        Ok(())
     })
 }
 
 #[test]
-fn list_inside_glob_metachars_dir() {
+fn list_inside_glob_metachars_dir() -> Result {
     Playground::setup("list_files_inside_glob_metachars_dir", |dirs, sandbox| {
         let sub_dir = "test[]";
         sandbox
             .within(sub_dir)
             .with_files(&[EmptyFile("test_file.txt")]);
 
-        let actual = nu!(
-            cwd: dirs.test().join(sub_dir),
-            "ls test_file.txt | get name.0 | path basename",
-        );
-        assert!(actual.out.contains("test_file.txt"));
-    });
+        test()
+            .cwd(dirs.test().join(sub_dir))
+            .run("(ls test_file.txt).name.0 | path basename")
+            .expect_value_eq("test_file.txt")
+    })
 }
 
 #[test]
-fn list_inside_tilde_glob_metachars_dir() {
+fn list_inside_tilde_glob_metachars_dir() -> Result {
     Playground::setup(
         "list_files_inside_tilde_glob_metachars_dir",
         |dirs, sandbox| {
@@ -744,25 +765,25 @@ fn list_inside_tilde_glob_metachars_dir() {
                 .within(sub_dir)
                 .with_files(&[EmptyFile("test_file.txt")]);
 
-            // need getname.0 | path basename because the output path
+            // need name.0 | path basename because the output path
             // might be too long to output as a single line.
-            let actual = nu!(
-                cwd: dirs.test().join(sub_dir),
-                "ls test_file.txt | get name.0 | path basename",
-            );
-            assert!(actual.out.contains("test_file.txt"));
+            test()
+                .cwd(dirs.test().join(sub_dir))
+                .run("(ls test_file.txt).name.0 | path basename")
+                .expect_value_eq("test_file.txt")?;
 
-            let actual = nu!(
-                cwd: dirs.test(),
-                "ls '~test[]' | get name.0 | path basename"
-            );
-            assert!(actual.out.contains("test_file.txt"));
+            test()
+                .cwd(dirs.test())
+                .run("(ls '~test[]').name.0 | path basename")
+                .expect_value_eq("test_file.txt")?;
+
+            Ok(())
         },
-    );
+    )
 }
 
 #[test]
-fn list_symlink_with_full_path() {
+fn list_symlink_with_full_path() -> Result {
     Playground::setup("list_symlink_with_full_path", |dirs, sandbox| {
         sandbox.with_files(&[EmptyFile("test_file.txt")]);
 
@@ -770,24 +791,23 @@ fn list_symlink_with_full_path() {
         let _ = std::os::unix::fs::symlink("test_file.txt", dirs.test().join("test_link1"));
         #[cfg(windows)]
         let _ = std::os::windows::fs::symlink_file("test_file.txt", dirs.test().join("test_link1"));
-        let actual = nu!(
-            cwd: dirs.test(),
-            "ls -l test_link1 | get target.0"
-        );
-        assert_eq!(actual.out, "test_file.txt");
-        let actual = nu!(
-            cwd: dirs.test(),
-            "ls -lf test_link1 | get target.0"
-        );
-        assert_eq!(
-            actual.out,
-            dirs.test().join("test_file.txt").to_string_lossy()
-        );
+
+        test()
+            .cwd(dirs.test())
+            .run("(ls -l test_link1).target.0")
+            .expect_value_eq("test_file.txt")?;
+
+        test()
+            .cwd(dirs.test())
+            .run("(ls -lf test_link1).target.0")
+            .expect_value_eq(dirs.test().join("test_file.txt").to_string_lossy())?;
+
+        Ok(())
     })
 }
 
 #[test]
-fn consistent_list_order() {
+fn consistent_list_order() -> Result {
     Playground::setup("ls_test_order", |dirs, sandbox| {
         sandbox.with_files(&[
             EmptyFile("los.txt"),
@@ -796,11 +816,12 @@ fn consistent_list_order() {
             EmptyFile("arepas.clu"),
         ]);
 
-        let no_arg = nu!(cwd: dirs.test(), "ls");
+        let no_arg: Value = test().cwd(dirs.test()).run("ls")?;
+        let with_arg: Value = test().cwd(dirs.test()).run("ls .")?;
 
-        let with_arg = nu!(cwd: dirs.test(), "ls .");
+        assert_eq!(no_arg, with_arg);
 
-        assert_eq!(no_arg.out, with_arg.out);
+        Ok(())
     })
 }
 

--- a/crates/nu-command/tests/commands/rotate.rs
+++ b/crates/nu-command/tests/commands/rotate.rs
@@ -1,83 +1,49 @@
-use nu_test_support::nu;
+use nu_protocol::test_table;
+use nu_test_support::prelude::*;
 
 #[test]
-fn counter_clockwise() {
-    let table = r#"[
-        [col1, col2, EXPECTED];
+fn counter_clockwise() -> Result {
+    let table = test_table![
+        ["col1", "col2", "EXPECTED"];
+        [ "---",  "|||",      "XX1"],
+        [ "---",  "|||",      "XX2"],
+        [ "---",  "|||",      "XX3"],
+    ];
+    let expected = test_table![
+        [  "column0", "column1", "column2", "column3"];
+        [ "EXPECTED",     "XX1",     "XX2",     "XX3"],
+        [     "col2",     "|||",     "|||",     "|||"],
+        [     "col1",     "---",     "---",     "---"],
+    ];
 
-        [---, "|||",      XX1]
-        [---, "|||",      XX2]
-        [---, "|||",      XX3]
-    ]"#;
-
-    let expected = nu!(r#"
-        [
-            [  column0, column1, column2, column3];
-        
-            [ EXPECTED,    XX1,      XX2,     XX3]
-            [     col2,  "|||",    "|||",   "|||"]
-            [     col1,    ---,      ---,     ---]
-        ]
-        | where column0 == EXPECTED
-        | get column1 column2 column3
-        | str join "-"
-    "#);
-
-    let actual = nu!(format!(
-        r#"
-            {table}
-            | rotate --ccw
-            | where column0 == EXPECTED
-            | get column1 column2 column3
-            | str join "-"
-        "#
-    ));
-
-    assert_eq!(actual.out, expected.out);
+    test()
+        .run_with_data("rotate --ccw", table)
+        .expect_value_eq(expected)
 }
 
 #[test]
-fn clockwise() {
-    let table = r#"[
-        [col1,  col2, EXPECTED];
+fn clockwise() -> Result {
+    let table = test_table![
+        ["col1", "col2", "EXPECTED"];
+        [ "---",  "|||",      "XX1"],
+        [ "---",  "|||",      "XX2"],
+        [ "---",  "|||",      "XX3"],
+    ];
+    let expected = test_table![
+        [ "column0", "column1", "column2",  "column3"];
+        [     "---",     "---",     "---",     "col1"],
+        [     "|||",     "|||",     "|||",     "col2"],
+        [     "XX3",     "XX2",     "XX1", "EXPECTED"],
+    ];
 
-        [ ---, "|||",      XX1]
-        [ ---, "|||",      XX2]
-        [ ---, "|||",      XX3]
-    ]"#;
-
-    let expected = nu!(r#"
-        [
-            [ column0, column1, column2,  column3];
-        
-            [     ---,     ---,     ---,     col1]
-            [   "|||",   "|||",   "|||",     col2]
-            [     XX3,     XX2,     XX1, EXPECTED]
-        ]
-        | where column3 == EXPECTED
-        | get column0 column1 column2
-        | str join "-"
-    "#);
-
-    let actual = nu!(format!(
-        r#"
-            {table}
-            | rotate
-            | where column3 == EXPECTED
-            | get column0 column1 column2
-            | str join "-"
-        "#,
-    ));
-
-    assert_eq!(actual.out, expected.out);
+    test()
+        .run_with_data("rotate", table)
+        .expect_value_eq(expected)
 }
 
 #[test]
-fn different_cols_vals_err() {
-    let actual = nu!("[[[one], [two, three]]] | first | rotate");
-    assert!(
-        actual
-            .err
-            .contains("Attempted to create a record from different number of columns and values")
-    )
+fn different_cols_vals_err() -> Result {
+    test()
+        .run("[[[one], [two, three]]] | first | rotate")
+        .expect_error_code_eq("nu::shell::record_cols_vals_mismatch")
 }

--- a/crates/nu-command/tests/commands/slice.rs
+++ b/crates/nu-command/tests/commands/slice.rs
@@ -1,73 +1,14 @@
-use nu_test_support::fs::Stub::EmptyFile;
-use nu_test_support::nu;
-use nu_test_support::playground::Playground;
+use nu_test_support::prelude::*;
+use rstest::rstest;
 
-#[test]
-fn selects_a_row() {
-    Playground::setup("slice_test_1", |dirs, sandbox| {
-        sandbox.with_files(&[EmptyFile("notes.txt"), EmptyFile("tests.txt")]);
-
-        let actual = nu!(cwd: dirs.test(), "
-            ls
-            | sort-by name
-            | slice 0..0
-            | get name.0
-        ");
-
-        assert_eq!(actual.out, "notes.txt");
-    });
-}
-
-#[test]
-fn selects_some_rows() {
-    Playground::setup("slice_test_2", |dirs, sandbox| {
-        sandbox.with_files(&[
-            EmptyFile("notes.txt"),
-            EmptyFile("tests.txt"),
-            EmptyFile("persons.txt"),
-        ]);
-
-        let actual = nu!(cwd: dirs.test(), "
-            ls
-            | get name
-            | slice 1..2
-            | length
-        ");
-
-        assert_eq!(actual.out, "2");
-    });
-}
-
-#[test]
-fn negative_indices() {
-    Playground::setup("slice_test_negative_indices", |dirs, sandbox| {
-        sandbox.with_files(&[
-            EmptyFile("notes.txt"),
-            EmptyFile("tests.txt"),
-            EmptyFile("persons.txt"),
-        ]);
-
-        let actual = nu!(cwd: dirs.test(), "
-            ls
-            | get name
-            | slice (-1..)
-            | length
-        ");
-
-        assert_eq!(actual.out, "1");
-    });
-}
-
-#[test]
-fn zero_to_zero_exclusive() {
-    let actual = nu!("[0 1 2 3] | slice 0..<0 | to nuon");
-
-    assert_eq!(actual.out, "[]");
-}
-
-#[test]
-fn to_negative_one_inclusive() {
-    let actual = nu!("[0 1 2 3] | slice 2..-1 | to nuon");
-
-    assert_eq!(actual.out, "[2, 3]");
+#[rstest]
+#[case::one_row("slice 0..0", [0])]
+#[case::some_rows("slice 1..2", [1, 2])]
+#[case::negative_indices("slice (-1..)", [3])]
+#[case::zero_to_zero_exclusive("slice 0..<0", [(); 0])]
+#[case::to_negative_one_inclusive("slice 2..-1", [2, 3])]
+fn test_slice(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    test()
+        .run_with_data(code, [0, 1, 2, 3])
+        .expect_value_eq(expect)
 }

--- a/crates/nu-command/tests/commands/tee.rs
+++ b/crates/nu-command/tests/commands/tee.rs
@@ -1,69 +1,95 @@
-use nu_test_support::{fs::file_contents, nu, playground::Playground};
+use nu_test_support::{fs::file_contents, playground::Playground, prelude::*};
 
 #[test]
-fn tee_save_values_to_file() {
+fn tee_save_values_to_file() -> Result {
     Playground::setup("tee_save_values_to_file_test", |dirs, _sandbox| {
-        let output = nu!(
-            cwd: dirs.test(),
-            "1..5 | tee { save copy.txt } | to text"
-        );
-        assert_eq!("12345", output.out);
+        test()
+            .cwd(dirs.test())
+            .run("1..5 | tee { save copy.txt }")
+            .expect_value_eq([1, 2, 3, 4, 5])?;
         assert_eq!(
             "1\n2\n3\n4\n5\n",
             file_contents(dirs.test().join("copy.txt"))
         );
+
+        Ok(())
     })
 }
 
 #[test]
-fn tee_save_stdout_to_file() {
+#[deps(NU)]
+fn tee_save_stdout_to_file() -> Result {
     Playground::setup("tee_save_stdout_to_file_test", |dirs, _sandbox| {
-        let output = nu!(
-            cwd: dirs.test(),
-            r#"
-                $env.FOO = "teststring"
-                nu --testbin echo_env FOO | tee { save copy.txt }
-            "#
-        );
-        assert_eq!("teststring", output.out);
+        let code = r#"
+            $env.FOO = "teststring"
+            nu --testbin echo_env FOO | tee { save copy.txt }
+        "#;
+
+        test()
+            .cwd(dirs.test())
+            .run(code)
+            .expect_value_eq("teststring")?;
+
         assert_eq!("teststring\n", file_contents(dirs.test().join("copy.txt")));
+
+        Ok(())
     })
 }
 
 #[test]
-fn tee_save_stderr_to_file() {
+#[deps(NU)]
+fn tee_save_stderr_to_file() -> Result {
     Playground::setup("tee_save_stderr_to_file_test", |dirs, _sandbox| {
-        let output = nu!(
-            cwd: dirs.test(),
-            "\
-                $env.FOO = \"teststring\"; \
-                do { nu --testbin echo_env_stderr FOO } | \
-                    tee --stderr { save copy.txt } | \
-                    complete | \
-                    get stderr
-            "
-        );
-        assert_eq!("teststring", output.out);
+        let code = r#"
+            $env.FOO = "teststring"
+            do { nu --testbin echo_env_stderr FOO }
+            | tee --stderr { save copy.txt }
+            | complete
+            | get stderr
+        "#;
+
+        test()
+            .cwd(dirs.test())
+            .run(code)
+            .expect_value_eq("teststring\n")?;
+
         assert_eq!("teststring\n", file_contents(dirs.test().join("copy.txt")));
+
+        Ok(())
     })
 }
 
 #[test]
-fn tee_single_value_streamable() {
-    let actual = nu!("'Hello, world!' | tee { print -e } | print");
-    assert!(actual.status.success());
-    assert_eq!("Hello, world!", actual.out);
+#[deps(NU)]
+fn tee_single_value_streamable() -> Result {
+    let code = "'Hello, world!' | tee { print -e } | print";
+    let result: CompleteResult =
+        test().run_with_data("let code; nu -n -c $code | complete", code)?;
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!("Hello, world!", result.stdout);
     // FIXME: note the lack of newline: this is a consequence of converting the string to a stream
     // for now, but most likely the printer should be checking whether a string stream ends with a
     // newline and adding it unless no_newline is true
-    assert_eq!("Hello, world!", actual.err);
+    assert_eq!("Hello, world!", result.stderr);
+
+    Ok(())
 }
 
 #[test]
-fn tee_single_value_non_streamable() {
+#[deps(NU)]
+fn tee_single_value_non_streamable() -> Result {
     // Non-streamable values don't have any synchronization point, so we have to wait.
-    let actual = nu!("500 | tee { print -e } | print; sleep 1sec");
-    assert!(actual.status.success());
-    assert_eq!("500", actual.out);
-    assert_eq!("500\n", actual.err);
+    let code = "
+        500 | tee { print -e } | print
+        sleep 0.1sec
+    ";
+    let result: CompleteResult =
+        test().run_with_data("let code; nu -n -c $code | complete", code)?;
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!("500\n", result.stdout);
+    assert_eq!("500\n", result.stderr);
+
+    Ok(())
 }

--- a/crates/nu-command/tests/commands/to_text.rs
+++ b/crates/nu-command/tests/commands/to_text.rs
@@ -1,54 +1,52 @@
-use nu_test_support::nu;
+use rstest::rstest;
+use rstest_reuse::{apply, template};
 
-const LINE_LEN: usize = if cfg!(target_os = "windows") { 2 } else { 1 };
+use nu_test_support::prelude::*;
+use nu_utils::consts::LINE_SEPARATOR_STR;
 
-#[test]
-fn list() {
-    // Using `str length` since nu! strips newlines, grr
-    let actual = nu!("[] | to text | str length");
-    assert_eq!(actual.out, "0");
+#[template]
+#[rstest]
+#[case(&[])]
+#[case(&["a"])]
+#[case(&["a", "b"])]
+fn input_template(#[case] input: &[&str]) -> Result {}
 
-    let actual = nu!("[a] | to text | str length");
-    assert_eq!(actual.out, (1 + LINE_LEN).to_string());
-
-    let actual = nu!("[a b] | to text | str length");
-    assert_eq!(actual.out, (2 * (1 + LINE_LEN)).to_string());
+#[apply(input_template)]
+fn list(#[case] input: &[&str]) -> Result {
+    let mut expect = input.join(LINE_SEPARATOR_STR);
+    if !expect.is_empty() {
+        expect += LINE_SEPARATOR_STR;
+    }
+    test()
+        .run_with_data("to text", input.to_vec())
+        .expect_value_eq(expect)
 }
 
 // The output should be the same when `to text` gets a ListStream instead of a Value::List.
-#[test]
-fn list_stream() {
-    let actual = nu!("[] | each {} | to text | str length");
-    assert_eq!(actual.out, "0");
-
-    let actual = nu!("[a] | each {} | to text | str length");
-    assert_eq!(actual.out, (1 + LINE_LEN).to_string());
-
-    let actual = nu!("[a b] | each {} | to text | str length");
-    assert_eq!(actual.out, (2 * (1 + LINE_LEN)).to_string());
+#[apply(input_template)]
+fn list_stream(#[case] input: &[&str]) -> Result {
+    let mut expect = input.join(LINE_SEPARATOR_STR);
+    if !expect.is_empty() {
+        expect += LINE_SEPARATOR_STR;
+    }
+    test()
+        .run_with_data("each {} | to text", input.to_vec())
+        .expect_value_eq(expect)
 }
 
-#[test]
-fn list_no_newline() {
-    let actual = nu!("[] | to text -n | str length");
-    assert_eq!(actual.out, "0");
-
-    let actual = nu!("[a] | to text -n | str length");
-    assert_eq!(actual.out, "1");
-
-    let actual = nu!("[a b] | to text -n | str length");
-    assert_eq!(actual.out, (2 + LINE_LEN).to_string());
+#[apply(input_template)]
+fn list_no_newline(#[case] input: &[&str]) -> Result {
+    let expect = input.join(LINE_SEPARATOR_STR);
+    test()
+        .run_with_data("to text --no-newline", input.to_vec())
+        .expect_value_eq(expect)
 }
 
 // The output should be the same when `to text` gets a ListStream instead of a Value::List.
-#[test]
-fn list_stream_no_newline() {
-    let actual = nu!("[] | each {} | to text -n | str length");
-    assert_eq!(actual.out, "0");
-
-    let actual = nu!("[a] | each {} | to text -n | str length");
-    assert_eq!(actual.out, "1");
-
-    let actual = nu!("[a b] | each {} | to text -n | str length");
-    assert_eq!(actual.out, (2 + LINE_LEN).to_string());
+#[apply(input_template)]
+fn list_stream_no_newline(#[case] input: &[&str]) -> Result {
+    let expect = input.join(LINE_SEPARATOR_STR);
+    test()
+        .run_with_data("each {} | to text --no-newline", input.to_vec())
+        .expect_value_eq(expect)
 }

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -323,12 +323,15 @@ fn list_stream_replacement_closure() -> Result {
 }
 
 #[test]
-fn upsert_nested_path_into_empty_list_errors_without_underflow() {
+fn upsert_nested_path_into_empty_list_errors_without_underflow() -> Result {
     // Regression test for #18426: upserting into a nested path of an empty list
     // used to underflow `pre_elems.len() - 1` to usize::MAX and print a garbage
     // error containing 18446744073709551615.
-    let actual = nu!("[] | upsert 0.0 1");
+    let err = test().run("[] | upsert 0.0 1").expect_shell_error()?;
+    let err_str = err.to_string();
 
-    assert!(!actual.err.contains("18446744073709551615"));
-    assert!(actual.err.contains("empty content"));
+    assert!(!err_str.contains("18446744073709551615"));
+    assert!(err_str.contains("empty content"));
+
+    Ok(())
 }

--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -59,6 +59,12 @@ static INITIAL_ENGINE_STATES: KeyedLazyLock<GroupKey, EngineState> = KeyedLazyLo
     .into_iter()
     .for_each(|(key, val)| engine_state.add_env_var(key.into(), val));
 
+    // Should this be inherited or do we want tighter testing?
+    #[cfg(windows)]
+    if let Ok(path_ext) = env::var("PATHEXT") {
+        engine_state.add_env_var("PATHEXT".into(), Value::test_string(path_ext));
+    }
+
     nu_std::load_standard_library(&mut engine_state).expect("could not load standard library");
 
     engine_state

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -384,12 +384,24 @@ fn complex_const_overlay_use(#[case] code: &str, #[case] expect: impl IntoValue)
     tester.run(code).expect_value_eq(expect)
 }
 
-#[ignore = "TODO: `overlay hide` should be possible to use after `overlay use` in the same source unit."]
 #[test]
+#[should_panic(expected = "Expected \"Variable not found.\", got \"Cannot hide default overlay.\"")]
+// #[ignore = "TODO: `overlay hide` should be possible to use after `overlay use` in the same source unit."]
 fn overlay_use_hide_in_single_source_unit() -> Result {
-    let inp = &[MODULE_SETUP, "overlay use spam", "overlay hide", "$eggs"];
-    let actual = nu!(&inp.join("; "));
-    assert!(actual.err.contains("nu::parser::variable_not_found"));
+    let mut tester = test();
+
+    let () = tester.run(MODULE_SETUP)?;
+    let code = "
+        overlay use spam
+        overlay hide
+        $eggs
+    ";
+    let err = tester.run(code).expect_parse_error()?;
+    assert!(
+        matches!(err, ParseError::VariableNotFound(..)),
+        "Expected \"Variable not found.\", got \"{err}\""
+    );
+
     Ok(())
 }
 

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,13 +1,12 @@
-use nu_test_support::nu;
-use pretty_assertions::assert_str_eq;
+use nu_test_support::prelude::*;
 
 mod cli;
 mod posix_end_of_options;
 mod shell_integration;
 
 #[test]
-fn multiword_commands_have_their_parent_commands() {
-    let out = nu!("
+fn multiword_commands_have_their_parent_commands() -> Result {
+    let code = "
         scope commands
         | where type == built-in and name like ' '
         | where ($it.name | split row ' ' | first) not-in (
@@ -16,13 +15,13 @@ fn multiword_commands_have_their_parent_commands() {
             | get name
         )
         | get name
-        | to json --raw
-    ");
+    ";
+    let out: Vec<String> = test().run(code)?;
 
-    assert_str_eq!(
-        "[]",
-        out.out,
-        "These multiword commands are missing their dummy parent commands: {}",
-        out.out
-    );
+    match out.as_slice() {
+        [] => Ok(()),
+        cmds => {
+            panic!("These multiword commands are missing their dummy parent commands: {cmds:?}")
+        }
+    }
 }

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -1,452 +1,370 @@
 mod escaping;
 
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::nu;
-use nu_test_support::playground::Playground;
-use pretty_assertions::assert_eq;
+use std::time::Duration;
+
+use pretty_assertions::{assert_eq, assert_matches};
 use rstest::rstest;
 
-#[test]
-fn source_file_relative_to_file() {
-    let actual = nu!(cwd: "tests/parsing/samples", "
-        nu source_file_relative.nu
-        ");
+use nu_protocol::Type;
+use nu_test_support::fs::Stub;
+use nu_test_support::playground::Playground;
+use nu_test_support::prelude::*;
 
-    assert_eq!(actual.out, "5");
+#[test]
+#[deps(NU)]
+fn source_file_relative_to_file() -> Result {
+    let result: CompleteResult = test()
+        .cwd("tests/parsing/samples")
+        .run("nu source_file_relative.nu | complete")?;
+
+    assert_eq!(result.stdout.trim(), "5");
+    Ok(())
 }
 
 #[test]
-fn source_file_relative_to_config() {
-    let actual = nu!("
-        nu --config tests/parsing/samples/source_file_relative.nu --commands ''
-        ");
+#[deps(NU)]
+fn source_file_relative_to_config() -> Result {
+    let code = "
+        (
+            nu
+            --config tests/parsing/samples/source_file_relative.nu
+            --commands ''
+        )
+        | complete
+    ";
+    let result: CompleteResult = test().run(code)?;
 
-    assert_eq!(actual.out, "5");
+    assert_eq!(result.stdout.trim(), "5");
+    Ok(())
 }
 
 #[test]
-fn source_const_file() {
-    let actual = nu!(cwd: "tests/parsing/samples",
-    "
-        const file = 'single_line.nu'
-        source $file
-    ");
-
-    assert_eq!(actual.out, "5");
+fn source_const_file() -> Result {
+    test()
+        .cwd("tests/parsing/samples")
+        .run("const file = 'single_line.nu'; source $file")
+        .expect_value_eq(5)
 }
 
 // Regression test for https://github.com/nushell/nushell/issues/17091
 // Bare-word string interpolation with constants should work in `source`
 #[test]
-fn source_const_in_bareword_interpolation() {
+fn source_const_in_bareword_interpolation() -> Result {
     Playground::setup("source_const_in_bareword_test", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "test_macos.nu",
-            "
-                print 'macos'
-            ",
-        )]);
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "test_linux.nu",
-            "
-                print 'linux'
-            ",
-        )]);
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "test_windows.nu",
-            "
-                print 'windows'
-            ",
-        )]);
+        sandbox.with_files(&[
+            Stub::FileWithContent("test_macos.nu", "'macos'"),
+            Stub::FileWithContent("test_linux.nu", "'linux'"),
+            Stub::FileWithContent("test_windows.nu", "'windows'"),
+        ]);
 
-        let actual = nu!(
-            cwd: dirs.test(),
-            "source test_($nu.os-info.name).nu"
-        );
-
-        let os_name = std::env::consts::OS;
-        assert_eq!(actual.out, os_name);
-    });
+        test()
+            .cwd(dirs.test())
+            .run("source test_($nu.os-info.name).nu")
+            .expect_value_eq(std::env::consts::OS)
+    })
 }
 
 // Test edge cases for paths with parentheses
 #[test]
-fn source_path_with_literal_parens() {
+fn source_path_with_literal_parens() -> Result {
     Playground::setup("source_literal_parens_test", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
+        sandbox.with_files(&[Stub::FileWithContent(
             "file(with)parens.nu",
-            "
-                print 'literal parens'
-            ",
+            "'literal parens'",
         )]);
 
         // Quoted path with literal parentheses should work
-        let actual = nu!(
-            cwd: dirs.test(),
-            r#"source "file(with)parens.nu""#
-        );
-
-        assert_eq!(actual.out, "literal parens");
-    });
-}
-
-#[test]
-fn source_path_interpolation_vs_literal() {
-    Playground::setup("source_interp_vs_literal_test", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "file(name).nu",
-            "
-                print 'literal file'
-            ",
-        )]);
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "file_macos.nu",
-            "
-                print 'interpolated file'
-            ",
-        )]);
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "file_linux.nu",
-            "
-                print 'interpolated file'
-            ",
-        )]);
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "file_windows.nu",
-            "
-                print 'interpolated file'
-            ",
-        )]);
-
-        // Quoted path should treat parens as literal
-        let actual_quoted = nu!(
-            cwd: dirs.test(),
-            r#"source "file(name).nu""#
-        );
-        assert_eq!(actual_quoted.out, "literal file");
-
-        // Bare word with parens containing variable should interpolate
-        let actual_interp = nu!(
-            cwd: dirs.test(),
-            "source file_($nu.os-info.name).nu"
-        );
-        assert_eq!(actual_interp.out, "interpolated file");
-    });
-}
-
-#[test]
-fn source_path_with_nested_parens() {
-    Playground::setup("source_nested_parens_test", |dirs, sandbox| {
-        let os_name = std::env::consts::OS;
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            &format!("test_{}_nested.nu", os_name),
-            "
-                print 'nested parens'
-            ",
-        )]);
-
-        // Nested parentheses in interpolation
-        let actual = nu!(
-            cwd: dirs.test(),
-            "source test_($nu.os-info | get name)_nested.nu"
-        );
-
-        assert_eq!(actual.out, "nested parens");
-    });
-}
-
-#[test]
-fn source_path_single_quote_no_interpolation() {
-    Playground::setup("source_single_quote_test", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "file($nu.os-info.name).nu",
-            "
-                print 'no interpolation'
-            ",
-        )]);
-
-        // Single quotes should prevent interpolation
-        let actual = nu!(
-            cwd: dirs.test(),
-            "source 'file($nu.os-info.name).nu'"
-        );
-
-        assert_eq!(actual.out, "no interpolation");
-    });
-}
-
-#[test]
-fn source_path_backtick_no_interpolation() {
-    Playground::setup("source_backtick_test", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "file($nu.os-info.name).nu",
-            "
-                print 'backtick no interp'
-            ",
-        )]);
-
-        // Backticks should also prevent interpolation
-        let actual = nu!(
-            cwd: dirs.test(),
-            "source `file($nu.os-info.name).nu`"
-        );
-
-        assert_eq!(actual.out, "backtick no interp");
-    });
-}
-
-#[test]
-fn source_path_dollar_interpolation() {
-    Playground::setup("source_dollar_interp_test", |dirs, sandbox| {
-        let os_name = std::env::consts::OS;
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            &format!("test_{}.nu", os_name),
-            "
-                print 'dollar interpolation'
-            ",
-        )]);
-
-        // Dollar prefix should enable interpolation in quotes
-        let actual = nu!(
-            cwd: dirs.test(),
-            r#"source $"test_($nu.os-info.name).nu""#
-        );
-
-        assert_eq!(actual.out, "dollar interpolation");
-    });
-}
-
-#[test]
-fn source_path_mixed_parens_and_quotes() {
-    Playground::setup("source_mixed_parens_test", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "test(1).nu",
-            "
-                print 'test 1'
-            ",
-        )]);
-        let os_name = std::env::consts::OS;
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            &format!("test_{}.nu", os_name),
-            "
-                print 'test interpolated'
-            ",
-        )]);
-
-        // Literal parentheses in quoted string
-        let actual1 = nu!(
-            cwd: dirs.test(),
-            r#"source "test(1).nu""#
-        );
-        assert_eq!(actual1.out, "test 1");
-
-        // Interpolation in bare word with constant
-        let actual2 = nu!(
-            cwd: dirs.test(),
-            "source test_($nu.os-info.name).nu"
-        );
-        assert_eq!(actual2.out, "test interpolated");
-    });
-}
-
-#[test]
-fn source_path_empty_parens() {
-    Playground::setup("source_empty_parens_test", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "file().nu",
-            "
-                print 'empty parens'
-            ",
-        )]);
-
-        // Empty parentheses should be treated as literal when quoted
-        let actual = nu!(
-            cwd: dirs.test(),
-            r#"source "file().nu""#
-        );
-        assert_eq!(actual.out, "empty parens");
-    });
-}
-
-#[test]
-fn source_path_unbalanced_parens_quoted() {
-    Playground::setup("source_unbalanced_parens_test", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "file(.nu",
-            "
-                print 'unbalanced open'
-            ",
-        )]);
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "file).nu",
-            "
-                print 'unbalanced close'
-            ",
-        )]);
-
-        // Unbalanced parentheses should work when quoted
-        let actual1 = nu!(
-            cwd: dirs.test(),
-            r#"source "file(.nu""#
-        );
-        assert_eq!(actual1.out, "unbalanced open");
-
-        let actual2 = nu!(
-            cwd: dirs.test(),
-            r#"source "file).nu""#
-        );
-        assert_eq!(actual2.out, "unbalanced close");
-    });
-}
-
-#[test]
-fn source_path_multiple_interpolations() {
-    Playground::setup("source_multiple_interp_test", |dirs, sandbox| {
-        let os_name = std::env::consts::OS;
-        let arch = std::env::consts::ARCH;
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            &format!("{}_{}.nu", os_name, arch),
-            "
-                print 'multiple interpolations'
-            ",
-        )]);
-
-        // Multiple interpolations in one path using constants
-        let actual = nu!(
-            cwd: dirs.test(),
-            "source ($nu.os-info.name)_($nu.os-info.arch).nu"
-        );
-        assert_eq!(actual.out, "multiple interpolations");
-    });
-}
-
-#[test]
-fn source_path_interpolation_with_spaces() {
-    Playground::setup("source_interp_spaces_test", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "file with spaces.nu",
-            "
-                print 'spaces in name'
-            ",
-        )]);
-
-        // Spaces in filename require quotes
-        let actual = nu!(
-            cwd: dirs.test(),
-            r#"const name = "file with spaces"; source $"($name).nu""#
-        );
-        assert_eq!(actual.out, "spaces in name");
-    });
-}
-
-#[test]
-fn source_path_raw_string_no_interpolation() {
-    Playground::setup("source_raw_string_test", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
-            "file($nu.os-info.name).nu",
-            "
-                print 'raw string'
-            ",
-        )]);
-
-        // Raw strings should not interpolate
-        let actual = nu!(
-            cwd: dirs.test(),
-            "source r#'file($nu.os-info.name).nu'#"
-        );
-
-        assert_eq!(actual.out, "raw string");
-    });
-}
-
-#[test]
-fn source_circular() {
-    let actual = nu!(cwd: "tests/parsing/samples", "
-        nu source_circular_1.nu
-        ");
-
-    assert!(actual.err.contains("nu::parser::circular_import"));
-}
-
-#[test]
-fn run_nu_script_single_line() {
-    let actual = nu!(cwd: "tests/parsing/samples", "
-        nu single_line.nu
-        ");
-
-    assert_eq!(actual.out, "5");
-}
-
-#[test]
-fn run_nu_script_multiline_start_pipe() {
-    let actual = nu!(cwd: "tests/parsing/samples", "
-        nu multiline_start_pipe.nu
-        ");
-
-    assert_eq!(actual.out, "4");
-}
-
-#[test]
-fn run_nu_script_multiline_start_pipe_win() {
-    let actual = nu!(cwd: "tests/parsing/samples", "
-        nu multiline_start_pipe_win.nu
-        ");
-
-    assert_eq!(actual.out, "3");
-}
-
-#[test]
-fn run_nu_script_multiline_end_pipe() {
-    let actual = nu!(cwd: "tests/parsing/samples", "
-        nu multiline_end_pipe.nu
-        ");
-
-    assert_eq!(actual.out, "2");
-}
-
-#[test]
-fn run_nu_script_multiline_end_pipe_win() {
-    let actual = nu!(cwd: "tests/parsing/samples", "
-        nu multiline_end_pipe_win.nu
-        ");
-
-    assert_eq!(actual.out, "3");
-}
-
-#[test]
-fn parse_file_relative_to_parsed_file_simple() {
-    Playground::setup("relative_files_simple", |dirs, sandbox| {
-        sandbox
-            .mkdir("lol")
-            .mkdir("lol/lol")
-            .with_files(&[FileWithContentToBeTrimmed(
-                "lol/lol/lol.nu",
-                "
-                    use ../lol_shell.nu
-
-                    $env.LOL = (lol_shell ls)
-                ",
-            )])
-            .with_files(&[FileWithContentToBeTrimmed(
-                "lol/lol_shell.nu",
-                r#"
-                    export def ls [] { "lol" }
-                "#,
-            )]);
-
-        let actual = nu!(cwd: dirs.test(), "
-            source-env lol/lol/lol.nu;
-            $env.LOL
-        ");
-
-        assert_eq!(actual.out, "lol");
+        test()
+            .cwd(dirs.test())
+            .run(r#"source "file(with)parens.nu""#)
+            .expect_value_eq("literal parens")
     })
 }
 
 #[test]
-fn predecl_signature_single_inp_out_type() {
+fn source_path_interpolation_vs_literal() -> Result {
+    Playground::setup("source_interp_vs_literal_test", |dirs, sandbox| {
+        sandbox.with_files(&[
+            Stub::FileWithContent("file(name).nu", "'literal file'"),
+            Stub::FileWithContent("file_macos.nu", "'interpolated file'"),
+            Stub::FileWithContent("file_linux.nu", "'interpolated file'"),
+            Stub::FileWithContent("file_windows.nu", "'interpolated file'"),
+        ]);
+
+        // Quoted path should treat parens as literal
+        test()
+            .cwd(dirs.test())
+            .run(r#"source "file(name).nu""#)
+            .expect_value_eq("literal file")?;
+
+        // Bare word with parens containing variable should interpolate
+        test()
+            .cwd(dirs.test())
+            .run("source file_($nu.os-info.name).nu")
+            .expect_value_eq("interpolated file")
+    })
+}
+
+#[test]
+fn source_path_with_nested_parens() -> Result {
+    Playground::setup("source_nested_parens_test", |dirs, sandbox| {
+        let os_name = std::env::consts::OS;
+        sandbox.with_files(&[Stub::FileWithContent(
+            &format!("test_{}_nested.nu", os_name),
+            "'nested parens'",
+        )]);
+
+        // Nested parentheses in interpolation
+        test()
+            .cwd(dirs.test())
+            .run("source test_($nu.os-info | get name)_nested.nu")
+            .expect_value_eq("nested parens")
+    })
+}
+
+#[test]
+fn source_path_single_quote_no_interpolation() -> Result {
+    Playground::setup("source_single_quote_test", |dirs, sandbox| {
+        sandbox.with_files(&[Stub::FileWithContent(
+            "file($nu.os-info.name).nu",
+            "'no interpolation'",
+        )]);
+
+        // Single quotes should prevent interpolation
+        test()
+            .cwd(dirs.test())
+            .run("source 'file($nu.os-info.name).nu'")
+            .expect_value_eq("no interpolation")
+    })
+}
+
+#[test]
+fn source_path_backtick_no_interpolation() -> Result {
+    Playground::setup("source_backtick_test", |dirs, sandbox| {
+        sandbox.with_files(&[Stub::FileWithContent(
+            "file($nu.os-info.name).nu",
+            "'backtick no interp'",
+        )]);
+
+        // Backticks should also prevent interpolation
+        test()
+            .cwd(dirs.test())
+            .run("source `file($nu.os-info.name).nu`")
+            .expect_value_eq("backtick no interp")
+    })
+}
+
+#[test]
+fn source_path_dollar_interpolation() -> Result {
+    Playground::setup("source_dollar_interp_test", |dirs, sandbox| {
+        let os_name = std::env::consts::OS;
+        sandbox.with_files(&[Stub::FileWithContent(
+            &format!("test_{}.nu", os_name),
+            "'dollar interpolation'",
+        )]);
+
+        // Dollar prefix should enable interpolation in quotes
+        test()
+            .cwd(dirs.test())
+            .run(r#"source $"test_($nu.os-info.name).nu""#)
+            .expect_value_eq("dollar interpolation")
+    })
+}
+
+#[test]
+fn source_path_mixed_parens_and_quotes() -> Result {
+    Playground::setup("source_mixed_parens_test", |dirs, sandbox| {
+        sandbox.with_files(&[Stub::FileWithContent("test(1).nu", "'test 1'")]);
+        let os_name = std::env::consts::OS;
+        sandbox.with_files(&[Stub::FileWithContent(
+            &format!("test_{}.nu", os_name),
+            "'test interpolated'",
+        )]);
+
+        // Literal parentheses in quoted string
+        test()
+            .cwd(dirs.test())
+            .run(r#"source "test(1).nu""#)
+            .expect_value_eq("test 1")?;
+
+        // Interpolation in bare word with constant
+        test()
+            .cwd(dirs.test())
+            .run("source test_($nu.os-info.name).nu")
+            .expect_value_eq("test interpolated")
+    })
+}
+
+#[test]
+fn source_path_empty_parens() -> Result {
+    Playground::setup("source_empty_parens_test", |dirs, sandbox| {
+        sandbox.with_files(&[Stub::FileWithContent("file().nu", "'empty parens'")]);
+
+        // Empty parentheses should be treated as literal when quoted
+        test()
+            .cwd(dirs.test())
+            .run(r#"source "file().nu""#)
+            .expect_value_eq("empty parens")
+    })
+}
+
+#[test]
+fn source_path_unbalanced_parens_quoted() -> Result {
+    Playground::setup("source_unbalanced_parens_test", |dirs, sandbox| {
+        sandbox.with_files(&[
+            Stub::FileWithContent("file(.nu", "'unbalanced open'"),
+            Stub::FileWithContent("file).nu", "'unbalanced close'"),
+        ]);
+
+        // Unbalanced parentheses should work when quoted
+        test()
+            .cwd(dirs.test())
+            .run(r#"source "file(.nu""#)
+            .expect_value_eq("unbalanced open")?;
+
+        test()
+            .cwd(dirs.test())
+            .run(r#"source "file).nu""#)
+            .expect_value_eq("unbalanced close")
+    })
+}
+
+#[test]
+fn source_path_multiple_interpolations() -> Result {
+    Playground::setup("source_multiple_interp_test", |dirs, sandbox| {
+        let os_name = std::env::consts::OS;
+        let arch = std::env::consts::ARCH;
+        sandbox.with_files(&[Stub::FileWithContent(
+            &format!("{}_{}.nu", os_name, arch),
+            "'multiple interpolations'",
+        )]);
+
+        // Multiple interpolations in one path using constants
+        test()
+            .cwd(dirs.test())
+            .run("source ($nu.os-info.name)_($nu.os-info.arch).nu")
+            .expect_value_eq("multiple interpolations")
+    })
+}
+
+#[test]
+fn source_path_interpolation_with_spaces() -> Result {
+    Playground::setup("source_interp_spaces_test", |dirs, sandbox| {
+        sandbox.with_files(&[Stub::FileWithContent(
+            "file with spaces.nu",
+            "'spaces in name'",
+        )]);
+
+        // Spaces in filename require quotes
+        test()
+            .cwd(dirs.test())
+            .run(r#"const name = "file with spaces"; source $"($name).nu""#)
+            .expect_value_eq("spaces in name")
+    })
+}
+
+#[test]
+fn source_path_raw_string_no_interpolation() -> Result {
+    Playground::setup("source_raw_string_test", |dirs, sandbox| {
+        sandbox.with_files(&[Stub::FileWithContent(
+            "file($nu.os-info.name).nu",
+            "'raw string'",
+        )]);
+
+        // Raw strings should not interpolate
+        test()
+            .cwd(dirs.test())
+            .run("source r#'file($nu.os-info.name).nu'#")
+            .expect_value_eq("raw string")
+    })
+}
+
+#[test]
+fn source_circular() -> Result {
+    test()
+        .cwd("tests/parsing/samples")
+        .run("source source_circular_1.nu")
+        .expect_error_code_eq("nu::parser::circular_import")
+}
+
+#[test]
+#[deps(NU)]
+fn run_nu_script_single_line() -> Result {
+    let result: CompleteResult = test()
+        .cwd("tests/parsing/samples")
+        .run("nu -n single_line.nu | complete")?;
+
+    assert_eq!(result.stdout.trim(), "5");
+    Ok(())
+}
+
+#[test]
+#[deps(NU)]
+fn run_nu_script_multiline_start_pipe() -> Result {
+    let result: CompleteResult = test()
+        .cwd("tests/parsing/samples")
+        .run("nu -n multiline_start_pipe.nu | complete")?;
+
+    assert_eq!(result.stdout.trim(), "4");
+    Ok(())
+}
+
+#[test]
+#[deps(NU)]
+fn run_nu_script_multiline_start_pipe_win() -> Result {
+    let result: CompleteResult = test()
+        .cwd("tests/parsing/samples")
+        .run("nu -n multiline_start_pipe_win.nu | complete")?;
+
+    assert_eq!(result.stdout.trim(), "3");
+    Ok(())
+}
+
+#[test]
+#[deps(NU)]
+fn run_nu_script_multiline_end_pipe() -> Result {
+    let result: CompleteResult = test()
+        .cwd("tests/parsing/samples")
+        .run("nu -n multiline_end_pipe.nu | complete")?;
+
+    assert_eq!(result.stdout.trim(), "2");
+    Ok(())
+}
+
+#[test]
+#[deps(NU)]
+fn run_nu_script_multiline_end_pipe_win() -> Result {
+    let result: CompleteResult = test()
+        .cwd("tests/parsing/samples")
+        .run("nu -n multiline_end_pipe_win.nu | complete")?;
+
+    assert_eq!(result.stdout.trim(), "3");
+    Ok(())
+}
+
+#[test]
+fn parse_file_relative_to_parsed_file_simple() -> Result {
+    Playground::setup("relative_files_simple", |dirs, sandbox| {
+        sandbox.mkdir("lol").mkdir("lol/lol").with_files(&[
+            Stub::FileWithContent(
+                "lol/lol/lol.nu",
+                "use ../lol_shell.nu; $env.LOL = (lol_shell ls)",
+            ),
+            Stub::FileWithContent("lol/lol_shell.nu", r#"export def ls [] { "lol" }"#),
+        ]);
+
+        test()
+            .cwd(dirs.test())
+            .run("source-env lol/lol/lol.nu; $env.LOL")
+            .expect_value_eq("lol")
+    })
+}
+
+#[test]
+#[deps(NU)]
+fn predecl_signature_single_inp_out_type() -> Result {
     Playground::setup("predecl_signature_single_inp_out_type", |dirs, sandbox| {
-        sandbox.with_files(&[FileWithContentToBeTrimmed(
+        sandbox.with_files(&[Stub::FileWithContent(
             "spam1.nu",
             "
                 def main [] { foo }
@@ -455,18 +373,19 @@ fn predecl_signature_single_inp_out_type() {
             ",
         )]);
 
-        let actual = nu!(cwd: dirs.test(), "nu spam1.nu");
-
-        assert_eq!(actual.out, "foo");
+        let result: CompleteResult = test().cwd(dirs.test()).run("nu spam1.nu | complete")?;
+        assert_eq!(result.stdout.trim(), "foo");
+        Ok(())
     })
 }
 
 #[test]
-fn predecl_signature_multiple_inp_out_types() {
+#[deps(NU)]
+fn predecl_signature_multiple_inp_out_types() -> Result {
     Playground::setup(
         "predecl_signature_multiple_inp_out_types",
         |dirs, sandbox| {
-            sandbox.with_files(&[FileWithContentToBeTrimmed(
+            sandbox.with_files(&[Stub::FileWithContent(
                 "spam2.nu",
                 "
                 def main [] { foo }
@@ -475,21 +394,19 @@ fn predecl_signature_multiple_inp_out_types() {
             ",
             )]);
 
-            let actual = nu!(cwd: dirs.test(), "nu spam2.nu");
+            let result: CompleteResult = test().cwd(dirs.test()).run("nu spam2.nu | complete")?;
+            assert_eq!(result.stdout.trim(), "foo");
 
-            assert_eq!(actual.out, "foo");
+            Ok(())
         },
     )
 }
 
-#[ignore]
 #[test]
-fn parse_file_relative_to_parsed_file() {
+fn parse_file_relative_to_parsed_file() -> Result {
     Playground::setup("relative_files", |dirs, sandbox| {
-        sandbox
-            .mkdir("lol")
-            .mkdir("lol/lol")
-            .with_files(&[FileWithContentToBeTrimmed(
+        sandbox.mkdir("lol").mkdir("lol/lol").with_files(&[
+            Stub::FileWithContentToBeTrimmed(
                 "lol/lol/lol.nu",
                 "
                     source-env ../../foo.nu
@@ -498,123 +415,106 @@ fn parse_file_relative_to_parsed_file() {
 
                     $env.LOL = $'($env.FOO) (lol_shell ls) (ls)'
                 ",
-            )])
-            .with_files(&[FileWithContentToBeTrimmed(
+            ),
+            Stub::FileWithContentToBeTrimmed(
                 "lol/lol_shell.nu",
                 r#"
                     export def ls [] { "lol" }
                 "#,
-            )])
-            .with_files(&[FileWithContentToBeTrimmed(
+            ),
+            Stub::FileWithContentToBeTrimmed(
                 "foo.nu",
                 "
                     $env.FOO = 'foo'
                 ",
-            )]);
+            ),
+        ]);
 
-        let actual = nu!(cwd: dirs.test(), "
-            source-env lol/lol/lol.nu;
-            $env.LOL
-        ");
-
-        assert_eq!(actual.out, "foo lol lol");
+        test()
+            .cwd(dirs.test())
+            .run("source-env lol/lol/lol.nu; $env.LOL")
+            .expect_value_eq("foo lol lol")
     })
 }
 
 #[test]
-fn parse_file_relative_to_parsed_file_dont_use_cwd_1() {
+fn parse_file_relative_to_parsed_file_dont_use_cwd_1() -> Result {
     Playground::setup("relative_files", |dirs, sandbox| {
         sandbox
             .mkdir("lol")
-            .with_files(&[FileWithContentToBeTrimmed(
+            .with_files(&[Stub::FileWithContentToBeTrimmed(
                 "lol/lol.nu",
                 "
                     source-env foo.nu
                 ",
             )])
-            .with_files(&[FileWithContentToBeTrimmed(
+            .with_files(&[Stub::FileWithContentToBeTrimmed(
                 "lol/foo.nu",
                 "
                     $env.FOO = 'good'
                 ",
             )])
-            .with_files(&[FileWithContentToBeTrimmed(
+            .with_files(&[Stub::FileWithContentToBeTrimmed(
                 "foo.nu",
                 "
                     $env.FOO = 'bad'
                 ",
             )]);
 
-        let actual = nu!(cwd: dirs.test(), "
-            source-env lol/lol.nu;
-            $env.FOO
-        ");
-
-        assert_eq!(actual.out, "good");
+        test()
+            .cwd(dirs.test())
+            .run("source-env lol/lol.nu; $env.FOO")
+            .expect_value_eq("good")
     })
 }
 
 #[test]
-fn parse_file_relative_to_parsed_file_dont_use_cwd_2() {
+fn parse_file_relative_to_parsed_file_dont_use_cwd_2() -> Result {
     Playground::setup("relative_files", |dirs, sandbox| {
-        sandbox
-            .mkdir("lol")
-            .with_files(&[FileWithContentToBeTrimmed(
+        sandbox.mkdir("lol").with_files(&[
+            Stub::FileWithContentToBeTrimmed(
                 "lol/lol.nu",
                 "
                     source-env foo.nu
-                ",
-            )])
-            .with_files(&[FileWithContentToBeTrimmed(
+             ",
+            ),
+            Stub::FileWithContentToBeTrimmed(
                 "foo.nu",
                 "
                     $env.FOO = 'bad'
                 ",
-            )]);
+            ),
+        ]);
 
-        let actual = nu!(cwd: dirs.test(), "
-            source-env lol/lol.nu
-        ");
-
-        assert!(actual.err.contains("File not found"));
+        test()
+            .cwd(dirs.test())
+            .run("source-env lol/lol.nu")
+            .expect_error_code_eq("nu::parser::sourced_file_not_found")
     })
 }
 
 #[test]
-fn parse_export_env_in_module() {
-    let actual = nu!("
-            module spam { export-env { } }
-        ");
-
-    assert!(actual.err.is_empty());
+fn parse_export_env_in_module() -> Result {
+    test().run("module spam { export-env { } }")
 }
 
 #[test]
-fn parse_export_env_missing_block() {
-    let actual = nu!("
-            module spam { export-env }
-        ");
-
-    assert!(actual.err.contains("missing block"));
+fn parse_export_env_missing_block() -> Result {
+    test()
+        .run("module spam { export-env }")
+        .expect_error_code_eq("nu::parser::missing_positional")
 }
 
 #[test]
-fn call_command_with_non_ascii_argument() {
-    let actual = nu!("
-            def nu-arg [--umlaut(-ö): int] {}
-            nu-arg -ö 42
-        ");
-
-    assert_eq!(actual.err.len(), 0);
+fn call_command_with_non_ascii_argument() -> Result {
+    test().run("def nu-arg [--umlaut(-ö): int] {}; nu-arg -ö 42")
 }
 
 #[test]
-fn parse_long_duration() {
-    let actual = nu!(r#"
-            "78.797877879789789sec" | into duration
-        "#);
-
-    assert_eq!(actual.out, "1min 18sec 797ms 877µs 879ns");
+fn parse_long_duration() -> Result {
+    test()
+        .run(r#" "78.797877879789789sec" | into duration"#)
+        .expect_value_eq(Duration::from_nanos(78797877879))
 }
 
 #[rstest]
@@ -631,15 +531,17 @@ fn parse_long_duration() {
 #[case("def test []: record<a: int b: int> -> record<c: int e: int> { {c: 1 e: 1} }")]
 #[case("def test []: table<a: int b: int> -> table<c: int e: int> { [ {c: 1 e: 1} ] }")]
 #[case("def test []: nothing -> record<c: int e: int> { {c: 1 e: 1} }")]
-fn parse_function_signature(#[case] phrase: &str) {
-    let actual = nu!(phrase);
-    assert!(actual.err.is_empty());
+fn parse_function_signature(#[case] phrase: &str) -> Result {
+    test().run(phrase)
 }
 
 #[test]
-fn parse_function_signature_switch_is_bool() {
-    let actual = nu!("def foo [--bar] { let baz: int = $bar }");
-    assert!(actual.err.contains("expected int, found bool"))
+fn parse_function_signature_switch_is_bool() -> Result {
+    let err = test()
+        .run("def foo [--bar] { let baz: int = $bar }")
+        .expect_parse_error()?;
+    assert_matches!(err, ParseError::TypeMismatch(Type::Int, Type::Bool, _));
+    Ok(())
 }
 
 #[rstest]
@@ -652,9 +554,10 @@ fn parse_function_signature_switch_is_bool() {
 #[case("def test [ --in (-i): list<any> ] {}")]
 #[case("def test [ a: string, b: int, in: table<a: int b: int> ] {}")]
 #[case("def test [ env, in, nu ] {}")]
-fn parse_function_signature_name_is_builtin_var(#[case] phrase: &str) {
-    let actual = nu!(phrase);
-    assert!(actual.err.contains("nu::parser::name_is_builtin_var"))
+fn parse_function_signature_name_is_builtin_var(#[case] phrase: &str) -> Result {
+    test()
+        .run(phrase)
+        .expect_error_code_eq("nu::parser::name_is_builtin_var")
 }
 
 #[rstest]
@@ -665,166 +568,163 @@ fn parse_function_signature_name_is_builtin_var(#[case] phrase: &str) {
 #[case("let a: record<a: int b: int> = {a: 1 b: 1}")]
 #[case("let a: table<a: int b: int> = [[a b]; [1 2] [3 4]]")]
 #[case("let a: record<a: record<name: string> b: int> = {a: {name: bob} b: 1}")]
-fn parse_let_signature(#[case] phrase: &str) {
-    let actual = nu!(phrase);
-    assert!(actual.err.is_empty());
+fn parse_let_signature(#[case] phrase: &str) -> Result {
+    test().run(phrase)
 }
 
 #[test]
-fn parse_let_signature_missing_colon() {
-    let actual = nu!("let a int = 1");
-    assert!(actual.err.contains("nu::parser::extra_tokens"));
+fn parse_let_signature_missing_colon() -> Result {
+    test()
+        .run("let a int = 1")
+        .expect_error_code_eq("nu::parser::extra_tokens")
 }
 
 #[test]
-fn parse_mut_signature_missing_colon() {
-    let actual = nu!("mut a record<a: int b: int> = {a: 1 b: 1}");
-    assert!(actual.err.contains("nu::parser::extra_tokens"));
+fn parse_mut_signature_missing_colon() -> Result {
+    test()
+        .run("mut a record<a: int b: int> = {a: 1 b: 1}")
+        .expect_error_code_eq("nu::parser::extra_tokens")
 }
 
 #[test]
-fn parse_const_signature_missing_colon() {
-    let actual = nu!("const a string = 'Hello World\n'");
-    assert!(actual.err.contains("nu::parser::extra_tokens"));
+fn parse_const_signature_missing_colon() -> Result {
+    test()
+        .run("const a string = 'Hello World\n'")
+        .expect_error_code_eq("nu::parser::extra_tokens")
 }
 
 /// https://github.com/nushell/nushell/issues/16969
-#[test]
-fn wacky_range_parse() {
-    let actual = nu!("0..(1..2 | first)");
-    assert!(actual.err.is_empty());
-}
+#[rstest]
+#[case("0..1", "0..(1..2 | first)")]
+#[case::lt("0..<1", "0..<(1..2 | first)")]
+#[case::eq("0..=1", "0..=(1..2 | first)")]
+#[case::no_end("..1", "..(1..2 | first)")]
+#[case("1..5..10", "1..(5)..10")]
+#[case("1..5..10", "1..(5..10 | first)..10")]
+fn wacky_range_parse(#[case] normal: &str, #[case] wacky: &str) -> Result {
+    let mut tester = test();
+    let expected: Value = tester.run(normal)?;
 
-#[test]
-fn wacky_range_parse_lt() {
-    let actual = nu!("0..<(1..2 | first)");
-    assert!(actual.err.is_empty());
-}
-
-#[test]
-fn wacky_range_parse_eq() {
-    let actual = nu!("0..=(1..2 | first)");
-    assert!(actual.err.is_empty());
-}
-
-#[test]
-fn wacky_range_parse_no_end() {
-    let actual = nu!("..(1..2 | first)");
-    assert!(actual.err.is_empty());
-}
-
-#[test]
-fn wacky_range_parse_regression() {
-    let actual = nu!("1..(5)..10");
-    assert!(actual.err.is_empty());
-}
-
-#[test]
-fn wacky_range_parse_comb() {
-    let actual = nu!("1..(5..10 | first)..10");
-    assert!(actual.err.is_empty());
+    tester.run(wacky).expect_value_eq(expected)
 }
 
 // Regression test https://github.com/nushell/nushell/issues/17146
 #[test]
-fn wacky_range_unmatched_paren() {
-    let actual = nu!("') ..");
-    assert!(!actual.err.is_empty());
+fn wacky_range_unmatched_paren() -> Result {
+    test()
+        .run("') ..")
+        .expect_error_code_eq("nu::parser::unexpected_eof")
 }
 
 #[test]
-fn issue_16769_recursive_module_command_variable_in_block() {
+#[deps(NU)]
+fn issue_16769_recursive_module_command_variable_in_block() -> Result {
     Playground::setup(
         "issue_16769_recursive_module_command_variable_in_block",
         |dirs, sandbox| {
-            sandbox
-                .with_files(&[FileWithContentToBeTrimmed(
+            sandbox.with_files(&[
+                Stub::FileWithContentToBeTrimmed(
                     "b.nu",
                     "
                         export def f [] { each {f} }
                     ",
-                )])
-                .with_files(&[FileWithContentToBeTrimmed(
+                ),
+                Stub::FileWithContentToBeTrimmed(
                     "a.nu",
                     "
                         use b.nu *
                         let i = [];
                         if true { $i | f }
                     ",
-                )]);
+                ),
+            ]);
 
-            let actual = nu!(cwd: dirs.test(), "nu a.nu");
-            assert!(actual.err.is_empty(), "unexpected error: {}", actual.err);
+            let result: CompleteResult = test().cwd(dirs.test()).run("nu a.nu | complete")?;
+            assert_eq!(result.exit_code, 0);
+            assert_eq!(result.stderr, "");
+
+            Ok(())
         },
     )
 }
 
 #[test]
-fn issue_16769_recursive_module_command_direct_recursion_closure() {
+#[deps(NU)]
+fn issue_16769_recursive_module_command_direct_recursion_closure() -> Result {
     Playground::setup(
         "issue_16769_recursive_module_command_direct_recursion_closure",
         |dirs, sandbox| {
-            sandbox
-                .with_files(&[FileWithContentToBeTrimmed(
+            sandbox.with_files(&[
+                Stub::FileWithContentToBeTrimmed(
                     "b.nu",
                     "
                         export def f [] { f }
                     ",
-                )])
-                .with_files(&[FileWithContentToBeTrimmed(
+                ),
+                Stub::FileWithContentToBeTrimmed(
                     "a.nu",
                     "
                         use b.nu f
                         { $in | f }
                     ",
-                )]);
+                ),
+            ]);
 
-            let actual = nu!(cwd: dirs.test(), "nu a.nu");
-            assert!(actual.err.is_empty(), "unexpected error: {}", actual.err);
+            let result: CompleteResult = test().cwd(dirs.test()).run("nu a.nu | complete")?;
+            assert_eq!(result.exit_code, 0);
+            assert_eq!(result.stderr, "");
+
+            Ok(())
         },
     )
 }
 
 #[test]
-fn issue_16769_recursive_module_command_source_def() {
+fn issue_16769_recursive_module_command_source_def() -> Result {
     Playground::setup(
         "issue_16769_recursive_module_command_source_def",
         |dirs, sandbox| {
-            sandbox
-                .with_files(&[FileWithContentToBeTrimmed(
+            sandbox.with_files(&[
+                Stub::FileWithContentToBeTrimmed(
                     "b.nu",
                     "
                     export def f [] { each {f} }
                 ",
-                )])
-                .with_files(&[FileWithContentToBeTrimmed(
+                ),
+                Stub::FileWithContentToBeTrimmed(
                     "a.nu",
                     "
                     use b.nu f
                     def a [] { $in | f }
                 ",
-                )]);
+                ),
+            ]);
 
-            let actual = nu!(cwd: dirs.test(), "source a.nu; [] | f");
-            assert!(actual.err.is_empty(), "unexpected error: {}", actual.err);
+            test()
+                .cwd(dirs.test())
+                .run("source a.nu; [] | f")
+                .expect_value_eq([(); 0])
         },
     )
 }
 
 #[test]
-fn issue_16209_mutual_recursion_closure_in_variable() {
-    let actual = nu!("
+fn issue_16209_mutual_recursion_closure_in_variable() -> Result {
+    let code = "
         def map [] {
-          return {
-           first: {|| $in | result second | $in + 3 }
-           second: {|| $in + 7 | result third | $in * 3 }
-           third: {|| $in }
-          }
+            return {
+                first: {|| $in | result second | $in + 3 }
+                second: {|| $in + 7 | result third | $in * 3 }
+                third: {|| $in }
+            }
         }
         def result [condition: string, ...args] {
-             do (map | get $condition) ...$args
+            do (map | get $condition) ...$args
         }
         map | describe
-    ");
-    assert!(actual.err.is_empty(), "unexpected error: {}", actual.err);
+    ";
+
+    test()
+        .run(code)
+        .expect_value_eq("record<first: closure, second: closure, third: closure>")
 }

--- a/tests/path/absolute.rs
+++ b/tests/path/absolute.rs
@@ -1,7 +1,7 @@
 use nu_path::absolute_with;
 use nu_test_support::fs::Stub::EmptyFile;
-use nu_test_support::nu;
 use nu_test_support::playground::Playground;
+use nu_test_support::prelude::*;
 use pretty_assertions::assert_eq;
 use std::path::Path;
 
@@ -176,13 +176,15 @@ fn absolute_path_with_many_double_dots_relative_to() {
 }
 
 #[test]
-fn absolute_ndots2() {
+fn absolute_ndots2() -> Result {
     // This test will fail if you have the nushell repo on the root partition
     // So, let's start in a nested folder before trying to absolute_with "..."
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.mkdir("aaa/bbb/ccc");
-        let output = nu!( cwd: dirs.root(), "cd nu_path_test_1/aaa/bbb/ccc; $env.PWD");
-        let cwd = Path::new(&output.out);
+        let output: String = test()
+            .cwd(dirs.root())
+            .run("cd nu_path_test_1/aaa/bbb/ccc; $env.PWD")?;
+        let cwd = Path::new(&output);
 
         let actual = absolute_with("...", cwd).expect("Failed to make absolute");
         // On Windows .. components are resolved. On Unix they are not.
@@ -196,7 +198,9 @@ fn absolute_ndots2() {
         let expected = cwd.join("../..");
 
         assert_eq!(actual, expected);
-    });
+
+        Ok(())
+    })
 }
 
 #[test]

--- a/tests/path/canonicalize.rs
+++ b/tests/path/canonicalize.rs
@@ -1,7 +1,7 @@
 use nu_path::canonicalize_with;
 use nu_test_support::fs::Stub::EmptyFile;
-use nu_test_support::nu;
 use nu_test_support::playground::Playground;
+use nu_test_support::prelude::*;
 use pretty_assertions::assert_eq;
 use std::path::Path;
 
@@ -182,13 +182,15 @@ fn canonicalize_path_with_many_double_dots_relative_to() {
 }
 
 #[test]
-fn canonicalize_ndots2() {
+fn canonicalize_ndots2() -> Result {
     // This test will fail if you have the nushell repo on the root partition
     // So, let's start in a nested folder before trying to canonicalize_with "..."
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.mkdir("aaa/bbb/ccc");
-        let output = nu!( cwd: dirs.root(), "cd nu_path_test_1/aaa/bbb/ccc; $env.PWD");
-        let cwd = Path::new(&output.out);
+        let output: String = test()
+            .cwd(dirs.root())
+            .run("cd nu_path_test_1/aaa/bbb/ccc; $env.PWD")?;
+        let cwd = Path::new(&output);
 
         let actual = canonicalize_with("...", cwd).expect("Failed to canonicalize");
         let expected = cwd
@@ -198,7 +200,9 @@ fn canonicalize_ndots2() {
             .expect("Could not get parent of a parent of current directory");
 
         assert_eq!(actual, expected);
-    });
+
+        Ok(())
+    })
 }
 
 #[test]

--- a/tests/repl/test_env.rs
+++ b/tests/repl/test_env.rs
@@ -1,46 +1,35 @@
-use crate::repl::tests::{TestResult, fail_test, run_test};
-use nu_test_support::nu;
+use rstest::rstest;
 
+use nu_test_support::prelude::*;
+
+#[rstest]
+#[case::env_shorthand("FOO=BAZ $env.FOO", "BAZ")]
+#[case::env_shorthand_multiple("FOO=BAZ BAR=MOO [$env.FOO, $env.BAR]", ["BAZ", "MOO"])]
+fn successful(#[case] code: &str, #[case] expect: impl IntoValue) -> Result {
+    test().run(code).expect_value_eq(expect)
+}
+
+#[rstest]
+#[case::default_env_nu_lib_dirs_type("$env.NU_LIB_DIRS | describe", "list<string>")]
+#[case::default_const_nu_lib_dirs_type("$NU_LIB_DIRS | describe", "list<string>")]
+// Previously, this was a list<string>
+// While we are transitioning to const NU_PLUGIN_DIRS
+// the env version will be empty, and thus a
+// list<any>
+#[case::default_env_plugin_dirs_type("$env.NU_PLUGIN_DIRS | describe", "list<any>")]
+#[case::default_const_plugin_dirs_type("$NU_PLUGIN_DIRS | describe", "list<string>")]
 #[test]
-fn shorthand_env_1() -> TestResult {
-    run_test("FOO=BAZ $env.FOO", "BAZ")
+#[deps(NU)]
+fn needs_nu_processes(#[case] child_code: &str, #[case] expect: impl IntoValue) -> Result {
+    let code = "let child_code; nu -n -c $child_code";
+    test()
+        .run_with_data(code, child_code)
+        .expect_value_eq(expect)
 }
 
 #[test]
-fn shorthand_env_2() -> TestResult {
-    fail_test("FOO=BAZ FOO=MOO $env.FOO", "defined_twice")
-}
-
-#[test]
-fn shorthand_env_3() -> TestResult {
-    run_test("FOO=BAZ BAR=MOO $env.FOO", "BAZ")
-}
-
-#[test]
-fn default_nu_lib_dirs_env_type() {
-    // Now that $env.NU_LIB_DIRS includes defaults, it's list<string>
-    let actual = nu!("$env.NU_LIB_DIRS | describe");
-    assert_eq!(actual.out, "list<string>");
-}
-
-#[test]
-fn default_nu_lib_dirs_type() {
-    let actual = nu!("$NU_LIB_DIRS | describe");
-    assert_eq!(actual.out, "list<string>");
-}
-
-#[test]
-fn default_nu_plugin_dirs_env_type() {
-    // Previously, this was a list<string>
-    // While we are transitioning to const NU_PLUGIN_DIRS
-    // the env version will be empty, and thus a
-    // list<any>
-    let actual = nu!("$env.NU_PLUGIN_DIRS | describe");
-    assert_eq!(actual.out, "list<any>");
-}
-
-#[test]
-fn default_nu_plugin_dirs_type() {
-    let actual = nu!("$NU_PLUGIN_DIRS | describe");
-    assert_eq!(actual.out, "list<string>");
+fn defined_twice_error() -> Result {
+    test()
+        .run("FOO=BAZ FOO=MOO $env.FOO")
+        .expect_error_code_eq("nu::shell::column_defined_twice")
 }

--- a/tests/shell/pipeline/mod.rs
+++ b/tests/shell/pipeline/mod.rs
@@ -1,17 +1,14 @@
 mod commands;
 
-use nu_test_support::nu;
-use pretty_assertions::assert_eq;
+use nu_test_support::prelude::*;
 
 #[test]
-fn doesnt_break_on_utf8() {
-    let actual = nu!("echo ö");
-    assert_eq!(actual.out, "ö", "'{}' should contain ö", actual.out);
+fn doesnt_break_on_utf8() -> Result {
+    test().run("echo ö").expect_value_eq("ö")
 }
 
 #[test]
-fn infinite_output_piped_to_value() {
-    let actual = nu!("nu --testbin iecho x | 1");
-    assert_eq!(actual.out, "1");
-    assert_eq!(actual.err, "");
+#[deps(NU)]
+fn infinite_output_piped_to_value() -> Result {
+    test().run("nu --testbin iecho x | 1").expect_value_eq(1)
 }

--- a/tests/shell/repl.rs
+++ b/tests/shell/repl.rs
@@ -1,9 +1,9 @@
-use nu_test_support::{nu, nu_repl_code};
-use pretty_assertions::assert_eq;
+use nu_test_support::prelude::*;
 
 #[test]
-fn mut_variable() {
-    let lines = &["mut x = 0", "$x = 1", "$x"];
-    let actual = nu!(nu_repl_code(lines));
-    assert_eq!(actual.out, "1");
+fn mut_variable() -> Result {
+    let mut tester = test();
+    let () = tester.run("mut x = 0")?;
+    let () = tester.run("$x = 1")?;
+    tester.run("$x").expect_value_eq(1)
 }


### PR DESCRIPTION
## Description

- Enabled `pretty_assertions`'s `unstable` feature to get `assert_matches!` (the stdlib version is available in 1.96)
- Tried to keep most tests 1:1, though I made some significant changes here and there.

## User-facing changes (Release notes)
N/A