### PR TITLE
make `$env.config` show default configuration when not set even with `nu -n`

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -2,13 +2,9 @@ use crate::{NuHelpCompleter, menus::NuMenuCompleter};
 use crossterm::event::{KeyCode, KeyModifiers};
 use nu_ansi_term::Style;
 use nu_color_config::{color_record_to_nustyle, lookup_ansi_color_style};
-use nu_engine::eval_block;
-use nu_parser::parse;
 use nu_protocol::{
-    Config, EditBindings, FromValue, ParsedKeybinding, ParsedMenu, PipelineData, Record,
-    ShellError, Span, Type, Value,
-    debugger::WithoutDebug,
-    engine::{EngineState, Stack, StateWorkingSet},
+    Config, EditBindings, ParsedKeybinding, ParsedMenu, Record, ShellError, Span, Type, Value,
+    engine::{EngineState, Stack},
     extract_value,
 };
 use reedline::{
@@ -21,104 +17,13 @@ use reedline::{
 };
 use std::{str::FromStr, sync::Arc};
 
-const DEFAULT_COMPLETION_MENU: &str = r#"
-{
-  name: completion_menu
-  only_buffer_difference: false
-  marker: "| "
-  type: {
-      layout: columnar
-      columns: 4
-      col_width: 20
-      col_padding: 2
-      tab_traversal: "horizontal"
-  }
-  style: {
-      text: green,
-      selected_text: green_reverse
-      description_text: yellow
-  }
-}"#;
-
-const DEFAULT_IDE_COMPLETION_MENU: &str = r#"
-{
-  name: ide_completion_menu
-  only_buffer_difference: false
-  marker: "| "
-  type: {
-    layout: ide
-    min_completion_width: 0,
-    max_completion_width: 50,
-    max_completion_height: 10, # will be limited by the available lines in the terminal
-    padding: 0,
-    border: true,
-    cursor_offset: 0,
-    description_mode: "prefer_right"
-    min_description_width: 15
-    max_description_width: 50
-    max_description_height: 10
-    description_offset: 1
-    # If true, the cursor pos will be corrected, so the suggestions match up with the typed text
-    #
-    # C:\> str
-    #      str join
-    #      str trim
-    #      str split
-    correct_cursor_pos: false
-  }
-  style: {
-    text: green
-    selected_text: { attr: r }
-    description_text: yellow
-    match_text: { attr: u }
-    selected_match_text: { attr: ur }
-  }
-}"#;
-
-const DEFAULT_HISTORY_MENU: &str = r#"
-{
-  name: history_menu
-  only_buffer_difference: true
-  marker: "? "
-  type: {
-      layout: list
-      page_size: 10
-  }
-  style: {
-      text: green,
-      selected_text: green_reverse
-      description_text: yellow
-  }
-}"#;
-
-const DEFAULT_HELP_MENU: &str = r#"
-{
-  name: help_menu
-  only_buffer_difference: true
-  marker: "? "
-  type: {
-      layout: description
-      columns: 4
-      col_width: 20
-      col_padding: 2
-      selection_rows: 4
-      description_rows: 15
-  }
-  style: {
-      text: green,
-      selected_text: green_reverse
-      description_text: yellow
-  }
-}"#;
-
-// Adds all menus to line editor
+// Adds all menus from `$env.config.menus` (defaults live on `Config::default()`).
 pub(crate) fn add_menus(
     mut line_editor: Reedline,
     engine_state_ref: Arc<EngineState>,
     stack: &Stack,
     config: Arc<Config>,
 ) -> Result<Reedline, ShellError> {
-    //log::trace!("add_menus: config: {:#?}", &config);
     line_editor = line_editor.clear_menus();
 
     for menu in &config.menus {
@@ -129,62 +34,6 @@ pub(crate) fn add_menus(
             stack,
             config.clone(),
         )?
-    }
-
-    // Checking if the default menus have been added from the config file
-    let default_menus = [
-        ("completion_menu", DEFAULT_COMPLETION_MENU),
-        ("ide_completion_menu", DEFAULT_IDE_COMPLETION_MENU),
-        ("history_menu", DEFAULT_HISTORY_MENU),
-        ("help_menu", DEFAULT_HELP_MENU),
-    ];
-
-    let mut engine_state = (*engine_state_ref).clone();
-    let mut menu_eval_results = vec![];
-
-    for (name, definition) in default_menus {
-        if !config
-            .menus
-            .iter()
-            .any(|menu| menu.name.to_expanded_string("", &config) == name)
-        {
-            let (block, delta) = {
-                let mut working_set = StateWorkingSet::new(&engine_state);
-                let output = parse(
-                    &mut working_set,
-                    Some(name), // format!("repl_entry #{}", entry_num)
-                    definition.as_bytes(),
-                    true,
-                );
-
-                (output, working_set.render())
-            };
-
-            engine_state.merge_delta(delta)?;
-
-            let mut temp_stack = Stack::new().collect_value();
-            let input = PipelineData::empty();
-            menu_eval_results.push(eval_block::<WithoutDebug>(
-                &engine_state,
-                &mut temp_stack,
-                &block,
-                input,
-            )?);
-        }
-    }
-
-    let new_engine_state_ref = Arc::new(engine_state);
-
-    for res in menu_eval_results.into_iter().map(|p| p.body) {
-        if let PipelineData::Value(value, None) = res {
-            line_editor = add_menu(
-                line_editor,
-                &ParsedMenu::from_value(value)?,
-                new_engine_state_ref.clone(),
-                stack,
-                config.clone(),
-            )?;
-        }
     }
 
     Ok(line_editor)
@@ -742,69 +591,6 @@ pub(crate) fn add_description_menu(
     Ok(line_editor.with_menu(completer))
 }
 
-fn add_menu_keybindings(keybindings: &mut Keybindings) {
-    // Completer menu keybindings
-    keybindings.add_binding(
-        KeyModifiers::NONE,
-        KeyCode::Tab,
-        ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::Menu("completion_menu".to_string()),
-            ReedlineEvent::MenuNext,
-            ReedlineEvent::Edit(vec![EditCommand::Complete]),
-        ]),
-    );
-
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        KeyCode::Char(' '),
-        ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::Menu("ide_completion_menu".to_string()),
-            ReedlineEvent::MenuNext,
-            ReedlineEvent::Edit(vec![EditCommand::Complete]),
-        ]),
-    );
-
-    keybindings.add_binding(
-        KeyModifiers::SHIFT,
-        KeyCode::BackTab,
-        ReedlineEvent::MenuPrevious,
-    );
-
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        KeyCode::Char('r'),
-        ReedlineEvent::Menu("history_menu".to_string()),
-    );
-
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        KeyCode::Char('x'),
-        ReedlineEvent::MenuPageNext,
-    );
-
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        KeyCode::Char('z'),
-        ReedlineEvent::UntilFound(vec![
-            ReedlineEvent::MenuPagePrevious,
-            ReedlineEvent::Edit(vec![EditCommand::Undo]),
-        ]),
-    );
-
-    // Help menu keybinding
-    keybindings.add_binding(
-        KeyModifiers::NONE,
-        KeyCode::F(1),
-        ReedlineEvent::Menu("help_menu".to_string()),
-    );
-
-    keybindings.add_binding(
-        KeyModifiers::CONTROL,
-        KeyCode::Char('q'),
-        ReedlineEvent::SearchHistory,
-    );
-}
-
 pub enum KeybindingsMode {
     Emacs(Keybindings),
     Vi {
@@ -816,19 +602,12 @@ pub enum KeybindingsMode {
 pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, ShellError> {
     let parsed_keybindings = &config.keybindings;
 
+    // Reedline base maps stay library-owned; Nushell menu bindings live on
+    // `config.keybindings` (including defaults from `Config::default()`).
     let mut emacs_keybindings = default_emacs_keybindings();
     let mut insert_keybindings = default_vi_insert_keybindings();
     let mut normal_keybindings = default_vi_normal_keybindings();
 
-    match config.edit_mode {
-        EditBindings::Emacs => {
-            add_menu_keybindings(&mut emacs_keybindings);
-        }
-        EditBindings::Vi => {
-            add_menu_keybindings(&mut insert_keybindings);
-            add_menu_keybindings(&mut normal_keybindings);
-        }
-    }
     for keybinding in parsed_keybindings {
         add_keybinding(
             &keybinding.mode,
@@ -2209,5 +1988,14 @@ mod test {
                 select: true
             }]))
         );
+    }
+
+    #[test]
+    fn default_config_keybindings_apply() {
+        // Nushell menu keybindings on Config::default must parse as valid reedline events.
+        let config = Config::default();
+        assert!(!config.keybindings.is_empty());
+        assert!(!config.menus.is_empty());
+        create_keybindings(&config).expect("default keybindings should apply cleanly");
     }
 }

--- a/crates/nu-color-config/src/matching_brackets_style.rs
+++ b/crates/nu-color-config/src/matching_brackets_style.rs
@@ -1,23 +1,29 @@
-use crate::color_config::lookup_ansi_color_style;
+use crate::{color_config::lookup_ansi_color_style, color_record_to_nustyle};
 use nu_ansi_term::Style;
-use nu_protocol::Config;
+use nu_protocol::{Config, Value};
 
 pub fn get_matching_brackets_style(default_style: Style, conf: &Config) -> Style {
     const MATCHING_BRACKETS_CONFIG_KEY: &str = "shape_matching_brackets";
 
     match conf.color_config.get(MATCHING_BRACKETS_CONFIG_KEY) {
-        Some(int_color) => match int_color.coerce_str() {
-            Ok(int_color) => merge_styles(default_style, lookup_ansi_color_style(&int_color)),
-            Err(_) => default_style,
-        },
-        None => default_style,
+        Some(Value::String { val, .. }) => {
+            merge_styles(default_style, lookup_ansi_color_style(val))
+        }
+        Some(value @ Value::Record { .. }) => {
+            merge_styles(default_style, color_record_to_nustyle(value))
+        }
+        // Missing or unusable types: keep the base shape style only
+        _ => default_style,
     }
 }
 
 fn merge_styles(base: Style, extra: Style) -> Style {
+    // `default_*` color names (e.g. `default_underline`) set `Color::Default`.
+    // For matching brackets we merge onto the shape style, so treat Default as
+    // "keep the base color" and only layer attributes / explicit colors.
     Style {
-        foreground: extra.foreground.or(base.foreground),
-        background: extra.background.or(base.background),
+        foreground: merge_color(base.foreground, extra.foreground),
+        background: merge_color(base.background, extra.background),
         is_bold: extra.is_bold || base.is_bold,
         is_dimmed: extra.is_dimmed || base.is_dimmed,
         is_italic: extra.is_italic || base.is_italic,
@@ -27,5 +33,15 @@ fn merge_styles(base: Style, extra: Style) -> Style {
         is_hidden: extra.is_hidden || base.is_hidden,
         is_strikethrough: extra.is_strikethrough || base.is_strikethrough,
         prefix_with_reset: false,
+    }
+}
+
+fn merge_color(
+    base: Option<nu_ansi_term::Color>,
+    extra: Option<nu_ansi_term::Color>,
+) -> Option<nu_ansi_term::Color> {
+    match extra {
+        None | Some(nu_ansi_term::Color::Default) => base,
+        other => other,
     }
 }

--- a/crates/nu-color-config/src/shape_color.rs
+++ b/crates/nu-color-config/src/shape_color.rs
@@ -1,61 +1,96 @@
 use crate::{color_config::lookup_ansi_color_style, color_record_to_nustyle};
-use nu_ansi_term::{Color, Style};
-use nu_protocol::{Config, Value};
+use nu_ansi_term::Style;
+use nu_protocol::{Config, Value, default_color_config};
+use std::{collections::HashMap, sync::LazyLock};
 
-// The default colors for shapes, used when there is no config for them.
-pub fn default_shape_color(shape: &str) -> Style {
-    match shape {
-        "shape_binary" => Style::new().fg(Color::Purple).bold(),
-        "shape_block" => Style::new().fg(Color::Blue).bold(),
-        "shape_bool" => Style::new().fg(Color::LightCyan),
-        "shape_closure" => Style::new().fg(Color::Green).bold(),
-        "shape_custom" => Style::new().fg(Color::Green),
-        "shape_datetime" => Style::new().fg(Color::Cyan).bold(),
-        "shape_directory" => Style::new().fg(Color::Cyan),
-        "shape_external" => Style::new().fg(Color::Cyan),
-        "shape_externalarg" => Style::new().fg(Color::Green).bold(),
-        "shape_external_resolved" => Style::new().fg(Color::LightYellow).bold(),
-        "shape_filepath" => Style::new().fg(Color::Cyan),
-        "shape_flag" => Style::new().fg(Color::Blue).bold(),
-        "shape_float" => Style::new().fg(Color::Purple).bold(),
-        "shape_garbage" => Style::new().fg(Color::Default).on(Color::Red).bold(),
-        "shape_glob_interpolation" => Style::new().fg(Color::Cyan).bold(),
-        "shape_globpattern" => Style::new().fg(Color::Cyan).bold(),
-        "shape_int" => Style::new().fg(Color::Purple).bold(),
-        "shape_internalcall" => Style::new().fg(Color::Cyan).bold(),
-        "shape_keyword" => Style::new().fg(Color::Cyan).bold(),
-        "shape_list" => Style::new().fg(Color::Cyan).bold(),
-        "shape_literal" => Style::new().fg(Color::Blue),
-        "shape_match_pattern" => Style::new().fg(Color::Green),
-        "shape_nothing" => Style::new().fg(Color::LightCyan),
-        "shape_operator" => Style::new().fg(Color::Yellow),
-        "shape_pipe" => Style::new().fg(Color::Purple).bold(),
-        "shape_range" => Style::new().fg(Color::Yellow).bold(),
-        "shape_raw_string" => Style::new().fg(Color::LightMagenta).bold(),
-        "shape_record" => Style::new().fg(Color::Cyan).bold(),
-        "shape_redirection" => Style::new().fg(Color::Purple).bold(),
-        "shape_signature" => Style::new().fg(Color::Green).bold(),
-        "shape_string" => Style::new().fg(Color::Green),
-        "shape_string_interpolation" => Style::new().fg(Color::Cyan).bold(),
-        "shape_table" => Style::new().fg(Color::Blue).bold(),
-        "shape_variable" => Style::new().fg(Color::Purple),
-        "shape_vardecl" => Style::new().fg(Color::Purple),
-        _ => Style::default(),
+/// Default `color_config` map — same source as `Config::default().color_config`
+/// (`nu_protocol::default_color_config`).
+fn default_color_map() -> &'static HashMap<String, Value> {
+    static MAP: LazyLock<HashMap<String, Value>> = LazyLock::new(default_color_config);
+    &MAP
+}
+
+/// Resolve a shape style from a color_config value (string or `{ fg, bg, attr }` record).
+fn style_from_color_value(value: &Value) -> Option<Style> {
+    match value {
+        Value::Record { .. } => Some(color_record_to_nustyle(value)),
+        Value::String { val, .. } => Some(lookup_ansi_color_style(val)),
+        // null / wrong types treated as unset
+        _ => None,
     }
+}
+
+/// Default style for a shape key, derived from `default_color_config()` (not a
+/// separate hard-coded table). Used when the live config is missing the key or
+/// has an unusable value type.
+pub fn default_shape_color(shape: &str) -> Style {
+    default_color_map()
+        .get(shape)
+        .and_then(style_from_color_value)
+        .unwrap_or_default()
 }
 
 pub fn get_shape_color(shape: &str, conf: &Config) -> Style {
     match conf.color_config.get(shape) {
         Some(int_color) => {
             // Shapes do not use color_config closures, currently.
-            match int_color {
-                Value::Record { .. } => color_record_to_nustyle(int_color),
-                Value::String { val, .. } => lookup_ansi_color_style(val),
-                // Defer to the default in the event of incorrect types being given
-                // (i.e. treat null, etc. as the value being unset)
-                _ => default_shape_color(shape),
-            }
+            style_from_color_value(int_color).unwrap_or_else(|| default_shape_color(shape))
         }
         None => default_shape_color(shape),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nu_ansi_term::Color;
+    use nu_protocol::record;
+
+    #[test]
+    fn default_shape_color_matches_config_defaults() {
+        let conf = Config::default();
+        // Missing key falls back to the same map as Config::default().color_config
+        let empty = Config {
+            color_config: Default::default(),
+            ..Config::default()
+        };
+        assert_eq!(
+            get_shape_color("shape_string", &empty),
+            get_shape_color("shape_string", &conf)
+        );
+        assert_eq!(
+            get_shape_color("shape_string", &conf),
+            lookup_ansi_color_style("green")
+        );
+        assert_eq!(
+            get_shape_color("shape_raw_string", &empty),
+            lookup_ansi_color_style("light_purple")
+        );
+    }
+
+    #[test]
+    fn matching_brackets_default_underline_merges() {
+        use crate::get_matching_brackets_style;
+
+        let conf = Config::default();
+        let base = Style::new().fg(Color::Green);
+        let merged = get_matching_brackets_style(base, &conf);
+        assert!(merged.is_underline);
+        assert_eq!(merged.foreground, Some(Color::Green));
+    }
+
+    #[test]
+    fn matching_brackets_accepts_record() {
+        use crate::get_matching_brackets_style;
+
+        let mut conf = Config::default();
+        conf.color_config.insert(
+            "shape_matching_brackets".into(),
+            Value::test_record(record! { "attr" => Value::test_string("b") }),
+        );
+        let base = Style::new().fg(Color::Cyan);
+        let merged = get_matching_brackets_style(base, &conf);
+        assert!(merged.is_bold);
+        assert_eq!(merged.foreground, Some(Color::Cyan));
     }
 }

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -1,5 +1,5 @@
 use crate::{TextStyle, color_record_to_nustyle, lookup_ansi_color_style, text_style::Alignment};
-use nu_ansi_term::{Color, Style};
+use nu_ansi_term::Style;
 use nu_engine::ClosureEvalOnce;
 use nu_protocol::{
     Span, Value,
@@ -108,41 +108,13 @@ impl<'a> StyleComputer<'a> {
     }
 
     // The main constructor.
+    //
+    // Defaults live on `Config::default().color_config` so `$env.config` is the
+    // single source of truth (including under `nu -n`).
     pub fn from_config(engine_state: &'a EngineState, stack: &'a Stack) -> StyleComputer<'a> {
         let config = stack.get_config(engine_state);
 
-        // Create the hashmap
-        #[rustfmt::skip]
-        let mut map: StyleMapping = [
-            ("separator".to_string(), ComputableStyle::Static(Color::Default.normal())),
-            ("leading_trailing_space_bg".to_string(), ComputableStyle::Static(Style::default().on(Color::Rgb(128, 128, 128)))),
-            ("header".to_string(), ComputableStyle::Static(Color::Green.bold())),
-            ("empty".to_string(), ComputableStyle::Static(Color::Blue.normal())),
-            ("bool".to_string(), ComputableStyle::Static(Color::LightCyan.normal())),
-            ("int".to_string(), ComputableStyle::Static(Color::Default.normal())),
-            ("filesize".to_string(), ComputableStyle::Static(Color::Cyan.normal())),
-            ("duration".to_string(), ComputableStyle::Static(Color::Default.normal())),
-            ("datetime".to_string(), ComputableStyle::Static(Color::Purple.normal())),
-            ("range".to_string(), ComputableStyle::Static(Color::Default.normal())),
-            ("float".to_string(), ComputableStyle::Static(Color::Default.normal())),
-            ("string".to_string(), ComputableStyle::Static(Color::Default.normal())),
-            ("nothing".to_string(), ComputableStyle::Static(Color::Default.normal())),
-            ("binary".to_string(), ComputableStyle::Static(Color::Default.normal())),
-            ("binary_null_char".to_string(), ComputableStyle::Static(Color::Fixed(242).normal())),
-            ("binary_printable".to_string(), ComputableStyle::Static(Color::Cyan.bold())),
-            ("binary_whitespace".to_string(), ComputableStyle::Static(Color::Green.bold())),
-            ("binary_ascii_other".to_string(), ComputableStyle::Static(Color::Purple.bold())),
-            ("binary_non_ascii".to_string(), ComputableStyle::Static(Color::Yellow.bold())),
-            ("cell-path".to_string(), ComputableStyle::Static(Color::Default.normal())),
-            ("row_index".to_string(), ComputableStyle::Static(Color::Green.bold())),
-            ("record".to_string(), ComputableStyle::Static(Color::Default.normal())),
-            ("list".to_string(), ComputableStyle::Static(Color::Default.normal())),
-            ("block".to_string(), ComputableStyle::Static(Color::Default.normal())),
-            ("hints".to_string(), ComputableStyle::Static(Color::DarkGray.normal())),
-            ("search_result".to_string(), ComputableStyle::Static(Color::Default.normal().on(Color::Red))),
-            ("semver".to_string(), ComputableStyle::Static(Color::Cyan.bold())),
-            ("semver-range".to_string(), ComputableStyle::Static(Color::Cyan.bold())),
-        ].into_iter().collect();
+        let mut map: StyleMapping = HashMap::new();
 
         for (key, value) in &config.color_config {
             let span = value.span();
@@ -160,13 +132,10 @@ impl<'a> StyleComputer<'a> {
                     );
                 }
                 Value::String { val, .. } => {
-                    // update the stylemap with the found key
-                    let color = lookup_ansi_color_style(val.as_str());
-                    if let Some(v) = map.get_mut(key) {
-                        *v = ComputableStyle::Static(color);
-                    } else {
-                        map.insert(key.to_string(), ComputableStyle::Static(color));
-                    }
+                    map.insert(
+                        key.to_string(),
+                        ComputableStyle::Static(lookup_ansi_color_style(val.as_str())),
+                    );
                 }
                 // This should never occur.
                 _ => (),

--- a/crates/nu-config/default_files/README.md
+++ b/crates/nu-config/default_files/README.md
@@ -17,7 +17,8 @@
 
 Counterpart to `default_env.nu`.
 
-* Contains any `$env.config` values that are not set via Rust defaults.
+* All `$env.config` defaults (including `color_config`, menus, and Nushell-owned menu keybindings) live in Rust `Config::default()` so they are visible under `nu -n` / `nu -n --no-std-lib` via `$env.config`.
+* This file is intentionally minimal (`$env.config = {}`) and exists only to preserve load order before the user's `config.nu`.
 * Is loaded *after* the user's `env.nu`.
 * Is loaded *before* the user's `config.nu`.
 * Will be loaded during any startup where the user's `config.nu` is also loaded. For example:
@@ -28,14 +29,8 @@ Counterpart to `default_env.nu`.
   * `nu -c "ls"`
   * `nu <script.nu>`
 * Is not commented - Comments are in `doc_config.nu`.
-* Should be optimized for fastest load times. Whenever possible, values should be set via nu-protocol::config
-  * Exception: `color_config` values are currently set in this file so that user's can introspect the values
-  * TODO: Implement defaults for `color_config` in nu-protocol::config and remove from `default_config.nu`
-* Can be introspected via `config nu --default | nu-highlight`
-* An ideal `default_config.nu` (when all values are set via `nu-protocol::config`) will simply be:
-  ```
-  $env.config = {}
-  ```
+* Should be optimized for fastest load times. Whenever possible, values should be set via nu-protocol::config.
+* Can be introspected via `config nu --default | nu-highlight` (source of this file). Inspect **values** with `$env.config` (including under `nu -n`).
 
 ## `doc_env.nu`
 

--- a/crates/nu-config/default_files/default_config.nu
+++ b/crates/nu-config/default_files/default_config.nu
@@ -1,75 +1,12 @@
-# Nushell Config File
+# Built-in default config file.
+#
+# All `$env.config` defaults (including color_config, menus, and Nushell menu
+# keybindings) now live in Rust `Config::default()` so they are visible under
+# `nu -n` / `nu -n --no-std-lib` via `$env.config`.
+#
+# This file is still evaluated before the user's `config.nu` during interactive
+# startup so users can rely on the load order. Leave it empty (or assign only
+# intentional overrides) unless you need Nu-side default setup.
 #
 # version = "0.114.2"
-$env.config.color_config = {
-    separator: default
-    leading_trailing_space_bg: { attr: n }
-    header: green_bold
-    empty: blue
-    bool: light_cyan
-    int: default
-    filesize: cyan
-    duration: default
-    datetime: purple
-    range: default
-    float: default
-    string: default
-    nothing: default
-    binary: default
-    binary_null_char: grey42
-    binary_printable: cyan_bold
-    binary_whitespace: green_bold
-    binary_ascii_other: purple_bold
-    binary_non_ascii: yellow_bold
-    cell-path: default
-    row_index: green_bold
-    record: default
-    list: default
-    closure: green_bold
-    glob:cyan_bold
-    semver: cyan_bold
-    semver-range: cyan_bold
-    block: default
-    hints: dark_gray
-    search_result: { bg: red fg: default }
-    shape_binary: purple_bold
-    shape_block: blue_bold
-    shape_bool: light_cyan
-    shape_closure: green_bold
-    shape_custom: green
-    shape_datetime: cyan_bold
-    shape_directory: cyan
-    shape_external: cyan
-    shape_externalarg: green_bold
-    shape_external_resolved: light_yellow_bold
-    shape_filepath: cyan
-    shape_flag: blue_bold
-    shape_float: purple_bold
-    shape_glob_interpolation: cyan_bold
-    shape_globpattern: cyan_bold
-    shape_int: purple_bold
-    shape_internalcall: cyan_bold
-    shape_keyword: cyan_bold
-    shape_list: cyan_bold
-    shape_literal: blue
-    shape_match_pattern: green
-    shape_matching_brackets: { attr: u }
-    shape_nothing: light_cyan
-    shape_operator: yellow
-    shape_pipe: purple_bold
-    shape_range: yellow_bold
-    shape_record: cyan_bold
-    shape_redirection: purple_bold
-    shape_signature: green_bold
-    shape_string: green
-    shape_string_interpolation: cyan_bold
-    shape_table: blue_bold
-    shape_variable: purple
-    shape_vardecl: purple
-    shape_raw_string: light_purple
-    shape_garbage: {
-        fg: default
-        bg: red
-        attr: b
-    }
-}
+$env.config = {}

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -1123,38 +1123,90 @@ $env.config.color_config.banner_highlight2 = "purple"
 # ------------------------
 # Explore Command Settings
 # ------------------------
-
-# explore (record): UI configuration for the `explore` command.
-# Configures colors and styles for the interactive data explorer.
-# Keys applied by `ExploreConfig::from_nu_config`:
-#   selected_cell, highlight, status_bar_text/background, command_bar_text/background,
-#   title_bar_text/background, status.{info,success,warn,error}, try.reactive
-# Table padding is taken from `$env.config.table.padding` (not explore.table).
+# `$env.config.explore` is read by `ExploreConfig::from_nu_config` in
+# `crates/nu-explore/src/explore/config.rs`. Only the keys listed below are applied.
+# Color values use the same forms as `color_config`: color names, `#RRGGBB`, or
+# records `{ fg?, bg?, attr? }`.
 #
-# Default (also inspect with `$env.config.explore`):
-$env.config.explore = {
-    selected_cell: { bg: light_blue },
-    highlight: { fg: black, bg: yellow },
-    status: {
-        success: { fg: black, bg: green },
-        error: { fg: white, bg: red },
-    },
-    try: { reactive: false },
+# Related settings that are NOT under `$env.config.explore`:
+#   - Column padding: `$env.config.table.padding` (left/right)
+#   - Table grid/separator color: `$env.config.color_config.separator`
+#   - Show header / index columns: `explore --head` / `explore --index` flags
+#     (not configurable via `$env.config.explore`)
+#
+# Inspect live defaults with: `$env.config.explore`
+#
+# NOT supported (ignored if present — common outdated examples):
+#   - `$env.config.explore.config` (e.g. `cursor_color`) — no such key
+#   - `$env.config.explore.table.selected_cell` — use top-level `selected_cell`
+#   - `$env.config.explore.table.show_cursor` — no such key
+#   - `$env.config.explore.table` nested record in general — not read from config
+
+# explore.selected_cell (color): Highlight for the currently selected table cell.
+# Default: { bg: light_blue }
+$env.config.explore.selected_cell = { bg: light_blue }
+
+# explore.highlight (color): Search-result highlight in the explore pager.
+# Default: { fg: black, bg: yellow }
+$env.config.explore.highlight = { fg: black, bg: yellow }
+
+# explore.status_bar_text (color): Text color of the bottom status bar.
+# Default: unset (inherit terminal / theme)
+# $env.config.explore.status_bar_text = { fg: "#C4C9C6" }
+
+# explore.status_bar_background (color): Background of the bottom status bar.
+# Default: unset (inherit terminal / theme)
+# $env.config.explore.status_bar_background = { fg: "#1D1F21", bg: "#C4C9C6" }
+
+# explore.command_bar_text (color): Text color of the command/search bar.
+# Default: unset (inherit terminal / theme)
+# $env.config.explore.command_bar_text = { fg: "#C4C9C6" }
+
+# explore.command_bar_background (color): Background of the command/search bar.
+# Default: unset (inherit terminal / theme)
+# $env.config.explore.command_bar_background = { bg: "#1D1F21" }
+
+# explore.title_bar_text (color): Text color of the top title bar.
+# Default: unset (inherit terminal / theme)
+# $env.config.explore.title_bar_text = { fg: white }
+
+# explore.title_bar_background (color): Background of the top title bar.
+# Default: unset (inherit terminal / theme)
+# $env.config.explore.title_bar_background = { bg: blue }
+
+# explore.status (record): Message severity styles in the status bar.
+# Keys: info, success, warn, error. Each is a color value as above.
+# Defaults: success { fg: black, bg: green }, error { fg: white, bg: red };
+#           info and warn unset (inherit / plain).
+$env.config.explore.status = {
+    success: { fg: black, bg: green }
+    error: { fg: white, bg: red }
+    # info: {}
+    # warn: {}
 }
 
-# Example: override bars and try mode (unset bar colors inherit the terminal):
+# explore.try.reactive (bool): In explore's `:try` mode, re-run the command as
+# you type when true; when false, run only on submit.
+# Default: false
+$env.config.explore.try.reactive = false
+
+# Full example (all supported keys):
 # $env.config.explore = {
-#     status_bar_background: { fg: "#1D1F21", bg: "#C4C9C6" },
-#     command_bar_text: { fg: "#C4C9C6" },
-#     highlight: { fg: "black", bg: "yellow" },
+#     selected_cell: { bg: light_blue }
+#     highlight: { fg: black, bg: yellow }
+#     status_bar_text: { fg: "#C4C9C6" }
+#     status_bar_background: { fg: "#1D1F21", bg: "#C4C9C6" }
+#     command_bar_text: { fg: "#C4C9C6" }
+#     command_bar_background: { bg: "#1D1F21" }
+#     title_bar_text: { fg: white }
+#     title_bar_background: { bg: blue }
 #     status: {
-#         error: { fg: "white", bg: "red" },
-#         success: { fg: "black", bg: "green" },
-#         warn: {}
 #         info: {}
-#     },
-#     selected_cell: { bg: light_blue },
-#     try: { reactive: true }
+#         success: { fg: black, bg: green }
+#         warn: {}
+#         error: { fg: white, bg: red }
+#     }
+#     try: { reactive: false }
 # }
 
 # ---------------------------------------------------------------------------------------

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -572,11 +572,17 @@ $env.config.hooks.command_not_found = null
 # Keybindings
 # -----------
 
-# keybindings (list): User-defined keybindings for Reedline.
+# keybindings (list): Keybindings for Reedline.
 # Each keybinding is a record with: name, modifier, keycode, mode, and event.
 # See https://www.nushell.sh/book/line_editor.html#keybindings for details.
-# Default: []
-$env.config.keybindings = []
+#
+# Default: Nushell menu keybindings (Tab completion, Ctrl-r history menu, F1 help,
+# etc.). Inspect with `$env.config.keybindings`. Reedline's base emacs/vi maps are
+# still applied underneath and are listed by `keybindings default`.
+#
+# Full list replacement (`=`) clears Nushell menu bindings. Prefer `++=` to add,
+# or set `event: null` on a matching binding to unbind a key.
+# $env.config.keybindings = []
 
 # Example: Add Alt+. keybinding to insert the last token from previous command:
 # $env.config.keybindings ++= [
@@ -634,8 +640,11 @@ $env.config.abbreviations = {}
 # List-layout menus accept description_position: "before" or "after" in their
 # `type` record, controlling whether an entry's description is shown before or
 # after its value. Unset keeps reedline's default.
-# Default: []
-$env.config.menus = []
+#
+# Default: completion_menu, ide_completion_menu, history_menu, help_menu.
+# Inspect with `$env.config.menus`. Full list replacement (`=`) clears defaults;
+# prefer `++=` to add custom menus.
+# $env.config.menus = []
 
 # Example: Custom completion menu configuration:
 # $env.config.menus ++= [{
@@ -770,8 +779,9 @@ $env.config.highlight_resolved_externals = false
 # color_config (record): Styling for shapes, types, and UI elements.
 # Values can be: color names, RGB values (#RRGGBB), or records with fg, bg, attr keys.
 # attr can include: 'n' (normal), 'b' (bold), 'u' (underline), 'r' (reverse), 'i' (italics), 'd' (dimmed).
-# Default: (see default_config.nu for full default theme)
-$env.config.color_config = {}
+# Default: full theme in Rust `Config::default()` — inspect with `$env.config.color_config`
+# (also under `nu -n`). Assigning a whole record replaces the map; prefer nested field updates.
+# $env.config.color_config = {}
 
 # Example: Using a theme from the standard library:
 # use std/config dark-theme
@@ -794,7 +804,7 @@ $env.config.color_config.cursor = null
 # ---------------------------
 # shape_* settings style elements on the commandline based on their parsed "shape".
 # Shapes are identified by Nushell's parser as you type.
-# Default styles are defined in nu-color-config/src/shape_color.rs.
+# Default styles live in Rust `Config::default().color_config` (see `$env.config.color_config`).
 
 # color_config.shape_string: Style for string values.
 # Applies to quoted strings, barewords, record keys, declared string arguments.
@@ -895,8 +905,9 @@ $env.config.color_config.shape_variable = "purple"
 $env.config.color_config.shape_vardecl = "purple"
 
 # color_config.shape_matching_brackets: Style for matching bracket pairs when cursor is on one.
-# Default: { attr: u }
-$env.config.color_config.shape_matching_brackets = {attr: "u"}
+# Merged onto the bracket's base shape style (adds underline by default).
+# Default: default_underline
+$env.config.color_config.shape_matching_brackets = "default_underline"
 
 # color_config.shape_pipe: Style for the pipe symbol (|) in pipelines.
 # Default: purple_bold
@@ -952,7 +963,7 @@ $env.config.color_config.shape_flag = "blue_bold"
 # --------------------------
 # These style *values* of a particular *type* in structured data output
 # (tables, records, lists). They can accept closures for dynamic styling.
-# Default styles are defined in nu-color-config/src/style_computer.rs.
+# Defaults live in Rust `Config::default().color_config` (same map as shapes).
 
 # color_config.bool: Style for boolean values in output.
 # Default: light_cyan
@@ -1115,25 +1126,34 @@ $env.config.color_config.banner_highlight2 = "purple"
 
 # explore (record): UI configuration for the `explore` command.
 # Configures colors and styles for the interactive data explorer.
-# Default: {}
-$env.config.explore = {}
+# Keys applied by `ExploreConfig::from_nu_config`:
+#   selected_cell, highlight, status_bar_text/background, command_bar_text/background,
+#   title_bar_text/background, status.{info,success,warn,error}, try.reactive
+# Table padding is taken from `$env.config.table.padding` (not explore.table).
+#
+# Default (also inspect with `$env.config.explore`):
+$env.config.explore = {
+    selected_cell: { bg: light_blue },
+    highlight: { fg: black, bg: yellow },
+    status: {
+        success: { fg: black, bg: green },
+        error: { fg: white, bg: red },
+    },
+    try: { reactive: false },
+}
 
-# Example explore configuration:
+# Example: override bars and try mode (unset bar colors inherit the terminal):
 # $env.config.explore = {
 #     status_bar_background: { fg: "#1D1F21", bg: "#C4C9C6" },
 #     command_bar_text: { fg: "#C4C9C6" },
 #     highlight: { fg: "black", bg: "yellow" },
 #     status: {
 #         error: { fg: "white", bg: "red" },
+#         success: { fg: "black", bg: "green" },
 #         warn: {}
 #         info: {}
 #     },
 #     selected_cell: { bg: light_blue },
-#     config: { cursor_color: 'red' },
-#     table: {
-#         selected_cell: { bg: 'blue' }
-#         show_cursor: false
-#     },
 #     try: { reactive: true }
 # }
 

--- a/crates/nu-explore/src/explore/config.rs
+++ b/crates/nu-explore/src/explore/config.rs
@@ -48,7 +48,21 @@ impl Default for ExploreConfig {
 }
 
 impl ExploreConfig {
-    /// take the default explore config and update it with relevant values from the nu config
+    /// Build an [`ExploreConfig`] from `$env.config` (via [`Config`]).
+    ///
+    /// Reads only these keys under `$env.config.explore` (others are ignored):
+    /// - color styles: `selected_cell`, `highlight`, `status_bar_text`,
+    ///   `status_bar_background`, `command_bar_text`, `command_bar_background`,
+    ///   `title_bar_text`, `title_bar_background`
+    /// - nested: `status.{info,success,warn,error}`, `try.reactive`
+    ///
+    /// Related values taken from elsewhere (not `$env.config.explore`):
+    /// - [`Config::table`] `.padding` → column padding
+    /// - header/index flags and separator style are set by the `explore` command
+    ///   after this call (`--head`, `--index`, `color_config.separator`)
+    ///
+    /// Unsupported (commonly seen but not applied): `explore.config.*`,
+    /// `explore.table.*` (including `table.selected_cell` / `table.show_cursor`).
     pub fn from_nu_config(config: &Config) -> Self {
         let mut ret = Self::default();
 

--- a/crates/nu-explore/src/explore/config.rs
+++ b/crates/nu-explore/src/explore/config.rs
@@ -74,12 +74,12 @@ impl ExploreConfig {
             ret.cmd_bar_background = *s;
         }
 
-        if let Some(s) = colors.get("command_bar_background") {
-            ret.cmd_bar_background = *s;
-        }
-
         if let Some(s) = colors.get("selected_cell") {
             ret.selected_cell = *s;
+        }
+
+        if let Some(s) = colors.get("highlight") {
+            ret.highlight = *s;
         }
 
         if let Some(s) = colors.get("title_bar_text") {
@@ -143,5 +143,46 @@ const fn color(foreground: Option<Color>, background: Option<Color>) -> Style {
         is_strikethrough: false,
         is_underline: false,
         prefix_with_reset: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nu_protocol::{Config, Value, record};
+    use std::collections::HashMap;
+
+    #[test]
+    fn from_nu_config_applies_highlight() {
+        let mut explore = HashMap::new();
+        explore.insert(
+            "highlight".into(),
+            Value::test_record(record! {
+                "fg" => Value::test_string("red"),
+                "bg" => Value::test_string("blue"),
+            }),
+        );
+        let config = Config {
+            explore,
+            ..Config::default()
+        };
+        let explore_cfg = ExploreConfig::from_nu_config(&config);
+        assert_eq!(explore_cfg.highlight.foreground, Some(Color::Red));
+        assert_eq!(explore_cfg.highlight.background, Some(Color::Blue));
+    }
+
+    #[test]
+    fn from_nu_config_default_highlight_matches_explore_default() {
+        let config = Config::default();
+        let explore_cfg = ExploreConfig::from_nu_config(&config);
+        let defaults = ExploreConfig::default();
+        assert_eq!(
+            explore_cfg.highlight.foreground,
+            defaults.highlight.foreground
+        );
+        assert_eq!(
+            explore_cfg.highlight.background,
+            defaults.highlight.background
+        );
     }
 }

--- a/crates/nu-protocol/src/config/defaults.rs
+++ b/crates/nu-protocol/src/config/defaults.rs
@@ -1,0 +1,344 @@
+//! Built-in defaults for `$env.config` that must be visible without loading
+//! `default_config.nu` (e.g. under `nu -n --no-std-lib`).
+//!
+//! Includes:
+//! - `color_config` theme (formerly only in `default_config.nu`)
+//! - default Reedline menus
+//! - Nushell-owned menu keybindings (not reedline's base emacs/vi maps)
+
+use super::reedline::{ParsedKeybinding, ParsedMenu};
+use crate::{Record, Span, Value, record};
+use std::collections::HashMap;
+
+fn span() -> Span {
+    Span::unknown()
+}
+
+fn str(s: &str) -> Value {
+    Value::string(s, span())
+}
+
+fn bool(b: bool) -> Value {
+    Value::bool(b, span())
+}
+
+fn int(i: i64) -> Value {
+    Value::int(i, span())
+}
+
+fn rec(r: Record) -> Value {
+    Value::record(r, span())
+}
+
+/// Default syntax/UI color theme, previously embedded in `default_config.nu`.
+pub fn default_color_config() -> HashMap<String, Value> {
+    let entries: &[(&str, Value)] = &[
+        ("separator", str("default")),
+        (
+            "leading_trailing_space_bg",
+            rec(record! { "attr" => str("n") }),
+        ),
+        ("header", str("green_bold")),
+        ("empty", str("blue")),
+        ("bool", str("light_cyan")),
+        ("int", str("default")),
+        ("filesize", str("cyan")),
+        ("duration", str("default")),
+        ("datetime", str("purple")),
+        ("range", str("default")),
+        ("float", str("default")),
+        ("string", str("default")),
+        ("nothing", str("default")),
+        ("binary", str("default")),
+        ("binary_null_char", str("grey42")),
+        ("binary_printable", str("cyan_bold")),
+        ("binary_whitespace", str("green_bold")),
+        ("binary_ascii_other", str("purple_bold")),
+        ("binary_non_ascii", str("yellow_bold")),
+        ("cell-path", str("default")),
+        ("row_index", str("green_bold")),
+        ("record", str("default")),
+        ("list", str("default")),
+        ("closure", str("green_bold")),
+        ("glob", str("cyan_bold")),
+        ("semver", str("cyan_bold")),
+        ("semver-range", str("cyan_bold")),
+        ("block", str("default")),
+        ("hints", str("dark_gray")),
+        (
+            "search_result",
+            rec(record! {
+                "bg" => str("red"),
+                "fg" => str("default"),
+            }),
+        ),
+        ("shape_binary", str("purple_bold")),
+        ("shape_block", str("blue_bold")),
+        ("shape_bool", str("light_cyan")),
+        ("shape_closure", str("green_bold")),
+        ("shape_custom", str("green")),
+        ("shape_datetime", str("cyan_bold")),
+        ("shape_directory", str("cyan")),
+        ("shape_external", str("cyan")),
+        ("shape_externalarg", str("green_bold")),
+        ("shape_external_resolved", str("light_yellow_bold")),
+        ("shape_filepath", str("cyan")),
+        ("shape_flag", str("blue_bold")),
+        ("shape_float", str("purple_bold")),
+        ("shape_glob_interpolation", str("cyan_bold")),
+        ("shape_globpattern", str("cyan_bold")),
+        ("shape_int", str("purple_bold")),
+        ("shape_internalcall", str("cyan_bold")),
+        ("shape_keyword", str("cyan_bold")),
+        ("shape_list", str("cyan_bold")),
+        ("shape_literal", str("blue")),
+        ("shape_match_pattern", str("green")),
+        // String form so matching-brackets merge works with `lookup_ansi_color_style`
+        ("shape_matching_brackets", str("default_underline")),
+        ("shape_nothing", str("light_cyan")),
+        ("shape_operator", str("yellow")),
+        ("shape_pipe", str("purple_bold")),
+        ("shape_range", str("yellow_bold")),
+        ("shape_record", str("cyan_bold")),
+        ("shape_redirection", str("purple_bold")),
+        ("shape_signature", str("green_bold")),
+        ("shape_string", str("green")),
+        ("shape_string_interpolation", str("cyan_bold")),
+        ("shape_table", str("blue_bold")),
+        ("shape_variable", str("purple")),
+        ("shape_vardecl", str("purple")),
+        ("shape_raw_string", str("light_purple")),
+        (
+            "shape_garbage",
+            rec(record! {
+                "fg" => str("default"),
+                "bg" => str("red"),
+                "attr" => str("b"),
+            }),
+        ),
+    ];
+
+    entries
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), v.clone()))
+        .collect()
+}
+
+fn menu_style_basic() -> Value {
+    rec(record! {
+        "text" => str("green"),
+        "selected_text" => str("green_reverse"),
+        "description_text" => str("yellow"),
+    })
+}
+
+/// Default Reedline menus applied when none are configured by the user.
+pub fn default_menus() -> Vec<ParsedMenu> {
+    vec![
+        ParsedMenu {
+            name: str("completion_menu"),
+            marker: str("| "),
+            only_buffer_difference: Some(bool(false)),
+            input_mode: None,
+            output_mode: None,
+            style: menu_style_basic(),
+            r#type: rec(record! {
+                "layout" => str("columnar"),
+                "columns" => int(4),
+                "col_width" => int(20),
+                "col_padding" => int(2),
+                "tab_traversal" => str("horizontal"),
+            }),
+            source: None,
+        },
+        ParsedMenu {
+            name: str("ide_completion_menu"),
+            marker: str("| "),
+            only_buffer_difference: Some(bool(false)),
+            input_mode: None,
+            output_mode: None,
+            style: rec(record! {
+                "text" => str("green"),
+                "selected_text" => rec(record! { "attr" => str("r") }),
+                "description_text" => str("yellow"),
+                "match_text" => rec(record! { "attr" => str("u") }),
+                "selected_match_text" => rec(record! { "attr" => str("ur") }),
+            }),
+            r#type: rec(record! {
+                "layout" => str("ide"),
+                "min_completion_width" => int(0),
+                "max_completion_width" => int(50),
+                "max_completion_height" => int(10),
+                "padding" => int(0),
+                "border" => bool(true),
+                "cursor_offset" => int(0),
+                "description_mode" => str("prefer_right"),
+                "min_description_width" => int(15),
+                "max_description_width" => int(50),
+                "max_description_height" => int(10),
+                "description_offset" => int(1),
+                "correct_cursor_pos" => bool(false),
+            }),
+            source: None,
+        },
+        ParsedMenu {
+            name: str("history_menu"),
+            marker: str("? "),
+            only_buffer_difference: Some(bool(true)),
+            input_mode: None,
+            output_mode: None,
+            style: menu_style_basic(),
+            r#type: rec(record! {
+                "layout" => str("list"),
+                "page_size" => int(10),
+            }),
+            source: None,
+        },
+        ParsedMenu {
+            name: str("help_menu"),
+            marker: str("? "),
+            only_buffer_difference: Some(bool(true)),
+            input_mode: None,
+            output_mode: None,
+            style: menu_style_basic(),
+            r#type: rec(record! {
+                "layout" => str("description"),
+                "columns" => int(4),
+                "col_width" => int(20),
+                "col_padding" => int(2),
+                "selection_rows" => int(4),
+                "description_rows" => int(15),
+            }),
+            source: None,
+        },
+    ]
+}
+
+fn all_modes() -> Value {
+    Value::list(
+        vec![str("emacs"), str("vi_normal"), str("vi_insert")],
+        span(),
+    )
+}
+
+fn keybinding(name: &str, modifier: &str, keycode: &str, event: Value) -> ParsedKeybinding {
+    ParsedKeybinding {
+        name: Some(str(name)),
+        modifier: str(modifier),
+        keycode: str(keycode),
+        event,
+        mode: all_modes(),
+    }
+}
+
+fn until(events: Vec<Value>) -> Value {
+    rec(record! {
+        "until" => Value::list(events, span()),
+    })
+}
+
+fn send(name: &str) -> Value {
+    rec(record! {
+        "send" => str(name),
+    })
+}
+
+fn send_menu(menu_name: &str) -> Value {
+    rec(record! {
+        "send" => str("menu"),
+        "name" => str(menu_name),
+    })
+}
+
+fn edit(name: &str) -> Value {
+    rec(record! {
+        "edit" => str(name),
+    })
+}
+
+/// Default `$env.config.explore` values matching `ExploreConfig::default()`
+/// colors in `nu-explore` (inherit-from-terminal styles stay unset).
+pub fn default_explore() -> HashMap<String, Value> {
+    [
+        ("selected_cell", rec(record! { "bg" => str("light_blue") })),
+        (
+            "highlight",
+            rec(record! {
+                "fg" => str("black"),
+                "bg" => str("yellow"),
+            }),
+        ),
+        (
+            "status",
+            rec(record! {
+                "success" => rec(record! {
+                    "fg" => str("black"),
+                    "bg" => str("green"),
+                }),
+                "error" => rec(record! {
+                    "fg" => str("white"),
+                    "bg" => str("red"),
+                }),
+            }),
+        ),
+        (
+            "try",
+            rec(record! {
+                "reactive" => bool(false),
+            }),
+        ),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), v))
+    .collect()
+}
+
+/// Nushell-owned menu keybindings (Tab completion, history menu, help, etc.).
+///
+/// Reedline's base emacs/vi maps are **not** included; those remain library
+/// defaults applied underneath in `create_keybindings`.
+pub fn default_keybindings() -> Vec<ParsedKeybinding> {
+    vec![
+        keybinding(
+            "completion_menu",
+            "none",
+            "tab",
+            until(vec![
+                send_menu("completion_menu"),
+                send("menunext"),
+                edit("complete"),
+            ]),
+        ),
+        keybinding(
+            "ide_completion_menu",
+            "control",
+            "space",
+            until(vec![
+                send_menu("ide_completion_menu"),
+                send("menunext"),
+                edit("complete"),
+            ]),
+        ),
+        keybinding(
+            "completion_previous",
+            "shift",
+            "backtab",
+            send("menuprevious"),
+        ),
+        keybinding(
+            "history_menu",
+            "control",
+            "char_r",
+            send_menu("history_menu"),
+        ),
+        keybinding("next_page_menu", "control", "char_x", send("menupagenext")),
+        keybinding(
+            "undo_or_previous_page_menu",
+            "control",
+            "char_z",
+            until(vec![send("menupageprevious"), edit("undo")]),
+        ),
+        keybinding("help_menu", "none", "f1", send_menu("help_menu")),
+        keybinding("search_history", "control", "char_q", send("searchhistory")),
+    ]
+}

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -12,6 +12,7 @@ pub use completions::{
     CompletionAlgorithm, CompletionConfig, CompletionSort, ExternalCompleterConfig,
 };
 pub use datetime_format::DatetimeFormatConfig;
+pub use defaults::default_color_config;
 pub use display_errors::DisplayErrors;
 pub use duration_max_unit::DurationMaxUnit;
 pub use filesize::FilesizeConfig;
@@ -31,6 +32,7 @@ mod ansi_coloring;
 mod clip;
 mod completions;
 mod datetime_format;
+mod defaults;
 mod display_errors;
 mod duration_max_unit;
 mod error;
@@ -105,7 +107,7 @@ impl Default for Config {
 
             datetime_format: DatetimeFormatConfig::default(),
 
-            explore: HashMap::new(),
+            explore: defaults::default_explore(),
 
             history: HistoryConfig::default(),
 
@@ -119,7 +121,7 @@ impl Default for Config {
 
             clip: ClipConfig::default(),
 
-            color_config: HashMap::new(),
+            color_config: defaults::default_color_config(),
             footer_mode: FooterMode::RowCount(25),
             float_precision: 2,
             buffer_editor: Value::nothing(Span::unknown()),
@@ -135,9 +137,9 @@ impl Default for Config {
 
             hooks: Hooks::new(),
 
-            menus: Vec::new(),
+            menus: defaults::default_menus(),
 
-            keybindings: Vec::new(),
+            keybindings: defaults::default_keybindings(),
             abbreviations: HashMap::new(),
 
             error_style: ErrorStyle::default(),

--- a/tests/repl/test_config.rs
+++ b/tests/repl/test_config.rs
@@ -1,5 +1,27 @@
 use crate::repl::tests::{TestResult, fail_test, run_test, run_test_std};
 
+/// Defaults for color_config, menus, and Nushell menu keybindings live on
+/// `Config::default()` so they are visible even under `nu -n` / without sourcing
+/// config files.
+#[test]
+fn default_config_color_menus_keybindings_viewable() -> TestResult {
+    run_test(
+        r#"
+            [
+                (($env.config.color_config | columns | length) > 0)
+                ($env.config.color_config.header == "green_bold")
+                ("completion_menu" in ($env.config.menus | get name))
+                ("history_menu" in ($env.config.menus | get name))
+                (($env.config.keybindings | length) > 0)
+                ("completion_menu" in ($env.config.keybindings | get name))
+                (($env.config.explore | columns | length) > 0)
+                ("selected_cell" in ($env.config.explore | columns))
+            ] | all {|x| $x }
+        "#,
+        "true",
+    )
+}
+
 #[test]
 fn mutate_nu_config() -> TestResult {
     run_test_std(


### PR DESCRIPTION


<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR has been a long time coming. It finally shows _most_ of the default config settings when you inspect them with `$env.confg` even if you haven't sourced any config.nu files.
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
Now it's easier to see what the default settings are when you don't have them configured. Show (nearly) all settings in `$env.config`. If you haven't set any, or launched with `nu -n`, it will show defaults.
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
For posterity, here are the things I found that are not contained in the $env.config.
- $env.PROMPT_* (could change soon)
- LS_COLORS default and $env.LS_COLORS
- $env.VISUAL / $env.EDITOR
- $env.config.buffer_editor: null — falls back to $env.VISUAL / $env.EDITOR
- Visual selection reverse style is hard-coded in REPL
- Parts of $env.config.use_ansi_coloring, namely $env.NO_COLOR, $env.FORCE_COLOR
- Filesize locale determined by system locale
- $env.config.datetime_format.normal / .table default to null, but display is hard-coded (RFC2822 + human / chrono_humanize).
- reedline vi keybindings and some emacs bindings
- $env.config.history.path: "" — means “use default under config home” (resolved path is not the same as the config value; see $nu.history-path)
- $env.config.plugins: {} — no default plugin settings
- $env.config.abbreviations: {} — no default abbreviations