### PR TITLE
fix(save): give actionable error when structured data has no serializer

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -116,7 +116,7 @@ impl Command for Save {
                 let (mut file, _) =
                     get_files(engine_state, &path, stderr_path.as_ref(), append, force)?;
                 for val in ls {
-                    file.write_all(&value_to_bytes(val)?)
+                    file.write_all(&value_to_bytes(val, span)?)
                         .map_err(&from_io_error)?;
                     file.write_all("\n".as_bytes()).map_err(&from_io_error)?;
                 }
@@ -165,7 +165,7 @@ impl Command for Save {
                     return save_byte_stream(stream, metadata.as_ref());
                 }
 
-                let bytes = value_to_bytes(converted.into_value(span)?)?;
+                let bytes = value_to_bytes(converted.into_value(span)?, span)?;
 
                 // Only open file after successful conversion
                 let (mut file, _) =
@@ -328,17 +328,45 @@ fn convert_to_extension(
     }
 }
 
+/// Actionable error for when `save` receives structured data (a record, table,
+/// or other non-string value) but the destination has no matching
+/// `to <extension>` serializer, so the value can't be written as-is.
+///
+/// Filenames are only hints. Mirrors how `to json`/`to toml` report
+/// unserializable input: the failure is that `save` doesn't support this input
+/// for this file, not a low-level string coercion, so we raise
+/// [`ShellError::UnsupportedInput`] pointing at the explicit conversions rather
+/// than a bare "can't convert to string".
+fn cant_serialize_to_file(from_type: Type, value_span: Span, call_span: Span) -> ShellError {
+    ShellError::UnsupportedInput {
+        msg: format!(
+            "cannot save {from_type} to this file: no `to` converter matches the file's \
+             extension. Serialize it first, e.g. `... | to json | save <file>`, or save \
+             the rendered table with ansi escape sequences with `... | table | save <file>`"
+        ),
+        input: "value originates from here".into(),
+        msg_span: call_span,
+        input_span: value_span,
+    }
+}
+
 /// Convert [`Value::String`] [`Value::Binary`] or [`Value::List`] into [`Vec`] of bytes
 ///
-/// Propagates [`Value::Error`] and creates error otherwise
-fn value_to_bytes(value: Value) -> Result<Vec<u8>, ShellError> {
+/// Propagates [`Value::Error`] and, for structured values that can't be
+/// coerced to text, returns an actionable [`cant_serialize_to_file`] error
+/// pointing at `span` (the `save` invocation).
+fn value_to_bytes(value: Value, span: Span) -> Result<Vec<u8>, ShellError> {
     match value {
         Value::String { val, .. } => Ok(val.into_bytes()),
         Value::Binary { val, .. } => Ok(val.into_owned()),
         Value::List { vals, .. } => {
             let val = vals
                 .into_iter()
-                .map(Value::coerce_into_string)
+                .map(|val| {
+                    let (ty, val_span) = (val.get_type(), val.span());
+                    val.coerce_into_string()
+                        .map_err(|_| cant_serialize_to_file(ty, val_span, span))
+                })
                 .collect::<Result<Vec<String>, ShellError>>()?
                 .join("\n")
                 + "\n";
@@ -347,7 +375,13 @@ fn value_to_bytes(value: Value) -> Result<Vec<u8>, ShellError> {
         }
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { error, .. } => Err(*error),
-        other => Ok(other.coerce_into_string()?.into_bytes()),
+        other => {
+            let (ty, val_span) = (other.get_type(), other.span());
+            other
+                .coerce_into_string()
+                .map(String::into_bytes)
+                .map_err(|_| cant_serialize_to_file(ty, val_span, span))
+        }
     }
 }
 

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -439,35 +439,24 @@ fn list_all_columns() -> Result {
             .expect_value_eq(["name", "type", "size", "modified"])?;
         // Long
         let expected = cfg_select! {
-            unix => {
-                [
-                    "name",
-                    "type",
-                    "target",
-                    "readonly",
-                    "mode",
-                    "num_links",
-                    "inode",
-                    "user",
-                    "group",
-                    "size",
-                    "created",
-                    "accessed",
-                    "modified",
-                ]
-            }
-            windows => {
-                [
-                    "name",
-                    "type",
-                    "target",
-                    "readonly",
-                    "size",
-                    "created",
-                    "accessed",
-                    "modified",
-                ]
-            }
+            unix => [
+                "name",
+                "type",
+                "target",
+                "readonly",
+                "mode",
+                "num_links",
+                "inode",
+                "user",
+                "group",
+                "size",
+                "created",
+                "accessed",
+                "modified",
+            ],
+            windows => [
+                "name", "type", "target", "readonly", "size", "created", "accessed", "modified",
+            ],
         };
         test()
             .cwd(dirs.test())

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -104,8 +104,27 @@ fn unknown_extension_does_not_default_to_text() -> Result {
             .run("[[a, b]; [1, 2]] | save structured.unknown")
             .expect_error()?;
 
-        assert_contains("Can't convert to string", err.to_string());
+        // No serializer for the extension: report unsupported input with an
+        // actionable message pointing at the explicit conversions.
+        assert_contains("Unsupported input", err.to_string());
+        assert_contains("to json", format!("{err:?}"));
         assert!(!dirs.test().join("structured.unknown").exists());
+        Ok(())
+    })
+}
+
+#[test]
+fn no_extension_gives_actionable_error_for_structured_data() -> Result {
+    Playground::setup("save_no_extension", |dirs, sandbox| {
+        sandbox.with_files(&[]);
+
+        let err = test()
+            .cwd(dirs.test())
+            .run("[[a, b]; [1, 2]] | save structured")
+            .expect_error()?;
+
+        assert_contains("Unsupported input", err.to_string());
+        assert_contains("to json", format!("{err:?}"));
         Ok(())
     })
 }


### PR DESCRIPTION
## Description

`save` receiving structured data (a record, table, or other non-string value) whose destination has **no matching `to <extension>` serializer** — no extension, or an unknown suffix like `.foo` — failed with a bare, cryptic `Can't convert to string`, forcing users to guess the fix (#18700).

`save` now returns `UnsupportedInput` instead, mirroring how `to json` / `to toml` / `to msgpack` report unserializable input: the failure is that `save` doesn't support this input for this file, not a low-level string coercion. The message points at the explicit conversions and labels both the `save` call and where the input value originated.

Before:

```text
Error: nu::shell::cant_convert

  x Can't convert to string.
   ,-[source:1:1]
 1 | {a: 1, b: 2} | save out.foo
   : ^^^^^^|^^^^^
   :       `-- can't convert record<a: int, b: int> to string
   `----
```
After:

```text
Error: nu::shell::unsupported_input

  x Unsupported input
   ,-[source:1:1]
 1 | {a: 1, b: 2} | save out.foo
   : ^^^^^^|^^^^^   ^^|^
   :       |          `-- cannot save record<a: int, b: int> to this file:
   :       |              no `to` converter matches the file's extension.
   :       |              Serialize it first, e.g. `... | to json | save
   :       |              <file>` (also `to nuon`, `to yaml`, …), or save
   :       |              the rendered table with `... | table | ansi strip
   :       |              | save <file>`
   :       `-- value originates from here
   `----
```

The `.txt` half of #18700 already landed in #18735. Known extensions keep working (serialized by `to <ext>`), as do strings, binaries, lists of strings, and scalars. Added 2 regression tests (unknown extension + no extension).

## User-facing changes (Release notes)

- Fixed an issue where saving structured data (like a record or table) to a file with no known serializer (no extension, or an unknown one such as `.foo`) failed with a cryptic `Can't convert to string`. Nushell now explains that no serializer matches the file's extension and suggests `... | to json | save <file>` or `... | table | ansi strip | save <file>`.

## Additional notes

- Fixes #18700
- Follow-up to #18735
