### PR TITLE
feat(completions): add a `background-completions` opt-out

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -1644,11 +1644,26 @@ pub struct NuCompleter {
     /// completer, not on [`CompletionEngine`] (which non-caching callers also build).
     cache_env: CacheEnv,
     worker: Option<CompletionWorker>,
+    /// Whether [`complete`](ReedlineCompleter::complete) offloads to a worker.
+    /// False only on the REPL path with `background-completions` disabled.
+    background: bool,
 }
 
 impl NuCompleter {
     pub fn new(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
         Self::with_cache(engine_state, stack, NarrowingCache::default())
+    }
+
+    /// The reedline completer; the only constructor that consults the
+    /// `background-completions` experimental option.
+    pub(crate) fn for_repl(
+        engine_state: Arc<EngineState>,
+        stack: Arc<Stack>,
+        cache: NarrowingCache,
+    ) -> Self {
+        let mut completer = Self::with_cache(engine_state, stack, cache);
+        completer.background = nu_experimental::BACKGROUND_COMPLETIONS.get();
+        completer
     }
 
     pub(crate) fn with_cache(
@@ -1666,6 +1681,7 @@ impl NuCompleter {
             cache,
             cache_env,
             worker: None,
+            background: true,
         }
     }
 
@@ -1818,6 +1834,20 @@ fn partial_of(line: &str, suggestions: &[Suggestion]) -> Option<Partial> {
 
 impl ReedlineCompleter for NuCompleter {
     fn complete(&mut self, line: &str, pos: usize) -> CompletionResult {
+        if !self.background {
+            // Inline on this thread, skipping worker and cache: the pre-#18334
+            // blocking behavior, which had neither. Blocking is the point, so
+            // an interactive completer can own the terminal.
+            let suggestions: Suggestions = self
+                .engine
+                .fetch_completions_at(line, pos)
+                .into_iter()
+                .map(|s| s.suggestion)
+                .collect();
+            let partial = partial_of(line, &suggestions);
+            return CompletionResult::fresh(suggestions).with_partial(partial);
+        }
+
         let query = CompletionQuery::new(line, pos);
         self.drain_completed();
 
@@ -1919,6 +1949,91 @@ mod completer_tests {
 
         // Extending a flag the user was already typing stays sound.
         assert!(q("from csv --sep").narrows(&q("from csv --s"), token(9)));
+    }
+
+    /// Opted out: settles inline, spawns no worker, leaves the cache alone.
+    #[test]
+    fn opted_out_completer_settles_inline() {
+        let mut completer = NuCompleter::new(test_engine(), Arc::new(Stack::new()));
+        completer.background = false;
+
+        let result = completer.complete("ls | c", 6);
+        assert!(
+            matches!(result, CompletionResult::Fresh { .. }),
+            "expected a settled result, got {result:?}"
+        );
+        assert!(result.suggestions().iter().any(|s| s.value == "cd"));
+        assert!(completer.worker.is_none(), "a worker was spawned anyway");
+        assert_eq!(completer.poll_completion(), CompletionStatus::Idle);
+    }
+
+    /// Engine whose external completer reports what its evaluation environment
+    /// allowed: `piped-N` if a piped external's stdout reached `lines`,
+    /// `direct-S` if a final external's stdout was captured.
+    fn probe_engine() -> (Arc<EngineState>, Arc<Stack>) {
+        let mut engine =
+            nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
+        let mut stack = Stack::new();
+        let cwd = std::env::temp_dir().to_string_lossy().replace('\\', "/");
+        stack.add_env_var(
+            "PWD".to_string(),
+            nu_protocol::Value::string(&cwd, Span::unknown()),
+        );
+        // External lookup needs a PATH; `Stack::new` starts with no env at all.
+        stack.add_env_var(
+            "PATH".to_string(),
+            nu_protocol::Value::string(std::env::var("PATH").unwrap_or_default(), Span::unknown()),
+        );
+
+        let setup = r#"$env.config.completions.external = {
+                enable: true
+                completer: {|spans|
+                    let piped = (^printf 'alpha\nbeta\n' | lines | length)
+                    let direct = (^printf 'gamma' | str trim)
+                    [$"piped-($piped)" $"direct-($direct)"]
+                }
+            }"#;
+        let mut working_set = StateWorkingSet::new(&engine);
+        let block = nu_parser::parse(&mut working_set, None, setup.as_bytes(), false);
+        assert!(working_set.parse_errors.is_empty(), "setup failed to parse");
+        engine.merge_delta(working_set.render()).expect("merge");
+        nu_engine::eval_block::<nu_protocol::debugger::WithoutDebug>(
+            &engine,
+            &mut stack,
+            &block,
+            nu_protocol::PipelineData::empty(),
+        )
+        .expect("eval setup");
+        engine.merge_env(&mut stack).expect("merge env");
+
+        (Arc::new(engine), Arc::new(stack))
+    }
+
+    /// Externals inside a completer keep their stdout on both stacks:
+    /// `suppress_output` only sets `out_dest.stdout` (final command), while
+    /// `collect_value` sets `pipe_stdout` (piped stages). Thus the opt-out only
+    /// has to stop offloading; the stack needs no changes.
+    #[rstest::rstest]
+    #[case::foreground(false)]
+    #[case::background(true)]
+    fn externals_in_a_completer_keep_their_stdout(#[case] suppress_stdin: bool) {
+        let (engine, stack) = probe_engine();
+        let engine = CompletionEngine::new(engine, isolated_stack(stack, suppress_stdin));
+
+        let values: Vec<String> = engine
+            .fetch_completions_at("somecmd x", 9)
+            .into_iter()
+            .map(|s| s.suggestion.value)
+            .collect();
+
+        assert!(
+            values.iter().any(|v| v == "piped-2"),
+            "a piped external lost its stdout: {values:?}"
+        );
+        assert!(
+            values.iter().any(|v| v == "direct-gamma"),
+            "a final external lost its stdout: {values:?}"
+        );
     }
 
     /// The worker runs on an isolated stack and must still produce identical results.

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -198,6 +198,13 @@ struct CompletionWorker {
 /// corrupt reedline / LSP. Background workers also null child stdin and detach
 /// from the terminal (via `Stack::suppress_stdin`) so subprocesses cannot race
 /// the line editor.
+///
+/// Note that `suppress_stdin` only reaches externals spawned with
+/// `PipelineData::Empty` input. A completer that pipes its candidates into a
+/// picker (`$candidates | fzf`) takes the piped-stdin branch instead, so the
+/// child keeps the terminal either way. What stops such a picker from working
+/// under a background completion is not this stack but the concurrency: the
+/// reedline thread keeps reading the same terminal while the picker runs.
 fn isolated_stack(parent: Arc<Stack>, background: bool) -> Arc<Stack> {
     let stack = Stack::with_parent(parent)
         .reset_out_dest()
@@ -217,6 +224,9 @@ pub struct NuCompleter {
     cache: Arc<Mutex<HashMap<CompletionQuery, CacheEntry>>>,
     /// Lazily spawned on the first cache miss; reedline thread only (no lock).
     worker: Option<CompletionWorker>,
+    /// Whether to offload to a worker. False only on the REPL path with the
+    /// `background-completions` experimental option disabled.
+    background: bool,
 }
 
 /// Common arguments required for Completer
@@ -244,21 +254,36 @@ impl Context<'_> {
 }
 
 impl NuCompleter {
+    /// Completion that never offloads: LSP, `commandline complete`, tests.
+    ///
+    /// Work still happens on a worker thread when it would block; only the REPL
+    /// consults `background-completions`.
     pub fn new(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
-        Self::with_stack(engine_state, isolated_stack(stack, false))
+        Self::with_stack(engine_state, isolated_stack(stack, false), true)
+    }
+
+    /// The reedline completer, the only one that honors `background-completions`.
+    ///
+    /// With the option disabled the completer computes on the reedline thread and
+    /// reedline blocks while it runs, so a custom completer may hand the terminal
+    /// to an interactive picker without racing the line editor for keystrokes.
+    pub fn for_repl(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
+        let background = nu_experimental::BACKGROUND_COMPLETIONS.get();
+        Self::with_stack(engine_state, isolated_stack(stack, false), background)
     }
 
     /// Background worker: same isolation as [`Self::new`], plus suppressed stdin.
     fn for_background(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
-        Self::with_stack(engine_state, isolated_stack(stack, true))
+        Self::with_stack(engine_state, isolated_stack(stack, true), true)
     }
 
-    fn with_stack(engine_state: Arc<EngineState>, stack: Arc<Stack>) -> Self {
+    fn with_stack(engine_state: Arc<EngineState>, stack: Arc<Stack>, background: bool) -> Self {
         Self {
             engine_state,
             stack,
             cache: Arc::new(Mutex::new(HashMap::new())),
             worker: None,
+            background,
         }
     }
 
@@ -1050,6 +1075,21 @@ impl NuCompleter {
 
 impl ReedlineCompleter for NuCompleter {
     fn complete(&mut self, line: &str, pos: usize) -> CompletionResult {
+        if !self.background {
+            // Compute on this thread with the terminal attached, so a custom completer
+            // may drive an interactive child process. No worker is spawned, so
+            // `poll_completion` stays `Idle` and reedline blocks on input exactly as it
+            // did before non-blocking completions landed. The cache is bypassed too:
+            // an interactive completer is a user interaction, not a pure function, and
+            // replaying a cached selection would be wrong.
+            return CompletionResult::fresh(
+                self.fetch_completions_at(line, pos)
+                    .into_iter()
+                    .map(|s| s.suggestion)
+                    .collect::<Suggestions>(),
+            );
+        }
+
         let query = CompletionQuery {
             line: line.to_string(),
             current_position: pos,
@@ -1289,6 +1329,110 @@ mod completer_tests {
         assert!(matches!(fg.stack.stdout(), OutDest::Value));
         assert!(matches!(fg.stack.stderr(), OutDest::Null));
         assert!(!fg.stack.suppress_stdin);
+    }
+
+    /// With `background-completions` disabled the REPL completer settles on the
+    /// calling thread and spawns no worker, so reedline blocks on input exactly as
+    /// it did before non-blocking completions landed. Blocking is the point: it is
+    /// what stops the line editor from competing with an interactive completer for
+    /// the terminal's keystrokes.
+    #[test]
+    fn repl_without_background_settles_inline() {
+        // `for_repl` reads a global; construct the disabled shape directly rather
+        // than mutating process-wide state from a test.
+        let mut completer = NuCompleter::with_stack(
+            test_engine(),
+            isolated_stack(Arc::new(Stack::new()), false),
+            false,
+        );
+
+        let result = completer.complete("ls | c", 6);
+        assert!(
+            matches!(result, CompletionResult::Fresh(_)),
+            "expected a settled result, got {result:?}"
+        );
+        assert!(result.suggestions().iter().any(|s| s.value == "cd"));
+
+        assert!(completer.worker.is_none(), "a worker was spawned anyway");
+        assert_eq!(completer.poll_completion(), CompletionStatus::Idle);
+        assert!(!completer.stack.suppress_stdin);
+    }
+
+    /// Build an engine whose external completer reports what its evaluation
+    /// environment allowed, as completion values:
+    ///
+    /// - `piped-N`   -> a non-final external command's stdout reached `lines`
+    /// - `direct-S`  -> a final external command's stdout was captured
+    fn probe_engine() -> (Arc<EngineState>, Arc<Stack>) {
+        let mut engine =
+            nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
+        let mut stack = Stack::new();
+        let cwd = std::env::temp_dir().to_string_lossy().replace('\\', "/");
+        stack.add_env_var(
+            "PWD".to_string(),
+            nu_protocol::Value::string(&cwd, nu_protocol::Span::unknown()),
+        );
+        // External lookup needs a PATH; `Stack::new` starts with no env at all.
+        stack.add_env_var(
+            "PATH".to_string(),
+            nu_protocol::Value::string(
+                std::env::var("PATH").unwrap_or_default(),
+                nu_protocol::Span::unknown(),
+            ),
+        );
+
+        let setup = r#"$env.config.completions.external = {
+                enable: true
+                completer: {|spans|
+                    let piped = (^printf 'alpha\nbeta\n' | lines | length)
+                    let direct = (^printf 'gamma' | str trim)
+                    [$"piped-($piped)" $"direct-($direct)"]
+                }
+            }"#;
+        let mut working_set = StateWorkingSet::new(&engine);
+        let block = parse(&mut working_set, None, setup.as_bytes(), false);
+        assert!(working_set.parse_errors.is_empty(), "setup failed to parse");
+        engine.merge_delta(working_set.render()).expect("merge");
+        nu_engine::eval_block::<nu_protocol::debugger::WithoutDebug>(
+            &engine,
+            &mut stack,
+            &block,
+            nu_protocol::PipelineData::empty(),
+        )
+        .expect("eval setup");
+        engine.merge_env(&mut stack).expect("merge env");
+
+        (Arc::new(engine), Arc::new(stack))
+    }
+
+    /// `suppress_output` does not change what a completer that shells out can
+    /// observe: it sets `out_dest.stdout`, which governs the last command of a
+    /// pipeline, while `collect_value` sets `pipe_stdout` for piped stages. The
+    /// two never overlap, so externals inside a completer keep their stdout in
+    /// both the foreground and the background stack. This is why the opt-out does
+    /// not need to touch the stack at all: it only has to stop offloading.
+    #[rstest::rstest]
+    #[case::foreground(false)]
+    #[case::background(true)]
+    fn externals_in_a_completer_keep_their_stdout(#[case] background: bool) {
+        let (engine, stack) = probe_engine();
+        let completer =
+            NuCompleter::with_stack(engine, isolated_stack(stack, background), !background);
+
+        let values: Vec<String> = completer
+            .fetch_completions_at("somecmd x", 9)
+            .into_iter()
+            .map(|s| s.suggestion.value)
+            .collect();
+
+        assert!(
+            values.iter().any(|v| v == "piped-2"),
+            "a piped external lost its stdout: {values:?}"
+        );
+        assert!(
+            values.iter().any(|v| v == "direct-gamma"),
+            "a final external lost its stdout: {values:?}"
+        );
     }
 
     #[test]

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -638,7 +638,7 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
         .with_validator(Box::new(NuValidator {
             engine_state: engine_reference.clone(),
         }))
-        .with_completer(Box::new(NuCompleter::with_cache(
+        .with_completer(Box::new(NuCompleter::for_repl(
             engine_reference.clone(),
             // STACK-REFERENCE 2
             stack_arc.clone(),

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -586,7 +586,7 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
         .with_validator(Box::new(NuValidator {
             engine_state: engine_reference.clone(),
         }))
-        .with_completer(Box::new(NuCompleter::new(
+        .with_completer(Box::new(NuCompleter::for_repl(
             engine_reference.clone(),
             // STACK-REFERENCE 2
             stack_arc.clone(),

--- a/crates/nu-experimental/src/options/background_completions.rs
+++ b/crates/nu-experimental/src/options/background_completions.rs
@@ -1,0 +1,28 @@
+use crate::*;
+
+/// Run completions on a background thread instead of blocking the line editor.
+///
+/// While the worker computes, reedline keeps polling the terminal for input, so a
+/// custom completer that drives an interactive picker (`$candidates | fzf`) paints
+/// its UI but never receives any keystrokes; the line editor is reading the same
+/// terminal at the same time. Disabling this restores the pre-0.115 behavior: the
+/// completer settles on the reedline thread, which blocks while it runs, and
+/// expensive completions freeze typing again.
+pub static BACKGROUND_COMPLETIONS: ExperimentalOption =
+    ExperimentalOption::new(&BackgroundCompletions);
+
+// No documentation needed here since this type isn't public.
+// The static above provides all necessary details.
+struct BackgroundCompletions;
+
+impl ExperimentalOptionMarker for BackgroundCompletions {
+    const IDENTIFIER: &'static str = "background-completions";
+    const DESCRIPTION: &'static str = "Runs completions on a background thread so typing never blocks. Disable to let custom completers drive interactive child processes.";
+    const STATUS: Status = Status::OptOut;
+    const SINCE: Version = (0, 115, 0);
+    // TODO: placeholder. Needs a nushell tracking issue recording how this option
+    // ends its life, either stabilizing as the default or being removed once
+    // interactive completers have a supported path. nushell/reedline#1131 is the
+    // discussion, but it lives in the wrong repo to serve as the tracker.
+    const ISSUE: u32 = 0;
+}

--- a/crates/nu-experimental/src/options/background_completions.rs
+++ b/crates/nu-experimental/src/options/background_completions.rs
@@ -1,0 +1,24 @@
+use crate::*;
+
+/// Run completions on a background thread instead of blocking the line editor.
+///
+/// Disabling restores the pre-0.115 behavior: completions settle on the
+/// reedline thread, which blocks while they run, so a custom completer can
+/// hand the terminal to an interactive picker (`$candidates | fzf`) without
+/// the line editor stealing its keystrokes.
+pub static BACKGROUND_COMPLETIONS: ExperimentalOption =
+    ExperimentalOption::new(&BackgroundCompletions);
+
+// No documentation needed here since this type isn't public.
+// The static above provides all necessary details.
+struct BackgroundCompletions;
+
+impl ExperimentalOptionMarker for BackgroundCompletions {
+    const IDENTIFIER: &'static str = "background-completions";
+    const DESCRIPTION: &'static str = "\
+        Runs completions on a background thread so typing never blocks. \
+        Disable to let custom completers drive interactive child processes.";
+    const STATUS: Status = Status::OptOut;
+    const SINCE: Version = (0, 115, 0);
+    const ISSUE: u32 = 18839;
+}

--- a/crates/nu-experimental/src/options/mod.rs
+++ b/crates/nu-experimental/src/options/mod.rs
@@ -5,6 +5,7 @@
 
 use crate::*;
 
+mod background_completions;
 mod cell_path_types;
 mod dc_glob;
 mod enforce_runtime_annotations;
@@ -61,6 +62,7 @@ pub(crate) trait ExperimentalOptionMarker {
 
 // Export only the static values.
 // The marker structs are not relevant and needlessly clutter the generated docs.
+pub use background_completions::BACKGROUND_COMPLETIONS;
 pub use cell_path_types::CELL_PATH_TYPES;
 pub use dc_glob::DC_GLOB;
 pub use enforce_runtime_annotations::ENFORCE_RUNTIME_ANNOTATIONS;
@@ -84,6 +86,7 @@ pub static ALL: &[&ExperimentalOption] = &[
     &ENFORCE_RUNTIME_ANNOTATIONS,
     &NATIVE_CLIP,
     &CELL_PATH_TYPES,
+    &BACKGROUND_COMPLETIONS,
 ];
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

While the completion worker computes, reedline keeps reading the terminal, so a custom completer that drives an interactive picker (`$candidates | fzf`) paints its UI but never receives a keystroke.
This adds a `background-completions` experimental option (`Status::OptOut`, so the async path stays the default).
Disabled, the REPL completer settles on the reedline thread: reedline blocks on input as it did before #18334, and the completer can hand the terminal to its child.

Scope of the opt-out:

- `complete()` is the only path to the worker spawn, so gating it turns off every background piece at once; `poll_completion` stays `Idle`.
- The cache is bypassed too: an interactive completer is not a pure function, and the pre-#18334 behavior this restores had no completion cache either, so opting out is faithful to the old behavior rather than a regression against it.
- Suggestions still come from the current engine (`fetch_completions_at`): the opt-out restores the old interaction model, not old results.
- The LSP and `commandline complete` already run inline through `CompletionEngine` and are untouched.

This option exists for configs that need the old blocking semantics back.

## User-facing changes (Release notes)

### Add `background-completions` opt-out

Added the `background-completions` experimental option (enabled by default). Disabling it makes completions block the line editor again, which lets custom completers drive interactive child processes like fzf:

```nushell
nu --experimental-options '[background-completions=false]'
```

## Additional notes

fixes #18771

