### PR TITLE
fix: date floor/ceil rounding for durations >= 1day

### DIFF
--- a/crates/nu-std/std-rfc/date/mod.nu
+++ b/crates/nu-std/std-rfc/date/mod.nu
@@ -13,6 +13,14 @@ def assert-duration-positive [value: duration metadata: record]: nothing -> dura
     }
 }
 
+def replace-timezone [tz: string]: datetime -> datetime {
+	into record | upsert timezone $tz | into datetime
+}
+
+def extract-offset []: datetime -> duration {
+	($in | replace-timezone "+00:00") - $in
+}
+
 # Round to the nearest specified datetime boundary before the input date.
 @category date
 @example "Round date up to nearest hour" "2026-07-15T12:11:10-04:00 | date floor 1hr" --result 2026-07-15T12:00:00-04:00
@@ -26,10 +34,11 @@ export def "date floor" [
 
     let input_nanos = $input | into int
     let timezone: string = ($input | into record).timezone
+    let offset_nanos = $input | extract-offset | into int
 
     let period_nanos = $period | into int
 
-    $input_nanos - ($input_nanos mod $period_nanos)
+    $input_nanos - (($input_nanos + $offset_nanos) mod $period_nanos)
     | into datetime
     | date to-timezone $timezone
 }

--- a/crates/nu-std/tests/test_std-rfc_date.nu
+++ b/crates/nu-std/tests/test_std-rfc_date.nu
@@ -12,6 +12,24 @@ def date_floor [] {
 }
 
 @test
+def date_floor_day_duration [] {
+    (
+        assert equal
+        (2026-07-15T12:11:10-04:00 | date floor 1day)
+        (2026-07-15T00:00:00-04:00)
+    )
+}
+
+@test
+def date_floor_fractional_timezone [] {
+    (
+        assert equal
+        (2026-07-15T12:11:10-04:30 | date floor 1day)
+        (2026-07-15T00:00:00-04:30)
+    )
+}
+
+@test
 def date_floor_before_epoch [] {
     (
         assert equal
@@ -26,6 +44,25 @@ def date_ceil [] {
         assert equal
         (2026-07-15T12:11:10-04:00 | date ceil 1hr)
         (2026-07-15T13:00:00-04:00)
+    )
+}
+
+
+@test
+def date_ceil_day_duration [] {
+    (
+        assert equal
+        (2026-07-15T12:11:10-04:00 | date ceil 1day)
+        (2026-07-16T00:00:00-04:00)
+    )
+}
+
+@test
+def date_ceil_fractional_timezone [] {
+    (
+        assert equal
+        (2026-07-15T12:11:10-04:30 | date ceil 1day)
+        (2026-07-16T00:00:00-04:30)
     )
 }
 


### PR DESCRIPTION
## Description

This PR fixes an error in #18640 where dates were being rounded to the UTC boundary rather than the boundaries of the input timezone.

```
# Erroneous
> 2026-07-15T12:00:00-04:00 | date floor 1day
Tue, 14 Jul 2026 20:00:00 -0400

# Corrected
Tue, 15 Jul 2026 00:00:00 -0400
```

Tests were added to cover cases where timezones are both whole and fractional hour offsets.

## User-facing changes (Release notes)

N/A