### PR TITLE
feat(error make)!: raise errors for invalid labels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,6 +316,9 @@ used_underscore_binding = "warn"
 # let's keep it until we update rustc version to 1.96
 # which resolve the issue: https://github.com/rust-lang/rust-clippy/issues/16875
 collapsible_match = "allow"
+# `.filter_map(|x| x)` has different performance characteristics than
+# `.flatten()` and `.flat_map(|x| x)`
+filter_map_identity = "allow"
 
 [lints]
 workspace = true

--- a/crates/nu-command/tests/commands/error_make.rs
+++ b/crates/nu-command/tests/commands/error_make.rs
@@ -30,17 +30,23 @@ fn error_make_no_label_text() -> Result {
 
     let err = test().run(code).expect_labeled_error()?;
 
-    assert_eq!(err.msg, "no_label_text");
-    assert_eq!(err.labels[0].span, Span::new(1, 1));
+    // the error should be due to the invalid argument given to `error make`, it should not be the
+    // error that the user is trying to raise
+    assert_ne!(err.msg, "no_label_text");
+    assert_ne!(err.labels[0].span, Span::new(1, 1));
+
+    assert_eq!(err.labels[0].text, "missing `text: string` column");
+
     Ok(())
 }
 
 #[test]
 fn error_label_works() -> Result {
     let code = "
+        let unseen = 'unseen val'
         error make {
             msg: foo,
-            label: { text: unseen }
+            label: { text: unseen, span: (metadata $unseen).span }
         }
     ";
 
@@ -53,11 +59,14 @@ fn error_label_works() -> Result {
 #[test]
 fn error_labels_list_works() -> Result {
     let code = "
+        let unseen = 'unseen val'
+        let hidden = 'hidden val'
         error make {
-            msg: foo,
+            msg: foo
             labels: [
-                { text: unseen },
-                { text: hidden },
+                [text, span];
+                [unseen, (metadata $unseen).span]
+                [hidden, (metadata $hidden).span]
             ]
         }
     ";
@@ -74,7 +83,7 @@ fn no_span_if_unspanned() -> Result {
     let code = "
         error make -u {
             msg: foo
-            label: { text: unseen }
+            label: { text: unseen, span: (metadata 'here').span }
         }
     ";
 
@@ -96,9 +105,20 @@ fn error_start_bigger_than_end_should_fail() -> Result {
         }
     ";
 
-    let err = test().run(code).expect_shell_error()?;
-    assert_eq!(err.clone().generic_error()?, "Unable to parse Span.");
-    assert_eq!(err.generic_msg()?, "`end` must not be less than `start`");
+    let mut err = match test().run(code).expect_shell_error()? {
+        ShellError::Generic(err) => err,
+        _ => panic!("expected a GenericError"),
+    };
+
+    assert_eq!(err.error, "Unable to parse ErrorLabel.");
+
+    let inner_err = err.inner.pop().expect("an inner error to be present");
+    assert_eq!(inner_err.clone().generic_error()?, "Unable to parse Span.");
+    assert_eq!(
+        inner_err.generic_msg()?,
+        "`end` must not be less than `start`"
+    );
+
     Ok(())
 }
 

--- a/crates/nu-command/tests/commands/error_make.rs
+++ b/crates/nu-command/tests/commands/error_make.rs
@@ -276,3 +276,36 @@ fn error_source() -> Result {
 
     Ok(())
 }
+
+#[test]
+fn helpful_error_for_incorrect_label_values() -> Result {
+    // sample from https://github.com/nushell/nushell/issues/4460
+    let code = r#"
+        def shl [] {
+            let inp = $in
+            if true {
+                let span = (metadata $inp).span
+                error make {
+                    msg: "Error"
+                    label: {
+                        text: "error"
+                        start: $span.start
+                        end: $span.end
+                    }
+                }
+            }
+        }
+    "#;
+
+    let mut tester = test();
+    let () = tester.run(code)?;
+
+    let err = tester.run("2 | shl").expect_labeled_error()?;
+    let labels: Vec<_> = err.labels.iter().map(|label| label.text.as_str()).collect();
+    assert_contains(
+        "missing `span: record<start: int, end: int>` column",
+        &labels,
+    );
+
+    Ok(())
+}

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -1,5 +1,8 @@
 use super::{ShellError, shell_error::io::IoError};
-use crate::{FromValue, IntoValue, Span, Type, Value, engine::StateWorkingSet, record};
+use crate::{
+    FromValue, IntoValue, Span, Type, Value, engine::StateWorkingSet, record,
+    shell_error::generic::GenericError,
+};
 use miette::{Diagnostic, LabeledSpan, NamedSource, SourceSpan};
 use serde::{Deserialize, Serialize};
 use std::{fmt, fs};
@@ -209,37 +212,47 @@ impl From<ErrorLabel> for SourceSpan {
 
 impl FromValue for ErrorLabel {
     fn from_value(v: Value) -> Result<Self, ShellError> {
-        let record = v.clone().into_record()?;
-        let text = String::from_value(match record.get("text") {
-            Some(val) => val.clone(),
-            None => Value::string("", v.span()),
-        })
-        .unwrap_or("originates from here".into());
-        let span = Span::from_value(match record.get("span") {
-            Some(val) => val.clone(),
-            // Maybe there's a better way...
-            None => Value::record(
-                record! {
-                    "start" => Value::int(v.span().start as i64, v.span()),
-                    "end" => Value::int(v.span().end as i64, v.span()),
-                },
-                v.span(),
-            ),
-        });
+        let span = v.span();
 
-        match span {
-            Ok(s) => Ok(Self { text, span: s }),
-            Err(e) => Err(e),
+        let Ok(mut record) = v.into_record() else {
+            return Err(ShellError::TypeMismatch {
+                err_message: "Must be a record".into(),
+                span,
+            });
+        };
+
+        let text = record
+            .remove("text")
+            .ok_or_else(|| ShellError::MissingRequiredColumn {
+                column: "text",
+                span,
+            })?
+            .into_string()?;
+
+        // TODO: consider removing this after a grace period
+        if record.contains("start") || record.contains("end") {
+            return Err(GenericError::new(
+                "Invalid fields.",
+                r#"error labels have a "span" field, not separate "start" and "end" fields"#,
+                span,
+            )
+            .with_code("nu::shell::incorrect_value")
+            .into());
         }
+
+        let span = record
+            .remove("span")
+            .ok_or_else(|| ShellError::MissingRequiredColumn {
+                column: "span",
+                span,
+            })?;
+        let span = Span::from_value(span)?;
+
+        Ok(Self { text, span })
     }
+
     fn expected_type() -> crate::Type {
-        Type::Record(
-            vec![
-                ("text".into(), Type::String),
-                ("span".into(), Type::record()),
-            ]
-            .into(),
-        )
+        Type::Record([("text", Type::String), ("span", Span::expected_type())].into())
     }
 }
 

--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -221,34 +221,38 @@ impl FromValue for ErrorLabel {
             });
         };
 
-        let text = record
-            .remove("text")
-            .ok_or_else(|| ShellError::MissingRequiredColumn {
-                column: "text",
-                span,
-            })?
-            .into_string()?;
+        let required_columns = [
+            ("text", String::expected_type()),
+            ("span", Span::expected_type()),
+        ];
 
-        // TODO: consider removing this after a grace period
-        if record.contains("start") || record.contains("end") {
-            return Err(GenericError::new(
-                "Invalid fields.",
-                r#"error labels have a "span" field, not separate "start" and "end" fields"#,
-                span,
-            )
-            .with_code("nu::shell::incorrect_value")
-            .into());
+        let [text_val, span_val] = match required_columns.map(|col| record.remove(col.0).ok_or(col))
+        {
+            [Ok(text_val), Ok(span_val)] => [text_val, span_val],
+            results => {
+                let err = LabeledError::new("Value is missing required columns.");
+                let err = results
+                    .into_iter()
+                    .filter_map(|x| x.err())
+                    .fold(err, |err, (col, col_ty)| {
+                        err.with_label(format!("missing `{col}: {col_ty}` column"), span)
+                    })
+                    .with_code("nu::shell::missing_required_columns");
+                return Err(err.into());
+            }
+        };
+
+        match (String::from_value(text_val), Span::from_value(span_val)) {
+            (Ok(text), Ok(span)) => Ok(Self { text, span }),
+            (r_0, r_1) => {
+                let errs = [r_0.err(), r_1.err()];
+                Err(
+                    GenericError::new("Unable to parse ErrorLabel.", "here", span)
+                        .with_inner(errs.into_iter().filter_map(|x| x))
+                        .into(),
+                )
+            }
         }
-
-        let span = record
-            .remove("span")
-            .ok_or_else(|| ShellError::MissingRequiredColumn {
-                column: "span",
-                span,
-            })?;
-        let span = Span::from_value(span)?;
-
-        Ok(Self { text, span })
     }
 
     fn expected_type() -> crate::Type {

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -1,6 +1,6 @@
 //! [`Span`] to point to sections of source code and the [`Spanned`] wrapper type
 use crate::shell_error::generic::GenericError;
-use crate::{FromValue, IntoValue, ShellError, Signals, SpanId, Value, record};
+use crate::{FromValue, IntoValue, ShellError, Signals, SpanId, Type, Value, record};
 use miette::SourceSpan;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -438,6 +438,9 @@ impl FromValue for Span {
                 span: value.span(),
             }),
         }
+    }
+    fn expected_type() -> Type {
+        Type::Record([("start", Type::Int), ("end", Type::Int)].into())
     }
 }
 

--- a/tests/repl/test_engine.rs
+++ b/tests/repl/test_engine.rs
@@ -297,7 +297,17 @@ fn dynamic_load_env() -> TestResult {
 #[test]
 fn reduce_spans() -> TestResult {
     fail_test(
-        r#"let x = ([1, 2, 3] | reduce --fold 0 { $it.item + 2 * $it.acc }); error make {msg: "oh that hurts", label: {text: "right here", start: (metadata $x).span.start, end: (metadata $x).span.end } }"#,
+        r#"
+            let x = ([1, 2, 3] | reduce --fold 0 {|it, acc| $it + 2 * $acc })
+            let span = (metadata $x).span
+            error make {
+                msg: "oh that hurts"
+                label: {
+                    text: "right here"
+                    span: $span
+                }
+            }
+        "#,
         "right here",
     )
 }


### PR DESCRIPTION
- closes #4460

## Description

Not providing spans for error labels fell back to using the *error label record*'s own span instead. This lead to confusing outcomes, especially because the error label's structure changed at some point:

|      |                                                            |
| -    | -                                                          |
| from | `record<text: string, start: int, end: int>`               |
| to   | `record<text: string, span: record<start: int, end: int>>` |

## User-facing changes (Release notes)

### Errors for... `error make`?

Not specifying the span for error labels (or not doing so correctly) confusingly fell back to using the record's own span instead:

<table>
<tr>
<td width="1000">

```nushell
let var = 2
let span = (metadata $var).span

error make {
	msg: "my error"
	label: { text: "two" }
}
```

</td>
</tr>
<tr>
<td>

```
Error: nu::shell::error

  × my error
   ╭─[repl_entry #1:6:9]
 5 │     msg: "my error"
 6 │     label: {text: "two"}
   ·            ──────┬──────
   ·                  ╰── two
 7 │ }
   ╰────
```

</td>
</tr>
</table>
<table>
<tr>
<td width="1000">

```nushell
let var = 2
let span = (metadata $var).span

error make {
	msg: "my error"
	label: { text: "two", start: $span.start, end: $span.end }
}
```

</td>
</tr>
<tr>
<td>

```
Error: nu::shell::error

  × my error
   ╭─[repl_entry #2:6:9]
 5 │     msg: "my error"
 6 │     label: { text: "two", start: $span.start, end: $span.end }
   ·            ─────────────────────────┬─────────────────────────
   ·                                     ╰── two
 7 │ }
   ╰────
```

</td>
</tr>
</table>

So `error make` succeeded instead of throwing an error. Well, it *did* throw an error, the one user was trying to, not the one it should due to `error make` receiving an invalid argument.

From now on `error make` will raise an error of its own when receiving an invalid argument.

<table>
<tr>
<td width="1000">

```nushell
let var = 2
let span = (metadata $var).span

error make {
	msg: "my error"
	label: { text: "two" }
}
```

</td>
</tr>
<tr>
<td>

```
Error: nu::shell::missing_required_columns

  × Value is missing required columns.
   ╭─[repl_entry #1:6:9]
 4 │ error make {
 5 │     msg: "my error"
 6 │     label: { text: "two" }
   ·            ───────┬───────
   ·                   ╰── missing `span: record<start: int, end: int>` column
 7 │ }
   ╰────
```

</td>
</tr>
</table>
<table>
<tr>
<td width="1000">

```nushell
let var = 2
let span = (metadata $var).span

error make {
	msg: "my error"
	label: { text: "two", start: $span.start, end: $span.end }
}
```

</td>
</tr>
<tr>
<td>

```
Error: nu::shell::missing_required_columns

  × Value is missing required columns.
   ╭─[repl_entry #2:6:9]
 4 │ error make {
 5 │     msg: "my error"
 6 │     label: { text: "two", start: $span.start, end: $span.end }
   ·            ─────────────────────────┬─────────────────────────
   ·                                     ╰── missing `span: record<start: int, end: int>` column
 7 │ }
   ╰────
```

</td>
</tr>
</table>