### PR TITLE
fix color config fallbacks

### DIFF
--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -2,7 +2,7 @@ use crate::{TextStyle, color_record_to_nustyle, lookup_ansi_color_style, text_st
 use nu_ansi_term::Style;
 use nu_engine::ClosureEvalOnce;
 use nu_protocol::{
-    Span, Value,
+    Span, Value, default_color_config,
     engine::{Closure, EngineState, Stack},
     report_shell_error,
 };
@@ -30,6 +30,27 @@ pub struct StyleComputer<'a> {
     engine_state: &'a EngineState,
     stack: &'a Stack,
     map: StyleMapping,
+}
+
+/// Insert a color_config value into a style map (string / record / closure).
+fn insert_style_from_value(map: &mut StyleMapping, key: String, value: &Value) {
+    let span = value.span();
+    match value {
+        Value::Closure { val, .. } => {
+            map.insert(key, ComputableStyle::Closure(*val.clone(), span));
+        }
+        Value::Record { .. } => {
+            map.insert(key, ComputableStyle::Static(color_record_to_nustyle(value)));
+        }
+        Value::String { val, .. } => {
+            map.insert(
+                key,
+                ComputableStyle::Static(lookup_ansi_color_style(val.as_str())),
+            );
+        }
+        // Unsupported types are ignored (same as pre-existing from_config behavior).
+        _ => (),
+    }
 }
 
 impl<'a> StyleComputer<'a> {
@@ -109,38 +130,24 @@ impl<'a> StyleComputer<'a> {
 
     // The main constructor.
     //
-    // Defaults live on `Config::default().color_config` so `$env.config` is the
-    // single source of truth (including under `nu -n`).
+    // Defaults come from `default_color_config()` (same source as
+    // `Config::default().color_config`). We seed with those defaults, then overlay
+    // the live `color_config` so partial theme assignments that omit keys
+    // (e.g. `binary_*`) still fall back to the built-in styles instead of plain
+    // `Style::default()`.
     pub fn from_config(engine_state: &'a EngineState, stack: &'a Stack) -> StyleComputer<'a> {
         let config = stack.get_config(engine_state);
 
         let mut map: StyleMapping = HashMap::new();
 
-        for (key, value) in &config.color_config {
-            let span = value.span();
-            match value {
-                Value::Closure { val, .. } => {
-                    map.insert(
-                        key.to_string(),
-                        ComputableStyle::Closure(*val.clone(), span),
-                    );
-                }
-                Value::Record { .. } => {
-                    map.insert(
-                        key.to_string(),
-                        ComputableStyle::Static(color_record_to_nustyle(value)),
-                    );
-                }
-                Value::String { val, .. } => {
-                    map.insert(
-                        key.to_string(),
-                        ComputableStyle::Static(lookup_ansi_color_style(val.as_str())),
-                    );
-                }
-                // This should never occur.
-                _ => (),
-            }
+        for (key, value) in default_color_config() {
+            insert_style_from_value(&mut map, key, &value);
         }
+
+        for (key, value) in &config.color_config {
+            insert_style_from_value(&mut map, key.clone(), value);
+        }
+
         StyleComputer::new(engine_state, stack, map)
     }
 }
@@ -148,6 +155,8 @@ impl<'a> StyleComputer<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nu_protocol::Config;
+    use std::sync::Arc;
 
     #[test]
     fn test_computable_style_static() {
@@ -173,6 +182,49 @@ mod tests {
         assert_eq!(
             style_computer.compute("row_index", &Value::nothing(Span::unknown())),
             style2
+        );
+    }
+
+    #[test]
+    fn partial_color_config_falls_back_to_defaults_for_binary() {
+        // Simulates `$env.config.color_config = { header: red }` which replaces
+        // the whole map and drops keys the theme never set (e.g. binary_*).
+        let engine_state = EngineState::new();
+        let mut stack = Stack::new();
+        let config = Config {
+            color_config: [("header".to_string(), Value::test_string("red"))]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        stack.config = Some(Arc::new(config));
+
+        let style_computer = StyleComputer::from_config(&engine_state, &stack);
+        let null = Value::nothing(Span::unknown());
+
+        assert_eq!(
+            style_computer.compute("header", &null),
+            lookup_ansi_color_style("red")
+        );
+        assert_eq!(
+            style_computer.compute("binary_null_char", &null),
+            lookup_ansi_color_style("grey42")
+        );
+        assert_eq!(
+            style_computer.compute("binary_printable", &null),
+            lookup_ansi_color_style("cyan_bold")
+        );
+        assert_eq!(
+            style_computer.compute("binary_whitespace", &null),
+            lookup_ansi_color_style("green_bold")
+        );
+        assert_eq!(
+            style_computer.compute("binary_ascii_other", &null),
+            lookup_ansi_color_style("purple_bold")
+        );
+        assert_eq!(
+            style_computer.compute("binary_non_ascii", &null),
+            lookup_ansi_color_style("yellow_bold")
         );
     }
 }

--- a/crates/nu-std/std/config/mod.nu
+++ b/crates/nu-std/std/config/mod.nu
@@ -19,6 +19,12 @@ export def dark-theme [] {
         string: default
         nothing: default
         binary: default
+        # binary hex viewer styles (table / explore)
+        binary_null_char: grey42
+        binary_printable: cyan_bold
+        binary_whitespace: green_bold
+        binary_ascii_other: purple_bold
+        binary_non_ascii: yellow_bold
         cell-path: default
         row_index: green_bold
         record: default
@@ -26,6 +32,7 @@ export def dark-theme [] {
         block: default
         hints: dark_gray
         search_result: { bg: red fg: white }
+        
         shape_binary: purple_bold
         shape_block: blue_bold
         shape_bool: light_cyan
@@ -87,6 +94,12 @@ export def light-theme [] {
         string: dark_gray
         nothing: dark_gray
         binary: dark_gray
+        # binary hex viewer styles (table / explore)
+        binary_null_char: grey42
+        binary_printable: cyan_bold
+        binary_whitespace: green_bold
+        binary_ascii_other: purple_bold
+        binary_non_ascii: yellow_bold
         cell-path: dark_gray
         row_index: green_bold
         record: dark_gray
@@ -94,6 +107,7 @@ export def light-theme [] {
         block: dark_gray
         hints: dark_gray
         search_result: { fg: white bg: red }
+
         shape_binary: purple_bold
         shape_block: blue_bold
         shape_bool: light_cyan


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR fixes and oversight in #18747 where color config fallbacks were set to the Color::Default.
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
If you set part of the color config, the defaults for the other parts will still be applied.
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->