### PR TITLE
job spawn closure should be ran with empty pipeline, not null

### DIFF
--- a/crates/nu-command/src/experimental/job_spawn.rs
+++ b/crates/nu-command/src/experimental/job_spawn.rs
@@ -101,7 +101,7 @@ impl Command for JobSpawn {
                     Some(Redirection::Pipe(OutDest::Null)),
                 );
                 ClosureEvalOnce::new_preserve_out_dest(&job_state, &stack, closure)
-                    .run_with_input(Value::nothing(head).into_pipeline_data())
+                    .run_with_input(PipelineData::Empty)
                     .and_then(|data| data.drain())
                     .unwrap_or_else(|err| {
                         if !job_state.signals().interrupted() {

--- a/crates/nu-command/tests/commands/job.rs
+++ b/crates/nu-command/tests/commands/job.rs
@@ -2,6 +2,17 @@
 // this improves the stability of these tests
 
 use nu_test_support::nu;
+use nu_test_support::prelude::*;
+
+#[test]
+fn job_spawn_runs_with_empty_pipeline_not_null_value() -> Result {
+    let code = "
+        job spawn { peek | metadata | job send 0 }
+        (job recv --timeout 1sec).peek.type
+    ";
+    // `null | peek | metadata | get peek.type` is `nothing`
+    test().run(code).expect_value_eq("empty")
+}
 
 #[test]
 #[serial]


### PR DESCRIPTION
## Description

There is a very small difference, but it can matter. Also this is more semantically correct.

## User-facing changes (Release notes)

N/A

## Additional notes

- Discovered alongside #18751