### PR TITLE
fix improper cant convert error in path-relative-to

### DIFF
--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -1,7 +1,7 @@
 use super::PathSubcommandArguments;
 use nu_engine::command_prelude::*;
 use nu_path::expand_to_real_path;
-use nu_protocol::engine::StateWorkingSet;
+use nu_protocol::{engine::StateWorkingSet, shell_error::generic::GenericError};
 use std::path::Path;
 
 struct Arguments {
@@ -92,17 +92,24 @@ path."
         )
     }
 
-    #[cfg(windows)]
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {
                 description: "Find a relative path from two absolute paths.",
-                example: r"'C:\Users\viking' | path relative-to 'C:\Users'",
+                example: if cfg!(windows) {
+                    r"'C:\Users\viking' | path relative-to 'C:\Users'"
+                } else {
+                    "'/home/viking' | path relative-to '/home'"
+                },
                 result: Some(Value::test_string("viking")),
             },
             Example {
                 description: "Find a relative path from absolute paths in list.",
-                example: r"[ C:\Users\viking, C:\Users\spam ] | path relative-to C:\Users",
+                example: if cfg!(windows) {
+                    r"[ C:\Users\viking, C:\Users\spam ] | path relative-to C:\Users"
+                } else {
+                    "[ /home/viking, /home/spam ] | path relative-to '/home'"
+                },
                 result: Some(Value::test_list(vec![
                     Value::test_string("viking"),
                     Value::test_string("spam"),
@@ -110,31 +117,11 @@ path."
             },
             Example {
                 description: "Find a relative path from two relative paths.",
-                example: r"'eggs\bacon\sausage\spam' | path relative-to 'eggs\bacon\sausage'",
-                result: Some(Value::test_string("spam")),
-            },
-        ]
-    }
-
-    #[cfg(not(windows))]
-    fn examples(&self) -> Vec<Example<'_>> {
-        vec![
-            Example {
-                description: "Find a relative path from two absolute paths.",
-                example: "'/home/viking' | path relative-to '/home'",
-                result: Some(Value::test_string("viking")),
-            },
-            Example {
-                description: "Find a relative path from absolute paths in list.",
-                example: "[ /home/viking, /home/spam ] | path relative-to '/home'",
-                result: Some(Value::test_list(vec![
-                    Value::test_string("viking"),
-                    Value::test_string("spam"),
-                ])),
-            },
-            Example {
-                description: "Find a relative path from two relative paths.",
-                example: "'eggs/bacon/sausage/spam' | path relative-to 'eggs/bacon/sausage'",
+                example: if cfg!(windows) {
+                    r"'eggs\bacon\sausage\spam' | path relative-to 'eggs\bacon\sausage'"
+                } else {
+                    "'eggs/bacon/sausage/spam' | path relative-to 'eggs/bacon/sausage'"
+                },
                 result: Some(Value::test_string("spam")),
             },
         ]
@@ -156,12 +143,12 @@ fn relative_to(path: &Path, span: Span, args: &Arguments) -> Value {
             }
 
             Value::error(
-                ShellError::CantConvert {
-                    to_type: e.to_string(),
-                    from_type: "string".into(),
+                GenericError::new(
+                    String::from("The argument path is not a parent of the input path."),
+                    e.to_string(),
                     span,
-                    help: None,
-                },
+                )
+                .into(),
                 span,
             )
         }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
Then:
```nu
  × Can't convert to prefix not found.
   ╭─[repl_entry #11:1:1]
 1 │ "/home/pheenty/" | path relative-to "/home/pheenty/git"
   · ────────┬───────
   ·         ╰── can't convert string to prefix not found
```
Now:
```nu
  × The argument path is not a parent of the input path.
   ╭─[repl_entry #1:1:1]
 1 │ "/home/pheenty/" | path relative-to "/home/pheenty/git"
   · ────────┬───────
   ·         ╰── prefix not found
```

Also changed two huge and almost identical `#[cfg(windows)]` and `#[cfg(not(windows))]` code blocks to just have three `if cfg!(windows)` inside while at was at it

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
Fixed `path relative-to` providing improper error messages when its argument was not a parent of the input.

<!--
## Additional notes
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->