### PR TITLE
feat(format duration/filesize): add completions for units

### DIFF
--- a/crates/nu-command/src/strings/format/duration.rs
+++ b/crates/nu-command/src/strings/format/duration.rs
@@ -1,6 +1,9 @@
 use nu_cmd_base::input_handler::{CmdArgument, operate};
 use nu_engine::command_prelude::*;
-use nu_protocol::SUPPORTED_DURATION_UNITS;
+
+pub const SUPPORTED_UNITS: &[&str] = &[
+    "ns", "us", "µs", "ms", "sec", "min", "hr", "day", "wk", "month", "yr", "dec",
+];
 
 struct Arguments {
     format_value: Spanned<String>,
@@ -33,11 +36,11 @@ impl Command for FormatDuration {
                 (Type::table(), Type::table()),
             ])
             .allow_variants_without_examples(true)
-            .required(
-                "format value",
-                SyntaxShape::String,
-                "The unit in which to display the duration.",
-            )
+            .param(Parameter::Required(
+                PositionalArg::new("format value", SyntaxShape::String)
+                    .desc("The unit in which to display the duration.")
+                    .completion(Completion::new_list(SUPPORTED_UNITS)),
+            ))
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
@@ -194,7 +197,7 @@ fn convert_inner_to_unit(val: i64, to_unit: &str, span: Span) -> Result<f64, She
 
         _ => Err(ShellError::InvalidUnit {
             span,
-            supported_units: SUPPORTED_DURATION_UNITS.join(", "),
+            supported_units: SUPPORTED_UNITS.join(", "),
         }),
     }
 }

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -32,11 +32,11 @@ impl Command for FormatFilesize {
                 (Type::record(), Type::record()),
             ])
             .allow_variants_without_examples(true)
-            .required(
-                "format value",
-                SyntaxShape::String,
-                "The format into which convert the file sizes.",
-            )
+            .param(Parameter::Required(
+                PositionalArg::new("format value", SyntaxShape::String)
+                    .desc("The format into which convert the file sizes.")
+                    .completion(Completion::new_list(SUPPORTED_FILESIZE_UNITS.as_slice())),
+            ))
             .rest(
                 "rest",
                 SyntaxShape::CellPath,


### PR DESCRIPTION
## User-facing changes (Release notes)

Added completions to `format duration`'s and `format filesize`'s unit argument.