### PR TITLE
fix(generate): handle `null` input the same as empty pipeline

### DIFF
--- a/crates/nu-command/src/generators/generate.rs
+++ b/crates/nu-command/src/generators/generate.rs
@@ -103,7 +103,7 @@ In this case, generation also stops when the input stream stops."
         let mut closure = ClosureEval::new(engine_state, stack, closure);
 
         match input {
-            PipelineData::Empty => {
+            PipelineData::Empty | PipelineData::Value(Value::Nothing { .. }, ..) => {
                 // A type of Option<S> is used to represent state. Invocation
                 // will stop on None. Using Option<S> allows functions to output
                 // one final value before stopping.

--- a/crates/nu-command/tests/commands/generate.rs
+++ b/crates/nu-command/tests/commands/generate.rs
@@ -16,6 +16,20 @@ fn generate_no_next_break() -> Result {
 }
 
 #[test]
+fn generate_null_input_same_as_empty_pipeline() -> Result {
+    let code = "
+        null | generate {|x|
+            if $x == 3 {
+                {out: $x}
+            } else {
+                {out: $x, next: ( $x + 1 )}
+            }
+        } 1
+    ";
+    test().run(code).expect_value_eq([1, 2, 3])
+}
+
+#[test]
 fn generate_null_break() -> Result {
     let code = "
         generate {|x|


### PR DESCRIPTION
## Description

There are few commands where the distinction matters, but I don't think `generate` is one of them.

## User-facing changes (Release notes)

Fixed `generate` rejecting `null` value pipeline input despite working with "empty" pipeline input.

## Additional notes

- Discovered alongside #18752