### PR TITLE
add more consistency with null types

### DIFF
--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -1,6 +1,8 @@
 use indexmap::IndexMap;
 use nu_engine::{ClosureEval, command_prelude::*};
-use nu_protocol::{FromValue, IntoValue, engine::Closure, shell_error::generic::GenericError};
+use nu_protocol::{
+    FromValue, ast::PathMember, engine::Closure, shell_error::generic::GenericError,
+};
 
 #[derive(Clone)]
 pub struct GroupBy;
@@ -44,7 +46,8 @@ impl Command for GroupBy {
     - if the input data is not a string, the grouper will convert the key to string but the values will remain in their original format. e.g. with bools, "true" and true would be in the same group (see example).
     - datetime is formatted based on your configuration setting. use `format date` to change the format.
     - filesize is formatted based on your configuration setting. use `format filesize` to change the format.
-    - some nushell values are not supported, such as closures."#
+    - some nushell values are not supported, such as closures.
+    - null group keys are never mapped to the empty string. The default record output omits null groups (records cannot use null as a key); use --to-table to include them as null values. Optional cell paths (e.g. `foo?`) still ignore rows where access yields null."#
     }
 
     fn run(
@@ -358,22 +361,57 @@ fn groupers_to_column_names(groupers: &[Spanned<Grouper>]) -> Result<Vec<String>
     Ok(column_names)
 }
 
+/// Internal group key. `Nothing` is distinct from the empty string so null and `""`
+/// do not collapse. Record output omits `Nothing` keys; `--to-table` emits them as null.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum GroupKey {
+    Nothing,
+    String(String),
+}
+
+impl GroupKey {
+    fn from_value(value: &Value, config: &nu_protocol::Config) -> Self {
+        if value.is_nothing() {
+            Self::Nothing
+        } else {
+            Self::String(value.to_expanded_string(", ", config))
+        }
+    }
+
+    fn into_value(self, span: Span) -> Value {
+        match self {
+            Self::Nothing => Value::nothing(span),
+            Self::String(s) => Value::string(s, span),
+        }
+    }
+}
+
+fn path_has_optional_member(column_name: &CellPath) -> bool {
+    column_name.members.iter().any(|member| match member {
+        PathMember::String { optional, .. } => *optional,
+        PathMember::Int { optional, .. } => *optional,
+    })
+}
+
 fn group_cell_path(
     column_name: &CellPath,
     prune: bool,
     values: Vec<Value>,
     config: &nu_protocol::Config,
-) -> Result<IndexMap<String, Vec<Value>>, ShellError> {
+) -> Result<IndexMap<GroupKey, Vec<Value>>, ShellError> {
     let mut groups = IndexMap::<_, Vec<_>>::new();
+    let optional_path = path_has_optional_member(column_name);
 
     for mut value in values.into_iter() {
-        let key = value.follow_cell_path(&column_name.members)?;
+        let key_val = value.follow_cell_path(&column_name.members)?;
 
-        if key.is_nothing() {
-            continue; // likely the result of a failed optional access, ignore this value
+        // Optional cell paths (`col?`) drop rows when access yields nothing (missing
+        // column or explicit null). Required paths keep null as a distinct group key.
+        if key_val.is_nothing() && optional_path {
+            continue;
         }
 
-        let key = key.to_expanded_string(", ", config);
+        let key = GroupKey::from_value(key_val.as_ref(), config);
 
         if prune {
             // it's okay if this fails since pruning is best-effort
@@ -402,16 +440,14 @@ fn group_closure(
     closure: Closure,
     engine_state: &EngineState,
     stack: &mut Stack,
-) -> Result<IndexMap<String, Vec<Value>>, ShellError> {
+) -> Result<IndexMap<GroupKey, Vec<Value>>, ShellError> {
     let mut groups = IndexMap::<_, Vec<_>>::new();
     let mut closure = ClosureEval::new(engine_state, stack, closure);
     let config = &stack.get_config(engine_state);
 
     for value in values {
-        let key = closure
-            .run_with_value(value.clone())?
-            .into_value(span)?
-            .to_expanded_string(", ", config);
+        let key_val = closure.run_with_value(value.clone())?.into_value(span)?;
+        let key = GroupKey::from_value(&key_val, config);
 
         groups.entry(key).or_default().push(value);
     }
@@ -442,8 +478,8 @@ struct Grouped {
 }
 
 enum Tree {
-    Leaf(IndexMap<String, Vec<Value>>),
-    Branch(IndexMap<String, Grouped>),
+    Leaf(IndexMap<GroupKey, Vec<Value>>),
+    Branch(IndexMap<GroupKey, Grouped>),
 }
 
 impl Grouped {
@@ -451,7 +487,7 @@ impl Grouped {
         let mut groups = IndexMap::<_, Vec<_>>::new();
 
         for value in values.into_iter() {
-            let key = value.to_expanded_string(", ", config);
+            let key = GroupKey::from_value(&value, config);
             groups.entry(key).or_default().push(value);
         }
 
@@ -530,14 +566,15 @@ impl Grouped {
         match self.groups {
             Tree::Leaf(leaf) => leaf
                 .into_iter()
-                .map(|(group, values)| vec![(values.into_value(head)), (group.into_value(head))])
+                .map(|(group, values)| vec![values.into_value(head), group.into_value(head)])
                 .collect::<Vec<Vec<Value>>>(),
             Tree::Branch(branch) => branch
                 .into_iter()
                 .flat_map(|(group, items)| {
+                    let group_val = group.into_value(head);
                     let mut inner = items._into_table(head);
                     for row in &mut inner {
-                        row.push(group.clone().into_value(head));
+                        row.push(group_val.clone());
                     }
                     inner
                 })
@@ -549,14 +586,22 @@ impl Grouped {
         match self.groups {
             Tree::Leaf(leaf) => Value::record(
                 leaf.into_iter()
-                    .map(|(k, v)| (k, v.into_value(head)))
+                    // Records cannot use null as a key; omit null groups rather than
+                    // mapping them to the empty string (which collides with "").
+                    .filter_map(|(k, v)| match k {
+                        GroupKey::String(key) => Some((key, v.into_value(head))),
+                        GroupKey::Nothing => None,
+                    })
                     .collect(),
                 head,
             ),
             Tree::Branch(branch) => {
                 let values = branch
                     .into_iter()
-                    .map(|(k, v)| (k, v.into_record(head)))
+                    .filter_map(|(k, v)| match k {
+                        GroupKey::String(key) => Some((key, v.into_record(head))),
+                        GroupKey::Nothing => None,
+                    })
                     .collect();
                 Value::record(values, head)
             }

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -1,114 +1,236 @@
-use nu_test_support::nu;
+use nu_protocol::test_value;
+use nu_test_support::prelude::*;
 
 #[test]
-fn groups() {
-    let sample = r#"[
-        [first_name, last_name, rusty_at, type];
-        [Andrés, Robalino, "10/11/2013", A],
-        [JT, Turner, "10/12/2013", B],
-        [Yehuda, Katz, "10/11/2013", A]
-    ]"#;
-
-    let actual = nu!(format!(
-        r#"
-            {sample}
-            | group-by rusty_at
-            | get "10/11/2013"
-            | length
-        "#
-    ));
-
-    assert_eq!(actual.out, "2");
-}
-
-#[test]
-fn errors_if_given_unknown_column_name() {
-    let sample = r#"[{
-    "nu": {
-        "committers": [
-            {"name": "Andrés N. Robalino"},
-            {"name": "JT Turner"},
-            {"name": "Yehuda Katz"}
-        ],
-        "releases": [
-            {"version": "0.2"}
-            {"version": "0.8"},
-            {"version": "0.9999999"}
-        ],
-        "0xATYKARNU": [
-            ["Th", "e", " "],
-            ["BIG", " ", "UnO"],
-            ["punto", "cero"]
+fn groups() -> Result {
+    let code = r#"
+        [
+            [first_name, last_name, rusty_at, type];
+            [Andrés, Robalino, "10/11/2013", A],
+            [JT, Turner, "10/12/2013", B],
+            [Yehuda, Katz, "10/11/2013", A]
         ]
+        | group-by rusty_at
+        | get "10/11/2013"
+        | length
+    "#;
+
+    test().run(code).expect_value_eq(2)
+}
+
+#[test]
+fn errors_if_given_unknown_column_name() -> Result {
+    let code = r#"
+        [{
+            nu: {
+                committers: [
+                    {name: "Andrés N. Robalino"},
+                    {name: "JT Turner"},
+                    {name: "Yehuda Katz"}
+                ],
+                releases: [
+                    {version: "0.2"},
+                    {version: "0.8"},
+                    {version: "0.9999999"}
+                ],
+                "0xATYKARNU": [
+                    ["Th", "e", " "],
+                    ["BIG", " ", "UnO"],
+                    ["punto", "cero"]
+                ]
+            }
+        }]
+        | group-by { get nu.releases.missing_column }
+    "#;
+
+    let err = test().run(code).expect_shell_error()?;
+    match err {
+        ShellError::CantFindColumn { col_name, .. } => {
+            assert_eq!(col_name, "missing_column");
+            Ok(())
+        }
+        err => Err(err.into()),
     }
-}]
-"#;
-
-    let actual = nu!(format!(
-        "
-            '{sample}'
-            | from json
-            | group-by {{|| get nu.releases.missing_column }}
-        "
-    ));
-    assert!(actual.err.contains("column 'missing_column' is missing"));
 }
 
 #[test]
-fn errors_if_column_not_found() {
-    let sample = r#"
-                [[first_name, last_name, rusty_at, type];
-                 [Andrés, Robalino, "10/11/2013", A],
-                 [JT, Turner, "10/12/2013", B],
-                 [Yehuda, Katz, "10/11/2013", A]]
-            "#;
+fn errors_if_column_not_found() -> Result {
+    let code = r#"
+        [
+            [first_name, last_name, rusty_at, type];
+            [Andrés, Robalino, "10/11/2013", A],
+            [JT, Turner, "10/12/2013", B],
+            [Yehuda, Katz, "10/11/2013", A]
+        ]
+        | group-by ttype
+    "#;
 
-    let actual = nu!(format!("{sample} | group-by ttype"));
-
-    assert!(actual.err.contains("did you mean 'type'"),);
+    let err = test().run(code).expect_shell_error()?;
+    match err {
+        ShellError::DidYouMean { suggestion, .. } => {
+            assert_eq!(suggestion, "type");
+            Ok(())
+        }
+        err => Err(err.into()),
+    }
 }
 
 #[test]
-fn group_by_on_empty_list_returns_empty_record() {
-    let actual = nu!("[[a b]; [1 2]] | where false | group-by a | to nuon --raw");
-    let expected = "{}";
-    assert!(actual.err.is_empty());
-    assert_eq!(actual.out, expected);
+fn group_by_on_empty_list_returns_empty_record() -> Result {
+    test()
+        .run("[[a b]; [1 2]] | where false | group-by a")
+        .expect_value_eq(test_value!({}))
 }
 
 #[test]
-fn group_by_to_table_on_empty_list_returns_empty_list() {
-    let actual = nu!("[[a b]; [1 2]] | where false | group-by --to-table a | to nuon --raw");
-    let expected = "[]";
-    assert!(actual.err.is_empty());
-    assert_eq!(actual.out, expected);
+fn group_by_to_table_on_empty_list_returns_empty_list() -> Result {
+    test()
+        .run("[[a b]; [1 2]] | where false | group-by --to-table a")
+        .expect_value_eq(test_value!([]))
 }
 
 #[test]
-fn optional_cell_path_works() {
-    let actual = nu!("[{foo: 123}, {foo: 234}, {bar: 345}] | group-by foo? | to nuon");
-    let expected = r#"{"123": [[foo]; [123]], "234": [[foo]; [234]]}"#;
-    assert_eq!(actual.out, expected)
+fn optional_cell_path_works() -> Result {
+    test()
+        .run("[{foo: 123}, {foo: 234}, {bar: 345}] | group-by foo?")
+        .expect_value_eq(test_value!({
+            "123": [{foo: 123}],
+            "234": [{foo: 234}],
+        }))
 }
 
 #[test]
-fn group_by_compound_values_are_grouped_distinctly() {
+fn group_by_compound_values_are_grouped_distinctly() -> Result {
     // Regression test for grouping by list values.
-    let actual = nu!("
-        let data = [[k v]; [a [2 1]] [b [1 2]] [c [3]] [d [2]]];
+    let code = "
+        let data = [[k v]; [a [2 1]] [b [1 2]] [c [3]] [d [2]]]
         $data | group-by v | columns | length
-    ");
-    assert_eq!(actual.out, "4");
+    ";
+    test().run(code).expect_value_eq(4)?;
 
     // Every distinct list value should produce a separate group with exactly 1 row.
-    let actual = nu!("
-        let data = [[k v]; [a [2 1]] [b [1 2]] [c [3]] [d [2]]];
+    let code = "
+        let data = [[k v]; [a [2 1]] [b [1 2]] [c [3]] [d [2]]]
         $data
         | group-by v
         | values
-        | each { |items| $items | length }
+        | each {|items| $items | length }
         | uniq
         | first
-    ");
-    assert_eq!(actual.out, "1");
+    ";
+    test().run(code).expect_value_eq(1)
+}
+
+// --- null key consistency (#18707) ---
+
+#[test]
+fn null_keys_omitted_from_record_for_list_cell_path_and_closure() -> Result {
+    // List values: null is not mapped to "" and is omitted from record output.
+    test()
+        .run("[ a null ] | group-by | columns")
+        .expect_value_eq(["a"])?;
+
+    // Required cell path: explicit null column value is omitted from records.
+    test()
+        .run("[ { x: a } { x: null } ] | group-by x | columns")
+        .expect_value_eq(["a"])?;
+
+    // Closure: same policy as list/cell path.
+    test()
+        .run("[ { x: a } { x: null } ] | group-by { get x } | columns")
+        .expect_value_eq(["a"])
+}
+
+#[test]
+fn null_keys_included_in_to_table() -> Result {
+    test()
+        .run("[ a null ] | group-by --to-table")
+        .expect_value_eq(test_value!([
+            {group: "a", items: ["a"]},
+            {group: (), items: [()]},
+        ]))?;
+
+    test()
+        .run("[ { x: a } { x: null } ] | group-by x --to-table")
+        .expect_value_eq(test_value!([
+            {x: "a", items: [{x: "a"}]},
+            {x: (), items: [{x: ()}]},
+        ]))?;
+
+    test()
+        .run("[ { x: a } { x: null } ] | group-by { get x } --to-table")
+        .expect_value_eq(test_value!([
+            {closure_0: "a", items: [{x: "a"}]},
+            {closure_0: (), items: [{x: ()}]},
+        ]))
+}
+
+#[test]
+fn null_and_empty_string_are_distinct_groups() -> Result {
+    // Record: null omitted, empty string kept under "".
+    test()
+        .run(r#"[ a "" null ] | group-by"#)
+        .expect_value_eq(test_value!({
+            a: ["a"],
+            "": [""],
+        }))?;
+
+    // Table: two separate group rows for "" and null.
+    test()
+        .run(r#"[ "" null ] | group-by --to-table"#)
+        .expect_value_eq(test_value!([
+            {group: "", items: [""]},
+            {group: (), items: [()]},
+        ]))?;
+
+    test()
+        .run(r#"[ { x: "" } { x: null } ] | group-by x --to-table | get x"#)
+        .expect_value_eq(test_value!(["", ()]))
+}
+
+#[test]
+fn optional_cell_path_still_skips_nothing() -> Result {
+    // Missing optional column is still ignored (historical #9020 behavior).
+    test()
+        .run("[{foo: 123}, {foo: 234}, {bar: 345}] | group-by foo?")
+        .expect_value_eq(test_value!({
+            "123": [{foo: 123}],
+            "234": [{foo: 234}],
+        }))?;
+
+    // Optional path with explicit null is also skipped (cannot distinguish from missing).
+    test()
+        .run("[{x: a}, {x: null}, {y: b}] | group-by x? | columns")
+        .expect_value_eq(["a"])
+}
+
+#[test]
+fn all_nulls_record_is_empty_table_has_null_group() -> Result {
+    test()
+        .run("[ null null ] | group-by")
+        .expect_value_eq(test_value!({}))?;
+
+    test()
+        .run("[ null null ] | group-by --to-table")
+        .expect_value_eq(test_value!([{group: (), items: [(), ()]}]))
+}
+
+#[test]
+fn multi_grouper_null_key_in_to_table() -> Result {
+    // Non-null keys are still stringified for grouping; null is preserved as nothing.
+    test()
+        .run("[ { a: null, b: 1 } { a: 2, b: 1 } ] | group-by a b --to-table")
+        .expect_value_eq(test_value!([
+            {a: (), b: "1", items: [{a: (), b: 1}]},
+            {a: "2", b: "1", items: [{a: 2, b: 1}]},
+        ]))?;
+
+    // Record mode drops the null branch entirely.
+    test()
+        .run("[ { a: null, b: 1 } { a: 2, b: 1 } ] | group-by a b")
+        .expect_value_eq(test_value!({
+            "2": {
+                "1": [{a: 2, b: 1}],
+            },
+        }))
 }


### PR DESCRIPTION
## Description

This PR fixes inconsistent handling of `null` group keys in `group-by` ([#18707](https://github.com/nushell/nushell/issues/18707)).

## User-facing changes (Release notes)

### Fixed inconsistent `group-by` handling of null keys

`group-by` no longer maps `null` to the empty string, and treats null the same for list values, cell paths, and closures.

#### Before (inconsistent):

```nushell
# list: null became "" → 2 groups
[ a null ] | group-by | values | length
# => 2

# cell path: null dropped → 1 group
[ { x: a } { x: null } ] | group-by x | values | length
# => 1

# closure: null became "" → 2 groups
[ { x: a } { x: null } ] | group-by { get x } | values | length
# => 2

# null and "" collapsed into one group
[ a "" null ] | group-by | to nuon --raw
# => {a: [a], "": ["", null]}
```

#### After (consistent):

```nushell
# All three return 1 (null omitted from record output)
[ a null ] | group-by | values | length
# => 1

[ { x: a } { x: null } ] | group-by x | values | length
# => 1

[ { x: a } { x: null } ] | group-by { get x } | values | length
# => 1

# Use --to-table to keep null groups
[ a null ] | group-by --to-table
# ╭───┬───────┬───────╮
# │ # │ group │ items │
# ├───┼───────┼───────┤
# │ 0 │ a     │ [a]   │
# │ 1 │       │ [null]│  # group is null
# ╰───┴───────┴───────╯

[ { x: a } { x: null } ] | group-by x --to-table
# ╭───┬────┬─────────────────╮
# │ # │ x  │      items      │
# ├───┼────┼─────────────────┤
# │ 0 │ a  │ [[x]; [a]]      │
# │ 1 │    │ [[x]; [null]]   │  # x is null
# ╰───┴────┴─────────────────╯

# null and empty string stay separate
[ "" null ] | group-by --to-table | to nuon --raw
# => [[group, items]; ["", [""]], [null, [null]]]

# record output: only "" remains; null is omitted
[ a "" null ] | group-by | to nuon --raw
# => {a: [a], "": [""]}
```

#### Optional cell path (unchanged):

```nushell
# Missing optional column still skipped
[{foo: 123}, {foo: 234}, {bar: 345}] | group-by foo?
# only groups "123" and "234"

# Optional path with explicit null is also skipped
[{x: a}, {x: null}] | group-by x?
# only group "a"
```


## Additional notes
closes https://github.com/nushell/nushell/issues/18707