### PR TITLE
fix test_default_config_path always failing if your config is a symlink

### DIFF
--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -284,8 +284,7 @@ fn test_default_config_path() -> Result {
 
     let try_canonicalized = |p: PathBuf| {
         p.canonicalize()
-            .ok() // windows!
-            .map(|c| c.strip_prefix(r"\\?\").map(From::from).unwrap_or(c))
+            .map(|c| c.strip_prefix(r"\\?\").map(From::from).unwrap_or(c)) // windows!
             .unwrap_or(p)
     };
 

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -18,7 +18,7 @@ use nu_protocol::{Config, HistoryConfig, HistoryFileFormat, HistoryPath};
 use nu_test_support::prelude::*;
 use pretty_assertions::assert_eq;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 #[cfg(not(windows))]
 use std::process::Command;
 
@@ -276,7 +276,7 @@ fn test_default_config_path() -> Result {
             .engine_state
             .config_dirs
             .plugin_file
-            .to_path_buf()
+            .as_path()
             .canonicalize()
             .ok();
     }
@@ -287,10 +287,10 @@ fn test_default_config_path() -> Result {
             .map(|c| {
                 c.to_str()
                     .and_then(|s| s.strip_prefix(r"\\?\")) // windows!
-                    .map(From::from)
+                    .map(PathBuf::from)
                     .unwrap_or(c)
             })
-            .unwrap_or(p)
+            .unwrap_or_else(|_| p.to_path_buf())
     };
 
     let home = dirs.config_home.as_path();
@@ -308,12 +308,12 @@ fn test_default_config_path() -> Result {
         .run("$nu.env-path")
         .expect_value_eq(try_canonicalized(environment))?;
 
-    let history = home.join("history.txt").as_path();
+    let history = &home.join("history.txt");
     tester
         .run("$nu.history-path")
         .expect_value_eq(try_canonicalized(history))?;
 
-    let login = home.join("login.nu").as_path();
+    let login = &home.join("login.nu");
     tester
         .run("$nu.loginshell-path")
         .expect_value_eq(try_canonicalized(login))?;

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -284,7 +284,12 @@ fn test_default_config_path() -> Result {
 
     let try_canonicalized = |p: PathBuf| {
         p.canonicalize()
-            .map(|c| c.strip_prefix(r"\\\\?\\").map(From::from).unwrap_or(c)) // windows!
+            .map(|c| {
+                c.to_str()
+                    .and_then(|s| s.strip_prefix(r"\\?\")) // windows!
+                    .map(From::from)
+                    .unwrap_or(c)
+            })
             .unwrap_or(p)
     };
 

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -284,7 +284,7 @@ fn test_default_config_path() -> Result {
 
     let try_canonicalized = |p: PathBuf| {
         p.canonicalize()
-            .map(|c| c.strip_prefix(r"\\?\").map(From::from).unwrap_or(c)) // windows!
+            .map(|c| c.strip_prefix(r"\\\\?\\").map(From::from).unwrap_or(c)) // windows!
             .unwrap_or(p)
     };
 

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -272,36 +272,47 @@ fn test_default_config_path() -> Result {
     tester.engine_state.config_dirs = dirs.clone();
     #[cfg(feature = "plugin")]
     {
-        tester.engine_state.plugin_path =
-            Some(tester.engine_state.config_dirs.plugin_file.to_path_buf());
+        tester.engine_state.plugin_path = tester
+            .engine_state
+            .config_dirs
+            .plugin_file
+            .to_path_buf()
+            .canonicalize()
+            .ok();
     }
     tester.engine_state.generate_nu_constant();
 
+    let home = dirs.config_home.to_path_buf();
     tester
         .run("$nu.default-config-dir")
-        .expect_value_eq(dirs.config_home.clone())?;
+        .expect_value_eq(home.canonicalize().unwrap_or(home.clone()))?;
 
+    let config = dirs.config_file.to_path_buf();
     tester
         .run("$nu.config-path")
-        .expect_value_eq(dirs.config_file.to_path_buf())?;
+        .expect_value_eq(config.canonicalize().unwrap_or(config))?;
 
+    let environment = dirs.env_file.to_path_buf();
     tester
         .run("$nu.env-path")
-        .expect_value_eq(dirs.env_file.to_path_buf())?;
+        .expect_value_eq(environment.canonicalize().unwrap_or(environment))?;
 
+    let history = home.join("history.txt");
     tester
         .run("$nu.history-path")
-        .expect_value_eq(dirs.config_home.join("history.txt"))?;
+        .expect_value_eq(history.canonicalize().unwrap_or(history))?;
 
+    let login = home.join("login.nu");
     tester
         .run("$nu.loginshell-path")
-        .expect_value_eq(dirs.config_home.join("login.nu"))?;
+        .expect_value_eq(login.canonicalize().unwrap_or(login))?;
 
     #[cfg(feature = "plugin")]
     {
+        let plugin = dirs.plugin_file.to_path_buf();
         tester
             .run("$nu.plugin-path")
-            .expect_value_eq(dirs.plugin_file.to_path_buf())?;
+            .expect_value_eq(plugin.canonicalize().unwrap_or(plugin))?;
     }
 
     Ok(())

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -282,37 +282,44 @@ fn test_default_config_path() -> Result {
     }
     tester.engine_state.generate_nu_constant();
 
+    let try_canonicalized = |p: PathBuf| {
+        p.canonicalize()
+            .ok() // windows!
+            .map(|c| c.strip_prefix(r"\\?\").map(From::from).unwrap_or(c))
+            .unwrap_or(p)
+    };
+
     let home = dirs.config_home.to_path_buf();
     tester
         .run("$nu.default-config-dir")
-        .expect_value_eq(home.canonicalize().unwrap_or(home.clone()))?;
+        .expect_value_eq(try_canonicalized(home.clone()))?;
 
     let config = dirs.config_file.to_path_buf();
     tester
         .run("$nu.config-path")
-        .expect_value_eq(config.canonicalize().unwrap_or(config))?;
+        .expect_value_eq(try_canonicalized(config))?;
 
     let environment = dirs.env_file.to_path_buf();
     tester
         .run("$nu.env-path")
-        .expect_value_eq(environment.canonicalize().unwrap_or(environment))?;
+        .expect_value_eq(try_canonicalized(environment))?;
 
     let history = home.join("history.txt");
     tester
         .run("$nu.history-path")
-        .expect_value_eq(history.canonicalize().unwrap_or(history))?;
+        .expect_value_eq(try_canonicalized(history))?;
 
     let login = home.join("login.nu");
     tester
         .run("$nu.loginshell-path")
-        .expect_value_eq(login.canonicalize().unwrap_or(login))?;
+        .expect_value_eq(try_canonicalized(login))?;
 
     #[cfg(feature = "plugin")]
     {
         let plugin = dirs.plugin_file.to_path_buf();
         tester
             .run("$nu.plugin-path")
-            .expect_value_eq(plugin.canonicalize().unwrap_or(plugin))?;
+            .expect_value_eq(try_canonicalized(plugin))?;
     }
 
     Ok(())

--- a/tests/repl/test_config_path.rs
+++ b/tests/repl/test_config_path.rs
@@ -282,7 +282,7 @@ fn test_default_config_path() -> Result {
     }
     tester.engine_state.generate_nu_constant();
 
-    let try_canonicalized = |p: PathBuf| {
+    let try_canonicalized = |p: &Path| {
         p.canonicalize()
             .map(|c| {
                 c.to_str()
@@ -293,34 +293,34 @@ fn test_default_config_path() -> Result {
             .unwrap_or(p)
     };
 
-    let home = dirs.config_home.to_path_buf();
+    let home = dirs.config_home.as_path();
     tester
         .run("$nu.default-config-dir")
-        .expect_value_eq(try_canonicalized(home.clone()))?;
+        .expect_value_eq(try_canonicalized(home))?;
 
-    let config = dirs.config_file.to_path_buf();
+    let config = dirs.config_file.as_path();
     tester
         .run("$nu.config-path")
         .expect_value_eq(try_canonicalized(config))?;
 
-    let environment = dirs.env_file.to_path_buf();
+    let environment = dirs.env_file.as_path();
     tester
         .run("$nu.env-path")
         .expect_value_eq(try_canonicalized(environment))?;
 
-    let history = home.join("history.txt");
+    let history = home.join("history.txt").as_path();
     tester
         .run("$nu.history-path")
         .expect_value_eq(try_canonicalized(history))?;
 
-    let login = home.join("login.nu");
+    let login = home.join("login.nu").as_path();
     tester
         .run("$nu.loginshell-path")
         .expect_value_eq(try_canonicalized(login))?;
 
     #[cfg(feature = "plugin")]
     {
-        let plugin = dirs.plugin_file.to_path_buf();
+        let plugin = dirs.plugin_file.as_path();
         tester
             .run("$nu.plugin-path")
             .expect_value_eq(try_canonicalized(plugin))?;


### PR DESCRIPTION
fixes this by just canonicalizing everything:
```sh
Error: TestError {
    location: tests/repl/test_config_path.rs:286:10,
    kind: UnexpectedValue {
        expected: String("/home/pheenty/.config/nushell/config.nu"),
        got: String("/home/pheenty/.dotfiles/.config/nushell/config.nu"),
    },
}
```