### PR TITLE
Pin CI actions to commit SHAs and declare workflow permissions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
@@ -18,6 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     # Prevent sudden announcement of a new advisory from failing ci:
     continue-on-error: true
+    permissions:
+      contents: read
+      # rustsec/audit-check documents these: a check run for the report,
+      # issues on scheduled-run findings.
+      checks: write
+      issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,10 +19,10 @@ jobs:
     # Prevent sudden announcement of a new advisory from failing ci:
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
-      - uses: taiki-e/install-action@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-audit
-      - uses: rustsec/audit-check@v2.0.0
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/beta-test.yml
+++ b/.github/workflows/beta-test.yml
@@ -12,6 +12,9 @@ on:
     # See: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/notifications-for-workflow-runs
     - cron: '0 0 * * *'  # Runs daily at midnight UTC
 
+permissions:
+  contents: read
+
 env:
   NUSHELL_CARGO_PROFILE: ci
   NU_LOG_LEVEL: DEBUG

--- a/.github/workflows/beta-test.yml
+++ b/.github/workflows/beta-test.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - run: rustup update beta
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 
 name: continuous-integration
 
+permissions:
+  contents: read
+
 env:
   NU_LOG_LEVEL: DEBUG
   NU_TEST_SKIP_DEPS_BUILD: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,14 +105,14 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Rust Toolchain
         run: rustup target add ${{ matrix.target.target }}
         working-directory: ${{ matrix.workspace.path }}
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ${{ matrix.workspace.path }} -> target
           cache-all-crates: true
@@ -174,16 +174,16 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.12.0
+        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
 
       - name: Install Nushell
         run: cargo install --path . --locked --force
 
       - name: Upload Nushell build (Ubuntu and macOS)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: runner.os != 'Windows'
         with:
           name: "nu-${{ github.event.number || github.ref_name }}-${{ matrix.platform }}"
@@ -191,7 +191,7 @@ jobs:
           retention-days: 14
 
       - name: Upload Nushell build (Windows)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: runner.os == 'Windows'
         with:
           name: "nu-${{ github.event.number || github.ref_name }}-${{ matrix.platform }}"
@@ -205,7 +205,7 @@ jobs:
         run: nu .github/workflows/check-msrv.nu
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/friendly-config-reminder.yml
+++ b/.github/workflows/friendly-config-reminder.yml
@@ -3,6 +3,11 @@ on:
   pull_request_target:
     paths:
       - 'crates/nu-protocol/src/config/**'
+permissions:
+  # Find and post the config reminder comment on the pull request.
+  issues: write
+  pull-requests: write
+
 jobs:
   comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/friendly-config-reminder.yml
+++ b/.github/workflows/friendly-config-reminder.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check if there is already a bot comment
-      uses: peter-evans/find-comment@v4
+      uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -16,7 +16,7 @@ jobs:
         body-includes: Hey, just a bot checking in!
     - name: Create comment if there is not
       if: steps.fc.outputs.comment-id == ''
-      uses: peter-evans/create-or-update-comment@v5
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
         body: |

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'nushell'
     steps:
-      - uses: actions/labeler@v7
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -9,6 +9,12 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions:
+  # The milestone action binds merged PRs and closed issues to the
+  # active milestone.
+  issues: write
+  pull-requests: write
+
 jobs:
   update-milestone:
     runs-on: ubuntu-latest

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -15,14 +15,14 @@ jobs:
     name: Milestone Update
     steps:
       - name: Set Milestone for PR
-        uses: hustcer/milestone-action@v3
+        uses: hustcer/milestone-action@ebed8d5daafd855a600d7e665c1b130f06d24130 # v3.1
         if: github.event.pull_request.merged == true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Bind milestone to closed issue that has a merged PR fix
       - name: Set Milestone for Issue
-        uses: hustcer/milestone-action@v3
+        uses: hustcer/milestone-action@ebed8d5daafd855a600d7e665c1b130f06d24130 # v3.1
         if: github.event.issue.state == 'closed'
         with:
           action: bind-issue

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -17,6 +17,9 @@ on:
     - cron: '15 0 * * *' # run at 00:15 AM UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -157,6 +160,11 @@ jobs:
           os: ubuntu-22.04
 
     runs-on: ${{matrix.os}}
+    permissions:
+      # Upload the nightly archives to the release; open an issue when
+      # the build fails.
+      contents: write
+      issues: write
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -228,6 +236,9 @@ jobs:
     name: Create Sha256sum
     runs-on: ubuntu-latest
     if: github.repository == 'nushell/nightly'
+    permissions:
+      # Update the nightly release with the checksum file.
+      contents: write
     steps:
     - name: Download Release Archives
       env:
@@ -255,6 +266,9 @@ jobs:
     if: github.repository == 'nushell/nightly'
     needs: [release, sha256sum]
     runs-on: ubuntu-latest
+    permissions:
+      # Delete outdated nightly releases.
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -34,7 +34,7 @@ jobs:
       nightly_tag: ${{ steps.vars.outputs.nightly_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: github.repository == 'nushell/nightly'
         with:
           ref: main
@@ -43,7 +43,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Setup Nushell
-        uses: hustcer/setup-nu@v3
+        uses: hustcer/setup-nu@f3fd65374ffc4d60974c0dd2f7263c6c5c285f81 # v3.26
         if: github.repository == 'nushell/nightly'
         with:
           version: 0.112.2
@@ -158,7 +158,7 @@ jobs:
 
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: main
         fetch-depth: 0
@@ -179,14 +179,14 @@ jobs:
         echo "targets = ['${{matrix.target}}']" >> rust-toolchain.toml
 
     - name: Setup Rust toolchain and cache
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       # WARN: Keep the rustflags to prevent from the winget submission error: `CAQuietExec: Error 0xc0000135`
       with:
         cache: false
         rustflags: ''
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3
+      uses: hustcer/setup-nu@f3fd65374ffc4d60974c0dd2f7263c6c5c285f81 # v3.26
       with:
         version: 0.112.2
 
@@ -200,7 +200,7 @@ jobs:
 
     - name: Create an Issue for Release Failure
       if: ${{ failure() }}
-      uses: JasonEtco/create-an-issue@v2
+      uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -211,7 +211,7 @@ jobs:
     # REF: https://github.com/marketplace/actions/gh-release
     # Create a release only in nushell/nightly repo
     - name: Publish Archive
-      uses: softprops/action-gh-release@v2.0.9
+      uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
       if: ${{ startsWith(github.repository, 'nushell/nightly') }}
       with:
         prerelease: true
@@ -240,7 +240,7 @@ jobs:
     - name: Create Checksums
       run: cd release && shasum -a 256 * > ../SHA256SUMS
     - name: Publish Checksums
-      uses: softprops/action-gh-release@v2.0.9
+      uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
       with:
         draft: false
         prerelease: true
@@ -256,12 +256,12 @@ jobs:
     needs: [release, sha256sum]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
 
       - name: Setup Nushell
-        uses: hustcer/setup-nu@v3
+        uses: hustcer/setup-nu@f3fd65374ffc4d60974c0dd2f7263c6c5c285f81 # v3.26
         with:
           version: 0.112.2
 

--- a/.github/workflows/pre-release-checkup.yml
+++ b/.github/workflows/pre-release-checkup.yml
@@ -22,8 +22,10 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: taiki-e/install-action@cargo-hack
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
+        with:
+          tool: cargo-hack
 
       - name: Feature power set
         run: |

--- a/.github/workflows/pre-release-checkup.yml
+++ b/.github/workflows/pre-release-checkup.yml
@@ -3,6 +3,9 @@ on:
   - workflow_dispatch
 
 
+permissions:
+  contents: read
+
 env:
   NUSHELL_CARGO_PROFILE: ci
   NU_LOG_LEVEL: DEBUG

--- a/.github/workflows/release-msi.yml
+++ b/.github/workflows/release-msi.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Install Wix Toolset 6 for Windows
       shell: pwsh
@@ -56,7 +56,7 @@ jobs:
         wix --version
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3
+      uses: hustcer/setup-nu@f3fd65374ffc4d60974c0dd2f7263c6c5c285f81 # v3.26
       with:
         version: 0.112.2
 
@@ -72,7 +72,7 @@ jobs:
 
     # REF: https://github.com/marketplace/actions/gh-release
     - name: Publish Archive
-      uses: softprops/action-gh-release@v2.0.5
+      uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
       with:
         tag_name: ${{ inputs.tag }}
         files: ${{ steps.nu.outputs.msi }}
@@ -97,7 +97,7 @@ jobs:
     - name: Create Checksums
       run: cd release && rm -f SHA256SUMS && shasum -a 256 * > ../SHA256SUMS
     - name: Publish Checksums
-      uses: softprops/action-gh-release@v2.0.5
+      uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
       with:
         files: SHA256SUMS
         tag_name: ${{ inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+*'
       - '!*nightly*'  # Don't trigger release for nightly tags
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -66,6 +69,9 @@ jobs:
 
     runs-on: ${{matrix.os}}
 
+    permissions:
+      # Upload the release archives to the GitHub release.
+      contents: write
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -121,6 +127,9 @@ jobs:
     needs: release
     name: Create Sha256sum
     runs-on: ubuntu-latest
+    permissions:
+      # Upload the release archives to the GitHub release.
+      contents: write
     steps:
     - name: Download Release Archives
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Install Wix Toolset 6 for Windows
       shell: pwsh
@@ -85,14 +85,14 @@ jobs:
         echo "targets = ['${{matrix.target}}']" >> rust-toolchain.toml
 
     - name: Setup Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1.12.0
+      uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
       # WARN: Keep the rustflags to prevent from the winget submission error: `CAQuietExec: Error 0xc0000135`
       with:
         cache: false
         rustflags: ''
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3
+      uses: hustcer/setup-nu@f3fd65374ffc4d60974c0dd2f7263c6c5c285f81 # v3.26
       with:
         version: 0.112.2
 
@@ -107,7 +107,7 @@ jobs:
     # WARN: Don't upgrade this action due to the release per asset issue.
     # See: https://github.com/softprops/action-gh-release/issues/445
     - name: Publish Archive
-      uses: softprops/action-gh-release@v2.0.5
+      uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       with:
         draft: true
@@ -133,7 +133,7 @@ jobs:
     - name: Create Checksums
       run: cd release && shasum -a 256 * > ../SHA256SUMS
     - name: Publish Checksums
-      uses: softprops/action-gh-release@v2.0.5
+      uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
       with:
         draft: true
         files: SHA256SUMS

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,6 +1,9 @@
 name: Typos
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   run:
     name: Spell Check with Typos

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check spelling
-        uses: crate-ci/typos@v1.48.0
+        uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0

--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Submit package to Windows Package Manager Community Repository
-        uses: vedantmgoyal2009/winget-releaser@v2
+        uses: vedantmgoyal2009/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # latest
         with:
           identifier: Nushell.Nushell
           # Exclude all `*-msvc-full.msi` full release files,


### PR DESCRIPTION
## Description

Drive-by CI hardening in two commits, one logical change each, found with the Plumber CLI (https://github.com/getplumber/plumber) and verified on main.

**Commit 1 pins every action to its commit sha**, versions kept as comments. A tag like `@v2` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's credentials. The paths that matter here: `release.yml` and `nightly-build.yml` upload the binaries users download, and `winget-submission.yml` holds `NUSHELL_PAT`, which opens PRs against winget-pkgs on your behalf. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). Two refs deserve a note:

- `taiki-e/install-action@cargo-hack` used the floating tool-name tag; it is now the pinned action plus an explicit `tool: cargo-hack` input, same behavior, immutable ref.
- `winget-releaser` only resolves through a redirect these days (the author renamed to vedantmgoyal9) and publishes no version tags. A sha pin fails closed if the old name is ever re-registered, instead of silently running substituted code.

Every sha was resolved from the upstream repo and cross checked against its release tag. The pins stay maintainable: a dependabot config with the `github-actions` ecosystem bumps them with the comments in sync (happy to add one here if you want).

**Commit 2 scopes the GITHUB_TOKEN per workflow**, derived from what each job actually uses: the test and lint workflows drop to `contents: read`; the release and nightly jobs get `contents: write` only where they upload archives, update checksums or prune old nightlies (the nightly prepare job pushes with its own dedicated token and needs nothing); `audit.yml` gets the `checks: write` and `issues: write` its action documents; the two `pull_request_target` workflows (milestone, config reminder) get exactly issues and pull-requests write. `labels.yml` and `winget-submission.yml` already declare scoped permissions (nicely done) and are untouched.

One heads up: if the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v2`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

I will also open a PR which adds the tool to CI so this does not quietly drift back; that one is a bonus, this PR stands on its own.

## User-facing changes (Release notes)

n/a (CI only)

## Tests + Formatting

CI itself is the test for this change; all workflow files parse and the pinned shas were cross-checked against their release tags.

## After Submitting

n/a