### PR TITLE
fix(idx): exclude tombstoned entries

### DIFF
--- a/crates/nu-command/src/filesystem/idx/state.rs
+++ b/crates/nu-command/src/filesystem/idx/state.rs
@@ -261,8 +261,12 @@ fn idx_status_from_picker(
         watch,
         scanning: picker.is_scan_active(),
         scan_duration_ns,
-        files: picker.get_files().len(),
-        dirs: picker.get_dirs().len(),
+        files: picker.live_file_count(),
+        dirs: picker
+            .get_dirs()
+            .iter()
+            .filter(|item| !item.is_deleted())
+            .count(),
         arena_bytes_base: picker.arena_bytes().0,
         arena_bytes_overflow: picker.arena_bytes().1,
         arena_bytes_untracked: picker.arena_bytes().2,
@@ -654,7 +658,7 @@ pub fn stream_dirs(
                 let item = picker
                     .get_dirs()
                     .iter()
-                    .find(|item| item.relative_path(picker) == path);
+                    .find(|item| !item.is_deleted() && item.relative_path(picker) == path);
                 if let Some(item) = item {
                     return Some(build_dir_record(item, picker, &base_path, span));
                 }
@@ -678,9 +682,13 @@ pub fn stream_dirs(
                 Err(err) => return Some(Value::error(err, span)),
             };
 
-            let item = picker.get_dirs().get(idx)?;
-            idx = idx.saturating_add(1);
-            Some(build_dir_record(item, picker, &base_path, span))
+            loop {
+                let item = picker.get_dirs().get(idx)?;
+                idx = idx.saturating_add(1);
+                if !item.is_deleted() {
+                    return Some(build_dir_record(item, picker, &base_path, span));
+                }
+            }
         }))
     };
 
@@ -800,7 +808,7 @@ pub fn stream_files(
                 let item = picker
                     .get_files()
                     .iter()
-                    .find(|item| item.relative_path(picker) == path);
+                    .find(|item| !item.is_deleted() && item.relative_path(picker) == path);
                 if let Some(item) = item {
                     return Some(build_file_record(item, picker, &base_path, span));
                 }
@@ -824,9 +832,13 @@ pub fn stream_files(
                 Err(err) => return Some(Value::error(err, span)),
             };
 
-            let item = picker.get_files().get(idx)?;
-            idx = idx.saturating_add(1);
-            Some(build_file_record(item, picker, &base_path, span))
+            loop {
+                let item = picker.get_files().get(idx)?;
+                idx = idx.saturating_add(1);
+                if !item.is_deleted() {
+                    return Some(build_file_record(item, picker, &base_path, span));
+                }
+            }
         }))
     };
 
@@ -1419,6 +1431,7 @@ pub fn store_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
     let files = picker
         .get_files()
         .iter()
+        .filter(|item| !item.is_deleted())
         .map(|item| IdxSnapshotFile {
             relative_path: item.relative_path(picker),
             full_path: item
@@ -1440,6 +1453,7 @@ pub fn store_snapshot(path: &Path, span: Span) -> Result<Value, ShellError> {
     let dirs = picker
         .get_dirs()
         .iter()
+        .filter(|item| !item.is_deleted())
         .map(|item| IdxSnapshotDir {
             relative_path: item.relative_path(picker),
             full_path: item
@@ -1686,7 +1700,7 @@ pub fn restore_snapshot(path: &Path, no_watch: bool, span: Span) -> Result<Value
 
     // Read all files from snapshot (offline restoration)
     let mut stmt = conn
-        .prepare("SELECT relative_path, full_path, file_name, directory, size, modified, access_frecency_score, modification_frecency_score, is_binary, is_deleted, is_overflow FROM files")
+        .prepare("SELECT relative_path, full_path, file_name, directory, size, modified, access_frecency_score, modification_frecency_score, is_binary, is_deleted, is_overflow FROM files WHERE NOT is_deleted")
         .map_err(|err| {
             ShellError::Generic(GenericError::new(
                 "idx snapshot file query failed",

--- a/crates/nu-command/tests/commands/idx.rs
+++ b/crates/nu-command/tests/commands/idx.rs
@@ -240,6 +240,104 @@ fn idx_export_and_import_roundtrip() -> Result {
 
 #[test]
 #[serial]
+fn idx_live_views_and_export_exclude_tombstones() -> Result {
+    Playground::setup(
+        "idx_live_views_and_export_exclude_tombstones",
+        |dirs, sandbox| {
+            sandbox.mkdir("removed-tree");
+            sandbox.with_files(&[EmptyFile("kept.txt"), EmptyFile("removed-tree/deleted.txt")]);
+
+            let mut tester = test().cwd(dirs.test());
+
+            // Wait through fuzzy queries (the watcher applies removals asynchronously)
+            let (): () = tester.run(
+                r#"
+                    idx init . --wait --no-content-indexing | ignore
+                    rm --recursive removed-tree
+                    mut attempts = 0
+                    loop {
+                        if (idx find deleted --files | is-empty) and (idx find removed-tree --dirs | is-empty) { break }
+                        if $attempts >= 100 { error make { msg: "idx watcher did not process deletion" } }
+                        $attempts += 1
+                        sleep 20ms
+                    }
+                "#,
+            )?;
+
+            // Unfiltered views/status should only show live entries.
+            tester
+                .run(
+                    r#"
+                        let files = idx files
+                        let dirs = idx dirs
+                        let status = idx status
+                        [
+                            (($files | where file_name == "deleted.txt") | is-empty)
+                            (($dirs | where relative_path =~ "removed-tree") | is-empty)
+                            ($status.files == ($files | length))
+                            ($status.dirs == ($dirs | length))
+                        ] | all {|value| $value }
+                    "#,
+                )
+                .expect_value_eq(true)?;
+
+            // Inspect the db directly, so import filtering can't hide bad exports.
+            tester
+                .run(
+                    r#"
+                        idx export snapshot.db | ignore
+                        let files = open snapshot.db | query db "SELECT file_name FROM files"
+                        let dirs = open snapshot.db | query db "SELECT relative_path FROM dirs"
+                        [
+                            (($files | where file_name == "deleted.txt") | is-empty)
+                            (($dirs | where relative_path =~ "removed-tree") | is-empty)
+                        ] | all {|value| $value }
+                    "#,
+                )
+                .expect_value_eq(true)
+        },
+    )
+}
+
+#[test]
+#[serial]
+fn idx_import_ignores_tombstoned_file_rows() -> Result {
+    Playground::setup(
+        "idx_import_ignores_tombstoned_file_rows",
+        |dirs, sandbox| {
+            sandbox.with_files(&[EmptyFile("legacy-deleted.txt")]);
+
+            let mut tester = test().cwd(dirs.test());
+
+            // Create a v1 snapshot, then simulate one written with a tombstoned file row.
+            let (): () = tester.run(
+                "idx init . --wait --no-content-indexing | ignore; idx export snapshot.db | ignore; idx drop | ignore",
+            )?;
+            let (): () = tester.run(
+                "open snapshot.db | query db \"UPDATE files SET is_deleted = TRUE WHERE file_name = 'legacy-deleted.txt'\" | ignore",
+            )?;
+
+            // Restored listing, search, and status should all treat the row as absent.
+            tester
+                .run(
+                    r#"
+                        idx import snapshot.db --no-watch | ignore
+                        let files = idx files
+                        let status = idx status
+                        [
+                            (($files | where file_name == "legacy-deleted.txt") | is-empty)
+                            (idx find legacy-deleted --files | is-empty)
+                            ($status.files == 0)
+                        ] | all {|value| $value }
+                    "#,
+                )
+                .expect_value_eq(true)
+        },
+    )
+}
+
+#[test]
+#[serial]
 fn idx_import_auto_initializes_runtime_for_queries() -> Result {
     Playground::setup(
         "idx_import_auto_initializes_runtime_for_queries",


### PR DESCRIPTION
## Description

The filesystem watcher kept deleted files and directories in the fff index as tombstones, but idx incorrectly exposed them as live entries, and snapshots could export or restore them.

The fix filters tombstones from live listings, exact query results, status counts, and snapshot export. Snapshot import also ignores tombstoned file rows so snapshots produced by affected versions do not restore deleted entries.

## User-facing changes (Release notes)

Fixed `idx` so deleted files and directories no longer appear as live index entries.

## Additional notes

Snapshot schema v1 remains unchanged. Import-side filtering preserves compatibility with existing snapshots that contain tombstoned file rows.