### PR TITLE
update some dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,7 +563,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2",
+ "sha2 0.10.9",
  "time",
  "tracing",
 ]
@@ -911,6 +911,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "chardetng"
-version = "0.1.17"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+checksum = "13de944a44b5064ee5d3a5ceccc49a41bfec50f2580e66f82e87703acdb88b53"
 dependencies = [
  "cfg-if",
  "encoding_rs",
@@ -1359,6 +1368,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,7 +1575,7 @@ dependencies = [
  "derive_more 2.1.1",
  "document-features",
  "filedescriptor",
- "mio 1.2.0",
+ "mio",
  "parking_lot",
  "rustix 1.1.4",
  "serde",
@@ -1592,6 +1607,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1854,9 +1878,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -2990,7 +3025,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3111,6 +3146,15 @@ name = "humantime"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3411,17 +3455,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "inotify"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
 ]
 
 [[package]]
@@ -4149,14 +4182,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "memchr"
-version = "2.8.0"
+name = "md-5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "mediatype"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120fa187be19d9962f0926633453784691731018a2bf936ddb4e29101b79c4a7"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -4240,18 +4289,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -4311,15 +4348,15 @@ dependencies = [
 
 [[package]]
 name = "multipart-rs"
-version = "0.1.13"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cae00e7e52aa5072342ef9a2ccd71669be913c2176a81a665b1f9cd79345f2"
+checksum = "df99820f865a1a6906bb5670cd149ee03094b2587ac883836590901080804442"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "mediatype",
  "memchr",
- "mime",
  "uuid",
 ]
 
@@ -4434,21 +4471,20 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.11.0",
- "crossbeam-channel",
- "filetime",
  "fsevent-sys",
- "inotify 0.9.6",
+ "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio",
+ "notify-types",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4458,11 +4494,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b44b771d4dd781ef14c84078693e67495da6b47f609f72e8a4da8420a861240e"
 dependencies = [
  "bitflags 2.11.0",
- "inotify 0.11.1",
+ "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 1.2.0",
+ "mio",
  "notify-types",
  "objc2-core-foundation",
  "objc2-core-services",
@@ -4473,14 +4509,14 @@ dependencies = [
 
 [[package]]
 name = "notify-debouncer-full"
-version = "0.3.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7fd166739789c9ff169e654dc1501373db9d80a4c3f972817c8a4d7cf8f34e"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
 dependencies = [
  "file-id",
  "log",
- "notify 6.1.1",
- "parking_lot",
+ "notify 8.2.0",
+ "notify-types",
  "walkdir",
 ]
 
@@ -4713,7 +4749,7 @@ dependencies = [
  "csv",
  "data-encoding",
  "devicons",
- "digest",
+ "digest 0.11.3",
  "dirs 6.0.0",
  "dns-lookup",
  "dtparse",
@@ -4733,7 +4769,7 @@ dependencies = [
  "kdl",
  "log",
  "lscolors",
- "md-5",
+ "md-5 0.11.0",
  "mime",
  "mime_guess",
  "mockito",
@@ -4791,7 +4827,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha2",
+ "sha2 0.11.0",
  "strum",
  "sysinfo 0.39.3",
  "tabled",
@@ -4849,7 +4885,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -5275,7 +5311,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -5694,7 +5730,7 @@ dependencies = [
  "humantime",
  "hyper",
  "itertools 0.14.0",
- "md-5",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.38.4",
@@ -6016,7 +6052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6721,7 +6757,7 @@ dependencies = [
  "recursive",
  "regex",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "slotmap",
  "strum_macros",
  "tokio",
@@ -8268,7 +8304,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -8285,7 +8321,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -8341,7 +8388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 1.2.0",
+ "mio",
  "signal-hook 0.3.18",
 ]
 
@@ -8749,6 +8796,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9086,7 +9144,7 @@ checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -9397,9 +9455,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
@@ -9794,14 +9852,14 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
- "md-5",
+ "md-5 0.10.6",
  "serde_core",
  "sha1_smol",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14668345710c92cb04181d9268407067689327d4b055273e3c4179a0777ee6a1"
+checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -4009,9 +4009,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-server"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad8be6fe0ca81b8298bfbbe8a77e9fcd8895ad6c84cd7794d5ebadcbb09ae43"
+checksum = "3ee25a31f2e571e426eef2896179450cafc7e2f5be00d8a93b1c2d21c0ff7656"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -7681,9 +7681,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64",
@@ -7712,9 +7712,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -8124,9 +8124,9 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.28"
+version = "0.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15e3bc297370dc9c526bcf0986f29167a9286cfaad404f2f572b3074dabe5ec"
+checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
@@ -9324,9 +9324,9 @@ dependencies = [
 
 [[package]]
 name = "trash"
-version = "5.2.5"
+version = "5.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b93a14fcf658568eb11b3ac4cb406822e916e2c55cdebc421beeb0bd7c94d8"
+checksum = "7602e0c7d66ec2d92a8c917219fbc7894039efa2063b9064260110828a356f46"
 dependencies = [
  "chrono",
  "libc",
@@ -9808,10 +9808,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "v_htmlescape"
-version = "0.15.8"
+name = "v_escape-base"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8257fbc510f0a46eb602c10215901938b5c2a7d5e70fc11483b1d3c9b5b18c"
+checksum = "f1212fce830b75af194b578e55b3db9049f2c8c45f58d397fb25602fdb50fb3d"
+
+[[package]]
+name = "v_htmlescape"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befb3d53c9e3ec641417685896cbc8cc5bd264d6a2e190c56aaef1af24740d99"
+dependencies = [
+ "v_escape-base",
+]
 
 [[package]]
 name = "valuable"
@@ -10216,9 +10225,9 @@ dependencies = [
 
 [[package]]
 name = "win_uds"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd30a1a28a3799479cbf4e17284a220ea9ff6bad098a9d0224543a5d1efe1da"
+checksum = "ff1222d47fad8fc0ce90a9d259c4b4b52995beeea984483323eacf56e113a074"
 dependencies = [
  "socket2 0.6.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ libproc = "0.14.11"
 log = "0.4"
 lru = "0.18.0"
 lscolors = { version = "0.21", default-features = false }
-lsp-server = "0.8.0"
+lsp-server = "0.10.0"
 lsp-types = { version = "0.97.0", features = ["proposed"] }
 lsp-textdocument = "0.5.0"
 linkme = "0.3.36"
@@ -248,7 +248,7 @@ rusqlite = "0.40.1"
 # Patch updates are allowed though.
 rustls = { version = "~0.23.38", default-features = false, features = ["std", "tls12"] }
 rustls-native-certs = "0.8"
-serde-saphyr = "0.0.28"
+serde-saphyr = "0.0.29"
 scopeguard = { version = "1.2.0" }
 ndarray = { version = "0.17", features = ["serde", "approx", "rayon", "matrixmultiply-threading"] }
 semver = "1.0"
@@ -269,7 +269,7 @@ tokio = { version = "1.52.1" }
 toml = "1.1.2"
 toml_edit = "0.25.11"
 kdl = "6.7.1"
-trash = "=5.2.5"
+trash = "=5.2.6"
 update-informer = { version = "1.3.0", default-features = false, features = ["github", "ureq"] }
 umask = "2.1"
 unicode-segmentation = "1.13"
@@ -285,13 +285,13 @@ uu_whoami = "0.9.0"
 uu_uname = "0.9.0"
 uucore = "0.9.0"
 uuid = "1.23.1"
-v_htmlescape = "0.15.8"
+v_htmlescape = "0.17.0"
 memchr = "2.8.0"
 wax = "0.7.0"
 web-time = "1.1.0"
 webpki-roots = "1.0.7"
 which = "8.0.2"
-win_uds = "=0.2.2"
+win_uds = "=0.2.4"
 windows = "0.62.2"
 windows-sys = "0.61.2"
 winnow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ bytes = "1"
 bytesize = "2.3.1"
 byteyarn = "0.5"
 calamine = "0.36"
-chardetng = "0.1.17"
+chardetng = "1.0.0"
 chrono = { default-features = false, version = "0.4.42" }
 chrono-humanize = "0.2.3"
 chrono-tz = "0.10"
@@ -156,7 +156,7 @@ ctrlc = "3.5"
 derive_more = "2.1.1"
 derive_setters = "0.1.9"
 devicons = "0.6.12"
-digest = { default-features = false, version = "0.10" }
+digest = { default-features = false, version = "0.11.3" }
 dirs = "6.0"
 dirs-sys = "0.5"
 dns-lookup = "3.0.1"
@@ -191,16 +191,16 @@ lsp-types = { version = "0.97.0", features = ["proposed"] }
 lsp-textdocument = "0.5.0"
 linkme = "0.3.36"
 mach2 = "0.6"
-md5 = { version = "0.10", package = "md-5" }
+md5 = { version = "0.11.0", package = "md-5" }
 miette = "7.6"
 mime = "0.3.17"
 mime_guess = "2.0"
 mq-markdown = "0.6.0"
 mockito = { version = "1.7.2", default-features = false }
-multipart-rs = "0.1.13"
+multipart-rs = "0.2.2"
 native-tls = "0.2.18"
 nix = { version = "0.31.3", default-features = false }
-notify-debouncer-full = { version = "0.3", default-features = false }
+notify-debouncer-full = { version = "0.7.0", default-features = false }
 nu-ansi-term = "0.50.3"
 nucleo-matcher = "0.3"
 num-format = "0.4"
@@ -255,11 +255,11 @@ semver = "1.0"
 serde = { version = "1.0" }
 serde_json = "1.0.149"
 serde_urlencoded = "0.7.1"
-sha2 = "0.10"
+sha2 = "0.11.0"
 strip-ansi-escapes = "0.2.1"
 strum = { version = "0.27.0", features = ["derive"] }
 strum_macros = "0.27.0"
-syn = "2.0.117"
+syn = "3.0.2"
 sysinfo = "0.39.3"
 tabled = { version = "0.21", default-features = false }
 tempfile = "3.27"

--- a/crates/nu-cmd-extra/src/extra/formats/to/html/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html/mod.rs
@@ -325,7 +325,7 @@ fn html_table(table: Vec<Value>, headers: Vec<String>, raw: bool, config: &Confi
     output_string.push_str("<thead><tr>");
     for header in &headers {
         output_string.push_str("<th>");
-        output_string.push_str(&v_htmlescape::escape(header).to_string());
+        output_string.push_str(&v_htmlescape::escape_fmt(header).to_string());
         output_string.push_str("</th>");
     }
     output_string.push_str("</tr></thead><tbody>");
@@ -370,7 +370,7 @@ fn html_value(value: Value, raw: bool, config: &Config) -> String {
                 )
             } else {
                 output_string.push_str(
-                    &v_htmlescape::escape(&other.to_abbreviated_string(config))
+                    &v_htmlescape::escape_fmt(&other.to_abbreviated_string(config))
                         .to_string()
                         .replace('\n', "<br>"),
                 )

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -1,8 +1,8 @@
 use itertools::Either;
 use notify_debouncer_full::{
-    DebouncedEvent, Debouncer, FileIdMap, new_debouncer,
+    DebouncedEvent, Debouncer, new_debouncer,
     notify::{
-        self, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+        Event, EventKind, RecommendedWatcher, RecursiveMode,
         event::{DataChange, ModifyKind, RenameMode},
     },
 };
@@ -196,21 +196,24 @@ impl Command for Watch {
         let iter = {
             let (tx, rx) = channel();
 
-            let mut debouncer = new_debouncer(debounce_duration, None, tx)
-                .and_then(|mut debouncer| {
-                    debouncer.watcher().watch(&path, recursive_mode)?;
-                    Ok(debouncer)
-                })
-                .map_err(|err| {
-                    ShellError::Generic(GenericError::new(
-                        "Failed to create watcher",
-                        err.to_string(),
-                        call.head,
-                    ))
-                })?;
+            let mut debouncer = new_debouncer(debounce_duration, None, move |result| {
+                let _ = tx.send(result);
+            })
+            .map_err(|err| {
+                ShellError::Generic(GenericError::new(
+                    "Failed to create watcher",
+                    err.to_string(),
+                    call.head,
+                ))
+            })?;
 
-            // need to cache to make sure that rename event works.
-            debouncer.cache().add_root(&path, recursive_mode);
+            debouncer.watch(&path, recursive_mode).map_err(|err| {
+                ShellError::Generic(GenericError::new(
+                    "Failed to create watcher",
+                    err.to_string(),
+                    call.head,
+                ))
+            })?;
 
             WatchIterator::new(debouncer, rx, engine_state.signals().clone())
         };
@@ -395,7 +398,7 @@ impl TryFrom<DebouncedEvent> for WatchEvent {
     fn try_from(ev: DebouncedEvent) -> Result<Self, Self::Error> {
         // TODO: Maybe we should handle all event kinds?
         let DebouncedEvent {
-            event: notify::Event {
+            event: Event {
                 kind, mut paths, ..
             },
             ..
@@ -425,15 +428,15 @@ impl TryFrom<DebouncedEvent> for WatchEvent {
 
 struct WatchIterator {
     /// Debouncer needs to be kept alive for `rx` to keep receiving events.
-    _debouncer: Debouncer<RecommendedWatcher, FileIdMap>,
-    rx: Option<Receiver<Result<Vec<DebouncedEvent>, Vec<notify::Error>>>>,
+    _debouncer: Debouncer<RecommendedWatcher, notify_debouncer_full::RecommendedCache>,
+    rx: Option<Receiver<notify_debouncer_full::DebounceEventResult>>,
     signals: Signals,
 }
 
 impl WatchIterator {
     fn new(
-        debouncer: Debouncer<RecommendedWatcher, FileIdMap>,
-        rx: Receiver<Result<Vec<DebouncedEvent>, Vec<notify::Error>>>,
+        debouncer: Debouncer<RecommendedWatcher, notify_debouncer_full::RecommendedCache>,
+        rx: Receiver<notify_debouncer_full::DebounceEventResult>,
         signals: Signals,
     ) -> Self {
         Self {

--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -390,7 +390,7 @@ fn escape_markdown_characters(input: String, escape_md: bool, for_table: bool) -
 fn escape_value(value: String, escape_md: bool, escape_html: bool, for_table: bool) -> String {
     escape_markdown_characters(
         if escape_html {
-            v_htmlescape::escape(&value).to_string()
+            v_htmlescape::escape_fmt(&value).to_string()
         } else {
             value
         },
@@ -452,7 +452,7 @@ fn collect_headers(headers: &[String], escape_md: bool) -> (Vec<String>, Vec<usi
     if !headers.is_empty() && (headers.len() > 1 || !headers[0].is_empty()) {
         for header in headers {
             let escaped_header_string = escape_markdown_characters(
-                v_htmlescape::escape(header).to_string(),
+                v_htmlescape::escape_fmt(header).to_string(),
                 escape_md,
                 true,
             );
@@ -515,7 +515,7 @@ fn table(
                         .to_expanded_string(", ", config);
                     let escaped_string = escape_markdown_characters(
                         if escape_html {
-                            v_htmlescape::escape(&value_string).to_string()
+                            v_htmlescape::escape_fmt(&value_string).to_string()
                         } else {
                             value_string
                         },
@@ -536,7 +536,7 @@ fn table(
             }
             p => {
                 let value_string =
-                    v_htmlescape::escape(&p.to_abbreviated_string(config)).to_string();
+                    v_htmlescape::escape_fmt(&p.to_abbreviated_string(config)).to_string();
                 escaped_row.push(value_string);
             }
         }

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -1,6 +1,6 @@
 use nu_cmd_base::input_handler::{CmdArgument, operate};
 use nu_engine::command_prelude::*;
-use std::{io::Write, marker::PhantomData};
+use std::{fmt::Write, marker::PhantomData};
 
 pub trait HashDigest: digest::Digest + Clone {
     fn name() -> &'static str;
@@ -35,10 +35,17 @@ impl CmdArgument for Arguments {
     }
 }
 
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
 impl<D> Command for GenericDigest<D>
 where
-    D: HashDigest + Write + Send + Sync + 'static,
-    digest::Output<D>: core::fmt::LowerHex,
+    D: HashDigest + Send + Sync + 'static,
 {
     fn name(&self) -> &str {
         &self.name
@@ -85,15 +92,17 @@ where
         let binary = call.has_flag(engine_state, stack, "binary")?;
         let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
-        let mut hasher = D::new();
 
         if let PipelineData::ByteStream(stream, ..) = input {
-            stream.write_to(&mut hasher)?;
-            let digest = hasher.finalize();
+            let bytes = stream.into_bytes()?;
+            let digest = D::digest(&bytes);
             if binary {
-                Ok(Value::binary(digest.to_vec(), head).into_pipeline_data())
+                Ok(
+                    Value::binary(<[u8]>::to_vec(AsRef::<[u8]>::as_ref(&digest)), head)
+                        .into_pipeline_data(),
+                )
             } else {
-                Ok(Value::string(format!("{digest:x}"), head).into_pipeline_data())
+                Ok(Value::string(hex_encode(digest.as_ref()), head).into_pipeline_data())
             }
         } else {
             let args = Arguments { binary, cell_paths };
@@ -105,7 +114,6 @@ where
 pub(super) fn action<D>(input: &Value, args: &Arguments, _span: Span) -> Value
 where
     D: HashDigest,
-    digest::Output<D>: core::fmt::LowerHex,
 {
     let span = input.span();
     let (bytes, span) = match input {
@@ -131,8 +139,8 @@ where
     let digest = D::digest(bytes);
 
     if args.binary {
-        Value::binary(digest.to_vec(), span)
+        Value::binary(<[u8]>::to_vec(AsRef::<[u8]>::as_ref(&digest)), span)
     } else {
-        Value::string(format!("{digest:x}"), span)
+        Value::string(hex_encode(AsRef::<[u8]>::as_ref(&digest)), span)
     }
 }

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -664,7 +664,7 @@ fn send_multipart_request(
                         .map_err(err)?;
                 }
             }
-            builder.finish();
+            builder.finish().map_err(err)?;
 
             let (boundary, data) = (builder.boundary, builder.data);
             let content_type = format!("multipart/form-data; boundary={boundary}");

--- a/crates/nu-command/src/strings/encode_decode/encoding.rs
+++ b/crates/nu-command/src/strings/encode_decode/encoding.rs
@@ -4,22 +4,14 @@ use nu_protocol::shell_error::generic::GenericError;
 use nu_protocol::{ShellError, Span, Spanned, Value};
 
 pub fn detect_encoding_name(
-    head: Span,
-    input: Span,
+    _head: Span,
+    _input: Span,
     bytes: &[u8],
 ) -> Result<&'static Encoding, ShellError> {
-    let mut detector = EncodingDetector::new();
+    let mut detector = EncodingDetector::new(chardetng::Iso2022JpDetection::Deny);
     let _non_ascii = detector.feed(bytes, false);
     //Guess(TLD=None(usually used in HTML), Allow_UTF8=True)
-    let (encoding, is_certain) = detector.guess_assess(None, true);
-    if !is_certain {
-        return Err(ShellError::UnsupportedInput {
-            msg: "Input contains unknown encoding, try giving a encoding name".into(),
-            input: "value originates from here".into(),
-            msg_span: head,
-            input_span: input,
-        });
-    }
+    let encoding = detector.guess(None, chardetng::Utf8Detection::Allow);
     Ok(encoding)
 }
 

--- a/crates/nu-heavy-utils/src/yaml/parse.rs
+++ b/crates/nu-heavy-utils/src/yaml/parse.rs
@@ -168,7 +168,7 @@ pub fn parse(yaml: Spanned<&str>, span: Span, options: ParseOptions) -> Result<V
     let mut documents = Vec::new();
     loop {
         match ctx.next_event()? {
-            Event::DocumentStart(_) => documents.push(parse_document(ctx)?),
+            Event::DocumentStart(..) => documents.push(parse_document(ctx)?),
             Event::StreamEnd => break,
             Event::Nothing | Event::Comment(..) => continue,
             event => return Err(ctx.unexpected_event(event).into()),

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -432,18 +432,14 @@ impl LanguageServer {
         match serde_json::from_value::<P>(req.params) {
             Ok(params) => Response {
                 id: req.id,
-                result: Some(
-                    param_handler(&params)
-                        .and_then(|response| serde_json::to_value(response).ok())
-                        .unwrap_or(serde_json::Value::Null),
-                ),
-                error: None,
+                response_result: Ok(param_handler(&params)
+                    .and_then(|response| serde_json::to_value(response).ok())
+                    .unwrap_or(serde_json::Value::Null)),
             },
 
             Err(err) => Response {
                 id: req.id,
-                result: None,
-                error: Some(ResponseError {
+                response_result: Err(ResponseError {
                     code: 1,
                     message: err.to_string(),
                     data: None,
@@ -661,7 +657,9 @@ mod tests {
 
     pub(crate) fn result_from_message(message: lsp_server::Message) -> serde_json::Value {
         match message {
-            Message::Response(Response { result, .. }) => result.expect("Empty result!"),
+            Message::Response(Response {
+                response_result, ..
+            }) => response_result.expect("Empty result!"),
             _ => panic!("Unexpected message type!"),
         }
     }

--- a/crates/nu-lsp/src/notification.rs
+++ b/crates/nu-lsp/src/notification.rs
@@ -133,8 +133,7 @@ impl LanguageServer {
             .sender
             .send(lsp_server::Message::Response(lsp_server::Response {
                 id,
-                result: None,
-                error: Some(lsp_server::ResponseError {
+                response_result: Err(lsp_server::ResponseError {
                     code,
                     message,
                     data: None,

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -304,8 +304,13 @@ impl LanguageServer {
             .sender
             .send(lsp_server::Message::Response(lsp_server::Response {
                 id: request.id,
-                result: serde_json::to_value(response).ok(),
-                error: None,
+                response_result: serde_json::to_value(response).map_err(|e| {
+                    lsp_server::ResponseError {
+                        code: 0,
+                        message: e.to_string(),
+                        data: None,
+                    }
+                }),
             }))
             .into_diagnostic()?;
 
@@ -851,7 +856,7 @@ mod tests {
                 Message::Notification(n) => assert_eq!(n.method, Progress::METHOD),
                 Message::Response(r) => {
                     has_response = true;
-                    let result = r.result.unwrap();
+                    let result = r.response_result.unwrap();
                     let array = result.as_array().unwrap();
 
                     for expected_ref in &expected_refs {
@@ -940,7 +945,7 @@ mod tests {
                 Message::Notification(n) => assert_eq!(n.method, Progress::METHOD),
                 Message::Response(r) => {
                     has_response = true;
-                    assert_json_eq!(r.result, expected_prepare)
+                    assert_json_eq!(r.response_result.unwrap(), expected_prepare)
                 }
                 _ => panic!("unexpected message type"),
             }
@@ -951,7 +956,7 @@ mod tests {
         if let Message::Response(r) =
             send_rename_request(&client_connection, script.clone(), rename_line, rename_char)
         {
-            let changes = r.result.unwrap()["changes"].clone();
+            let changes = r.response_result.unwrap()["changes"].clone();
 
             for (file_suffix, expected_file_changes) in expected_changes {
                 let file_uri = if file_suffix == main_file.strip_suffix(".nu").unwrap() {
@@ -1027,7 +1032,7 @@ mod tests {
                 Message::Response(r) => {
                     has_response = true;
                     assert_json_eq!(
-                        r.result,
+                        r.response_result.unwrap(),
                         serde_json::json!({
                                 "contents": {
                                 "kind": "markdown",
@@ -1043,7 +1048,7 @@ mod tests {
 
         if let Message::Response(r) = send_rename_request(&client_connection, script, 6, 11) {
             // should not return any changes
-            assert_json_eq!(r.result.unwrap()["changes"], serde_json::json!({}));
+            assert_json_eq!(r.response_result.unwrap()["changes"], serde_json::json!({}));
         } else {
             panic!()
         }
@@ -1130,6 +1135,6 @@ mod tests {
         let Message::Response(r) = message else {
             panic!("unexpected message type");
         };
-        assert_json_eq!(r.result, expected);
+        assert_json_eq!(r.response_result.unwrap(), expected);
     }
 }

--- a/crates/nu-mcp/Cargo.toml
+++ b/crates/nu-mcp/Cargo.toml
@@ -21,7 +21,7 @@ nu-json = { workspace = true, features = ["nu-protocol", "preserve_order"] }
 nu-parser.workspace = true
 nuon.workspace = true
 
-rmcp = { version = "1.7.0", features = ["server", "transport-io", "schemars", "transport-streamable-http-server"] }
+rmcp = { version = "2.2.0", features = ["server", "transport-io", "schemars", "transport-streamable-http-server"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "service"] }
 schemars = "1.2.1"
 serde = { workspace = true, features = ["derive"] }

--- a/crates/nu-mcp/src/evaluation.rs
+++ b/crates/nu-mcp/src/evaluation.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
     debugger::WithoutDebug,
     engine::{EngineState, Job, Jobs, Mail, Stack, StateWorkingSet, ThreadJob},
 };
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 use serde_json::{Value as JsonValue, json};
 use std::{
     fmt::Write,
@@ -495,7 +495,7 @@ impl EvalOutput {
 }
 
 fn call_tool_result(text: String, structured_content: JsonValue, is_error: bool) -> CallToolResult {
-    let mut result = CallToolResult::success(vec![Content::text(text)]);
+    let mut result = CallToolResult::success(vec![ContentBlock::text(text)]);
     result.is_error = Some(is_error);
     result.structured_content = Some(structured_content);
     result


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR updates some dependencies. Some had api changes, others were just easy bumps, and yet others weren't able to be upgraded yet.

### Dependency Upgrades

| Dependency | From | To | Notes |
|---|---|---|---|
| `chardetng` | 0.1.17 | 1.0.0 | `new()` takes `Iso2022JpDetection` arg; `guess_assess()` → `guess()` |
| `digest` | 0.10 | 0.11.3 | `Output<D>` no longer `LowerHex`; hash types no longer implement `Write` |
| `lsp-server` | 0.8.0 | 0.10.0 | `Response` fields `result`/`error` merged into `response_result: Result<...>` |
| `md-5` | 0.10 | 0.11.0 | Same `digest` v0.11 API changes as `sha2` |
| `multipart-rs` | 0.1.13 | 0.2.2 | `add()` takes `impl Read`; `finish()` returns `io::Result` |
| `notify-debouncer-full` | 0.3 | 0.7.0 | `.watcher().watch()` → `.watch()`; `.cache().add_root()` removed; `new_debouncer` takes closure |
| `rmcp` | 1.7.0 | 2.2.0 | `Content` renamed to `ContentBlock` |
| `serde-saphyr` | 0.0.28 | 0.0.29 | Transitive `granit-parser` `DocumentStart` gained a second field |
| `sha2` | 0.10 | 0.11.0 | `digest` v0.11 API — no more `Write` impl, use `Update` trait |
| `syn` | 2.0.117 | 3.0.2 | No code changes needed |
| `trash` | =5.2.5 | =5.2.6 | No code changes needed |
| `v_htmlescape` | 0.15.8 | 0.17.0 | `escape()` → `escape_fmt()` |
| `win_uds` | =0.2.2 | =0.2.4 | No code changes needed |

## Not upgraded

| Dependency | Reason |
|---|---|
| `strum` 0.28.0 | Blocked by `reedline` and `ratatui-core` still on 0.27.x |
| `generic-array` 0.14.9 | Locked to 0.14.7 by `crypto-common` v0.1.7 (used by `digest` v0.10, kept for `object_store`) |
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->