### PR TITLE
Add `run_multiple` to `NuTester` and update `ShellErrorExt`

### DIFF
--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -468,7 +468,7 @@ impl NuTester {
     }
 
     /// Run multiple Nushell command pipelines after each other and extract the value into `T`.
-    /// 
+    ///
     /// This shortcircuits if any pipeline fails.
     #[track_caller]
     pub fn run_multiple<T: FromValue>(

--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -2,6 +2,7 @@ use std::{
     env,
     error::Error,
     fmt::{Debug, Display},
+    io,
     panic::Location,
     path::{Path, PathBuf},
     sync::{Arc, LazyLock},
@@ -610,6 +611,10 @@ pub enum TestErrorKind {
         code: String,
         err: Box<TestErrorKind>,
     },
+    Io {
+        message: String,
+        kind: io::ErrorKind,
+    },
 }
 
 impl Display for TestError {
@@ -636,6 +641,19 @@ impl From<ParseError> for TestError {
         Self {
             location: TestLocation(Location::caller()),
             kind: TestErrorKind::Parse(err),
+        }
+    }
+}
+
+impl From<io::Error> for TestError {
+    #[track_caller]
+    fn from(value: io::Error) -> Self {
+        Self {
+            location: TestLocation(Location::caller()),
+            kind: TestErrorKind::Io {
+                message: value.to_string(),
+                kind: value.kind(),
+            },
         }
     }
 }

--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -467,6 +467,21 @@ impl NuTester {
         Self::extract_value(self.run_raw_with_data(code, input)?)
     }
 
+    /// Run multiple Nushell command pipelines after each other and extract the value into `T`.
+    /// 
+    /// This shortcircuits if any pipeline fails.
+    #[track_caller]
+    pub fn run_multiple<T: FromValue>(
+        &mut self,
+        pipelines: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Result<T> {
+        let last = pipelines
+            .into_iter()
+            .map(|pipeline| self.run(pipeline))
+            .try_fold(Value::test_nothing(), |_, value| value)?;
+        Ok(T::from_value(last)?)
+    }
+
     /// Run Nushell code and return the raw [`PipelineExecutionData`].
     #[track_caller]
     pub fn run_raw(&mut self, code: impl AsRef<str>) -> Result<PipelineExecutionData> {

--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -605,6 +605,9 @@ pub enum TestErrorKind {
         got: Value,
     },
     NoInner,
+    MultipleInner {
+        count: usize,
+    },
     UnexpectedErrorKind {
         expected: &'static str,
         got: ShellError,
@@ -902,12 +905,13 @@ pub trait ShellErrorExt {
     /// Useful if the error is expected to be a generic error that contains an inner error or a
     /// chained error that chained another error.
     ///
-    /// However, this function returns [`None`]
+    /// However, this function returns [`TestErrorKind::NoInner`]
     /// - if `inner` of [`ShellError::Generic`] is empty
     /// - if `sources` of [`ShellError::ChainedError`] is empty
+    /// - if `sources` of [`ShellError::EvalBlockWithInput`] is empty
     /// - the error is none of the above types
     ///
-    /// So make sure that a [`None`] value is not surprise.
+    /// Also if multiple inner values are found a [`TestErrorKind::MultipleInner`] is returned.
     fn into_inner(self) -> Result<ShellError>;
 
     /// Extract the [`LabeledError`] from [`ShellError::LabeledError`], if it is one.
@@ -927,11 +931,27 @@ impl ShellErrorExt for ShellError {
             location: TestLocation(Location::caller()),
             kind: TestErrorKind::NoInner,
         };
-        match self {
-            ShellError::Generic(err) => err.inner.into_iter().next().ok_or(no_inner),
-            ShellError::ChainedError(err) => err.sources_iter().next().ok_or(no_inner),
-            _ => Err(no_inner),
+
+        let iter: &mut dyn Iterator<Item = ShellError> = match self {
+            ShellError::Generic(err) => &mut err.inner.into_iter(),
+            ShellError::ChainedError(err) => &mut err.sources_iter(),
+            ShellError::EvalBlockWithInput { sources, .. } => &mut sources.into_iter(),
+            _ => return Err(no_inner),
+        };
+
+        let Some(inner) = iter.next() else {
+            return Err(no_inner);
+        };
+
+        let rest = iter.count();
+        if rest != 0 {
+            return Err(TestError {
+                location: TestLocation(Location::caller()),
+                kind: TestErrorKind::MultipleInner { count: rest + 1 },
+            });
         }
+
+        Ok(inner)
     }
 
     #[track_caller]

--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -917,6 +917,10 @@ pub trait ShellErrorExt {
     /// Extract the [`LabeledError`] from [`ShellError::LabeledError`], if it is one.
     fn into_labeled(self) -> Result<LabeledError>;
 
+    /// Extract the iterator on the sources of the [`ChainedError`] from
+    /// [`ShellError::ChainedError`], it it is one.
+    fn into_chained_iter(self) -> Result<impl Iterator<Item = ShellError>>;
+
     /// Extract the error field from [`ShellError::Generic`], if it is one.
     fn generic_error(self) -> Result<String>;
 
@@ -962,6 +966,20 @@ impl ShellErrorExt for ShellError {
                 location: TestLocation(Location::caller()),
                 kind: TestErrorKind::UnexpectedErrorKind {
                     expected: "Labeled",
+                    got,
+                },
+            }),
+        }
+    }
+
+    #[track_caller]
+    fn into_chained_iter(self) -> Result<impl Iterator<Item = ShellError>> {
+        match self {
+            ShellError::ChainedError(err) => Ok(err.sources_iter()),
+            got => Err(TestError {
+                location: TestLocation(Location::caller()),
+                kind: TestErrorKind::UnexpectedErrorKind {
+                    expected: "Chained",
                     got,
                 },
             }),


### PR DESCRIPTION
<!--

Thanks for contributing to Nushell!



Before submitting, please read the contributing guide:

https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md



This template helps reviewers understand your changes and allows us to generate high-quality release notes.

-->



## Description

<!--

Explain what this PR does and why.



This section is intentionally flexible:

- Describe the problem

- Explain your approach

- Include technical details if relevant



Good examples:

- "In this PR, I fixed..."

- "In this PR, I added support for..."

- "This change improves X by..."



Write as much or as little as needed for reviewers to understand your changes.

-->
This PR adds the `NuTester::run_multiple` method which takes an iterator of pipelines and executes each one any only calls `from_value` on the last one.

This is useful for tests that replicate the REPL experience by running multiple pipelines after each other. All pipelines have to run successfully but only the last one will be extracted.

Besides that, this PR also updates the `ShellErrorExt` to make some tests further up the stack a bit more comfortable.

## User-facing changes (Release notes)

<!--

This section is used (mostly as-is) for https://www.nushell.sh/blog/



Describe how Nushell behavior changes from a user's perspective.

Do NOT describe internal Rust changes here.



Write in a release note style, for example:

- "Added support for..."

- "Fixed an issue where..."

- "Nushell now supports..."

- "Improved performance of..."



If your changes do NOT affect users (internal refactors, cleanup, etc.),

just write:

- "n/a"

- "nan"

- or similar



This tells us the change should not appear in the changelog.



Tips:

- Focus on observable behavior

- Include examples if helpful

- Keep it concise



You can:

- Write a short paragraph (will appear as a bullet point), OR

- Use headings (###) if your change needs more structure



Avoid writing things like:

- "In this PR, I refactored..."

- "This updates internal code..."



You may leave this blank until the PR is ready.

-->
n/a

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>