### PR TITLE
ci: add plumber workflow security check

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,35 @@
+name: Plumber
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: getplumber/plumber@24de99968c08ffe230545f413695ad933208b0d2 # v0.4.29
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,33 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: '2.0'
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the Rust ecosystem
+      # tooling and release actions this repo already uses on top of
+      # it, plus the actions maintained by a nushell core team member
+      # (hustcer).
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - JasonEtco/create-an-issue
+        - Swatinem/rust-cache
+        - actions-rust-lang/setup-rust-toolchain
+        - crate-ci/typos
+        - hustcer/milestone-action
+        - hustcer/setup-nu
+        - rustsec/audit-check
+        - softprops/action-gh-release
+        - taiki-e/install-action
+        - vedantmgoyal2009/winget-releaser
+
+    # Off for now: the finding is rustup's own install script
+    # (sh.rustup.rs piped to sh) inside setup-rust-toolchain, the
+    # standard way every Rust CI bootstraps a toolchain. Flagging it
+    # here is noise until the ecosystem offers a checksummed install
+    # path.
+    actionsMustNotExecuteMutableRemoteCode:
+      enabled: false

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![The Changelog #363](https://img.shields.io/badge/The%20Changelog-%23363-61c192.svg)](https://changelog.com/podcast/363)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/nushell/nushell)](https://github.com/nushell/nushell/graphs/commit-activity)
 [![GitHub contributors](https://img.shields.io/github/contributors/nushell/nushell)](https://github.com/nushell/nushell/graphs/contributors)
+[![Plumber Score](https://score.getplumber.io/github.com/nushell/nushell.svg)](https://score.getplumber.io/github.com/nushell/nushell)
 
 A new type of shell.
 


### PR DESCRIPTION
## Description

Companion to https://github.com/nushell/nushell/pull/18787, merge that one first: the check added here flags the unpinned actions and the missing permission scopes until the hardening lands, then it goes green.

This adds [Plumber](https://github.com/getplumber/plumber) to CI, the tool I used to find those issues in the first place. It scans the workflows on each push to main and on each PR, and fails when something regresses: an unpinned action, a job without a permissions block, a secret handed to a workflow that does not need it, that kind of thing. The gate passes at 85 of 100 points, so one small finding does not block your PRs.

- `plumber.yml`: pinned by sha, minimal permissions, findings go to the Security tab as SARIF (skipped on PRs from forks, the report stays as a workflow artifact there).
- `.plumber.yaml`: a small overlay that inherits the tool's built-in baseline; only what differs for this repo is written. The Rust ecosystem tooling and release actions already in use are trusted on top of the curated default source list, and one control is off with a comment saying why: its only finding is rustup's own install script inside setup-rust-toolchain, which is how every Rust CI bootstraps a toolchain. Everything else, including new controls in future releases, follows the defaults automatically.
- `README.md`: one line, the score badge next to the existing ones.

## Score badge

I enabled `score-push` on the action. It works like OpenSSF Scorecard's published results: every run, on any branch, publishes the score to score.getplumber.io, and that feeds the badge in the README. Scores are public and the badge always shows the state of main. A failed publish never fails your CI. Until the first run the badge reads UNKNOWN in gray, then it flips to the grade. If you would rather not have it, drop the README line and the `score-push` input, the rest works the same.

With the hardening in, this runs green with a score of A. Set `soft-fail: true` if you prefer report only, without gating PRs.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, say so and I close this PR, the hardening PR stands on its own.

## User-facing changes (Release notes)

n/a (CI only)

## Tests + Formatting

Validated with the v0.4.29 release binary: with https://github.com/nushell/nushell/pull/18787 merged the check passes at A (100/100).

## After Submitting

n/a