### PR TITLE
fix(parser): restore scopes before interpolation fallback

### DIFF
--- a/crates/nu-parser/src/parse_literals.rs
+++ b/crates/nu-parser/src/parse_literals.rs
@@ -496,6 +496,7 @@ pub fn parse_paren_expr(
         return parse_signature(working_set, span, true);
     }
 
+    let starting_scope_count = working_set.delta.scope.len();
     let fcp_expr = parse_full_cell_path(working_set, None, span, None);
     let fcp_error_count = working_set.parse_errors.len();
     if fcp_error_count > starting_error_count {
@@ -508,6 +509,9 @@ pub fn parse_paren_expr(
             });
         if malformed_subexpr {
             working_set.parse_errors.truncate(starting_error_count);
+            while working_set.delta.scope.len() > starting_scope_count {
+                working_set.exit_scope();
+            }
             if matches!(shape, SyntaxShape::GlobPattern) {
                 parse_glob_pattern(working_set, span)
             } else {

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -633,38 +633,22 @@ fn string_interpolation_paren_test3() -> TestResult {
     run_test(r#"$"('(')("test")test(')')""#, "(testtest)")
 }
 
-#[test]
-fn bare_interpolation_does_not_hide_redefined_command() -> TestResult {
-    let cases = [
-        ("subexpression", "(do {0})-str"),
-        ("closure", "({|| })-str"),
-        ("ambiguous block", r#"(if true { "T" } else { "F" })-str"#),
-        ("spaced subexpression", "(do {0} )-str"),
-        ("spaced closure", "({|| } )-str"),
-        (
-            "spaced ambiguous block",
-            r#"(if true { "T" } else { "F" } )-str"#,
-        ),
-        ("unambiguous block", r#"(if true { "T" })-str"#),
-    ];
-    let mut observations = vec![];
+#[rstest]
+#[case::subexpression("(do {0})-str")]
+#[case::closure("({|| })-str")]
+#[case::ambiguous_block(r#"(if true { "T" } else { "F" })-str"#)]
+#[case::spaced_subexpression("(do {0} )-str")]
+#[case::spaced_closure("({|| } )-str")]
+#[case::spaced_ambiguous_block(r#"(if true { "T" } else { "F" } )-str"#)]
+#[case::unambiguous_block(r#"(if true { "T" })-str"#)]
+fn bare_interpolation_does_not_hide_redefined_command(#[case] body: &str) -> TestResult {
+    let mut tester = test();
+    tester.run::<()>(r#"def cmd [] { "fallback" }"#)?;
+    let same_entry: String = tester.run(format!("def cmd [] {{ {body} }}; cmd"))?;
+    let later_entry: String = tester.run("cmd")?;
 
-    for (name, body) in cases {
-        let mut tester = test();
-        tester.run::<()>(r#"def cmd [] { "fallback" }"#)?;
-        let same_entry: String = tester.run(format!("def cmd [] {{ {body} }}; cmd"))?;
-        let later_entry: String = tester.run("cmd")?;
-        observations.push((name, same_entry, later_entry));
-    }
-
-    assert_eq!(observations[0].1, "0-str");
-    assert!(
-        observations
-            .iter()
-            .all(|(_, same_entry, later_entry)| same_entry != "fallback"
-                && same_entry == later_entry),
-        "command definitions did not persist across entries: {observations:?}"
-    );
+    assert_ne!(same_entry, "fallback");
+    assert_eq!(same_entry, later_entry);
     Ok(())
 }
 

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -634,6 +634,41 @@ fn string_interpolation_paren_test3() -> TestResult {
 }
 
 #[test]
+fn bare_interpolation_does_not_hide_redefined_command() -> TestResult {
+    let cases = [
+        ("subexpression", "(do {0})-str"),
+        ("closure", "({|| })-str"),
+        ("ambiguous block", r#"(if true { "T" } else { "F" })-str"#),
+        ("spaced subexpression", "(do {0} )-str"),
+        ("spaced closure", "({|| } )-str"),
+        (
+            "spaced ambiguous block",
+            r#"(if true { "T" } else { "F" } )-str"#,
+        ),
+        ("unambiguous block", r#"(if true { "T" })-str"#),
+    ];
+    let mut observations = vec![];
+
+    for (name, body) in cases {
+        let mut tester = test();
+        tester.run::<()>(r#"def cmd [] { "fallback" }"#)?;
+        let same_entry: String = tester.run(format!("def cmd [] {{ {body} }}; cmd"))?;
+        let later_entry: String = tester.run("cmd")?;
+        observations.push((name, same_entry, later_entry));
+    }
+
+    assert_eq!(observations[0].1, "0-str");
+    assert!(
+        observations
+            .iter()
+            .all(|(_, same_entry, later_entry)| same_entry != "fallback"
+                && same_entry == later_entry),
+        "command definitions did not persist across entries: {observations:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn string_interpolation_escaping() -> TestResult {
     run_test(r#"$"hello\nworld" | lines | length"#, "2")
 }


### PR DESCRIPTION
## Description

Closes #18346.

Malformed bare-word interpolations are first attempted as full cell paths. When
that speculative parse retained scopes for incomplete-input completion, the
expected `Unclosed` error was cleared but the scopes remained. This could keep
a redefined command out of the scope later merged into `EngineState`.

This captures the scope depth before the speculative parse and restores that
depth only when its expected error is intentionally discarded before the
interpolation fallback.

## User-Facing Changes

Command definitions containing these bare-word interpolations now persist
across REPL entries. Incomplete-input variable and command completion behavior
is preserved.

## Tests + Formatting

- [x] Focused multi-entry REPL regression test
- [x] `cargo +1.95.0 test -p nu-parser` (298 passed, 2 ignored)
- [x] Targeted local-variable and incomplete-block completion tests
- [x] Unclosed interpolation REPL test
- [x] `cargo +1.95.0 fmt --all -- --check`
- [x] Targeted Clippy checks with warnings and `unwrap_used` denied

The broader `nu-cli` `completions::` group produced 151 passes, 23 failures,
and 2 ignored tests on Windows. All 23 failures depend on the repository's
`test_a_symlink` fixture being checked out as a regular file because
`core.symlinks=false`; none involve incomplete-input or parser-scope behavior.

## Additional Notes

No new dependencies or generated-file changes.

AI assistance was used during investigation and drafting. I manually reviewed
and locally verified the code, tests, and explanation, understand the change,
and take responsibility for it.
