### PR TITLE
fix: don't tint unstyled prompts with default colors

### DIFF
--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -1,8 +1,9 @@
 #[cfg(windows)]
 use nu_utils::enable_vt_processing;
 use reedline::{
-    DefaultPrompt, Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus,
-    PromptViMode,
+    Color, DEFAULT_INDICATOR_COLOR, DEFAULT_PROMPT_COLOR, DEFAULT_PROMPT_MULTILINE_COLOR,
+    DEFAULT_PROMPT_RIGHT_COLOR, DefaultPrompt, Prompt, PromptEditMode, PromptHistorySearch,
+    PromptHistorySearchStatus, PromptViMode,
 };
 use std::borrow::Cow;
 
@@ -154,6 +155,37 @@ impl Prompt for NushellPrompt {
             "({}reverse-search: {})",
             prefix, history_search.term
         ))
+    }
+
+    // The left and right prompt keep the terminal foreground when the user
+    // supplies them, so their own styling (e.g. starship) isn't tinted, while
+    // the built-in fallback keeps nushell's default color.
+    fn get_prompt_color(&self) -> Color {
+        if self.left_prompt.is_some() {
+            Color::Default
+        } else {
+            DEFAULT_PROMPT_COLOR
+        }
+    }
+
+    // The indicators are nushell's own rather than the user's prompt generator,
+    // thus they always keep the default color. Styling one means putting the
+    // escapes in the indicator value. These override the trait defaults on
+    // purpose, so nushell's appearance doesn't follow reedline's.
+    fn get_prompt_multiline_color(&self) -> Color {
+        DEFAULT_PROMPT_MULTILINE_COLOR
+    }
+
+    fn get_indicator_color(&self) -> Color {
+        DEFAULT_INDICATOR_COLOR
+    }
+
+    fn get_prompt_right_color(&self) -> Color {
+        if self.right_prompt.is_some() {
+            Color::Default
+        } else {
+            DEFAULT_PROMPT_RIGHT_COLOR
+        }
     }
 
     fn right_prompt_on_last_line(&self) -> bool {


### PR DESCRIPTION
NushellPrompt forced nushells default foregrounds on every prompt piece, so an unstyled custom prompt, like starship `syle = none`, inherited them instead of the terminal foreground. Now we return `Color::reset` for any user-supplied piece.

Fixes #16384

<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->