### PR TITLE
treat empty string as an invalid path in path type

### DIFF
--- a/crates/nu-command/src/path/type.rs
+++ b/crates/nu-command/src/path/type.rs
@@ -95,6 +95,11 @@ If the path does not exist, null will be returned."
                 result: Some(Value::test_string("dir")),
             },
             Example {
+                description: "Empty string is not a path.",
+                example: "'' | path type | is-empty",
+                result: Some(Value::test_bool(true)),
+            },
+            Example {
                 description: "Show type of filepaths in a list.",
                 example: "ls | get name | path type",
                 result: None,
@@ -104,6 +109,11 @@ If the path does not exist, null will be returned."
 }
 
 fn path_type(path: &Path, span: Span, args: &Arguments) -> Value {
+    // To the OS, an empty string is just the CWD,
+    // however logically we want to treat it as an invalid path.
+    if path == "" {
+        return Value::nothing(span);
+    }
     let path = nu_path::expand_path_with(path, &args.pwd, true);
     match path.symlink_metadata() {
         Ok(metadata) => Value::string(get_file_type(&metadata), span),


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

Currently (at least on linux):
```sh
"" | path type
dir
```

I suppose this is bc an empty string is treated as the CWD.
This is very annoying when you're glueing external tools together.
Even though I found no issue for `"" | path type`, I'm still 100% sure this was not indeded, especially considering that `"" | path exists` returns false.

I fixed it:
```sh
"" | path type | is-empty
true
```

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

### Fixed `path type` treating empty strings as directories

`"" | path type` now returns `null` instead of `"dir"`

<!--
## Additional notes
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
