### PR TITLE
Fix crash on circular import reached through a `..` path

### DIFF
--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1192,17 +1192,26 @@ impl miette::SourceCode for &StateWorkingSet<'_> {
     }
 }
 
+/// A file on the [`FileStack`].
+#[derive(Debug)]
+struct StackedFile {
+    /// The path the file was reached by, used for error messages and to resolve the paths
+    /// of the files it sources or imports.
+    path: PathBuf,
+    /// The path the file is identified by when detecting circular imports.
+    identity: PathBuf,
+}
+
 /// Files being evaluated, arranged as a stack.
 ///
 /// The current active file is on the top of the stack.
 /// When a file source/import another file, the new file is pushed onto the stack.
 /// Attempting to add files that are already in the stack (circular import) results in an error.
 ///
-/// Note that file paths are compared without canonicalization, so the same
-/// physical file may still appear multiple times under different paths.
-/// This doesn't affect circular import detection though.
+/// Files are identified by their canonical path, so the same physical file is recognized
+/// however it was spelled.
 #[derive(Debug, Default)]
-pub struct FileStack(Vec<PathBuf>);
+pub struct FileStack(Vec<StackedFile>);
 
 impl FileStack {
     /// Creates an empty stack.
@@ -1215,41 +1224,62 @@ impl FileStack {
     /// This is a convenience method that creates an empty stack, then pushes the file onto it.
     /// It skips the circular import check and always succeeds.
     pub fn with_file(path: PathBuf) -> Self {
-        Self(vec![path])
+        Self(vec![Self::stacked_file(path)])
     }
 
     /// Adds a file to the stack.
     ///
     /// If the same file is already present in the stack, returns `ParseError::CircularImport`.
     pub fn push(&mut self, path: PathBuf, span: Span) -> Result<(), ParseError> {
+        let file = Self::stacked_file(path);
+
         // Check for circular import.
-        if let Some(i) = self.0.iter().rposition(|p| p == &path) {
+        if let Some(i) = self.0.iter().rposition(|f| f.identity == file.identity) {
             let filenames: Vec<String> = self.0[i..]
                 .iter()
-                .chain(std::iter::once(&path))
-                .map(|p| p.to_string_lossy().to_string())
+                .chain(std::iter::once(&file))
+                .map(|f| f.path.to_string_lossy().to_string())
                 .collect();
             let msg = filenames.join("\nuses ");
             return Err(ParseError::CircularImport(msg, span));
         }
 
-        self.0.push(path);
+        self.0.push(file);
         Ok(())
+    }
+
+    /// Pairs a path with the identity used to compare it against the other files on the stack.
+    ///
+    /// The paths reaching the stack are absolute but not canonical: on unix, `..` components
+    /// are a kind of link and so are kept as they are, which means one file can be stacked
+    /// under several spellings (`mod.nu` and `sub/../mod.nu` for instance). Canonicalizing
+    /// resolves those to a single path, and with it symlinks pointing at an already stacked
+    /// file. Paths that don't exist on disk, such as the virtual paths of the standard
+    /// library, keep their textually expanded form instead.
+    ///
+    /// The paths are already absolute, so the directory they are resolved against only
+    /// matters for the rare relative path, which the rest of the parser resolves against
+    /// the current directory as well.
+    fn stacked_file(path: PathBuf) -> StackedFile {
+        let identity = nu_path::canonicalize_with(&path, ".")
+            .unwrap_or_else(|_| nu_path::expand_path(&path, false));
+
+        StackedFile { path, identity }
     }
 
     /// Removes a file from the stack and returns its path, or None if the stack is empty.
     pub fn pop(&mut self) -> Option<PathBuf> {
-        self.0.pop()
+        self.0.pop().map(|file| file.path)
     }
 
     /// Returns the active file (that is, the file on the top of the stack), or None if the stack is empty.
     pub fn top(&self) -> Option<&Path> {
-        self.0.last().map(PathBuf::as_path)
+        self.0.last().map(|file| file.path.as_path())
     }
 
     /// Returns the parent directory of the active file, or None if the stack is empty
     /// or the active file doesn't have a parent directory as part of its path.
     pub fn current_working_directory(&self) -> Option<&Path> {
-        self.0.last().and_then(|path| path.parent())
+        self.0.last().and_then(|file| file.path.parent())
     }
 }

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -570,6 +570,22 @@ fn module_dir_missing_mod_nu() -> Result {
 }
 
 #[test]
+fn module_dir_circular_import_through_parent_dir() -> Result {
+    Playground::setup("module_dir_circular_import", |dirs, sandbox| -> Result {
+        sandbox
+            .mkdir("spam")
+            .mkdir("spam/spam2")
+            .with_files(&[FileWithContent("spam/mod.nu", "export module spam2")])
+            .with_files(&[FileWithContent("spam/spam2/mod.nu", "use ../mod.nu")]);
+
+        test()
+            .cwd(dirs.test())
+            .run("use spam")
+            .expect_error_code_eq("nu::parser::circular_import")
+    })
+}
+
+#[test]
 fn allowed_local_module() -> Result {
     test()
         .run("module spam { module spam {} }")


### PR DESCRIPTION
## Description

On unix, importing a module that imports one of its parents back through a `..` path never
terminates and nushell dies with a segfault instead of reporting a circular import (#18731):

```nu
mkdir /tmp/nucrash/c/i
"export module i" | save /tmp/nucrash/c/mod.nu
"use ../mod.nu"   | save /tmp/nucrash/c/i/mod.nu

nu -c "use /tmp/nucrash/c"
# Segmentation fault (core dumped)
```

The parser builds these paths with `std::path::absolute`, which drops `.` components but keeps
`..` on unix, because a `..` component is not the same thing as the parent directory once
symlinks are in play. `FileStack`, which is what detects circular imports, compared those paths
as they were, so `/tmp/nucrash/c/mod.nu` and `/tmp/nucrash/c/i/../mod.nu` looked like two
different files. Each trip around the cycle appended another `/i/..` to the path, so the import
never repeated itself, the check never fired, and the parser recursed until the stack ran out.

That also explains why the symptom is not the same everywhere. Whether you get a crash depends
on which limit the growing path hits first: on macOS the path stops resolving before the stack
runs out, so it surfaces as a `module_not_found` naming a path with several hundred `../i`
components in it, as @pickx saw on the issue. Windows was already fine, because
`std::path::absolute` resolves `..` there, so the same repro reports `nu::parser::circular_import`
today. This makes the other platforms behave that way too.

Files on the stack are now identified by their canonical path, which resolves `..` along with
symlinks pointing at a file that is already being parsed. The path a file was actually reached
by is kept as it was, since that is what error messages show and what the files it imports are
resolved against, so nothing else changes. Paths with no file behind them, such as the virtual
paths of the standard library, fall back to expanding `.` and `..` textually.

Legitimate `..` imports are unaffected: a module importing a sibling through `../other/mod.nu`
still resolves and is not reported as circular (`module_nested_imports_in_dirs` covers this).

Tested on Linux, where the repro now prints a circular import error and exits 1 instead of
dying on SIGSEGV, and on Windows, where behavior is unchanged. The new regression test fails
on Linux without the fix and passes with it.

## User-facing changes (Release notes)

Fixed a crash when importing a module that imports one of its parents back through a `..` path,
for example a `c/i/mod.nu` containing `use ../mod.nu`. Nushell reported a circular import on
Windows but crashed on other platforms, and now reports the circular import everywhere.

## Additional notes

fixes #18731
