### PR TITLE
lines: do not prematurely collect output for string value input

### DIFF
--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::Signals;
 
 #[derive(Clone)]
 pub struct Lines;
@@ -30,25 +31,21 @@ impl Command for Lines {
         let skip_empty = call.has_flag(engine_state, stack, "skip-empty")?;
         let strict = call.has_flag(engine_state, stack, "strict")?;
 
-        let span = input.span().unwrap_or(call.head);
         match input {
             PipelineData::Value(value, ..) => match value {
                 Value::String { val, .. } => {
-                    let lines = if skip_empty {
-                        val.lines()
-                            .filter_map(|s| {
-                                if s.trim().is_empty() {
-                                    None
-                                } else {
-                                    Some(Value::string(s, span))
-                                }
-                            })
-                            .collect()
-                    } else {
-                        val.lines().map(|s| Value::string(s, span)).collect()
-                    };
+                    let lines = ByteStream::read_string(val, head, Signals::empty())
+                        .lines()
+                        .expect(".lines() always succeeds for ByteStreamSource::Read");
+                    // source is a UTF-8 String, so strict mode should always produce valid UTF-8 strings
+                    let lines = lines.strict(true);
 
-                    Ok(Value::list(lines, span).into_pipeline_data())
+                    Ok(lines
+                        .map(move |line| match line {
+                            Ok(line) => Value::string(line, head),
+                            Err(err) => Value::error(err, head),
+                        })
+                        .into_pipeline_data(head, engine_state.signals().clone()))
                 }
                 // Propagate existing errors
                 Value::Error { error, .. } => Err(*error),


### PR DESCRIPTION
## Description

Should mostly be transparent to users, only a performance improvement.

## User-facing changes (Release notes)

`lines` command with string *value* (non-stream) input no longer eagerly creates a list. Instead it returns a list stream, producing items lazily just like it does with text/byte stream inputs.