### PR TITLE
Improve `format pattern` errors

### DIFF
--- a/crates/nu-cmd-extra/src/extra/strings/format/command.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/command.rs
@@ -252,6 +252,9 @@ fn format_record(
     pattern: &Spanned<String>,
     head_span: Span,
 ) -> Result<String, ShellError> {
+    // whether any of the columns starts with "$"
+    let mut dollar_column = false;
+
     let result = format_operations
         .iter()
         .map(|op| match op {
@@ -274,10 +277,15 @@ fn format_record(
 
                 match data_as_value.follow_cell_path(&path_members) {
                     Ok(val) => Ok(Ok(Cow::Owned(val.to_expanded_string(", ", config)))),
-                    Err(ShellError::CantFindColumn { col_name, .. }) => Ok(Err(ErrorLabel {
-                        text: format!("column '{col_name}' is missing in one or more values"),
-                        span: *span,
-                    })),
+                    Err(ShellError::CantFindColumn { col_name, .. }) => {
+                        if !dollar_column && col_name.starts_with('$') {
+                            dollar_column = true;
+                        }
+                        Ok(Err(ErrorLabel {
+                            text: format!("column '{col_name}' is missing in one or more values"),
+                            span: *span,
+                        }))
+                    }
                     Err(err) => Err(err),
                 }
             }
@@ -297,13 +305,21 @@ fn format_record(
                 inner: vec![],
             };
 
-            Err(ShellError::from(
-                LabeledError::new("Invalid value")
-                    .with_code("nu::shell::invalid_value")
-                    .with_label("format string", pattern.span)
-                    .with_label("value originates here", data_as_value.span())
-                    .with_inner(format_str_source),
-            ))
+            let mut labeled_err = LabeledError::new("Invalid value")
+                .with_code("nu::shell::invalid_value")
+                .with_label("format string", pattern.span)
+                .with_label("value originates here", data_as_value.span())
+                .with_inner(format_str_source);
+
+            if dollar_column {
+                labeled_err = labeled_err.with_help(
+                    "`format pattern` reads values from the pipeline input, \
+                    it does not read the variables in scope.\n\
+                    You might want to use string interpolation instead: `$\"($name): ($type)\"`",
+                );
+            }
+
+            Err(ShellError::from(labeled_err))
         }
     }
 }

--- a/crates/nu-cmd-extra/src/extra/strings/format/command.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/command.rs
@@ -1,8 +1,9 @@
 use itertools::Itertools;
 use nu_engine::command_prelude::*;
 use nu_protocol::{
-    Config, ListStream, ast::PathMember, casing::Casing, shell_error::generic::GenericError,
+    Config, ErrorLabel, ErrorSource, LabeledError, ListStream, ast::PathMember, casing::Casing,
 };
+use nu_utils::MultiResult;
 
 #[derive(Clone)]
 pub struct FormatPattern;
@@ -41,10 +42,10 @@ impl Command for FormatPattern {
         let pattern: Spanned<String> = call.req(engine_state, stack, 0)?;
         let input_val = input.into_value(call.head)?;
 
-        let ops = extract_formatting_operations(pattern, call.head)?;
+        let ops = extract_formatting_operations(&pattern)?;
         let config = stack.get_config(engine_state);
 
-        format(input_val, &ops, engine_state, &config, call.head)
+        format(input_val, &ops, engine_state, &config, &pattern, call.head)
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -84,16 +85,7 @@ impl Command for FormatPattern {
 enum FormatOperation {
     FixedText(String),
     // raw input is something like {column1.column2}
-    ValueFromColumn { content: String, span: Option<Span> },
-}
-
-impl FormatOperation {
-    fn update_span(mut self, f: impl FnOnce(Option<Span>) -> Option<Span>) -> Self {
-        if let FormatOperation::ValueFromColumn { span, .. } = &mut self {
-            *span = f(*span);
-        }
-        self
-    }
+    ValueFromColumn { content: String, span: Span },
 }
 
 /// Given a pattern that is fed into the Format command, we can process it and subdivide it
@@ -104,41 +96,12 @@ impl FormatOperation {
 /// formatted according to the input pattern.
 /// "$it.column1.column2" or "$variable"
 fn extract_formatting_operations(
-    input: Spanned<String>,
-    call_head: Span,
+    input: &Spanned<String>,
 ) -> Result<Vec<FormatOperation>, ShellError> {
     let Spanned {
         item: pattern,
         span: pattern_span,
     } = input;
-
-    // To have proper spans for the extracted operations, we need the span of the pattern string.
-    // Specifically we need the *string content*, without any surrounding quotes.
-    //
-    // NOTE: This implementation can't accurately derive spans for strings containing escape
-    // sequences ("\n", "\t", "\u{3bd}", ...). I don't think we can without parser support.
-    // NOTE: Pattern strings provided with variables are also problematic. The spans we get for
-    // arguments are from the call site, we can't get the original span of a value passed as a
-    // variable.
-    let pattern_span = {
-        //
-        //    .----------span len: 21
-        //    |     .--string len: 12
-        //    |     |       delta:  9
-        //  .-+-----|-----------.
-        //  |    .--+-------.   |
-        //  r###'hello {user}'###
-        //
-        let delta = pattern_span.len() - pattern.len();
-        // might be `r'foo'` or `$'foo'`
-        // either 1 or 0
-        let str_prefix_len = delta % 2;
-        //
-        //    r###'hello {user}'###
-        //    ^^^^
-        let span_str_start_delta = delta / 2 + str_prefix_len;
-        pattern_span.subspan(span_str_start_delta, span_str_start_delta + pattern.len())
-    };
 
     let mut is_fixed = true;
     let ops = pattern.char_indices().peekable().batching(move |it| {
@@ -159,14 +122,17 @@ fn extract_formatting_operations(
                         if it.next_if(|(_, next_ch)| *next_ch == '}').is_some() {
                             buf.push(ch);
                         } else {
-                            return Some(Err(()));
+                            return Some(Err(ErrorLabel {
+                                text: "Unbalanced { and }".into(),
+                                span: Span::new(index, index + 1),
+                            }));
                         }
                     } else {
                         is_fixed = true;
                         return Some(Ok(FormatOperation::ValueFromColumn {
                             content: buf,
                             // span is relative to `pattern`
-                            span: Some(Span::new(start_index, index)),
+                            span: Span::new(start_index, index),
                         }));
                     }
                 }
@@ -181,42 +147,33 @@ fn extract_formatting_operations(
                 .map(FormatOperation::FixedText)
                 .map(Ok)
         } else {
-            Some(Err(()))
+            Some(Err(ErrorLabel {
+                text: "Unclosed delimiter".into(),
+                span: Span::new(start_index - 1, start_index),
+            }))
         }
     });
 
-    let adjust_span = move |col_span: Span| -> Option<Span> {
-        pattern_span?.subspan(col_span.start, col_span.end)
-    };
+    match ops.collect::<MultiResult<Vec<_>, Vec<_>>>().result() {
+        Ok(x) => Ok(x),
+        Err(errors) => {
+            let labels = errors.into_iter().map(Into::into).collect();
 
-    let make_delimiter_error = move |_| ShellError::DelimiterError {
-        msg: "there are unmatched curly braces".to_string(),
-        span: call_head,
-    };
+            let format_str_source = ShellError::OutsideSourceNoUrl {
+                src: ErrorSource::new(Some("format string".into()), pattern.clone()).into(),
+                msg: "Format string has errors.".into(),
+                help: None,
+                labels,
+                inner: vec![],
+            };
 
-    let make_removed_functionality_error = |span: Span| {
-        ShellError::Generic(
-            GenericError::new(
-                "Removed functionality",
-                "The ability to use variables ($it) in `format pattern` has been removed.",
-                span,
-            )
-            .with_help("You can use other formatting options, such as string interpolation."),
-        )
-    };
-
-    ops.map(|res_op| {
-        res_op
-            .map(|op| op.update_span(|col_span| col_span.and_then(adjust_span)))
-            .map_err(make_delimiter_error)
-            .and_then(|op| match op {
-                FormatOperation::ValueFromColumn { content, span } if content.starts_with('$') => {
-                    Err(make_removed_functionality_error(span.unwrap_or(call_head)))
-                }
-                op => Ok(op),
-            })
-    })
-    .collect()
+            Err(LabeledError::new("Invalid value.")
+                .with_code("nu::shell::invalid_value")
+                .with_label("format string", *pattern_span)
+                .with_inner(format_str_source)
+                .into())
+        }
+    }
 }
 
 /// Format the incoming PipelineData according to the pattern
@@ -225,6 +182,7 @@ fn format(
     format_operations: &[FormatOperation],
     engine_state: &EngineState,
     config: &Config,
+    pattern: &Spanned<String>,
     head_span: Span,
 ) -> Result<PipelineData, ShellError> {
     let data_as_value = input_data;
@@ -232,7 +190,13 @@ fn format(
     //  We can only handle a Record or a List of Records
     match data_as_value {
         Value::Record { .. } => {
-            match format_record(format_operations, &data_as_value, config, head_span) {
+            match format_record(
+                format_operations,
+                &data_as_value,
+                config,
+                pattern,
+                head_span,
+            ) {
                 Ok(value) => Ok(PipelineData::value(Value::string(value, head_span), None)),
                 Err(value) => Err(value),
             }
@@ -243,7 +207,7 @@ fn format(
             for val in vals.iter() {
                 match val {
                     Value::Record { .. } => {
-                        match format_record(format_operations, val, config, head_span) {
+                        match format_record(format_operations, val, config, pattern, head_span) {
                             Ok(value) => {
                                 list.push(Value::string(value, head_span));
                             }
@@ -282,6 +246,7 @@ fn format_record(
     format_operations: &[FormatOperation],
     data_as_value: &Value,
     config: &Config,
+    pattern: &Spanned<String>,
     head_span: Span,
 ) -> Result<String, ShellError> {
     let mut output = String::new();
@@ -298,15 +263,43 @@ fn format_record(
                     .split('.')
                     .map(|path| PathMember::String {
                         val: path.to_string(),
-                        span: span.unwrap_or(head_span),
+                        span: head_span,
                         optional: false,
                         casing: Casing::Sensitive,
                     })
                     .collect();
 
-                let expanded_string = data_as_value
-                    .follow_cell_path(&path_members)?
-                    .to_expanded_string(", ", config);
+                let expanded_string = match data_as_value.follow_cell_path(&path_members) {
+                    Ok(val) => val.to_expanded_string(", ", config),
+                    Err(ShellError::CantFindColumn {
+                        col_name, src_span, ..
+                    }) => {
+                        let label = ErrorLabel {
+                            text: format!("column '{col_name}' is missing in one or more values"),
+                            span: *span,
+                        };
+                        let format_str_source = ShellError::OutsideSourceNoUrl {
+                            src: ErrorSource::new(
+                                Some("format string".into()),
+                                pattern.item.clone(),
+                            )
+                            .into(),
+                            msg: "Format string has errors.".into(),
+                            help: None,
+                            labels: vec![label.into()],
+                            inner: vec![],
+                        };
+
+                        return Err(LabeledError::new("Invalid value")
+                            .with_code("nu::shell::invalid_value")
+                            .with_label("format string", pattern.span)
+                            .with_label("value originates here", src_span)
+                            .with_inner(format_str_source)
+                            .into());
+                    }
+                    Err(err) => return Err(err),
+                };
+
                 output.push_str(expanded_string.as_str())
             }
         }

--- a/crates/nu-cmd-extra/src/extra/strings/format/command.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/command.rs
@@ -1,4 +1,7 @@
+use std::borrow::Cow;
+
 use itertools::Itertools;
+
 use nu_engine::command_prelude::*;
 use nu_protocol::{
     Config, ErrorLabel, ErrorSource, LabeledError, ListStream, ast::PathMember, casing::Casing,
@@ -249,15 +252,15 @@ fn format_record(
     pattern: &Spanned<String>,
     head_span: Span,
 ) -> Result<String, ShellError> {
-    let mut output = String::new();
-
-    for op in format_operations {
-        match op {
-            FormatOperation::FixedText(s) => output.push_str(s.as_str()),
+    let result = format_operations
+        .iter()
+        .map(|op| match op {
+            FormatOperation::FixedText(s) => Ok(Ok(Cow::Borrowed(s.as_str()))),
             FormatOperation::ValueFromColumn {
                 content: col_name,
                 span,
             } => {
+                // TODO: use `CellPath::from_str`
                 // path member should split by '.' to handle for nested structure.
                 let path_members: Vec<PathMember> = col_name
                     .split('.')
@@ -269,42 +272,40 @@ fn format_record(
                     })
                     .collect();
 
-                let expanded_string = match data_as_value.follow_cell_path(&path_members) {
-                    Ok(val) => val.to_expanded_string(", ", config),
-                    Err(ShellError::CantFindColumn {
-                        col_name, src_span, ..
-                    }) => {
-                        let label = ErrorLabel {
-                            text: format!("column '{col_name}' is missing in one or more values"),
-                            span: *span,
-                        };
-                        let format_str_source = ShellError::OutsideSourceNoUrl {
-                            src: ErrorSource::new(
-                                Some("format string".into()),
-                                pattern.item.clone(),
-                            )
-                            .into(),
-                            msg: "Format string has errors.".into(),
-                            help: None,
-                            labels: vec![label.into()],
-                            inner: vec![],
-                        };
-
-                        return Err(LabeledError::new("Invalid value")
-                            .with_code("nu::shell::invalid_value")
-                            .with_label("format string", pattern.span)
-                            .with_label("value originates here", src_span)
-                            .with_inner(format_str_source)
-                            .into());
-                    }
-                    Err(err) => return Err(err),
-                };
-
-                output.push_str(expanded_string.as_str())
+                match data_as_value.follow_cell_path(&path_members) {
+                    Ok(val) => Ok(Ok(Cow::Owned(val.to_expanded_string(", ", config)))),
+                    Err(ShellError::CantFindColumn { col_name, .. }) => Ok(Err(ErrorLabel {
+                        text: format!("column '{col_name}' is missing in one or more values"),
+                        span: *span,
+                    })),
+                    Err(err) => Err(err),
+                }
             }
+        })
+        .collect::<Result<MultiResult<Vec<_>, Vec<_>>, _>>()?
+        .result();
+
+    match result {
+        Ok(strings) => Ok(strings.into_iter().map(Cow::into_owned).collect::<String>()),
+        Err(labels) => {
+            let labels = labels.into_iter().map(Into::into).collect();
+            let format_str_source = ShellError::OutsideSourceNoUrl {
+                src: ErrorSource::new(Some("format string".into()), pattern.item.clone()).into(),
+                msg: "Format string has errors.".into(),
+                help: None,
+                labels,
+                inner: vec![],
+            };
+
+            Err(ShellError::from(
+                LabeledError::new("Invalid value")
+                    .with_code("nu::shell::invalid_value")
+                    .with_label("format string", pattern.span)
+                    .with_label("value originates here", data_as_value.span())
+                    .with_inner(format_str_source),
+            ))
         }
     }
-    Ok(output)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/tests/commands/format/filesize.rs
+++ b/crates/nu-command/tests/commands/format/filesize.rs
@@ -1,3 +1,4 @@
+use nu_test_support::fs::Stub;
 use nu_test_support::prelude::*;
 
 #[test]
@@ -22,4 +23,48 @@ fn format_filesize_with_invalid_unit() -> Result {
     let err = test().run(code).expect_error()?;
     assert!(matches!(err, ShellError::InvalidUnit { .. }));
     Ok(())
+}
+
+#[test]
+fn format_filesize_works() -> Result {
+    Playground::setup("format_filesize_test_1", |dirs, sandbox| {
+        sandbox.with_files(&[
+            Stub::EmptyFile("yehuda.txt"),
+            Stub::EmptyFile("jttxt"),
+            Stub::EmptyFile("andres.txt"),
+        ]);
+
+        let code = "
+            ls
+            | format filesize kB size
+            | get size
+            | first
+        ";
+
+        test().cwd(dirs.test()).run(code).expect_value_eq("0 kB")
+    })
+}
+
+#[test]
+fn format_filesize_works_with_nonempty_files() -> Result {
+    Playground::setup(
+        "format_filesize_works_with_nonempty_files",
+        |dirs, sandbox| {
+            sandbox.with_files(&[Stub::FileWithContentToBeTrimmed(
+                "sample.toml",
+                r#"
+                    [dependency]
+                    name = "nu"
+                "#,
+            )]);
+
+            let code = "ls sample.toml | format filesize B size | get size | first";
+            #[cfg(not(windows))]
+            let expected = "25 B";
+            #[cfg(windows)]
+            let expected = "27 B";
+
+            test().cwd(dirs.test()).run(code).expect_value_eq(expected)
+        },
+    )
 }

--- a/crates/nu-command/tests/commands/format/filesize.rs
+++ b/crates/nu-command/tests/commands/format/filesize.rs
@@ -1,5 +1,68 @@
-use nu_test_support::fs::Stub;
+use rstest::rstest;
+use rstest_reuse::{apply, template};
+
+use nu_protocol::{Filesize, FilesizeUnit};
 use nu_test_support::prelude::*;
+
+#[template]
+#[rstest]
+#[case(Filesize::ZERO, FilesizeUnit::B.as_str(), "0 B")]
+#[case(Filesize::ZERO, FilesizeUnit::KB.as_str(), "0 kB")]
+#[case(FilesizeUnit::KiB.as_filesize(), FilesizeUnit::B.as_str(), "1024 B")]
+#[case(Filesize::from_unit(2442, FilesizeUnit::KB).unwrap(), FilesizeUnit::B.as_str(), "2442000 B")]
+fn filesize_cases(
+    #[case] size: Filesize,
+    #[case] unit_str: &str,
+    #[case] expected: &str,
+) -> Result {
+}
+
+#[apply(filesize_cases)]
+fn format_filesize_works(
+    #[case] size: Filesize,
+    #[case] unit_str: &str,
+    #[case] expected: &str,
+) -> Result {
+    let mut tester = test();
+    let () = tester.run_with_data("let unit = $in", unit_str)?;
+    tester
+        .run_with_data("format filesize $unit", size)
+        .expect_value_eq(expected)
+}
+
+#[apply(filesize_cases)]
+fn format_filesize_works_with_records(
+    #[case] size: Filesize,
+    #[case] unit_str: &str,
+    #[case] expected: &str,
+) -> Result {
+    let mut tester = test();
+    let () = tester.run_with_data("let unit = $in", unit_str)?;
+    tester
+        .run_with_data("format filesize $unit foo", test_value!({ foo: size }))
+        .expect_value_eq(test_value!({foo: expected}))
+}
+
+#[test]
+fn format_filesize_works_with_tables() -> Result {
+    let input = test_table![
+        ["name", "type", "size"];
+        ["yehuda.txt", "file", Filesize::ZERO],
+        ["jt.txt", "file", Filesize::ZERO],
+        ["andres.txt", "file", Filesize::ZERO],
+    ];
+
+    let expected = test_table![
+        ["name", "type", "size"];
+        ["yehuda.txt", "file", "0 kB"],
+        ["jt.txt", "file", "0 kB"],
+        ["andres.txt", "file", "0 kB"],
+    ];
+
+    test()
+        .run_with_data("format filesize kB size", input)
+        .expect_value_eq(expected)
+}
 
 #[test]
 fn format_filesize_without_fraction_keeps_old_output() -> Result {
@@ -23,48 +86,4 @@ fn format_filesize_with_invalid_unit() -> Result {
     let err = test().run(code).expect_error()?;
     assert!(matches!(err, ShellError::InvalidUnit { .. }));
     Ok(())
-}
-
-#[test]
-fn format_filesize_works() -> Result {
-    Playground::setup("format_filesize_test_1", |dirs, sandbox| {
-        sandbox.with_files(&[
-            Stub::EmptyFile("yehuda.txt"),
-            Stub::EmptyFile("jttxt"),
-            Stub::EmptyFile("andres.txt"),
-        ]);
-
-        let code = "
-            ls
-            | format filesize kB size
-            | get size
-            | first
-        ";
-
-        test().cwd(dirs.test()).run(code).expect_value_eq("0 kB")
-    })
-}
-
-#[test]
-fn format_filesize_works_with_nonempty_files() -> Result {
-    Playground::setup(
-        "format_filesize_works_with_nonempty_files",
-        |dirs, sandbox| {
-            sandbox.with_files(&[Stub::FileWithContentToBeTrimmed(
-                "sample.toml",
-                r#"
-                    [dependency]
-                    name = "nu"
-                "#,
-            )]);
-
-            let code = "ls sample.toml | format filesize B size | get size | first";
-            #[cfg(not(windows))]
-            let expected = "25 B";
-            #[cfg(windows)]
-            let expected = "27 B";
-
-            test().cwd(dirs.test()).run(code).expect_value_eq(expected)
-        },
-    )
 }

--- a/crates/nu-command/tests/commands/format/mod.rs
+++ b/crates/nu-command/tests/commands/format/mod.rs
@@ -31,9 +31,22 @@ fn cant_use_variables() -> Result {
             r#"format pattern "{$it.package.name} is {$it.package.description}""#,
             test_value!({package: {name: "nu", description: "a new type of shell"}}),
         )
-        .expect_error()?;
+        .expect_labeled_error()?;
 
-    assert_eq!(err.generic_error()?, "Removed functionality");
+    assert_contains("does not read the variables", err.help.as_ref().unwrap());
+    Ok(())
+}
+
+#[test]
+fn cant_use_variables_no_false_positive() -> Result {
+    let err = test()
+        .run_with_data(
+            r#"format pattern "{it.package.name} is {it.package.description}""#,
+            test_value!({package: {name: "nu", description: "a new type of shell"}}),
+        )
+        .expect_labeled_error()?;
+
+    assert!(err.help.is_none());
     Ok(())
 }
 

--- a/crates/nu-command/tests/commands/format/mod.rs
+++ b/crates/nu-command/tests/commands/format/mod.rs
@@ -4,49 +4,33 @@ use rstest::rstest;
 mod duration;
 mod filesize;
 
-#[test]
-fn creates_the_resulting_string_from_the_given_fields() -> Result {
-    let code = r#"
-        open cargo_sample.toml
-        | get package
-        | format pattern "{name} has license {license}"
-    "#;
-
-    test()
-        .cwd("tests/fixtures/formats")
-        .run(code)
-        .expect_value_eq("nu has license ISC")
-}
-
-#[test]
-fn format_input_record_output_string() -> Result {
-    let code = r#"{name: Downloads} | format pattern "{name}""#;
-    test().run(code).expect_value_eq("Downloads")
-}
-
-#[test]
-fn given_fields_can_be_column_paths() -> Result {
-    let code = r#"
-        open cargo_sample.toml
-        | format pattern "{package.name} is {package.description}"
-    "#;
-
-    test()
-        .cwd("tests/fixtures/formats")
-        .run(code)
-        .expect_value_eq("nu is a new type of shell")
+#[rstest]
+#[case::simple(test_value!({name: "Downloads"}), "{name}", "Downloads")]
+#[case::multiple(test_value!({name: "nu", license: "ISC"}), "{name} has license {license}", "nu has license ISC")]
+#[case::nested_columns(
+    test_value!({package: {name: "nu", description: "a new type of shell"}}),
+    "{package.name} is {package.description}",
+    "nu is a new type of shell",
+)]
+fn record_input(
+    #[case] input: impl IntoValue,
+    #[case] format_str: &str,
+    #[case] expected: impl IntoValue,
+) -> Result {
+    let mut tester = test();
+    let () = tester.run_with_data("let format_str = $in", format_str)?;
+    tester
+        .run_with_data("format pattern $format_str", input)
+        .expect_value_eq(expected)
 }
 
 #[test]
 fn cant_use_variables() -> Result {
-    let code = r#"
-        open cargo_sample.toml
-        | format pattern "{$it.package.name} is {$it.package.description}"
-    "#;
-
     let err = test()
-        .cwd("tests/fixtures/formats")
-        .run(code)
+        .run_with_data(
+            r#"format pattern "{$it.package.name} is {$it.package.description}""#,
+            test_value!({package: {name: "nu", description: "a new type of shell"}}),
+        )
         .expect_error()?;
 
     assert_eq!(err.generic_error()?, "Removed functionality");

--- a/crates/nu-command/tests/commands/format/mod.rs
+++ b/crates/nu-command/tests/commands/format/mod.rs
@@ -1,7 +1,4 @@
-use nu_test_support::{
-    fs::Stub::{EmptyFile, FileWithContentToBeTrimmed},
-    prelude::*,
-};
+use nu_test_support::prelude::*;
 use rstest::rstest;
 
 mod duration;
@@ -91,65 +88,5 @@ fn format_string_error(
     let (start, end) = (label.offset(), label.offset() + label.len());
     assert_eq!(&format_str[start..end], label_text);
 
-    Ok(())
-}
-
-#[test]
-fn format_filesize_works() -> Result {
-    Playground::setup("format_filesize_test_1", |dirs, sandbox| {
-        sandbox.with_files(&[
-            EmptyFile("yehuda.txt"),
-            EmptyFile("jttxt"),
-            EmptyFile("andres.txt"),
-        ]);
-
-        let code = "
-            ls
-            | format filesize kB size
-            | get size
-            | first
-        ";
-
-        test().cwd(dirs.test()).run(code).expect_value_eq("0 kB")
-    })
-}
-
-#[test]
-fn format_filesize_works_with_nonempty_files() -> Result {
-    Playground::setup(
-        "format_filesize_works_with_nonempty_files",
-        |dirs, sandbox| {
-            sandbox.with_files(&[FileWithContentToBeTrimmed(
-                "sample.toml",
-                r#"
-                    [dependency]
-                    name = "nu"
-                "#,
-            )]);
-
-            let code = "ls sample.toml | format filesize B size | get size | first";
-            #[cfg(not(windows))]
-            let expected = "25 B";
-            #[cfg(windows)]
-            let expected = "27 B";
-
-            test().cwd(dirs.test()).run(code).expect_value_eq(expected)
-        },
-    )
-}
-
-#[test]
-fn format_filesize_with_invalid_unit() -> Result {
-    let code = "1MB | format filesize sec";
-    let err = test().run(code).expect_error()?;
-    assert!(matches!(err, ShellError::InvalidUnit { .. }));
-    Ok(())
-}
-
-#[test]
-fn format_duration_with_invalid_unit() -> Result {
-    let code = "1sec | format duration MB";
-    let err = test().run(code).expect_error()?;
-    assert!(matches!(err, ShellError::InvalidUnit { .. }));
     Ok(())
 }

--- a/crates/nu-command/tests/commands/format/mod.rs
+++ b/crates/nu-command/tests/commands/format/mod.rs
@@ -2,6 +2,7 @@ use nu_test_support::{
     fs::Stub::{EmptyFile, FileWithContentToBeTrimmed},
     prelude::*,
 };
+use rstest::rstest;
 
 mod duration;
 mod filesize;
@@ -55,23 +56,41 @@ fn cant_use_variables() -> Result {
     Ok(())
 }
 
-#[test]
-fn error_unmatched_brace() -> Result {
-    let code = r#"
-        open cargo_sample.toml
-        | format pattern "{package.name"
-    "#;
+#[rstest]
+#[case::unclosed_brace("name -> {package.name", "Unclosed delimiter", "{")]
+#[case::not_opened_brace("package.name} <- name", "Unbalanced { and }", "}")]
+#[case::missing_column(
+    "version -> {package.version}",
+    "column 'version' is missing in one or more values",
+    "package.version"
+)]
+fn format_string_error(
+    #[case] format_str: &str,
+    #[case] label_msg: &str,
+    #[case] label_text: &str,
+) -> Result {
+    let input = test_value!({ package: { name: "dummy" } });
 
-    let err = test()
-        .cwd("tests/fixtures/formats")
-        .run(code)
-        .expect_error()?;
+    let mut tester = test();
+    let () = tester.run_with_data("let format_str = $in", format_str)?;
 
-    let ShellError::DelimiterError { msg, .. } = err else {
-        return Err(err.into());
+    let err = tester
+        .run_with_data("format pattern $format_str", input)
+        .expect_labeled_error()?;
+
+    let inner_err = err.inner.iter().next().expect("at least one inner error");
+    let ShellError::OutsideSourceNoUrl { msg, labels, .. } = inner_err else {
+        panic!("Expected `ShellError::OutsideSourceNoUrl`, got {inner_err:?}");
     };
+    assert_eq!(msg, "Format string has errors.");
 
-    assert_eq!(msg, "there are unmatched curly braces");
+    let [label] = labels.as_slice() else {
+        panic!("Expected only one label, got {labels:?}")
+    };
+    assert_eq!(label.label().unwrap(), label_msg);
+    let (start, end) = (label.offset(), label.offset() + label.len());
+    assert_eq!(&format_str[start..end], label_text);
+
     Ok(())
 }
 

--- a/crates/nu-utils/src/iter.rs
+++ b/crates/nu-utils/src/iter.rs
@@ -5,7 +5,7 @@
 /// collecting errors until the iterator is exhausted.
 ///
 /// ```
-/// # use nu_utils::iter::MultiResult;
+/// # use nu_utils::MultiResult;
 /// let outcome = [Ok(1), Err(2), Ok(3), Err(4), Ok(5), Err(6)]
 ///     .into_iter()
 ///     .collect::<MultiResult<Vec<_>, Vec<_>>>()

--- a/crates/nu-utils/src/iter.rs
+++ b/crates/nu-utils/src/iter.rs
@@ -1,0 +1,119 @@
+/// A result type with the sole purpose of collecting multiple errors from [`Iterator::collect`].
+///
+/// `Iterator::collect<MultiResult<Vec<T>, Vec<E>>>` is similar to
+/// `Iterator::collect<Result<Vec<T>, E>>`, but instead of stopping at the first error, it keeps
+/// collecting errors until the iterator is exhausted.
+///
+/// ```
+/// # use nu_utils::iter::MultiResult;
+/// let outcome = [Ok(1), Err(2), Ok(3), Err(4), Ok(5), Err(6)]
+///     .into_iter()
+///     .collect::<MultiResult<Vec<_>, Vec<_>>>()
+///     .result();
+///
+/// assert_eq!(outcome, Err(vec![2, 4, 6]))
+/// ```
+///
+/// To collect both `Ok` and `Err` variants separately see [`Iterator::partition`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum MultiResult<Ts, Es> {
+    Ok(Ts),
+    Err(Es),
+}
+
+impl<Ts, Es> MultiResult<Ts, Es> {
+    pub fn result(self) -> Result<Ts, Es> {
+        match self {
+            Self::Ok(ok) => Ok(ok),
+            Self::Err(err) => Err(err),
+        }
+    }
+}
+
+impl<Ts, Es> From<MultiResult<Ts, Es>> for Result<Ts, Es> {
+    fn from(value: MultiResult<Ts, Es>) -> Self {
+        value.result()
+    }
+}
+
+impl<T, E, Ts, Es> FromIterator<Result<T, E>> for MultiResult<Ts, Es>
+where
+    Ts: FromIterator<T>,
+    Es: FromIterator<E>,
+{
+    fn from_iter<Iter: IntoIterator<Item = Result<T, E>>>(iter: Iter) -> Self {
+        let mut iter = iter.into_iter();
+        match iter.by_ref().collect::<Result<Ts, E>>() {
+            Ok(oks) => Self::Ok(oks),
+            Err(err) => Self::Err(
+                std::iter::once(err)
+                    .chain(iter.filter_map(Result::err))
+                    .collect::<Es>(),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_ok() {
+        let outcome = [1, 2, 3]
+            .into_iter()
+            .map(Ok::<i32, ()>)
+            .collect::<MultiResult<Vec<_>, Vec<_>>>()
+            .result();
+
+        assert_eq!(outcome, Ok(vec![1, 2, 3]))
+    }
+
+    #[test]
+    fn all_err() {
+        let outcome = [1, 2, 3]
+            .into_iter()
+            .map(Err::<(), i32>)
+            .collect::<MultiResult<Vec<_>, Vec<_>>>()
+            .result();
+
+        assert_eq!(outcome, Err(vec![1, 2, 3]))
+    }
+
+    #[test]
+    fn mixed_ok_err() {
+        let outcome = [Ok(1), Err(2), Ok(3), Err(4), Ok(5), Err(6)]
+            .into_iter()
+            .collect::<MultiResult<Vec<_>, Vec<_>>>()
+            .result();
+
+        assert_eq!(outcome, Err(vec![2, 4, 6]))
+    }
+
+    #[test]
+    fn nested_all_ok_ok() {
+        let outcome = [Ok(Ok(1)), Ok(Ok(2)), Ok(Ok(3))]
+            .into_iter()
+            .collect::<MultiResult<MultiResult<Vec<i32>, Vec<i32>>, Vec<i32>>>();
+
+        assert_eq!(outcome, MultiResult::Ok(MultiResult::Ok(vec![1, 2, 3])))
+    }
+
+    #[test]
+    fn nested_ok_err() {
+        let outcome = [Ok(Ok(1)), Ok(Err(2)), Ok(Ok(3)), Ok(Err(4))]
+            .into_iter()
+            .collect::<MultiResult<MultiResult<Vec<i32>, Vec<i32>>, Vec<i32>>>();
+
+        assert_eq!(outcome, MultiResult::Ok(MultiResult::Err(vec![2, 4])))
+    }
+
+    #[test]
+    fn nested_err() {
+        let outcome = [Ok(Ok(1)), Err(2), Ok(Ok(3)), Err(4)]
+            .into_iter()
+            .collect::<MultiResult<MultiResult<Vec<i32>, Vec<i32>>, Vec<i32>>>();
+
+        assert_eq!(outcome, MultiResult::Err(vec![2, 4]))
+    }
+}

--- a/crates/nu-utils/src/lib.rs
+++ b/crates/nu-utils/src/lib.rs
@@ -9,6 +9,7 @@ pub mod emoji;
 pub mod filesystem;
 pub mod flatten_json;
 pub mod float;
+mod iter;
 pub mod locale;
 pub mod location;
 #[doc(hidden)]
@@ -38,6 +39,7 @@ pub use downcast::downcast;
 pub use emoji::contains_emoji;
 pub use flatten_json::JsonFlattener;
 pub use float::ObviousFloat;
+pub use iter::MultiResult;
 pub use multilife::MultiLife;
 pub use nu_cow::NuCow;
 pub use quoting::{as_raw_string, escape_quote_string, needs_quoting};


### PR DESCRIPTION
## Description

- Format string errors now have labels relative to the actual contents of the format string, rather than attempting to place the labels in the source code relative to the string literal. This is accomplished with `ShellError::OutsideSourceNoUrl`.
- If multiple syntax errors can be detected, they are reported together instead of reporting just the first error encountered.
- If the format string has no syntax error but refers to non-existent columns, all the missing columns are reported together.

Aside from the actual feature:
- Updated existing `format pattern`, `format filesize` and `format duration` tests to not be dependent on the file system and used `rstest` to de-duplicate code.
- Added a new `MultiResult` that type implements `FromIterator`.
  - Unlike collecting into `Result<Vec<T>, E>` which stops iterating at the first error, `MultiResult<Vec<T>, Vec<E>>` continues to collect errors.
  - Any type that implements `FromIterator` can be used in place of `Vec`.
  - When the first error is encountered, previously collected `Ok` values are dropped and further `Ok` items are filtered out, only collecting `Err` items.

## User-facing changes (Release notes)

TODO