### PR TITLE
allow parameters with `#` to be passed

### DIFF
--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -15,6 +15,10 @@ fn string_should_be_quoted(input: &str) -> bool {
                 || c == '\\'
                 || c == ';'
                 || c == '|'
+                // `#` starts a comment when it begins a token (or after whitespace).
+                // Without quoting, `nu script.nu #000000` becomes `main #000000` and
+                // the argument is stripped.
+                || c == '#'
         })
 }
 
@@ -24,7 +28,7 @@ fn string_should_be_quoted(input: &str) -> bool {
 // input argument is a flag without =, it's passed as it is (--foo -> --foo)
 // input argument is a flag with =, the first two points apply to the value (--foo=bar -> --foo=bar; --foo=bar' -> --foo="bar'")
 //
-// special characters are white space, (, ', `, ",and \
+// special characters are white space, (, [, {, }, ', `, ", \, ;, |, and #
 pub fn escape_for_script_arg(input: &str) -> String {
     // handle for flag, maybe we need to escape the value.
     if input.starts_with("--") {
@@ -68,11 +72,23 @@ mod test {
             ("`123", r#""`123""#),
             ("this|cat", r#""this|cat""#),
             ("this;cat", r#""this;cat""#),
+            // `#` would start a comment when re-parsed as `main <arg>`
+            ("#000000", r##""#000000""##),
+            ("#", r##""#""##),
+            ("foo#bar", r##""foo#bar""##),
         ];
 
         for (input, expected) in cases {
             assert_eq!(escape_for_script_arg(input).as_str(), expected);
         }
+    }
+
+    #[test]
+    fn test_flag_value_with_hash() {
+        assert_eq!(
+            escape_for_script_arg("--color=#000000"),
+            r##"--color="#000000""##.to_string()
+        );
     }
 
     #[test]

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -337,6 +337,36 @@ fn script_with_newline_arg_does_not_split_commands() -> Result {
     })
 }
 
+// regression test for https://github.com/nushell/nushell/issues/18778
+#[test]
+#[deps(NU)]
+fn script_with_hash_arg_is_not_treated_as_comment() -> Result {
+    Playground::setup("script_hash_arg", |dirs, sandbox| -> Result {
+        sandbox.mkdir("script_hash_arg");
+        sandbox.with_files(&[FileWithContent(
+            "script.nu",
+            "def main [color: string] { print $color }",
+        )]);
+
+        let result: CompleteResult = test()
+            .cwd(dirs.test())
+            .run(r##"nu script.nu "#000000" | complete"##)?;
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "#000000\n");
+        assert!(result.stderr.is_empty());
+
+        let result: CompleteResult = test()
+            .cwd(dirs.test())
+            .run(r##"nu script.nu "#" | complete"##)?;
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "#\n");
+        assert!(result.stderr.is_empty());
+        Ok(())
+    })
+}
+
 // regression test for https://github.com/nushell/nushell/issues/17719
 #[test]
 #[deps(NU)]


### PR DESCRIPTION
## Description

This PR fixes a bug where `"#00abcd"` couldn't be passed as a parameter because `#` indicates to nushell that a comment is following.

## User-facing changes (Release notes)

### Fixed passing quoted `#` strings as script parameters

Quotes strings with `"#"` in them like `"#00abcd"` are now allowed to be passed as parameters.

### Example
A script named test.nu
```nushell
def main [color: string] {
  $"Your color is ($color)"
}
```
Then pass a hex color as a parameter.
```nushell
❯ let myColor = "#000000"
❯ nu test.nu $myColor
Your color is #000000
❯ nu test.nu "#abcdef"
Your color is #abcdef
```

## Additional notes

closes https://github.com/nushell/nushell/issues/18778
