### PR TITLE
fix `ls **` when using dc-glob experimental option

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -539,7 +539,15 @@ fn ls_for_one_pattern(
                                         prefix.to_path_buf()
                                     };
 
-                                    Some(new_prefix.join(remainder).to_string_lossy().to_string())
+                                    // Bare trailing `**` (dc-glob) can match the
+                                    // start dir itself; after stripping the prefix
+                                    // that is an empty relative path → show ".".
+                                    let joined = new_prefix.join(remainder);
+                                    if joined.as_os_str().is_empty() {
+                                        Some(".".to_string())
+                                    } else {
+                                        Some(joined.to_string_lossy().to_string())
+                                    }
                                 }
                             } else {
                                 Some(path.to_string_lossy().to_string())

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -964,6 +964,80 @@ fn ls_literal_empty_directory() -> Result {
     Ok(())
 }
 
+/// Regression for https://github.com/nushell/nushell/issues/18600#issuecomment-5077246342
+///
+/// `ls **` goes through `glob_from`, which rewrites the pattern to absolute
+/// `{cwd}/**`. Multi-component trailing `**` must expand (directories only).
+#[test]
+#[exp(nu_experimental::DC_GLOB)]
+fn ls_dc_glob_bare_double_star() -> Result {
+    Playground::setup("ls_dc_bare_double_star", |dirs, sandbox| {
+        sandbox.mkdir("1");
+        sandbox.mkdir("1/2");
+        sandbox.mkdir("1/2/3");
+        sandbox.within("1/2/3").with_files(&[EmptyFile("file.txt")]);
+        sandbox.mkdir("foo");
+        sandbox.mkdir("foo/bar");
+
+        // Nested directories present; file.txt must not appear (trailing ** is dir-only).
+        // Must not error with "No matches found".
+        // Compare expanded paths so relative vs absolute display names both work.
+        test()
+            .cwd(dirs.test())
+            .run(
+                "
+                let paths = (ls ** | get name | each { path expand } | sort)
+                (
+                    ($paths | length) >= 5
+                    and ($paths | any {|p| $p | str ends-with $'(char psep)1'})
+                    and ($paths | any {|p| $p | str ends-with $'(char psep)1(char psep)2'})
+                    and ($paths | any {|p| $p | str ends-with $'(char psep)1(char psep)2(char psep)3'})
+                    and ($paths | any {|p| $p | str ends-with $'(char psep)foo'})
+                    and ($paths | any {|p| $p | str ends-with $'(char psep)foo(char psep)bar'})
+                    and not ($paths | any {|p| $p | str ends-with 'file.txt'})
+                )
+                ",
+            )
+            .expect_value_eq(true)
+            .expect("ls ** should list nested dirs and not files with dc-glob");
+    });
+
+    Ok(())
+}
+
+#[test]
+#[exp(nu_experimental::DC_GLOB)]
+fn ls_dc_glob_prefixed_trailing_double_star() -> Result {
+    Playground::setup("ls_dc_prefixed_trailing", |dirs, sandbox| {
+        sandbox.mkdir("foo");
+        sandbox.mkdir("foo/bar");
+        sandbox
+            .within("foo")
+            .with_files(&[EmptyFile("sibling.txt")]);
+        sandbox
+            .within("foo/bar")
+            .with_files(&[EmptyFile("nested.txt")]);
+
+        test()
+            .cwd(dirs.test())
+            .run(
+                "
+                let paths = (ls foo/** | get name | each { path expand } | sort)
+                (
+                    ($paths | any {|p| $p | str ends-with $'(char psep)foo'})
+                    and ($paths | any {|p| $p | str ends-with $'(char psep)foo(char psep)bar'})
+                    and not ($paths | any {|p| $p | str ends-with 'sibling.txt'})
+                    and not ($paths | any {|p| $p | str ends-with 'nested.txt'})
+                )
+                ",
+            )
+            .expect_value_eq(true)
+            .expect("ls foo/** should list foo and nested dirs only with dc-glob");
+    });
+
+    Ok(())
+}
+
 // Windows does not allow `*` in filenames, so this regression only applies on Unix.
 #[cfg(not(windows))]
 #[test]

--- a/crates/nu-glob/src/dc_glob/compiler.rs
+++ b/crates/nu-glob/src/dc_glob/compiler.rs
@@ -140,12 +140,19 @@ fn append_nodes(out: &mut Program, nodes: &[AstNode]) -> anyhow::Result<()> {
     let mut i = 0;
     while i < nodes.len() {
         match &nodes[i] {
-            // Separator immediately before a trailing-recursive suffix (`**`,
-            // `{**}`, `foo/{**}`, …) is not emitted. The terminal recurse gadget
+            // Separator immediately before a *pure* terminal-recursive suffix
+            // (`**`, `{**}`, …) is not emitted. The terminal recurse gadget
             // starts with `ComponentBoundary` so path `foo` matches `foo/**`
             // without requiring Separator to succeed at EOF (which would break
             // `*/*` min-depth — issue #18600).
-            AstNode::Separator if pattern_is_trailing_recursive(&nodes[i + 1..]) => {}
+            //
+            // Important: only skip when the *remainder is itself* pure trailing
+            // recursive (starts with terminal `**` / pure recursive alts). Using
+            // [`pattern_is_trailing_recursive`] here would also skip separators
+            // in multi-component patterns like `a/b/**` and absolute `{cwd}/**`
+            // (what `ls **` builds via `glob_from`), because those suffixes still
+            // *end* with `**` even though they start with literals.
+            AstNode::Separator if pattern_is_pure_trailing_recursive(&nodes[i + 1..]) => {}
             AstNode::Recurse => {
                 let terminal = is_terminal_recurse(nodes, i);
                 // Fold the `/` in `**/` into the recurse gadget so a zero-length
@@ -293,6 +300,10 @@ fn is_terminal_recurse(nodes: &[AstNode], index: usize) -> bool {
 /// Also true for alternatives where **every** choice is trailing-recursive
 /// (e.g. `{**}`, `foo/{**}`, `{a/**,b/**}`), but not mixed choices like
 /// `{**,README.md}` so non-directory matches are still emitted.
+///
+/// This is used for `Program::trailing_recursive` (directory-only emission). It
+/// is **not** the predicate for eliding separators — see
+/// [`pattern_is_pure_trailing_recursive`].
 fn pattern_is_trailing_recursive(nodes: &[AstNode]) -> bool {
     let mut end = nodes.len();
     while end > 0 && matches!(&nodes[end - 1], AstNode::Separator) {
@@ -308,6 +319,36 @@ fn pattern_is_trailing_recursive(nodes: &[AstNode]) -> bool {
                 && choices
                     .iter()
                     .all(|choice| pattern_is_trailing_recursive(&choice.nodes))
+        }
+        _ => false,
+    }
+}
+
+/// True when `nodes` is a pure terminal-recursive pattern with no non-recursive
+/// prefix: bare `**` (optional trailing separator), or alternatives where every
+/// choice is pure trailing-recursive (e.g. `{**}`). Patterns like `b/**` or
+/// `{a/**}` start with a literal and are **not** pure.
+///
+/// Used only to decide whether a preceding `Separator` can be elided before the
+/// terminal recurse gadget. Multi-component prefixes like `a/b/**` must keep the
+/// `/` between `a` and `b`; only the separator immediately before the pure
+/// trailing `**` is skipped so path `a/b` matches `a/b/**`.
+fn pattern_is_pure_trailing_recursive(nodes: &[AstNode]) -> bool {
+    let mut start = 0;
+    while start < nodes.len() && matches!(&nodes[start], AstNode::Separator) {
+        start += 1;
+    }
+    let nodes = &nodes[start..];
+    if nodes.is_empty() {
+        return false;
+    }
+    match &nodes[0] {
+        AstNode::Recurse => is_terminal_recurse(nodes, 0),
+        AstNode::Alternatives { choices } => {
+            !choices.is_empty()
+                && choices
+                    .iter()
+                    .all(|choice| pattern_is_pure_trailing_recursive(&choice.nodes))
         }
         _ => false,
     }

--- a/crates/nu-glob/src/dc_glob/mod.rs
+++ b/crates/nu-glob/src/dc_glob/mod.rs
@@ -684,6 +684,45 @@ mod tests {
     }
 
     #[test]
+    fn compiler_multi_component_trailing_recursive_keeps_intermediate_separators() {
+        // Regression: separator elision must only drop the `/` immediately before
+        // pure terminal `**`, not every `/` in `a/b/**` (broke `ls **` via absolute
+        // `{cwd}/**` rewriting in glob_from).
+        let prog = compile_pattern("a/b/**");
+        assert!(
+            prog.trailing_recursive,
+            "a/b/** must set trailing_recursive"
+        );
+
+        let mut saw_a = false;
+        let mut saw_sep_after_a = false;
+        let mut saw_b = false;
+        let mut saw_boundary = false;
+        for inst in &prog.instructions {
+            match inst {
+                Instruction::LiteralString(bytes) if &**bytes == b"a" => {
+                    saw_a = true;
+                }
+                Instruction::Separator if saw_a && !saw_b => {
+                    saw_sep_after_a = true;
+                }
+                Instruction::LiteralString(bytes) if &**bytes == b"b" => {
+                    assert!(
+                        saw_sep_after_a,
+                        "a/b/** must keep Separator between a and b, got {prog}"
+                    );
+                    saw_b = true;
+                }
+                Instruction::ComponentBoundary if saw_b => {
+                    saw_boundary = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_a && saw_b && saw_boundary, "unexpected program: {prog}");
+    }
+
+    #[test]
     fn compiler_nested_terminal_recurse_in_alternatives() {
         // `{**}` should compile a terminal recurse gadget and be dir-only.
         let prog = compile_pattern("{**}");
@@ -1043,6 +1082,81 @@ mod tests {
                 .iter()
                 .any(|p| p.ends_with("file.txt") || p.ends_with("sibling.txt")),
             "foo/** must not list files, got {paths:?}"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn glob_with_multi_component_trailing_double_star() {
+        // `a/b/**` must keep intermediate separators and emit a/b + nested dirs only.
+        let root = unique_test_dir("multi_component_trailing");
+        fs::create_dir_all(root.join("a/b/c")).expect("failed to create nested dirs");
+        write_file(&root.join("a/b/c/file.txt"));
+        write_file(&root.join("a/sibling.txt"));
+
+        let paths = collect_ok_paths(
+            glob_with(root.as_path(), "a/b/**", &GlobWalkOptions::default())
+                .expect("glob a/b/** should succeed"),
+        )
+        .expect("collect a/b/**");
+
+        assert!(
+            paths.contains(&expected_path(&["a", "b"])),
+            "a/b/** should include the prefix directory itself, got {paths:?}"
+        );
+        assert!(paths.contains(&expected_path(&["a", "b", "c"])));
+        assert!(
+            !paths
+                .iter()
+                .any(|p| p.ends_with("file.txt") || p.ends_with("sibling.txt")),
+            "a/b/** must not list files, got {paths:?}"
+        );
+        assert!(
+            !paths.contains(&expected_path(&["a"])),
+            "a/b/** must not list the parent of the prefix, got {paths:?}"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn glob_with_absolute_trailing_double_star() {
+        // Absolute `{root}/**` is the shape `glob_from` builds for `ls **`.
+        let root = unique_test_dir("absolute_trailing");
+        fs::create_dir_all(root.join("1/2")).expect("failed to create nested dirs");
+        write_file(&root.join("1/2/file.txt"));
+
+        let pattern = format!("{}/**", root.to_string_lossy());
+        let paths = collect_ok_paths(
+            glob_with(root.as_path(), &pattern, &GlobWalkOptions::default())
+                .expect("glob absolute /** should succeed"),
+        )
+        .expect("collect absolute /**");
+
+        let root_str = root.to_string_lossy().to_string();
+        assert!(
+            paths.iter().any(|p| {
+                let p = p.trim_end_matches(['/', '\\']);
+                p == root_str.trim_end_matches(['/', '\\'])
+            }),
+            "absolute /** should include the start directory, got {paths:?}"
+        );
+        assert!(
+            paths
+                .iter()
+                .any(|p| Path::new(p).ends_with(expected_path(&["1"]))),
+            "absolute /** should include nested dir 1, got {paths:?}"
+        );
+        assert!(
+            paths
+                .iter()
+                .any(|p| Path::new(p).ends_with(expected_path(&["1", "2"]))),
+            "absolute /** should include nested dir 1/2, got {paths:?}"
+        );
+        assert!(
+            !paths.iter().any(|p| p.ends_with("file.txt")),
+            "absolute /** must not list files, got {paths:?}"
         );
 
         let _ = fs::remove_dir_all(&root);


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR fixes a bug when using the dc-glob experimental-option where `ls **` wouldn't work. Now it works the same as before.
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
With the dc-glob experimental option enabled `ls **` now works again.
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->