### PR TITLE
update math commands to handle records and support cell path rest params

### DIFF
--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -1,4 +1,4 @@
-use crate::math::utils::ensure_bounded;
+use crate::math::utils::run_with_elementwise;
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
@@ -23,7 +23,13 @@ impl Command for MathAbs {
                     Type::List(Box::new(Type::Duration)),
                 ),
                 (Type::Range, Type::List(Box::new(Type::Number))),
+                (Type::record(), Type::record()),
             ])
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .allow_variants_without_examples(true)
             .category(Category::Math)
     }
@@ -43,16 +49,20 @@ impl Command for MathAbs {
     fn run(
         &self,
         engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let head = call.head;
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        input.map(move |value| abs_helper(value, head), engine_state.signals())
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
+            engine_state.signals(),
+            false,
+            move |value| abs_helper(value, head),
+        )
     }
 
     fn run_const(
@@ -61,30 +71,61 @@ impl Command for MathAbs {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
         let head = call.head;
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        input.map(
-            move |value| abs_helper(value, head),
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
             working_set.permanent().signals(),
+            false,
+            move |value| abs_helper(value, head),
         )
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![Example {
-            description: "Compute absolute value of each number in a list of numbers.",
-            example: "[-50 -100.0 25] | math abs",
-            result: Some(Value::list(
-                vec![
-                    Value::test_int(50),
-                    Value::test_float(100.0),
-                    Value::test_int(25),
-                ],
-                Span::test_data(),
-            )),
-        }]
+        vec![
+            Example {
+                description: "Compute absolute value of each number in a list of numbers.",
+                example: "[-50 -100.0 25] | math abs",
+                result: Some(Value::list(
+                    vec![
+                        Value::test_int(50),
+                        Value::test_float(100.0),
+                        Value::test_int(25),
+                    ],
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Compute the absolute value of list-valued columns in a record.",
+                example: "{alice: [-1 -2 -3], bob: [-4 -5]} | math abs",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_int(1), Value::test_int(2), Value::test_int(3)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_int(4), Value::test_int(5)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
+            Example {
+                description: "Compute the absolute value of a single column using a cell path.",
+                example: "{alice: [-1 -2 -3], bob: [-4 -5]} | math abs alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_int(1), Value::test_int(2), Value::test_int(3)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_int(-4), Value::test_int(-5)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
+        ]
     }
 }
 

--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -14,6 +14,7 @@ impl Command for MathAbs {
             .input_output_types(vec![
                 (Type::Number, Type::Number),
                 (Type::Duration, Type::Duration),
+                (Type::Filesize, Type::Filesize),
                 (
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Number)),
@@ -21,6 +22,10 @@ impl Command for MathAbs {
                 (
                     Type::List(Box::new(Type::Duration)),
                     Type::List(Box::new(Type::Duration)),
+                ),
+                (
+                    Type::List(Box::new(Type::Filesize)),
+                    Type::List(Box::new(Type::Filesize)),
                 ),
                 (Type::Range, Type::List(Box::new(Type::Number))),
                 (Type::record(), Type::record()),
@@ -159,10 +164,23 @@ fn abs_helper(val: Value, head: Span) -> Value {
                 span,
             ),
         },
+        Value::Filesize { val, .. } => match val.get().checked_abs() {
+            Some(abs) => Value::filesize(abs, span),
+            None => Value::error(
+                ShellError::OperatorOverflow {
+                    msg: "absolute value operation overflowed".into(),
+                    span,
+                    help: Some(
+                        "the absolute value of the minimum filesize cannot be represented".into(),
+                    ),
+                },
+                span,
+            ),
+        },
         Value::Error { .. } => val,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "numeric".into(),
+                exp_input_type: crate::math::utils::NUMERIC_INPUT_TYPES.into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -1,6 +1,6 @@
 use crate::math::{
     reducers::{Reduce, reducer_for},
-    utils::run_with_function,
+    utils::{run_with_function_with_cell_paths, run_with_function_with_cell_paths_const},
 };
 use nu_engine::command_prelude::*;
 
@@ -27,6 +27,11 @@ impl Command for MathAvg {
                 (Type::record(), Type::record()),
             ])
             .allow_variants_without_examples(true)
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .category(Category::Math)
     }
 
@@ -44,21 +49,21 @@ impl Command for MathAvg {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, average)
+        run_with_function_with_cell_paths(engine_state, stack, call, input, average)
     }
 
     fn run_const(
         &self,
-        _working_set: &StateWorkingSet,
+        working_set: &StateWorkingSet,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, average)
+        run_with_function_with_cell_paths_const(working_set, call, input, average)
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -79,6 +84,25 @@ impl Command for MathAvg {
                 result: Some(Value::test_record(record! {
                     "a" => Value::test_int(2),
                     "b" => Value::test_int(3),
+                })),
+            },
+            Example {
+                description: "Compute the average of list-valued columns in a record.",
+                example: "{alice: [1 2 3], bob: [4 5 6]} | math avg",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(2),
+                    "bob" => Value::test_int(5),
+                })),
+            },
+            Example {
+                description: "Compute the average of a single column using a cell path.",
+                example: "{alice: [1 2 3], bob: [4 5 6]} | math avg alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(2),
+                    "bob" => Value::list(
+                        vec![Value::test_int(4), Value::test_int(5), Value::test_int(6)],
+                        Span::test_data(),
+                    ),
                 })),
             },
         ]

--- a/crates/nu-command/src/math/cbrt.rs
+++ b/crates/nu-command/src/math/cbrt.rs
@@ -1,4 +1,4 @@
-use crate::math::utils::ensure_bounded;
+use crate::math::utils::run_with_elementwise;
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
@@ -18,7 +18,13 @@ impl Command for MathCbrt {
                     Type::List(Box::new(Type::Float)),
                 ),
                 (Type::Range, Type::List(Box::new(Type::Number))),
+                (Type::record(), Type::record()),
             ])
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .allow_variants_without_examples(true)
             .category(Category::Math)
     }
@@ -38,20 +44,20 @@ impl Command for MathCbrt {
     fn run(
         &self,
         engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let head = call.head;
-        // This doesn't match explicit nulls
-        if let PipelineData::Empty = input {
-            return Err(ShellError::PipelineEmpty { dst_span: head });
-        }
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        input.map(move |value| operate(value, head), engine_state.signals())
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
+            engine_state.signals(),
+            true,
+            move |value| operate(value, head),
+        )
     }
 
     fn run_const(
@@ -60,30 +66,57 @@ impl Command for MathCbrt {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
         let head = call.head;
-        // This doesn't match explicit nulls
-        if let PipelineData::Empty = input {
-            return Err(ShellError::PipelineEmpty { dst_span: head });
-        }
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        input.map(
-            move |value| operate(value, head),
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
             working_set.permanent().signals(),
+            true,
+            move |value| operate(value, head),
         )
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![Example {
-            description: "Compute the cube root of each number in a list.",
-            example: "[8 -27] | math cbrt",
-            result: Some(Value::list(
-                vec![Value::test_float(2.0), Value::test_float(-3.0)],
-                Span::test_data(),
-            )),
-        }]
+        vec![
+            Example {
+                description: "Compute the cube root of each number in a list.",
+                example: "[8 -27] | math cbrt",
+                result: Some(Value::list(
+                    vec![Value::test_float(2.0), Value::test_float(-3.0)],
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Compute the cube root of list-valued columns in a record.",
+                example: "{alice: [8 27 64], bob: [125 216]} | math cbrt",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_float(2.0), Value::test_float(3.0), Value::test_float(4.0)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_float(5.0), Value::test_float(6.0)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
+            Example {
+                description: "Compute the cube root of a single column using a cell path.",
+                example: "{alice: [8 27 64], bob: [125 216]} | math cbrt alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_float(2.0), Value::test_float(3.0), Value::test_float(4.0)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_float(125.0), Value::test_float(216.0)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
+        ]
     }
 }
 

--- a/crates/nu-command/src/math/cbrt.rs
+++ b/crates/nu-command/src/math/cbrt.rs
@@ -111,7 +111,7 @@ impl Command for MathCbrt {
                         Span::test_data(),
                     ),
                     "bob" => Value::list(
-                        vec![Value::test_float(125.0), Value::test_float(216.0)],
+                        vec![Value::test_int(125), Value::test_int(216)],
                         Span::test_data(),
                     ),
                 })),
@@ -128,7 +128,7 @@ fn operate(value: Value, head: Span) -> Value {
         Value::Error { .. } => value,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "numeric".into(),
+                exp_input_type: crate::math::utils::NUMBER_INPUT_TYPES.into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -46,7 +46,7 @@ impl Command for MathCeil {
     fn extra_description(&self) -> &str {
         "Filesize and duration values are stored as whole numbers of base units \
          (bytes and nanoseconds). Without a display unit to round against, \
-         `math ceil` is a no-op for those types."
+         `math ceil` is the identity function for those types."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -44,8 +44,8 @@ impl Command for MathCeil {
     }
 
     fn extra_description(&self) -> &str {
-        "Filesize and duration values are stored as whole numbers of base units \
-         (bytes and nanoseconds). Without a display unit to round against, \
+        "Filesize and duration values are stored as integers in base units \
+         (bytes and nanoseconds). With no display unit to round against, \
          `math ceil` is the identity function for those types."
     }
 

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -13,9 +13,19 @@ impl Command for MathCeil {
         Signature::build("math ceil")
             .input_output_types(vec![
                 (Type::Number, Type::Int),
+                (Type::Duration, Type::Duration),
+                (Type::Filesize, Type::Filesize),
                 (
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Int)),
+                ),
+                (
+                    Type::List(Box::new(Type::Duration)),
+                    Type::List(Box::new(Type::Duration)),
+                ),
+                (
+                    Type::List(Box::new(Type::Filesize)),
+                    Type::List(Box::new(Type::Filesize)),
                 ),
                 (Type::Range, Type::List(Box::new(Type::Number))),
                 (Type::record(), Type::record()),
@@ -123,12 +133,13 @@ impl Command for MathCeil {
 fn operate(value: Value, head: Span) -> Value {
     let span = value.span();
     match value {
-        Value::Int { .. } => value,
+        // Duration and filesize are already integer units (ns / bytes).
+        Value::Int { .. } | Value::Duration { .. } | Value::Filesize { .. } => value,
         Value::Float { val, .. } => Value::int(val.ceil() as i64, span),
         Value::Error { .. } => value,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "numeric".into(),
+                exp_input_type: crate::math::utils::NUMERIC_INPUT_TYPES.into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -1,4 +1,4 @@
-use crate::math::utils::ensure_bounded;
+use crate::math::utils::run_with_elementwise;
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
@@ -18,7 +18,13 @@ impl Command for MathCeil {
                     Type::List(Box::new(Type::Int)),
                 ),
                 (Type::Range, Type::List(Box::new(Type::Number))),
+                (Type::record(), Type::record()),
             ])
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .allow_variants_without_examples(true)
             .category(Category::Math)
     }
@@ -38,20 +44,20 @@ impl Command for MathCeil {
     fn run(
         &self,
         engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let head = call.head;
-        // This doesn't match explicit nulls
-        if let PipelineData::Empty = input {
-            return Err(ShellError::PipelineEmpty { dst_span: head });
-        }
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        input.map(move |value| operate(value, head), engine_state.signals())
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
+            engine_state.signals(),
+            true,
+            move |value| operate(value, head),
+        )
     }
 
     fn run_const(
@@ -60,30 +66,57 @@ impl Command for MathCeil {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
         let head = call.head;
-        // This doesn't match explicit nulls
-        if let PipelineData::Empty = input {
-            return Err(ShellError::PipelineEmpty { dst_span: head });
-        }
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        input.map(
-            move |value| operate(value, head),
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
             working_set.permanent().signals(),
+            true,
+            move |value| operate(value, head),
         )
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![Example {
-            description: "Apply the ceil function to a list of numbers.",
-            example: "[1.5 2.3 -3.1] | math ceil",
-            result: Some(Value::list(
-                vec![Value::test_int(2), Value::test_int(3), Value::test_int(-3)],
-                Span::test_data(),
-            )),
-        }]
+        vec![
+            Example {
+                description: "Apply the ceil function to a list of numbers.",
+                example: "[1.5 2.3 -3.1] | math ceil",
+                result: Some(Value::list(
+                    vec![Value::test_int(2), Value::test_int(3), Value::test_int(-3)],
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Apply ceiling to list-valued columns in a record.",
+                example: "{alice: [1.2 2.7 3.5], bob: [4.1 5.9]} | math ceil",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_int(2), Value::test_int(3), Value::test_int(4)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_int(5), Value::test_int(6)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
+            Example {
+                description: "Apply ceiling to a single column using a cell path.",
+                example: "{alice: [1.2 2.7 3.5], bob: [4.1 5.9]} | math ceil alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_int(2), Value::test_int(3), Value::test_int(4)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_float(4.1), Value::test_float(5.9)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
+        ]
     }
 }
 

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -43,6 +43,12 @@ impl Command for MathCeil {
         "Returns the ceil of a number (smallest integer greater than or equal to that number)."
     }
 
+    fn extra_description(&self) -> &str {
+        "Filesize and duration values are stored as whole numbers of base units \
+         (bytes and nanoseconds). Without a display unit to round against, \
+         `math ceil` is a no-op for those types."
+    }
+
     fn search_terms(&self) -> Vec<&str> {
         vec!["ceiling", "round up", "rounding", "integer"]
     }
@@ -125,6 +131,12 @@ impl Command for MathCeil {
                         Span::test_data(),
                     ),
                 })),
+            },
+            Example {
+                // Filesize is already whole bytes; ceiling cannot use the display unit (KB).
+                description: "Filesize values are already whole bytes, so ceiling is a no-op.",
+                example: "2.1KB | math ceil",
+                result: Some(Value::test_filesize(2100)),
             },
         ]
     }

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -44,8 +44,8 @@ impl Command for MathFloor {
     }
 
     fn extra_description(&self) -> &str {
-        "Filesize and duration values are stored as whole numbers of base units \
-         (bytes and nanoseconds). Without a display unit to round against, \
+        "Filesize and duration values are stored as integers in base units \
+         (bytes and nanoseconds). With no display unit to round against, \
          `math floor` is the identity function for those types."
     }
 

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -43,6 +43,12 @@ impl Command for MathFloor {
         "Returns the floor of a number (largest integer less than or equal to that number)."
     }
 
+    fn extra_description(&self) -> &str {
+        "Filesize and duration values are stored as whole numbers of base units \
+         (bytes and nanoseconds). Without a display unit to round against, \
+         `math floor` is a no-op for those types."
+    }
+
     fn search_terms(&self) -> Vec<&str> {
         vec!["round down", "rounding", "integer"]
     }
@@ -125,6 +131,12 @@ impl Command for MathFloor {
                         Span::test_data(),
                     ),
                 })),
+            },
+            Example {
+                // Filesize is already whole bytes; flooring cannot use the display unit (KB).
+                description: "Filesize values are already whole bytes, so flooring is a no-op.",
+                example: "2.1KB | math floor",
+                result: Some(Value::test_filesize(2100)),
             },
         ]
     }

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -46,7 +46,7 @@ impl Command for MathFloor {
     fn extra_description(&self) -> &str {
         "Filesize and duration values are stored as whole numbers of base units \
          (bytes and nanoseconds). Without a display unit to round against, \
-         `math floor` is a no-op for those types."
+         `math floor` is the identity function for those types."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -13,9 +13,19 @@ impl Command for MathFloor {
         Signature::build("math floor")
             .input_output_types(vec![
                 (Type::Number, Type::Int),
+                (Type::Duration, Type::Duration),
+                (Type::Filesize, Type::Filesize),
                 (
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Int)),
+                ),
+                (
+                    Type::List(Box::new(Type::Duration)),
+                    Type::List(Box::new(Type::Duration)),
+                ),
+                (
+                    Type::List(Box::new(Type::Filesize)),
+                    Type::List(Box::new(Type::Filesize)),
                 ),
                 (Type::Range, Type::List(Box::new(Type::Number))),
                 (Type::record(), Type::record()),
@@ -123,12 +133,13 @@ impl Command for MathFloor {
 fn operate(value: Value, head: Span) -> Value {
     let span = value.span();
     match value {
-        Value::Int { .. } => value,
+        // Duration and filesize are already integer units (ns / bytes).
+        Value::Int { .. } | Value::Duration { .. } | Value::Filesize { .. } => value,
         Value::Float { val, .. } => Value::int(val.floor() as i64, span),
         Value::Error { .. } => value,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "numeric".into(),
+                exp_input_type: crate::math::utils::NUMERIC_INPUT_TYPES.into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -1,4 +1,4 @@
-use crate::math::utils::ensure_bounded;
+use crate::math::utils::run_with_elementwise;
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
@@ -18,7 +18,13 @@ impl Command for MathFloor {
                     Type::List(Box::new(Type::Int)),
                 ),
                 (Type::Range, Type::List(Box::new(Type::Number))),
+                (Type::record(), Type::record()),
             ])
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .allow_variants_without_examples(true)
             .category(Category::Math)
     }
@@ -38,20 +44,20 @@ impl Command for MathFloor {
     fn run(
         &self,
         engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let head = call.head;
-        match input {
-            // This doesn't match explicit nulls
-            PipelineData::Empty => return Err(ShellError::PipelineEmpty { dst_span: head }),
-            PipelineData::Value(ref value @ Value::Range { val: ref range, .. }, ..) => {
-                ensure_bounded(range, value.span(), head)?
-            }
-            _ => (),
-        }
-        input.map(move |value| operate(value, head), engine_state.signals())
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
+            engine_state.signals(),
+            true,
+            move |value| operate(value, head),
+        )
     }
 
     fn run_const(
@@ -60,30 +66,57 @@ impl Command for MathFloor {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
         let head = call.head;
-        // This doesn't match explicit nulls
-        if let PipelineData::Empty = input {
-            return Err(ShellError::PipelineEmpty { dst_span: head });
-        }
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        input.map(
-            move |value| operate(value, head),
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
             working_set.permanent().signals(),
+            true,
+            move |value| operate(value, head),
         )
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![Example {
-            description: "Apply the floor function to a list of numbers.",
-            example: "[1.5 2.3 -3.1] | math floor",
-            result: Some(Value::list(
-                vec![Value::test_int(1), Value::test_int(2), Value::test_int(-4)],
-                Span::test_data(),
-            )),
-        }]
+        vec![
+            Example {
+                description: "Apply the floor function to a list of numbers.",
+                example: "[1.5 2.3 -3.1] | math floor",
+                result: Some(Value::list(
+                    vec![Value::test_int(1), Value::test_int(2), Value::test_int(-4)],
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Apply the floor function to list-valued columns in a record.",
+                example: "{alice: [1.2 2.7 3.5], bob: [4.1 5.9]} | math floor",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_int(1), Value::test_int(2), Value::test_int(3)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_int(4), Value::test_int(5)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
+            Example {
+                description: "Apply the floor function to a single column using a cell path.",
+                example: "{alice: [1.2 2.7 3.5], bob: [4.1 5.9]} | math floor alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_int(1), Value::test_int(2), Value::test_int(3)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_float(4.1), Value::test_float(5.9)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
+        ]
     }
 }
 

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -127,7 +127,7 @@ impl Command for MathLog {
                         Span::test_data(),
                     ),
                     "bob" => Value::list(
-                        vec![Value::test_float(1000.0), Value::test_float(10000.0)],
+                        vec![Value::test_int(1000), Value::test_int(10000)],
                         Span::test_data(),
                     ),
                 })),
@@ -184,7 +184,7 @@ fn operate(value: Value, head: Span, base: f64) -> Value {
         Value::Error { .. } => value,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "numeric".into(),
+                exp_input_type: crate::math::utils::NUMBER_INPUT_TYPES.into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -1,6 +1,5 @@
-use crate::math::utils::ensure_bounded;
+use crate::math::utils::run_with_elementwise;
 use nu_engine::command_prelude::*;
-use nu_protocol::Signals;
 
 #[derive(Clone)]
 pub struct MathLog;
@@ -24,7 +23,13 @@ impl Command for MathLog {
                     Type::List(Box::new(Type::Float)),
                 ),
                 (Type::Range, Type::List(Box::new(Type::Number))),
+                (Type::record(), Type::record()),
             ])
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .allow_variants_without_examples(true)
             .category(Category::Math)
     }
@@ -48,13 +53,17 @@ impl Command for MathLog {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let base = require_positive_base(call.req(engine_state, stack, 0)?, call.head)?;
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
         let head = call.head;
-        let base: Spanned<f64> = call.req(engine_state, stack, 0)?;
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        log(base, call.head, input, engine_state.signals())
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
+            engine_state.signals(),
+            true,
+            move |value| operate(value, head, base),
+        )
     }
 
     fn run_const(
@@ -63,13 +72,17 @@ impl Command for MathLog {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let base = require_positive_base(call.req_const(working_set, 0)?, call.head)?;
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 1)?;
         let head = call.head;
-        let base: Spanned<f64> = call.req_const(working_set, 0)?;
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        log(base, call.head, input, working_set.permanent().signals())
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
+            working_set.permanent().signals(),
+            true,
+            move |value| operate(value, head, base),
+        )
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -91,16 +104,39 @@ impl Command for MathLog {
                     Span::test_data(),
                 )),
             },
+            Example {
+                description: "Compute the log base 10 of list-valued columns in a record.",
+                example: "{alice: [1 10 100], bob: [1000 10000]} | math log 10",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_float(0.0), Value::test_float(1.0), Value::test_float(2.0)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_float(3.0), Value::test_float(4.0)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
+            Example {
+                description: "Compute the log base 10 of a single column using a cell path.",
+                example: "{alice: [1 10 100], bob: [1000 10000]} | math log 10 alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_float(0.0), Value::test_float(1.0), Value::test_float(2.0)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_float(1000.0), Value::test_float(10000.0)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
         ]
     }
 }
 
-fn log(
-    base: Spanned<f64>,
-    head: Span,
-    input: PipelineData,
-    signals: &Signals,
-) -> Result<PipelineData, ShellError> {
+fn require_positive_base(base: Spanned<f64>, head: Span) -> Result<f64, ShellError> {
     if base.item <= 0.0f64 {
         return Err(ShellError::UnsupportedInput {
             msg: "Base has to be greater 0".into(),
@@ -109,12 +145,7 @@ fn log(
             input_span: base.span,
         });
     }
-    // This doesn't match explicit nulls
-    if let PipelineData::Empty = input {
-        return Err(ShellError::PipelineEmpty { dst_span: head });
-    }
-    let base = base.item;
-    input.map(move |value| operate(value, head, base), signals)
+    Ok(base.item)
 }
 
 fn operate(value: Value, head: Span, base: f64) -> Value {

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -1,6 +1,6 @@
 use crate::math::{
     reducers::{Reduce, reducer_for},
-    utils::run_with_function,
+    utils::{run_with_function_with_cell_paths, run_with_function_with_cell_paths_const},
 };
 use nu_engine::command_prelude::*;
 
@@ -24,6 +24,11 @@ impl Command for MathMax {
                 (Type::record(), Type::record()),
             ])
             .allow_variants_without_examples(true)
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .category(Category::Math)
     }
 
@@ -41,21 +46,21 @@ impl Command for MathMax {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, maximum)
+        run_with_function_with_cell_paths(engine_state, stack, call, input, maximum)
     }
 
     fn run_const(
         &self,
-        _working_set: &StateWorkingSet,
+        working_set: &StateWorkingSet,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, maximum)
+        run_with_function_with_cell_paths_const(working_set, call, input, maximum)
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -79,6 +84,25 @@ impl Command for MathMax {
                 result: Some(Value::test_date(
                     "2022-12-30 00:00:00Z".parse().unwrap_or_default(),
                 )),
+            },
+            Example {
+                description: "Find the maximum of list-valued columns in a record.",
+                example: "{alice: [1 5 3], bob: [4 5 6]} | math max",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(5),
+                    "bob" => Value::test_int(6),
+                })),
+            },
+            Example {
+                description: "Find the maximum of a single column using a cell path.",
+                example: "{alice: [1 5 3], bob: [4 5 6]} | math max alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(5),
+                    "bob" => Value::list(
+                        vec![Value::test_int(4), Value::test_int(5), Value::test_int(6)],
+                        Span::test_data(),
+                    ),
+                })),
             },
         ]
     }

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -1,4 +1,7 @@
-use crate::math::{avg::average, utils::run_with_function};
+use crate::math::{
+    avg::average,
+    utils::{run_with_function_with_cell_paths, run_with_function_with_cell_paths_const},
+};
 use nu_engine::command_prelude::*;
 use std::cmp::Ordering;
 
@@ -21,6 +24,11 @@ impl Command for MathMedian {
                 (Type::record(), Type::record()),
             ])
             .allow_variants_without_examples(true)
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .category(Category::Math)
     }
 
@@ -38,21 +46,21 @@ impl Command for MathMedian {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, median)
+        run_with_function_with_cell_paths(engine_state, stack, call, input, median)
     }
 
     fn run_const(
         &self,
-        _working_set: &StateWorkingSet,
+        working_set: &StateWorkingSet,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, median)
+        run_with_function_with_cell_paths_const(working_set, call, input, median)
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -74,6 +82,25 @@ impl Command for MathMedian {
                 description: "Find the median of a list of file sizes.",
                 example: "[5KB 10MB 200B] | math median",
                 result: Some(Value::test_filesize(5 * 1_000)),
+            },
+            Example {
+                description: "Compute the median of list-valued columns in a record.",
+                example: "{alice: [3 1 2], bob: [4 5 6]} | math median",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(2),
+                    "bob" => Value::test_int(5),
+                })),
+            },
+            Example {
+                description: "Compute the median of a single column using a cell path.",
+                example: "{alice: [3 1 2], bob: [4 5 6]} | math median alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(2),
+                    "bob" => Value::list(
+                        vec![Value::test_int(4), Value::test_int(5), Value::test_int(6)],
+                        Span::test_data(),
+                    ),
+                })),
             },
         ]
     }

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -112,6 +112,25 @@ enum Pick {
 }
 
 pub fn median(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
+    // Reject unsupported types up front so record columns error like other reducers.
+    for value in values {
+        match value {
+            Value::Int { .. }
+            | Value::Float { .. }
+            | Value::Duration { .. }
+            | Value::Filesize { .. } => {}
+            Value::Error { error, .. } => return Err(*error.clone()),
+            other => {
+                return Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: crate::math::utils::NUMERIC_INPUT_TYPES.into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: head,
+                    src_span: other.span(),
+                });
+            }
+        }
+    }
+
     let mut sorted = values
         .iter()
         .filter(|x| !x.as_float().is_ok_and(f64::is_nan))

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -1,6 +1,6 @@
 use crate::math::{
     reducers::{Reduce, reducer_for},
-    utils::run_with_function,
+    utils::{run_with_function_with_cell_paths, run_with_function_with_cell_paths_const},
 };
 use nu_engine::command_prelude::*;
 
@@ -24,6 +24,11 @@ impl Command for MathMin {
                 (Type::record(), Type::record()),
             ])
             .allow_variants_without_examples(true)
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .category(Category::Math)
     }
 
@@ -41,21 +46,21 @@ impl Command for MathMin {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, minimum)
+        run_with_function_with_cell_paths(engine_state, stack, call, input, minimum)
     }
 
     fn run_const(
         &self,
-        _working_set: &StateWorkingSet,
+        working_set: &StateWorkingSet,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, minimum)
+        run_with_function_with_cell_paths_const(working_set, call, input, minimum)
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -77,6 +82,25 @@ impl Command for MathMin {
                 description: "Find the minimum of a list of arbitrary values (Warning: Weird).",
                 example: "[-50 'hello' true] | math min",
                 result: Some(Value::test_bool(true)),
+            },
+            Example {
+                description: "Compute the minimum of list-valued columns in a record.",
+                example: "{alice: [5 3 9], bob: [2 7]} | math min",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(3),
+                    "bob" => Value::test_int(2),
+                })),
+            },
+            Example {
+                description: "Compute the minimum of a single column using a cell path.",
+                example: "{alice: [5 3 9], bob: [2 7]} | math min alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(3),
+                    "bob" => Value::list(
+                        vec![Value::test_int(2), Value::test_int(7)],
+                        Span::test_data(),
+                    ),
+                })),
             },
         ]
     }

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -1,4 +1,6 @@
-use crate::math::utils::run_with_function;
+use crate::math::utils::{
+    run_with_function_with_cell_paths, run_with_function_with_cell_paths_const,
+};
 use nu_engine::command_prelude::*;
 use std::{cmp::Ordering, collections::HashMap};
 
@@ -49,8 +51,14 @@ impl Command for MathMode {
                     Type::List(Box::new(Type::Filesize)),
                 ),
                 (Type::table(), Type::record()),
+                (Type::record(), Type::record()),
             ])
             .allow_variants_without_examples(true)
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .category(Category::Math)
     }
 
@@ -68,21 +76,21 @@ impl Command for MathMode {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, mode)
+        run_with_function_with_cell_paths(engine_state, stack, call, input, mode)
     }
 
     fn run_const(
         &self,
-        _working_set: &StateWorkingSet,
+        working_set: &StateWorkingSet,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, mode)
+        run_with_function_with_cell_paths_const(working_set, call, input, mode)
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -104,6 +112,25 @@ impl Command for MathMode {
                             vec![Value::test_int(-1), Value::test_int(3), Value::test_int(5)],
                             Span::test_data(),
                         ),
+                })),
+            },
+            Example {
+                description: "Compute the mode(s) of list-valued columns in a record.",
+                example: "{alice: [1 1 2 3], bob: [5 5 6]} | math mode",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(vec![Value::test_int(1)], Span::test_data()),
+                    "bob" => Value::list(vec![Value::test_int(5)], Span::test_data()),
+                })),
+            },
+            Example {
+                description: "Compute the mode(s) of a single column using a cell path.",
+                example: "{alice: [1 1 2 3], bob: [5 5 6]} | math mode alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(vec![Value::test_int(1)], Span::test_data()),
+                    "bob" => Value::list(
+                        vec![Value::test_int(5), Value::test_int(5), Value::test_int(6)],
+                        Span::test_data(),
+                    ),
                 })),
             },
         ]

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -137,7 +137,7 @@ impl Command for MathMode {
     }
 }
 
-pub fn mode(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
+pub fn mode(values: &[Value], _span: Span, head: Span) -> Result<Value, ShellError> {
     //In e-q, Value doesn't implement Hash or Eq, so we have to get the values inside
     // But f64 doesn't implement Hash, so we get the binary representation to use as
     // key in the HashMap
@@ -157,11 +157,11 @@ pub fn mode(values: &[Value], span: Span, head: Span) -> Result<Value, ShellErro
                 NumberTypes::Filesize,
             )),
             Value::Error { error, .. } => Err(*error.clone()),
-            _ => Err(ShellError::UnsupportedInput {
-                msg: "Unable to give a result with this input".to_string(),
-                input: "value originates from here".into(),
-                msg_span: head,
-                input_span: span,
+            other => Err(ShellError::OnlySupportsThisInputType {
+                exp_input_type: "int, float, filesize, or duration".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.span(),
             }),
         })
         .collect::<Result<Vec<HashableType>, ShellError>>()?;

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -1,5 +1,5 @@
 use crate::math::utils::{
-    run_with_function_with_cell_paths, run_with_function_with_cell_paths_const,
+    NUMERIC_INPUT_TYPES, run_with_function_with_cell_paths, run_with_function_with_cell_paths_const,
 };
 use nu_engine::command_prelude::*;
 use std::{cmp::Ordering, collections::HashMap};
@@ -158,7 +158,7 @@ pub fn mode(values: &[Value], _span: Span, head: Span) -> Result<Value, ShellErr
             )),
             Value::Error { error, .. } => Err(*error.clone()),
             other => Err(ShellError::OnlySupportsThisInputType {
-                exp_input_type: "int, float, filesize, or duration".into(),
+                exp_input_type: NUMERIC_INPUT_TYPES.into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-command/src/math/product.rs
+++ b/crates/nu-command/src/math/product.rs
@@ -1,6 +1,6 @@
 use crate::math::{
     reducers::{Reduce, reducer_for},
-    utils::run_with_function,
+    utils::{run_with_function_with_cell_paths, run_with_function_with_cell_paths_const},
 };
 use nu_engine::command_prelude::*;
 
@@ -21,6 +21,11 @@ impl Command for MathProduct {
                 (Type::record(), Type::record()),
             ])
             .allow_variants_without_examples(true)
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .category(Category::Math)
     }
 
@@ -38,21 +43,21 @@ impl Command for MathProduct {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, product)
+        run_with_function_with_cell_paths(engine_state, stack, call, input, product)
     }
 
     fn run_const(
         &self,
-        _working_set: &StateWorkingSet,
+        working_set: &StateWorkingSet,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, product)
+        run_with_function_with_cell_paths_const(working_set, call, input, product)
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -68,6 +73,25 @@ impl Command for MathProduct {
                 result: Some(Value::test_record(record! {
                     "a" => Value::test_int(3),
                     "b" => Value::test_int(8),
+                })),
+            },
+            Example {
+                description: "Compute the product of list-valued columns in a record.",
+                example: "{alice: [2 3 4], bob: [4 5 6]} | math product",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(24),
+                    "bob" => Value::test_int(120),
+                })),
+            },
+            Example {
+                description: "Compute the product of a single column using a cell path.",
+                example: "{alice: [2 3 4], bob: [4 5 6]} | math product alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(24),
+                    "bob" => Value::list(
+                        vec![Value::test_int(4), Value::test_int(5), Value::test_int(6)],
+                        Span::test_data(),
+                    ),
                 })),
             },
         ]

--- a/crates/nu-command/src/math/reducers.rs
+++ b/crates/nu-command/src/math/reducers.rs
@@ -90,15 +90,11 @@ pub fn sum(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellError
             }
             Value::Error { error, .. } => return Err(*error.clone()),
             other => {
-                return Err(ShellError::UnsupportedInput {
-                    msg: format!(
-                        "Attempted to compute the sum of a value '{}' that cannot be summed with a type of `{}`.",
-                        other.coerce_string()?,
-                        other.get_type()
-                    ),
-                    input: "value originates from here".into(),
-                    msg_span: head,
-                    input_span: other.span(),
+                return Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "int, float, filesize, or duration".into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: head,
+                    src_span: other.span(),
                 });
             }
         }
@@ -132,15 +128,11 @@ pub fn product(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellE
             }
             Value::Error { error, .. } => return Err(*error.clone()),
             other => {
-                return Err(ShellError::UnsupportedInput {
-                    msg: format!(
-                        "Attempted to compute the product of a value '{}' that cannot be multiplied with a type of `{}`.",
-                        other.coerce_string()?,
-                        other.get_type()
-                    ),
-                    input: "value originates from here".into(),
-                    msg_span: head,
-                    input_span: other.span(),
+                return Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "int or float".into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: head,
+                    src_span: other.span(),
                 });
             }
         }

--- a/crates/nu-command/src/math/reducers.rs
+++ b/crates/nu-command/src/math/reducers.rs
@@ -1,6 +1,8 @@
 use nu_protocol::{ShellError, Span, Value};
 use std::cmp::Ordering;
 
+use super::utils::{NUMBER_INPUT_TYPES, NUMERIC_INPUT_TYPES};
+
 pub enum Reduce {
     Summation,
     Product,
@@ -91,7 +93,7 @@ pub fn sum(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellError
             Value::Error { error, .. } => return Err(*error.clone()),
             other => {
                 return Err(ShellError::OnlySupportsThisInputType {
-                    exp_input_type: "int, float, filesize, or duration".into(),
+                    exp_input_type: NUMERIC_INPUT_TYPES.into(),
                     wrong_type: other.get_type().to_string(),
                     dst_span: head,
                     src_span: other.span(),
@@ -129,7 +131,7 @@ pub fn product(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellE
             Value::Error { error, .. } => return Err(*error.clone()),
             other => {
                 return Err(ShellError::OnlySupportsThisInputType {
-                    exp_input_type: "int or float".into(),
+                    exp_input_type: NUMBER_INPUT_TYPES.into(),
                     wrong_type: other.get_type().to_string(),
                     dst_span: head,
                     src_span: other.span(),

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -52,7 +52,7 @@ impl Command for MathRound {
     fn extra_description(&self) -> &str {
         "Filesize and duration values are stored as whole numbers of base units \
          (bytes and nanoseconds). Without a display unit to round against, \
-         `math round` is a no-op for those types. `--precision` is not supported \
+         `math round` is the identity function for those types. `--precision` is not supported \
          for filesize or duration."
     }
 

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -49,6 +49,13 @@ impl Command for MathRound {
         "Returns the input number rounded to the specified precision."
     }
 
+    fn extra_description(&self) -> &str {
+        "Filesize and duration values are stored as whole numbers of base units \
+         (bytes and nanoseconds). Without a display unit to round against, \
+         `math round` is a no-op for those types. `--precision` is not supported \
+         for filesize or duration."
+    }
+
     fn search_terms(&self) -> Vec<&str> {
         vec!["approx", "closest", "nearest"]
     }
@@ -157,6 +164,12 @@ impl Command for MathRound {
                         Span::test_data(),
                     ),
                 })),
+            },
+            Example {
+                // Filesize is already whole bytes; rounding cannot use the display unit (KB).
+                description: "Filesize values are already whole bytes, so rounding is a no-op.",
+                example: "2.1KB | math round",
+                result: Some(Value::test_filesize(2100)),
             },
         ]
     }

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -50,8 +50,8 @@ impl Command for MathRound {
     }
 
     fn extra_description(&self) -> &str {
-        "Filesize and duration values are stored as whole numbers of base units \
-         (bytes and nanoseconds). Without a display unit to round against, \
+        "Filesize and duration values are stored as integers in base units \
+         (bytes and nanoseconds). With no display unit to round against, \
          `math round` is the identity function for those types. `--precision` is not supported \
          for filesize or duration."
     }

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -1,4 +1,4 @@
-use crate::math::utils::ensure_bounded;
+use crate::math::utils::run_with_elementwise;
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
@@ -18,7 +18,13 @@ impl Command for MathRound {
                     Type::List(Box::new(Type::Number)),
                 ),
                 (Type::Range, Type::List(Box::new(Type::Number))),
+                (Type::record(), Type::record()),
             ])
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .allow_variants_without_examples(true)
             .named(
                 "precision",
@@ -49,18 +55,15 @@ impl Command for MathRound {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let precision_param: Option<i64> = call.get_flag(engine_state, stack, "precision")?;
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let head = call.head;
-        // This doesn't match explicit nulls
-        if let PipelineData::Empty = input {
-            return Err(ShellError::PipelineEmpty { dst_span: head });
-        }
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        input.map(
-            move |value| operate(value, head, precision_param),
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
             engine_state.signals(),
+            true,
+            move |value| operate(value, head, precision_param),
         )
     }
 
@@ -71,18 +74,15 @@ impl Command for MathRound {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let precision_param: Option<i64> = call.get_flag_const(working_set, "precision")?;
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
         let head = call.head;
-        // This doesn't match explicit nulls
-        if let PipelineData::Empty = input {
-            return Err(ShellError::PipelineEmpty { dst_span: head });
-        }
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        input.map(
-            move |value| operate(value, head, precision_param),
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
             working_set.permanent().signals(),
+            true,
+            move |value| operate(value, head, precision_param),
         )
     }
 
@@ -119,6 +119,34 @@ impl Command for MathRound {
                     ],
                     Span::test_data(),
                 )),
+            },
+            Example {
+                description: "Apply the round function to list-valued columns in a record.",
+                example: "{alice: [1.2 2.7 3.5], bob: [4.1 5.9]} | math round",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_int(1), Value::test_int(3), Value::test_int(4)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_int(4), Value::test_int(6)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
+            Example {
+                description: "Apply the round function to a single column using a cell path.",
+                example: "{alice: [1.2 2.7 3.5], bob: [4.1 5.9]} | math round alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_int(1), Value::test_int(3), Value::test_int(4)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_float(4.1), Value::test_float(5.9)],
+                        Span::test_data(),
+                    ),
+                })),
             },
         ]
     }

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -13,9 +13,19 @@ impl Command for MathRound {
         Signature::build("math round")
             .input_output_types(vec![
                 (Type::Number, Type::Number),
+                (Type::Duration, Type::Duration),
+                (Type::Filesize, Type::Filesize),
                 (
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Number)),
+                ),
+                (
+                    Type::List(Box::new(Type::Duration)),
+                    Type::List(Box::new(Type::Duration)),
+                ),
+                (
+                    Type::List(Box::new(Type::Filesize)),
+                    Type::List(Box::new(Type::Filesize)),
                 ),
                 (Type::Range, Type::List(Box::new(Type::Number))),
                 (Type::record(), Type::record()),
@@ -153,47 +163,63 @@ impl Command for MathRound {
 }
 
 fn operate(value: Value, head: Span, precision: Option<i64>) -> Value {
-    // We treat int values as float values in order to avoid code repetition in the match closure
     let span = value.span();
-    let value = if let Value::Int { val, .. } = value {
-        Value::float(val as f64, span)
-    } else {
-        value
+
+    // Duration and filesize are already integer units (ns / bytes). Identity is
+    // correct without --precision; decimal precision is not meaningful for units.
+    if matches!(value, Value::Duration { .. } | Value::Filesize { .. }) {
+        if precision.is_some() {
+            return Value::error(
+                ShellError::UnsupportedInput {
+                    msg: "'math round --precision' is not supported for duration or filesize"
+                        .into(),
+                    input: "value originates from here".into(),
+                    msg_span: head,
+                    input_span: span,
+                },
+                span,
+            );
+        }
+        return value;
+    }
+
+    // We treat int values as float values to share the rounding path.
+    let float_val = match &value {
+        Value::Int { val, .. } => *val as f64,
+        Value::Float { val, .. } => *val,
+        Value::Error { .. } => return value,
+        other => {
+            return Value::error(
+                ShellError::OnlySupportsThisInputType {
+                    exp_input_type: crate::math::utils::NUMERIC_INPUT_TYPES.into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: head,
+                    src_span: other.span(),
+                },
+                head,
+            );
+        }
     };
 
-    match value {
-        Value::Float { val, .. } => {
-            if !val.is_finite() {
-                return Value::error(
-                    ShellError::UnsupportedInput {
-                        msg: "cannot round non-finite number".into(),
-                        input: "value originates from here".into(),
-                        msg_span: span,
-                        input_span: span,
-                    },
-                    span,
-                );
-            }
-
-            match precision {
-                Some(precision_number) => Value::float(
-                    (val * ((10_f64).powf(precision_number as f64))).round()
-                        / (10_f64).powf(precision_number as f64),
-                    span,
-                ),
-                None => Value::int(val.round() as i64, span),
-            }
-        }
-        Value::Error { .. } => value,
-        other => Value::error(
-            ShellError::OnlySupportsThisInputType {
-                exp_input_type: "numeric".into(),
-                wrong_type: other.get_type().to_string(),
-                dst_span: head,
-                src_span: other.span(),
+    if !float_val.is_finite() {
+        return Value::error(
+            ShellError::UnsupportedInput {
+                msg: "cannot round non-finite number".into(),
+                input: "value originates from here".into(),
+                msg_span: span,
+                input_span: span,
             },
-            head,
+            span,
+        );
+    }
+
+    match precision {
+        Some(precision_number) => Value::float(
+            (float_val * ((10_f64).powf(precision_number as f64))).round()
+                / (10_f64).powf(precision_number as f64),
+            span,
         ),
+        None => Value::int(float_val.round() as i64, span),
     }
 }
 

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -111,7 +111,7 @@ impl Command for MathSqrt {
                         Span::test_data(),
                     ),
                     "bob" => Value::list(
-                        vec![Value::test_float(16.0), Value::test_float(25.0), Value::test_float(36.0)],
+                        vec![Value::test_int(16), Value::test_int(25), Value::test_int(36)],
                         Span::test_data(),
                     ),
                 })),
@@ -140,7 +140,7 @@ fn operate(value: Value, head: Span) -> Value {
         Value::Error { .. } => value,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "numeric".into(),
+                exp_input_type: crate::math::utils::NUMBER_INPUT_TYPES.into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -1,4 +1,4 @@
-use crate::math::utils::ensure_bounded;
+use crate::math::utils::run_with_elementwise;
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
@@ -18,7 +18,13 @@ impl Command for MathSqrt {
                     Type::List(Box::new(Type::Float)),
                 ),
                 (Type::Range, Type::List(Box::new(Type::Number))),
+                (Type::record(), Type::record()),
             ])
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .allow_variants_without_examples(true)
             .category(Category::Math)
     }
@@ -38,20 +44,20 @@ impl Command for MathSqrt {
     fn run(
         &self,
         engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let head = call.head;
-        // This doesn't match explicit nulls
-        if let PipelineData::Empty = input {
-            return Err(ShellError::PipelineEmpty { dst_span: head });
-        }
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        input.map(move |value| operate(value, head), engine_state.signals())
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
+            engine_state.signals(),
+            true,
+            move |value| operate(value, head),
+        )
     }
 
     fn run_const(
@@ -60,30 +66,57 @@ impl Command for MathSqrt {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
         let head = call.head;
-        // This doesn't match explicit nulls
-        if let PipelineData::Empty = input {
-            return Err(ShellError::PipelineEmpty { dst_span: head });
-        }
-        if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
-            let span = v.span();
-            ensure_bounded(val, span, head)?;
-        }
-        input.map(
-            move |value| operate(value, head),
+        run_with_elementwise(
+            input,
+            cell_paths,
+            head,
             working_set.permanent().signals(),
+            true,
+            move |value| operate(value, head),
         )
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![Example {
-            description: "Compute the square root of each number in a list.",
-            example: "[9 16] | math sqrt",
-            result: Some(Value::list(
-                vec![Value::test_float(3.0), Value::test_float(4.0)],
-                Span::test_data(),
-            )),
-        }]
+        vec![
+            Example {
+                description: "Compute the square root of each number in a list.",
+                example: "[9 16] | math sqrt",
+                result: Some(Value::list(
+                    vec![Value::test_float(3.0), Value::test_float(4.0)],
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Apply square root to list-valued columns in a record.",
+                example: "{alice: [1 4 9], bob: [16 25 36]} | math sqrt",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_float(1.0), Value::test_float(2.0), Value::test_float(3.0)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_float(4.0), Value::test_float(5.0), Value::test_float(6.0)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
+            Example {
+                description: "Apply square root to a single column using a cell path.",
+                example: "{alice: [1 4 9], bob: [16 25 36]} | math sqrt alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::list(
+                        vec![Value::test_float(1.0), Value::test_float(2.0), Value::test_float(3.0)],
+                        Span::test_data(),
+                    ),
+                    "bob" => Value::list(
+                        vec![Value::test_float(16.0), Value::test_float(25.0), Value::test_float(36.0)],
+                        Span::test_data(),
+                    ),
+                })),
+            },
+        ]
     }
 }
 

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -1,5 +1,5 @@
 use super::variance::compute_variance as variance;
-use crate::math::utils::run_with_function;
+use crate::math::utils::{expand_range_input, run_with_function, run_with_function_and_cell_paths};
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
@@ -22,6 +22,11 @@ impl Command for MathStddev {
                 "sample",
                 "Calculate sample standard deviation (i.e. using N-1 as the denominator).",
                 Some('s'),
+            )
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Math)
@@ -53,20 +58,14 @@ impl Command for MathStddev {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let sample = call.has_flag(engine_state, stack, "sample")?;
-        let name = call.head;
-        let span = input.span().unwrap_or(name);
-        let input: PipelineData = match input.try_expand_range() {
-            Err(_) => {
-                return Err(ShellError::IncorrectValue {
-                    msg: "Range must be bounded".to_string(),
-                    val_span: span,
-                    call_span: name,
-                });
-            }
-            Ok(val) => val,
-        };
-        run_with_function(call, input, compute_stddev(sample))
+        let mf = compute_stddev(sample);
+        if cell_paths.is_empty() {
+            let input = expand_range_input(input, call.head)?;
+            return run_with_function(call, input, mf);
+        }
+        run_with_function_and_cell_paths(call, input, cell_paths, engine_state.signals(), mf)
     }
 
     fn run_const(
@@ -75,20 +74,20 @@ impl Command for MathStddev {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
         let sample = call.has_flag_const(working_set, "sample")?;
-        let name = call.head;
-        let span = input.span().unwrap_or(name);
-        let input: PipelineData = match input.try_expand_range() {
-            Err(_) => {
-                return Err(ShellError::IncorrectValue {
-                    msg: "Range must be bounded".to_string(),
-                    val_span: span,
-                    call_span: name,
-                });
-            }
-            Ok(val) => val,
-        };
-        run_with_function(call, input, compute_stddev(sample))
+        let mf = compute_stddev(sample);
+        if cell_paths.is_empty() {
+            let input = expand_range_input(input, call.head)?;
+            return run_with_function(call, input, mf);
+        }
+        run_with_function_and_cell_paths(
+            call,
+            input,
+            cell_paths,
+            working_set.permanent().signals(),
+            mf,
+        )
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -109,6 +108,25 @@ impl Command for MathStddev {
                 result: Some(Value::test_record(record! {
                     "a" => Value::test_int(1),
                     "b" => Value::test_int(1),
+                })),
+            },
+            Example {
+                description: "Compute the standard deviation of list-valued columns in a record.",
+                example: "{alice: [1 3], bob: [4 6]} | math stddev",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(1),
+                    "bob" => Value::test_int(1),
+                })),
+            },
+            Example {
+                description: "Compute the standard deviation of a single column using a cell path.",
+                example: "{alice: [1 3], bob: [4 6]} | math stddev alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(1),
+                    "bob" => Value::list(
+                        vec![Value::test_int(4), Value::test_int(6)],
+                        Span::test_data(),
+                    ),
                 })),
             },
         ]

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -1,5 +1,8 @@
-use super::variance::compute_variance as variance;
-use crate::math::utils::{expand_range_input, run_with_function, run_with_function_and_cell_paths};
+use super::variance::{compute_variance as variance, values_unit};
+use crate::math::utils::{
+    NumericUnit, expand_range_input, run_with_function, run_with_function_and_cell_paths,
+    wrap_unit_f64,
+};
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
@@ -14,6 +17,8 @@ impl Command for MathStddev {
         Signature::build("math stddev")
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::List(Box::new(Type::Duration)), Type::Duration),
+                (Type::List(Box::new(Type::Filesize)), Type::Filesize),
                 (Type::Range, Type::Number),
                 (Type::table(), Type::record()),
                 (Type::record(), Type::record()),
@@ -106,23 +111,23 @@ impl Command for MathStddev {
                 description: "Compute the standard deviation of each column in a table.",
                 example: "[[a b]; [1 2] [3 4]] | math stddev",
                 result: Some(Value::test_record(record! {
-                    "a" => Value::test_int(1),
-                    "b" => Value::test_int(1),
+                    "a" => Value::test_float(1.0),
+                    "b" => Value::test_float(1.0),
                 })),
             },
             Example {
                 description: "Compute the standard deviation of list-valued columns in a record.",
                 example: "{alice: [1 3], bob: [4 6]} | math stddev",
                 result: Some(Value::test_record(record! {
-                    "alice" => Value::test_int(1),
-                    "bob" => Value::test_int(1),
+                    "alice" => Value::test_float(1.0),
+                    "bob" => Value::test_float(1.0),
                 })),
             },
             Example {
                 description: "Compute the standard deviation of a single column using a cell path.",
                 example: "{alice: [1 3], bob: [4 6]} | math stddev alice",
                 result: Some(Value::test_record(record! {
-                    "alice" => Value::test_int(1),
+                    "alice" => Value::test_float(1.0),
                     "bob" => Value::list(
                         vec![Value::test_int(4), Value::test_int(6)],
                         Span::test_data(),
@@ -135,13 +140,20 @@ impl Command for MathStddev {
 
 pub fn compute_stddev(sample: bool) -> impl Fn(&[Value], Span, Span) -> Result<Value, ShellError> {
     move |values: &[Value], span: Span, head: Span| {
-        // variance() produces its own usable error, so we can use `?` to propagated the error.
+        let unit = values_unit(values, head)?;
+        // variance() produces its own usable error, so we can use `?` to propagate the error.
         let variance = variance(sample)(values, span, head)?;
         let val_span = variance.span();
-        match variance {
-            Value::Float { val, .. } => Ok(Value::float(val.sqrt(), val_span)),
-            Value::Int { val, .. } => Ok(Value::float((val as f64).sqrt(), val_span)),
-            other => Ok(other),
+        let sqrt = match variance {
+            Value::Float { val, .. } => val.sqrt(),
+            Value::Int { val, .. } => (val as f64).sqrt(),
+            other => return Ok(other),
+        };
+        // Duration/filesize keep their unit (stddev has the same unit as the inputs).
+        // Numbers stay floats, matching the previous behavior.
+        match unit {
+            NumericUnit::Number => Ok(Value::float(sqrt, val_span)),
+            other => Ok(wrap_unit_f64(other, sqrt, val_span)),
         }
     }
 }

--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -1,6 +1,6 @@
 use crate::math::{
     reducers::{Reduce, reducer_for},
-    utils::run_with_function,
+    utils::{run_with_function_with_cell_paths, run_with_function_with_cell_paths_const},
 };
 use nu_engine::command_prelude::*;
 
@@ -23,6 +23,11 @@ impl Command for MathSum {
                 (Type::record(), Type::record()),
             ])
             .allow_variants_without_examples(true)
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
+            )
             .category(Category::Math)
     }
 
@@ -40,21 +45,21 @@ impl Command for MathSum {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, summation)
+        run_with_function_with_cell_paths(engine_state, stack, call, input, summation)
     }
 
     fn run_const(
         &self,
-        _working_set: &StateWorkingSet,
+        working_set: &StateWorkingSet,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        run_with_function(call, input, summation)
+        run_with_function_with_cell_paths_const(working_set, call, input, summation)
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -75,6 +80,25 @@ impl Command for MathSum {
                 result: Some(Value::test_record(record! {
                     "a" => Value::test_int(4),
                     "b" => Value::test_int(6),
+                })),
+            },
+            Example {
+                description: "Sum the values of list-valued columns in a record.",
+                example: "{alice: [1 2 3], bob: [4 5 6]} | math sum",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(6),
+                    "bob" => Value::test_int(15),
+                })),
+            },
+            Example {
+                description: "Sum a single column using a cell path.",
+                example: "{alice: [1 2 3], bob: [4 5 6]} | math sum alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(6),
+                    "bob" => Value::list(
+                        vec![Value::test_int(4), Value::test_int(5), Value::test_int(6)],
+                        Span::test_data(),
+                    ),
                 })),
             },
         ]

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -1,8 +1,12 @@
 use core::slice;
 use indexmap::IndexMap;
+use nu_engine::CallExt;
 use nu_protocol::{
-    IntoPipelineData, PipelineData, Range, ShellError, Signals, Span, Value, engine::Call,
+    IntoPipelineData, PipelineData, Range, ShellError, Signals, Span, Value,
+    ast::CellPath,
+    engine::{Call, EngineState, Stack, StateWorkingSet},
 };
+use std::sync::Arc;
 
 pub fn run_with_function(
     call: &Call,
@@ -23,8 +27,6 @@ fn helper_for_tables(
     name: Span,
     mf: impl Fn(&[Value], Span, Span) -> Result<Value, ShellError>,
 ) -> Result<Value, ShellError> {
-    // If we are not dealing with Primitives, then perhaps we are dealing with a table
-    // Create a key for each column name
     let mut column_values = IndexMap::new();
     for val in values {
         match val {
@@ -38,12 +40,10 @@ fn helper_for_tables(
             }
             Value::Error { error, .. } => return Err(*error.clone()),
             _ => {
-                //Turns out we are not dealing with a table
                 return mf(values, val.span(), name);
             }
         }
     }
-    // The mathematical function operates over the columns of the table
     let mut column_totals = IndexMap::new();
     for (col_name, col_vals) in column_values {
         column_totals.insert(col_name, mf(&col_vals, val_span, name)?);
@@ -57,7 +57,6 @@ pub fn calculate(
     name: Span,
     mf: impl Fn(&[Value], Span, Span) -> Result<Value, ShellError>,
 ) -> Result<Value, ShellError> {
-    // TODO implement spans for ListStream, thus negating the need for unwrap_or().
     let span = values.span().unwrap_or(name);
     match values {
         PipelineData::ListStream(s, ..) => {
@@ -77,7 +76,11 @@ pub fn calculate(
             record
                 .iter_mut()
                 .try_for_each(|(_, val)| -> Result<(), ShellError> {
-                    *val = mf(slice::from_ref(val), span, name)?;
+                    let result = match val {
+                        Value::List { vals, .. } => mf(vals, span, name),
+                        _ => mf(slice::from_ref(val), span, name),
+                    };
+                    *val = result?;
                     Ok(())
                 })?;
             Ok(Value::record(record, span))
@@ -104,6 +107,145 @@ pub fn calculate(
     }
 }
 
+/// Apply a reducing math function (`mf`) to the values under each cell path.
+///
+/// List-valued cells are reduced as a whole (e.g. average of the list). Errors
+/// under a path are left alone. When `cell_paths` is empty, falls through to
+/// [`run_with_function`].
+pub fn run_with_function_and_cell_paths(
+    call: &Call,
+    input: PipelineData,
+    cell_paths: Vec<CellPath>,
+    signals: &Signals,
+    mf: impl Fn(&[Value], Span, Span) -> Result<Value, ShellError> + Send + Sync + 'static,
+) -> Result<PipelineData, ShellError> {
+    if cell_paths.is_empty() {
+        return run_with_function(call, input, mf);
+    }
+
+    let name = call.head;
+    let span = input.span().unwrap_or(name);
+    let mf = Arc::new(mf);
+
+    input.map(
+        move |mut v| {
+            for path in &cell_paths {
+                let mf = mf.clone();
+                let r = v.update_cell_path(
+                    &path.members,
+                    Box::new(move |old| {
+                        let result = match old {
+                            Value::List { vals, .. } => mf(vals, span, name),
+                            Value::Error { .. } => Ok(old.clone()),
+                            other => mf(slice::from_ref(other), span, name),
+                        };
+                        match result {
+                            Ok(val) => val,
+                            Err(e) => Value::error(e, span),
+                        }
+                    }),
+                );
+                if let Err(error) = r {
+                    return Value::error(error, span);
+                }
+            }
+            v
+        },
+        signals,
+    )
+}
+
+pub fn run_with_function_with_cell_paths(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+    input: PipelineData,
+    mf: impl Fn(&[Value], Span, Span) -> Result<Value, ShellError> + Send + Sync + 'static,
+) -> Result<PipelineData, ShellError> {
+    let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
+    run_with_function_and_cell_paths(call, input, cell_paths, engine_state.signals(), mf)
+}
+
+pub fn run_with_function_with_cell_paths_const(
+    working_set: &StateWorkingSet,
+    call: &Call,
+    input: PipelineData,
+    mf: impl Fn(&[Value], Span, Span) -> Result<Value, ShellError> + Send + Sync + 'static,
+) -> Result<PipelineData, ShellError> {
+    let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
+    run_with_function_and_cell_paths(
+        call,
+        input,
+        cell_paths,
+        working_set.permanent().signals(),
+        mf,
+    )
+}
+
+/// Apply an element-wise operation (`op`) across pipeline input.
+///
+/// - With cell paths: update those columns, mapping list cells element-wise.
+/// - With a record and no cell paths: map every column element-wise (lists keep
+///   their shape; scalars are transformed in place).
+/// - Otherwise: optionally reject empty input, ensure ranges are bounded, then
+///   map `op` over the pipeline stream.
+pub fn run_with_elementwise(
+    input: PipelineData,
+    cell_paths: Vec<CellPath>,
+    head: Span,
+    signals: &Signals,
+    reject_empty: bool,
+    op: impl Fn(Value) -> Value + Send + Sync + 'static,
+) -> Result<PipelineData, ShellError> {
+    if !cell_paths.is_empty() {
+        let op = Arc::new(op);
+        return input.map(
+            move |mut v| {
+                for path in &cell_paths {
+                    let op = op.clone();
+                    let r = v.update_cell_path(
+                        &path.members,
+                        Box::new(move |old| map_elementwise(old, head, op.as_ref())),
+                    );
+                    if let Err(error) = r {
+                        return Value::error(error, head);
+                    }
+                }
+                v
+            },
+            signals,
+        );
+    }
+
+    if let PipelineData::Value(Value::Record { val, .. }, metadata) = input {
+        let mut record = val.into_owned();
+        for (_, col_val) in record.iter_mut() {
+            *col_val = map_elementwise(col_val, head, &op);
+        }
+        return Ok(PipelineData::Value(Value::record(record, head), metadata));
+    }
+
+    if reject_empty && matches!(input, PipelineData::Empty) {
+        return Err(ShellError::PipelineEmpty { dst_span: head });
+    }
+
+    if let PipelineData::Value(ref v @ Value::Range { ref val, .. }, ..) = input {
+        ensure_bounded(val, v.span(), head)?;
+    }
+
+    input.map(op, signals)
+}
+
+/// Map `op` over a list value element-wise; otherwise apply `op` once.
+/// Errors are propagated unchanged.
+fn map_elementwise(value: &Value, head: Span, op: &impl Fn(Value) -> Value) -> Value {
+    match value {
+        Value::Error { .. } => value.clone(),
+        Value::List { vals, .. } => Value::list(vals.iter().map(|v| op(v.clone())).collect(), head),
+        other => op(other.clone()),
+    }
+}
+
 pub fn ensure_bounded(range: &Range, val_span: Span, call_span: Span) -> Result<(), ShellError> {
     if range.is_bounded() {
         return Ok(());
@@ -113,4 +255,20 @@ pub fn ensure_bounded(range: &Range, val_span: Span, call_span: Span) -> Result<
         val_span,
         call_span,
     })
+}
+
+/// Expand range input into a concrete list, erroring if the range is unbounded.
+pub fn expand_range_input(
+    input: PipelineData,
+    call_span: Span,
+) -> Result<PipelineData, ShellError> {
+    let span = input.span().unwrap_or(call_span);
+    match input.try_expand_range() {
+        Ok(val) => Ok(val),
+        Err(_) => Err(ShellError::IncorrectValue {
+            msg: "Range must be bounded".to_string(),
+            val_span: span,
+            call_span,
+        }),
+    }
 }

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -107,11 +107,18 @@ pub fn calculate(
     }
 }
 
-/// Apply a reducing math function (`mf`) to the values under each cell path.
+/// Apply a reducing math function (`mf`) under each cell path, **per pipeline item**.
 ///
-/// List-valued cells are reduced as a whole (e.g. average of the list). Errors
-/// under a path are left alone. When `cell_paths` is empty, falls through to
-/// [`run_with_function`].
+/// List-valued cells are reduced as a whole (e.g. average of the list). Scalar
+/// cells are reduced as a one-element list. Tables are handled row-by-row (like
+/// `input_handler::operate`), not by collecting a whole column and writing the
+/// same result into every row.
+///
+/// When `cell_paths` is empty, falls through to [`run_with_function`].
+///
+/// Path update failures and math errors surface as top-level [`ShellError`] for a
+/// single concrete value (`PipelineData::map` converts `Value::Error`), and as
+/// in-band `Value::Error` items in streams.
 pub fn run_with_function_and_cell_paths(
     call: &Call,
     input: PipelineData,
@@ -127,6 +134,8 @@ pub fn run_with_function_and_cell_paths(
     let span = input.span().unwrap_or(name);
     let mf = Arc::new(mf);
 
+    // Always map per pipeline item so tables (list of records) update each row
+    // independently rather than reducing the whole column once.
     input.map(
         move |mut v| {
             for path in &cell_paths {
@@ -136,11 +145,12 @@ pub fn run_with_function_and_cell_paths(
                     Box::new(move |old| {
                         let result = match old {
                             Value::List { vals, .. } => mf(vals, span, name),
-                            Value::Error { .. } => Ok(old.clone()),
                             other => mf(slice::from_ref(other), span, name),
                         };
                         match result {
                             Ok(val) => val,
+                            // `update_cell_path` turns this into `Err`, which we
+                            // re-embed below so stream rows stay in-band.
                             Err(e) => Value::error(e, span),
                         }
                     }),
@@ -184,11 +194,16 @@ pub fn run_with_function_with_cell_paths_const(
 
 /// Apply an element-wise operation (`op`) across pipeline input.
 ///
-/// - With cell paths: update those columns, mapping list cells element-wise.
+/// - With cell paths: update those columns **per pipeline item** (row-by-row for
+///   tables), mapping list cells element-wise.
 /// - With a record and no cell paths: map every column element-wise (lists keep
 ///   their shape; scalars are transformed in place).
 /// - Otherwise: optionally reject empty input, ensure ranges are bounded, then
 ///   map `op` over the pipeline stream.
+///
+/// For a single concrete record (no cell paths), errors from `op` are returned as
+/// top-level [`ShellError`]. `PipelineData::map` also promotes a single
+/// `Value::Error` to a top-level error; stream rows keep errors in-band.
 pub fn run_with_elementwise(
     input: PipelineData,
     cell_paths: Vec<CellPath>,
@@ -205,7 +220,10 @@ pub fn run_with_elementwise(
                     let op = op.clone();
                     let r = v.update_cell_path(
                         &path.members,
-                        Box::new(move |old| map_elementwise(old, head, op.as_ref())),
+                        Box::new(move |old| match map_elementwise(old, op.as_ref()) {
+                            Ok(val) => val,
+                            Err(e) => Value::error(e, head),
+                        }),
                     );
                     if let Err(error) = r {
                         return Value::error(error, head);
@@ -217,12 +235,21 @@ pub fn run_with_elementwise(
         );
     }
 
-    if let PipelineData::Value(Value::Record { val, .. }, metadata) = input {
+    if let PipelineData::Value(
+        Value::Record {
+            val, internal_span, ..
+        },
+        metadata,
+    ) = input
+    {
         let mut record = val.into_owned();
         for (_, col_val) in record.iter_mut() {
-            *col_val = map_elementwise(col_val, head, &op);
+            *col_val = map_elementwise(col_val, &op)?;
         }
-        return Ok(PipelineData::Value(Value::record(record, head), metadata));
+        return Ok(PipelineData::Value(
+            Value::record(record, internal_span),
+            metadata,
+        ));
     }
 
     if reject_empty && matches!(input, PipelineData::Empty) {
@@ -233,16 +260,31 @@ pub fn run_with_elementwise(
         ensure_bounded(val, v.span(), head)?;
     }
 
+    // `PipelineData::map` maps list/range elements, and turns a single
+    // `Value::Error` into a top-level `ShellError`.
     input.map(op, signals)
 }
 
 /// Map `op` over a list value element-wise; otherwise apply `op` once.
-/// Errors are propagated unchanged.
-fn map_elementwise(value: &Value, head: Span, op: &impl Fn(Value) -> Value) -> Value {
+/// Errors from `op` (or nested [`Value::Error`]s) are returned as [`ShellError`].
+fn map_elementwise(value: &Value, op: &impl Fn(Value) -> Value) -> Result<Value, ShellError> {
     match value {
-        Value::Error { .. } => value.clone(),
-        Value::List { vals, .. } => Value::list(vals.iter().map(|v| op(v.clone())).collect(), head),
-        other => op(other.clone()),
+        Value::Error { error, .. } => Err(*error.clone()),
+        Value::List { vals, .. } => {
+            let list_span = value.span();
+            let mut out = Vec::with_capacity(vals.len());
+            for v in vals {
+                match op(v.clone()) {
+                    Value::Error { error, .. } => return Err(*error),
+                    other => out.push(other),
+                }
+            }
+            Ok(Value::list(out, list_span))
+        }
+        other => match op(other.clone()) {
+            Value::Error { error, .. } => Err(*error),
+            result => Ok(result),
+        },
     }
 }
 
@@ -270,5 +312,90 @@ pub fn expand_range_input(
             val_span: span,
             call_span,
         }),
+    }
+}
+
+/// Shared expected-type string for math commands that accept numeric-like values
+/// (int, float, filesize, duration).
+pub const NUMERIC_INPUT_TYPES: &str = "int, float, filesize, or duration";
+
+/// Expected-type string for math commands that only accept plain numbers.
+pub const NUMBER_INPUT_TYPES: &str = "int or float";
+
+/// Classify the unit of a math-compatible numeric value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NumericUnit {
+    Number,
+    Duration,
+    Filesize,
+}
+
+impl NumericUnit {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            NumericUnit::Number => "int or float",
+            NumericUnit::Duration => "duration",
+            NumericUnit::Filesize => "filesize",
+        }
+    }
+}
+
+/// Convert a math-compatible value to an `f64` for statistical calculations,
+/// reporting its unit kind. Int/float share [`NumericUnit::Number`].
+pub fn to_unit_f64(value: &Value, head: Span) -> Result<(NumericUnit, f64), ShellError> {
+    match value {
+        Value::Int { val, .. } => Ok((NumericUnit::Number, *val as f64)),
+        Value::Float { val, .. } => Ok((NumericUnit::Number, *val)),
+        Value::Duration { val, .. } => Ok((NumericUnit::Duration, *val as f64)),
+        Value::Filesize { val, .. } => Ok((NumericUnit::Filesize, val.get() as f64)),
+        Value::Error { error, .. } => Err(*error.clone()),
+        other => Err(ShellError::OnlySupportsThisInputType {
+            exp_input_type: NUMERIC_INPUT_TYPES.into(),
+            wrong_type: other.get_type().to_string(),
+            dst_span: head,
+            src_span: other.span(),
+        }),
+    }
+}
+
+/// Re-wrap a computed numeric result into the unit of the original data.
+///
+/// For [`NumericUnit::Number`] the raw float is returned (as float). For duration
+/// and filesize the value is rounded to the nearest integer unit.
+pub fn wrap_unit_f64(unit: NumericUnit, val: f64, span: Span) -> Value {
+    match unit {
+        NumericUnit::Number => Value::float(val, span),
+        NumericUnit::Duration => Value::duration(val.round() as i64, span),
+        NumericUnit::Filesize => Value::filesize(val.round() as i64, span),
+    }
+}
+
+/// Shared empty / sample-size checks for variance-like reducers.
+pub fn variance_denominator(
+    n: usize,
+    sample: bool,
+    head: Span,
+    input_span: Span,
+) -> Result<usize, ShellError> {
+    if n == 0 {
+        return Err(ShellError::UnsupportedInput {
+            msg: "Empty input".to_string(),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span,
+        });
+    }
+    if sample {
+        if n < 2 {
+            return Err(ShellError::UnsupportedInput {
+                msg: "Sample variance requires at least 2 values".to_string(),
+                input: "value originates from here".into(),
+                msg_span: head,
+                input_span,
+            });
+        }
+        Ok(n - 1)
+    } else {
+        Ok(n)
     }
 }

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -125,7 +125,7 @@ impl Command for MathVariance {
     }
 }
 
-fn sum_of_squares(values: &[Value], span: Span) -> Result<Value, ShellError> {
+fn sum_of_squares(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
     let n = Value::int(values.len() as i64, span);
     let mut sum_x = Value::int(0, span);
     let mut sum_x2 = Value::int(0, span);
@@ -133,15 +133,11 @@ fn sum_of_squares(values: &[Value], span: Span) -> Result<Value, ShellError> {
         let v = match &value {
             Value::Int { .. } | Value::Float { .. } => Ok(value),
             Value::Error { error, .. } => Err(*error.clone()),
-            other => Err(ShellError::UnsupportedInput {
-                msg: format!(
-                    "Attempted to compute the sum of squares of a non-int, non-float value '{}' with a type of `{}`.",
-                    other.coerce_string()?,
-                    other.get_type()
-                ),
-                input: "value originates from here".into(),
-                msg_span: span,
-                input_span: value.span(),
+            other => Err(ShellError::OnlySupportsThisInputType {
+                exp_input_type: "int or float".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.span(),
             }),
         }?;
         let v_squared = &v.mul(span, v, span)?;
@@ -166,8 +162,8 @@ pub fn compute_variance(
         } else {
             values.len()
         };
-        // sum_of_squares() needs the span of the original value, not the call head.
-        let ss = sum_of_squares(values, span)?;
+        // Arithmetic uses the original value span; errors point at the call head.
+        let ss = sum_of_squares(values, span, head)?;
         let n = Value::int(n as i64, head);
         ss.div(head, &n, head)
     }

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -1,4 +1,4 @@
-use crate::math::utils::run_with_function;
+use crate::math::utils::{expand_range_input, run_with_function, run_with_function_and_cell_paths};
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
@@ -21,6 +21,11 @@ impl Command for MathVariance {
                 "sample",
                 "Calculate sample variance (i.e. using N-1 as the denominator).",
                 Some('s'),
+            )
+            .rest(
+                "columns",
+                SyntaxShape::CellPath,
+                "The cell-paths/columns to operate on.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Math)
@@ -45,20 +50,14 @@ impl Command for MathVariance {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let sample = call.has_flag(engine_state, stack, "sample")?;
-        let name = call.head;
-        let span = input.span().unwrap_or(name);
-        let input: PipelineData = match input.try_expand_range() {
-            Err(_) => {
-                return Err(ShellError::IncorrectValue {
-                    msg: "Range must be bounded".to_string(),
-                    val_span: span,
-                    call_span: name,
-                });
-            }
-            Ok(val) => val,
-        };
-        run_with_function(call, input, compute_variance(sample))
+        let mf = compute_variance(sample);
+        if cell_paths.is_empty() {
+            let input = expand_range_input(input, call.head)?;
+            return run_with_function(call, input, mf);
+        }
+        run_with_function_and_cell_paths(call, input, cell_paths, engine_state.signals(), mf)
     }
 
     fn run_const(
@@ -67,20 +66,20 @@ impl Command for MathVariance {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
         let sample = call.has_flag_const(working_set, "sample")?;
-        let name = call.head;
-        let span = input.span().unwrap_or(name);
-        let input: PipelineData = match input.try_expand_range() {
-            Err(_) => {
-                return Err(ShellError::IncorrectValue {
-                    msg: "Range must be bounded".to_string(),
-                    val_span: span,
-                    call_span: name,
-                });
-            }
-            Ok(val) => val,
-        };
-        run_with_function(call, input, compute_variance(sample))
+        let mf = compute_variance(sample);
+        if cell_paths.is_empty() {
+            let input = expand_range_input(input, call.head)?;
+            return run_with_function(call, input, mf);
+        }
+        run_with_function_and_cell_paths(
+            call,
+            input,
+            cell_paths,
+            working_set.permanent().signals(),
+            mf,
+        )
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -101,6 +100,25 @@ impl Command for MathVariance {
                 result: Some(Value::test_record(record! {
                     "a" => Value::test_int(1),
                     "b" => Value::test_int(1),
+                })),
+            },
+            Example {
+                description: "Compute the variance of list-valued columns in a record.",
+                example: "{alice: [1 3], bob: [4 6]} | math variance",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(1),
+                    "bob" => Value::test_int(1),
+                })),
+            },
+            Example {
+                description: "Compute the variance of a single column using a cell path.",
+                example: "{alice: [1 3], bob: [4 6]} | math variance alice",
+                result: Some(Value::test_record(record! {
+                    "alice" => Value::test_int(1),
+                    "bob" => Value::list(
+                        vec![Value::test_int(4), Value::test_int(6)],
+                        Span::test_data(),
+                    ),
                 })),
             },
         ]

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -1,4 +1,7 @@
-use crate::math::utils::{expand_range_input, run_with_function, run_with_function_and_cell_paths};
+use crate::math::utils::{
+    NUMBER_INPUT_TYPES, NumericUnit, expand_range_input, run_with_function,
+    run_with_function_and_cell_paths, to_unit_f64, variance_denominator,
+};
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
@@ -13,6 +16,8 @@ impl Command for MathVariance {
         Signature::build("math variance")
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::List(Box::new(Type::Duration)), Type::Number),
+                (Type::List(Box::new(Type::Filesize)), Type::Number),
                 (Type::Range, Type::Number),
                 (Type::table(), Type::record()),
                 (Type::record(), Type::record()),
@@ -131,18 +136,20 @@ fn sum_of_squares(values: &[Value], span: Span, head: Span) -> Result<Value, She
     let mut sum_x2 = Value::int(0, span);
     for value in values {
         let v = match &value {
-            Value::Int { .. } | Value::Float { .. } => Ok(value),
-            Value::Error { error, .. } => Err(*error.clone()),
-            other => Err(ShellError::OnlySupportsThisInputType {
-                exp_input_type: "int or float".into(),
-                wrong_type: other.get_type().to_string(),
-                dst_span: head,
-                src_span: other.span(),
-            }),
-        }?;
-        let v_squared = &v.mul(span, v, span)?;
+            Value::Int { .. } | Value::Float { .. } => value.clone(),
+            Value::Error { error, .. } => return Err(*error.clone()),
+            other => {
+                return Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: NUMBER_INPUT_TYPES.into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: head,
+                    src_span: other.span(),
+                });
+            }
+        };
+        let v_squared = &v.mul(span, &v, span)?;
         sum_x2 = sum_x2.add(span, v_squared, span)?;
-        sum_x = sum_x.add(span, v, span)?;
+        sum_x = sum_x.add(span, &v, span)?;
     }
 
     let sum_x_squared = sum_x.mul(span, &sum_x, span)?;
@@ -153,20 +160,78 @@ fn sum_of_squares(values: &[Value], span: Span, head: Span) -> Result<Value, She
     Ok(ss)
 }
 
+/// Variance for duration/filesize via `f64` units (ns / bytes) to avoid i64 overflow
+/// when squaring large values such as multi-second durations.
+fn variance_unit_f64(
+    values: &[Value],
+    sample: bool,
+    span: Span,
+    head: Span,
+) -> Result<f64, ShellError> {
+    let mut nums = Vec::with_capacity(values.len());
+    for value in values {
+        let (_, n) = to_unit_f64(value, head)?;
+        nums.push(n);
+    }
+    let denom = variance_denominator(nums.len(), sample, head, span)? as f64;
+    let mean = nums.iter().sum::<f64>() / nums.len() as f64;
+    let ss = nums
+        .iter()
+        .map(|x| {
+            let d = x - mean;
+            d * d
+        })
+        .sum::<f64>();
+    Ok(ss / denom)
+}
+
 pub fn compute_variance(
     sample: bool,
 ) -> impl Fn(&[Value], Span, Span) -> Result<Value, ShellError> {
     move |values: &[Value], span: Span, head: Span| {
-        let n = if sample {
-            values.len() - 1
-        } else {
-            values.len()
-        };
-        // Arithmetic uses the original value span; errors point at the call head.
-        let ss = sum_of_squares(values, span, head)?;
-        let n = Value::int(n as i64, head);
-        ss.div(head, &n, head)
+        let unit = values_unit(values, head)?;
+        let denom = variance_denominator(values.len(), sample, head, span)?;
+        match unit {
+            // Duration/filesize: compute in f64 so large units (e.g. seconds as ns) don't overflow.
+            // Result is a plain number (squared units).
+            NumericUnit::Duration | NumericUnit::Filesize => {
+                let var = variance_unit_f64(values, sample, span, head)?;
+                Ok(Value::float(var, span))
+            }
+            NumericUnit::Number => {
+                // Arithmetic uses the original value span; errors point at the call head.
+                let ss = sum_of_squares(values, span, head)?;
+                let n = Value::int(denom as i64, head);
+                ss.div(head, &n, head)
+            }
+        }
     }
+}
+
+/// Determine the common unit of a value list for re-wrapping stddev results.
+pub fn values_unit(values: &[Value], head: Span) -> Result<NumericUnit, ShellError> {
+    let mut unit = NumericUnit::Number;
+    for (i, value) in values.iter().enumerate() {
+        let (this_unit, _) = to_unit_f64(value, head)?;
+        if i == 0 {
+            unit = this_unit;
+            continue;
+        }
+        // int and float may mix; duration/filesize must stay homogeneous.
+        match (unit, this_unit) {
+            (NumericUnit::Number, NumericUnit::Number) => {}
+            (a, b) if a == b => {}
+            (a, _) => {
+                return Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: a.as_str().into(),
+                    wrong_type: value.get_type().to_string(),
+                    dst_span: head,
+                    src_span: value.span(),
+                });
+            }
+        }
+    }
+    Ok(unit)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -40,6 +40,14 @@ impl Command for MathVariance {
         "Returns the variance of a list of numbers or of each column in a table."
     }
 
+    fn extra_description(&self) -> &str {
+        "For filesize and duration inputs, variance is computed in base units \
+         (bytes and nanoseconds) and returned as a plain number. There is no \
+         squared unit type in Nushell, so the result is the variance of the \
+         underlying byte or nanosecond values (B² or ns²), not of the display \
+         unit used when the values were written."
+    }
+
     fn search_terms(&self) -> Vec<&str> {
         vec!["deviation", "dispersion", "variation", "statistics"]
     }
@@ -125,6 +133,12 @@ impl Command for MathVariance {
                         Span::test_data(),
                     ),
                 })),
+            },
+            Example {
+                // 1KB=1000B, 3KB=3000B; population variance is 1_000_000 (B²), not 1 (KB²).
+                description: "Variance of filesizes is a number of base units squared (bytes²).",
+                example: "[1KB 3KB] | math variance",
+                result: Some(Value::test_float(1_000_000.0)),
             },
         ]
     }

--- a/crates/nu-command/tests/commands/math/abs.rs
+++ b/crates/nu-command/tests/commands/math/abs.rs
@@ -35,6 +35,33 @@ fn abs_int_min_overflows_without_panic() -> Result {
 }
 
 #[test]
+fn abs_list_valued_record_columns() -> Result {
+    test()
+        .run("{alice: [-1 -2], bob: [-3]} | math abs")
+        .expect_value_eq(test_value!({
+            alice: [1, 2],
+            bob: [3],
+        }))
+}
+
+#[test]
+fn abs_unsupported_record_field_is_top_level_error() -> Result {
+    let err = test()
+        .run("{alice: true, bob: [1 2 3]} | math abs")
+        .expect_shell_error()?;
+    assert!(matches!(err, ShellError::OnlySupportsThisInputType { .. }));
+    Ok(())
+}
+
+#[test]
+fn abs_filesize() -> Result {
+    let expected: Value = test().run("[2KB 3KB]")?;
+    test()
+        .run("[-2KB 3KB] | math abs")
+        .expect_value_eq(expected)
+}
+
+#[test]
 fn abs_duration_min_overflows_without_panic() -> Result {
     let code = "0x[00 00 00 00 00 00 00 80] | into int --endian little --signed | into duration | math abs";
     let outcome = test().run(code).expect_shell_error()?;

--- a/crates/nu-command/tests/commands/math/ceil.rs
+++ b/crates/nu-command/tests/commands/math/ceil.rs
@@ -22,3 +22,10 @@ fn cannot_ceil_infinite_range() -> Result {
     assert!(matches!(outcome, ShellError::IncorrectValue { .. }));
     Ok(())
 }
+
+#[test]
+fn filesize_ceil_is_noop_on_base_units() -> Result {
+    // 2.1KB is stored as 2100 bytes; ceiling cannot use the display unit (KB).
+    let expected: Value = test().run("2.1KB")?;
+    test().run("2.1KB | math ceil").expect_value_eq(expected)
+}

--- a/crates/nu-command/tests/commands/math/floor.rs
+++ b/crates/nu-command/tests/commands/math/floor.rs
@@ -22,3 +22,10 @@ fn cannot_floor_infinite_range() -> Result {
     assert!(matches!(outcome, ShellError::IncorrectValue { .. }));
     Ok(())
 }
+
+#[test]
+fn filesize_floor_is_noop_on_base_units() -> Result {
+    // 2.1KB is stored as 2100 bytes; flooring cannot use the display unit (KB).
+    let expected: Value = test().run("2.1KB")?;
+    test().run("2.1KB | math floor").expect_value_eq(expected)
+}

--- a/crates/nu-command/tests/commands/math/product.rs
+++ b/crates/nu-command/tests/commands/math/product.rs
@@ -14,3 +14,13 @@ fn cannot_product_infinite_range() -> Result {
     assert!(matches!(outcome, ShellError::IncorrectValue { .. }));
     Ok(())
 }
+
+#[test]
+fn product_rejects_duration() -> Result {
+    // Bypass input-type signature check so we hit the reducer type error.
+    let err = test()
+        .run("{a: [2ms 3ms]} | math product")
+        .expect_shell_error()?;
+    assert!(matches!(err, ShellError::OnlySupportsThisInputType { .. }));
+    Ok(())
+}

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -60,3 +60,26 @@ fn cannot_round_infinite_range() -> Result {
     assert!(matches!(outcome, ShellError::IncorrectValue { .. }));
     Ok(())
 }
+
+#[test]
+fn filesize_round_is_noop_on_base_units() -> Result {
+    // 2.1KB is stored as 2100 bytes; rounding cannot use the display unit (KB).
+    let expected: Value = test().run("2.1KB")?;
+    test().run("2.1KB | math round").expect_value_eq(expected)
+}
+
+#[test]
+fn duration_round_is_noop_on_base_units() -> Result {
+    // 2.1min is stored as whole nanoseconds; rounding cannot use minutes.
+    let expected: Value = test().run("2.1min")?;
+    test().run("2.1min | math round").expect_value_eq(expected)
+}
+
+#[test]
+fn filesize_round_rejects_precision() -> Result {
+    let err = test()
+        .run("2.1KB | math round --precision 0")
+        .expect_shell_error()?;
+    assert!(matches!(err, ShellError::UnsupportedInput { .. }));
+    Ok(())
+}

--- a/crates/nu-command/tests/commands/math/stddev.rs
+++ b/crates/nu-command/tests/commands/math/stddev.rs
@@ -20,3 +20,11 @@ fn cannot_stddev_infinite_range() -> Result {
     assert!(matches!(outcome, ShellError::IncorrectValue { .. }));
     Ok(())
 }
+
+#[test]
+fn stddev_duration_keeps_unit() -> Result {
+    let expected: Value = test().run("1sec")?;
+    test()
+        .run("[1sec 3sec] | math stddev")
+        .expect_value_eq(expected)
+}

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -97,6 +97,48 @@ fn cannot_sum_infinite_range() -> Result {
 }
 
 #[test]
+fn sum_list_valued_record_columns() -> Result {
+    test()
+        .run("{alice: [1 2 3], bob: [4 5]} | math sum")
+        .expect_value_eq(test_record! {
+            "alice" => 6,
+            "bob" => 9,
+        })
+}
+
+#[test]
+fn sum_record_cell_path_only_touches_named_column() -> Result {
+    test()
+        .run("{alice: [1 2 3], bob: [4 5 6]} | math sum alice")
+        .expect_value_eq(test_value!({
+            alice: 6,
+            bob: [4, 5, 6],
+        }))
+}
+
+#[test]
+fn sum_table_cell_path_updates_per_row() -> Result {
+    // Per-row path update: sum of a single scalar cell is the cell itself.
+    // Must NOT collect the whole column and write the column sum into every row.
+    test()
+        .run("[[a]; [1] [2]] | math sum a")
+        .expect_value_eq(test_table![
+            ["a"];
+            [1],
+            [2],
+        ])
+}
+
+#[test]
+fn sum_unsupported_record_field_is_top_level_error() -> Result {
+    let err = test()
+        .run("{alice: true, bob: [1 2]} | math sum")
+        .expect_shell_error()?;
+    assert!(matches!(err, ShellError::OnlySupportsThisInputType { .. }));
+    Ok(())
+}
+
+#[test]
 fn overflow_error_is_consistent_between_list_and_table() -> Result {
     // Large durations that sum beyond i64::MAX nanoseconds
     let durations = "[618019200000000000ns, 650422800000000000ns, 652579200000000000ns, 657849600000000000ns, 660873600000000000ns, 662342400000000000ns, 664416000000000000ns, 667782000000000000ns, 669855600000000000ns, 673311600000000000ns, 675903600000000000ns, 677462400000000000ns, 681609600000000000ns, 683766000000000000ns]";

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -73,8 +73,8 @@ fn sum_of_a_row_containing_a_table_is_an_error() -> Result {
         .run("open sample-sys-output.json | math sum")
         .expect_shell_error()?;
     match outcome {
-        ShellError::CantConvert { from_type, .. } => {
-            assert_contains("record", from_type);
+        ShellError::OnlySupportsThisInputType { wrong_type, .. } => {
+            assert_contains("record", wrong_type);
         }
         err => return Err(err.into()),
     }

--- a/crates/nu-command/tests/commands/math/variance.rs
+++ b/crates/nu-command/tests/commands/math/variance.rs
@@ -20,3 +20,29 @@ fn cannot_variance_infinite_range() -> Result {
     assert!(matches!(outcome, ShellError::IncorrectValue { .. }));
     Ok(())
 }
+
+#[test]
+fn sample_variance_empty_is_error_not_panic() -> Result {
+    let err = test()
+        .run("[] | math variance --sample")
+        .expect_shell_error()?;
+    assert!(matches!(err, ShellError::UnsupportedInput { .. }));
+    Ok(())
+}
+
+#[test]
+fn sample_variance_single_value_is_error() -> Result {
+    let err = test()
+        .run("[1] | math variance --sample")
+        .expect_shell_error()?;
+    assert!(matches!(err, ShellError::UnsupportedInput { .. }));
+    Ok(())
+}
+
+#[test]
+fn variance_duration_returns_number() -> Result {
+    // Population variance of [1sec, 3sec] is 1e18 (nanoseconds squared).
+    test()
+        .run("[1sec 3sec] | math variance")
+        .expect_value_eq(1_000_000_000_000_000_000.0)
+}

--- a/crates/nu-command/tests/commands/math/variance.rs
+++ b/crates/nu-command/tests/commands/math/variance.rs
@@ -46,3 +46,11 @@ fn variance_duration_returns_number() -> Result {
         .run("[1sec 3sec] | math variance")
         .expect_value_eq(1_000_000_000_000_000_000.0)
 }
+
+#[test]
+fn variance_filesize_returns_number_in_bytes_squared() -> Result {
+    // 1KB=1000B, 3KB=3000B → population variance 1_000_000 (B²), not 1 (KB²).
+    test()
+        .run("[1KB 3KB] | math variance")
+        .expect_value_eq(1_000_000.0)
+}


### PR DESCRIPTION
## Description
What started out as a small fix ballooned into a bigger one. I wanted to fix the bug in #18749 and allow `math avg` handle records. I thought it should work in 2 ways, 1) by supplying cell-paths 2) by averaging a list in records. Neither worked so I added that. But then, I thought that all math subcommands should work this way and not just one. So, that's what this PR does:

1. Records with list-valued columns work correctly.
2. Optional cell-path / column arguments.

## User-facing changes (Release notes)

### Math commands: records with list columns and optional cell paths

Fixed reducing math commands on records whose columns are lists (including uneven lengths). For example:

```nushell
{ alice: [0.1 0.6 0.2], bob: [0.8 0.3 0.2 0.9] } | math avg
# ╭───────┬──────╮
# │ alice │ 0.30 │
# │ bob   │ 0.55 │
# ╰───────┴──────╯
```

All of the following math commands now accept optional cell paths / columns to operate on only those fields:

**Reducing** (list cells become a scalar):  
`math avg`, `math sum`, `math product`, `math max`, `math min`, `math median`, `math mode`, `math stddev`, `math variance`

**Element-wise** (list cells stay lists):  
`math abs`, `math cbrt`, `math ceil`, `math floor`, `math sqrt`, `math round`, `math log`

```nushell
# Reduce only one column
{ alice: [1 2 3], bob: [4 5 6] } | math avg alice
# {alice: 2.00, bob: [list 3 items]}

# Element-wise on one column
{ alice: [-1 -2 -3], bob: [-4 -5] } | math abs alice
# {alice: [1, 2, 3], bob: [-4, -5]}

# Works in const context too
const data = {alice: [1 2 3], bob: [4 5 6]}
$data | math sum alice
```

Examples for each command:

```nushell
let rec = { alice: [1 2 3], bob: [4 5 6] }

$rec | math avg alice       # alice: 2
$rec | math sum alice       # alice: 6
$rec | math product alice   # alice: 24
$rec | math max bob         # bob: 6
$rec | math min bob         # bob: 4
$rec | math median alice    # alice: 2
$rec | math mode alice      # alice: [1, 2, 3] modes as list
$rec | math stddev alice    # alice: ~0.82
$rec | math variance alice  # alice: ~0.67

{ alice: [-1 -2], bob: [-3 -4] } | math abs alice | to nuon
# {alice: [1, 2], bob: [-3, -4]}
{ alice: [8 27], bob: [64] } | math cbrt alice | to nuon
# {alice: [2.0, 3.0], bob: [64]}
{ alice: [1.2 2.3], bob: [3.4] } | math ceil alice | to nuon
# {alice: [2, 3], bob: [3.4]}
{ alice: [1.2 2.3], bob: [3.4] } | math floor alice | to nuon
# {alice: [1, 2], bob: [3.4]}
{ alice: [4 9], bob: [16] } | math sqrt alice | to nuon
# {alice: [2.0, 3.0], bob: [16]}
{ alice: [1.2 2.7], bob: [3.1] } | math round alice | to nuon
# {alice: [1, 3], bob: [3.1]}
{ alice: [1 10 100], bob: [1000] } | math log 10 alice | to nuon
# {alice: [0.0, 1.0, 2.0], bob: [1000]}
```

Existing list, table, number, duration, and range inputs keep their previous behavior when no cell paths are given.

Made error messages more consistent.
On the commands that make sense, I added int, float, duration, filesize. On others, product, sqrt, cbrt, and log, only work with ints and floats.

## Additional notes
closes https://github.com/nushell/nushell/issues/18749