### PR TITLE
named parameters can pass null or omit parameter entirely for easier shadowing

### DIFF
--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -122,17 +122,10 @@ impl CallExt for ast::Call {
             // Signature-aware null: omit when the flag type does not accept nothing
             // (IR path does this in normalize_call_arguments before get_flag runs).
             if result.is_nothing() {
-                let signature = engine_state.get_decl(self.decl_id).signature();
-                // Long name first, then single-char short (parity with find_signature_flag).
-                let accepts = signature
+                let accepts = engine_state
+                    .get_decl(self.decl_id)
+                    .signature()
                     .get_long_flag(name)
-                    .or_else(|| {
-                        let mut chars = name.chars();
-                        match (chars.next(), chars.next()) {
-                            (Some(c), None) => signature.get_short_flag(c),
-                            _ => None,
-                        }
-                    })
                     .is_some_and(|flag| flag_type_accepts_nothing(&flag));
                 if !accepts {
                     return Ok(None);

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -86,11 +86,12 @@ impl CallExt for ast::Call {
         for name in self.named_iter() {
             if flag_name == name.0.item {
                 return if let Some(expr) = &name.2 {
-                    // Check --flag=false
+                    // Check --flag=false / --flag=null (null means omitted)
                     let stack = &mut stack.use_call_arg_out_dest();
                     let result = eval_expression::<WithoutDebug>(engine_state, stack, expr)?;
                     match result {
                         Value::Bool { val, .. } => Ok(val),
+                        Value::Nothing { .. } => Ok(false),
                         _ => Err(ShellError::CantConvert {
                             to_type: "bool".into(),
                             from_type: result.get_type().to_string(),
@@ -116,7 +117,11 @@ impl CallExt for ast::Call {
         if let Some(expr) = self.get_flag_expr(name) {
             let stack = &mut stack.use_call_arg_out_dest();
             let result = eval_expression::<WithoutDebug>(engine_state, stack, expr)?;
-            FromValue::from_value(result).map(Some)
+            if result.is_nothing() {
+                Ok(None)
+            } else {
+                FromValue::from_value(result).map(Some)
+            }
         } else {
             Ok(None)
         }
@@ -251,8 +256,11 @@ impl CallExt for ir::Call {
             .named_iter(stack)
             .find(|(name, _)| name.item == flag_name)
             .is_some_and(|(_, value)| {
-                // Handle --flag=false
-                !matches!(value, Some(Value::Bool { val: false, .. }))
+                // Handle --flag=false and --flag=null (null means omitted)
+                !matches!(
+                    value,
+                    Some(Value::Bool { val: false, .. }) | Some(Value::Nothing { .. })
+                )
             }))
     }
 
@@ -263,7 +271,12 @@ impl CallExt for ir::Call {
         name: &str,
     ) -> Result<Option<T>, ShellError> {
         if let Some(val) = self.get_named_arg(stack, name) {
-            T::from_value(val.clone()).map(Some)
+            // Null named values are treated as if the flag was not passed.
+            if val.is_nothing() {
+                Ok(None)
+            } else {
+                T::from_value(val.clone()).map(Some)
+            }
         } else {
             Ok(None)
         }

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -1,4 +1,5 @@
 use crate::eval_expression;
+use crate::named_flags::flag_type_accepts_nothing;
 use nu_protocol::{
     FromValue, ShellError, Span, Value, ast,
     debugger::WithoutDebug,
@@ -116,8 +117,18 @@ impl CallExt for ast::Call {
         if let Some(expr) = self.get_flag_expr(name) {
             let stack = &mut stack.use_call_arg_out_dest();
             let result = eval_expression::<WithoutDebug>(engine_state, stack, expr)?;
-            // Null may still appear here on AST-eval paths; conversion decides validity.
-            // IR path drops null first when the flag type does not accept nothing.
+            // Signature-aware null: omit when the flag type does not accept nothing
+            // (IR path does this in normalize_call_arguments before get_flag runs).
+            if result.is_nothing() {
+                let accepts = engine_state
+                    .get_decl(self.decl_id)
+                    .signature()
+                    .get_long_flag(name)
+                    .is_some_and(|flag| flag_type_accepts_nothing(&flag));
+                if !accepts {
+                    return Ok(None);
+                }
+            }
             FromValue::from_value(result).map(Some)
         } else {
             Ok(None)

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -122,10 +122,17 @@ impl CallExt for ast::Call {
             // Signature-aware null: omit when the flag type does not accept nothing
             // (IR path does this in normalize_call_arguments before get_flag runs).
             if result.is_nothing() {
-                let accepts = engine_state
-                    .get_decl(self.decl_id)
-                    .signature()
+                let signature = engine_state.get_decl(self.decl_id).signature();
+                // Long name first, then single-char short (parity with find_signature_flag).
+                let accepts = signature
                     .get_long_flag(name)
+                    .or_else(|| {
+                        let mut chars = name.chars();
+                        match (chars.next(), chars.next()) {
+                            (Some(c), None) => signature.get_short_flag(c),
+                            _ => None,
+                        }
+                    })
                     .is_some_and(|flag| flag_type_accepts_nothing(&flag));
                 if !accepts {
                     return Ok(None);

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -86,12 +86,11 @@ impl CallExt for ast::Call {
         for name in self.named_iter() {
             if flag_name == name.0.item {
                 return if let Some(expr) = &name.2 {
-                    // Check --flag=false / --flag=null (null means omitted)
+                    // Check --flag=false
                     let stack = &mut stack.use_call_arg_out_dest();
                     let result = eval_expression::<WithoutDebug>(engine_state, stack, expr)?;
                     match result {
                         Value::Bool { val, .. } => Ok(val),
-                        Value::Nothing { .. } => Ok(false),
                         _ => Err(ShellError::CantConvert {
                             to_type: "bool".into(),
                             from_type: result.get_type().to_string(),
@@ -117,11 +116,9 @@ impl CallExt for ast::Call {
         if let Some(expr) = self.get_flag_expr(name) {
             let stack = &mut stack.use_call_arg_out_dest();
             let result = eval_expression::<WithoutDebug>(engine_state, stack, expr)?;
-            if result.is_nothing() {
-                Ok(None)
-            } else {
-                FromValue::from_value(result).map(Some)
-            }
+            // Null may still appear here on AST-eval paths; conversion decides validity.
+            // IR path drops null first when the flag type does not accept nothing.
+            FromValue::from_value(result).map(Some)
         } else {
             Ok(None)
         }
@@ -256,11 +253,8 @@ impl CallExt for ir::Call {
             .named_iter(stack)
             .find(|(name, _)| name.item == flag_name)
             .is_some_and(|(_, value)| {
-                // Handle --flag=false and --flag=null (null means omitted)
-                !matches!(
-                    value,
-                    Some(Value::Bool { val: false, .. }) | Some(Value::Nothing { .. })
-                )
+                // Handle --flag=false
+                !matches!(value, Some(Value::Bool { val: false, .. }))
             }))
     }
 
@@ -270,13 +264,10 @@ impl CallExt for ir::Call {
         stack: &mut Stack,
         name: &str,
     ) -> Result<Option<T>, ShellError> {
+        // Null flags that are not type-accepted are dropped in normalize_call_arguments.
+        // Remaining null values are intentional (flag type accepts nothing).
         if let Some(val) = self.get_named_arg(stack, name) {
-            // Null named values are treated as if the flag was not passed.
-            if val.is_nothing() {
-                Ok(None)
-            } else {
-                T::from_value(val.clone()).map(Some)
-            }
+            T::from_value(val.clone()).map(Some)
         } else {
             Ok(None)
         }

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -92,6 +92,8 @@ impl CallExt for ast::Call {
                     let result = eval_expression::<WithoutDebug>(engine_state, stack, expr)?;
                     match result {
                         Value::Bool { val, .. } => Ok(val),
+                        // Null means unset (same as IR null-omit for switches).
+                        Value::Nothing { .. } => Ok(false),
                         _ => Err(ShellError::CantConvert {
                             to_type: "bool".into(),
                             from_type: result.get_type().to_string(),
@@ -264,8 +266,11 @@ impl CallExt for ir::Call {
             .named_iter(stack)
             .find(|(name, _)| name.item == flag_name)
             .is_some_and(|(_, value)| {
-                // Handle --flag=false
-                !matches!(value, Some(Value::Bool { val: false, .. }))
+                // Handle --flag=false and residual null (treat as unset).
+                !matches!(
+                    value,
+                    Some(Value::Bool { val: false, .. }) | Some(Value::Nothing { .. })
+                )
             }))
     }
 

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -92,8 +92,6 @@ impl CallExt for ast::Call {
                     let result = eval_expression::<WithoutDebug>(engine_state, stack, expr)?;
                     match result {
                         Value::Bool { val, .. } => Ok(val),
-                        // Null means unset (same as IR null-omit for switches).
-                        Value::Nothing { .. } => Ok(false),
                         _ => Err(ShellError::CantConvert {
                             to_type: "bool".into(),
                             from_type: result.get_type().to_string(),
@@ -266,11 +264,8 @@ impl CallExt for ir::Call {
             .named_iter(stack)
             .find(|(name, _)| name.item == flag_name)
             .is_some_and(|(_, value)| {
-                // Handle --flag=false and residual null (treat as unset).
-                !matches!(
-                    value,
-                    Some(Value::Bool { val: false, .. }) | Some(Value::Nothing { .. })
-                )
+                // Handle --flag=false
+                !matches!(value, Some(Value::Bool { val: false, .. }))
             }))
     }
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1,13 +1,18 @@
 #[allow(deprecated)]
 use crate::get_full_help;
+use crate::named_flags::{expand_flag_record, flag_type_accepts_nothing};
 use crate::{EvalBlockWithEarlyReturnFn, eval_ir::eval_ir_block};
 use nu_protocol::{
     BlockId, CompareTypes, Config, ENV_VARIABLE_ID, IntoPipelineData, PipelineData,
-    PipelineExecutionData, ShellError, Signature, Span, Type, Value, VarId,
-    ast::{Assignment, Block, Call, Expr, Expression, ExternalArgument, PathMember},
+    PipelineExecutionData, ShellError, Signature, Span, Value, VarId,
+    ast::{
+        Argument as AstArgument, Assignment, Block, Call, Expr, Expression, ExternalArgument,
+        PathMember,
+    },
     debugger::{DebugContext, WithDebug, WithoutDebug},
-    engine::{Closure, EngineState, EnvName, EnvVars, Stack},
+    engine::{Argument as EngineArgument, Closure, EngineState, EnvName, EnvVars, Stack},
     eval_base::Eval,
+    shell_error::generic::GenericError,
 };
 use nu_utils::IgnoreCaseExt;
 use std::borrow::Cow;
@@ -327,43 +332,92 @@ pub fn eval_call<D: DebugContext>(
             block.span.unwrap_or(Span::unknown()),
             eval_block_with_early_return::<D>,
         );
-        for arg in call.positional_iter() {
-            let result = eval_expression::<D>(engine_state, caller_stack, arg)?;
-            call_eval.add_positional(&decl.signature(), Cow::Owned(result))?;
-        }
         let signature = decl.signature();
-        for call_named in call.named_iter() {
-            let result: Option<Cow<Value>> = if let Some(arg) = &call_named.2 {
-                let value = eval_expression::<D>(engine_state, caller_stack, arg)?;
-                // Null → omit unless the flag type accepts `nothing` (same as IR normalize).
-                if value.is_nothing() {
-                    let accepts_nothing = signature
-                        .get_long_flag(&call_named.0.item)
-                        .or_else(|| {
-                            call_named
-                                .1
-                                .as_ref()
-                                .and_then(|s| s.item.chars().next())
-                                .and_then(|c| signature.get_short_flag(c))
-                        })
-                        .is_some_and(|flag| match &flag.arg {
-                            Some(shape) => Type::Nothing.is_assignable_to(&shape.to_type()),
-                            None => false,
-                        });
-                    if !accepts_nothing {
-                        continue;
+        // Walk all arguments in order so record/list spreads interleave with positionals/flags
+        // the same way the IR path does after normalize_call_arguments.
+        for arg in &call.arguments {
+            match arg {
+                AstArgument::Positional(expr) | AstArgument::Unknown(expr) => {
+                    let result = eval_expression::<D>(engine_state, caller_stack, expr)?;
+                    call_eval.add_positional(&signature, Cow::Owned(result))?;
+                }
+                AstArgument::Named((long, short, maybe_expr)) => {
+                    let result: Option<Cow<Value>> = if let Some(expr) = maybe_expr {
+                        let value = eval_expression::<D>(engine_state, caller_stack, expr)?;
+                        if value.is_nothing() {
+                            let accepts_nothing = signature
+                                .get_long_flag(&long.item)
+                                .or_else(|| {
+                                    short
+                                        .as_ref()
+                                        .and_then(|s| s.item.chars().next())
+                                        .and_then(|c| signature.get_short_flag(c))
+                                })
+                                .is_some_and(|flag| flag_type_accepts_nothing(&flag));
+                            if !accepts_nothing {
+                                continue;
+                            }
+                        }
+                        Some(Cow::Owned(value))
+                    } else {
+                        None
+                    };
+                    call_eval.add_named(
+                        &signature,
+                        &long.item,
+                        short.as_ref().map(|s| s.item.clone()),
+                        result,
+                    )?;
+                }
+                AstArgument::Spread(expr) => {
+                    let val = eval_expression::<D>(engine_state, caller_stack, expr)?;
+                    match val {
+                        Value::Record { val, .. } => {
+                            for engine_arg in
+                                expand_flag_record(&signature, val.into_owned(), expr.span)?
+                            {
+                                match engine_arg {
+                                    EngineArgument::Flag { data, name, .. } => {
+                                        let long =
+                                            std::str::from_utf8(&data[name]).unwrap_or_default();
+                                        call_eval.add_named(&signature, long, None, None)?;
+                                    }
+                                    EngineArgument::Named {
+                                        data, name, val, ..
+                                    } => {
+                                        let long =
+                                            std::str::from_utf8(&data[name]).unwrap_or_default();
+                                        call_eval.add_named(
+                                            &signature,
+                                            long,
+                                            None,
+                                            Some(Cow::Owned(val)),
+                                        )?;
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                        Value::List { vals, .. } => {
+                            if signature.rest_positional.is_none() && !signature.allows_unknown_args
+                            {
+                                return Err(ShellError::Generic(GenericError::new(
+                                    "Cannot spread a list into this command",
+                                    "This command has no ...rest parameter to receive a list spread. Use a record to spread named flags, e.g. ...{flag: value}",
+                                    expr.span,
+                                )));
+                            }
+                            for v in vals {
+                                call_eval.add_positional(&signature, Cow::Owned(v))?;
+                            }
+                        }
+                        Value::Nothing { .. } => {}
+                        other => {
+                            return Err(ShellError::CannotSpreadAsList { span: other.span() });
+                        }
                     }
                 }
-                Some(Cow::Owned(value))
-            } else {
-                None
-            };
-            call_eval.add_named(
-                &signature,
-                &call_named.0.item,
-                call_named.1.clone().map(|x| x.item),
-                result,
-            )?;
+            }
         }
 
         let result = call_eval.run(engine_state, block, input);

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -2,7 +2,7 @@
 use crate::get_full_help;
 use crate::named_flags::{
     data_from_name_and_short, expand_flag_record, flag_type_accepts_nothing,
-    list_spread_before_required_error, normalize_engine_arguments,
+    list_spread_before_required_error, long_short_from_data, normalize_engine_arguments,
 };
 use crate::{EvalBlockWithEarlyReturnFn, eval_ir::eval_ir_block};
 use nu_protocol::{
@@ -164,9 +164,18 @@ impl CallEval {
     }
 
     /// Mark rest mode without adding values (null list spread; IR `always_spread` parity).
-    pub fn add_null_spread(&mut self) -> &mut Self {
+    ///
+    /// Errors if required positionals are still unbound (same rule as list spreads).
+    pub fn add_null_spread(
+        &mut self,
+        signature: &Signature,
+        spread_span: Span,
+    ) -> Result<&mut Self, ShellError> {
+        if self.arg_index < signature.required_positional.len() && !self.always_spread {
+            return Err(list_spread_before_required_error(spread_span));
+        }
         self.always_spread = true;
-        self
+        Ok(self)
     }
 
     /// Add a named parameter to the call stack.
@@ -430,23 +439,8 @@ pub fn eval_call<D: DebugContext>(
                                     EngineArgument::Flag {
                                         data, name, short, ..
                                     } => {
-                                        let long = std::str::from_utf8(&data[name]).map_err(
-                                            |_| ShellError::Generic(GenericError::new(
-                                                "Invalid flag name encoding",
-                                                "flag long name is not valid UTF-8",
-                                                expr.span,
-                                            )),
-                                        )?;
-                                        let short_str = std::str::from_utf8(&data[short])
-                                            .map_err(|_| {
-                                                ShellError::Generic(GenericError::new(
-                                                    "Invalid flag name encoding",
-                                                    "flag short name is not valid UTF-8",
-                                                    expr.span,
-                                                ))
-                                            })?;
-                                        let short =
-                                            (!short_str.is_empty()).then(|| short_str.to_string());
+                                        let (long, short) =
+                                            long_short_from_data(&data, name, short, expr.span)?;
                                         call_eval.add_named(&signature, long, short, None)?;
                                     }
                                     EngineArgument::Named {
@@ -456,29 +450,18 @@ pub fn eval_call<D: DebugContext>(
                                         val,
                                         ..
                                     } => {
-                                        let long = std::str::from_utf8(&data[name]).map_err(
-                                            |_| ShellError::Generic(GenericError::new(
-                                                "Invalid flag name encoding",
-                                                "flag long name is not valid UTF-8",
-                                                expr.span,
-                                            )),
-                                        )?;
-                                        let short_str = std::str::from_utf8(&data[short])
-                                            .map_err(|_| {
-                                                ShellError::Generic(GenericError::new(
-                                                    "Invalid flag name encoding",
-                                                    "flag short name is not valid UTF-8",
-                                                    expr.span,
-                                                ))
-                                            })?;
-                                        let short =
-                                            (!short_str.is_empty()).then(|| short_str.to_string());
+                                        let (long, short) =
+                                            long_short_from_data(&data, name, short, expr.span)?;
                                         call_eval.add_named(
                                             &signature,
                                             long,
                                             short,
                                             Some(Cow::Owned(val)),
                                         )?;
+                                    }
+                                    // Unknown keys under allows_unknown_args become positionals.
+                                    EngineArgument::Positional { val, .. } => {
+                                        call_eval.add_positional(&signature, Cow::Owned(val))?;
                                     }
                                     _ => {}
                                 }
@@ -493,16 +476,13 @@ pub fn eval_call<D: DebugContext>(
                                     expr.span,
                                 )));
                             }
-                            call_eval.add_list_spread(
-                                &signature,
-                                vals.into_owned(),
-                                expr.span,
-                            )?;
+                            call_eval.add_list_spread(&signature, vals.into_owned(), expr.span)?;
                         }
                         // Null spread: rest mode only (IR parity).
                         Value::Nothing { .. } => {
-                            call_eval.add_null_spread();
+                            call_eval.add_null_spread(&signature, expr.span)?;
                         }
+                        Value::Error { error, .. } => return Err(*error),
                         other => {
                             return Err(ShellError::CannotSpreadAsList { span: other.span() });
                         }
@@ -545,6 +525,7 @@ fn eval_ast_builtin_with_spreads<D: DebugContext>(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let signature = decl.signature();
+    let keep_ast = decl.requires_ast_for_arguments();
     let mut raw = Vec::with_capacity(call.arguments.len());
 
     for arg in &call.arguments {
@@ -554,7 +535,7 @@ fn eval_ast_builtin_with_spreads<D: DebugContext>(
                 raw.push(EngineArgument::Positional {
                     span: expr.span,
                     val,
-                    ast: None,
+                    ast: keep_ast.then(|| Arc::new(expr.clone())),
                 });
             }
             AstArgument::Named((long, short, maybe_expr)) => {
@@ -569,7 +550,7 @@ fn eval_ast_builtin_with_spreads<D: DebugContext>(
                         short: short_slice,
                         span: long.span,
                         val,
-                        ast: None,
+                        ast: keep_ast.then(|| Arc::new(expr.clone())),
                     });
                 } else {
                     raw.push(EngineArgument::Flag {
@@ -585,7 +566,7 @@ fn eval_ast_builtin_with_spreads<D: DebugContext>(
                 raw.push(EngineArgument::Spread {
                     vals,
                     span: expr.span,
-                    ast: None,
+                    ast: keep_ast.then(|| Arc::new(expr.clone())),
                 });
             }
         }
@@ -611,7 +592,7 @@ fn eval_ast_builtin_with_spreads<D: DebugContext>(
                 required_left = required_left.saturating_sub(1);
             }
             EngineArgument::Spread {
-                vals: Value::List { .. },
+                vals: Value::List { .. } | Value::Nothing { .. },
                 span,
                 ..
             } if required_left > 0 && !always_spread => {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1,8 +1,7 @@
 #[allow(deprecated)]
 use crate::get_full_help;
 use crate::named_flags::{
-    data_from_name_and_short, expand_flag_record, flag_type_accepts_nothing,
-    list_spread_before_required_error, long_short_from_data, normalize_engine_arguments,
+    expand_flag_record, flag_type_accepts_nothing, list_spread_before_required_error,
 };
 use crate::{EvalBlockWithEarlyReturnFn, eval_ir::eval_ir_block};
 use nu_protocol::{
@@ -15,7 +14,6 @@ use nu_protocol::{
     debugger::{DebugContext, WithDebug, WithoutDebug},
     engine::{Argument as EngineArgument, Closure, EngineState, EnvName, EnvVars, Stack},
     eval_base::Eval,
-    ir,
     shell_error::generic::GenericError,
 };
 use nu_utils::IgnoreCaseExt;
@@ -406,12 +404,6 @@ pub fn eval_call<D: DebugContext>(
                         if value.is_nothing() {
                             let accepts_nothing = signature
                                 .get_long_flag(&long.item)
-                                .or_else(|| {
-                                    short
-                                        .as_ref()
-                                        .and_then(|s| s.item.chars().next())
-                                        .and_then(|c| signature.get_short_flag(c))
-                                })
                                 .is_some_and(|flag| flag_type_accepts_nothing(&flag));
                             if !accepts_nothing {
                                 continue;
@@ -428,6 +420,8 @@ pub fn eval_call<D: DebugContext>(
                         result,
                     )?;
                 }
+                // Light AST support: expand long-key record flag spreads; rest list/null spreads.
+                // Builtins/plugins use the IR path (normalize_engine_arguments) in normal scripts.
                 AstArgument::Spread(expr) => {
                     let val = eval_expression::<D>(engine_state, caller_stack, expr)?;
                     match val {
@@ -439,8 +433,12 @@ pub fn eval_call<D: DebugContext>(
                                     EngineArgument::Flag {
                                         data, name, short, ..
                                     } => {
-                                        let (long, short) =
-                                            long_short_from_data(&data, name, short, expr.span)?;
+                                        let long =
+                                            std::str::from_utf8(&data[name]).unwrap_or_default();
+                                        let short_str =
+                                            std::str::from_utf8(&data[short]).unwrap_or_default();
+                                        let short =
+                                            (!short_str.is_empty()).then(|| short_str.to_string());
                                         call_eval.add_named(&signature, long, short, None)?;
                                     }
                                     EngineArgument::Named {
@@ -450,18 +448,18 @@ pub fn eval_call<D: DebugContext>(
                                         val,
                                         ..
                                     } => {
-                                        let (long, short) =
-                                            long_short_from_data(&data, name, short, expr.span)?;
+                                        let long =
+                                            std::str::from_utf8(&data[name]).unwrap_or_default();
+                                        let short_str =
+                                            std::str::from_utf8(&data[short]).unwrap_or_default();
+                                        let short =
+                                            (!short_str.is_empty()).then(|| short_str.to_string());
                                         call_eval.add_named(
                                             &signature,
                                             long,
                                             short,
                                             Some(Cow::Owned(val)),
                                         )?;
-                                    }
-                                    // Unknown keys under allows_unknown_args become positionals.
-                                    EngineArgument::Positional { val, .. } => {
-                                        call_eval.add_positional(&signature, Cow::Owned(val))?;
                                     }
                                     _ => {}
                                 }
@@ -478,7 +476,6 @@ pub fn eval_call<D: DebugContext>(
                             }
                             call_eval.add_list_spread(&signature, vals.into_owned(), expr.span)?;
                         }
-                        // Null spread: rest mode only (IR parity).
                         Value::Nothing { .. } => {
                             call_eval.add_null_spread(&signature, expr.span)?;
                         }
@@ -498,124 +495,10 @@ pub fn eval_call<D: DebugContext>(
         }
 
         result
-    } else if call
-        .arguments
-        .iter()
-        .any(|a| matches!(a, AstArgument::Spread(_)))
-    {
-        // Builtin/plugin path with record/list spreads: evaluate into engine args, normalize
-        // (expand records, null-omit), then run via IR `Call` so `CallExt` sees expanded flags.
-        eval_ast_builtin_with_spreads::<D>(engine_state, caller_stack, call, decl, input)
     } else {
-        // call is a builtin or external command without spreads
-        // We pass caller_stack here with the knowledge that internal commands
-        // are going to be specifically looking for global state in the stack
-        // rather than any local state.
+        // Builtin or external: IR evaluation path normalizes flags/spreads for normal scripts.
         decl.run(engine_state, caller_stack, &call.into(), input)
     }
-}
-
-/// Evaluate AST call arguments into engine arguments, normalize flag spreads/nulls, and run a
-/// builtin/plugin via an IR [`ir::Call`].
-fn eval_ast_builtin_with_spreads<D: DebugContext>(
-    engine_state: &EngineState,
-    caller_stack: &mut Stack,
-    call: &Call,
-    decl: &dyn nu_protocol::engine::Command,
-    input: PipelineData,
-) -> Result<PipelineData, ShellError> {
-    let signature = decl.signature();
-    let keep_ast = decl.requires_ast_for_arguments();
-    let mut raw = Vec::with_capacity(call.arguments.len());
-
-    for arg in &call.arguments {
-        match arg {
-            AstArgument::Positional(expr) | AstArgument::Unknown(expr) => {
-                let val = eval_expression::<D>(engine_state, caller_stack, expr)?;
-                raw.push(EngineArgument::Positional {
-                    span: expr.span,
-                    val,
-                    ast: keep_ast.then(|| Arc::new(expr.clone())),
-                });
-            }
-            AstArgument::Named((long, short, maybe_expr)) => {
-                let short_str = short.as_ref().map(|s| s.item.as_str()).unwrap_or("");
-                let (data, name_slice, short_slice) =
-                    data_from_name_and_short(&long.item, short_str);
-                if let Some(expr) = maybe_expr {
-                    let val = eval_expression::<D>(engine_state, caller_stack, expr)?;
-                    raw.push(EngineArgument::Named {
-                        data,
-                        name: name_slice,
-                        short: short_slice,
-                        span: long.span,
-                        val,
-                        ast: keep_ast.then(|| Arc::new(expr.clone())),
-                    });
-                } else {
-                    raw.push(EngineArgument::Flag {
-                        data,
-                        name: name_slice,
-                        short: short_slice,
-                        span: long.span,
-                    });
-                }
-            }
-            AstArgument::Spread(expr) => {
-                let vals = eval_expression::<D>(engine_state, caller_stack, expr)?;
-                raw.push(EngineArgument::Spread {
-                    vals,
-                    span: expr.span,
-                    ast: keep_ast.then(|| Arc::new(expr.clone())),
-                });
-            }
-        }
-    }
-
-    for (name, expr) in &call.parser_info {
-        let (data, name_slice, _) = data_from_name_and_short(name, "");
-        raw.push(EngineArgument::ParserInfo {
-            data,
-            name: name_slice,
-            info: Box::new(expr.clone()),
-        });
-    }
-
-    let expanded = normalize_engine_arguments(&signature, raw)?;
-
-    // Reject list spreads that would leave required positionals unbound (same rule as IR).
-    let mut required_left = signature.required_positional.len();
-    let mut always_spread = false;
-    for arg in &expanded {
-        match arg {
-            EngineArgument::Positional { .. } if !always_spread && required_left > 0 => {
-                required_left = required_left.saturating_sub(1);
-            }
-            EngineArgument::Spread {
-                vals: Value::List { .. } | Value::Nothing { .. },
-                span,
-                ..
-            } if required_left > 0 && !always_spread => {
-                return Err(list_spread_before_required_error(*span));
-            }
-            EngineArgument::Spread {
-                vals: Value::List { .. } | Value::Nothing { .. },
-                ..
-            } => {
-                always_spread = true;
-            }
-            _ => {}
-        }
-    }
-
-    let mut builder = ir::Call::build(call.decl_id, call.head);
-    for arg in expanded {
-        builder.add_argument(caller_stack, arg);
-    }
-    let ir_call = builder.finish();
-    let result = decl.run(engine_state, caller_stack, &(&ir_call).into(), input);
-    ir_call.leave(caller_stack);
-    result
 }
 
 /// Redirect the environment from callee to the caller.

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -377,20 +377,34 @@ pub fn eval_call<D: DebugContext>(
                                 expand_flag_record(&signature, val.into_owned(), expr.span)?
                             {
                                 match engine_arg {
-                                    EngineArgument::Flag { data, name, .. } => {
-                                        let long =
-                                            std::str::from_utf8(&data[name]).unwrap_or_default();
-                                        call_eval.add_named(&signature, long, None, None)?;
-                                    }
-                                    EngineArgument::Named {
-                                        data, name, val, ..
+                                    EngineArgument::Flag {
+                                        data, name, short, ..
                                     } => {
                                         let long =
                                             std::str::from_utf8(&data[name]).unwrap_or_default();
+                                        let short_str =
+                                            std::str::from_utf8(&data[short]).unwrap_or_default();
+                                        let short =
+                                            (!short_str.is_empty()).then(|| short_str.to_string());
+                                        call_eval.add_named(&signature, long, short, None)?;
+                                    }
+                                    EngineArgument::Named {
+                                        data,
+                                        name,
+                                        short,
+                                        val,
+                                        ..
+                                    } => {
+                                        let long =
+                                            std::str::from_utf8(&data[name]).unwrap_or_default();
+                                        let short_str =
+                                            std::str::from_utf8(&data[short]).unwrap_or_default();
+                                        let short =
+                                            (!short_str.is_empty()).then(|| short_str.to_string());
                                         call_eval.add_named(
                                             &signature,
                                             long,
-                                            None,
+                                            short,
                                             Some(Cow::Owned(val)),
                                         )?;
                                     }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -333,11 +333,12 @@ pub fn eval_call<D: DebugContext>(
         }
         for call_named in call.named_iter() {
             let result: Option<Cow<Value>> = if let Some(arg) = &call_named.2 {
-                Some(Cow::Owned(eval_expression::<D>(
-                    engine_state,
-                    caller_stack,
-                    arg,
-                )?))
+                let value = eval_expression::<D>(engine_state, caller_stack, arg)?;
+                // Null means omit the flag (same as IR PushNamed).
+                if value.is_nothing() {
+                    continue;
+                }
+                Some(Cow::Owned(value))
             } else {
                 None
             };

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -3,7 +3,7 @@ use crate::get_full_help;
 use crate::{EvalBlockWithEarlyReturnFn, eval_ir::eval_ir_block};
 use nu_protocol::{
     BlockId, CompareTypes, Config, ENV_VARIABLE_ID, IntoPipelineData, PipelineData,
-    PipelineExecutionData, ShellError, Signature, Span, Value, VarId,
+    PipelineExecutionData, ShellError, Signature, Span, Type, Value, VarId,
     ast::{Assignment, Block, Call, Expr, Expression, ExternalArgument, PathMember},
     debugger::{DebugContext, WithDebug, WithoutDebug},
     engine::{Closure, EngineState, EnvName, EnvVars, Stack},
@@ -331,19 +331,35 @@ pub fn eval_call<D: DebugContext>(
             let result = eval_expression::<D>(engine_state, caller_stack, arg)?;
             call_eval.add_positional(&decl.signature(), Cow::Owned(result))?;
         }
+        let signature = decl.signature();
         for call_named in call.named_iter() {
             let result: Option<Cow<Value>> = if let Some(arg) = &call_named.2 {
                 let value = eval_expression::<D>(engine_state, caller_stack, arg)?;
-                // Null means omit the flag (same as IR PushNamed).
+                // Null → omit unless the flag type accepts `nothing` (same as IR normalize).
                 if value.is_nothing() {
-                    continue;
+                    let accepts_nothing = signature
+                        .get_long_flag(&call_named.0.item)
+                        .or_else(|| {
+                            call_named
+                                .1
+                                .as_ref()
+                                .and_then(|s| s.item.chars().next())
+                                .and_then(|c| signature.get_short_flag(c))
+                        })
+                        .is_some_and(|flag| match &flag.arg {
+                            Some(shape) => Type::Nothing.is_assignable_to(&shape.to_type()),
+                            None => false,
+                        });
+                    if !accepts_nothing {
+                        continue;
+                    }
                 }
                 Some(Cow::Owned(value))
             } else {
                 None
             };
             call_eval.add_named(
-                &decl.signature(),
+                &signature,
                 &call_named.0.item,
                 call_named.1.clone().map(|x| x.item),
                 result,

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1,6 +1,9 @@
 #[allow(deprecated)]
 use crate::get_full_help;
-use crate::named_flags::{expand_flag_record, flag_type_accepts_nothing};
+use crate::named_flags::{
+    data_from_name_and_short, expand_flag_record, flag_type_accepts_nothing,
+    list_spread_before_required_error, normalize_engine_arguments,
+};
 use crate::{EvalBlockWithEarlyReturnFn, eval_ir::eval_ir_block};
 use nu_protocol::{
     BlockId, CompareTypes, Config, ENV_VARIABLE_ID, IntoPipelineData, PipelineData,
@@ -12,6 +15,7 @@ use nu_protocol::{
     debugger::{DebugContext, WithDebug, WithoutDebug},
     engine::{Argument as EngineArgument, Closure, EngineState, EnvName, EnvVars, Stack},
     eval_base::Eval,
+    ir,
     shell_error::generic::GenericError,
 };
 use nu_utils::IgnoreCaseExt;
@@ -36,8 +40,11 @@ pub struct CallEval {
     head_span: Span,
     callee_span: Span,
     arg_index: usize,
-    named_args: Vec<String>,
+    /// Provided named flags, tracked by `var_id` so short-only flags (empty long name) do not collide.
+    provided_named_var_ids: Vec<VarId>,
     rest_args: Vec<Value>,
+    /// After a list/null rest spread, further positionals go to rest (matches IR `always_spread`).
+    always_spread: bool,
     eval: EvalBlockWithEarlyReturnFn,
 }
 
@@ -54,8 +61,9 @@ impl CallEval {
             head_span: call_head,
             callee_span,
             arg_index: 0,
-            named_args: Vec::new(),
+            provided_named_var_ids: Vec::new(),
             rest_args: Vec::new(),
+            always_spread: false,
             eval,
         }
     }
@@ -69,6 +77,11 @@ impl CallEval {
         signature: &Signature,
         value: Cow<Value>,
     ) -> Result<&mut Self, ShellError> {
+        // After a rest spread, further positionals always go to rest (IR parity).
+        if self.always_spread {
+            return self.push_rest(signature, value);
+        }
+
         let maybe_param = match self
             .arg_index
             .checked_sub(signature.required_positional.len())
@@ -101,27 +114,59 @@ impl CallEval {
             self.arg_index += 1;
             Ok(self)
         } else {
-            // assign arg to rest params
-            let Some(rest_positional) = &signature.rest_positional else {
-                // We do not consider it an error if more arguments
-                // are added than the closure takes. This makes it possible
-                // to omit any unused arguments in the closure definition.
-                return Ok(self);
-            };
-
-            let param_type = rest_positional.shape.to_type();
-            if !value.is_subtype_of(&param_type) {
-                return Err(ShellError::CantConvert {
-                    to_type: param_type.to_string(),
-                    from_type: value.get_type().to_string(),
-                    span: value.span(),
-                    help: None,
-                });
-            }
-
-            self.rest_args.push(value.into_owned());
-            Ok(self)
+            self.push_rest(signature, value)
         }
+    }
+
+    fn push_rest(
+        &mut self,
+        signature: &Signature,
+        value: Cow<Value>,
+    ) -> Result<&mut Self, ShellError> {
+        let Some(rest_positional) = &signature.rest_positional else {
+            // We do not consider it an error if more arguments
+            // are added than the closure takes. This makes it possible
+            // to omit any unused arguments in the closure definition.
+            return Ok(self);
+        };
+
+        let param_type = rest_positional.shape.to_type();
+        if !value.is_subtype_of(&param_type) {
+            return Err(ShellError::CantConvert {
+                to_type: param_type.to_string(),
+                from_type: value.get_type().to_string(),
+                span: value.span(),
+                help: None,
+            });
+        }
+
+        self.rest_args.push(value.into_owned());
+        Ok(self)
+    }
+
+    /// Spread a list into rest arguments (IR parity: does not fill positionals).
+    ///
+    /// Errors if required positionals are still unbound.
+    pub fn add_list_spread(
+        &mut self,
+        signature: &Signature,
+        vals: Vec<Value>,
+        spread_span: Span,
+    ) -> Result<&mut Self, ShellError> {
+        if self.arg_index < signature.required_positional.len() && !self.always_spread {
+            return Err(list_spread_before_required_error(spread_span));
+        }
+        for v in vals {
+            self.push_rest(signature, Cow::Owned(v))?;
+        }
+        self.always_spread = true;
+        Ok(self)
+    }
+
+    /// Mark rest mode without adding values (null list spread; IR `always_spread` parity).
+    pub fn add_null_spread(&mut self) -> &mut Self {
+        self.always_spread = true;
+        self
     }
 
     /// Add a named parameter to the call stack.
@@ -132,8 +177,9 @@ impl CallEval {
         short: Option<String>,
         value: Option<Cow<Value>>,
     ) -> Result<&mut Self, ShellError> {
+        // Match non-empty long first; never match empty long against short-only flags by name alone.
         let named = signature.named.iter().find(|named| {
-            long == named.long
+            (!long.is_empty() && long == named.long)
                 || short
                     .as_deref()
                     .zip(named.short)
@@ -153,7 +199,7 @@ impl CallEval {
                 .unwrap_or_else(|| Cow::Owned(Value::bool(true, self.head_span)));
 
             self.callee_stack.add_var(var_id, value.into_owned());
-            self.named_args.push(long.to_string());
+            self.provided_named_var_ids.push(var_id);
         }
 
         Ok(self)
@@ -270,8 +316,12 @@ impl CallEval {
         let remaining_flags = signature
             .named
             .iter()
-            // Skip provided flags
-            .filter(|flag| !self.named_args.contains(&flag.long))
+            // Skip provided flags (by var_id so short-only flags work)
+            .filter(|flag| {
+                !flag
+                    .var_id
+                    .is_some_and(|id| self.provided_named_var_ids.contains(&id))
+            })
             // Ignore named arguments without var_id.
             // There is some code in nu_cli::completions that relies on this behavior of `eval_call`.
             .filter_map(|flag| Some((flag.var_id?, flag)));
@@ -380,10 +430,21 @@ pub fn eval_call<D: DebugContext>(
                                     EngineArgument::Flag {
                                         data, name, short, ..
                                     } => {
-                                        let long =
-                                            std::str::from_utf8(&data[name]).unwrap_or_default();
-                                        let short_str =
-                                            std::str::from_utf8(&data[short]).unwrap_or_default();
+                                        let long = std::str::from_utf8(&data[name]).map_err(
+                                            |_| ShellError::Generic(GenericError::new(
+                                                "Invalid flag name encoding",
+                                                "flag long name is not valid UTF-8",
+                                                expr.span,
+                                            )),
+                                        )?;
+                                        let short_str = std::str::from_utf8(&data[short])
+                                            .map_err(|_| {
+                                                ShellError::Generic(GenericError::new(
+                                                    "Invalid flag name encoding",
+                                                    "flag short name is not valid UTF-8",
+                                                    expr.span,
+                                                ))
+                                            })?;
                                         let short =
                                             (!short_str.is_empty()).then(|| short_str.to_string());
                                         call_eval.add_named(&signature, long, short, None)?;
@@ -395,10 +456,21 @@ pub fn eval_call<D: DebugContext>(
                                         val,
                                         ..
                                     } => {
-                                        let long =
-                                            std::str::from_utf8(&data[name]).unwrap_or_default();
-                                        let short_str =
-                                            std::str::from_utf8(&data[short]).unwrap_or_default();
+                                        let long = std::str::from_utf8(&data[name]).map_err(
+                                            |_| ShellError::Generic(GenericError::new(
+                                                "Invalid flag name encoding",
+                                                "flag long name is not valid UTF-8",
+                                                expr.span,
+                                            )),
+                                        )?;
+                                        let short_str = std::str::from_utf8(&data[short])
+                                            .map_err(|_| {
+                                                ShellError::Generic(GenericError::new(
+                                                    "Invalid flag name encoding",
+                                                    "flag short name is not valid UTF-8",
+                                                    expr.span,
+                                                ))
+                                            })?;
                                         let short =
                                             (!short_str.is_empty()).then(|| short_str.to_string());
                                         call_eval.add_named(
@@ -421,11 +493,16 @@ pub fn eval_call<D: DebugContext>(
                                     expr.span,
                                 )));
                             }
-                            for v in vals {
-                                call_eval.add_positional(&signature, Cow::Owned(v))?;
-                            }
+                            call_eval.add_list_spread(
+                                &signature,
+                                vals.into_owned(),
+                                expr.span,
+                            )?;
                         }
-                        Value::Nothing { .. } => {}
+                        // Null spread: rest mode only (IR parity).
+                        Value::Nothing { .. } => {
+                            call_eval.add_null_spread();
+                        }
                         other => {
                             return Err(ShellError::CannotSpreadAsList { span: other.span() });
                         }
@@ -441,13 +518,123 @@ pub fn eval_call<D: DebugContext>(
         }
 
         result
+    } else if call
+        .arguments
+        .iter()
+        .any(|a| matches!(a, AstArgument::Spread(_)))
+    {
+        // Builtin/plugin path with record/list spreads: evaluate into engine args, normalize
+        // (expand records, null-omit), then run via IR `Call` so `CallExt` sees expanded flags.
+        eval_ast_builtin_with_spreads::<D>(engine_state, caller_stack, call, decl, input)
     } else {
-        // call is a builtin or external command
+        // call is a builtin or external command without spreads
         // We pass caller_stack here with the knowledge that internal commands
         // are going to be specifically looking for global state in the stack
         // rather than any local state.
         decl.run(engine_state, caller_stack, &call.into(), input)
     }
+}
+
+/// Evaluate AST call arguments into engine arguments, normalize flag spreads/nulls, and run a
+/// builtin/plugin via an IR [`ir::Call`].
+fn eval_ast_builtin_with_spreads<D: DebugContext>(
+    engine_state: &EngineState,
+    caller_stack: &mut Stack,
+    call: &Call,
+    decl: &dyn nu_protocol::engine::Command,
+    input: PipelineData,
+) -> Result<PipelineData, ShellError> {
+    let signature = decl.signature();
+    let mut raw = Vec::with_capacity(call.arguments.len());
+
+    for arg in &call.arguments {
+        match arg {
+            AstArgument::Positional(expr) | AstArgument::Unknown(expr) => {
+                let val = eval_expression::<D>(engine_state, caller_stack, expr)?;
+                raw.push(EngineArgument::Positional {
+                    span: expr.span,
+                    val,
+                    ast: None,
+                });
+            }
+            AstArgument::Named((long, short, maybe_expr)) => {
+                let short_str = short.as_ref().map(|s| s.item.as_str()).unwrap_or("");
+                let (data, name_slice, short_slice) =
+                    data_from_name_and_short(&long.item, short_str);
+                if let Some(expr) = maybe_expr {
+                    let val = eval_expression::<D>(engine_state, caller_stack, expr)?;
+                    raw.push(EngineArgument::Named {
+                        data,
+                        name: name_slice,
+                        short: short_slice,
+                        span: long.span,
+                        val,
+                        ast: None,
+                    });
+                } else {
+                    raw.push(EngineArgument::Flag {
+                        data,
+                        name: name_slice,
+                        short: short_slice,
+                        span: long.span,
+                    });
+                }
+            }
+            AstArgument::Spread(expr) => {
+                let vals = eval_expression::<D>(engine_state, caller_stack, expr)?;
+                raw.push(EngineArgument::Spread {
+                    vals,
+                    span: expr.span,
+                    ast: None,
+                });
+            }
+        }
+    }
+
+    for (name, expr) in &call.parser_info {
+        let (data, name_slice, _) = data_from_name_and_short(name, "");
+        raw.push(EngineArgument::ParserInfo {
+            data,
+            name: name_slice,
+            info: Box::new(expr.clone()),
+        });
+    }
+
+    let expanded = normalize_engine_arguments(&signature, raw)?;
+
+    // Reject list spreads that would leave required positionals unbound (same rule as IR).
+    let mut required_left = signature.required_positional.len();
+    let mut always_spread = false;
+    for arg in &expanded {
+        match arg {
+            EngineArgument::Positional { .. } if !always_spread && required_left > 0 => {
+                required_left = required_left.saturating_sub(1);
+            }
+            EngineArgument::Spread {
+                vals: Value::List { .. },
+                span,
+                ..
+            } if required_left > 0 && !always_spread => {
+                return Err(list_spread_before_required_error(*span));
+            }
+            EngineArgument::Spread {
+                vals: Value::List { .. } | Value::Nothing { .. },
+                ..
+            } => {
+                always_spread = true;
+            }
+            _ => {}
+        }
+    }
+
+    let mut builder = ir::Call::build(call.decl_id, call.head);
+    for arg in expanded {
+        builder.add_argument(caller_stack, arg);
+    }
+    let ir_call = builder.finish();
+    let result = decl.run(engine_state, caller_stack, &(&ir_call).into(), input);
+    ir_call.leave(caller_stack);
+    result
 }
 
 /// Redirect the environment from callee to the caller.

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1,6 +1,8 @@
 #[allow(deprecated)]
 use crate::get_full_help;
-use crate::named_flags::{expand_flag_record, flag_type_accepts_nothing};
+use crate::named_flags::{
+    expand_flag_record, flag_type_accepts_nothing, list_spread_before_required_error,
+};
 use crate::{EvalBlockWithEarlyReturnFn, eval_ir::eval_ir_block};
 use nu_protocol::{
     BlockId, CompareTypes, Config, ENV_VARIABLE_ID, IntoPipelineData, PipelineData,
@@ -38,6 +40,8 @@ pub struct CallEval {
     arg_index: usize,
     named_args: Vec<String>,
     rest_args: Vec<Value>,
+    /// After a list/null rest spread, further positionals go to rest (matches IR `always_spread`).
+    always_spread: bool,
     eval: EvalBlockWithEarlyReturnFn,
 }
 
@@ -56,6 +60,7 @@ impl CallEval {
             arg_index: 0,
             named_args: Vec::new(),
             rest_args: Vec::new(),
+            always_spread: false,
             eval,
         }
     }
@@ -69,6 +74,11 @@ impl CallEval {
         signature: &Signature,
         value: Cow<Value>,
     ) -> Result<&mut Self, ShellError> {
+        // After a rest spread, further positionals always go to rest (IR parity).
+        if self.always_spread {
+            return self.push_rest(signature, value);
+        }
+
         let maybe_param = match self
             .arg_index
             .checked_sub(signature.required_positional.len())
@@ -101,27 +111,64 @@ impl CallEval {
             self.arg_index += 1;
             Ok(self)
         } else {
-            // assign arg to rest params
-            let Some(rest_positional) = &signature.rest_positional else {
-                // We do not consider it an error if more arguments
-                // are added than the closure takes. This makes it possible
-                // to omit any unused arguments in the closure definition.
-                return Ok(self);
-            };
-
-            let param_type = rest_positional.shape.to_type();
-            if !value.is_subtype_of(&param_type) {
-                return Err(ShellError::CantConvert {
-                    to_type: param_type.to_string(),
-                    from_type: value.get_type().to_string(),
-                    span: value.span(),
-                    help: None,
-                });
-            }
-
-            self.rest_args.push(value.into_owned());
-            Ok(self)
+            self.push_rest(signature, value)
         }
+    }
+
+    fn push_rest(
+        &mut self,
+        signature: &Signature,
+        value: Cow<Value>,
+    ) -> Result<&mut Self, ShellError> {
+        let Some(rest_positional) = &signature.rest_positional else {
+            // We do not consider it an error if more arguments
+            // are added than the closure takes. This makes it possible
+            // to omit any unused arguments in the closure definition.
+            return Ok(self);
+        };
+
+        let param_type = rest_positional.shape.to_type();
+        if !value.is_subtype_of(&param_type) {
+            return Err(ShellError::CantConvert {
+                to_type: param_type.to_string(),
+                from_type: value.get_type().to_string(),
+                span: value.span(),
+                help: None,
+            });
+        }
+
+        self.rest_args.push(value.into_owned());
+        Ok(self)
+    }
+
+    /// Spread a list into rest (IR parity). Errors if required positionals remain unbound.
+    pub fn add_list_spread(
+        &mut self,
+        signature: &Signature,
+        vals: Vec<Value>,
+        spread_span: Span,
+    ) -> Result<&mut Self, ShellError> {
+        if self.arg_index < signature.required_positional.len() && !self.always_spread {
+            return Err(list_spread_before_required_error(spread_span));
+        }
+        for v in vals {
+            self.push_rest(signature, Cow::Owned(v))?;
+        }
+        self.always_spread = true;
+        Ok(self)
+    }
+
+    /// Null rest-mode spread (IR parity). Errors if required positionals remain unbound.
+    pub fn add_null_spread(
+        &mut self,
+        signature: &Signature,
+        spread_span: Span,
+    ) -> Result<&mut Self, ShellError> {
+        if self.arg_index < signature.required_positional.len() && !self.always_spread {
+            return Err(list_spread_before_required_error(spread_span));
+        }
+        self.always_spread = true;
+        Ok(self)
     }
 
     /// Add a named parameter to the call stack.
@@ -369,6 +416,9 @@ pub fn eval_call<D: DebugContext>(
                         result,
                     )?;
                 }
+                // Light AST path: keep custom-command spreads aligned with IR gather/normalize
+                // semantics. Normal scripts use IR (`eval_block` → IR); this path still matters
+                // for residual AST `eval_call` consumers.
                 AstArgument::Spread(expr) => {
                     let val = eval_expression::<D>(engine_state, caller_stack, expr)?;
                     match val {
@@ -407,11 +457,12 @@ pub fn eval_call<D: DebugContext>(
                                     expr.span,
                                 )));
                             }
-                            for v in vals {
-                                call_eval.add_positional(&signature, Cow::Owned(v))?;
-                            }
+                            call_eval.add_list_spread(&signature, vals.into_owned(), expr.span)?;
                         }
-                        Value::Nothing { .. } => {}
+                        Value::Nothing { .. } => {
+                            call_eval.add_null_spread(&signature, expr.span)?;
+                        }
+                        Value::Error { error, .. } => return Err(*error),
                         other => {
                             return Err(ShellError::CannotSpreadAsList { span: other.span() });
                         }
@@ -428,10 +479,9 @@ pub fn eval_call<D: DebugContext>(
 
         result
     } else {
-        // call is a builtin or external command
-        // We pass caller_stack here with the knowledge that internal commands
-        // are going to be specifically looking for global state in the stack
-        // rather than any local state.
+        // Builtin/plugin/external: normal scripts evaluate via IR, which runs
+        // `normalize_engine_arguments` for null omit and record flag spreads. This AST
+        // `eval_call` branch does not re-implement that path (IR-first).
         decl.run(engine_state, caller_stack, &call.into(), input)
     }
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1,8 +1,6 @@
 #[allow(deprecated)]
 use crate::get_full_help;
-use crate::named_flags::{
-    expand_flag_record, flag_type_accepts_nothing, list_spread_before_required_error,
-};
+use crate::named_flags::{expand_flag_record, flag_type_accepts_nothing};
 use crate::{EvalBlockWithEarlyReturnFn, eval_ir::eval_ir_block};
 use nu_protocol::{
     BlockId, CompareTypes, Config, ENV_VARIABLE_ID, IntoPipelineData, PipelineData,
@@ -38,11 +36,8 @@ pub struct CallEval {
     head_span: Span,
     callee_span: Span,
     arg_index: usize,
-    /// Provided named flags, tracked by `var_id` so short-only flags (empty long name) do not collide.
-    provided_named_var_ids: Vec<VarId>,
+    named_args: Vec<String>,
     rest_args: Vec<Value>,
-    /// After a list/null rest spread, further positionals go to rest (matches IR `always_spread`).
-    always_spread: bool,
     eval: EvalBlockWithEarlyReturnFn,
 }
 
@@ -59,9 +54,8 @@ impl CallEval {
             head_span: call_head,
             callee_span,
             arg_index: 0,
-            provided_named_var_ids: Vec::new(),
+            named_args: Vec::new(),
             rest_args: Vec::new(),
-            always_spread: false,
             eval,
         }
     }
@@ -75,11 +69,6 @@ impl CallEval {
         signature: &Signature,
         value: Cow<Value>,
     ) -> Result<&mut Self, ShellError> {
-        // After a rest spread, further positionals always go to rest (IR parity).
-        if self.always_spread {
-            return self.push_rest(signature, value);
-        }
-
         let maybe_param = match self
             .arg_index
             .checked_sub(signature.required_positional.len())
@@ -112,68 +101,27 @@ impl CallEval {
             self.arg_index += 1;
             Ok(self)
         } else {
-            self.push_rest(signature, value)
-        }
-    }
+            // assign arg to rest params
+            let Some(rest_positional) = &signature.rest_positional else {
+                // We do not consider it an error if more arguments
+                // are added than the closure takes. This makes it possible
+                // to omit any unused arguments in the closure definition.
+                return Ok(self);
+            };
 
-    fn push_rest(
-        &mut self,
-        signature: &Signature,
-        value: Cow<Value>,
-    ) -> Result<&mut Self, ShellError> {
-        let Some(rest_positional) = &signature.rest_positional else {
-            // We do not consider it an error if more arguments
-            // are added than the closure takes. This makes it possible
-            // to omit any unused arguments in the closure definition.
-            return Ok(self);
-        };
+            let param_type = rest_positional.shape.to_type();
+            if !value.is_subtype_of(&param_type) {
+                return Err(ShellError::CantConvert {
+                    to_type: param_type.to_string(),
+                    from_type: value.get_type().to_string(),
+                    span: value.span(),
+                    help: None,
+                });
+            }
 
-        let param_type = rest_positional.shape.to_type();
-        if !value.is_subtype_of(&param_type) {
-            return Err(ShellError::CantConvert {
-                to_type: param_type.to_string(),
-                from_type: value.get_type().to_string(),
-                span: value.span(),
-                help: None,
-            });
+            self.rest_args.push(value.into_owned());
+            Ok(self)
         }
-
-        self.rest_args.push(value.into_owned());
-        Ok(self)
-    }
-
-    /// Spread a list into rest arguments (IR parity: does not fill positionals).
-    ///
-    /// Errors if required positionals are still unbound.
-    pub fn add_list_spread(
-        &mut self,
-        signature: &Signature,
-        vals: Vec<Value>,
-        spread_span: Span,
-    ) -> Result<&mut Self, ShellError> {
-        if self.arg_index < signature.required_positional.len() && !self.always_spread {
-            return Err(list_spread_before_required_error(spread_span));
-        }
-        for v in vals {
-            self.push_rest(signature, Cow::Owned(v))?;
-        }
-        self.always_spread = true;
-        Ok(self)
-    }
-
-    /// Mark rest mode without adding values (null list spread; IR `always_spread` parity).
-    ///
-    /// Errors if required positionals are still unbound (same rule as list spreads).
-    pub fn add_null_spread(
-        &mut self,
-        signature: &Signature,
-        spread_span: Span,
-    ) -> Result<&mut Self, ShellError> {
-        if self.arg_index < signature.required_positional.len() && !self.always_spread {
-            return Err(list_spread_before_required_error(spread_span));
-        }
-        self.always_spread = true;
-        Ok(self)
     }
 
     /// Add a named parameter to the call stack.
@@ -184,9 +132,8 @@ impl CallEval {
         short: Option<String>,
         value: Option<Cow<Value>>,
     ) -> Result<&mut Self, ShellError> {
-        // Match non-empty long first; never match empty long against short-only flags by name alone.
         let named = signature.named.iter().find(|named| {
-            (!long.is_empty() && long == named.long)
+            long == named.long
                 || short
                     .as_deref()
                     .zip(named.short)
@@ -206,7 +153,7 @@ impl CallEval {
                 .unwrap_or_else(|| Cow::Owned(Value::bool(true, self.head_span)));
 
             self.callee_stack.add_var(var_id, value.into_owned());
-            self.provided_named_var_ids.push(var_id);
+            self.named_args.push(long.to_string());
         }
 
         Ok(self)
@@ -323,12 +270,8 @@ impl CallEval {
         let remaining_flags = signature
             .named
             .iter()
-            // Skip provided flags (by var_id so short-only flags work)
-            .filter(|flag| {
-                !flag
-                    .var_id
-                    .is_some_and(|id| self.provided_named_var_ids.contains(&id))
-            })
+            // Skip provided flags
+            .filter(|flag| !self.named_args.contains(&flag.long))
             // Ignore named arguments without var_id.
             // There is some code in nu_cli::completions that relies on this behavior of `eval_call`.
             .filter_map(|flag| Some((flag.var_id?, flag)));
@@ -404,6 +347,12 @@ pub fn eval_call<D: DebugContext>(
                         if value.is_nothing() {
                             let accepts_nothing = signature
                                 .get_long_flag(&long.item)
+                                .or_else(|| {
+                                    short
+                                        .as_ref()
+                                        .and_then(|s| s.item.chars().next())
+                                        .and_then(|c| signature.get_short_flag(c))
+                                })
                                 .is_some_and(|flag| flag_type_accepts_nothing(&flag));
                             if !accepts_nothing {
                                 continue;
@@ -420,8 +369,6 @@ pub fn eval_call<D: DebugContext>(
                         result,
                     )?;
                 }
-                // Light AST support: expand long-key record flag spreads; rest list/null spreads.
-                // Builtins/plugins use the IR path (normalize_engine_arguments) in normal scripts.
                 AstArgument::Spread(expr) => {
                     let val = eval_expression::<D>(engine_state, caller_stack, expr)?;
                     match val {
@@ -430,34 +377,20 @@ pub fn eval_call<D: DebugContext>(
                                 expand_flag_record(&signature, val.into_owned(), expr.span)?
                             {
                                 match engine_arg {
-                                    EngineArgument::Flag {
-                                        data, name, short, ..
-                                    } => {
+                                    EngineArgument::Flag { data, name, .. } => {
                                         let long =
                                             std::str::from_utf8(&data[name]).unwrap_or_default();
-                                        let short_str =
-                                            std::str::from_utf8(&data[short]).unwrap_or_default();
-                                        let short =
-                                            (!short_str.is_empty()).then(|| short_str.to_string());
-                                        call_eval.add_named(&signature, long, short, None)?;
+                                        call_eval.add_named(&signature, long, None, None)?;
                                     }
                                     EngineArgument::Named {
-                                        data,
-                                        name,
-                                        short,
-                                        val,
-                                        ..
+                                        data, name, val, ..
                                     } => {
                                         let long =
                                             std::str::from_utf8(&data[name]).unwrap_or_default();
-                                        let short_str =
-                                            std::str::from_utf8(&data[short]).unwrap_or_default();
-                                        let short =
-                                            (!short_str.is_empty()).then(|| short_str.to_string());
                                         call_eval.add_named(
                                             &signature,
                                             long,
-                                            short,
+                                            None,
                                             Some(Cow::Owned(val)),
                                         )?;
                                     }
@@ -474,12 +407,11 @@ pub fn eval_call<D: DebugContext>(
                                     expr.span,
                                 )));
                             }
-                            call_eval.add_list_spread(&signature, vals.into_owned(), expr.span)?;
+                            for v in vals {
+                                call_eval.add_positional(&signature, Cow::Owned(v))?;
+                            }
                         }
-                        Value::Nothing { .. } => {
-                            call_eval.add_null_spread(&signature, expr.span)?;
-                        }
-                        Value::Error { error, .. } => return Err(*error),
+                        Value::Nothing { .. } => {}
                         other => {
                             return Err(ShellError::CannotSpreadAsList { span: other.span() });
                         }
@@ -496,7 +428,10 @@ pub fn eval_call<D: DebugContext>(
 
         result
     } else {
-        // Builtin or external: IR evaluation path normalizes flags/spreads for normal scripts.
+        // call is a builtin or external command
+        // We pass caller_stack here with the knowledge that internal commands
+        // are going to be specifically looking for global state in the stack
+        // rather than any local state.
         decl.run(engine_state, caller_stack, &call.into(), input)
     }
 }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1607,7 +1607,7 @@ fn gather_arguments(
                 }
                 Value::Nothing { .. } => {
                     // Same rule as list spreads: null rest-mode before required positionals
-                    // would leave them unbound (IR would bind `nothing` then rest-only after).
+                    // would leave them unbound.
                     if remaining_required > 0 && !always_spread {
                         return Err(crate::named_flags::list_spread_before_required_error(
                             spread_span,

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -650,6 +650,11 @@ fn eval_instruction<D: DebugContext>(
         }
         Instruction::PushNamed { name, src } => {
             let val = ctx.collect_reg(*src, *span)?.with_span(*span);
+            // Null means "omit this flag" so optional named args can be forwarded
+            // when shadowing builtins (e.g. `%cp --preserve=$preserve`).
+            if val.is_nothing() {
+                return Ok(Continue);
+            }
             let data = ctx.data.clone();
             ctx.stack.arguments.push(Argument::Named {
                 data,
@@ -663,6 +668,9 @@ fn eval_instruction<D: DebugContext>(
         }
         Instruction::PushShortNamed { short, src } => {
             let val = ctx.collect_reg(*src, *span)?.with_span(*span);
+            if val.is_nothing() {
+                return Ok(Continue);
+            }
             let data = ctx.data.clone();
             ctx.stack.arguments.push(Argument::Named {
                 data,
@@ -1354,6 +1362,14 @@ fn eval_call<D: DebugContext>(
             // check types after acquiring block to avoid unnecessarily cloning Signature
             check_input_types(&input, &block.signature, head)?;
 
+            // Expand record spreads into named flags; drop null named values.
+            let args_len = normalize_call_arguments(
+                &block.signature,
+                &mut caller_stack,
+                *args_base,
+                args_len,
+            )?;
+
             // Set up a callee stack with the captures and move arguments from the stack into variables
             let mut callee_stack = caller_stack.gather_captures(engine_state, &block.captures);
 
@@ -1399,6 +1415,15 @@ fn eval_call<D: DebugContext>(
             if !allow_error_input {
                 check_input_types(&input, &decl.signature(), head)?;
             }
+
+            // Expand record spreads into named flags; drop null named values.
+            let args_len = normalize_call_arguments(
+                &decl.signature(),
+                &mut caller_stack,
+                *args_base,
+                args_len,
+            )?;
+
             // FIXME: precalculate this and save it somewhere
             let span = Span::merge_many(
                 std::iter::once(head).chain(
@@ -1485,6 +1510,143 @@ fn expect_positional_var_id(arg: &PositionalArg, span: Span) -> Result<VarId, Sh
     })
 }
 
+/// Expand a record into named/flag arguments for a call.
+///
+/// - `null` field values are omitted (same as null→omit for `--flag=$v`)
+/// - switch flags (`--flag` with no value): `true` sets the flag, `false`/`null` omit it
+/// - valued flags: non-null values become `--name value`
+fn expand_flag_record(
+    signature: &Signature,
+    record: Record,
+    spread_span: Span,
+) -> Result<Vec<Argument>, ShellError> {
+    let mut out = Vec::with_capacity(record.len());
+    for (key, val) in record {
+        if val.is_nothing() {
+            continue;
+        }
+        let Some(flag) = signature.get_long_flag(&key) else {
+            return Err(ShellError::Generic(GenericError::new(
+                format!("Unknown flag `{key}` in spread record"),
+                format!("`{key}` is not a named argument of this command"),
+                spread_span,
+            )));
+        };
+
+        let short = flag
+            .short
+            .map(|c| {
+                let mut buf = [0u8; 4];
+                c.encode_utf8(&mut buf).to_string()
+            })
+            .unwrap_or_default();
+        let (data, name_slice, short_slice) = data_from_name_and_short(&flag.long, &short);
+
+        if flag.arg.is_none() {
+            // Switch: only `true` sets the flag; `false` omits (like `--flag=false`).
+            match val {
+                Value::Bool { val: true, .. } => {
+                    out.push(Argument::Flag {
+                        data,
+                        name: name_slice,
+                        short: short_slice,
+                        span: spread_span,
+                    });
+                }
+                Value::Bool { val: false, .. } => {}
+                other => {
+                    return Err(ShellError::CantConvert {
+                        to_type: "bool".into(),
+                        from_type: other.get_type().to_string(),
+                        span: other.span(),
+                        help: Some(format!(
+                            "spread field `{key}` is a switch; use true/false or omit/null"
+                        )),
+                    });
+                }
+            }
+        } else {
+            out.push(Argument::Named {
+                data,
+                name: name_slice,
+                short: short_slice,
+                span: spread_span,
+                val,
+                ast: None,
+            });
+        }
+    }
+    Ok(out)
+}
+
+fn data_from_name_and_short(name: &str, short: &str) -> (Arc<[u8]>, DataSlice, DataSlice) {
+    let data: Vec<u8> = name.bytes().chain(short.bytes()).collect();
+    let data: Arc<[u8]> = data.into();
+    let name = DataSlice {
+        start: 0,
+        len: name.len().try_into().expect("flag name too big"),
+    };
+    let short = DataSlice {
+        start: name.start.checked_add(name.len).expect("flag name too big"),
+        len: short.len().try_into().expect("flag short name too big"),
+    };
+    (data, name, short)
+}
+
+/// Normalize call arguments: expand record spreads into named flags, drop named nulls.
+///
+/// Returns the new argument list length after rewriting the frame starting at `args_base`.
+fn normalize_call_arguments(
+    signature: &Signature,
+    stack: &mut Stack,
+    args_base: usize,
+    args_len: usize,
+) -> Result<usize, ShellError> {
+    let raw: Vec<Argument> = stack.arguments.drain_args(args_base, args_len).collect();
+    let mut expanded = Vec::with_capacity(raw.len());
+
+    for arg in raw {
+        match arg {
+            Argument::Named {
+                val: Value::Nothing { .. },
+                ..
+            } => {
+                // Belt-and-suspenders: null named values are omitted.
+            }
+            Argument::Spread {
+                vals,
+                span: spread_span,
+                ast,
+            } => match vals {
+                Value::Record { val, .. } => {
+                    expanded.extend(expand_flag_record(
+                        signature,
+                        val.into_owned(),
+                        spread_span,
+                    )?);
+                }
+                Value::List { .. } | Value::Nothing { .. } | Value::Error { .. } => {
+                    expanded.push(Argument::Spread {
+                        vals,
+                        span: spread_span,
+                        ast,
+                    });
+                }
+                other => {
+                    return Err(ShellError::CannotSpreadAsList { span: other.span() });
+                }
+            },
+            other => expanded.push(other),
+        }
+    }
+
+    let new_len = expanded.len();
+    for arg in expanded {
+        stack.arguments.push(arg);
+    }
+    Ok(new_len)
+}
+
 /// Move arguments from the stack into variables for a custom command
 fn gather_arguments(
     engine_state: &EngineState,
@@ -1561,6 +1723,13 @@ fn gather_arguments(
                     rest_span = Some(rest_span.map_or(spread_span, |s| s.append(spread_span)));
                     always_spread = true;
                 }
+                // Record spreads should already be expanded by `normalize_call_arguments`.
+                Value::Record { .. } => {
+                    return Err(ShellError::IrEvalError {
+                        msg: "internal error: unexpanded record spread in gather_arguments".into(),
+                        span: Some(spread_span),
+                    });
+                }
                 Value::Error { error, .. } => return Err(*error),
                 _ => return Err(ShellError::CannotSpreadAsList { span: vals.span() }),
             },
@@ -1581,6 +1750,10 @@ fn gather_arguments(
                 val,
                 ..
             } => {
+                // Null named values are treated as omitted (defaults apply).
+                if val.is_nothing() {
+                    continue;
+                }
                 let var_id = find_named_var_id(&block.signature, &data[name], &data[short], span)?;
                 callee_stack.add_var(var_id, val)
             }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1561,6 +1561,7 @@ fn gather_arguments(
 
     // If we encounter a spread, all further positionals should go to rest
     let mut always_spread = false;
+    let mut remaining_required = block.signature.required_positional.len();
 
     for arg in caller_stack.arguments.drain_args(args_base, args_len) {
         match arg {
@@ -1574,6 +1575,7 @@ fn gather_arguments(
                         // SyntaxShape here, we might be able to save some allocations and effort
                         let variable = engine_state.get_var(var_id);
                         check_type(&val, &variable.ty)?;
+                        remaining_required = remaining_required.saturating_sub(1);
                     }
                     callee_stack.add_var(var_id, val);
                 } else {
@@ -1592,6 +1594,13 @@ fn gather_arguments(
                 ..
             } => match vals {
                 Value::List { vals, .. } => {
+                    // Dual-purpose `...$x`: a list before unfilled required positionals would
+                    // leave them unbound (list items go only to rest).
+                    if remaining_required > 0 && !always_spread {
+                        return Err(crate::named_flags::list_spread_before_required_error(
+                            spread_span,
+                        ));
+                    }
                     rest.extend(vals);
                     rest_span = Some(rest_span.map_or(spread_span, |s| s.append(spread_span)));
                     always_spread = true;

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -21,6 +21,7 @@ use nu_utils::IgnoreCaseExt;
 
 use crate::{
     ENV_CONVERSIONS, convert_env_vars, eval::is_automatic_env_var, eval_block_with_early_return,
+    named_flags::normalize_engine_arguments,
 };
 
 /// For `def --wrapped` and `known extern` rest params (`SyntaxShape::ExternalArgument`), convert
@@ -1504,116 +1505,6 @@ fn expect_positional_var_id(arg: &PositionalArg, span: Span) -> Result<VarId, Sh
     })
 }
 
-/// Whether a named flag's value type accepts `nothing`/`null`.
-///
-/// Used so `--flag=$null` can either:
-/// - pass `null` through when the signature allows it (`any`, `nothing`, `oneof<…, nothing>`, …)
-/// - omit the flag when it does not (`--x: int`), so defaults / "flag absent" still work for shadowing
-fn flag_type_accepts_nothing(flag: &Flag) -> bool {
-    match &flag.arg {
-        Some(shape) => Type::Nothing.is_assignable_to(&shape.to_type()),
-        // Switches are booleans; null means omit (same as false / not passed).
-        None => false,
-    }
-}
-
-fn find_signature_flag<'a>(
-    signature: &'a Signature,
-    long: &[u8],
-    short: &[u8],
-) -> Option<&'a Flag> {
-    signature.named.iter().find(|flag| {
-        (!long.is_empty() && flag.long.as_bytes() == long)
-            || (!short.is_empty()
-                && flag.short.is_some_and(|c| {
-                    let mut buf = [0u8; 4];
-                    c.encode_utf8(&mut buf).as_bytes() == short
-                }))
-    })
-}
-
-/// Expand a record into named/flag arguments for a call.
-///
-/// - `null` field values: passed through if the flag type accepts `nothing`, otherwise omitted
-/// - switch flags (`--flag` with no value): `true` sets the flag, `false`/`null` omit it
-/// - valued flags: non-null values become `--name value`
-fn expand_flag_record(
-    signature: &Signature,
-    record: Record,
-    spread_span: Span,
-) -> Result<Vec<Argument>, ShellError> {
-    let mut out = Vec::with_capacity(record.len());
-    for (key, val) in record {
-        let Some(flag) = signature.get_long_flag(&key) else {
-            return Err(ShellError::Generic(GenericError::new(
-                format!("Unknown flag `{key}` in spread record"),
-                format!("`{key}` is not a named argument of this command"),
-                spread_span,
-            )));
-        };
-
-        let short = flag
-            .short
-            .map(|c| {
-                let mut buf = [0u8; 4];
-                c.encode_utf8(&mut buf).to_string()
-            })
-            .unwrap_or_default();
-        let (data, name_slice, short_slice) = data_from_name_and_short(&flag.long, &short);
-
-        if flag.arg.is_none() {
-            // Switch: only `true` sets the flag; `false`/`null` omit (like `--flag=false`).
-            match val {
-                Value::Bool { val: true, .. } => {
-                    out.push(Argument::Flag {
-                        data,
-                        name: name_slice,
-                        short: short_slice,
-                        span: spread_span,
-                    });
-                }
-                Value::Bool { val: false, .. } | Value::Nothing { .. } => {}
-                other => {
-                    return Err(ShellError::CantConvert {
-                        to_type: "bool".into(),
-                        from_type: other.get_type().to_string(),
-                        span: other.span(),
-                        help: Some(format!(
-                            "spread field `{key}` is a switch; use true/false or omit/null"
-                        )),
-                    });
-                }
-            }
-        } else if val.is_nothing() && !flag_type_accepts_nothing(&flag) {
-            // Null → omit when the flag type does not accept nothing.
-        } else {
-            out.push(Argument::Named {
-                data,
-                name: name_slice,
-                short: short_slice,
-                span: spread_span,
-                val,
-                ast: None,
-            });
-        }
-    }
-    Ok(out)
-}
-
-fn data_from_name_and_short(name: &str, short: &str) -> (Arc<[u8]>, DataSlice, DataSlice) {
-    let data: Vec<u8> = name.bytes().chain(short.bytes()).collect();
-    let data: Arc<[u8]> = data.into();
-    let name = DataSlice {
-        start: 0,
-        len: name.len().try_into().expect("flag name too big"),
-    };
-    let short = DataSlice {
-        start: name.start.checked_add(name.len).expect("flag name too big"),
-        len: short.len().try_into().expect("flag short name too big"),
-    };
-    (data, name, short)
-}
-
 /// Normalize call arguments: expand record spreads into named flags; drop null
 /// named values unless the flag type accepts `nothing`.
 ///
@@ -1625,59 +1516,7 @@ fn normalize_call_arguments(
     args_len: usize,
 ) -> Result<usize, ShellError> {
     let raw: Vec<Argument> = stack.arguments.drain_args(args_base, args_len).collect();
-    let mut expanded = Vec::with_capacity(raw.len());
-
-    for arg in raw {
-        match arg {
-            Argument::Named {
-                data,
-                name,
-                short,
-                span,
-                val: Value::Nothing { .. },
-                ast,
-            } => {
-                let accepts = find_signature_flag(signature, &data[name], &data[short])
-                    .is_some_and(flag_type_accepts_nothing);
-                if accepts {
-                    expanded.push(Argument::Named {
-                        data,
-                        name,
-                        short,
-                        span,
-                        val: Value::nothing(span),
-                        ast,
-                    });
-                }
-                // else: null → omit (shadowing / optional flag forwarding)
-            }
-            Argument::Spread {
-                vals,
-                span: spread_span,
-                ast,
-            } => match vals {
-                Value::Record { val, .. } => {
-                    expanded.extend(expand_flag_record(
-                        signature,
-                        val.into_owned(),
-                        spread_span,
-                    )?);
-                }
-                Value::List { .. } | Value::Nothing { .. } | Value::Error { .. } => {
-                    expanded.push(Argument::Spread {
-                        vals,
-                        span: spread_span,
-                        ast,
-                    });
-                }
-                other => {
-                    return Err(ShellError::CannotSpreadAsList { span: other.span() });
-                }
-            },
-            other => expanded.push(other),
-        }
-    }
-
+    let expanded = normalize_engine_arguments(signature, raw)?;
     let new_len = expanded.len();
     for arg in expanded {
         stack.arguments.push(arg);

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -649,12 +649,9 @@ fn eval_instruction<D: DebugContext>(
             Ok(Continue)
         }
         Instruction::PushNamed { name, src } => {
+            // Null may be omitted or passed through depending on the target flag's type;
+            // that decision is made in `normalize_call_arguments` once the signature is known.
             let val = ctx.collect_reg(*src, *span)?.with_span(*span);
-            // Null means "omit this flag" so optional named args can be forwarded
-            // when shadowing builtins (e.g. `%cp --preserve=$preserve`).
-            if val.is_nothing() {
-                return Ok(Continue);
-            }
             let data = ctx.data.clone();
             ctx.stack.arguments.push(Argument::Named {
                 data,
@@ -668,9 +665,6 @@ fn eval_instruction<D: DebugContext>(
         }
         Instruction::PushShortNamed { short, src } => {
             let val = ctx.collect_reg(*src, *span)?.with_span(*span);
-            if val.is_nothing() {
-                return Ok(Continue);
-            }
             let data = ctx.data.clone();
             ctx.stack.arguments.push(Argument::Named {
                 data,
@@ -1510,9 +1504,37 @@ fn expect_positional_var_id(arg: &PositionalArg, span: Span) -> Result<VarId, Sh
     })
 }
 
+/// Whether a named flag's value type accepts `nothing`/`null`.
+///
+/// Used so `--flag=$null` can either:
+/// - pass `null` through when the signature allows it (`any`, `nothing`, `oneof<…, nothing>`, …)
+/// - omit the flag when it does not (`--x: int`), so defaults / "flag absent" still work for shadowing
+fn flag_type_accepts_nothing(flag: &Flag) -> bool {
+    match &flag.arg {
+        Some(shape) => Type::Nothing.is_assignable_to(&shape.to_type()),
+        // Switches are booleans; null means omit (same as false / not passed).
+        None => false,
+    }
+}
+
+fn find_signature_flag<'a>(
+    signature: &'a Signature,
+    long: &[u8],
+    short: &[u8],
+) -> Option<&'a Flag> {
+    signature.named.iter().find(|flag| {
+        (!long.is_empty() && flag.long.as_bytes() == long)
+            || (!short.is_empty()
+                && flag.short.is_some_and(|c| {
+                    let mut buf = [0u8; 4];
+                    c.encode_utf8(&mut buf).as_bytes() == short
+                }))
+    })
+}
+
 /// Expand a record into named/flag arguments for a call.
 ///
-/// - `null` field values are omitted (same as null→omit for `--flag=$v`)
+/// - `null` field values: passed through if the flag type accepts `nothing`, otherwise omitted
 /// - switch flags (`--flag` with no value): `true` sets the flag, `false`/`null` omit it
 /// - valued flags: non-null values become `--name value`
 fn expand_flag_record(
@@ -1522,9 +1544,6 @@ fn expand_flag_record(
 ) -> Result<Vec<Argument>, ShellError> {
     let mut out = Vec::with_capacity(record.len());
     for (key, val) in record {
-        if val.is_nothing() {
-            continue;
-        }
         let Some(flag) = signature.get_long_flag(&key) else {
             return Err(ShellError::Generic(GenericError::new(
                 format!("Unknown flag `{key}` in spread record"),
@@ -1543,7 +1562,7 @@ fn expand_flag_record(
         let (data, name_slice, short_slice) = data_from_name_and_short(&flag.long, &short);
 
         if flag.arg.is_none() {
-            // Switch: only `true` sets the flag; `false` omits (like `--flag=false`).
+            // Switch: only `true` sets the flag; `false`/`null` omit (like `--flag=false`).
             match val {
                 Value::Bool { val: true, .. } => {
                     out.push(Argument::Flag {
@@ -1553,7 +1572,7 @@ fn expand_flag_record(
                         span: spread_span,
                     });
                 }
-                Value::Bool { val: false, .. } => {}
+                Value::Bool { val: false, .. } | Value::Nothing { .. } => {}
                 other => {
                     return Err(ShellError::CantConvert {
                         to_type: "bool".into(),
@@ -1565,6 +1584,8 @@ fn expand_flag_record(
                     });
                 }
             }
+        } else if val.is_nothing() && !flag_type_accepts_nothing(&flag) {
+            // Null → omit when the flag type does not accept nothing.
         } else {
             out.push(Argument::Named {
                 data,
@@ -1593,7 +1614,8 @@ fn data_from_name_and_short(name: &str, short: &str) -> (Arc<[u8]>, DataSlice, D
     (data, name, short)
 }
 
-/// Normalize call arguments: expand record spreads into named flags, drop named nulls.
+/// Normalize call arguments: expand record spreads into named flags; drop null
+/// named values unless the flag type accepts `nothing`.
 ///
 /// Returns the new argument list length after rewriting the frame starting at `args_base`.
 fn normalize_call_arguments(
@@ -1608,10 +1630,26 @@ fn normalize_call_arguments(
     for arg in raw {
         match arg {
             Argument::Named {
+                data,
+                name,
+                short,
+                span,
                 val: Value::Nothing { .. },
-                ..
+                ast,
             } => {
-                // Belt-and-suspenders: null named values are omitted.
+                let accepts = find_signature_flag(signature, &data[name], &data[short])
+                    .is_some_and(flag_type_accepts_nothing);
+                if accepts {
+                    expanded.push(Argument::Named {
+                        data,
+                        name,
+                        short,
+                        span,
+                        val: Value::nothing(span),
+                        ast,
+                    });
+                }
+                // else: null → omit (shadowing / optional flag forwarding)
             }
             Argument::Spread {
                 vals,
@@ -1750,10 +1788,8 @@ fn gather_arguments(
                 val,
                 ..
             } => {
-                // Null named values are treated as omitted (defaults apply).
-                if val.is_nothing() {
-                    continue;
-                }
+                // Null should already have been dropped in `normalize_call_arguments`
+                // when the flag type does not accept nothing. If still present, bind it.
                 let var_id = find_named_var_id(&block.signature, &data[name], &data[short], span)?;
                 callee_stack.add_var(var_id, val)
             }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1606,6 +1606,13 @@ fn gather_arguments(
                     always_spread = true;
                 }
                 Value::Nothing { .. } => {
+                    // Same rule as list spreads: null rest-mode before required positionals
+                    // would leave them unbound (IR would bind `nothing` then rest-only after).
+                    if remaining_required > 0 && !always_spread {
+                        return Err(crate::named_flags::list_spread_before_required_error(
+                            spread_span,
+                        ));
+                    }
                     rest_span = Some(rest_span.map_or(spread_span, |s| s.append(spread_span)));
                     always_spread = true;
                 }

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -11,6 +11,7 @@ mod eval_helpers;
 mod eval_ir;
 pub mod exit;
 mod glob_from;
+mod named_flags;
 pub mod scope;
 
 #[cfg(test)]

--- a/crates/nu-engine/src/named_flags.rs
+++ b/crates/nu-engine/src/named_flags.rs
@@ -1,5 +1,5 @@
 //! Helpers for signature-aware named flag handling (null omit/pass-through and
-//! record flag spreads). Shared by IR and AST evaluation paths.
+//! long-key record flag spreads). Shared by IR and AST evaluation paths.
 
 use std::sync::Arc;
 
@@ -9,9 +9,6 @@ use nu_protocol::{
 };
 
 /// Whether a named flag's value type accepts `nothing`/`null`.
-///
-/// Thin wrapper around [`Flag::type_accepts_nothing`] for call sites that already
-/// have a [`Flag`] reference.
 #[inline]
 pub(crate) fn flag_type_accepts_nothing(flag: &Flag) -> bool {
     flag.type_accepts_nothing()
@@ -33,8 +30,6 @@ pub(crate) fn find_signature_flag<'a>(
 }
 
 /// Build the packed long+short name buffer used by engine [`Argument`]s.
-///
-/// Flag names are always short identifiers from the parser; lengths always fit in `u32`.
 pub(crate) fn data_from_name_and_short(
     name: &str,
     short: &str,
@@ -57,62 +52,12 @@ pub(crate) fn data_from_name_and_short(
     (data, name, short)
 }
 
-/// Decode long/short flag name slices packed by [`data_from_name_and_short`].
-pub(crate) fn long_short_from_data(
-    data: &[u8],
-    name: DataSlice,
-    short: DataSlice,
-    span: Span,
-) -> Result<(&str, Option<String>), ShellError> {
-    let long = std::str::from_utf8(&data[name]).map_err(|_| {
-        ShellError::Generic(GenericError::new(
-            "Invalid flag name encoding",
-            "flag long name is not valid UTF-8",
-            span,
-        ))
-    })?;
-    let short_str = std::str::from_utf8(&data[short]).map_err(|_| {
-        ShellError::Generic(GenericError::new(
-            "Invalid flag name encoding",
-            "flag short name is not valid UTF-8",
-            span,
-        ))
-    })?;
-    Ok((long, (!short_str.is_empty()).then(|| short_str.to_string())))
-}
-
-/// Resolve a record key to a signature flag: long name first, then single-char short.
-/// Long wins when both a long flag named `a` and a short `-a` exist.
-fn flag_for_spread_key(signature: &Signature, key: &str) -> Option<Flag> {
-    signature.get_long_flag(key).or_else(|| {
-        // Single Unicode scalar → short flag (e.g. key "a" → `-a`, including short-only flags).
-        let mut chars = key.chars();
-        match (chars.next(), chars.next()) {
-            (Some(c), None) => signature.get_short_flag(c),
-            _ => None,
-        }
-    })
-}
-
-fn flag_cli_name(flag: &Flag) -> String {
-    if let Some(long) = flag.long_name() {
-        format!("--{long}")
-    } else if let Some(short) = flag.short {
-        format!("-{short}")
-    } else {
-        "<flag>".into()
-    }
-}
-
 /// Expand a record into named/flag arguments for a call.
 ///
-/// - Record keys match **long** flag names first; a single-character key may also match a
-///   **short** flag (including short-only flags). Long form wins on collision.
-/// - Unknown keys: error, unless [`Signature::allows_unknown_args`] is set (then passed through
-///   as positionals / rest tokens, matching CLI unknown-flag handling).
-/// - `null` field values: passed through if the flag type accepts `nothing`, otherwise omitted
-/// - switch flags (`--flag` with no value): `true` sets the flag, `false`/`null` omit it
-/// - valued flags: non-null values become `--name value` (type-checked against the signature)
+/// - Record keys match **long** flag names only (`--flag` form).
+/// - Unknown keys error.
+/// - `null` field values: passed through if the flag type accepts `nothing`, otherwise omitted.
+/// - Switch flags: `true` sets the flag; `false`/`null` omit.
 pub(crate) fn expand_flag_record(
     signature: &Signature,
     record: Record,
@@ -120,11 +65,7 @@ pub(crate) fn expand_flag_record(
 ) -> Result<Vec<Argument>, ShellError> {
     let mut out = Vec::with_capacity(record.len());
     for (key, val) in record {
-        let Some(flag) = flag_for_spread_key(signature, &key) else {
-            if signature.allows_unknown_args {
-                push_unknown_spread_field(&mut out, &key, val, spread_span);
-                continue;
-            }
+        let Some(flag) = signature.get_long_flag(&key) else {
             return Err(ShellError::Generic(GenericError::new(
                 format!("Unknown flag `{key}` in spread record"),
                 format!("`{key}` is not a named argument of this command"),
@@ -142,7 +83,6 @@ pub(crate) fn expand_flag_record(
         let (data, name_slice, short_slice) = data_from_name_and_short(&flag.long, &short);
 
         if flag.arg.is_none() {
-            // Switch: only `true` sets the flag; `false`/`null` omit (like `--flag=false`).
             match val {
                 Value::Bool { val: true, .. } => {
                     out.push(Argument::Flag {
@@ -177,8 +117,7 @@ pub(crate) fn expand_flag_record(
                         from_type: val.get_type().to_string(),
                         span: val.span(),
                         help: Some(format!(
-                            "spread field `{key}` does not match the type of `{}`",
-                            flag_cli_name(&flag)
+                            "spread field `{key}` does not match the type of `--{key}`"
                         )),
                     });
                 }
@@ -196,53 +135,12 @@ pub(crate) fn expand_flag_record(
     Ok(out)
 }
 
-/// Forward an unknown record field when `allows_unknown_args` is set.
-///
-/// Emits CLI-like rest/unknown tokens as [`Argument::Positional`] (`--key` / `-k` plus optional
-/// value), matching how the parser turns unknown flags into `Unknown` args (which compile to
-/// positionals). Custom commands bind these into remaining positionals / `...rest` in order —
-/// the same as `f --extra hello` on a `--wrapped` command. We do not emit [`Argument::Named`] /
-/// [`Argument::Flag`]: custom commands only bind declared named params by `var_id`.
-fn push_unknown_spread_field(out: &mut Vec<Argument>, key: &str, val: Value, spread_span: Span) {
-    let flag_token = if key.chars().count() == 1 {
-        format!("-{key}")
-    } else {
-        format!("--{key}")
-    };
-
-    match val {
-        Value::Bool { val: true, .. } => {
-            out.push(Argument::Positional {
-                span: spread_span,
-                val: Value::string(flag_token, spread_span),
-                ast: None,
-            });
-        }
-        Value::Bool { val: false, .. } | Value::Nothing { .. } => {}
-        other => {
-            out.push(Argument::Positional {
-                span: spread_span,
-                val: Value::string(flag_token, spread_span),
-                ast: None,
-            });
-            out.push(Argument::Positional {
-                span: other.span(),
-                val: other,
-                ast: None,
-            });
-        }
-    }
-}
-
 /// Whether this signature can accept a list rest spread.
 pub(crate) fn can_rest_spread(signature: &Signature) -> bool {
     signature.rest_positional.is_some() || signature.allows_unknown_args
 }
 
-/// Error when a list is spread while required positionals remain unbound.
-///
-/// Dual-purpose commands accept both flag records and rest lists via `...$x`. Spreading a list
-/// before required positionals are filled would leave them unbound (list items go to rest).
+/// Error when a list (or null rest-mode) is spread while required positionals remain unbound.
 pub(crate) fn list_spread_before_required_error(spread_span: Span) -> ShellError {
     ShellError::Generic(GenericError::new(
         "Cannot spread a list before required positional arguments are provided",
@@ -252,9 +150,6 @@ pub(crate) fn list_spread_before_required_error(spread_span: Span) -> ShellError
 }
 
 /// Apply signature-aware null handling and expand record spreads for engine [`Argument`]s.
-///
-/// List spreads are rejected when the command has no rest parameter (and does not allow
-/// unknown args), so `...$list` cannot be silently dropped on named-only commands.
 pub(crate) fn normalize_engine_arguments(
     signature: &Signature,
     args: Vec<Argument>,

--- a/crates/nu-engine/src/named_flags.rs
+++ b/crates/nu-engine/src/named_flags.rs
@@ -1,5 +1,9 @@
 //! Helpers for signature-aware named flag handling (null omit/pass-through and
-//! record flag spreads). Shared by IR and AST evaluation paths.
+//! long-key record flag spreads).
+//!
+//! **IR-first:** Normal script evaluation uses IR (`normalize_engine_arguments` before
+//! custom/builtin dispatch). The light AST custom-command path reuses these helpers for
+//! parity; builtins on the residual AST `eval_call` path rely on IR for everyday use.
 
 use std::sync::Arc;
 
@@ -37,14 +41,11 @@ pub(crate) fn data_from_name_and_short(
 ) -> (Arc<[u8]>, DataSlice, DataSlice) {
     let data: Vec<u8> = name.bytes().chain(short.bytes()).collect();
     let data: Arc<[u8]> = data.into();
-    let name_len: u32 = name
-        .len()
-        .try_into()
-        .expect("flag long name length fits u32");
-    let short_len: u32 = short
-        .len()
-        .try_into()
-        .expect("flag short name length fits u32");
+    // Flag names are parser identifiers — never near u32::MAX.
+    #[allow(clippy::cast_possible_truncation)]
+    let name_len = name.len() as u32;
+    #[allow(clippy::cast_possible_truncation)]
+    let short_len = short.len() as u32;
     let name = DataSlice {
         start: 0,
         len: name_len,

--- a/crates/nu-engine/src/named_flags.rs
+++ b/crates/nu-engine/src/named_flags.rs
@@ -4,21 +4,17 @@
 use std::sync::Arc;
 
 use nu_protocol::{
-    CompareTypes, Flag, Record, ShellError, Signature, Span, Type, Value, engine::Argument,
+    CompareTypes, Flag, Record, ShellError, Signature, Span, Value, engine::Argument,
     ir::DataSlice, shell_error::generic::GenericError,
 };
 
 /// Whether a named flag's value type accepts `nothing`/`null`.
 ///
-/// Used so `--flag=$null` can either:
-/// - pass `null` through when the signature allows it (`any`, `nothing`, `oneof<…, nothing>`, …)
-/// - omit the flag when it does not (`--x: int`), so defaults / "flag absent" still work for shadowing
+/// Thin wrapper around [`Flag::type_accepts_nothing`] for call sites that already
+/// have a [`Flag`] reference.
+#[inline]
 pub(crate) fn flag_type_accepts_nothing(flag: &Flag) -> bool {
-    match &flag.arg {
-        Some(shape) => Type::Nothing.is_assignable_to(&shape.to_type()),
-        // Switches are booleans; null means omit (same as false / not passed).
-        None => false,
-    }
+    flag.type_accepts_nothing()
 }
 
 pub(crate) fn find_signature_flag<'a>(
@@ -36,20 +32,20 @@ pub(crate) fn find_signature_flag<'a>(
     })
 }
 
+/// Build the packed long+short name buffer used by engine [`Argument`]s.
+///
+/// Flag names are always short identifiers from the parser; lengths always fit in `u32`.
 pub(crate) fn data_from_name_and_short(
     name: &str,
     short: &str,
 ) -> (Arc<[u8]>, DataSlice, DataSlice) {
     let data: Vec<u8> = name.bytes().chain(short.bytes()).collect();
     let data: Arc<[u8]> = data.into();
-    let name_len: u32 = name
-        .len()
-        .try_into()
-        .expect("flag long name length fits u32");
-    let short_len: u32 = short
-        .len()
-        .try_into()
-        .expect("flag short name length fits u32");
+    // Flag names are parser identifiers — never near u32::MAX.
+    #[allow(clippy::cast_possible_truncation)]
+    let name_len = name.len() as u32;
+    #[allow(clippy::cast_possible_truncation)]
+    let short_len = short.len() as u32;
     let name = DataSlice {
         start: 0,
         len: name_len,
@@ -59,6 +55,30 @@ pub(crate) fn data_from_name_and_short(
         len: short_len,
     };
     (data, name, short)
+}
+
+/// Decode long/short flag name slices packed by [`data_from_name_and_short`].
+pub(crate) fn long_short_from_data(
+    data: &[u8],
+    name: DataSlice,
+    short: DataSlice,
+    span: Span,
+) -> Result<(&str, Option<String>), ShellError> {
+    let long = std::str::from_utf8(&data[name]).map_err(|_| {
+        ShellError::Generic(GenericError::new(
+            "Invalid flag name encoding",
+            "flag long name is not valid UTF-8",
+            span,
+        ))
+    })?;
+    let short_str = std::str::from_utf8(&data[short]).map_err(|_| {
+        ShellError::Generic(GenericError::new(
+            "Invalid flag name encoding",
+            "flag short name is not valid UTF-8",
+            span,
+        ))
+    })?;
+    Ok((long, (!short_str.is_empty()).then(|| short_str.to_string())))
 }
 
 /// Resolve a record key to a signature flag: long name first, then single-char short.
@@ -88,7 +108,8 @@ fn flag_cli_name(flag: &Flag) -> String {
 ///
 /// - Record keys match **long** flag names first; a single-character key may also match a
 ///   **short** flag (including short-only flags). Long form wins on collision.
-/// - Unknown keys: error, unless [`Signature::allows_unknown_args`] is set (then passed through).
+/// - Unknown keys: error, unless [`Signature::allows_unknown_args`] is set (then passed through
+///   as positionals / rest tokens, matching CLI unknown-flag handling).
 /// - `null` field values: passed through if the flag type accepts `nothing`, otherwise omitted
 /// - switch flags (`--flag` with no value): `true` sets the flag, `false`/`null` omit it
 /// - valued flags: non-null values become `--name value` (type-checked against the signature)
@@ -101,8 +122,7 @@ pub(crate) fn expand_flag_record(
     for (key, val) in record {
         let Some(flag) = flag_for_spread_key(signature, &key) else {
             if signature.allows_unknown_args {
-                // Best-effort: forward unknown keys as named args (or flags when `true`).
-                push_unknown_spread_field(&mut out, &key, val, spread_span)?;
+                push_unknown_spread_field(&mut out, &key, val, spread_span);
                 continue;
             }
             return Err(ShellError::Generic(GenericError::new(
@@ -144,7 +164,7 @@ pub(crate) fn expand_flag_record(
                     });
                 }
             }
-        } else if val.is_nothing() && !flag_type_accepts_nothing(&flag) {
+        } else if val.is_nothing() && !flag.type_accepts_nothing() {
             // Null → omit when the flag type does not accept nothing.
         } else {
             if !val.is_nothing()
@@ -178,16 +198,12 @@ pub(crate) fn expand_flag_record(
 
 /// Forward an unknown record field when `allows_unknown_args` is set.
 ///
-/// Synthesize CLI-like rest tokens (`--key` / `-k` plus optional value) so custom
-/// `--wrapped` commands and other unknown-arg signatures receive them on rest/unknown
-/// paths. We do not emit [`Argument::Named`] / [`Argument::Flag`] here: custom commands
-/// only bind declared named params by `var_id` and would error on unknown names.
-fn push_unknown_spread_field(
-    out: &mut Vec<Argument>,
-    key: &str,
-    val: Value,
-    spread_span: Span,
-) -> Result<(), ShellError> {
+/// Emits CLI-like rest/unknown tokens as [`Argument::Positional`] (`--key` / `-k` plus optional
+/// value), matching how the parser turns unknown flags into `Unknown` args (which compile to
+/// positionals). Custom commands bind these into remaining positionals / `...rest` in order —
+/// the same as `f --extra hello` on a `--wrapped` command. We do not emit [`Argument::Named`] /
+/// [`Argument::Flag`]: custom commands only bind declared named params by `var_id`.
+fn push_unknown_spread_field(out: &mut Vec<Argument>, key: &str, val: Value, spread_span: Span) {
     let flag_token = if key.chars().count() == 1 {
         format!("-{key}")
     } else {
@@ -216,7 +232,6 @@ fn push_unknown_spread_field(
             });
         }
     }
-    Ok(())
 }
 
 /// Whether this signature can accept a list rest spread.
@@ -253,7 +268,7 @@ pub(crate) fn normalize_engine_arguments(
                 name,
                 short,
                 span,
-                val: Value::Nothing { .. },
+                val: val @ Value::Nothing { .. },
                 ast,
             } => {
                 let accepts = find_signature_flag(signature, &data[name], &data[short])
@@ -264,7 +279,7 @@ pub(crate) fn normalize_engine_arguments(
                         name,
                         short,
                         span,
-                        val: Value::nothing(span),
+                        val,
                         ast,
                     });
                 }

--- a/crates/nu-engine/src/named_flags.rs
+++ b/crates/nu-engine/src/named_flags.rs
@@ -61,8 +61,33 @@ pub(crate) fn data_from_name_and_short(
     (data, name, short)
 }
 
+/// Resolve a record key to a signature flag: long name first, then single-char short.
+/// Long wins when both a long flag named `a` and a short `-a` exist.
+fn flag_for_spread_key(signature: &Signature, key: &str) -> Option<Flag> {
+    signature.get_long_flag(key).or_else(|| {
+        // Single Unicode scalar → short flag (e.g. key "a" → `-a`, including short-only flags).
+        let mut chars = key.chars();
+        match (chars.next(), chars.next()) {
+            (Some(c), None) => signature.get_short_flag(c),
+            _ => None,
+        }
+    })
+}
+
+fn flag_cli_name(flag: &Flag) -> String {
+    if let Some(long) = flag.long_name() {
+        format!("--{long}")
+    } else if let Some(short) = flag.short {
+        format!("-{short}")
+    } else {
+        "<flag>".into()
+    }
+}
+
 /// Expand a record into named/flag arguments for a call.
 ///
+/// - Record keys match **long** flag names first; a single-character key may also match a
+///   **short** flag (including short-only flags). Long form wins on collision.
 /// - `null` field values: passed through if the flag type accepts `nothing`, otherwise omitted
 /// - switch flags (`--flag` with no value): `true` sets the flag, `false`/`null` omit it
 /// - valued flags: non-null values become `--name value` (type-checked against the signature)
@@ -73,7 +98,7 @@ pub(crate) fn expand_flag_record(
 ) -> Result<Vec<Argument>, ShellError> {
     let mut out = Vec::with_capacity(record.len());
     for (key, val) in record {
-        let Some(flag) = signature.get_long_flag(&key) else {
+        let Some(flag) = flag_for_spread_key(signature, &key) else {
             return Err(ShellError::Generic(GenericError::new(
                 format!("Unknown flag `{key}` in spread record"),
                 format!("`{key}` is not a named argument of this command"),
@@ -126,7 +151,8 @@ pub(crate) fn expand_flag_record(
                         from_type: val.get_type().to_string(),
                         span: val.span(),
                         help: Some(format!(
-                            "spread field `{key}` does not match the type of `--{key}`"
+                            "spread field `{key}` does not match the type of `{}`",
+                            flag_cli_name(&flag)
                         )),
                     });
                 }

--- a/crates/nu-engine/src/named_flags.rs
+++ b/crates/nu-engine/src/named_flags.rs
@@ -88,6 +88,7 @@ fn flag_cli_name(flag: &Flag) -> String {
 ///
 /// - Record keys match **long** flag names first; a single-character key may also match a
 ///   **short** flag (including short-only flags). Long form wins on collision.
+/// - Unknown keys: error, unless [`Signature::allows_unknown_args`] is set (then passed through).
 /// - `null` field values: passed through if the flag type accepts `nothing`, otherwise omitted
 /// - switch flags (`--flag` with no value): `true` sets the flag, `false`/`null` omit it
 /// - valued flags: non-null values become `--name value` (type-checked against the signature)
@@ -99,6 +100,11 @@ pub(crate) fn expand_flag_record(
     let mut out = Vec::with_capacity(record.len());
     for (key, val) in record {
         let Some(flag) = flag_for_spread_key(signature, &key) else {
+            if signature.allows_unknown_args {
+                // Best-effort: forward unknown keys as named args (or flags when `true`).
+                push_unknown_spread_field(&mut out, &key, val, spread_span)?;
+                continue;
+            }
             return Err(ShellError::Generic(GenericError::new(
                 format!("Unknown flag `{key}` in spread record"),
                 format!("`{key}` is not a named argument of this command"),
@@ -170,9 +176,64 @@ pub(crate) fn expand_flag_record(
     Ok(out)
 }
 
+/// Forward an unknown record field when `allows_unknown_args` is set.
+///
+/// Synthesize CLI-like rest tokens (`--key` / `-k` plus optional value) so custom
+/// `--wrapped` commands and other unknown-arg signatures receive them on rest/unknown
+/// paths. We do not emit [`Argument::Named`] / [`Argument::Flag`] here: custom commands
+/// only bind declared named params by `var_id` and would error on unknown names.
+fn push_unknown_spread_field(
+    out: &mut Vec<Argument>,
+    key: &str,
+    val: Value,
+    spread_span: Span,
+) -> Result<(), ShellError> {
+    let flag_token = if key.chars().count() == 1 {
+        format!("-{key}")
+    } else {
+        format!("--{key}")
+    };
+
+    match val {
+        Value::Bool { val: true, .. } => {
+            out.push(Argument::Positional {
+                span: spread_span,
+                val: Value::string(flag_token, spread_span),
+                ast: None,
+            });
+        }
+        Value::Bool { val: false, .. } | Value::Nothing { .. } => {}
+        other => {
+            out.push(Argument::Positional {
+                span: spread_span,
+                val: Value::string(flag_token, spread_span),
+                ast: None,
+            });
+            out.push(Argument::Positional {
+                span: other.span(),
+                val: other,
+                ast: None,
+            });
+        }
+    }
+    Ok(())
+}
+
 /// Whether this signature can accept a list rest spread.
 pub(crate) fn can_rest_spread(signature: &Signature) -> bool {
     signature.rest_positional.is_some() || signature.allows_unknown_args
+}
+
+/// Error when a list is spread while required positionals remain unbound.
+///
+/// Dual-purpose commands accept both flag records and rest lists via `...$x`. Spreading a list
+/// before required positionals are filled would leave them unbound (list items go to rest).
+pub(crate) fn list_spread_before_required_error(spread_span: Span) -> ShellError {
+    ShellError::Generic(GenericError::new(
+        "Cannot spread a list before required positional arguments are provided",
+        "List spreads fill rest arguments. Provide required positionals first, or use a record to spread named flags, e.g. ...{flag: value}",
+        spread_span,
+    ))
 }
 
 /// Apply signature-aware null handling and expand record spreads for engine [`Argument`]s.

--- a/crates/nu-engine/src/named_flags.rs
+++ b/crates/nu-engine/src/named_flags.rs
@@ -1,5 +1,5 @@
 //! Helpers for signature-aware named flag handling (null omit/pass-through and
-//! long-key record flag spreads). Shared by IR and AST evaluation paths.
+//! record flag spreads). Shared by IR and AST evaluation paths.
 
 use std::sync::Arc;
 
@@ -9,6 +9,8 @@ use nu_protocol::{
 };
 
 /// Whether a named flag's value type accepts `nothing`/`null`.
+///
+/// Thin wrapper around [`Flag::type_accepts_nothing`] for local call sites.
 #[inline]
 pub(crate) fn flag_type_accepts_nothing(flag: &Flag) -> bool {
     flag.type_accepts_nothing()
@@ -29,18 +31,20 @@ pub(crate) fn find_signature_flag<'a>(
     })
 }
 
-/// Build the packed long+short name buffer used by engine [`Argument`]s.
 pub(crate) fn data_from_name_and_short(
     name: &str,
     short: &str,
 ) -> (Arc<[u8]>, DataSlice, DataSlice) {
     let data: Vec<u8> = name.bytes().chain(short.bytes()).collect();
     let data: Arc<[u8]> = data.into();
-    // Flag names are parser identifiers — never near u32::MAX.
-    #[allow(clippy::cast_possible_truncation)]
-    let name_len = name.len() as u32;
-    #[allow(clippy::cast_possible_truncation)]
-    let short_len = short.len() as u32;
+    let name_len: u32 = name
+        .len()
+        .try_into()
+        .expect("flag long name length fits u32");
+    let short_len: u32 = short
+        .len()
+        .try_into()
+        .expect("flag short name length fits u32");
     let name = DataSlice {
         start: 0,
         len: name_len,
@@ -54,10 +58,9 @@ pub(crate) fn data_from_name_and_short(
 
 /// Expand a record into named/flag arguments for a call.
 ///
-/// - Record keys match **long** flag names only (`--flag` form).
-/// - Unknown keys error.
-/// - `null` field values: passed through if the flag type accepts `nothing`, otherwise omitted.
-/// - Switch flags: `true` sets the flag; `false`/`null` omit.
+/// - `null` field values: passed through if the flag type accepts `nothing`, otherwise omitted
+/// - switch flags (`--flag` with no value): `true` sets the flag, `false`/`null` omit it
+/// - valued flags: non-null values become `--name value` (type-checked against the signature)
 pub(crate) fn expand_flag_record(
     signature: &Signature,
     record: Record,
@@ -83,6 +86,7 @@ pub(crate) fn expand_flag_record(
         let (data, name_slice, short_slice) = data_from_name_and_short(&flag.long, &short);
 
         if flag.arg.is_none() {
+            // Switch: only `true` sets the flag; `false`/`null` omit (like `--flag=false`).
             match val {
                 Value::Bool { val: true, .. } => {
                     out.push(Argument::Flag {
@@ -104,7 +108,7 @@ pub(crate) fn expand_flag_record(
                     });
                 }
             }
-        } else if val.is_nothing() && !flag.type_accepts_nothing() {
+        } else if val.is_nothing() && !flag_type_accepts_nothing(&flag) {
             // Null → omit when the flag type does not accept nothing.
         } else {
             if !val.is_nothing()
@@ -141,6 +145,9 @@ pub(crate) fn can_rest_spread(signature: &Signature) -> bool {
 }
 
 /// Error when a list (or null rest-mode) is spread while required positionals remain unbound.
+///
+/// Dual-purpose commands accept both flag records and rest lists via `...$x`. Spreading a list
+/// before required positionals are filled would leave them unbound (list items go to rest).
 pub(crate) fn list_spread_before_required_error(spread_span: Span) -> ShellError {
     ShellError::Generic(GenericError::new(
         "Cannot spread a list before required positional arguments are provided",
@@ -150,6 +157,9 @@ pub(crate) fn list_spread_before_required_error(spread_span: Span) -> ShellError
 }
 
 /// Apply signature-aware null handling and expand record spreads for engine [`Argument`]s.
+///
+/// List spreads are rejected when the command has no rest parameter (and does not allow
+/// unknown args), so `...$list` cannot be silently dropped on named-only commands.
 pub(crate) fn normalize_engine_arguments(
     signature: &Signature,
     args: Vec<Argument>,
@@ -163,7 +173,7 @@ pub(crate) fn normalize_engine_arguments(
                 name,
                 short,
                 span,
-                val: val @ Value::Nothing { .. },
+                val: Value::Nothing { .. },
                 ast,
             } => {
                 let accepts = find_signature_flag(signature, &data[name], &data[short])
@@ -174,7 +184,7 @@ pub(crate) fn normalize_engine_arguments(
                         name,
                         short,
                         span,
-                        val,
+                        val: Value::nothing(span),
                         ast,
                     });
                 }

--- a/crates/nu-engine/src/named_flags.rs
+++ b/crates/nu-engine/src/named_flags.rs
@@ -1,0 +1,228 @@
+//! Helpers for signature-aware named flag handling (null omit/pass-through and
+//! record flag spreads). Shared by IR and AST evaluation paths.
+
+use std::sync::Arc;
+
+use nu_protocol::{
+    CompareTypes, Flag, Record, ShellError, Signature, Span, Type, Value, engine::Argument,
+    ir::DataSlice, shell_error::generic::GenericError,
+};
+
+/// Whether a named flag's value type accepts `nothing`/`null`.
+///
+/// Used so `--flag=$null` can either:
+/// - pass `null` through when the signature allows it (`any`, `nothing`, `oneof<…, nothing>`, …)
+/// - omit the flag when it does not (`--x: int`), so defaults / "flag absent" still work for shadowing
+pub(crate) fn flag_type_accepts_nothing(flag: &Flag) -> bool {
+    match &flag.arg {
+        Some(shape) => Type::Nothing.is_assignable_to(&shape.to_type()),
+        // Switches are booleans; null means omit (same as false / not passed).
+        None => false,
+    }
+}
+
+pub(crate) fn find_signature_flag<'a>(
+    signature: &'a Signature,
+    long: &[u8],
+    short: &[u8],
+) -> Option<&'a Flag> {
+    signature.named.iter().find(|flag| {
+        (!long.is_empty() && flag.long.as_bytes() == long)
+            || (!short.is_empty()
+                && flag.short.is_some_and(|c| {
+                    let mut buf = [0u8; 4];
+                    c.encode_utf8(&mut buf).as_bytes() == short
+                }))
+    })
+}
+
+pub(crate) fn data_from_name_and_short(
+    name: &str,
+    short: &str,
+) -> (Arc<[u8]>, DataSlice, DataSlice) {
+    let data: Vec<u8> = name.bytes().chain(short.bytes()).collect();
+    let data: Arc<[u8]> = data.into();
+    let name_len: u32 = name
+        .len()
+        .try_into()
+        .expect("flag long name length fits u32");
+    let short_len: u32 = short
+        .len()
+        .try_into()
+        .expect("flag short name length fits u32");
+    let name = DataSlice {
+        start: 0,
+        len: name_len,
+    };
+    let short = DataSlice {
+        start: name_len,
+        len: short_len,
+    };
+    (data, name, short)
+}
+
+/// Expand a record into named/flag arguments for a call.
+///
+/// - `null` field values: passed through if the flag type accepts `nothing`, otherwise omitted
+/// - switch flags (`--flag` with no value): `true` sets the flag, `false`/`null` omit it
+/// - valued flags: non-null values become `--name value` (type-checked against the signature)
+pub(crate) fn expand_flag_record(
+    signature: &Signature,
+    record: Record,
+    spread_span: Span,
+) -> Result<Vec<Argument>, ShellError> {
+    let mut out = Vec::with_capacity(record.len());
+    for (key, val) in record {
+        let Some(flag) = signature.get_long_flag(&key) else {
+            return Err(ShellError::Generic(GenericError::new(
+                format!("Unknown flag `{key}` in spread record"),
+                format!("`{key}` is not a named argument of this command"),
+                spread_span,
+            )));
+        };
+
+        let short = flag
+            .short
+            .map(|c| {
+                let mut buf = [0u8; 4];
+                c.encode_utf8(&mut buf).to_string()
+            })
+            .unwrap_or_default();
+        let (data, name_slice, short_slice) = data_from_name_and_short(&flag.long, &short);
+
+        if flag.arg.is_none() {
+            // Switch: only `true` sets the flag; `false`/`null` omit (like `--flag=false`).
+            match val {
+                Value::Bool { val: true, .. } => {
+                    out.push(Argument::Flag {
+                        data,
+                        name: name_slice,
+                        short: short_slice,
+                        span: spread_span,
+                    });
+                }
+                Value::Bool { val: false, .. } | Value::Nothing { .. } => {}
+                other => {
+                    return Err(ShellError::CantConvert {
+                        to_type: "bool".into(),
+                        from_type: other.get_type().to_string(),
+                        span: other.span(),
+                        help: Some(format!(
+                            "spread field `{key}` is a switch; use true/false or omit/null"
+                        )),
+                    });
+                }
+            }
+        } else if val.is_nothing() && !flag_type_accepts_nothing(&flag) {
+            // Null → omit when the flag type does not accept nothing.
+        } else {
+            if !val.is_nothing()
+                && let Some(shape) = &flag.arg
+            {
+                let expected = shape.to_type();
+                if !val.is_assignable_to(&expected) {
+                    return Err(ShellError::CantConvert {
+                        to_type: expected.to_string(),
+                        from_type: val.get_type().to_string(),
+                        span: val.span(),
+                        help: Some(format!(
+                            "spread field `{key}` does not match the type of `--{key}`"
+                        )),
+                    });
+                }
+            }
+            out.push(Argument::Named {
+                data,
+                name: name_slice,
+                short: short_slice,
+                span: spread_span,
+                val,
+                ast: None,
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Whether this signature can accept a list rest spread.
+pub(crate) fn can_rest_spread(signature: &Signature) -> bool {
+    signature.rest_positional.is_some() || signature.allows_unknown_args
+}
+
+/// Apply signature-aware null handling and expand record spreads for engine [`Argument`]s.
+///
+/// List spreads are rejected when the command has no rest parameter (and does not allow
+/// unknown args), so `...$list` cannot be silently dropped on named-only commands.
+pub(crate) fn normalize_engine_arguments(
+    signature: &Signature,
+    args: Vec<Argument>,
+) -> Result<Vec<Argument>, ShellError> {
+    let mut expanded = Vec::with_capacity(args.len());
+
+    for arg in args {
+        match arg {
+            Argument::Named {
+                data,
+                name,
+                short,
+                span,
+                val: Value::Nothing { .. },
+                ast,
+            } => {
+                let accepts = find_signature_flag(signature, &data[name], &data[short])
+                    .is_some_and(flag_type_accepts_nothing);
+                if accepts {
+                    expanded.push(Argument::Named {
+                        data,
+                        name,
+                        short,
+                        span,
+                        val: Value::nothing(span),
+                        ast,
+                    });
+                }
+                // else: null → omit
+            }
+            Argument::Spread {
+                vals,
+                span: spread_span,
+                ast,
+            } => match vals {
+                Value::Record { val, .. } => {
+                    expanded.extend(expand_flag_record(
+                        signature,
+                        val.into_owned(),
+                        spread_span,
+                    )?);
+                }
+                Value::List { .. } => {
+                    if !can_rest_spread(signature) {
+                        return Err(ShellError::Generic(GenericError::new(
+                            "Cannot spread a list into this command",
+                            "This command has no ...rest parameter to receive a list spread. Use a record to spread named flags, e.g. ...{flag: value}",
+                            spread_span,
+                        )));
+                    }
+                    expanded.push(Argument::Spread {
+                        vals,
+                        span: spread_span,
+                        ast,
+                    });
+                }
+                Value::Nothing { .. } | Value::Error { .. } => {
+                    expanded.push(Argument::Spread {
+                        vals,
+                        span: spread_span,
+                        ast,
+                    });
+                }
+                other => {
+                    return Err(ShellError::CannotSpreadAsList { span: other.span() });
+                }
+            },
+            other => expanded.push(other),
+        }
+    }
+
+    Ok(expanded)
+}

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -9,8 +9,8 @@ use crate::{
 use log::trace;
 use nu_engine::DIR_VAR_PARSER_INFO;
 use nu_protocol::{
-    CompareTypes, DeclId, Flag, IntoSpanned, ParseError, PositionalArg, ShellError, Signature, Span,
-    Spanned, SyntaxShape, Type, TypeSet,
+    DeclId, Flag, IntoSpanned, ParseError, PositionalArg, ShellError, Signature, Span, Spanned,
+    SyntaxShape, Type, TypeSet,
     ast::*,
     did_you_mean,
     engine::{CommandType, StateWorkingSet},
@@ -123,13 +123,6 @@ enum RequiredFlagPresence {
     MaybeDynamic,
 }
 
-fn flag_type_accepts_nothing_shape(flag: &Flag) -> bool {
-    match &flag.arg {
-        Some(shape) => Type::Nothing.is_assignable_to(&shape.to_type()),
-        None => false,
-    }
-}
-
 fn named_matches_flag(flag: &Flag, long: &str, short: Option<&str>) -> bool {
     (!flag.long.is_empty() && flag.long == long)
         || short.is_some_and(|s| {
@@ -142,15 +135,23 @@ fn named_matches_flag(flag: &Flag, long: &str, short: Option<&str>) -> bool {
 
 fn key_matches_flag(flag: &Flag, key: &str) -> bool {
     (!flag.long.is_empty() && flag.long == key)
-        || (key.chars().count() == 1
-            && flag.short.is_some_and(|c| key.chars().next() == Some(c)))
+        || (key.chars().count() == 1 && flag.short.is_some_and(|c| key.chars().next() == Some(c)))
 }
 
 /// Static keys/values from a record expression used as a flag spread.
 /// Returns `None` when the expression is not a fully static record (dynamic / nested spreads).
+///
+/// Bare `{key: val}` is often parsed as [`Expr::FullCellPath`] with an empty tail and a
+/// [`Expr::Record`] head (via `parse_brace_expr` → `parse_full_cell_path`), so both forms
+/// must be accepted.
 fn static_record_flag_entries(expr: &Expression) -> Option<Vec<(String, &Expression)>> {
-    let Expr::Record(items) = &expr.expr else {
-        return None;
+    let items = match &expr.expr {
+        Expr::Record(items) => items.as_slice(),
+        Expr::FullCellPath(path) if path.tail.is_empty() => match &path.head.expr {
+            Expr::Record(items) => items.as_slice(),
+            _ => return None,
+        },
+        _ => return None,
     };
     let mut entries = Vec::with_capacity(items.len());
     for item in items {
@@ -166,23 +167,73 @@ fn static_record_flag_entries(expr: &Expression) -> Option<Vec<(String, &Express
     Some(entries)
 }
 
+/// True when a static expression is `null` and the flag will omit it at runtime.
+fn is_static_null_omit(flag: &Flag, expr: &Expression) -> bool {
+    matches!(expr.expr, Expr::Nothing) && !flag.type_accepts_nothing()
+}
+
+/// Whether a non-static-record spread expression could still evaluate to a flag record.
+///
+/// Used so static lists (and other non-record literals) do not suppress
+/// `MissingRequiredFlag` via a false `MaybeDynamic`.
+fn spread_could_be_flag_record(expr: &Expression) -> bool {
+    match &expr.expr {
+        // Explicit non-record literals cannot supply named flags.
+        Expr::List(_)
+        | Expr::Nothing
+        | Expr::Bool(_)
+        | Expr::Int(_)
+        | Expr::Float(_)
+        | Expr::String(_)
+        | Expr::RawString(_)
+        | Expr::Binary(_)
+        | Expr::DateTime(_)
+        | Expr::Filepath(_, _)
+        | Expr::Directory(_, _)
+        | Expr::GlobPattern(_, _)
+        | Expr::Range(_)
+        | Expr::Table(_) => false,
+        // FullCellPath with empty tail was already handled as a static record (or not a record).
+        // Non-empty tail or non-record head: dynamic.
+        Expr::FullCellPath(path) if path.tail.is_empty() => !matches!(
+            path.head.expr,
+            Expr::List(_)
+                | Expr::Nothing
+                | Expr::Bool(_)
+                | Expr::Int(_)
+                | Expr::Float(_)
+                | Expr::String(_)
+                | Expr::Table(_)
+        ),
+        // Variables, calls, subexpressions, nested spreads inside records, etc.
+        _ => true,
+    }
+}
+
 fn required_flag_presence(call: &Call, req_flag: &Flag) -> RequiredFlagPresence {
+    // Scan all sources: a static null does not end the search — a later explicit value or
+    // dynamic spread may still supply the required flag.
+    let mut present = false;
+    let mut saw_dynamic_spread = false;
+
     // Explicit `--flag` / `-f` (including `=value`)
     for (long, short, maybe_expr) in call.named_iter() {
-        if !named_matches_flag(req_flag, &long.item, short.as_ref().map(|s| s.item.as_str())) {
+        if !named_matches_flag(
+            req_flag,
+            &long.item,
+            short.as_ref().map(|s| s.item.as_str()),
+        ) {
             continue;
         }
-        // Static null is omitted at runtime when the type does not accept nothing.
         if let Some(expr) = maybe_expr
-            && matches!(expr.expr, Expr::Nothing)
-            && !flag_type_accepts_nothing_shape(req_flag)
+            && is_static_null_omit(req_flag, expr)
         {
-            return RequiredFlagPresence::Absent;
+            // Omitted at runtime; keep scanning.
+            continue;
         }
-        return RequiredFlagPresence::Present;
+        present = true;
     }
 
-    let mut saw_dynamic_spread = false;
     for arg in &call.arguments {
         let Argument::Spread(expr) = arg else {
             continue;
@@ -193,20 +244,22 @@ fn required_flag_presence(call: &Call, req_flag: &Flag) -> RequiredFlagPresence 
                     if !key_matches_flag(req_flag, &key) {
                         continue;
                     }
-                    if matches!(val_expr.expr, Expr::Nothing)
-                        && !flag_type_accepts_nothing_shape(req_flag)
-                    {
-                        return RequiredFlagPresence::Absent;
+                    if is_static_null_omit(req_flag, val_expr) {
+                        continue;
                     }
-                    return RequiredFlagPresence::Present;
+                    present = true;
                 }
             }
-            // Variable / subexpression / list / partial record: may be a flag record at runtime.
-            None => saw_dynamic_spread = true,
+            // Only shapes that could still evaluate to a flag record at runtime.
+            // Static lists / scalars can never supply named flags.
+            None if spread_could_be_flag_record(expr) => saw_dynamic_spread = true,
+            None => {}
         }
     }
 
-    if saw_dynamic_spread {
+    if present {
+        RequiredFlagPresence::Present
+    } else if saw_dynamic_spread {
         RequiredFlagPresence::MaybeDynamic
     } else {
         RequiredFlagPresence::Absent

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -90,7 +90,9 @@ pub(crate) fn check_call(
         return CallKind::Invalid;
     } else {
         // Spreads may supply required named flags at runtime (`...{flag: val}` / `...$flags`).
-        // Defer to the command rather than parse-erroring when any spread is present.
+        // When any spread is present, skip parse-time MissingRequiredFlag and let runtime /
+        // the command fail if a required flag is still missing. This also defers for pure
+        // list rest spreads (slightly weaker diagnostics; acceptable for dual-purpose `...$x`).
         if !has_spread {
             for req_flag in sig.named.iter().filter(|x| x.required) {
                 if call.named_iter().all(|(n, _, _)| n.item != req_flag.long) {

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -89,21 +89,17 @@ pub(crate) fn check_call(
         ));
         return CallKind::Invalid;
     } else {
-        for req_flag in sig.named.iter().filter(|x| x.required) {
-            match required_flag_presence(call, req_flag) {
-                RequiredFlagPresence::Present => {}
-                // Dynamic spreads (`...$flags`) may supply the flag at runtime.
-                RequiredFlagPresence::MaybeDynamic => {}
-                RequiredFlagPresence::Absent => {
+        // Spreads may supply required named flags at runtime (`...{flag: val}` / `...$flags`).
+        // Defer to runtime when any spread is present rather than static-analyzing records.
+        let has_spread = call
+            .arguments
+            .iter()
+            .any(|arg| matches!(arg, Argument::Spread(_)));
+        if !has_spread {
+            for req_flag in sig.named.iter().filter(|x| x.required) {
+                if call.named_iter().all(|(n, _, _)| n.item != req_flag.long) {
                     working_set.error(ParseError::MissingRequiredFlag(
-                        if req_flag.long.is_empty() {
-                            req_flag
-                                .short
-                                .map(|c| c.to_string())
-                                .unwrap_or_else(|| req_flag.long.clone())
-                        } else {
-                            req_flag.long.clone()
-                        },
+                        req_flag.long.clone(),
                         command,
                     ));
                     return CallKind::Invalid;
@@ -112,158 +108,6 @@ pub(crate) fn check_call(
         }
     }
     CallKind::Valid
-}
-
-/// Whether a required named flag is known to be present at parse time.
-#[derive(Debug, PartialEq, Eq)]
-enum RequiredFlagPresence {
-    Present,
-    Absent,
-    /// A non-literal / dynamic spread may supply the flag at runtime.
-    MaybeDynamic,
-}
-
-fn named_matches_flag(flag: &Flag, long: &str, short: Option<&str>) -> bool {
-    (!flag.long.is_empty() && flag.long == long)
-        || short.is_some_and(|s| {
-            flag.short.is_some_and(|c| {
-                let mut buf = [0u8; 4];
-                c.encode_utf8(&mut buf) == s
-            })
-        })
-}
-
-fn key_matches_flag(flag: &Flag, key: &str) -> bool {
-    (!flag.long.is_empty() && flag.long == key)
-        || (key.chars().count() == 1 && flag.short.is_some_and(|c| key.starts_with(c)))
-}
-
-/// Static keys/values from a record expression used as a flag spread.
-/// Returns `None` when the expression is not a fully static record (dynamic / nested spreads).
-///
-/// Bare `{key: val}` is often parsed as [`Expr::FullCellPath`] with an empty tail and a
-/// [`Expr::Record`] head (via `parse_brace_expr` → `parse_full_cell_path`), so both forms
-/// must be accepted.
-fn static_record_flag_entries(expr: &Expression) -> Option<Vec<(String, &Expression)>> {
-    let items = match &expr.expr {
-        Expr::Record(items) => items.as_slice(),
-        Expr::FullCellPath(path) if path.tail.is_empty() => match &path.head.expr {
-            Expr::Record(items) => items.as_slice(),
-            _ => return None,
-        },
-        _ => return None,
-    };
-    let mut entries = Vec::with_capacity(items.len());
-    for item in items {
-        match item {
-            RecordItem::Pair(key_expr, val_expr) => {
-                let key = key_expr.as_string()?;
-                entries.push((key, val_expr));
-            }
-            // Nested record spreads make the full key set dynamic.
-            RecordItem::Spread(_, _) => return None,
-        }
-    }
-    Some(entries)
-}
-
-/// True when a static expression is `null` and the flag will omit it at runtime.
-fn is_static_null_omit(flag: &Flag, expr: &Expression) -> bool {
-    matches!(expr.expr, Expr::Nothing) && !flag.type_accepts_nothing()
-}
-
-/// Whether a non-static-record spread expression could still evaluate to a flag record.
-///
-/// Used so static lists (and other non-record literals) do not suppress
-/// `MissingRequiredFlag` via a false `MaybeDynamic`.
-fn spread_could_be_flag_record(expr: &Expression) -> bool {
-    match &expr.expr {
-        // Explicit non-record literals cannot supply named flags.
-        Expr::List(_)
-        | Expr::Nothing
-        | Expr::Bool(_)
-        | Expr::Int(_)
-        | Expr::Float(_)
-        | Expr::String(_)
-        | Expr::RawString(_)
-        | Expr::Binary(_)
-        | Expr::DateTime(_)
-        | Expr::Filepath(_, _)
-        | Expr::Directory(_, _)
-        | Expr::GlobPattern(_, _)
-        | Expr::Range(_)
-        | Expr::Table(_) => false,
-        // FullCellPath with empty tail was already handled as a static record (or not a record).
-        // Non-empty tail or non-record head: dynamic.
-        Expr::FullCellPath(path) if path.tail.is_empty() => !matches!(
-            path.head.expr,
-            Expr::List(_)
-                | Expr::Nothing
-                | Expr::Bool(_)
-                | Expr::Int(_)
-                | Expr::Float(_)
-                | Expr::String(_)
-                | Expr::Table(_)
-        ),
-        // Variables, calls, subexpressions, nested spreads inside records, etc.
-        _ => true,
-    }
-}
-
-fn required_flag_presence(call: &Call, req_flag: &Flag) -> RequiredFlagPresence {
-    // Scan all sources: a static null does not end the search — a later explicit value or
-    // dynamic spread may still supply the required flag.
-    let mut present = false;
-    let mut saw_dynamic_spread = false;
-
-    // Explicit `--flag` / `-f` (including `=value`)
-    for (long, short, maybe_expr) in call.named_iter() {
-        if !named_matches_flag(
-            req_flag,
-            &long.item,
-            short.as_ref().map(|s| s.item.as_str()),
-        ) {
-            continue;
-        }
-        if let Some(expr) = maybe_expr
-            && is_static_null_omit(req_flag, expr)
-        {
-            // Omitted at runtime; keep scanning.
-            continue;
-        }
-        present = true;
-    }
-
-    for arg in &call.arguments {
-        let Argument::Spread(expr) = arg else {
-            continue;
-        };
-        match static_record_flag_entries(expr) {
-            Some(entries) => {
-                for (key, val_expr) in entries {
-                    if !key_matches_flag(req_flag, &key) {
-                        continue;
-                    }
-                    if is_static_null_omit(req_flag, val_expr) {
-                        continue;
-                    }
-                    present = true;
-                }
-            }
-            // Only shapes that could still evaluate to a flag record at runtime.
-            // Static lists / scalars can never supply named flags.
-            None if spread_could_be_flag_record(expr) => saw_dynamic_spread = true,
-            None => {}
-        }
-    }
-
-    if present {
-        RequiredFlagPresence::Present
-    } else if saw_dynamic_spread {
-        RequiredFlagPresence::MaybeDynamic
-    } else {
-        RequiredFlagPresence::Absent
-    }
 }
 
 fn parse_unknown_arg(

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -1,6 +1,8 @@
 use crate::{
     lite_parser::LiteCommand,
-    parse_helpers::{PERCENT_FORCED_BUILTIN_PARSER_INFO, extract_spread_list, garbage},
+    parse_helpers::{
+        PERCENT_FORCED_BUILTIN_PARSER_INFO, extract_spread_list, extract_spread_record, garbage,
+    },
     parse_source::find_dirs_var,
     type_check::type_compatible,
 };
@@ -384,7 +386,9 @@ fn ensure_flag_arg_type(
     arg_shape: &SyntaxShape,
     long_name_span: Span,
 ) -> (Spanned<String>, Expression) {
-    if !type_compatible(&arg_shape.to_type(), &arg.ty) {
+    // `nothing` is allowed so optional named flags can be forwarded with
+    // `--flag=$maybe_null`; at runtime a null value omits the flag entirely.
+    if arg.ty != Type::Nothing && !type_compatible(&arg_shape.to_type(), &arg.ty) {
         working_set.error(ParseError::TypeMismatch(
             arg_shape.to_type(),
             arg.ty,
@@ -1184,46 +1188,116 @@ pub fn parse_internal_call(
 
         {
             let contents = working_set.get_span_contents(spans[spans_idx]);
+            let can_rest_spread =
+                signature.rest_positional.is_some() || signature.allows_unknown_args;
+            // Named flag spreads (`...{flag: value}`) need at least one real named param.
+            let can_named_spread = signature.named.iter().any(|n| n.long != "help");
+
+            // Explicit record spread: `...{ preserve: $p, recursive: true }`
+            // (must be checked before list extract, which also accepts `$`/`(` forms)
+            if let Some(Spanned {
+                span: spread_arg_span,
+                ..
+            }) = extract_spread_record(contents.into_spanned(spans[spans_idx]))
+            {
+                let after_dots = working_set.get_span_contents(spread_arg_span);
+                if after_dots.first() == Some(&b'{') {
+                    // Record spreads always parse; unknown keys error at runtime when expanded
+                    // into named flags (not into ...rest).
+                    let args = crate::parser::parse_value(
+                        working_set,
+                        spread_arg_span,
+                        // Open record; field types are validated against the signature at runtime.
+                        &SyntaxShape::Record(std::iter::empty().collect()),
+                        None,
+                    );
+                    call.add_spread(args);
+                    spans_idx += 1;
+                    continue;
+                }
+            }
 
             if let Some(Spanned {
                 span: spread_arg_span,
                 ..
             }) = extract_spread_list(contents.into_spanned(spans[spans_idx]))
             {
-                if signature.rest_positional.is_none() && !signature.allows_unknown_args {
+                let after_dots = working_set.get_span_contents(spread_arg_span);
+                let is_explicit_list = after_dots.first() == Some(&b'[');
+                // `...$var` / `...(expr)` may be a rest list or a named-flag record at runtime.
+                let is_dynamic = matches!(after_dots.first(), Some(b'$' | b'('));
+
+                if is_explicit_list {
+                    if !can_rest_spread {
+                        working_set.error(ParseError::UnexpectedSpreadArg(
+                            signature.call_signature(),
+                            arg_span,
+                        ));
+                        call.add_positional(Expression::garbage(working_set, arg_span));
+                    } else if positional_idx < signature.required_positional.len() {
+                        working_set.error(ParseError::MissingPositional(
+                            signature.required_positional[positional_idx].name.clone(),
+                            Span::new(spans[spans_idx].start, spans[spans_idx].start),
+                            signature.call_signature(),
+                        ));
+                        call.add_positional(Expression::garbage(working_set, arg_span));
+                    } else {
+                        let rest_shape = match &signature.rest_positional {
+                            Some(arg) if matches!(arg.shape, SyntaxShape::ExternalArgument) => {
+                                // External args aren't parsed inside lists in spread position.
+                                SyntaxShape::Any
+                            }
+                            Some(arg) => arg.shape.clone(),
+                            None => SyntaxShape::Any,
+                        };
+                        let args = crate::parser::parse_value(
+                            working_set,
+                            spread_arg_span,
+                            &SyntaxShape::List(Box::new(rest_shape)),
+                            None,
+                        );
+                        call.add_spread(args);
+                        positional_idx = signature.required_positional.len()
+                            + signature.optional_positional.len();
+                    }
+                } else if is_dynamic {
+                    if !can_rest_spread && !can_named_spread {
+                        working_set.error(ParseError::UnexpectedSpreadArg(
+                            signature.call_signature(),
+                            arg_span,
+                        ));
+                        call.add_positional(Expression::garbage(working_set, arg_span));
+                    } else if can_rest_spread
+                        && positional_idx < signature.required_positional.len()
+                    {
+                        // Rest spreads cannot fill required positionals.
+                        working_set.error(ParseError::MissingPositional(
+                            signature.required_positional[positional_idx].name.clone(),
+                            Span::new(spans[spans_idx].start, spans[spans_idx].start),
+                            signature.call_signature(),
+                        ));
+                        call.add_positional(Expression::garbage(working_set, arg_span));
+                    } else {
+                        // Parse as Any so both lists (rest) and records (named flags) work.
+                        let args = crate::parser::parse_value(
+                            working_set,
+                            spread_arg_span,
+                            &SyntaxShape::Any,
+                            None,
+                        );
+                        call.add_spread(args);
+                        if can_rest_spread {
+                            positional_idx = signature.required_positional.len()
+                                + signature.optional_positional.len();
+                        }
+                    }
+                } else {
+                    // Unreachable for extract_spread_list, but keep a safe fallback.
                     working_set.error(ParseError::UnexpectedSpreadArg(
                         signature.call_signature(),
                         arg_span,
                     ));
                     call.add_positional(Expression::garbage(working_set, arg_span));
-                } else if positional_idx < signature.required_positional.len() {
-                    working_set.error(ParseError::MissingPositional(
-                        signature.required_positional[positional_idx].name.clone(),
-                        Span::new(spans[spans_idx].start, spans[spans_idx].start),
-                        signature.call_signature(),
-                    ));
-                    call.add_positional(Expression::garbage(working_set, arg_span));
-                } else {
-                    let rest_shape = match &signature.rest_positional {
-                        Some(arg) if matches!(arg.shape, SyntaxShape::ExternalArgument) => {
-                            // External args aren't parsed inside lists in spread position.
-                            SyntaxShape::Any
-                        }
-                        Some(arg) => arg.shape.clone(),
-                        None => SyntaxShape::Any,
-                    };
-                    // Parse list of arguments to be spread
-                    let args = crate::parser::parse_value(
-                        working_set,
-                        spread_arg_span,
-                        &SyntaxShape::List(Box::new(rest_shape)),
-                        None,
-                    );
-
-                    call.add_spread(args);
-                    // Let the parser know that it's parsing rest arguments now
-                    positional_idx =
-                        signature.required_positional.len() + signature.optional_positional.len();
                 }
 
                 spans_idx += 1;

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -36,9 +36,27 @@ pub(crate) fn check_call(
         return CallKind::Help;
     }
 
-    if call.positional_iter().count() < sig.required_positional.len() {
-        let end_offset = call
-            .positional_iter()
+    // `positional_iter` stops at the first `...` spread (historically rest-only). Flag-record
+    // spreads (`...{…}` / dual-purpose `...$flags`) do not consume positionals, so arguments
+    // after them must still count toward required positionals.
+    let has_spread = call
+        .arguments
+        .iter()
+        .any(|arg| matches!(arg, Argument::Spread(_)));
+    let positional_exprs: Vec<_> = if has_spread {
+        call.arguments
+            .iter()
+            .filter_map(|arg| match arg {
+                Argument::Positional(e) | Argument::Unknown(e) => Some(e),
+                _ => None,
+            })
+            .collect()
+    } else {
+        call.positional_iter().collect()
+    };
+
+    if positional_exprs.len() < sig.required_positional.len() {
+        let end_offset = positional_exprs
             .last()
             .map(|last| last.span.end)
             .unwrap_or(command.end);
@@ -46,7 +64,7 @@ pub(crate) fn check_call(
         // expressions found in the call. If one type is not found then it could be assumed
         // that positional argument is missing from the parsed call
         for argument in &sig.required_positional {
-            let found = call.positional_iter().fold(false, |ac, expr| {
+            let found = positional_exprs.iter().fold(false, |ac, expr| {
                 if argument.shape.to_type() == expr.ty || argument.shape == SyntaxShape::Any {
                     true
                 } else {
@@ -63,7 +81,7 @@ pub(crate) fn check_call(
             }
         }
 
-        let missing = &sig.required_positional[call.positional_iter().count()];
+        let missing = &sig.required_positional[positional_exprs.len()];
         working_set.error(ParseError::MissingPositional(
             missing.name.clone(),
             Span::new(end_offset, end_offset),
@@ -387,7 +405,8 @@ fn ensure_flag_arg_type(
     long_name_span: Span,
 ) -> (Spanned<String>, Expression) {
     // `nothing` is allowed so optional named flags can be forwarded with
-    // `--flag=$maybe_null`; at runtime a null value omits the flag entirely.
+    // `--flag=$maybe_null`. At runtime: omit if the flag type does not accept
+    // nothing; pass through if it does (`any`, `nothing`, `oneof<…, nothing>`).
     if arg.ty != Type::Nothing && !type_compatible(&arg_shape.to_type(), &arg.ty) {
         working_set.error(ParseError::TypeMismatch(
             arg_shape.to_type(),
@@ -1202,16 +1221,22 @@ pub fn parse_internal_call(
             {
                 let after_dots = working_set.get_span_contents(spread_arg_span);
                 if after_dots.first() == Some(&b'{') {
-                    // Record spreads always parse; unknown keys error at runtime when expanded
-                    // into named flags (not into ...rest).
-                    let args = crate::parser::parse_value(
-                        working_set,
-                        spread_arg_span,
-                        // Open record; field types are validated against the signature at runtime.
-                        &SyntaxShape::Record(std::iter::empty().collect()),
-                        None,
-                    );
-                    call.add_spread(args);
+                    if !can_named_spread {
+                        working_set.error(ParseError::UnexpectedSpreadArg(
+                            signature.call_signature(),
+                            arg_span,
+                        ));
+                        call.add_positional(Expression::garbage(working_set, arg_span));
+                    } else {
+                        // Field types / unknown keys are validated at runtime against the signature.
+                        let args = crate::parser::parse_value(
+                            working_set,
+                            spread_arg_span,
+                            &SyntaxShape::Record(std::iter::empty().collect()),
+                            None,
+                        );
+                        call.add_spread(args);
+                    }
                     spans_idx += 1;
                     continue;
                 }
@@ -1268,9 +1293,10 @@ pub fn parse_internal_call(
                         ));
                         call.add_positional(Expression::garbage(working_set, arg_span));
                     } else if can_rest_spread
+                        && !can_named_spread
                         && positional_idx < signature.required_positional.len()
                     {
-                        // Rest spreads cannot fill required positionals.
+                        // Pure rest spreads cannot fill required positionals.
                         working_set.error(ParseError::MissingPositional(
                             signature.required_positional[positional_idx].name.clone(),
                             Span::new(spans[spans_idx].start, spans[spans_idx].start),
@@ -1279,6 +1305,9 @@ pub fn parse_internal_call(
                         call.add_positional(Expression::garbage(working_set, arg_span));
                     } else {
                         // Parse as Any so both lists (rest) and records (named flags) work.
+                        // Do not advance positional_idx when named spreads are possible: a
+                        // flag record does not consume positionals, so `f ...$flags a` must
+                        // still bind `a`. Pure rest-only commands still advance below.
                         let args = crate::parser::parse_value(
                             working_set,
                             spread_arg_span,
@@ -1286,7 +1315,7 @@ pub fn parse_internal_call(
                             None,
                         );
                         call.add_spread(args);
-                        if can_rest_spread {
+                        if can_rest_spread && !can_named_spread {
                             positional_idx = signature.required_positional.len()
                                 + signature.optional_positional.len();
                         }

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -135,7 +135,7 @@ fn named_matches_flag(flag: &Flag, long: &str, short: Option<&str>) -> bool {
 
 fn key_matches_flag(flag: &Flag, key: &str) -> bool {
     (!flag.long.is_empty() && flag.long == key)
-        || (key.chars().count() == 1 && flag.short.is_some_and(|c| key.chars().next() == Some(c)))
+        || (key.chars().count() == 1 && flag.short.is_some_and(|c| key.starts_with(c)))
 }
 
 /// Static keys/values from a record expression used as a flag spread.

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -90,11 +90,7 @@ pub(crate) fn check_call(
         return CallKind::Invalid;
     } else {
         // Spreads may supply required named flags at runtime (`...{flag: val}` / `...$flags`).
-        // Defer to runtime when any spread is present rather than static-analyzing records.
-        let has_spread = call
-            .arguments
-            .iter()
-            .any(|arg| matches!(arg, Argument::Spread(_)));
+        // Defer to the command rather than parse-erroring when any spread is present.
         if !has_spread {
             for req_flag in sig.named.iter().filter(|x| x.required) {
                 if call.named_iter().all(|(n, _, _)| n.item != req_flag.long) {

--- a/crates/nu-parser/src/parse_calls.rs
+++ b/crates/nu-parser/src/parse_calls.rs
@@ -9,8 +9,8 @@ use crate::{
 use log::trace;
 use nu_engine::DIR_VAR_PARSER_INFO;
 use nu_protocol::{
-    DeclId, Flag, IntoSpanned, ParseError, PositionalArg, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Type, TypeSet,
+    CompareTypes, DeclId, Flag, IntoSpanned, ParseError, PositionalArg, ShellError, Signature, Span,
+    Spanned, SyntaxShape, Type, TypeSet,
     ast::*,
     did_you_mean,
     engine::{CommandType, StateWorkingSet},
@@ -90,16 +90,127 @@ pub(crate) fn check_call(
         return CallKind::Invalid;
     } else {
         for req_flag in sig.named.iter().filter(|x| x.required) {
-            if call.named_iter().all(|(n, _, _)| n.item != req_flag.long) {
-                working_set.error(ParseError::MissingRequiredFlag(
-                    req_flag.long.clone(),
-                    command,
-                ));
-                return CallKind::Invalid;
+            match required_flag_presence(call, req_flag) {
+                RequiredFlagPresence::Present => {}
+                // Dynamic spreads (`...$flags`) may supply the flag at runtime.
+                RequiredFlagPresence::MaybeDynamic => {}
+                RequiredFlagPresence::Absent => {
+                    working_set.error(ParseError::MissingRequiredFlag(
+                        if req_flag.long.is_empty() {
+                            req_flag
+                                .short
+                                .map(|c| c.to_string())
+                                .unwrap_or_else(|| req_flag.long.clone())
+                        } else {
+                            req_flag.long.clone()
+                        },
+                        command,
+                    ));
+                    return CallKind::Invalid;
+                }
             }
         }
     }
     CallKind::Valid
+}
+
+/// Whether a required named flag is known to be present at parse time.
+#[derive(Debug, PartialEq, Eq)]
+enum RequiredFlagPresence {
+    Present,
+    Absent,
+    /// A non-literal / dynamic spread may supply the flag at runtime.
+    MaybeDynamic,
+}
+
+fn flag_type_accepts_nothing_shape(flag: &Flag) -> bool {
+    match &flag.arg {
+        Some(shape) => Type::Nothing.is_assignable_to(&shape.to_type()),
+        None => false,
+    }
+}
+
+fn named_matches_flag(flag: &Flag, long: &str, short: Option<&str>) -> bool {
+    (!flag.long.is_empty() && flag.long == long)
+        || short.is_some_and(|s| {
+            flag.short.is_some_and(|c| {
+                let mut buf = [0u8; 4];
+                c.encode_utf8(&mut buf) == s
+            })
+        })
+}
+
+fn key_matches_flag(flag: &Flag, key: &str) -> bool {
+    (!flag.long.is_empty() && flag.long == key)
+        || (key.chars().count() == 1
+            && flag.short.is_some_and(|c| key.chars().next() == Some(c)))
+}
+
+/// Static keys/values from a record expression used as a flag spread.
+/// Returns `None` when the expression is not a fully static record (dynamic / nested spreads).
+fn static_record_flag_entries(expr: &Expression) -> Option<Vec<(String, &Expression)>> {
+    let Expr::Record(items) = &expr.expr else {
+        return None;
+    };
+    let mut entries = Vec::with_capacity(items.len());
+    for item in items {
+        match item {
+            RecordItem::Pair(key_expr, val_expr) => {
+                let key = key_expr.as_string()?;
+                entries.push((key, val_expr));
+            }
+            // Nested record spreads make the full key set dynamic.
+            RecordItem::Spread(_, _) => return None,
+        }
+    }
+    Some(entries)
+}
+
+fn required_flag_presence(call: &Call, req_flag: &Flag) -> RequiredFlagPresence {
+    // Explicit `--flag` / `-f` (including `=value`)
+    for (long, short, maybe_expr) in call.named_iter() {
+        if !named_matches_flag(req_flag, &long.item, short.as_ref().map(|s| s.item.as_str())) {
+            continue;
+        }
+        // Static null is omitted at runtime when the type does not accept nothing.
+        if let Some(expr) = maybe_expr
+            && matches!(expr.expr, Expr::Nothing)
+            && !flag_type_accepts_nothing_shape(req_flag)
+        {
+            return RequiredFlagPresence::Absent;
+        }
+        return RequiredFlagPresence::Present;
+    }
+
+    let mut saw_dynamic_spread = false;
+    for arg in &call.arguments {
+        let Argument::Spread(expr) = arg else {
+            continue;
+        };
+        match static_record_flag_entries(expr) {
+            Some(entries) => {
+                for (key, val_expr) in entries {
+                    if !key_matches_flag(req_flag, &key) {
+                        continue;
+                    }
+                    if matches!(val_expr.expr, Expr::Nothing)
+                        && !flag_type_accepts_nothing_shape(req_flag)
+                    {
+                        return RequiredFlagPresence::Absent;
+                    }
+                    return RequiredFlagPresence::Present;
+                }
+            }
+            // Variable / subexpression / list / partial record: may be a flag record at runtime.
+            None => saw_dynamic_spread = true,
+        }
+    }
+
+    if saw_dynamic_spread {
+        RequiredFlagPresence::MaybeDynamic
+    } else {
+        RequiredFlagPresence::Absent
+    }
 }
 
 fn parse_unknown_arg(

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -49,6 +49,18 @@ impl Flag {
         (!self.long.is_empty()).then_some(self.long.as_str())
     }
 
+    /// Whether this flag's value type accepts `nothing`/`null`.
+    ///
+    /// Used so `--flag=$null` can either pass `null` through (when the type allows it) or omit
+    /// the flag (when it does not). Switches (`arg: None`) never accept nothing — null means omit.
+    #[inline]
+    pub fn type_accepts_nothing(&self) -> bool {
+        match &self.arg {
+            Some(shape) => Type::Nothing.is_assignable_to(&shape.to_type()),
+            None => false,
+        }
+    }
+
     #[inline]
     pub fn new(long: impl Into<String>) -> Self {
         Flag {

--- a/tests/repl/test_custom_commands.rs
+++ b/tests/repl/test_custom_commands.rs
@@ -85,7 +85,6 @@ fn custom_switch1() -> Result {
 fn custom_flag_with_type_checking(
     #[values(
         ("int", "\"3\""),
-        ("int", "null"),
         ("record<i: int>", "{i: \"\"}"),
         ("list<int>", "[\"\"]")
     )]
@@ -101,6 +100,19 @@ fn custom_flag_with_type_checking(
     test()
         .run(code)
         .expect_error_code_eq("nu::parser::type_mismatch")
+}
+
+/// `null` is intentionally allowed for optional named flags: it omits the flag
+/// (same as not passing it) rather than type-mismatching.
+#[rstest]
+fn custom_flag_null_is_omitted(#[values("--dry-run", "-d")] flag: &str) -> Result {
+    let code = format! {"
+        def florb [--dry-run (-d): int] {{ $dry_run }}
+        let y = null
+        florb {flag} $y
+    "};
+
+    test().run(code).expect_value_eq(())
 }
 
 #[test]

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -321,6 +321,58 @@ fn named_flag_null_is_omitted() -> Result {
 }
 
 #[test]
+fn named_flag_null_passed_when_type_allows_nothing() -> Result {
+    // oneof with nothing: explicit null is bound; omit still uses default
+    let code = "
+        def f [--x: oneof<int, nothing> = 5] { $x }
+        f --x=(null)
+    ";
+    test().run(code).expect_value_eq(())?;
+
+    let code = "
+        def f [--x: oneof<int, nothing> = 5] { $x }
+        f
+    ";
+    test().run(code).expect_value_eq(5)?;
+
+    let code = "
+        def f [--x: oneof<int, nothing> = 5] { $x }
+        f --x=3
+    ";
+    test().run(code).expect_value_eq(3)?;
+
+    // `any` accepts nothing, so null is passed through (not the default)
+    let code = "
+        def f [--x: any = 5] { $x }
+        f --x=(null)
+    ";
+    test().run(code).expect_value_eq(())?;
+
+    // `nothing` type: null is passed through
+    let code = "
+        def f [--x: nothing] { $x }
+        f --x=(null)
+    ";
+    test().run(code).expect_value_eq(())?;
+
+    // Record spread: null passes when type allows nothing
+    let code = "
+        def f [--x: oneof<int, nothing> = 5] { $x }
+        f ...{x: null}
+    ";
+    test().run(code).expect_value_eq(())?;
+
+    // Record spread: null still omits when type does not allow nothing
+    let code = "
+        def f [--x: int = 5] { $x }
+        f ...{x: null}
+    ";
+    test().run(code).expect_value_eq(5)?;
+
+    Ok(())
+}
+
+#[test]
 fn named_flag_record_spread() -> Result {
     let code = r#"
         def f [--x: int, --y: string, --verbose] {

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -458,13 +458,13 @@ fn named_flag_record_spread() -> Result {
 }
 
 #[test]
-fn named_flag_record_spread_long_key_with_short_alias() -> Result {
-    // Dual long+short: only the long key is used in record spreads.
+fn named_flag_record_spread_unknown_flag_errors() -> Result {
     let code = "
-        def f [--verbose(-v)] { $verbose }
-        f ...{verbose: true}
+        def f [--x: int] { $x }
+        f ...{x: 1, nope: true}
     ";
-    test().run(code).expect_value_eq(true)?;
+    let err = test().run(code).expect_shell_error()?;
+    assert_matches!(err, ShellError::Generic(_));
     Ok(())
 }
 
@@ -490,27 +490,16 @@ fn named_flag_list_spread_before_required_errors() -> Result {
 }
 
 #[test]
-fn named_flag_null_spread_rest_mode() -> Result {
-    // Null spread enables rest mode: later positionals go to rest
-    let code = "
-        def f [a?, ...rest] { {a: $a, rest: $rest} }
-        f ...(null) later
-    ";
-    test().run(code).expect_value_eq(test_value!({
-        a: (),
-        rest: ["later"]
-    }))?;
-    Ok(())
-}
+fn named_flag_record_spread_required_named_deferred() -> Result {
+    // Bare required named still parse-errors
+    let err = test().run("stor create").expect_parse_error()?;
+    assert_matches!(err, ParseError::MissingRequiredFlag(..));
 
-#[test]
-fn named_flag_record_spread_unknown_flag_errors() -> Result {
-    let code = "
-        def f [--x: int] { $x }
-        f ...{x: 1, nope: true}
-    ";
-    let err = test().run(code).expect_shell_error()?;
-    assert_matches!(err, ShellError::Generic(_));
+    // With a record spread, required named is deferred to runtime (no MissingRequiredFlag)
+    test()
+        .run(r#"stor create ...{table-name: "t_spread_ok", columns: {id: int}} | describe"#)
+        .expect_value_eq("SQLiteDatabase")?;
+
     Ok(())
 }
 

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -458,102 +458,13 @@ fn named_flag_record_spread() -> Result {
 }
 
 #[test]
-fn named_flag_record_spread_short_flags() -> Result {
-    // Short-only valued flag + switch
-    let code = "
-        def f [-a: int, -b] { {a: $a, b: $b} }
-        f ...{a: 3, b: true}
-    ";
-    test().run(code).expect_value_eq(test_value!({
-        a: 3,
-        b: true
-    }))?;
-
-    // Short-only: null omits when type does not accept nothing
-    let code = "
-        def f [-a: int = 9] { $a }
-        f ...{a: null}
-    ";
-    test().run(code).expect_value_eq(9)?;
-
-    // Dual long+short: short key works
-    let code = "
-        def f [--verbose(-v)] { $verbose }
-        f ...{v: true}
-    ";
-    test().run(code).expect_value_eq(true)?;
-
-    // Dual long+short: long key still works
+fn named_flag_record_spread_long_key_with_short_alias() -> Result {
+    // Dual long+short: only the long key is used in record spreads.
     let code = "
         def f [--verbose(-v)] { $verbose }
         f ...{verbose: true}
     ";
     test().run(code).expect_value_eq(true)?;
-
-    // Unknown short key errors
-    let code = "
-        def f [-a: int] { $a }
-        f ...{z: 1}
-    ";
-    let err = test().run(code).expect_shell_error()?;
-    assert_matches!(err, ShellError::Generic(_));
-
-    // Long flag named `a` wins over short `-a` of another flag when key is "a"
-    let code = "
-        def f [--a: int, -b: int] { {a: $a, b: $b} }
-        f ...{a: 1, b: 2}
-    ";
-    test().run(code).expect_value_eq(test_value!({
-        a: 1,
-        b: 2
-    }))?;
-
-    // Multi short-only: both bind correctly (not only the first)
-    let code = "
-        def f [-a: int, -b: int] { {a: $a, b: $b} }
-        f ...{a: 3, b: 4}
-    ";
-    test().run(code).expect_value_eq(test_value!({
-        a: 3,
-        b: 4
-    }))?;
-
-    Ok(())
-}
-
-#[test]
-fn named_flag_record_spread_required_named() -> Result {
-    // Builtin with required_named: missing flags still parse-error
-    let err = test().run("stor create").expect_parse_error()?;
-    assert_matches!(err, ParseError::MissingRequiredFlag(..));
-
-    // Static record spread supplies required named flags (no MissingRequiredFlag)
-    test()
-        .run(r#"stor create ...{table-name: "t_spread_ok", columns: {id: int}} | describe"#)
-        .expect_value_eq("SQLiteDatabase")?;
-
-    // Static null alone for a required flag is still missing (omitted at runtime)
-    let err = test()
-        .run("stor create ...{table-name: null, columns: {id: int}}")
-        .expect_parse_error()?;
-    assert_matches!(err, ParseError::MissingRequiredFlag(..));
-
-    // Missing key entirely in static record is also missing
-    let err = test()
-        .run("stor create ...{columns: {id: int}}")
-        .expect_parse_error()?;
-    assert_matches!(err, ParseError::MissingRequiredFlag(..));
-
-    // Static null + later dynamic spread: may supply required flag at runtime (not parse error)
-    test()
-        .run(
-            r#"
-            let more = {table-name: "t_spread_dyn", columns: {id: int}}
-            stor create ...{table-name: null} ...$more | describe
-            "#,
-        )
-        .expect_value_eq("SQLiteDatabase")?;
-
     Ok(())
 }
 
@@ -568,7 +479,7 @@ fn named_flag_list_spread_before_required_errors() -> Result {
     let err = test().run(code).expect_shell_error()?;
     assert_matches!(err, ShellError::Generic(_));
 
-    // Null rest-mode before required positionals must also error (not bind nothing to `a`)
+    // Null rest-mode before required positionals must also error
     let code = "
         def f [a: string, --x: int, ...rest] { {a: $a, x: $x, rest: $rest} }
         f ...(null) hello
@@ -580,7 +491,7 @@ fn named_flag_list_spread_before_required_errors() -> Result {
 
 #[test]
 fn named_flag_null_spread_rest_mode() -> Result {
-    // Null spread enables rest mode: later positionals go to rest (IR parity)
+    // Null spread enables rest mode: later positionals go to rest
     let code = "
         def f [a?, ...rest] { {a: $a, rest: $rest} }
         f ...(null) later
@@ -600,21 +511,6 @@ fn named_flag_record_spread_unknown_flag_errors() -> Result {
     ";
     let err = test().run(code).expect_shell_error()?;
     assert_matches!(err, ShellError::Generic(_));
-    Ok(())
-}
-
-#[test]
-fn named_flag_record_spread_unknown_allowed() -> Result {
-    // allows_unknown_args + a known named flag so record spreads are parse-allowed.
-    // Unknown keys are forwarded as rest tokens (not "Unknown flag").
-    let code = "
-        def --wrapped f [--known: int, ...rest] { {known: $known, rest: $rest} }
-        f ...{known: 1, extra: true}
-    ";
-    test().run(code).expect_value_eq(test_value!({
-        known: 1,
-        rest: ["--extra"]
-    }))?;
     Ok(())
 }
 

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -524,7 +524,7 @@ fn named_flag_record_spread_short_flags() -> Result {
 #[test]
 fn named_flag_record_spread_required_named() -> Result {
     // Builtin with required_named: missing flags still parse-error
-    let err = test().run(r#"stor create"#).expect_parse_error()?;
+    let err = test().run("stor create").expect_parse_error()?;
     assert_matches!(err, ParseError::MissingRequiredFlag(..));
 
     // Static record spread supplies required named flags (no MissingRequiredFlag)
@@ -534,13 +534,13 @@ fn named_flag_record_spread_required_named() -> Result {
 
     // Static null alone for a required flag is still missing (omitted at runtime)
     let err = test()
-        .run(r#"stor create ...{table-name: null, columns: {id: int}}"#)
+        .run("stor create ...{table-name: null, columns: {id: int}}")
         .expect_parse_error()?;
     assert_matches!(err, ParseError::MissingRequiredFlag(..));
 
     // Missing key entirely in static record is also missing
     let err = test()
-        .run(r#"stor create ...{columns: {id: int}}"#)
+        .run("stor create ...{columns: {id: int}}")
         .expect_parse_error()?;
     assert_matches!(err, ParseError::MissingRequiredFlag(..));
 
@@ -607,10 +607,10 @@ fn named_flag_record_spread_unknown_flag_errors() -> Result {
 fn named_flag_record_spread_unknown_allowed() -> Result {
     // allows_unknown_args + a known named flag so record spreads are parse-allowed.
     // Unknown keys are forwarded as rest tokens (not "Unknown flag").
-    let code = r#"
+    let code = "
         def --wrapped f [--known: int, ...rest] { {known: $known, rest: $rest} }
         f ...{known: 1, extra: true}
-    "#;
+    ";
     test().run(code).expect_value_eq(test_value!({
         known: 1,
         rest: ["--extra"]

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -464,6 +464,60 @@ fn named_flag_record_spread_unknown_flag_errors() -> Result {
         f ...{x: 1, nope: true}
     ";
     let err = test().run(code).expect_shell_error()?;
-    assert_matches!(err, ShellError::Generic { .. });
+    assert_matches!(err, ShellError::Generic(_));
+    Ok(())
+}
+
+#[test]
+fn named_flag_list_spread_without_rest_errors() -> Result {
+    // Dynamic list on a named-only command must not silently drop the list.
+    let code = "
+        def f [--x: int] { $x }
+        let list = [1]
+        f ...$list
+    ";
+    let err = test().run(code).expect_shell_error()?;
+    assert_matches!(err, ShellError::Generic(_));
+
+    // Explicit list spread is still a parse error (no rest).
+    let err = test()
+        .run("def f [--x: int] { $x }; f ...[1]")
+        .expect_parse_error()?;
+    assert_matches!(err, ParseError::UnexpectedSpreadArg(_, _));
+    Ok(())
+}
+
+#[test]
+fn named_flag_record_spread_type_mismatch_errors() -> Result {
+    let code = r#"
+        def f [--x: int] { $x }
+        f ...{x: "hi"}
+    "#;
+    let err = test().run(code).expect_shell_error()?;
+    assert_matches!(err, ShellError::CantConvert { .. });
+    Ok(())
+}
+
+#[test]
+fn named_flag_dynamic_record_before_required_positional() -> Result {
+    // Dual-purpose commands: flag record before required positionals is allowed.
+    let code = "
+        def f [a: string, --x: int, ...rest] { {a: $a, x: $x, rest: $rest} }
+        let flags = {x: 7}
+        f ...$flags hello more
+    ";
+    test().run(code).expect_value_eq(test_value!({
+        a: "hello",
+        x: 7,
+        rest: ["more"]
+    }))
+}
+
+#[test]
+fn named_flag_record_spread_without_named_params_is_parse_error() -> Result {
+    let err = test()
+        .run("def f [] { 1 }; f ...{x: 1}")
+        .expect_parse_error()?;
+    assert_matches!(err, ParseError::UnexpectedSpreadArg(_, _));
     Ok(())
 }

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -458,6 +458,50 @@ fn named_flag_record_spread() -> Result {
 }
 
 #[test]
+fn named_flag_record_spread_short_flags() -> Result {
+    // Short-only valued flag + switch
+    let code = "
+        def f [-a: int, -b] { {a: $a, b: $b} }
+        f ...{a: 3, b: true}
+    ";
+    test().run(code).expect_value_eq(test_value!({
+        a: 3,
+        b: true
+    }))?;
+
+    // Short-only: null omits when type does not accept nothing
+    let code = "
+        def f [-a: int = 9] { $a }
+        f ...{a: null}
+    ";
+    test().run(code).expect_value_eq(9)?;
+
+    // Dual long+short: short key works
+    let code = "
+        def f [--verbose(-v)] { $verbose }
+        f ...{v: true}
+    ";
+    test().run(code).expect_value_eq(true)?;
+
+    // Dual long+short: long key still works
+    let code = "
+        def f [--verbose(-v)] { $verbose }
+        f ...{verbose: true}
+    ";
+    test().run(code).expect_value_eq(true)?;
+
+    // Unknown short key errors
+    let code = "
+        def f [-a: int] { $a }
+        f ...{z: 1}
+    ";
+    let err = test().run(code).expect_shell_error()?;
+    assert_matches!(err, ShellError::Generic(_));
+
+    Ok(())
+}
+
+#[test]
 fn named_flag_record_spread_unknown_flag_errors() -> Result {
     let code = "
         def f [--x: int] { $x }

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -269,3 +269,149 @@ fn spread_null() -> Result {
 
     Ok(())
 }
+
+#[test]
+fn named_flag_null_is_omitted() -> Result {
+    // Null named value uses signature default
+    let code = "
+        def f [--x: int = 5] { $x }
+        f --x=(null)
+    ";
+    test().run(code).expect_value_eq(5)?;
+
+    // Null named value without default is same as omitting the flag
+    let code = "
+        def f [--x: int] { $x }
+        f --x=(null)
+    ";
+    test().run(code).expect_value_eq(())?;
+
+    // Forwarding an unbound optional flag (null) into another command
+    let code = "
+        def outer [--preserve: list<string>] {
+            inner --preserve=$preserve
+        }
+        def inner [--preserve: list<string>] {
+            $preserve
+        }
+        outer
+    ";
+    test().run(code).expect_value_eq(())?;
+
+    // Explicit empty list is distinct from null/omit
+    let code = "
+        def outer [--preserve: list<string>] {
+            inner --preserve=$preserve
+        }
+        def inner [--preserve: list<string>] {
+            $preserve
+        }
+        outer --preserve=[]
+    ";
+    test().run(code).expect_value_eq(test_value!([]))?;
+
+    // Null switch value is treated as omitted (false)
+    let code = "
+        def f [--verbose] { $verbose }
+        f --verbose=(null)
+    ";
+    test().run(code).expect_value_eq(false)?;
+
+    Ok(())
+}
+
+#[test]
+fn named_flag_record_spread() -> Result {
+    let code = r#"
+        def f [--x: int, --y: string, --verbose] {
+            {x: $x, y: $y, verbose: $verbose}
+        }
+        f ...{x: 1, y: "a", verbose: true}
+    "#;
+    test().run(code).expect_value_eq(test_value!({
+        x: 1,
+        y: "a",
+        verbose: true
+    }))?;
+
+    // Null fields are omitted (defaults / null apply)
+    let code = r#"
+        def f [--x: int = 9, --y: string, --verbose] {
+            {x: $x, y: $y, verbose: $verbose}
+        }
+        f ...{x: null, y: "hi", verbose: false}
+    "#;
+    test().run(code).expect_value_eq(test_value!({
+        x: 9,
+        y: "hi",
+        verbose: false
+    }))?;
+
+    // Dynamic record variable
+    let code = r#"
+        def f [--x: int, --y: string] { [$x $y] }
+        let flags = {x: 3, y: "z"}
+        f ...$flags
+    "#;
+    test().run(code).expect_value_eq(test_value!([3, "z"]))?;
+
+    // Combine named spread with rest positionals
+    let code = "
+        def f [--flag: int, ...rest] { {flag: $flag, rest: $rest} }
+        f ...{flag: 7} a b
+    ";
+    test().run(code).expect_value_eq(test_value!({
+        flag: 7,
+        rest: ["a", "b"]
+    }))?;
+
+    // Shadowing-style call: flags record + rest paths
+    let code = "
+        def wrap [--preserve: list<string>, --recursive, ...rest] {
+            inner ...{
+                preserve: $preserve
+                recursive: $recursive
+            } ...$rest
+        }
+        def inner [--preserve: list<string>, --recursive, ...rest] {
+            {preserve: $preserve, recursive: $recursive, rest: $rest}
+        }
+        wrap src dest
+    ";
+    test().run(code).expect_value_eq(test_value!({
+        preserve: (),
+        recursive: false,
+        rest: ["src", "dest"]
+    }))?;
+
+    let code = "
+        def wrap [--preserve: list<string>, --recursive, ...rest] {
+            inner ...{
+                preserve: $preserve
+                recursive: $recursive
+            } ...$rest
+        }
+        def inner [--preserve: list<string>, --recursive, ...rest] {
+            {preserve: $preserve, recursive: $recursive, rest: $rest}
+        }
+        wrap --preserve=[mode] --recursive src dest
+    ";
+    test().run(code).expect_value_eq(test_value!({
+        preserve: ["mode"],
+        recursive: true,
+        rest: ["src", "dest"]
+    }))?;
+
+    Ok(())
+}
+
+#[test]
+fn named_flag_record_spread_unknown_flag_errors() -> Result {
+    let code = "
+        def f [--x: int] { $x }
+        f ...{x: 1, nope: true}
+    ";
+    let err = test().run(code).expect_shell_error()?;
+    assert_matches!(err, ShellError::Generic { .. });
+    Ok(())
+}

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -498,6 +498,67 @@ fn named_flag_record_spread_short_flags() -> Result {
     let err = test().run(code).expect_shell_error()?;
     assert_matches!(err, ShellError::Generic(_));
 
+    // Long flag named `a` wins over short `-a` of another flag when key is "a"
+    let code = "
+        def f [--a: int, -b: int] { {a: $a, b: $b} }
+        f ...{a: 1, b: 2}
+    ";
+    test().run(code).expect_value_eq(test_value!({
+        a: 1,
+        b: 2
+    }))?;
+
+    // Multi short-only: both bind correctly (not only the first)
+    let code = "
+        def f [-a: int, -b: int] { {a: $a, b: $b} }
+        f ...{a: 3, b: 4}
+    ";
+    test().run(code).expect_value_eq(test_value!({
+        a: 3,
+        b: 4
+    }))?;
+
+    Ok(())
+}
+
+#[test]
+fn named_flag_record_spread_required_named() -> Result {
+    // Builtin with required_named: missing flags still parse-error
+    let err = test().run(r#"stor create"#).expect_parse_error()?;
+    assert_matches!(err, ParseError::MissingRequiredFlag(..));
+
+    // Static record spread supplies required named flags (no MissingRequiredFlag)
+    test()
+        .run(r#"stor create ...{table-name: "t", columns: {id: int}} | describe"#)
+        .expect_value_eq("SQLiteDatabase")?;
+
+    Ok(())
+}
+
+#[test]
+fn named_flag_list_spread_before_required_errors() -> Result {
+    // Dual-purpose: dynamic list before required positionals must error (not leave them unbound)
+    let code = "
+        def f [a: string, --x: int, ...rest] { {a: $a, x: $x, rest: $rest} }
+        let list = [1]
+        f ...$list hello
+    ";
+    let err = test().run(code).expect_shell_error()?;
+    assert_matches!(err, ShellError::Generic(_));
+    Ok(())
+}
+
+#[test]
+fn named_flag_null_spread_rest_mode() -> Result {
+    // Null spread enables rest mode: later positionals go to rest (IR parity)
+    let code = "
+        def f [a?, ...rest] { {a: $a, rest: $rest} }
+        f ...(null) later
+    ";
+    test().run(code).expect_value_eq(test_value!({
+        a: (),
+        rest: ["later"]
+    }))?;
     Ok(())
 }
 
@@ -509,6 +570,21 @@ fn named_flag_record_spread_unknown_flag_errors() -> Result {
     ";
     let err = test().run(code).expect_shell_error()?;
     assert_matches!(err, ShellError::Generic(_));
+    Ok(())
+}
+
+#[test]
+fn named_flag_record_spread_unknown_allowed() -> Result {
+    // allows_unknown_args + a known named flag so record spreads are parse-allowed.
+    // Unknown keys are forwarded as rest tokens (not "Unknown flag").
+    let code = r#"
+        def --wrapped f [--known: int, ...rest] { {known: $known, rest: $rest} }
+        f ...{known: 1, extra: true}
+    "#;
+    test().run(code).expect_value_eq(test_value!({
+        known: 1,
+        rest: ["--extra"]
+    }))?;
     Ok(())
 }
 

--- a/tests/repl/test_spread.rs
+++ b/tests/repl/test_spread.rs
@@ -529,7 +529,29 @@ fn named_flag_record_spread_required_named() -> Result {
 
     // Static record spread supplies required named flags (no MissingRequiredFlag)
     test()
-        .run(r#"stor create ...{table-name: "t", columns: {id: int}} | describe"#)
+        .run(r#"stor create ...{table-name: "t_spread_ok", columns: {id: int}} | describe"#)
+        .expect_value_eq("SQLiteDatabase")?;
+
+    // Static null alone for a required flag is still missing (omitted at runtime)
+    let err = test()
+        .run(r#"stor create ...{table-name: null, columns: {id: int}}"#)
+        .expect_parse_error()?;
+    assert_matches!(err, ParseError::MissingRequiredFlag(..));
+
+    // Missing key entirely in static record is also missing
+    let err = test()
+        .run(r#"stor create ...{columns: {id: int}}"#)
+        .expect_parse_error()?;
+    assert_matches!(err, ParseError::MissingRequiredFlag(..));
+
+    // Static null + later dynamic spread: may supply required flag at runtime (not parse error)
+    test()
+        .run(
+            r#"
+            let more = {table-name: "t_spread_dyn", columns: {id: int}}
+            stor create ...{table-name: null} ...$more | describe
+            "#,
+        )
         .expect_value_eq("SQLiteDatabase")?;
 
     Ok(())
@@ -542,6 +564,14 @@ fn named_flag_list_spread_before_required_errors() -> Result {
         def f [a: string, --x: int, ...rest] { {a: $a, x: $x, rest: $rest} }
         let list = [1]
         f ...$list hello
+    ";
+    let err = test().run(code).expect_shell_error()?;
+    assert_matches!(err, ShellError::Generic(_));
+
+    // Null rest-mode before required positionals must also error (not bind nothing to `a`)
+    let code = "
+        def f [a: string, --x: int, ...rest] { {a: $a, x: $x, rest: $rest} }
+        f ...(null) hello
     ";
     let err = test().run(code).expect_shell_error()?;
     assert_matches!(err, ShellError::Generic(_));


### PR DESCRIPTION
## Description

This PR makes it much easier to **shadow builtins and forward optional named flags**, especially cases where “flag absent” and “flag present with a value” mean different things (the current example is `cp --preserve`).

When shadowing a builtin, people write:

```nushell
def cp [
  --preserve: list<string>
  --recursive (-r)
  ...rest
] {
  %cp --preserve=$preserve --recursive=$recursive ...$rest
}
```

If the user does not pass `--preserve`, `$preserve` is `null`. Passing `--preserve=$preserve` used to **attach** the named flag with a null value. Builtins then rejected it (e.g. `--preserve` expects `list<string>`), even though omitting the flag would have used the builtin’s normal default path.

There was also no good way to build a dynamic set of flags the way people build rest args with `...$list`.

## User-facing changes (Release notes)

### Named flags: null can omit or pass through based on type

When a named flag is given `null`, Nushell now:

- **Omits** the flag if its type does not accept `nothing` (e.g. `--x: int`, `--preserve: list<string>`), so defaults and “flag not passed” behavior work—especially useful when shadowing builtins with `%cp` / `%ls` and writing `--flag=$maybe_null`
- **Passes `null` through** if the type accepts `nothing` (e.g. `--x: any`, `--x: oneof<int, nothing>`), so callers can still express an explicit null when they opt into that in the signature

```nushell
def f [--x: oneof<int, nothing> = 5] { $x }
f            # 5
f --x=null   # null

def g [--x: int = 5] { $x }
g --x=(null)   # 5 (omitted → default) note: in this example null is wrapped in parens because this syntax would fail with `g --x=null` as you're typing due to parse checking.
```

### Record spread into named flags

Internal and custom commands accept spreading a record as named flags:

```nushell
def wrap [--preserve: list<string>, --recursive, ...rest] {
  %cp ...{ preserve: $preserve, recursive: $recursive } ...$rest
}

let flags = {preserve: [mode], recursive: true}
wrap ...$flags src dest
```

- Null fields follow the same type rule as named flags above
- Switch fields: `true` sets the flag; `false` / `null` omit
- Field values are type-checked against the flag signature
- Unknown flag names in the record error at runtime
- Spreading a **list** into a command with no `...rest` errors clearly (it is not treated as named flags)


## Additional notes

closes https://github.com/nushell/nushell/issues/18790