### PR TITLE
Fix RHS pipeline input type checking (issue #18682)

### DIFF
--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -1378,7 +1378,7 @@ pub fn parse_math_expression(
                 return garbage(working_set, spans[idx - 1]);
             }
         }
-        let mut rhs = parse_value(working_set, spans[idx], &SyntaxShape::Any, None);
+        let mut rhs = parse_value(working_set, spans[idx], &SyntaxShape::Any, input_type);
 
         for not_start_span in not_start_spans.iter().rev() {
             rhs = Expression::new(

--- a/tests/repl/test_type_check.rs
+++ b/tests/repl/test_type_check.rs
@@ -304,6 +304,14 @@ fn in_variable_expression_wrong_output_type() -> TestResult {
     )
 }
 
+#[test]
+fn pipeline_input_on_rhs_is_type_checked() -> TestResult {
+    fail_test(
+        r#"def test []: int -> any { "x" + $in }; 3 | test"#,
+        "nu::parser::operator_incompatible_types",
+    )
+}
+
 #[rstest]
 #[case("if true {} else { foo 1 }")]
 #[case("if true {} else if (foo 1) == null { }")]


### PR DESCRIPTION
## Description

`parse_math_expression` passed the pipeline input type when parsing the left-hand side, but parsed the right-hand side without it.

As a result, an incompatible expression such as `"x" + $in` inside a command with typed pipeline input was accepted by the parser and only failed at runtime, while the equivalent `$in + "x"` expression produced a parse-time type error.

This change passes the same pipeline input type to the right-hand side and adds a regression test alongside the existing `$in` type-checking tests.

## User-facing changes (Release notes)

Nushell now reports incompatible right-hand-side uses of `$in` in typed math expressions during parsing, matching the existing behavior for the left-hand side.

## Additional notes

Fixes #18682

Local verification:

- `cargo fmt --all -- --check`
- focused RHS pipeline input regression
- closure input-type isolation regressions
- block RHS pipeline input regression
- complete type-checking test module: 55 passed
- `nu-parser` tests: 302 passed, 2 ignored
- strict Clippy with default features