### PR TITLE
upgrade `kdl` to support `--spec 1` or `--spec 2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3797,11 +3797,23 @@ dependencies = [
 
 [[package]]
 name = "kdl"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e03e2e96c5926fe761088d66c8c2aee3a4352a2573f4eaca50043ad130af9117"
+dependencies = [
+ "miette 5.10.0",
+ "nom 7.1.3",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "kdl"
 version = "6.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "082ddf81b2acd76fe04412655d17befedfff1837db772f8e74c38050d25ed670"
 dependencies = [
- "miette",
+ "kdl 4.7.1",
+ "miette 7.6.0",
  "num-traits",
  "serde",
  "winnow 0.7.15",
@@ -4291,6 +4303,18 @@ dependencies = [
 
 [[package]]
 name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "miette-derive 5.10.0",
+ "once_cell",
+ "thiserror 1.0.69",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
@@ -4298,7 +4322,7 @@ dependencies = [
  "backtrace",
  "backtrace-ext",
  "cfg-if",
- "miette-derive",
+ "miette-derive 7.6.0",
  "owo-colors",
  "supports-color",
  "supports-hyperlinks",
@@ -4306,6 +4330,17 @@ dependencies = [
  "terminal_size",
  "textwrap",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4405,7 +4440,7 @@ checksum = "791c374af833381678f62652884282f70043110e35b8a4a9f76c72cefca2def2"
 dependencies = [
  "itertools 0.14.0",
  "markdown",
- "miette",
+ "miette 7.6.0",
  "rustc-hash",
  "smol_str",
 ]
@@ -4623,7 +4658,7 @@ dependencies = [
  "itertools 0.15.0",
  "lexopt",
  "log",
- "miette",
+ "miette 7.6.0",
  "multipart-rs",
  "nix 0.31.3",
  "nu-cli",
@@ -4682,7 +4717,7 @@ dependencies = [
  "log",
  "lru 0.18.0",
  "lscolors",
- "miette",
+ "miette 7.6.0",
  "nu-ansi-term",
  "nu-cmd-base",
  "nu-cmd-lang",
@@ -4716,7 +4751,7 @@ name = "nu-cmd-base"
 version = "0.114.2"
 dependencies = [
  "indexmap 2.14.0",
- "miette",
+ "miette 7.6.0",
  "nu-engine",
  "nu-parser",
  "nu-path",
@@ -4756,7 +4791,7 @@ name = "nu-cmd-lang"
 version = "0.114.2"
 dependencies = [
  "itertools 0.15.0",
- "miette",
+ "miette 7.6.0",
  "nu-cmd-base",
  "nu-engine",
  "nu-experimental",
@@ -4832,7 +4867,7 @@ dependencies = [
  "indicatif",
  "indoc",
  "itertools 0.15.0",
- "kdl",
+ "kdl 6.7.1",
  "log",
  "lscolors",
  "md-5 0.11.0",
@@ -5025,7 +5060,7 @@ dependencies = [
  "chrono",
  "derive_setters",
  "indoc",
- "miette",
+ "miette 7.6.0",
  "nu-protocol",
  "nu-test-support",
  "nu-utils",
@@ -5066,7 +5101,7 @@ dependencies = [
  "lsp-textdocument",
  "lsp-types",
  "memchr",
- "miette",
+ "miette 7.6.0",
  "nu-cli",
  "nu-cmd-lang",
  "nu-command",
@@ -5094,7 +5129,7 @@ dependencies = [
  "futures",
  "hyper-util",
  "indoc",
- "miette",
+ "miette 7.6.0",
  "nix 0.31.3",
  "nu-cmd-lang",
  "nu-engine",
@@ -5247,7 +5282,7 @@ dependencies = [
  "log",
  "lru 0.18.0",
  "memchr",
- "miette",
+ "miette 7.6.0",
  "nix 0.31.3",
  "nu-config",
  "nu-derive-value",
@@ -5281,7 +5316,7 @@ name = "nu-std"
 version = "0.114.2"
 dependencies = [
  "log",
- "miette",
+ "miette 7.6.0",
  "nu-engine",
  "nu-parser",
  "nu-protocol",
@@ -5340,7 +5375,7 @@ dependencies = [
  "kitest",
  "lexopt",
  "linkme",
- "miette",
+ "miette 7.6.0",
  "nu-ansi-term",
  "nu-cli",
  "nu-cmd-base",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,7 +269,7 @@ titlecase = "3.6"
 tokio = { version = "1.53.1" }
 toml = "1.1.2"
 toml_edit = "0.25.11"
-kdl = "6.7.1"
+kdl = { version = "6.7.1", features = ["v1"] }
 trash = "=5.2.6"
 update-informer = { version = "1.3.0", default-features = false, features = ["github", "ureq"] }
 umask = "2.1"

--- a/crates/nu-command/src/formats/from/kdl.rs
+++ b/crates/nu-command/src/formats/from/kdl.rs
@@ -2,7 +2,9 @@ use crate::formats::kdl::{
     KdlFormat, KdlMetadata, KdlSpec, jik_document_to_value, nodes_document_to_value,
     parse_kdl_document,
 };
+use chrono::TimeZone;
 use nu_engine::command_prelude::*;
+use std::str::FromStr;
 
 #[derive(Clone)]
 pub struct FromKdl;
@@ -182,6 +184,73 @@ impl Command for FromKdl {
                         "children" => Value::test_list(vec![]),
                     }),
                 ])),
+            },
+            Example {
+                description: "Promote Nushell type annotations on node arguments (filesize, duration).",
+                example: r#""node (filesize)1024 (duration)5000000000" | from kdl"#,
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                    "name" => Value::string("node", span),
+                    "args" => Value::test_list(vec![
+                        Value::test_filesize(1024),
+                        Value::test_duration(5_000_000_000),
+                    ]),
+                    "props" => Value::test_record(record! {}),
+                    "children" => Value::test_list(vec![]),
+                })])),
+            },
+            Example {
+                description: "Parse JSON-in-KDL with filesize, duration, and datetime (timestamp) annotations.",
+                example: r#"'- size=(filesize)1024 wait=(duration)5000000000 when=(timestamp)"2020-01-02T03:04:05+00:00"' | from kdl --format jik"#,
+                result: Some(Value::test_record(record! {
+                    "size" => Value::test_filesize(1024),
+                    "wait" => Value::test_duration(5_000_000_000),
+                    "when" => Value::test_date(
+                        chrono::FixedOffset::east_opt(0)
+                            .expect("offset")
+                            .with_ymd_and_hms(2020, 1, 2, 3, 4, 5)
+                            .unwrap()
+                    ),
+                })),
+            },
+            Example {
+                description: "Accept (datetime) as an alias for (timestamp) when parsing.",
+                example: r#"'- when=(datetime)"2020-01-02T03:04:05+00:00"' | from kdl --format jik"#,
+                result: Some(Value::test_record(record! {
+                    "when" => Value::test_date(
+                        chrono::FixedOffset::east_opt(0)
+                            .expect("offset")
+                            .with_ymd_and_hms(2020, 1, 2, 3, 4, 5)
+                            .unwrap()
+                    ),
+                })),
+            },
+            Example {
+                description: "Parse cell-path, range, glob, and binary type annotations.",
+                example: r#"'- path=(cell-path)$.1.abc span=(range)"1..3" pat=(glob)*.rs blob=(binary)AQID' | from kdl --format jik"#,
+                result: Some(Value::test_record(record! {
+                    "path" => Value::test_cell_path(nu_protocol::ast::CellPath {
+                        members: vec![
+                            nu_protocol::ast::PathMember::test_int(1, false),
+                            nu_protocol::ast::PathMember::test_string(
+                                "abc",
+                                false,
+                                nu_protocol::casing::Casing::Sensitive,
+                            ),
+                        ],
+                    }),
+                    "span" => Value::test_range(
+                        nu_protocol::Range::from_str("1..3").expect("range")
+                    ),
+                    "pat" => Value::test_glob("*.rs"),
+                    "blob" => Value::test_binary(vec![1, 2, 3]),
+                })),
+            },
+            Example {
+                description: "Ignore type annotations and keep base KDL types with --ignore-types.",
+                example: "'- size=(filesize)1024' | from kdl --format jik --ignore-types",
+                result: Some(Value::test_record(record! {
+                    "size" => Value::test_int(1024),
+                })),
             },
         ]
     }

--- a/crates/nu-command/src/formats/from/kdl.rs
+++ b/crates/nu-command/src/formats/from/kdl.rs
@@ -1,10 +1,8 @@
-use crate::formats::{KDL_CANONICAL_METADATA_KEY, KDL_CANONICAL_METADATA_VALUE};
-use kdl::{KdlDocument, KdlError, KdlNode, KdlValue};
-use nu_engine::command_prelude::*;
-use nu_protocol::{
-    DEFAULT_ERROR_CONTEXT, shell_error::generic::GenericError, truncated_source_window,
+use crate::formats::kdl::{
+    KdlFormat, KdlMetadata, KdlSpec, jik_document_to_value, nodes_document_to_value,
+    parse_kdl_document,
 };
-use num_traits::ToPrimitive;
+use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
 pub struct FromKdl;
@@ -18,9 +16,32 @@ impl Command for FromKdl {
         "Convert KDL text into structured data."
     }
 
-    fn signature(&self) -> nu_protocol::Signature {
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "import", "config"]
+    }
+
+    fn signature(&self) -> Signature {
         Signature::build("from kdl")
             .input_output_types(vec![(Type::String, Type::Any)])
+            .param(
+                Flag::new("spec")
+                    .arg(SyntaxShape::Int)
+                    .desc("KDL language version (1 or 2 (default)).")
+                    .completion(Completion::new_list(&["1", "2"])),
+            )
+            .param(
+                Flag::new("format")
+                    .arg(SyntaxShape::String)
+                    .desc(
+                        "Data model: 'nodes' (default) for KDL AST rows, or 'jik' for JSON-in-KDL values.",
+                    )
+                    .completion(Completion::new_list(&["nodes", "jik"])),
+            )
+            .switch(
+                "ignore-types",
+                "Ignore type annotations (return base KDL types only).",
+                None,
+            )
             .category(Category::Formats)
     }
 
@@ -30,7 +51,7 @@ impl Command for FromKdl {
         vec![
             Example {
                 example: r#""node attr=1 attr2=#true {bloc}" | from kdl"#,
-                description: "Converts KDL formatted string to canonical node rows.",
+                description: "Convert KDL to node rows (default format, KDL v2).",
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "name" => Value::string("node", span),
                     "args" => Value::test_list(vec![]),
@@ -47,7 +68,7 @@ impl Command for FromKdl {
                 })])),
             },
             Example {
-                description: "Converts KDL formatted string to canonical node rows.",
+                description: "Parse a package-style KDL document into node rows.",
                 example: r#"'package { name nu; version 0.1; description "new type of shell" }' | from kdl"#,
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "name" => Value::string("package", span),
@@ -76,6 +97,75 @@ impl Command for FromKdl {
                 })])),
             },
             Example {
+                description: "Parse JSON-in-KDL (v2 keywords use #true / #null).",
+                example: "'- a=1 b=#true' | from kdl --format jik",
+                result: Some(Value::test_record(record! {
+                    "a" => Value::int(1, span),
+                    "b" => Value::bool(true, span),
+                })),
+            },
+            Example {
+                description: "Parse KDL v2 keyword arguments with --spec 2 (default).",
+                example: r#""node #true #false #null" | from kdl --spec 2"#,
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                    "name" => Value::string("node", span),
+                    "args" => Value::test_list(vec![
+                        Value::bool(true, span),
+                        Value::bool(false, span),
+                        Value::nothing(span),
+                    ]),
+                    "props" => Value::test_record(record! {}),
+                    "children" => Value::test_list(vec![]),
+                })])),
+            },
+            Example {
+                description: "Parse KDL v1 keyword arguments with --spec 1 (bare true/false/null).",
+                example: r#""node true false null" | from kdl --spec 1"#,
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                    "name" => Value::string("node", span),
+                    "args" => Value::test_list(vec![
+                        Value::bool(true, span),
+                        Value::bool(false, span),
+                        Value::nothing(span),
+                    ]),
+                    "props" => Value::test_record(record! {}),
+                    "children" => Value::test_list(vec![]),
+                })])),
+            },
+            Example {
+                description: "Parse a KDL v1 property boolean with --spec 1.",
+                example: r#""item 1 enabled=true" | from kdl --spec 1"#,
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                    "name" => Value::string("item", span),
+                    "args" => Value::test_list(vec![Value::int(1, span)]),
+                    "props" => Value::test_record(record! {
+                        "enabled" => Value::bool(true, span),
+                    }),
+                    "children" => Value::test_list(vec![]),
+                })])),
+            },
+            Example {
+                description: "Parse a KDL v2 property boolean with --spec 2.",
+                example: r#""item 1 enabled=#true" | from kdl --spec 2"#,
+                result: Some(Value::test_list(vec![Value::test_record(record! {
+                    "name" => Value::string("item", span),
+                    "args" => Value::test_list(vec![Value::int(1, span)]),
+                    "props" => Value::test_record(record! {
+                        "enabled" => Value::bool(true, span),
+                    }),
+                    "children" => Value::test_list(vec![]),
+                })])),
+            },
+            Example {
+                description: "Parse JSON-in-KDL written in KDL v1 keyword style.",
+                example: "'- a=1 b=true c=null' | from kdl --format jik --spec 1",
+                result: Some(Value::test_record(record! {
+                    "a" => Value::int(1, span),
+                    "b" => Value::bool(true, span),
+                    "c" => Value::nothing(span),
+                })),
+            },
+            Example {
                 description: "Duplicate sibling node names are preserved in-order.",
                 example: r#""node one; node two" | from kdl"#,
                 result: Some(Value::test_list(vec![
@@ -98,8 +188,8 @@ impl Command for FromKdl {
 
     fn run(
         &self,
-        _engine: &EngineState,
-        _stack: &mut Stack,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         call: &Call,
         mut input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
@@ -109,168 +199,45 @@ impl Command for FromKdl {
             .unwrap_or_default()
             .with_content_type(None);
 
-        let kdl_string_object = input.collect_string_strict(span)?;
+        let kdl_string = input.collect_string_strict(span)?;
 
-        let kdl_data = parse_kdl_document_with_diagnostics(&kdl_string_object.0, span)?;
-        let rows = convert_kdl_document_to_node_rows(kdl_data.nodes(), span)?;
+        let spec = match call.get_flag::<i64>(engine_state, stack, "spec")? {
+            Some(n) => {
+                let flag_span = call.get_flag_span(stack, "spec").unwrap_or(call.head);
+                KdlSpec::from_i64(n, flag_span)?
+            }
+            None => KdlSpec::default(),
+        };
 
-        // Mark this output as canonical KDL node rows so `to kdl` can round-trip
-        // without guessing by shape and accidentally reinterpreting normal records.
-        metadata.custom.insert(
-            KDL_CANONICAL_METADATA_KEY,
-            Value::string(KDL_CANONICAL_METADATA_VALUE, span),
-        );
+        let format = match call.get_flag::<String>(engine_state, stack, "format")? {
+            Some(s) => {
+                let flag_span = call.get_flag_span(stack, "format").unwrap_or(call.head);
+                KdlFormat::parse(&s, flag_span)?
+            }
+            None => KdlFormat::Nodes,
+        };
 
-        Ok(Value::list(rows, span).into_pipeline_data_with_metadata(Some(metadata)))
-    }
-}
+        let ignore_types = call.has_flag(engine_state, stack, "ignore-types")?;
 
-fn parse_kdl_document_with_diagnostics(input: &str, span: Span) -> Result<KdlDocument, ShellError> {
-    KdlDocument::parse(input).map_err(|err| kdl_error_to_shell_error(input, span, &err))
-}
+        let document = parse_kdl_document(&kdl_string.0, spec, span)?;
 
-fn kdl_error_to_shell_error(input: &str, span: Span, err: &KdlError) -> ShellError {
-    if let Some(diagnostic) = err.diagnostics.first() {
-        let diagnostic_message = kdl_diagnostics_message(&err.diagnostics);
-        let byte_offset = diagnostic.span.offset();
-        let (src, label_span) = truncated_source_window(
-            input,
-            Span::new(byte_offset, byte_offset),
-            DEFAULT_ERROR_CONTEXT,
-        );
+        let value = match format {
+            KdlFormat::Nodes => nodes_document_to_value(&document, span, ignore_types)?,
+            KdlFormat::Jik => jik_document_to_value(&document, span, ignore_types)?,
+        };
 
-        return ShellError::Generic(
-            GenericError::new(
-                "Error while parsing KDL text",
-                "error parsing KDL text",
-                span,
-            )
-            .with_inner([ShellError::OutsideSpannedLabeledError {
-                src,
-                error: "Error while parsing KDL text".into(),
-                msg: diagnostic_message,
-                span: label_span,
-            }]),
-        );
-    }
+        KdlMetadata { format, spec }.write_to(&mut metadata, span);
 
-    ShellError::CantConvert {
-        to_type: format!("structured kdl data ({err})"),
-        from_type: "string".into(),
-        span,
-        help: None,
-    }
-}
-
-fn kdl_diagnostics_message(diagnostics: &[kdl::KdlDiagnostic]) -> String {
-    if diagnostics.len() == 1 {
-        return kdl_diagnostic_message(&diagnostics[0]);
-    }
-
-    diagnostics
-        .iter()
-        .enumerate()
-        .map(|(index, diagnostic)| {
-            format!(
-                "diagnostic {}:\n{}",
-                index + 1,
-                kdl_diagnostic_message(diagnostic)
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n\n")
-}
-
-fn kdl_diagnostic_message(diagnostic: &kdl::KdlDiagnostic) -> String {
-    let mut parts = Vec::new();
-
-    if let Some(message) = &diagnostic.message {
-        parts.push(message.clone());
-    }
-
-    if let Some(label) = &diagnostic.label
-        && parts.last() != Some(label)
-    {
-        parts.push(label.clone());
-    }
-
-    if let Some(help) = &diagnostic.help {
-        parts.push(format!("help: {help}"));
-    }
-
-    if parts.is_empty() {
-        "error parsing KDL text".to_owned()
-    } else {
-        parts.join("\n")
-    }
-}
-
-fn convert_kdl_document_to_node_rows(
-    nodes: &[KdlNode],
-    span: Span,
-) -> Result<Vec<Value>, ShellError> {
-    let mut rows = Vec::with_capacity(nodes.len());
-
-    for node in nodes {
-        rows.push(convert_kdl_node_to_node_row(node, span)?);
-    }
-
-    Ok(rows)
-}
-
-fn convert_kdl_node_to_node_row(kdl_node: &KdlNode, span: Span) -> Result<Value, ShellError> {
-    let mut args = Vec::new();
-    let mut props = Record::new();
-
-    for entry in kdl_node.entries() {
-        if let Some(name) = entry.name() {
-            props.insert(
-                name.value().to_string(),
-                convert_kdl_value_to_nu_value(entry.value(), span)?,
-            );
-            continue;
-        }
-
-        args.push(convert_kdl_value_to_nu_value(entry.value(), span)?);
-    }
-
-    let children = if let Some(children_doc) = kdl_node.children() {
-        convert_kdl_document_to_node_rows(children_doc.nodes(), span)?
-    } else {
-        Vec::new()
-    };
-
-    let row = record! {
-        "name" => Value::string(kdl_node.name().value(), span),
-        "args" => Value::list(args, span),
-        "props" => props.into_value(span),
-        "children" => Value::list(children, span),
-    };
-
-    Ok(row.into_value(span))
-}
-
-fn convert_kdl_value_to_nu_value(value: &KdlValue, span: Span) -> Result<Value, ShellError> {
-    match value {
-        KdlValue::String(val) => Ok(Value::string(val, span)),
-        KdlValue::Integer(val) => Ok(Value::int(
-            val.to_i64().ok_or(ShellError::UnsupportedInput {
-                msg: "integer value is too large to fit in i64".to_owned(),
-                input: "value originates from here".to_owned(),
-                msg_span: span,
-                input_span: span,
-            })?,
-            span,
-        )),
-        KdlValue::Float(val) => Ok(Value::float(*val, span)),
-        KdlValue::Bool(val) => Ok(Value::bool(*val, span)),
-        KdlValue::Null => Ok(Value::nothing(span)),
+        Ok(value.into_pipeline_data_with_metadata(Some(metadata)))
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::formats::kdl::{kdl_diagnostics_message, parse_kdl_document};
+    use kdl::KdlDocument;
+    use nu_protocol::shell_error::generic::GenericError;
 
     fn node_name(row: &Value) -> &str {
         row.as_record()
@@ -291,51 +258,43 @@ mod test {
         let kdl_document = KdlDocument::parse("node one\nnode two\nnode three")
             .expect("failed to parse duplicate sibling document");
 
-        let output_rows = convert_kdl_document_to_node_rows(kdl_document.nodes(), span)
-            .expect("conversion failed");
+        let output =
+            nodes_document_to_value(&kdl_document, span, false).expect("conversion failed");
+        let output_rows = output.as_list().expect("list");
 
         assert_eq!(output_rows.len(), 3);
         assert_eq!(node_name(&output_rows[0]), "node");
         assert_eq!(node_name(&output_rows[1]), "node");
         assert_eq!(node_name(&output_rows[2]), "node");
-
-        let second_args = output_rows[1]
-            .as_record()
-            .ok()
-            .and_then(|record| record.get("args"))
-            .and_then(|value| value.as_list().ok())
-            .expect("missing args list");
-
-        assert_eq!(
-            second_args.first().cloned(),
-            Some(Value::string("two", span))
-        );
     }
 
     #[test]
-    fn duplicate_properties_use_rightmost_value() {
+    fn duplicate_properties_use_at_suffix() {
         let span = Span::test_data();
         let kdl_document = KdlDocument::parse("node attr=1 attr=2")
             .expect("failed to parse duplicate property document");
 
-        let output_rows = convert_kdl_document_to_node_rows(kdl_document.nodes(), span)
-            .expect("conversion failed");
-
-        let props = output_rows[0]
-            .as_record()
+        let output =
+            nodes_document_to_value(&kdl_document, span, false).expect("conversion failed");
+        let props = output
+            .as_list()
             .ok()
+            .and_then(|rows| rows.first())
+            .and_then(|row| row.as_record().ok())
             .and_then(|record| record.get("props"))
             .and_then(|value| value.as_record().ok())
-            .expect("missing props record");
+            .expect("missing props record")
+            .clone();
 
-        assert_eq!(props.len(), 1);
-        assert_eq!(props.get("attr"), Some(&Value::int(2, span)));
+        assert_eq!(props.len(), 2);
+        assert_eq!(props.get("attr"), Some(&Value::int(1, span)));
+        assert_eq!(props.get("attr@2"), Some(&Value::int(2, span)));
     }
 
     #[test]
     fn parse_errors_use_structured_kdl_diagnostics() {
-        let error = parse_kdl_document_with_diagnostics("node 1.", Span::test_data())
-            .expect_err("invalid KDL should fail");
+        let error =
+            parse_kdl_document("node 1.", KdlSpec::V2, Span::test_data()).expect_err("invalid KDL");
 
         let ShellError::Generic(generic) = error else {
             panic!("expected generic shell error");
@@ -368,155 +327,113 @@ mod test {
     }
 
     #[test]
-    fn canonical_row_shape_splits_args_props_and_children() {
+    fn jik_object_round_trip_shape() {
         let span = Span::test_data();
-        let kdl_document = KdlDocument::parse("item 1 2 enabled=#true { child 9 }")
-            .expect("failed to parse mixed kdl node");
+        let doc = parse_kdl_document("- a=1 b=#true", KdlSpec::V2, span).expect("parse");
+        let value = jik_document_to_value(&doc, span, false).expect("jik");
+        let record = value.as_record().expect("record");
+        assert_eq!(record.get("a"), Some(&Value::int(1, span)));
+        assert_eq!(record.get("b"), Some(&Value::bool(true, span)));
+    }
 
-        let output_rows = convert_kdl_document_to_node_rows(kdl_document.nodes(), span)
-            .expect("conversion failed");
+    #[test]
+    fn filesize_type_annotation_is_promoted() {
+        let span = Span::test_data();
+        let doc = parse_kdl_document("node (filesize)1024", KdlSpec::V2, span).expect("parse");
+        let output = nodes_document_to_value(&doc, span, false).expect("convert");
+        let args = output
+            .as_list()
+            .ok()
+            .and_then(|rows| rows.first())
+            .and_then(|row| row.as_record().ok())
+            .and_then(|record| record.get("args"))
+            .and_then(|value| value.as_list().ok())
+            .expect("args");
+        assert_eq!(args.first(), Some(&Value::filesize(1024, span)));
+    }
 
-        let row = output_rows
-            .first()
+    #[test]
+    fn v1_spec_parses_v1_booleans() {
+        let span = Span::test_data();
+        // KDL v1 uses bare `true`/`false`/`null` keywords (not #true).
+        let doc = parse_kdl_document("node flag=true", KdlSpec::V1, span).expect("v1 parse");
+        let output = nodes_document_to_value(&doc, span, false).expect("convert");
+        let props = output
+            .as_list()
+            .ok()
+            .and_then(|rows| rows.first())
+            .and_then(|row| row.as_record().ok())
+            .and_then(|record| record.get("props"))
             .and_then(|value| value.as_record().ok())
-            .expect("missing top-level row");
+            .expect("props");
+        assert_eq!(props.get("flag"), Some(&Value::bool(true, span)));
+    }
 
-        assert_eq!(row.get("name").cloned(), Some(Value::string("item", span)));
-        assert_eq!(
-            row.get("args")
-                .and_then(|value| value.as_list().ok())
-                .map(|args| args.len()),
-            Some(2)
-        );
-        assert_eq!(
-            row.get("props")
-                .and_then(|value| value.as_record().ok())
-                .and_then(|props| props.get("enabled"))
-                .cloned(),
-            Some(Value::bool(true, span))
-        );
-        assert_eq!(
-            row.get("children")
-                .and_then(|value| value.as_list().ok())
-                .map(|children| children.len()),
-            Some(1)
+    #[test]
+    fn v2_rejects_v1_style_bare_true_property() {
+        assert!(
+            parse_kdl_document("node flag=true", KdlSpec::V2, Span::test_data()).is_err(),
+            "v2 should reject bare true property"
         );
     }
 
     #[test]
-    fn test_official_kdl_website_example() {
-        const KDL_WEBSITE_EXAMPLE: &str = r#"
-        package {
-          name my-pkg
-          version "1.2.3"
+    fn v1_rejects_v2_style_hash_true_property() {
+        assert!(
+            parse_kdl_document("node flag=#true", KdlSpec::V1, Span::test_data()).is_err(),
+            "v1 should reject #true property"
+        );
+    }
 
-          dependencies {
-            // Nodes can have standalone values as well as
-            // key/value pairs.
-            lodash "^3.2.1" optional=#true alias=underscore
-          }
-
-          scripts {
-            // "Raw" and dedented multi-line strings are supported.
-            message """
-            hello
-            world
-            """
-          }
-
-          // `\` breaks up a single node across multiple lines.
-          the-matrix 1 2 3 \
-          4 5 6 \
-          7 8 9
-
-          // "Slashdash" comments operate at the node level,
-          // with just `/-`.
-          /-this-is-commented {
-            this entire node {
-              is gone
-            }
-          }
-        }"#;
-
-        let kdl_document =
-            KdlDocument::parse(KDL_WEBSITE_EXAMPLE).expect("failed to parse kdl string");
-
+    #[test]
+    fn v1_and_v2_keyword_args_decode_identically() {
         let span = Span::test_data();
+        let v1 = parse_kdl_document("node true false null", KdlSpec::V1, span).unwrap();
+        let v2 = parse_kdl_document("node #true #false #null", KdlSpec::V2, span).unwrap();
+        let rows_v1 = nodes_document_to_value(&v1, span, false).unwrap();
+        let rows_v2 = nodes_document_to_value(&v2, span, false).unwrap();
+        assert_eq!(rows_v1, rows_v2);
+    }
 
-        let output_rows = convert_kdl_document_to_node_rows(kdl_document.nodes(), span)
-            .expect("kdl conversion failed");
-
-        let package = output_rows
-            .first()
-            .and_then(|row| row.as_record().ok())
-            .expect("missing package node");
-
-        let package_children = package
-            .get("children")
-            .and_then(|value| value.as_list().ok())
-            .expect("missing package children");
-
-        let matrix_row = package_children
-            .iter()
-            .find(|node| {
-                node.as_record()
-                    .ok()
-                    .and_then(|record| record.get("name"))
-                    .and_then(|name| name.as_str().ok())
-                    == Some("the-matrix")
-            })
-            .expect("missing matrix row");
-
+    #[test]
+    fn v1_jik_parse_bare_keywords() {
+        let span = Span::test_data();
+        let doc = parse_kdl_document("- a=1 b=true c=null", KdlSpec::V1, span).unwrap();
+        let value = jik_document_to_value(&doc, span, false).unwrap();
         assert_eq!(
-            matrix_row
-                .as_record()
-                .ok()
-                .and_then(|record| record.get("args"))
-                .and_then(|args| args.as_list().ok())
-                .and_then(|args| args.first())
-                .cloned()
-                .expect("missing matrix first arg"),
-            Value::int(1, span)
+            value,
+            Value::test_record(record! {
+                "a" => Value::int(1, span),
+                "b" => Value::bool(true, span),
+                "c" => Value::nothing(span),
+            })
         );
+    }
 
-        let scripts_row = package_children
-            .iter()
-            .find(|node| {
-                node.as_record()
-                    .ok()
-                    .and_then(|record| record.get("name"))
-                    .and_then(|name| name.as_str().ok())
-                    == Some("scripts")
-            })
-            .expect("missing scripts row");
-
-        let message_row = scripts_row
-            .as_record()
-            .ok()
-            .and_then(|record| record.get("children"))
-            .and_then(|children| children.as_list().ok())
-            .and_then(|children| {
-                children.iter().find(|node| {
-                    node.as_record()
-                        .ok()
-                        .and_then(|record| record.get("name"))
-                        .and_then(|name| name.as_str().ok())
-                        == Some("message")
-                })
-            })
-            .expect("missing message row");
-
+    #[test]
+    fn v2_jik_parse_hash_keywords() {
+        let span = Span::test_data();
+        let doc = parse_kdl_document("- a=1 b=#true c=#null", KdlSpec::V2, span).unwrap();
+        let value = jik_document_to_value(&doc, span, false).unwrap();
         assert_eq!(
-            message_row
-                .as_record()
-                .ok()
-                .and_then(|record| record.get("args"))
-                .and_then(|args| args.as_list().ok())
-                .and_then(|args| args.first())
-                .cloned()
-                .expect("missing message text"),
-            Value::string("hello\nworld", span)
+            value,
+            Value::test_record(record! {
+                "a" => Value::int(1, span),
+                "b" => Value::bool(true, span),
+                "c" => Value::nothing(span),
+            })
         );
+    }
+
+    #[test]
+    fn v1_parse_error_is_structured() {
+        // #true is invalid in v1
+        let error =
+            parse_kdl_document("node #true", KdlSpec::V1, Span::test_data()).expect_err("v1 fail");
+        assert!(matches!(
+            error,
+            ShellError::Generic(_) | ShellError::CantConvert { .. }
+        ));
     }
 
     #[test]
@@ -525,9 +442,9 @@ mod test {
         for _ in 0..2000 {
             input.push_str("node1 key=1; ");
         }
-        input.push_str("node2 \"unclosed"); // Syntax error: unclosed string
+        input.push_str("node2 \"unclosed");
 
-        let result = parse_kdl_document_with_diagnostics(&input, Span::test_data());
+        let result = parse_kdl_document(&input, KdlSpec::V2, Span::test_data());
         assert!(result.is_err(), "should fail to parse");
 
         let err = result.unwrap_err();
@@ -547,14 +464,5 @@ mod test {
             }
             other => panic!("expected Generic error, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn kdl_parse_success_not_affected() {
-        let result = parse_kdl_document_with_diagnostics(
-            r#"node1 key=1; node2 key="val""#,
-            Span::test_data(),
-        );
-        assert!(result.is_ok(), "valid KDL should still parse");
     }
 }

--- a/crates/nu-command/src/formats/from/kdl.rs
+++ b/crates/nu-command/src/formats/from/kdl.rs
@@ -252,6 +252,26 @@ impl Command for FromKdl {
                     "size" => Value::test_int(1024),
                 })),
             },
+            Example {
+                description: "JiK: multiple '-' children are a list, not an object with duplicate keys.",
+                example: "'- { - a=1; - a=2 }' | from kdl --format jik",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! { "a" => Value::int(1, span) }),
+                    Value::test_record(record! { "a" => Value::int(2, span) }),
+                ])),
+            },
+            Example {
+                description: "JiK: a sole '-' child is still a one-element list unless annotated (object).",
+                example: "'- { - 1 }' | from kdl --format jik",
+                result: Some(Value::test_list(vec![Value::int(1, span)])),
+            },
+            Example {
+                description: "JiK: object with key '-' must use the (object) annotation.",
+                example: "'(object)- { - 1 }' | from kdl --format jik",
+                result: Some(Value::test_record(record! {
+                    "-" => Value::int(1, span),
+                })),
+            },
         ]
     }
 

--- a/crates/nu-command/src/formats/kdl/jik.rs
+++ b/crates/nu-command/src/formats/kdl/jik.rs
@@ -104,7 +104,7 @@ fn jik_node_to_value(node: &KdlNode, span: Span, ignore_types: bool) -> Result<V
     let looks_like_array =
         !has_props && (has_args || any_children) && all_children_anon && !is_object_annotated;
 
-    // Object: only named props and/or children (any names), no? wait - arrays can't have non-anon children
+    // Object: only named props and/or children (any names)
     let looks_like_object = !has_args && (has_props || any_children) && !is_array_annotated;
 
     // Mixed args+props is invalid JiK for both (except we allow array with only args)
@@ -115,7 +115,11 @@ fn jik_node_to_value(node: &KdlNode, span: Span, ignore_types: bool) -> Result<V
         ));
     }
 
-    if is_array_annotated || (looks_like_array && !looks_like_object) {
+    // Prefer array when both shapes match (all children named `-`, no props).
+    // JiK: an object whose sole key is `-` written as children must be annotated
+    // `(object)`; without that annotation, input is always an array — regardless of
+    // child count (not only the single-child case).
+    if is_array_annotated || looks_like_array {
         if has_props || !all_children_anon {
             return Err(invalid_jik(
                 "JiK array nodes may only have unnamed arguments and '-' children",
@@ -131,17 +135,6 @@ fn jik_node_to_value(node: &KdlNode, span: Span, ignore_types: bool) -> Result<V
                 "JiK object nodes may only have properties and children",
                 span,
             ));
-        }
-        // Ambiguous: single child named "-" with no props could be array or object.
-        // JiK says object with sole key "-" written as children needs (object).
-        if !has_props
-            && children.len() == 1
-            && children[0].name().value() == ANON
-            && !is_object_annotated
-            && all_children_anon
-        {
-            // Treat as array of one complex element (common case) unless (object)
-            return jik_array_to_value(entries, children, span, ignore_types);
         }
         return jik_object_to_value(entries, children, span, ignore_types);
     }

--- a/crates/nu-command/src/formats/kdl/jik.rs
+++ b/crates/nu-command/src/formats/kdl/jik.rs
@@ -1,0 +1,391 @@
+//! JSON-in-KDL (JiK) mapping between Nushell values and KDL documents.
+//!
+//! Spec: https://github.com/kdl-org/kdl/blob/main/JSON-IN-KDL.md
+
+use super::identifier_for;
+use super::types::{
+    NonRoundtrip, TY_ARRAY, TY_OBJECT, TypeMode, apply_type_annotation, entry_from_nu_value,
+    is_kdl_literal,
+};
+use kdl::{KdlDocument, KdlNode};
+use nu_engine::command_prelude::*;
+
+const ANON: &str = "-";
+
+/// Parse a JiK document into a single Nushell value.
+pub(crate) fn jik_document_to_value(
+    document: &KdlDocument,
+    span: Span,
+    ignore_types: bool,
+) -> Result<Value, ShellError> {
+    let nodes = document.nodes();
+    if nodes.is_empty() {
+        return Err(ShellError::CantConvert {
+            to_type: "JiK value".into(),
+            from_type: "empty KDL document".into(),
+            span,
+            help: Some(
+                "JiK expects a single top-level node; use --format nodes for documents".into(),
+            ),
+        });
+    }
+    if nodes.len() > 1 {
+        return Err(ShellError::CantConvert {
+            to_type: "JiK value".into(),
+            from_type: "multi-node KDL document".into(),
+            span,
+            help: Some(
+                "JiK expects a single top-level node (use --format nodes for full documents)"
+                    .into(),
+            ),
+        });
+    }
+    jik_node_to_value(&nodes[0], span, ignore_types)
+}
+
+fn jik_node_to_value(node: &KdlNode, span: Span, ignore_types: bool) -> Result<Value, ShellError> {
+    let node_ty = node.ty().map(|t| t.value());
+
+    // Reject unknown node-level type annotations in strict JiK (except array/object).
+    if let Some(ty) = node_ty
+        && ty != TY_ARRAY
+        && ty != TY_OBJECT
+        && !ignore_types
+        && !is_known_value_type(ty)
+    {
+        return Err(unknown_jik_type(ty, span));
+    }
+
+    let entries = node.entries();
+    let children = node.children().map(|d| d.nodes()).unwrap_or(&[]);
+
+    let has_props = entries.iter().any(|e| e.name().is_some());
+    let has_args = entries.iter().any(|e| e.name().is_none());
+    let all_children_anon = children.iter().all(|c| c.name().value() == ANON);
+    let any_children = !children.is_empty();
+
+    let is_array_annotated = node_ty == Some(TY_ARRAY);
+    let is_object_annotated = node_ty == Some(TY_OBJECT);
+
+    // Empty node
+    if entries.is_empty() && !any_children {
+        return match node_ty {
+            Some(TY_ARRAY) => Ok(Value::list(vec![], span)),
+            Some(TY_OBJECT) => Ok(Value::record(Record::new(), span)),
+            _ => Err(ShellError::CantConvert {
+                to_type: "JiK value".into(),
+                from_type: "empty KDL node without (array) or (object)".into(),
+                span,
+                help: Some(
+                    "empty array is `(array)-`; empty object is `(object)-`. Or use --format nodes."
+                        .into(),
+                ),
+            }),
+        };
+    }
+
+    // Literal node: single unnamed argument, no props, no children
+    // Ambiguous with single-element array unless (array) is present.
+    if !has_props && !any_children && entries.len() == 1 && entries[0].name().is_none() {
+        if is_array_annotated {
+            let item = entry_to_jik_literal(&entries[0], span, ignore_types)?;
+            return Ok(Value::list(vec![item], span));
+        }
+        if is_object_annotated {
+            return Err(invalid_jik(
+                "object node cannot be a single bare argument",
+                span,
+            ));
+        }
+        return entry_to_jik_literal(&entries[0], span, ignore_types);
+    }
+
+    // Array: only unnamed args and/or `-` children
+    let looks_like_array =
+        !has_props && (has_args || any_children) && all_children_anon && !is_object_annotated;
+
+    // Object: only named props and/or children (any names), no? wait - arrays can't have non-anon children
+    let looks_like_object = !has_args && (has_props || any_children) && !is_array_annotated;
+
+    // Mixed args+props is invalid JiK for both (except we allow array with only args)
+    if has_args && has_props {
+        return Err(invalid_jik(
+            "JiK node cannot mix unnamed arguments and properties",
+            span,
+        ));
+    }
+
+    if is_array_annotated || (looks_like_array && !looks_like_object) {
+        if has_props || !all_children_anon {
+            return Err(invalid_jik(
+                "JiK array nodes may only have unnamed arguments and '-' children",
+                span,
+            ));
+        }
+        return jik_array_to_value(entries, children, span, ignore_types);
+    }
+
+    if is_object_annotated || looks_like_object {
+        if has_args {
+            return Err(invalid_jik(
+                "JiK object nodes may only have properties and children",
+                span,
+            ));
+        }
+        // Ambiguous: single child named "-" with no props could be array or object.
+        // JiK says object with sole key "-" written as children needs (object).
+        if !has_props
+            && children.len() == 1
+            && children[0].name().value() == ANON
+            && !is_object_annotated
+            && all_children_anon
+        {
+            // Treat as array of one complex element (common case) unless (object)
+            return jik_array_to_value(entries, children, span, ignore_types);
+        }
+        return jik_object_to_value(entries, children, span, ignore_types);
+    }
+
+    // Args + non-anon children mixed: invalid
+    if has_args && any_children && !all_children_anon {
+        return Err(invalid_jik("JiK array children must be named '-'", span));
+    }
+
+    Err(invalid_jik(
+        "node is not valid JSON-in-KDL (try --format nodes)",
+        span,
+    ))
+}
+
+fn jik_array_to_value(
+    entries: &[kdl::KdlEntry],
+    children: &[KdlNode],
+    span: Span,
+    ignore_types: bool,
+) -> Result<Value, ShellError> {
+    let mut items = Vec::new();
+    for entry in entries {
+        if entry.name().is_some() {
+            return Err(invalid_jik("JiK array cannot have properties", span));
+        }
+        items.push(entry_to_jik_literal(entry, span, ignore_types)?);
+    }
+    for child in children {
+        if child.name().value() != ANON {
+            return Err(invalid_jik("JiK array children must be named '-'", span));
+        }
+        items.push(jik_node_to_value(child, span, ignore_types)?);
+    }
+    Ok(Value::list(items, span))
+}
+
+fn jik_object_to_value(
+    entries: &[kdl::KdlEntry],
+    children: &[KdlNode],
+    span: Span,
+    ignore_types: bool,
+) -> Result<Value, ShellError> {
+    let mut record = Record::new();
+    let mut keys = std::collections::HashSet::new();
+
+    for entry in entries {
+        let Some(name) = entry.name() else {
+            return Err(invalid_jik(
+                "JiK object cannot have unnamed arguments",
+                span,
+            ));
+        };
+        let key = name.value().to_string();
+        if !keys.insert(key.clone()) {
+            return Err(invalid_jik(
+                &format!("duplicate object key '{key}' in JiK node"),
+                span,
+            ));
+        }
+        record.insert(key, entry_to_jik_literal(entry, span, ignore_types)?);
+    }
+
+    for child in children {
+        let key = child.name().value().to_string();
+        if !keys.insert(key.clone()) {
+            return Err(invalid_jik(
+                &format!("duplicate object key '{key}' in JiK node"),
+                span,
+            ));
+        }
+        // Child encodes key; value is the JiK interpretation of the child node.
+        record.insert(key, jik_node_to_value(child, span, ignore_types)?);
+    }
+
+    Ok(record.into_value(span))
+}
+
+fn entry_to_jik_literal(
+    entry: &kdl::KdlEntry,
+    span: Span,
+    ignore_types: bool,
+) -> Result<Value, ShellError> {
+    let ty = entry.ty().map(|t| t.value());
+    if let Some(t) = ty
+        && (t == TY_ARRAY || t == TY_OBJECT)
+    {
+        return Err(invalid_jik(
+            "array/object type annotations belong on nodes, not entry values",
+            span,
+        ));
+    }
+    let typed = apply_type_annotation(entry.value(), ty, span, ignore_types, TypeMode::Strict)?;
+    Ok(typed.into_value(span))
+}
+
+fn is_known_value_type(ty: &str) -> bool {
+    matches!(
+        ty,
+        super::types::TY_FILESIZE
+            | super::types::TY_DURATION
+            | super::types::TY_TIMESTAMP
+            | super::types::TY_BINARY
+            | super::types::TY_GLOB
+            | super::types::TY_RANGE
+            | super::types::TY_CELL_PATH
+    )
+}
+
+fn unknown_jik_type(ty: &str, span: Span) -> ShellError {
+    ShellError::UnsupportedInput {
+        msg: format!(
+            "unknown KDL type annotation '{ty}' in JiK mode; use --ignore-types or --format nodes"
+        ),
+        input: "value originates from here".into(),
+        msg_span: span,
+        input_span: span,
+    }
+}
+
+fn invalid_jik(msg: &str, span: Span) -> ShellError {
+    ShellError::CantConvert {
+        to_type: "JiK / Nushell value".into(),
+        from_type: "KDL".into(),
+        span,
+        help: Some(format!(
+            "{msg}. Hint: use `from kdl --format nodes` for full KDL documents."
+        )),
+    }
+}
+
+/// Serialize a Nushell value as a JiK document (single top-level `-` node).
+pub(crate) fn value_to_jik_document(
+    value: &Value,
+    non_roundtrip: &NonRoundtrip,
+    call_span: Span,
+) -> Result<KdlDocument, ShellError> {
+    let node = value_to_jik_node(value, ANON, non_roundtrip, call_span)?;
+    let mut document = KdlDocument::new();
+    document.nodes_mut().push(node);
+    Ok(document)
+}
+
+fn value_to_jik_node(
+    value: &Value,
+    name: &str,
+    non_roundtrip: &NonRoundtrip,
+    call_span: Span,
+) -> Result<KdlNode, ShellError> {
+    match value {
+        Value::List { vals, .. } => list_to_jik_node(vals, name, non_roundtrip, call_span),
+        Value::Record { val, .. } => record_to_jik_node(val, name, non_roundtrip, call_span),
+        literal => {
+            let mut node = KdlNode::new(identifier_for(name));
+            node.push(entry_from_nu_value(
+                literal,
+                None,
+                non_roundtrip,
+                call_span,
+            )?);
+            Ok(node)
+        }
+    }
+}
+
+fn list_to_jik_node(
+    vals: &[Value],
+    name: &str,
+    non_roundtrip: &NonRoundtrip,
+    call_span: Span,
+) -> Result<KdlNode, ShellError> {
+    let mut node = KdlNode::new(identifier_for(name));
+
+    if vals.is_empty() {
+        node.set_ty(identifier_for(TY_ARRAY));
+        return Ok(node);
+    }
+
+    // Single-element array of a literal must be annotated (array) when using args.
+    if vals.len() == 1 && is_kdl_literal(&vals[0]) {
+        node.set_ty(identifier_for(TY_ARRAY));
+        node.push(entry_from_nu_value(
+            &vals[0],
+            None,
+            non_roundtrip,
+            call_span,
+        )?);
+        return Ok(node);
+    }
+
+    // All literals → arguments on one node (`- 1 2 3`).
+    if vals.iter().all(is_kdl_literal) {
+        for val in vals {
+            node.push(entry_from_nu_value(val, None, non_roundtrip, call_span)?);
+        }
+        return Ok(node);
+    }
+
+    // Any nested structures → each item as a `-` child node.
+    let mut child_doc = KdlDocument::new();
+    for val in vals {
+        child_doc
+            .nodes_mut()
+            .push(value_to_jik_node(val, ANON, non_roundtrip, call_span)?);
+    }
+    *node.ensure_children() = child_doc;
+    Ok(node)
+}
+
+fn record_to_jik_node(
+    record: &Record,
+    name: &str,
+    non_roundtrip: &NonRoundtrip,
+    call_span: Span,
+) -> Result<KdlNode, ShellError> {
+    let mut node = KdlNode::new(identifier_for(name));
+
+    if record.is_empty() {
+        node.set_ty(identifier_for(TY_OBJECT));
+        return Ok(node);
+    }
+
+    let mut child_doc = KdlDocument::new();
+    let mut has_children = false;
+
+    for (key, value) in record.iter() {
+        if is_kdl_literal(value) {
+            node.push(entry_from_nu_value(
+                value,
+                Some(key),
+                non_roundtrip,
+                call_span,
+            )?);
+        } else {
+            has_children = true;
+            child_doc
+                .nodes_mut()
+                .push(value_to_jik_node(value, key, non_roundtrip, call_span)?);
+        }
+    }
+
+    if has_children {
+        *node.ensure_children() = child_doc;
+    }
+
+    Ok(node)
+}

--- a/crates/nu-command/src/formats/kdl/jik.rs
+++ b/crates/nu-command/src/formats/kdl/jik.rs
@@ -244,6 +244,7 @@ fn is_known_value_type(ty: &str) -> bool {
         super::types::TY_FILESIZE
             | super::types::TY_DURATION
             | super::types::TY_TIMESTAMP
+            | super::types::TY_DATETIME
             | super::types::TY_BINARY
             | super::types::TY_GLOB
             | super::types::TY_RANGE

--- a/crates/nu-command/src/formats/kdl/mod.rs
+++ b/crates/nu-command/src/formats/kdl/mod.rs
@@ -1,0 +1,569 @@
+//! Shared KDL conversion logic for `from kdl` / `to kdl`.
+//!
+//! Two data models:
+//! - **nodes** — KDL document AST as node rows (`name`/`args`/`props`/`children`/`type`)
+//! - **jik** — JSON-in-KDL mapping of ordinary Nushell values
+//!
+//! Language versions are selected with `--spec 1|2` (default 2).
+
+mod jik;
+mod nodes;
+mod types;
+
+pub(crate) use jik::{jik_document_to_value, value_to_jik_document};
+pub(crate) use nodes::{node_rows_to_kdl_document, nodes_document_to_value};
+pub(crate) use types::NonRoundtrip;
+
+use kdl::{KdlDocument, KdlError};
+use nu_engine::command_prelude::*;
+use nu_protocol::{
+    DEFAULT_ERROR_CONTEXT, PipelineMetadata, shell_error::generic::GenericError,
+    truncated_source_window,
+};
+
+/// Private metadata key written by `from kdl` so `to kdl` can restore format/spec defaults.
+pub(crate) const KDL_META_KEY: &str = "nu_kdl";
+
+/// Schema version embedded in metadata.
+const KDL_META_VERSION: &str = "v2";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum KdlSpec {
+    V1,
+    #[default]
+    V2,
+}
+
+impl KdlSpec {
+    pub(crate) fn from_i64(value: i64, span: Span) -> Result<Self, ShellError> {
+        match value {
+            1 => Ok(Self::V1),
+            2 => Ok(Self::V2),
+            _ => Err(ShellError::IncorrectValue {
+                msg: "KDL --spec must be 1 or 2".into(),
+                val_span: span,
+                call_span: span,
+            }),
+        }
+    }
+
+    pub(crate) fn as_i64(self) -> i64 {
+        match self {
+            Self::V1 => 1,
+            Self::V2 => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KdlFormat {
+    Nodes,
+    Jik,
+}
+
+impl KdlFormat {
+    pub(crate) fn parse(value: &str, span: Span) -> Result<Self, ShellError> {
+        match value {
+            "nodes" => Ok(Self::Nodes),
+            "jik" => Ok(Self::Jik),
+            _ => Err(ShellError::IncorrectValue {
+                msg: "KDL --format must be 'nodes' or 'jik'".into(),
+                val_span: span,
+                call_span: span,
+            }),
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Nodes => "nodes",
+            Self::Jik => "jik",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct KdlMetadata {
+    pub format: KdlFormat,
+    pub spec: KdlSpec,
+}
+
+impl KdlMetadata {
+    pub(crate) fn write_to(self, metadata: &mut PipelineMetadata, span: Span) {
+        metadata.custom.insert(
+            KDL_META_KEY,
+            Value::record(
+                record! {
+                    "version" => Value::string(KDL_META_VERSION, span),
+                    "format" => Value::string(self.format.as_str(), span),
+                    "spec" => Value::int(self.spec.as_i64(), span),
+                },
+                span,
+            ),
+        );
+    }
+
+    pub(crate) fn read_from(metadata: &PipelineMetadata) -> Option<Self> {
+        let value = metadata.custom.get(KDL_META_KEY)?;
+        let record = value.as_record().ok()?;
+        let version = record.get("version")?.as_str().ok()?;
+        if version != KDL_META_VERSION {
+            return None;
+        }
+        let format =
+            KdlFormat::parse(record.get("format")?.as_str().ok()?, Span::unknown()).ok()?;
+        let spec = KdlSpec::from_i64(record.get("spec")?.as_int().ok()?, Span::unknown()).ok()?;
+        Some(Self { format, spec })
+    }
+
+    pub(crate) fn clear(metadata: &mut PipelineMetadata) {
+        metadata.custom.remove(KDL_META_KEY);
+        // Drop legacy marker from older from kdl implementations.
+        metadata.custom.remove("nu_kdl_canonical");
+    }
+}
+
+pub(crate) fn parse_kdl_document(
+    input: &str,
+    spec: KdlSpec,
+    span: Span,
+) -> Result<KdlDocument, ShellError> {
+    let result = match spec {
+        KdlSpec::V1 => KdlDocument::parse_v1(input),
+        KdlSpec::V2 => KdlDocument::parse(input),
+    };
+    result.map_err(|err| kdl_error_to_shell_error(input, span, &err))
+}
+
+pub(crate) fn document_to_string(mut document: KdlDocument, spec: KdlSpec) -> String {
+    document.autoformat();
+    match spec {
+        KdlSpec::V1 => {
+            document.ensure_v1();
+            document.to_string()
+        }
+        KdlSpec::V2 => {
+            document.ensure_v2();
+            document.to_string()
+        }
+    }
+}
+
+pub(crate) fn kdl_error_to_shell_error(input: &str, span: Span, err: &KdlError) -> ShellError {
+    if let Some(diagnostic) = err.diagnostics.first() {
+        let diagnostic_message = kdl_diagnostics_message(&err.diagnostics);
+        let byte_offset = diagnostic.span.offset();
+        let (src, label_span) = truncated_source_window(
+            input,
+            Span::new(byte_offset, byte_offset),
+            DEFAULT_ERROR_CONTEXT,
+        );
+
+        return ShellError::Generic(
+            GenericError::new(
+                "Error while parsing KDL text",
+                "error parsing KDL text",
+                span,
+            )
+            .with_inner([ShellError::OutsideSpannedLabeledError {
+                src,
+                error: "Error while parsing KDL text".into(),
+                msg: diagnostic_message,
+                span: label_span,
+            }]),
+        );
+    }
+
+    ShellError::CantConvert {
+        to_type: format!("structured kdl data ({err})"),
+        from_type: "string".into(),
+        span,
+        help: None,
+    }
+}
+
+pub(crate) fn kdl_diagnostics_message(diagnostics: &[kdl::KdlDiagnostic]) -> String {
+    if diagnostics.len() == 1 {
+        return kdl_diagnostic_message(&diagnostics[0]);
+    }
+
+    diagnostics
+        .iter()
+        .enumerate()
+        .map(|(index, diagnostic)| {
+            format!(
+                "diagnostic {}:\n{}",
+                index + 1,
+                kdl_diagnostic_message(diagnostic)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn kdl_diagnostic_message(diagnostic: &kdl::KdlDiagnostic) -> String {
+    let mut parts = Vec::new();
+
+    if let Some(message) = &diagnostic.message {
+        parts.push(message.clone());
+    }
+
+    if let Some(label) = &diagnostic.label
+        && parts.last() != Some(label)
+    {
+        parts.push(label.clone());
+    }
+
+    if let Some(help) = &diagnostic.help {
+        parts.push(format!("help: {help}"));
+    }
+
+    if parts.is_empty() {
+        "error parsing KDL text".to_owned()
+    } else {
+        parts.join("\n")
+    }
+}
+
+pub(crate) fn resolve_non_roundtrip(
+    serialize: bool,
+    non_roundtrip: Option<Spanned<String>>,
+    engine_state: &EngineState,
+) -> Result<NonRoundtrip, ShellError> {
+    match (serialize, non_roundtrip.as_ref().map(|nr| nr.item.as_str())) {
+        (false, None | Some("error")) => Ok(NonRoundtrip::Error),
+        (true, None | Some("lossy")) => Ok(NonRoundtrip::Lossy {
+            engine_state: Box::new(engine_state.clone()),
+        }),
+        (false, Some("null")) => Ok(NonRoundtrip::Null),
+        (false, Some("lossy")) => Ok(NonRoundtrip::Lossy {
+            engine_state: Box::new(engine_state.clone()),
+        }),
+        (false, Some(_)) => Err(ShellError::IncompatibleParametersSingle {
+            msg: "expected `error`, `null` or `lossy`".into(),
+            span: non_roundtrip.expect("non_roundtrip is some").span,
+        }),
+        (true, Some(_)) => Err(ShellError::IncompatibleParameters {
+            left_message: "this is a shorthand to".into(),
+            left_span: Span::unknown(),
+            right_message: "this with `lossy`".into(),
+            right_span: non_roundtrip.expect("non_roundtrip is some").span,
+        }),
+    }
+}
+
+/// Identifier helper that clears inherited formatting.
+pub(crate) fn identifier_for(key: &str) -> kdl::KdlIdentifier {
+    let mut identifier = kdl::KdlIdentifier::from(key.to_owned());
+    identifier.clear_format();
+    identifier
+}
+
+#[cfg(test)]
+mod spec_tests {
+    use super::*;
+    use crate::formats::kdl::{
+        document_to_string, jik_document_to_value, node_rows_to_kdl_document,
+        nodes_document_to_value, parse_kdl_document, value_to_jik_document,
+    };
+    use nu_protocol::PipelineMetadata;
+    use types::NonRoundtrip;
+
+    #[test]
+    fn invalid_spec_is_rejected() {
+        let err = KdlSpec::from_i64(0, Span::test_data()).expect_err("0 invalid");
+        assert!(matches!(err, ShellError::IncorrectValue { .. }));
+        let err = KdlSpec::from_i64(3, Span::test_data()).expect_err("3 invalid");
+        assert!(matches!(err, ShellError::IncorrectValue { .. }));
+        assert_eq!(
+            KdlSpec::from_i64(1, Span::test_data()).unwrap(),
+            KdlSpec::V1
+        );
+        assert_eq!(
+            KdlSpec::from_i64(2, Span::test_data()).unwrap(),
+            KdlSpec::V2
+        );
+        assert_eq!(KdlSpec::default(), KdlSpec::V2);
+    }
+
+    #[test]
+    fn v2_parses_hash_keywords_and_rejects_bare_true_property() {
+        let span = Span::test_data();
+        parse_kdl_document("node #true #false #null", KdlSpec::V2, span)
+            .expect("v2 hash keywords should parse");
+        parse_kdl_document("node flag=#true", KdlSpec::V2, span).expect("v2 #true prop");
+        assert!(
+            parse_kdl_document("node flag=true", KdlSpec::V2, span).is_err(),
+            "v2 must not accept bare true as boolean property"
+        );
+        assert!(
+            parse_kdl_document("node true false null", KdlSpec::V2, span).is_err(),
+            "v2 must not accept bare true/false/null as keyword args"
+        );
+    }
+
+    #[test]
+    fn v1_parses_bare_keywords_and_rejects_hash_keywords() {
+        let span = Span::test_data();
+        parse_kdl_document("node true false null", KdlSpec::V1, span)
+            .expect("v1 bare keywords should parse");
+        parse_kdl_document("node flag=true", KdlSpec::V1, span).expect("v1 bare true prop");
+        assert!(
+            parse_kdl_document("node flag=#true", KdlSpec::V1, span).is_err(),
+            "v1 must not accept #true"
+        );
+        assert!(
+            parse_kdl_document("node #true #false #null", KdlSpec::V1, span).is_err(),
+            "v1 must not accept #true/#false/#null args"
+        );
+    }
+
+    #[test]
+    fn v1_and_v2_parse_to_equivalent_node_values_for_keywords() {
+        let span = Span::test_data();
+        let v1 = parse_kdl_document("node true false null", KdlSpec::V1, span).unwrap();
+        let v2 = parse_kdl_document("node #true #false #null", KdlSpec::V2, span).unwrap();
+        let rows_v1 = nodes_document_to_value(&v1, span, false).unwrap();
+        let rows_v2 = nodes_document_to_value(&v2, span, false).unwrap();
+        assert_eq!(rows_v1, rows_v2);
+    }
+
+    #[test]
+    fn emit_v1_vs_v2_keyword_spelling_for_jik() {
+        let span = Span::test_data();
+        let value = Value::test_record(record! {
+            "a" => Value::int(1, span),
+            "b" => Value::bool(true, span),
+            "c" => Value::nothing(span),
+            "d" => Value::bool(false, span),
+        });
+        let doc = value_to_jik_document(&value, &NonRoundtrip::Error, span).unwrap();
+        let v2 = document_to_string(doc.clone(), KdlSpec::V2);
+        let v1 = document_to_string(doc, KdlSpec::V1);
+        assert_eq!(v2, "- a=1 b=#true c=#null d=#false\n");
+        assert_eq!(v1, "- a=1 b=true c=null d=false\n");
+    }
+
+    #[test]
+    fn emit_v1_vs_v2_keyword_spelling_for_nodes() {
+        let span = Span::test_data();
+        let rows = Value::test_list(vec![Value::test_record(record! {
+            "name" => Value::string("item", span),
+            "args" => Value::test_list(vec![
+                Value::bool(true, span),
+                Value::bool(false, span),
+                Value::nothing(span),
+            ]),
+            "props" => Value::test_record(record! {
+                "enabled" => Value::bool(true, span),
+            }),
+            "children" => Value::test_list(vec![]),
+        })]);
+        let doc = node_rows_to_kdl_document(&rows, &NonRoundtrip::Error, span).unwrap();
+        assert_eq!(
+            document_to_string(doc.clone(), KdlSpec::V2),
+            "item #true #false #null enabled=#true\n"
+        );
+        assert_eq!(
+            document_to_string(doc, KdlSpec::V1),
+            "item true false null enabled=true\n"
+        );
+    }
+
+    #[test]
+    fn jik_round_trip_v2_text() {
+        let span = Span::test_data();
+        let original = Value::test_record(record! {
+            "name" => Value::string("nu", span),
+            "ok" => Value::bool(true, span),
+            "count" => Value::int(3, span),
+        });
+        let doc = value_to_jik_document(&original, &NonRoundtrip::Error, span).unwrap();
+        let text = document_to_string(doc, KdlSpec::V2);
+        let parsed = parse_kdl_document(&text, KdlSpec::V2, span).unwrap();
+        let back = jik_document_to_value(&parsed, span, false).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn jik_round_trip_v1_text() {
+        let span = Span::test_data();
+        let original = Value::test_record(record! {
+            "name" => Value::string("nu", span),
+            "ok" => Value::bool(true, span),
+            "count" => Value::int(3, span),
+        });
+        let doc = value_to_jik_document(&original, &NonRoundtrip::Error, span).unwrap();
+        let text = document_to_string(doc, KdlSpec::V1);
+        assert!(
+            text.contains("ok=true"),
+            "v1 emit should use bare true: {text}"
+        );
+        assert!(
+            !text.contains("#true"),
+            "v1 emit should not use #true: {text}"
+        );
+        let parsed = parse_kdl_document(&text, KdlSpec::V1, span).unwrap();
+        let back = jik_document_to_value(&parsed, span, false).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn nodes_round_trip_v1_and_v2_text() {
+        let span = Span::test_data();
+        // Flat nodes avoid v1 nested bare-identifier quirks; keyword spelling is what we care about.
+        let v1_src = "item 1 enabled=true\n";
+        let v2_src = "item 1 enabled=#true\n";
+
+        let v1_doc = parse_kdl_document(v1_src, KdlSpec::V1, span).unwrap();
+        let rows = nodes_document_to_value(&v1_doc, span, false).unwrap();
+        let rebuilt = node_rows_to_kdl_document(&rows, &NonRoundtrip::Error, span).unwrap();
+        assert_eq!(document_to_string(rebuilt.clone(), KdlSpec::V1), v1_src);
+        assert_eq!(document_to_string(rebuilt, KdlSpec::V2), v2_src);
+
+        let v2_doc = parse_kdl_document(v2_src, KdlSpec::V2, span).unwrap();
+        let rows2 = nodes_document_to_value(&v2_doc, span, false).unwrap();
+        assert_eq!(rows, rows2);
+    }
+
+    #[test]
+    fn nested_v2_document_round_trips() {
+        let span = Span::test_data();
+        let v2_src = "package {\n    name nu\n    enabled #true\n}\n";
+        let doc = parse_kdl_document(v2_src, KdlSpec::V2, span).unwrap();
+        let rows = nodes_document_to_value(&doc, span, false).unwrap();
+        let rebuilt = node_rows_to_kdl_document(&rows, &NonRoundtrip::Error, span).unwrap();
+        assert_eq!(document_to_string(rebuilt, KdlSpec::V2), v2_src);
+    }
+
+    #[test]
+    fn nested_v1_document_with_quoted_string_args_round_trips() {
+        let span = Span::test_data();
+        // KDL v1 often needs quoted strings for values that v2 can leave bare.
+        let v1_src = "package {\n    name \"nu\"\n    enabled true\n}\n";
+        let doc = parse_kdl_document(v1_src, KdlSpec::V1, span).unwrap();
+        let rows = nodes_document_to_value(&doc, span, false).unwrap();
+        let rebuilt = node_rows_to_kdl_document(&rows, &NonRoundtrip::Error, span).unwrap();
+        let emitted = document_to_string(rebuilt, KdlSpec::V1);
+        // Re-parse emitted v1 text to confirm it is valid and value-equivalent.
+        let again = parse_kdl_document(&emitted, KdlSpec::V1, span).unwrap();
+        let rows2 = nodes_document_to_value(&again, span, false).unwrap();
+        assert_eq!(rows, rows2);
+        assert!(
+            emitted.contains("enabled true") || emitted.contains("enabled=true"),
+            "{emitted}"
+        );
+    }
+
+    #[test]
+    fn cross_spec_parse_then_emit_converts_keywords() {
+        let span = Span::test_data();
+        // Parse v1, emit v2
+        let doc = parse_kdl_document("item 1 enabled=true", KdlSpec::V1, span).unwrap();
+        let rows = nodes_document_to_value(&doc, span, false).unwrap();
+        let rebuilt = node_rows_to_kdl_document(&rows, &NonRoundtrip::Error, span).unwrap();
+        assert_eq!(
+            document_to_string(rebuilt, KdlSpec::V2),
+            "item 1 enabled=#true\n"
+        );
+
+        // Parse v2, emit v1
+        let doc = parse_kdl_document("item 1 enabled=#true", KdlSpec::V2, span).unwrap();
+        let rows = nodes_document_to_value(&doc, span, false).unwrap();
+        let rebuilt = node_rows_to_kdl_document(&rows, &NonRoundtrip::Error, span).unwrap();
+        assert_eq!(
+            document_to_string(rebuilt, KdlSpec::V1),
+            "item 1 enabled=true\n"
+        );
+    }
+
+    #[test]
+    fn jik_v1_and_v2_text_parse_to_same_value() {
+        let span = Span::test_data();
+        let v1 = parse_kdl_document("- a=1 b=true c=null", KdlSpec::V1, span).unwrap();
+        let v2 = parse_kdl_document("- a=1 b=#true c=#null", KdlSpec::V2, span).unwrap();
+        let val1 = jik_document_to_value(&v1, span, false).unwrap();
+        let val2 = jik_document_to_value(&v2, span, false).unwrap();
+        assert_eq!(val1, val2);
+        assert_eq!(
+            val1,
+            Value::test_record(record! {
+                "a" => Value::int(1, span),
+                "b" => Value::bool(true, span),
+                "c" => Value::nothing(span),
+            })
+        );
+    }
+
+    #[test]
+    fn nested_structure_emits_consistently_across_specs() {
+        let span = Span::test_data();
+        let value = Value::test_record(record! {
+            "meta" => Value::test_record(record! {
+                "active" => Value::bool(true, span),
+            }),
+            "tags" => Value::test_list(vec![
+                Value::string("a", span),
+                Value::string("b", span),
+            ]),
+        });
+        let doc = value_to_jik_document(&value, &NonRoundtrip::Error, span).unwrap();
+        let v1 = document_to_string(doc.clone(), KdlSpec::V1);
+        let v2 = document_to_string(doc, KdlSpec::V2);
+        // Structure should match; only keyword spelling differs.
+        assert!(
+            v2.contains("active=#true") || v2.contains("#true"),
+            "v2: {v2}"
+        );
+        assert!(
+            v1.contains("active=true") && !v1.contains("#true"),
+            "v1: {v1}"
+        );
+        let back1 = jik_document_to_value(
+            &parse_kdl_document(&v1, KdlSpec::V1, span).unwrap(),
+            span,
+            false,
+        )
+        .unwrap();
+        let back2 = jik_document_to_value(
+            &parse_kdl_document(&v2, KdlSpec::V2, span).unwrap(),
+            span,
+            false,
+        )
+        .unwrap();
+        assert_eq!(back1, value);
+        assert_eq!(back2, value);
+    }
+
+    #[test]
+    fn metadata_preserves_spec_one_and_two() {
+        let span = Span::test_data();
+        for spec in [KdlSpec::V1, KdlSpec::V2] {
+            let mut metadata = PipelineMetadata::default();
+            KdlMetadata {
+                format: KdlFormat::Nodes,
+                spec,
+            }
+            .write_to(&mut metadata, span);
+            let read = KdlMetadata::read_from(&metadata).expect("read");
+            assert_eq!(read.spec, spec);
+            assert_eq!(read.format, KdlFormat::Nodes);
+        }
+    }
+
+    #[test]
+    fn list_of_bools_emits_keyword_args_per_spec() {
+        let span = Span::test_data();
+        let value = Value::test_list(vec![
+            Value::nothing(span),
+            Value::bool(false, span),
+            Value::bool(true, span),
+        ]);
+        let doc = value_to_jik_document(&value, &NonRoundtrip::Error, span).unwrap();
+        assert_eq!(
+            document_to_string(doc.clone(), KdlSpec::V2),
+            "- #null #false #true\n"
+        );
+        assert_eq!(document_to_string(doc, KdlSpec::V1), "- null false true\n");
+    }
+}

--- a/crates/nu-command/src/formats/kdl/nodes.rs
+++ b/crates/nu-command/src/formats/kdl/nodes.rs
@@ -1,0 +1,244 @@
+//! Nodes-mode conversion: KDL document ↔ list of node-row records.
+
+use super::identifier_for;
+use super::types::{NonRoundtrip, TypeMode, apply_type_annotation, entry_from_nu_value};
+use kdl::{KdlDocument, KdlNode};
+use nu_engine::command_prelude::*;
+use std::collections::HashSet;
+
+/// Convert a parsed KDL document into a list of node-row values.
+pub(crate) fn nodes_document_to_value(
+    document: &KdlDocument,
+    span: Span,
+    ignore_types: bool,
+) -> Result<Value, ShellError> {
+    let rows = convert_nodes(document.nodes(), span, ignore_types)?;
+    Ok(Value::list(rows, span))
+}
+
+fn convert_nodes(
+    nodes: &[KdlNode],
+    span: Span,
+    ignore_types: bool,
+) -> Result<Vec<Value>, ShellError> {
+    nodes
+        .iter()
+        .map(|node| convert_node(node, span, ignore_types))
+        .collect()
+}
+
+fn convert_node(node: &KdlNode, span: Span, ignore_types: bool) -> Result<Value, ShellError> {
+    let mut args = Vec::new();
+    let mut props = Record::new();
+    let mut used_keys: HashSet<String> = HashSet::new();
+
+    for entry in node.entries() {
+        let ty = entry.ty().map(|t| t.value());
+        let typed = apply_type_annotation(
+            entry.value(),
+            ty,
+            span,
+            ignore_types,
+            TypeMode::PreserveUnknown,
+        )?;
+        let value = typed.into_value(span);
+
+        if let Some(name) = entry.name() {
+            let key = unique_prop_key(name.value(), &mut used_keys);
+            props.insert(key, value);
+        } else {
+            args.push(value);
+        }
+    }
+
+    let children = if let Some(children_doc) = node.children() {
+        convert_nodes(children_doc.nodes(), span, ignore_types)?
+    } else {
+        Vec::new()
+    };
+
+    let mut row = record! {
+        "name" => Value::string(node.name().value(), span),
+        "args" => Value::list(args, span),
+        "props" => props.into_value(span),
+        "children" => Value::list(children, span),
+    };
+
+    if !ignore_types && let Some(ty) = node.ty() {
+        row.insert("type", Value::string(ty.value(), span));
+    }
+
+    Ok(row.into_value(span))
+}
+
+/// Encode duplicate property names as `key`, `key@2`, `key@3`, …
+fn unique_prop_key(base: &str, used: &mut HashSet<String>) -> String {
+    if used.insert(base.to_owned()) {
+        return base.to_owned();
+    }
+    let mut n = 2u32;
+    loop {
+        let candidate = format!("{base}@{n}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        n = n.saturating_add(1);
+        if n == u32::MAX {
+            // Extremely unlikely; fall back to a longer suffix.
+            let candidate = format!("{base}@dup-{n}");
+            used.insert(candidate.clone());
+            return candidate;
+        }
+    }
+}
+
+/// Convert Nu node-row value(s) into a KDL document.
+pub(crate) fn node_rows_to_kdl_document(
+    value: &Value,
+    non_roundtrip: &NonRoundtrip,
+    call_span: Span,
+) -> Result<KdlDocument, ShellError> {
+    let rows = match value {
+        Value::List { vals, .. } => vals.as_slice(),
+        Value::Record { .. } if value_is_node_row(value) => std::slice::from_ref(value),
+        other => {
+            return Err(ShellError::UnsupportedInput {
+                msg: "nodes format expects a list of node rows (or a single node row record) with name/args/props/children".into(),
+                input: format!("got {}", other.get_type()),
+                msg_span: call_span,
+                input_span: other.span(),
+            });
+        }
+    };
+
+    if !rows.iter().all(value_is_node_row) {
+        return Err(ShellError::UnsupportedInput {
+            msg: "nodes format expects each row to be a record with name (string), args (list), props (record), children (list); optional type (string)".into(),
+            input: "value originates from here".into(),
+            msg_span: call_span,
+            input_span: value.span(),
+        });
+    }
+
+    let mut document = KdlDocument::new();
+    for row in rows {
+        let Value::Record { val, .. } = row else {
+            unreachable!("checked by value_is_node_row");
+        };
+        document
+            .nodes_mut()
+            .push(node_row_to_kdl_node(val, non_roundtrip, call_span)?);
+    }
+    Ok(document)
+}
+
+pub(crate) fn value_is_node_row(value: &Value) -> bool {
+    let Value::Record { val, .. } = value else {
+        return false;
+    };
+    record_is_node_row(val)
+}
+
+fn record_is_node_row(record: &Record) -> bool {
+    matches!(record.get("name"), Some(Value::String { .. }))
+        && record
+            .get("args")
+            .is_some_and(|value| value.as_list().is_ok())
+        && record
+            .get("props")
+            .is_some_and(|value| value.as_record().is_ok())
+        && record
+            .get("children")
+            .is_some_and(|value| value.as_list().is_ok())
+        && record
+            .get("type")
+            .map(|value| matches!(value, Value::String { .. } | Value::Nothing { .. }))
+            .unwrap_or(true)
+        // Allow only known fields so random records aren't treated as node rows.
+        && record.columns().all(|col| {
+            matches!(
+                col.as_str(),
+                "name" | "args" | "props" | "children" | "type"
+            )
+        })
+}
+
+fn node_row_to_kdl_node(
+    row: &Record,
+    non_roundtrip: &NonRoundtrip,
+    call_span: Span,
+) -> Result<KdlNode, ShellError> {
+    let name = row
+        .get("name")
+        .and_then(|v| v.as_str().ok())
+        .ok_or_else(|| ShellError::UnsupportedInput {
+            msg: "node row field 'name' must be a string".into(),
+            input: "value originates from here".into(),
+            msg_span: call_span,
+            input_span: call_span,
+        })?;
+
+    let args = row
+        .get("args")
+        .and_then(|v| v.as_list().ok())
+        .ok_or_else(|| ShellError::UnsupportedInput {
+            msg: "node row field 'args' must be a list".into(),
+            input: "value originates from here".into(),
+            msg_span: call_span,
+            input_span: call_span,
+        })?;
+
+    let props = row
+        .get("props")
+        .and_then(|v| v.as_record().ok())
+        .ok_or_else(|| ShellError::UnsupportedInput {
+            msg: "node row field 'props' must be a record".into(),
+            input: "value originates from here".into(),
+            msg_span: call_span,
+            input_span: call_span,
+        })?;
+
+    let children = row
+        .get("children")
+        .and_then(|v| v.as_list().ok())
+        .ok_or_else(|| ShellError::UnsupportedInput {
+            msg: "node row field 'children' must be a list".into(),
+            input: "value originates from here".into(),
+            msg_span: call_span,
+            input_span: call_span,
+        })?;
+
+    let mut node = KdlNode::new(identifier_for(name));
+
+    if let Some(ty_val) = row.get("type")
+        && let Ok(ty) = ty_val.as_str()
+    {
+        node.set_ty(identifier_for(ty));
+    }
+
+    for arg in args {
+        node.push(entry_from_nu_value(arg, None, non_roundtrip, call_span)?);
+    }
+
+    for (key, value) in props.iter() {
+        node.push(entry_from_nu_value(
+            value,
+            Some(key),
+            non_roundtrip,
+            call_span,
+        )?);
+    }
+
+    if !children.is_empty() {
+        let child_doc = node_rows_to_kdl_document(
+            &Value::list(children.to_vec(), call_span),
+            non_roundtrip,
+            call_span,
+        )?;
+        node.ensure_children()
+            .nodes_mut()
+            .extend(child_doc.nodes().iter().cloned());
+    }
+
+    Ok(node)
+}

--- a/crates/nu-command/src/formats/kdl/types.rs
+++ b/crates/nu-command/src/formats/kdl/types.rs
@@ -1,0 +1,369 @@
+//! Nushell type annotations for KDL (YAML-tag analogue).
+//!
+//! Known annotations: filesize, duration, timestamp, binary, glob, range, cell-path.
+//! JiK also uses structural annotations: array, object.
+
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use chrono::{DateTime, FixedOffset};
+use kdl::{KdlEntry, KdlValue};
+use nu_engine::command_prelude::*;
+use nu_protocol::{Range, ast::CellPath, engine::EngineState};
+use num_traits::ToPrimitive;
+use std::str::FromStr;
+
+pub(crate) const TY_ARRAY: &str = "array";
+pub(crate) const TY_OBJECT: &str = "object";
+pub(crate) const TY_FILESIZE: &str = "filesize";
+pub(crate) const TY_DURATION: &str = "duration";
+pub(crate) const TY_TIMESTAMP: &str = "timestamp";
+pub(crate) const TY_BINARY: &str = "binary";
+pub(crate) const TY_GLOB: &str = "glob";
+pub(crate) const TY_RANGE: &str = "range";
+pub(crate) const TY_CELL_PATH: &str = "cell-path";
+
+#[derive(Debug, Clone)]
+pub(crate) enum NonRoundtrip {
+    Error,
+    Null,
+    Lossy { engine_state: Box<EngineState> },
+}
+
+/// Result of interpreting a KDL value with an optional type annotation.
+#[derive(Debug, Clone)]
+pub(crate) enum TypedValue {
+    /// Plain Nu value (base KDL type or promoted Nu type).
+    Plain(Value),
+    /// Unknown type annotation preserved for nodes mode: `{ value, type }`.
+    Wrapped { value: Value, ty: String },
+}
+
+impl TypedValue {
+    pub(crate) fn into_value(self, span: Span) -> Value {
+        match self {
+            Self::Plain(value) => value,
+            Self::Wrapped { value, ty } => Value::record(
+                record! {
+                    "value" => value,
+                    "type" => Value::string(ty, span),
+                },
+                span,
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TypeMode {
+    /// Closed dialect: unknown types error. Used for JiK.
+    Strict,
+    /// Unknown types become wrapped `{value, type}`. Used for nodes.
+    PreserveUnknown,
+}
+
+/// Convert a KDL entry value + annotation into a Nu value according to policy.
+pub(crate) fn apply_type_annotation(
+    value: &KdlValue,
+    ty: Option<&str>,
+    span: Span,
+    ignore_types: bool,
+    mode: TypeMode,
+) -> Result<TypedValue, ShellError> {
+    let base = kdl_value_to_base_nu(value, span)?;
+
+    if ignore_types {
+        return Ok(TypedValue::Plain(base));
+    }
+
+    let Some(ty) = ty else {
+        return Ok(TypedValue::Plain(base));
+    };
+
+    // Structural JiK annotations are not Nu value types; caller handles them.
+    if ty == TY_ARRAY || ty == TY_OBJECT {
+        return Ok(TypedValue::Plain(base));
+    }
+
+    match promote_known_type(ty, &base, span) {
+        Ok(Some(promoted)) => Ok(TypedValue::Plain(promoted)),
+        Ok(None) => match mode {
+            TypeMode::Strict => Err(ShellError::UnsupportedInput {
+                msg: format!(
+                    "unknown KDL type annotation '{ty}'; use --ignore-types or --format nodes"
+                ),
+                input: "value originates from here".into(),
+                msg_span: span,
+                input_span: span,
+            }),
+            TypeMode::PreserveUnknown => Ok(TypedValue::Wrapped {
+                value: base,
+                ty: ty.to_owned(),
+            }),
+        },
+        Err(err) => Err(err),
+    }
+}
+
+fn promote_known_type(ty: &str, base: &Value, span: Span) -> Result<Option<Value>, ShellError> {
+    Ok(Some(match ty {
+        TY_FILESIZE => {
+            let n = base
+                .as_int()
+                .map_err(|_| type_payload_error(ty, base, span))?;
+            Value::filesize(n, span)
+        }
+        TY_DURATION => {
+            let n = base
+                .as_int()
+                .map_err(|_| type_payload_error(ty, base, span))?;
+            Value::duration(n, span)
+        }
+        TY_TIMESTAMP => {
+            let s = base
+                .as_str()
+                .map_err(|_| type_payload_error(ty, base, span))?;
+            let dt = parse_timestamp(s).map_err(|msg| ShellError::CantConvert {
+                to_type: "datetime".into(),
+                from_type: "string".into(),
+                span: base.span(),
+                help: Some(msg),
+            })?;
+            Value::date(dt, span)
+        }
+        TY_BINARY => {
+            let s = base
+                .as_str()
+                .map_err(|_| type_payload_error(ty, base, span))?;
+            let filtered: String = s.chars().filter(|c| !c.is_whitespace()).collect();
+            let bytes =
+                BASE64_STANDARD
+                    .decode(filtered)
+                    .map_err(|err| ShellError::CantConvert {
+                        to_type: "binary".into(),
+                        from_type: "string".into(),
+                        span: base.span(),
+                        help: Some(err.to_string()),
+                    })?;
+            Value::binary(bytes, span)
+        }
+        TY_GLOB => {
+            let s = base
+                .as_str()
+                .map_err(|_| type_payload_error(ty, base, span))?;
+            Value::glob(s, false, span)
+        }
+        TY_RANGE => {
+            let s = base
+                .as_str()
+                .map_err(|_| type_payload_error(ty, base, span))?;
+            let range = Range::from_str(s).map_err(|err| ShellError::CantConvert {
+                to_type: "range".into(),
+                from_type: "string".into(),
+                span: base.span(),
+                help: Some(err.to_string()),
+            })?;
+            Value::range(range, span)
+        }
+        TY_CELL_PATH => {
+            let s = base
+                .as_str()
+                .map_err(|_| type_payload_error(ty, base, span))?;
+            let path = CellPath::from_str(s)
+                .map(|cp| cp.with_fallback_span(span))
+                .map_err(|err| ShellError::CantConvert {
+                    to_type: "cell-path".into(),
+                    from_type: "string".into(),
+                    span: base.span(),
+                    help: Some(err.to_string()),
+                })?;
+            Value::cell_path(path, span)
+        }
+        _ => return Ok(None),
+    }))
+}
+
+fn type_payload_error(ty: &str, base: &Value, _span: Span) -> ShellError {
+    ShellError::CantConvert {
+        to_type: format!("value for type annotation '{ty}'"),
+        from_type: base.get_type().to_string(),
+        span: base.span(),
+        help: Some(format!("expected a compatible base KDL value for ({ty})")),
+    }
+}
+
+fn parse_timestamp(s: &str) -> Result<DateTime<FixedOffset>, String> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Ok(dt);
+    }
+    if let Ok(dt) = DateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f%z") {
+        return Ok(dt);
+    }
+    if let Ok(dt) = DateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f %z") {
+        return Ok(dt);
+    }
+    // Date-only → midnight UTC
+    if let Ok(date) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        let naive = date
+            .and_hms_opt(0, 0, 0)
+            .ok_or_else(|| format!("invalid date '{s}'"))?;
+        return Ok(
+            DateTime::<chrono::Utc>::from_naive_utc_and_offset(naive, chrono::Utc).fixed_offset(),
+        );
+    }
+    Err(format!("could not parse timestamp '{s}'"))
+}
+
+pub(crate) fn kdl_value_to_base_nu(value: &KdlValue, span: Span) -> Result<Value, ShellError> {
+    match value {
+        KdlValue::String(val) => Ok(Value::string(val, span)),
+        KdlValue::Integer(val) => Ok(Value::int(
+            val.to_i64().ok_or(ShellError::UnsupportedInput {
+                msg: "integer value is too large to fit in i64".to_owned(),
+                input: "value originates from here".to_owned(),
+                msg_span: span,
+                input_span: span,
+            })?,
+            span,
+        )),
+        KdlValue::Float(val) => Ok(Value::float(*val, span)),
+        KdlValue::Bool(val) => Ok(Value::bool(*val, span)),
+        KdlValue::Null => Ok(Value::nothing(span)),
+    }
+}
+
+/// Build a KDL entry (argument or property) from a Nu value, applying type annotations.
+pub(crate) fn entry_from_nu_value(
+    value: &Value,
+    prop_name: Option<&str>,
+    non_roundtrip: &NonRoundtrip,
+    call_span: Span,
+) -> Result<KdlEntry, ShellError> {
+    // Wrapped unknown type: { value, type }
+    if let Value::Record { val, .. } = value
+        && val.len() == 2
+        && val.get("value").is_some()
+        && val.get("type").is_some()
+    {
+        let inner = val.get("value").expect("checked");
+        let ty = val.get("type").expect("checked").as_str().map_err(|_| {
+            ShellError::UnsupportedInput {
+                msg: "wrapped KDL value 'type' field must be a string".into(),
+                input: "value originates from here".into(),
+                msg_span: call_span,
+                input_span: value.span(),
+            }
+        })?;
+        let (kdl_value, _) = nu_literal_to_kdl(inner, non_roundtrip, call_span)?;
+        let mut entry = match prop_name {
+            Some(name) => KdlEntry::new_prop(super::identifier_for(name), kdl_value),
+            None => KdlEntry::new(kdl_value),
+        };
+        entry.set_ty(super::identifier_for(ty));
+        return Ok(entry);
+    }
+
+    let (kdl_value, ty) = nu_literal_to_kdl(value, non_roundtrip, call_span)?;
+    let mut entry = match prop_name {
+        Some(name) => KdlEntry::new_prop(super::identifier_for(name), kdl_value),
+        None => KdlEntry::new(kdl_value),
+    };
+    if let Some(ty) = ty {
+        entry.set_ty(super::identifier_for(ty));
+    }
+    Ok(entry)
+}
+
+/// Convert a Nu scalar (or non-roundtrip case) to KDL value + optional type annotation name.
+pub(crate) fn nu_literal_to_kdl(
+    value: &Value,
+    non_roundtrip: &NonRoundtrip,
+    call_span: Span,
+) -> Result<(KdlValue, Option<&'static str>), ShellError> {
+    match value {
+        Value::Bool { val, .. } => Ok((KdlValue::Bool(*val), None)),
+        Value::Int { val, .. } => Ok((KdlValue::Integer(*val as i128), None)),
+        Value::Float { val, .. } => Ok((KdlValue::Float(*val), None)),
+        Value::String { val, .. } => Ok((KdlValue::String(val.clone()), None)),
+        Value::Nothing { .. } => Ok((KdlValue::Null, None)),
+        Value::Filesize { val, .. } => Ok((KdlValue::Integer(val.get() as i128), Some(TY_FILESIZE))),
+        Value::Duration { val, .. } => Ok((KdlValue::Integer(*val as i128), Some(TY_DURATION))),
+        Value::Date { val, .. } => Ok((
+            KdlValue::String(val.to_rfc3339()),
+            Some(TY_TIMESTAMP),
+        )),
+        Value::Binary { val, .. } => Ok((
+            KdlValue::String(BASE64_STANDARD.encode(val)),
+            Some(TY_BINARY),
+        )),
+        Value::Glob { val, .. } => Ok((KdlValue::String(val.clone()), Some(TY_GLOB))),
+        Value::Range { val, .. } => Ok((KdlValue::String(val.to_string()), Some(TY_RANGE))),
+        Value::CellPath { val, .. } => Ok((KdlValue::String(val.to_string()), Some(TY_CELL_PATH))),
+        Value::Closure { val, .. } => match non_roundtrip {
+            NonRoundtrip::Error => Err(ShellError::UnsupportedInput {
+                msg: "closures cannot round-trip through KDL (use --serialize or --non-roundtrip lossy)".into(),
+                input: "value originates from here".into(),
+                msg_span: call_span,
+                input_span: value.span(),
+            }),
+            NonRoundtrip::Null => Ok((KdlValue::Null, None)),
+            NonRoundtrip::Lossy { engine_state } => Ok((
+                KdlValue::String(
+                    val.coerce_into_string(engine_state.as_ref(), call_span)?
+                        .to_string(),
+                ),
+                None,
+            )),
+        },
+        Value::Error { error, .. } => match non_roundtrip {
+            NonRoundtrip::Error => Err(*error.clone()),
+            NonRoundtrip::Null => Ok((KdlValue::Null, None)),
+            NonRoundtrip::Lossy { .. } => Ok((KdlValue::String(error.to_string()), None)),
+        },
+        Value::Custom { val, .. } => match non_roundtrip {
+            NonRoundtrip::Error => Err(ShellError::UnsupportedInput {
+                msg: format!(
+                    "custom value '{}' cannot round-trip through KDL (use --serialize or --non-roundtrip)",
+                    val.type_name()
+                ),
+                input: "value originates from here".into(),
+                msg_span: call_span,
+                input_span: value.span(),
+            }),
+            NonRoundtrip::Null => Ok((KdlValue::Null, None)),
+            NonRoundtrip::Lossy { .. } => {
+                Ok((KdlValue::String(format!("<{}>", val.type_name())), None))
+            }
+        },
+        Value::List { .. } | Value::Record { .. } => Err(ShellError::UnsupportedInput {
+            msg: "nested list/record is not a KDL literal".into(),
+            input: "value originates from here".into(),
+            msg_span: call_span,
+            input_span: value.span(),
+        }),
+    }
+}
+
+pub(crate) fn is_kdl_literal(value: &Value) -> bool {
+    matches!(
+        value,
+        Value::Bool { .. }
+            | Value::Int { .. }
+            | Value::Float { .. }
+            | Value::String { .. }
+            | Value::Nothing { .. }
+            | Value::Filesize { .. }
+            | Value::Duration { .. }
+            | Value::Date { .. }
+            | Value::Binary { .. }
+            | Value::Glob { .. }
+            | Value::Range { .. }
+            | Value::CellPath { .. }
+    ) || is_wrapped_typed_value(value)
+}
+
+pub(crate) fn is_wrapped_typed_value(value: &Value) -> bool {
+    matches!(
+        value,
+        Value::Record { val, .. }
+            if val.len() == 2 && val.get("value").is_some() && val.get("type").is_some()
+    )
+}

--- a/crates/nu-command/src/formats/kdl/types.rs
+++ b/crates/nu-command/src/formats/kdl/types.rs
@@ -1,6 +1,6 @@
 //! Nushell type annotations for KDL (YAML-tag analogue).
 //!
-//! Known annotations: filesize, duration, timestamp, binary, glob, range, cell-path.
+//! Known annotations: filesize, duration, timestamp (alias: datetime), binary, glob, range, cell-path.
 //! JiK also uses structural annotations: array, object.
 
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
@@ -16,6 +16,8 @@ pub(crate) const TY_OBJECT: &str = "object";
 pub(crate) const TY_FILESIZE: &str = "filesize";
 pub(crate) const TY_DURATION: &str = "duration";
 pub(crate) const TY_TIMESTAMP: &str = "timestamp";
+/// Parse-only alias for [`TY_TIMESTAMP`] (Nu users often say "datetime").
+pub(crate) const TY_DATETIME: &str = "datetime";
 pub(crate) const TY_BINARY: &str = "binary";
 pub(crate) const TY_GLOB: &str = "glob";
 pub(crate) const TY_RANGE: &str = "range";
@@ -117,7 +119,7 @@ fn promote_known_type(ty: &str, base: &Value, span: Span) -> Result<Option<Value
                 .map_err(|_| type_payload_error(ty, base, span))?;
             Value::duration(n, span)
         }
-        TY_TIMESTAMP => {
+        TY_TIMESTAMP | TY_DATETIME => {
             let s = base
                 .as_str()
                 .map_err(|_| type_payload_error(ty, base, span))?;

--- a/crates/nu-command/src/formats/mod.rs
+++ b/crates/nu-command/src/formats/mod.rs
@@ -1,36 +1,8 @@
 mod from;
+pub(crate) mod kdl;
 mod nu_xml_format;
 mod to;
 mod toml_utils;
-
-// Metadata key used for KDL canonical round-trip mode.
-//
-// What:
-// - `from kdl` writes this key into `PipelineMetadata.custom`.
-//
-// How:
-// - `to kdl` checks this key to decide whether values should be interpreted as
-//   canonical node rows (`name/args/props/children`) instead of ordinary
-//   Nushell records.
-//
-// Why:
-// - Shape-only detection is ambiguous because user data can legitimately contain
-//   the same field names; this explicit marker avoids misclassification.
-pub(crate) const KDL_CANONICAL_METADATA_KEY: &str = "nu_kdl_canonical";
-
-// Versioned metadata value paired with `KDL_CANONICAL_METADATA_KEY`.
-//
-// What:
-// - Identifies the canonical KDL node-row schema variant.
-//
-// How:
-// - `from kdl` writes this value.
-// - `to kdl` only enables canonical handling when both key and value match.
-//
-// Why:
-// - Versioning keeps the contract forward-compatible if the canonical schema
-//   evolves in future changes.
-pub(crate) const KDL_CANONICAL_METADATA_VALUE: &str = "node_rows_v1";
 
 pub use from::*;
 pub use to::*;

--- a/crates/nu-command/src/formats/to/kdl.rs
+++ b/crates/nu-command/src/formats/to/kdl.rs
@@ -1,7 +1,8 @@
-use crate::formats::{KDL_CANONICAL_METADATA_KEY, KDL_CANONICAL_METADATA_VALUE};
-use kdl::{KdlDocument, KdlEntry, KdlIdentifier, KdlNode, KdlValue};
+use crate::formats::kdl::{
+    KdlFormat, KdlMetadata, KdlSpec, document_to_string, node_rows_to_kdl_document,
+    resolve_non_roundtrip, value_to_jik_document,
+};
 use nu_engine::command_prelude::*;
-use nu_protocol::PipelineMetadata;
 
 #[derive(Clone)]
 pub struct ToKdl;
@@ -14,16 +15,40 @@ impl Command for ToKdl {
     fn signature(&self) -> Signature {
         Signature::build("to kdl")
             .input_output_types(vec![(Type::Any, Type::String)])
+            .param(
+                Flag::new("spec")
+                    .arg(SyntaxShape::Int)
+                    .desc("KDL language version (1 or 2 (default)).")
+                    .completion(Completion::new_list(&["1", "2"])),
+            )
+            .param(
+                Flag::new("format")
+                    .arg(SyntaxShape::String)
+                    .desc(
+                        "Data model: 'jik' (default) for JSON-in-KDL, or 'nodes' for KDL AST rows.",
+                    )
+                    .completion(Completion::new_list(&["nodes", "jik"])),
+            )
             .switch(
                 "serialize",
-                "Serialize nushell types that cannot be deserialized.",
+                "Serialize nushell types that cannot be deserialized (shorthand for --non-roundtrip lossy).",
                 Some('s'),
+            )
+            .param(
+                Flag::new("non-roundtrip")
+                    .arg(SyntaxShape::String)
+                    .desc("How to handle values that are non-roundtrippable ('error' (default), 'null', or 'lossy').")
+                    .completion(Completion::new_list(&["error", "null", "lossy"])),
             )
             .category(Category::Formats)
     }
 
     fn description(&self) -> &str {
-        "Converts table data into KDL text."
+        "Converts structured data into KDL text."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "export", "config"]
     }
 
     fn run(
@@ -35,26 +60,57 @@ impl Command for ToKdl {
     ) -> Result<PipelineData, ShellError> {
         let call_span = input.span().unwrap_or(call.head);
         let mut metadata = input.take_metadata().unwrap_or_default();
-        // Consume the explicit round-trip marker written by `from kdl`.
-        // We require this marker to opt into canonical node-row interpretation.
-        let canonical_node_rows = metadata_marks_canonical_kdl_rows(&metadata);
-        // Remove the internal marker from outgoing metadata so it does not leak
-        // beyond this conversion boundary.
-        metadata.custom.remove(KDL_CANONICAL_METADATA_KEY);
+
+        let from_meta = KdlMetadata::read_from(&metadata);
+        KdlMetadata::clear(&mut metadata);
         let metadata = metadata.with_content_type(Some("application/x-kdl".to_owned()));
 
-        // get args
-        let serialize_types = call.has_flag(engine_state, stack, "serialize")?;
+        let format = match call.get_flag::<String>(engine_state, stack, "format")? {
+            Some(s) => {
+                let flag_span = call.get_flag_span(stack, "format").unwrap_or(call.head);
+                KdlFormat::parse(&s, flag_span)?
+            }
+            None => from_meta
+                .as_ref()
+                .map(|m| m.format)
+                .unwrap_or(KdlFormat::Jik),
+        };
+
+        let spec = match call.get_flag::<i64>(engine_state, stack, "spec")? {
+            Some(n) => {
+                let flag_span = call.get_flag_span(stack, "spec").unwrap_or(call.head);
+                KdlSpec::from_i64(n, flag_span)?
+            }
+            None => from_meta.as_ref().map(|m| m.spec).unwrap_or_default(),
+        };
+
+        let non_roundtrip_flag =
+            call.get_flag::<Spanned<String>>(engine_state, stack, "non-roundtrip")?;
+        let serialize = call.has_flag(engine_state, stack, "serialize")?;
+
+        // Match YAML mutual exclusion for --serialize vs --non-roundtrip when both set with non-lossy.
+        if serialize
+            && let Some(nr) = non_roundtrip_flag.as_ref()
+            && nr.item != "lossy"
+        {
+            return Err(ShellError::IncompatibleParameters {
+                left_message: "this is a shorthand to".into(),
+                left_span: call.get_flag_span(stack, "serialize").unwrap_or(call.head),
+                right_message: "this with `lossy`".into(),
+                right_span: nr.span,
+            });
+        }
+
+        let non_roundtrip = resolve_non_roundtrip(serialize, non_roundtrip_flag, engine_state)?;
 
         let value = input.into_value(call_span)?;
-        let output_string = value_to_kdl_document(
-            engine_state,
-            &value,
-            canonical_node_rows,
-            serialize_types,
-            call_span,
-        )?
-        .to_string();
+
+        let document = match format {
+            KdlFormat::Jik => value_to_jik_document(&value, &non_roundtrip, call_span)?,
+            KdlFormat::Nodes => node_rows_to_kdl_document(&value, &non_roundtrip, call_span)?,
+        };
+
+        let output_string = document_to_string(document, spec);
 
         Ok(output_string
             .into_value(call_span)
@@ -64,437 +120,95 @@ impl Command for ToKdl {
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
-                description: "Convert yaml file to kdl file",
-                example: "{this: that list: [1 2 3 {bool: true} {this: should be: a-block}]} | to yaml | from yaml | to kdl",
-                result: Some(Value::test_string(
-                    "this that\nlist 1 2 3 bool=#true {\n    this should\n    be a-block\n}\n",
-                )),
+                description: "Convert a record to JSON-in-KDL (default KDL v2 keywords).",
+                example: "{a: 1, b: true} | to kdl",
+                result: Some(Value::test_string("- a=1 b=#true\n")),
             },
             Example {
-                description: "Convert nu record to kdl",
-                example: "{one: [{one: two, 1: 2} {three: 3} [1 2 3] 4 5 6 {bool: true}] } | to kdl",
-                result: Some(Value::test_string(
-                    "one three=3 1 2 3 4 5 6 bool=#true {\n    one two\n    \"1\" 2\n}\n",
-                )),
+                description: "Emit KDL v2 explicitly with --spec 2.",
+                example: "{a: 1, b: true} | to kdl --spec 2",
+                result: Some(Value::test_string("- a=1 b=#true\n")),
             },
             Example {
-                description: "Convert nu list to kdl string",
+                description: "Emit KDL v1 keywords with --spec 1 (bare true/false/null).",
+                example: "{a: 1, b: true} | to kdl --spec 1",
+                result: Some(Value::test_string("- a=1 b=true\n")),
+            },
+            Example {
+                description: "Convert a list to JSON-in-KDL.",
                 example: "[1 2 3] | to kdl",
-                result: Some(Value::test_string("root 1 2 3\n")),
+                result: Some(Value::test_string("- 1 2 3\n")),
             },
             Example {
-                description: "Convert nu closure to kdl string",
-                example: "{2: {|| 1 + 1} } | to kdl --serialize",
-                result: Some(Value::test_string("\"2\" \"{|| 1 + 1}\"\n")),
+                description: "Emit null/bool keywords as KDL v2.",
+                example: "[null false true] | to kdl --spec 2",
+                result: Some(Value::test_string("- #null #false #true\n")),
             },
             Example {
-                description: "Round-trip KDL through canonical node rows.",
+                description: "Emit null/bool keywords as KDL v1.",
+                example: "[null false true] | to kdl --spec 1",
+                result: Some(Value::test_string("- null false true\n")),
+            },
+            Example {
+                description: "Round-trip KDL through node rows (default v2).",
                 example: "'node one; node two' | from kdl | to kdl",
                 result: Some(Value::test_string("node one\nnode two\n")),
             },
+            Example {
+                description: "Round-trip a KDL v1 document; metadata keeps --spec 1 on to kdl.",
+                example: r#""item 1 enabled=true" | from kdl --spec 1 | to kdl"#,
+                result: Some(Value::test_string("item 1 enabled=true\n")),
+            },
+            Example {
+                description: "Round-trip a KDL v2 document with --spec 2 on both sides.",
+                example: r#""item 1 enabled=#true" | from kdl --spec 2 | to kdl --spec 2"#,
+                result: Some(Value::test_string("item 1 enabled=#true\n")),
+            },
+            Example {
+                description: "Override metadata: parse as v1 but emit as v2.",
+                example: r#""item 1 enabled=true" | from kdl --spec 1 | to kdl --spec 2"#,
+                result: Some(Value::test_string("item 1 enabled=#true\n")),
+            },
+            Example {
+                description: "Serialize a closure as a string.",
+                example: "{|| 1 + 1} | to kdl --serialize",
+                result: Some(Value::test_string("- \"{|| 1 + 1}\"\n")),
+            },
         ]
-    }
-}
-
-fn metadata_marks_canonical_kdl_rows(metadata: &PipelineMetadata) -> bool {
-    // Canonical KDL mode is opt-in and carried via pipeline metadata from
-    // `from kdl`, so ordinary records with `name/args/props/children` keys
-    // are not reinterpreted accidentally.
-    matches!(
-        metadata.custom.get(KDL_CANONICAL_METADATA_KEY),
-        Some(Value::String { val, .. }) if val == KDL_CANONICAL_METADATA_VALUE
-    )
-}
-
-fn value_is_canonical_node_row(value: &Value) -> bool {
-    let Value::Record { val, .. } = value else {
-        return false;
-    };
-
-    record_is_canonical_node_row(val)
-}
-
-fn record_is_canonical_node_row(record: &Record) -> bool {
-    record.len() == 4
-        && matches!(record.get("name"), Some(Value::String { .. }))
-        && record
-            .get("args")
-            .is_some_and(|value| value.as_list().is_ok())
-        && record
-            .get("props")
-            .is_some_and(|value| value.as_record().is_ok())
-        && record
-            .get("children")
-            .is_some_and(|value| value.as_list().is_ok())
-}
-
-fn list_is_canonical_node_rows(rows: &[Value]) -> bool {
-    rows.iter().all(value_is_canonical_node_row)
-}
-
-fn convert_record_into_formatted_kdl_document_recursively(
-    engine_state: &EngineState,
-    record: &Record,
-    serialize_types: bool,
-    call_span: Span,
-) -> Result<KdlDocument, ShellError> {
-    let mut kdl_document = KdlDocument::new();
-
-    for (key, value) in record.iter() {
-        let mut node = KdlNode::new(identifier_for_key(key));
-        append_value_to_kdl_node(engine_state, &mut node, value, serialize_types, call_span)?;
-
-        kdl_document.nodes_mut().push(node);
-    }
-
-    // format the document before returning it
-    kdl_document.autoformat();
-    Ok(kdl_document)
-}
-
-fn convert_list_into_entries_of_kdl_node_recursively(
-    engine_state: &EngineState,
-    node: &mut KdlNode,
-    list: &[Value],
-    serialize_types: bool,
-    call_span: Span,
-) -> Result<(), ShellError> {
-    for value in list {
-        match value {
-            Value::Record { val, .. } => {
-                append_record_to_kdl_node(engine_state, node, val, serialize_types, call_span)?;
-            }
-            Value::List { vals, .. } => {
-                convert_list_into_entries_of_kdl_node_recursively(
-                    engine_state,
-                    node,
-                    vals,
-                    serialize_types,
-                    call_span,
-                )?;
-            }
-            val => {
-                ensure_closure_is_serializable(val, serialize_types, call_span)?;
-                node.push(convert_nu_value_to_kdl_value(engine_state, call_span, val)?);
-            }
-        };
-    }
-
-    Ok(())
-}
-
-fn value_to_kdl_document(
-    engine_state: &EngineState,
-    value: &Value,
-    canonical_node_rows: bool,
-    serialize_types: bool,
-    call_span: Span,
-) -> Result<KdlDocument, ShellError> {
-    match value {
-        // Only enter canonical mode when both metadata and value shape agree.
-        // This guards against stale metadata after downstream transformations.
-        Value::Record { val, .. } if canonical_node_rows && record_is_canonical_node_row(val) => {
-            canonical_node_rows_to_kdl_document(
-                std::slice::from_ref(value),
-                engine_state,
-                serialize_types,
-                call_span,
-            )
-        }
-        Value::Record { val, .. } => convert_record_into_formatted_kdl_document_recursively(
-            engine_state,
-            val,
-            serialize_types,
-            call_span,
-        ),
-        Value::List { vals, .. } if canonical_node_rows && list_is_canonical_node_rows(vals) => {
-            canonical_node_rows_to_kdl_document(vals, engine_state, serialize_types, call_span)
-        }
-        Value::List { vals, .. } => {
-            let mut kdl_document = KdlDocument::new();
-            let mut node = KdlNode::new("root");
-            convert_list_into_entries_of_kdl_node_recursively(
-                engine_state,
-                &mut node,
-                vals,
-                serialize_types,
-                call_span,
-            )?;
-            kdl_document.nodes_mut().push(node);
-            kdl_document.autoformat();
-            Ok(kdl_document)
-        }
-        val => {
-            ensure_closure_is_serializable(val, serialize_types, call_span)?;
-            let mut kdl_document = KdlDocument::new();
-            let mut node = KdlNode::new("root");
-            node.push(convert_nu_value_to_kdl_value(engine_state, call_span, val)?);
-            kdl_document.nodes_mut().push(node);
-            kdl_document.autoformat();
-            Ok(kdl_document)
-        }
-    }
-}
-
-fn canonical_node_rows_to_kdl_document(
-    rows: &[Value],
-    engine_state: &EngineState,
-    serialize_types: bool,
-    call_span: Span,
-) -> Result<KdlDocument, ShellError> {
-    let mut kdl_document = KdlDocument::new();
-
-    for row in rows {
-        let Value::Record { val, .. } = row else {
-            return Err(ShellError::UnsupportedInput {
-                msg: "canonical node rows must be records".into(),
-                input: "value originates from here".into(),
-                msg_span: call_span,
-                input_span: row.span(),
-            });
-        };
-
-        kdl_document
-            .nodes_mut()
-            .push(convert_canonical_node_row_to_kdl_node(
-                engine_state,
-                val,
-                serialize_types,
-                call_span,
-            )?);
-    }
-
-    kdl_document.autoformat();
-    Ok(kdl_document)
-}
-
-fn convert_canonical_node_row_to_kdl_node(
-    engine_state: &EngineState,
-    row: &Record,
-    serialize_types: bool,
-    call_span: Span,
-) -> Result<KdlNode, ShellError> {
-    let name = node_row_string_field(row, "name", call_span)?;
-    let args = node_row_list_field(row, "args", call_span)?;
-    let props = node_row_record_field(row, "props", call_span)?;
-    let children = node_row_list_field(row, "children", call_span)?;
-
-    let mut node = KdlNode::new(identifier_for_key(name));
-
-    for arg in args {
-        ensure_closure_is_serializable(arg, serialize_types, call_span)?;
-        node.push(convert_nu_value_to_kdl_value(engine_state, call_span, arg)?);
-    }
-
-    for (key, value) in props.iter() {
-        ensure_closure_is_serializable(value, serialize_types, call_span)?;
-        node.push(KdlEntry::new_prop(
-            identifier_for_key(key),
-            convert_nu_value_to_kdl_value(engine_state, call_span, value)?,
-        ));
-    }
-
-    if !children.is_empty() {
-        let child_document = canonical_node_rows_to_kdl_document(
-            children,
-            engine_state,
-            serialize_types,
-            call_span,
-        )?;
-        merge_children(&mut node, child_document, call_span, children[0].span())?;
-    }
-
-    Ok(node)
-}
-
-fn node_row_string_field<'a>(
-    row: &'a Record,
-    field: &str,
-    call_span: Span,
-) -> Result<&'a str, ShellError> {
-    let value = node_row_field(row, field, call_span)?;
-    value.as_str().map_err(|_| ShellError::UnsupportedInput {
-        msg: format!("canonical node row field '{field}' must be a string"),
-        input: "value originates from here".into(),
-        msg_span: call_span,
-        input_span: value.span(),
-    })
-}
-
-fn node_row_list_field<'a>(
-    row: &'a Record,
-    field: &str,
-    call_span: Span,
-) -> Result<&'a [Value], ShellError> {
-    let value = node_row_field(row, field, call_span)?;
-    value.as_list().map_err(|_| ShellError::UnsupportedInput {
-        msg: format!("canonical node row field '{field}' must be a list"),
-        input: "value originates from here".into(),
-        msg_span: call_span,
-        input_span: value.span(),
-    })
-}
-
-fn node_row_record_field<'a>(
-    row: &'a Record,
-    field: &str,
-    call_span: Span,
-) -> Result<&'a Record, ShellError> {
-    let value = node_row_field(row, field, call_span)?;
-    value.as_record().map_err(|_| ShellError::UnsupportedInput {
-        msg: format!("canonical node row field '{field}' must be a record"),
-        input: "value originates from here".into(),
-        msg_span: call_span,
-        input_span: value.span(),
-    })
-}
-
-fn node_row_field<'a>(
-    row: &'a Record,
-    field: &str,
-    call_span: Span,
-) -> Result<&'a Value, ShellError> {
-    row.get(field).ok_or_else(|| ShellError::UnsupportedInput {
-        msg: format!("canonical node row is missing '{field}' field"),
-        input: "value originates from here".into(),
-        msg_span: call_span,
-        input_span: call_span,
-    })
-}
-
-fn append_value_to_kdl_node(
-    engine_state: &EngineState,
-    node: &mut KdlNode,
-    value: &Value,
-    serialize_types: bool,
-    call_span: Span,
-) -> Result<(), ShellError> {
-    match value {
-        Value::Record { val, .. } => {
-            append_record_to_kdl_node(engine_state, node, val, serialize_types, call_span)
-        }
-        Value::List { vals, .. } => convert_list_into_entries_of_kdl_node_recursively(
-            engine_state,
-            node,
-            vals,
-            serialize_types,
-            call_span,
-        ),
-        val => {
-            ensure_closure_is_serializable(val, serialize_types, call_span)?;
-            node.push(convert_nu_value_to_kdl_value(engine_state, call_span, val)?);
-            Ok(())
-        }
-    }
-}
-
-fn append_record_to_kdl_node(
-    engine_state: &EngineState,
-    node: &mut KdlNode,
-    record: &Record,
-    serialize_types: bool,
-    call_span: Span,
-) -> Result<(), ShellError> {
-    let entries = record.iter().collect::<Vec<_>>();
-
-    if let [(key, value)] = entries.as_slice()
-        && value.as_record().is_err()
-        && value.as_list().is_err()
-    {
-        ensure_closure_is_serializable(value, serialize_types, call_span)?;
-        node.push(KdlEntry::new_prop(
-            identifier_for_key(key),
-            convert_nu_value_to_kdl_value(engine_state, call_span, value)?,
-        ));
-        return Ok(());
-    }
-
-    let children = convert_record_into_formatted_kdl_document_recursively(
-        engine_state,
-        record,
-        serialize_types,
-        call_span,
-    )?;
-    merge_children(
-        node,
-        children,
-        call_span,
-        entries.first().map_or(call_span, |(_, value)| value.span()),
-    )
-}
-
-fn merge_children(
-    node: &mut KdlNode,
-    mut children: KdlDocument,
-    _call_span: Span,
-    _input_span: Span,
-) -> Result<(), ShellError> {
-    node.ensure_children()
-        .nodes_mut()
-        .append(children.nodes_mut());
-    Ok(())
-}
-
-fn identifier_for_key(key: &str) -> KdlIdentifier {
-    let mut identifier = KdlIdentifier::from(key.to_owned());
-    identifier.clear_format();
-    identifier
-}
-
-fn ensure_closure_is_serializable(
-    value: &Value,
-    serialize_types: bool,
-    call_span: Span,
-) -> Result<(), ShellError> {
-    if value.as_closure().is_ok() && !serialize_types {
-        return Err(ShellError::UnsupportedInput {
-            msg: "closures are currently not deserializable (use --serialize to serialize as a string)".into(),
-            input: "value originates from here".into(),
-            msg_span: call_span,
-            input_span: value.span(),
-        });
-    }
-
-    Ok(())
-}
-
-fn convert_nu_value_to_kdl_value(
-    engine_state: &EngineState,
-    span: Span,
-    value: &Value,
-) -> Result<KdlValue, ShellError> {
-    match value {
-        Value::Bool { val, .. } => Ok(KdlValue::Bool(*val)),
-        Value::Int { val, .. } => Ok(KdlValue::Integer(*val as i128)),
-        Value::Float { val, .. } => Ok(KdlValue::Float(*val)),
-        Value::Filesize { val, .. } => Ok(KdlValue::String(val.to_string())),
-        Value::Duration { val, .. } => Ok(KdlValue::String(val.to_string())),
-        Value::Date { val, .. } => Ok(KdlValue::String(val.to_string())),
-        Value::Range { val, .. } => Ok(KdlValue::String(val.to_string())),
-        Value::String { val, .. } => Ok(KdlValue::String(val.clone())),
-        Value::Glob { val, .. } => Ok(KdlValue::String(val.clone())),
-        Value::Closure { val, .. } => Ok(KdlValue::String(
-            val.coerce_into_string(engine_state, span)?.to_string(),
-        )),
-        Value::Nothing { .. } => Ok(KdlValue::Null),
-        Value::Binary { val, .. } => Ok(KdlValue::String(format!("{val:?}"))),
-        Value::CellPath { val, .. } => Ok(KdlValue::String(val.to_string())),
-        Value::Custom { val, .. } => Ok(KdlValue::String(format!("<{}>", val.type_name()))),
-        Value::Error { error, .. } => Err(*(error.clone())),
-        _ => Err(ShellError::UnsupportedInput {
-            msg: "value cannot be stringified".to_owned(),
-            input: value.get_type().to_string(),
-            msg_span: span,
-            input_span: value.span(),
-        }),
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::formats::kdl::{
+        KdlMetadata, NonRoundtrip, document_to_string, node_rows_to_kdl_document,
+        value_to_jik_document,
+    };
     use crate::{Get, Metadata};
     use nu_cmd_lang::eval_pipeline_without_terminal_expression;
+    use nu_protocol::PipelineMetadata;
+
+    fn eval_kdl(cmd: &str) -> Value {
+        let mut engine_state = Box::new(EngineState::new());
+        let delta = {
+            let mut working_set = StateWorkingSet::new(&engine_state);
+            working_set.add_decl(Box::new(crate::formats::FromKdl));
+            working_set.add_decl(Box::new(ToKdl));
+            working_set.add_decl(Box::new(Metadata {}));
+            working_set.add_decl(Box::new(Get {}));
+            working_set.render()
+        };
+        engine_state
+            .merge_delta(delta)
+            .expect("error merging delta");
+        eval_pipeline_without_terminal_expression(
+            cmd,
+            std::env::temp_dir().as_ref(),
+            &mut engine_state,
+        )
+        .expect("pipeline should succeed")
+    }
 
     #[test]
     fn test_examples() -> nu_test_support::Result {
@@ -502,23 +216,29 @@ mod test {
     }
 
     #[test]
-    fn top_level_scalars_are_wrapped_in_root_node() {
-        let engine_state = EngineState::default();
-        let result = value_to_kdl_document(
-            &engine_state,
-            &Value::test_int(5),
-            false,
-            false,
-            Span::test_data(),
-        )
-        .expect("scalar document should serialize");
+    fn jik_wraps_scalars_in_anon_node() {
+        let document =
+            value_to_jik_document(&Value::test_int(5), &NonRoundtrip::Error, Span::test_data())
+                .expect("scalar should serialize");
 
-        assert_eq!(result.to_string(), "root 5\n");
+        assert_eq!(document.to_string(), "- 5\n");
     }
 
     #[test]
-    fn canonical_node_rows_round_trip_to_document_shape() {
-        let engine_state = EngineState::default();
+    fn jik_empty_list_and_record() {
+        let span = Span::test_data();
+        let list_doc = value_to_jik_document(&Value::test_list(vec![]), &NonRoundtrip::Error, span)
+            .expect("empty list");
+        assert_eq!(list_doc.to_string(), "(array)-\n");
+
+        let rec_doc =
+            value_to_jik_document(&Value::test_record(record! {}), &NonRoundtrip::Error, span)
+                .expect("empty record");
+        assert_eq!(rec_doc.to_string(), "(object)-\n");
+    }
+
+    #[test]
+    fn node_rows_round_trip_shape() {
         let span = Span::test_data();
         let rows = Value::test_list(vec![Value::test_record(record! {
             "name" => Value::string("item", span),
@@ -527,146 +247,148 @@ mod test {
             "children" => Value::test_list(vec![]),
         })]);
 
-        let result = value_to_kdl_document(&engine_state, &rows, true, false, span)
-            .expect("canonical rows should serialize");
-
-        assert_eq!(result.to_string(), "item 1 enabled=#true\n");
+        let document =
+            node_rows_to_kdl_document(&rows, &NonRoundtrip::Error, span).expect("serialize");
+        assert_eq!(document.to_string(), "item 1 enabled=#true\n");
     }
 
     #[test]
-    fn list_conversion_merges_multiple_child_blocks() {
-        let engine_state = EngineState::default();
-        let span = Span::test_data();
-        let value = Value::test_list(vec![
-            Value::test_record(
-                record! { "a" => Value::test_record(record! { "b" => Value::int(1, span) }) },
-            ),
-            Value::test_record(
-                record! { "c" => Value::test_record(record! { "d" => Value::int(2, span) }) },
-            ),
-        ]);
-
-        let document = value_to_kdl_document(&engine_state, &value, false, false, span)
-            .expect("multiple child blocks should merge");
-
-        assert_eq!(
-            document.to_string(),
-            "root {
-    a b=1
-    c d=2
-}
-"
-        );
-    }
-
-    #[test]
-    fn shape_matching_record_is_not_treated_as_canonical_without_metadata() {
-        let engine_state = EngineState::default();
+    fn nodes_format_rejects_plain_records() {
         let span = Span::test_data();
         let value = Value::test_record(record! {
-            "name" => Value::string("item", span),
-            "args" => Value::test_list(vec![]),
-            "props" => Value::test_record(record! {}),
-            "children" => Value::test_list(vec![]),
+            "plain" => Value::int(7, span),
         });
 
-        let document = value_to_kdl_document(&engine_state, &value, false, false, span)
-            .expect("plain records should use normal record serialization");
-
-        assert_eq!(
-            document.to_string(),
-            "name item\nargs\nprops {\n}\nchildren\n"
-        );
+        let err = node_rows_to_kdl_document(&value, &NonRoundtrip::Error, span)
+            .expect_err("should reject");
+        match err {
+            ShellError::UnsupportedInput { msg, .. } => {
+                assert!(
+                    msg.contains("nodes format") || msg.contains("node row"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected UnsupportedInput, got {other:?}"),
+        }
     }
 
     #[test]
-    fn metadata_marker_enables_canonical_row_serialization() {
+    fn metadata_round_trip_defaults_format_and_spec() {
         let span = Span::test_data();
         let mut metadata = PipelineMetadata::default();
-        // `from kdl` writes this key/value pair to mark that values are
-        // canonical KDL node rows and should be interpreted in round-trip mode.
-        metadata.custom.insert(
-            KDL_CANONICAL_METADATA_KEY,
-            Value::string(KDL_CANONICAL_METADATA_VALUE, span),
-        );
+        KdlMetadata {
+            format: KdlFormat::Nodes,
+            spec: KdlSpec::V1,
+        }
+        .write_to(&mut metadata, span);
 
-        assert!(metadata_marks_canonical_kdl_rows(&metadata));
+        let read = KdlMetadata::read_from(&metadata).expect("metadata");
+        assert_eq!(read.format, KdlFormat::Nodes);
+        assert_eq!(read.spec, KdlSpec::V1);
     }
 
     #[test]
     fn from_kdl_marker_flows_to_to_kdl_command() {
-        let mut engine_state = Box::new(EngineState::new());
-        let delta = {
-            let mut working_set = StateWorkingSet::new(&engine_state);
-
-            working_set.add_decl(Box::new(crate::formats::FromKdl));
-            working_set.add_decl(Box::new(ToKdl));
-            working_set.add_decl(Box::new(Metadata {}));
-            working_set.add_decl(Box::new(Get {}));
-
-            working_set.render()
-        };
-
-        engine_state
-            .merge_delta(delta)
-            .expect("error merging delta");
-
-        let cmd = "'node one; node two' | from kdl | to kdl | metadata | get content_type | $in";
-        let result = eval_pipeline_without_terminal_expression(
-            cmd,
-            std::env::temp_dir().as_ref(),
-            &mut engine_state,
-        )
-        .expect("pipeline should succeed");
-
+        // eval_pipeline_without_terminal_expression drops the last pipeline element,
+        // so end with `$in` (or any dummy) to keep the expression under test.
+        let result = eval_kdl(
+            "'node one; node two' | from kdl | to kdl | metadata | get content_type | $in",
+        );
         assert_eq!(result, Value::test_string("application/x-kdl"));
     }
 
     #[test]
-    fn canonical_metadata_constants_define_round_trip_contract() {
-        let span = Span::test_data();
-        let mut metadata = PipelineMetadata::default();
-
-        metadata.custom.insert(
-            KDL_CANONICAL_METADATA_KEY,
-            Value::string(KDL_CANONICAL_METADATA_VALUE, span),
-        );
-
-        assert!(metadata_marks_canonical_kdl_rows(&metadata));
-
-        metadata.custom.insert(
-            KDL_CANONICAL_METADATA_KEY,
-            Value::string("wrong_version", span),
-        );
-
-        assert!(!metadata_marks_canonical_kdl_rows(&metadata));
+    fn pipeline_to_kdl_spec_1_emits_bare_keywords() {
+        let result = eval_kdl("{a: 1, b: true} | to kdl --spec 1 | $in");
+        assert_eq!(result, Value::test_string("- a=1 b=true\n"));
     }
 
     #[test]
-    fn stale_canonical_metadata_falls_back_to_regular_record_serialization() {
-        let engine_state = EngineState::default();
-        let span = Span::test_data();
-        let value = Value::test_record(record! {
-            "plain" => Value::int(7, span),
-        });
-
-        let document = value_to_kdl_document(&engine_state, &value, true, false, span)
-            .expect("stale canonical marker should not force canonical conversion");
-
-        assert_eq!(document.to_string(), "plain 7\n");
+    fn pipeline_to_kdl_spec_2_emits_hash_keywords() {
+        let result = eval_kdl("{a: 1, b: true} | to kdl --spec 2 | $in");
+        assert_eq!(result, Value::test_string("- a=1 b=#true\n"));
     }
 
     #[test]
-    fn stale_canonical_metadata_falls_back_to_regular_list_serialization() {
-        let engine_state = EngineState::default();
+    fn pipeline_default_spec_is_v2() {
+        let result = eval_kdl("{a: 1, b: true} | to kdl | $in");
+        assert_eq!(result, Value::test_string("- a=1 b=#true\n"));
+    }
+
+    #[test]
+    fn pipeline_from_spec_1_metadata_keeps_v1_on_to_kdl() {
+        let result = eval_kdl(r#""item 1 enabled=true" | from kdl --spec 1 | to kdl | $in"#);
+        assert_eq!(result, Value::test_string("item 1 enabled=true\n"));
+    }
+
+    #[test]
+    fn pipeline_from_spec_2_metadata_keeps_v2_on_to_kdl() {
+        let result = eval_kdl(r#""item 1 enabled=#true" | from kdl --spec 2 | to kdl | $in"#);
+        assert_eq!(result, Value::test_string("item 1 enabled=#true\n"));
+    }
+
+    #[test]
+    fn pipeline_explicit_spec_overrides_metadata() {
+        let to_v2 =
+            eval_kdl(r#""item 1 enabled=true" | from kdl --spec 1 | to kdl --spec 2 | $in"#);
+        assert_eq!(to_v2, Value::test_string("item 1 enabled=#true\n"));
+        let to_v1 =
+            eval_kdl(r#""item 1 enabled=#true" | from kdl --spec 2 | to kdl --spec 1 | $in"#);
+        assert_eq!(to_v1, Value::test_string("item 1 enabled=true\n"));
+    }
+
+    #[test]
+    fn pipeline_list_keywords_follow_spec() {
+        assert_eq!(
+            eval_kdl("[null false true] | to kdl --spec 1 | $in"),
+            Value::test_string("- null false true\n")
+        );
+        assert_eq!(
+            eval_kdl("[null false true] | to kdl --spec 2 | $in"),
+            Value::test_string("- #null #false #true\n")
+        );
+    }
+
+    #[test]
+    fn pipeline_from_spec_1_and_2_decode_same_data() {
+        let v1 = eval_kdl(r#""node true false null" | from kdl --spec 1 | get 0.args | $in"#);
+        let v2 = eval_kdl(r#""node #true #false #null" | from kdl --spec 2 | get 0.args | $in"#);
+        assert_eq!(v1, v2);
+    }
+
+    #[test]
+    fn pipeline_from_v1_jik_and_to_v1_jik_round_trip() {
+        let result = eval_kdl(
+            "'- a=1 b=true' | from kdl --format jik --spec 1 | to kdl --format jik --spec 1 | $in",
+        );
+        assert_eq!(result, Value::test_string("- a=1 b=true\n"));
+    }
+
+    #[test]
+    fn pipeline_from_v2_jik_and_to_v2_jik_round_trip() {
+        let result = eval_kdl(
+            "'- a=1 b=#true' | from kdl --format jik --spec 2 | to kdl --format jik --spec 2 | $in",
+        );
+        assert_eq!(result, Value::test_string("- a=1 b=#true\n"));
+    }
+
+    #[test]
+    fn document_to_string_respects_spec_for_node_rows() {
         let span = Span::test_data();
-        let value = Value::test_list(vec![Value::test_record(record! {
-            "plain" => Value::int(7, span),
+        let rows = Value::test_list(vec![Value::test_record(record! {
+            "name" => Value::string("item", span),
+            "args" => Value::test_list(vec![Value::int(1, span)]),
+            "props" => Value::test_record(record! { "enabled" => Value::bool(true, span) }),
+            "children" => Value::test_list(vec![]),
         })]);
-
-        let document = value_to_kdl_document(&engine_state, &value, true, false, span)
-            .expect("stale canonical marker should not force canonical conversion");
-
-        assert_eq!(document.to_string(), "root plain=7\n");
+        let doc = node_rows_to_kdl_document(&rows, &NonRoundtrip::Error, span).unwrap();
+        assert_eq!(
+            document_to_string(doc.clone(), KdlSpec::V1),
+            "item 1 enabled=true\n"
+        );
+        assert_eq!(
+            document_to_string(doc, KdlSpec::V2),
+            "item 1 enabled=#true\n"
+        );
     }
 }

--- a/crates/nu-command/src/formats/to/kdl.rs
+++ b/crates/nu-command/src/formats/to/kdl.rs
@@ -216,6 +216,14 @@ impl Command for ToKdl {
                     "wait" => Value::test_duration(5_000_000_000),
                 })),
             },
+            Example {
+                description: "Round-trip a list of records (table-shaped data) as JSON-in-KDL.",
+                example: "[{a: 1}, {a: 2}] | to kdl | from kdl --format jik",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! { "a" => Value::test_int(1) }),
+                    Value::test_record(record! { "a" => Value::test_int(2) }),
+                ])),
+            },
         ]
     }
 }
@@ -412,6 +420,49 @@ mod test {
             "'- a=1 b=#true' | from kdl --format jik --spec 2 | to kdl --format jik --spec 2 | $in",
         );
         assert_eq!(result, Value::test_string("- a=1 b=#true\n"));
+    }
+
+    #[test]
+    fn pipeline_list_of_records_jik_round_trip() {
+        // Regression: multi-row tables used to be misread as objects (duplicate key '-').
+        let result = eval_kdl("[{a: 1}, {a: 2}] | to kdl | from kdl --format jik | $in");
+        let span = Span::test_data();
+        assert_eq!(
+            result,
+            Value::test_list(vec![
+                Value::test_record(record! { "a" => Value::int(1, span) }),
+                Value::test_record(record! { "a" => Value::int(2, span) }),
+            ])
+        );
+    }
+
+    #[test]
+    fn pipeline_jik_multi_anon_children_is_list() {
+        let result = eval_kdl("'- { - a=1; - a=2 }' | from kdl --format jik | $in");
+        let span = Span::test_data();
+        assert_eq!(
+            result,
+            Value::test_list(vec![
+                Value::test_record(record! { "a" => Value::int(1, span) }),
+                Value::test_record(record! { "a" => Value::int(2, span) }),
+            ])
+        );
+    }
+
+    #[test]
+    fn pipeline_jik_sole_anon_child_is_list_not_object() {
+        let result = eval_kdl("'- { - 1 }' | from kdl --format jik | $in");
+        assert_eq!(result, Value::test_list(vec![Value::test_int(1)]));
+    }
+
+    #[test]
+    fn pipeline_jik_object_key_dash_needs_annotation() {
+        let result = eval_kdl("'(object)- { - 1 }' | from kdl --format jik | $in");
+        let span = Span::test_data();
+        assert_eq!(
+            result,
+            Value::test_record(record! { "-" => Value::int(1, span) })
+        );
     }
 
     #[test]

--- a/crates/nu-command/src/formats/to/kdl.rs
+++ b/crates/nu-command/src/formats/to/kdl.rs
@@ -174,6 +174,48 @@ impl Command for ToKdl {
                 example: "{|| 1 + 1} | to kdl --serialize",
                 result: Some(Value::test_string("- \"{|| 1 + 1}\"\n")),
             },
+            Example {
+                description: "Emit Nushell filesize and duration with type annotations.",
+                example: "{size: 1kib, wait: 5sec} | to kdl",
+                result: Some(Value::test_string(
+                    "- size=(filesize)1024 wait=(duration)5000000000\n",
+                )),
+            },
+            Example {
+                description: "Emit a datetime as a (timestamp) annotation (RFC 3339 string).",
+                example: "{when: 2020-01-02T03:04:05+00:00} | to kdl",
+                result: Some(Value::test_string(
+                    "- when=(timestamp)\"2020-01-02T03:04:05+00:00\"\n",
+                )),
+            },
+            Example {
+                description: "Emit a cell-path with a (cell-path) annotation.",
+                example: "$.1.abc | to kdl",
+                result: Some(Value::test_string("- (cell-path)$.1.abc\n")),
+            },
+            Example {
+                description: "Emit a range with a (range) annotation.",
+                example: "1..3 | to kdl",
+                result: Some(Value::test_string("- (range)\"1..3\"\n")),
+            },
+            Example {
+                description: "Emit a glob with a (glob) annotation.",
+                example: r#""*.rs" | into glob | to kdl"#,
+                result: Some(Value::test_string("- (glob)*.rs\n")),
+            },
+            Example {
+                description: "Emit binary data as base64 with a (binary) annotation.",
+                example: "0x[01 02 03] | to kdl",
+                result: Some(Value::test_string("- (binary)AQID\n")),
+            },
+            Example {
+                description: "Round-trip annotated Nushell types through KDL.",
+                example: "{size: 1kib, wait: 5sec} | to kdl | from kdl --format jik",
+                result: Some(Value::test_record(record! {
+                    "size" => Value::test_filesize(1024),
+                    "wait" => Value::test_duration(5_000_000_000),
+                })),
+            },
         ]
     }
 }


### PR DESCRIPTION
## Description

This PR refactors `from kdl` and `to kdl` so Nushell can work with **KDL language versions 1 and 2**, and so ordinary Nushell data maps cleanly to KDL.

### Breaking changes

- Default `to kdl` output is **JiK** (leading `-` node), not the old record-key-as-node / `root …` heuristic.
- Node rows may include optional `type` and typed/wrapped args/props; duplicate props become `key`, `key@2`, …
- Scripts that assumed the old flattening must switch to `--format nodes` with proper node rows, or adopt JiK.

## User-facing changes (Release notes)

### Added KDL v1/v2 support and JSON-in-KDL output

`from kdl` and `to kdl` now support KDL language versions with `--spec 1` or `--spec 2` (default **2**). Parsing is strict: v1 keyword style (`true`/`false`/`null`) and v2 style (`#true`/`#false`/`#null`) are not mixed unless you convert with an explicit emit spec.

```nushell
{a: 1, b: true} | to kdl --spec 1
# - a=1 b=true

{a: 1, b: true} | to kdl --spec 2
# - a=1 b=#true

"item 1 enabled=true" | from kdl --spec 1 | to kdl
# item 1 enabled=true
```
#### Nu type annotations (YAML-tag analogue)

```nushell
# Promote (filesize) on from
'node (filesize)1024' | from kdl | get 0.args.0
# 1.0 KiB (filesize)

# Emit annotated Nu types
{size: 1kb} | to kdl
# - size=(filesize)1024   # exact formatting may vary with autoformat
```

#### Dual data models: `nodes` and JSON-in-KDL

- **`from kdl`** defaults to **`--format nodes`**: a list of node rows (`name`, `args`, `props`, `children`) suitable for real config documents.
- **`to kdl`** defaults to **`--format jik`**: [JSON-in-KDL](https://github.com/kdl-org/kdl/blob/main/JSON-IN-KDL.md) with a single top-level `-` node, so records and lists serialize predictably.

```nushell
{a: 1, b: true} | to kdl
# - a=1 b=#true

[1 2 3] | to kdl
# - 1 2 3

'node one; node two' | from kdl | to kdl
# node one
# node two
```

This replaces the previous `to kdl` heuristic that flattened values under synthetic node names such as `root`.

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
