### PR TITLE
Pass Stack to the IR debugger instruction callbacks

### DIFF
--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -252,12 +252,13 @@ fn eval_ir_block_impl<D: DebugContext>(
         let span = &ir_block.spans[pc];
         let ast = &ir_block.ast[pc];
 
-        D::enter_instruction(ctx.engine_state, ir_block, pc, ctx.registers);
+        D::enter_instruction(ctx.engine_state, ctx.stack, ir_block, pc, ctx.registers);
 
         let result = eval_instruction::<D>(ctx, instruction, span, ast, need_backtrace);
 
         D::leave_instruction(
             ctx.engine_state,
+            ctx.stack,
             ir_block,
             pc,
             ctx.registers,

--- a/crates/nu-protocol/src/debugger/debugger_trait.rs
+++ b/crates/nu-protocol/src/debugger/debugger_trait.rs
@@ -16,7 +16,7 @@
 use crate::{
     PipelineData, PipelineExecutionData, ShellError, Span, Value,
     ast::{Block, PipelineElement},
-    engine::EngineState,
+    engine::{EngineState, Stack},
     ir::IrBlock,
 };
 use std::{fmt::Debug, ops::DerefMut};
@@ -53,6 +53,7 @@ pub trait DebugContext: Clone + Copy + Debug {
     #[allow(unused_variables)]
     fn enter_instruction(
         engine_state: &EngineState,
+        stack: &Stack,
         ir_block: &IrBlock,
         instruction_index: usize,
         registers: &[PipelineExecutionData],
@@ -63,6 +64,7 @@ pub trait DebugContext: Clone + Copy + Debug {
     #[allow(unused_variables)]
     fn leave_instruction(
         engine_state: &EngineState,
+        stack: &Stack,
         ir_block: &IrBlock,
         instruction_index: usize,
         registers: &[PipelineExecutionData],
@@ -110,6 +112,7 @@ impl DebugContext for WithDebug {
 
     fn enter_instruction(
         engine_state: &EngineState,
+        stack: &Stack,
         ir_block: &IrBlock,
         instruction_index: usize,
         registers: &[PipelineExecutionData],
@@ -117,6 +120,7 @@ impl DebugContext for WithDebug {
         if let Ok(mut debugger) = engine_state.debugger.lock() {
             debugger.deref_mut().enter_instruction(
                 engine_state,
+                stack,
                 ir_block,
                 instruction_index,
                 registers,
@@ -126,6 +130,7 @@ impl DebugContext for WithDebug {
 
     fn leave_instruction(
         engine_state: &EngineState,
+        stack: &Stack,
         ir_block: &IrBlock,
         instruction_index: usize,
         registers: &[PipelineExecutionData],
@@ -134,6 +139,7 @@ impl DebugContext for WithDebug {
         if let Ok(mut debugger) = engine_state.debugger.lock() {
             debugger.deref_mut().leave_instruction(
                 engine_state,
+                stack,
                 ir_block,
                 instruction_index,
                 registers,
@@ -188,22 +194,29 @@ pub trait Debugger: Send + Debug {
     ) {
     }
 
-    /// Called before the IR evaluator runs an instruction
+    /// Called before the IR evaluator runs an instruction.
+    ///
+    /// `stack` is the live evaluation stack, so a debugger can read variable
+    /// values directly instead of reconstructing them from instructions.
     #[allow(unused_variables)]
     fn enter_instruction(
         &mut self,
         engine_state: &EngineState,
+        stack: &Stack,
         ir_block: &IrBlock,
         instruction_index: usize,
         registers: &[PipelineExecutionData],
     ) {
     }
 
-    /// Called after the IR evaluator runs an instruction
+    /// Called after the IR evaluator runs an instruction.
+    ///
+    /// `stack` is the live evaluation stack (see [`Debugger::enter_instruction`]).
     #[allow(unused_variables)]
     fn leave_instruction(
         &mut self,
         engine_state: &EngineState,
+        stack: &Stack,
         ir_block: &IrBlock,
         instruction_index: usize,
         registers: &[PipelineExecutionData],

--- a/crates/nu-protocol/src/debugger/profiler.rs
+++ b/crates/nu-protocol/src/debugger/profiler.rs
@@ -7,7 +7,7 @@ use crate::{
     PipelineData, PipelineExecutionData, ShellError, Span, Value,
     ast::{Block, Expr, PipelineElement},
     debugger::Debugger,
-    engine::EngineState,
+    engine::{EngineState, Stack},
     ir::IrBlock,
     record,
     shell_error::generic::GenericError,
@@ -207,6 +207,7 @@ impl Debugger for Profiler {
     fn enter_instruction(
         &mut self,
         engine_state: &EngineState,
+        _stack: &Stack,
         ir_block: &IrBlock,
         instruction_index: usize,
         _registers: &[PipelineExecutionData],
@@ -251,6 +252,7 @@ impl Debugger for Profiler {
     fn leave_instruction(
         &mut self,
         _engine_state: &EngineState,
+        _stack: &Stack,
         ir_block: &IrBlock,
         instruction_index: usize,
         registers: &[PipelineExecutionData],


### PR DESCRIPTION
## Description

The IR instruction-level `Debugger` callbacks (`enter_instruction` / `leave_instruction`) receive `&EngineState`, the `IrBlock`, the instruction index, and the registers, but not the `Stack`. That leaves an external debugger unable to read variable values directly; it has to reconstruct them by shadow-tracking `store-variable`, `push-positional`, and `push-flag` instructions, which misses closure parameters and values held only on the stack.

The `Stack` is already in scope at the call site in `eval_ir_block_impl` (`ctx.stack`), so this threads a read-only `&Stack` through `enter_instruction` and `leave_instruction` on both `Debugger` and `DebugContext`, plus the `WithDebug` forwarder. `WithoutDebug` still optimizes away; the only in-tree implementor, `Profiler`, ignores the new argument.

## User-facing changes (Release notes)

n/a

## Additional notes

Discussed with @fdncred in #design-discussions. Context: the author built a DAP-based Nushell debugger for VS Code ([dreamcode.nu-dap-vscode](https://marketplace.visualstudio.com/items?itemName=dreamcode.nu-dap-vscode)); this lets it drop its shadow-tracking layer and read real locals.

Testing reported by the author:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` verified on the touched crates
- `cargo test --workspace`; no new tests because this is a pure signature addition, and existing `Profiler` coverage exercises the callback path