### PR TITLE
Fix `do -i` not ignoring non-zero exit codes when output is piped or …

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -1,9 +1,7 @@
 use nu_engine::{ClosureEvalOnce, command_prelude::*};
 #[cfg(feature = "os")]
 use nu_protocol::process::{ChildPipe, ChildProcess};
-use nu_protocol::{
-    ByteStream, ByteStreamSource, OutDest, engine::Closure, shell_error::io::IoError,
-};
+use nu_protocol::{ByteStream, ByteStreamSource, engine::Closure, shell_error::io::IoError};
 
 use std::{
     io::{Cursor, Read},
@@ -159,13 +157,12 @@ impl Command for Do {
                     Err(stream) => Ok(PipelineData::byte_stream(stream, metadata)),
                 }
             }
-            Ok(PipelineData::ByteStream(mut stream, metadata))
-                if ignore_all_errors
-                    && !matches!(
-                        caller_stack.stdout(),
-                        OutDest::Pipe | OutDest::PipeSeparate | OutDest::Value
-                    ) =>
-            {
+            Ok(PipelineData::ByteStream(mut stream, metadata)) if ignore_all_errors => {
+                // Mark the child so that a non-zero exit code is ignored regardless of
+                // where the stream is consumed. The exit code is only checked once the
+                // stream is drained, which may happen downstream (e.g. `do -i { ... } | collect`)
+                // or when collected into a value (e.g. `let x = do -i { ... }`). Without this,
+                // those cases would still surface the error even though `-i` was given.
                 #[cfg(feature = "os")]
                 if let ByteStreamSource::Child(child) = stream.source_mut() {
                     child.ignore_error(true);

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -67,6 +67,25 @@ fn ignore_error_works_with_list_stream() -> Result {
     Ok(())
 }
 
+// Regression test for #18732: `do -i` must suppress a non-zero exit code even
+// when the external command's output is piped downstream (the exit code is only
+// checked once the byte stream is drained, which happens inside `collect` here).
+#[test]
+#[deps(TESTBIN_FAIL)]
+fn ignore_error_works_for_external_piped_downstream() -> Result {
+    test().run("do -i { fail 1 } | collect").expect_value_eq("")
+}
+
+// Regression test for #18732: the same must hold when the external command's
+// output is collected into a value (`let` puts the pipeline in value position).
+#[test]
+#[deps(TESTBIN_FAIL)]
+fn ignore_error_works_for_external_collected_into_value() -> Result {
+    test()
+        .run("let x = do -i { fail 1 }; $x")
+        .expect_value_eq("")
+}
+
 #[test]
 fn run_closure_with_do_using() -> Result {
     test()


### PR DESCRIPTION
## Description
`do --ignore-errors` (`do -i`) failed to suppress a non-zero exit code from an
external command when its output was piped downstream (e.g. `do -i { ... } | collect`)
or collected into a value (e.g. `let x = do -i { ... }`).

The exit code of an external command is only checked when its byte stream is drained,
which in those cases happens after `do` returns. The `ByteStream` arm that marks the
child with `ignore_error(true)` was guarded to run only when the output destination was
not `Pipe`/`PipeSeparate`/`Value`, so in exactly those cases the flag was never set and
the error surfaced despite `-i`. This removes that guard so `do -i` always marks the
child, regardless of output destination.

Fixes #18732

## User-facing changes (Release notes)
`do -i { external_that_fails } | collect` and `let x = do -i { external_that_fails }`
no longer error on a non-zero exit code. `complete` still reports the real `exit_code`,
and behavior without `-i` is unchanged.

## Tests + Formatting
Added two regression tests in `crates/nu-command/tests/commands/do_.rs`.
`toolkit check pr` passes (fmt, clippy, test, stdlib).